### PR TITLE
fix: resolve release-please version calculation issue

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,4 +42,6 @@ jobs:
       - name: 🚀 Run release‑please
         uses: googleapis/release-please-action@v3
         with:
+          release-type: node
+          package-name: "io.github.hatayama.umcp"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,9 +42,4 @@ jobs:
       - name: 🚀 Run release‑please
         uses: googleapis/release-please-action@v3
         with:
-          path: Packages/src
-          release-type: node
-          package-name: "io.github.hatayama.umcp"
           token: ${{ secrets.GITHUB_TOKEN }}
-          extra-files: |
-            .TypeScriptServer/package.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,5 @@
   "include-v-in-tag": true,
   "extra-files": [
     "Packages/src/.TypeScriptServer/package.json"
-  ],
-  "packages": {
-    "Packages/src": {}
-  }
+  ]
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,10 @@
 {
+  "release-type": "node",
+  "include-v-in-tag": true,
+  "extra-files": [
+    "Packages/src/.TypeScriptServer/package.json"
+  ],
   "packages": {
-    "Packages/src": {
-      "release-type": "node",
-      "include-v-in-tag": true,
-      "extra-files": [
-        ".TypeScriptServer/package.json"
-      ]
-    }
+    "Packages/src": {}
   }
 }


### PR DESCRIPTION
## Summary
- Simplify release-please workflow configuration to resolve 0.1.1 version calculation issue
- Remove conflicting parameters from workflow and rely on release-please-config.json
- Standardize configuration format for better compatibility

## Changes
- Updated `.github/workflows/release-please.yml` to use minimal configuration
- Modified `release-please-config.json` to use standard format with packages section
- Configuration now relies entirely on config files instead of workflow parameters

## Test plan
- Merge this PR to main branch
- Run release-please workflow to verify it calculates correct next version from 0.17.1
- Confirm no more 0.1.1 downgrade issues

## Background
The issue was caused by conflicting configuration between workflow parameters and config file, causing release-please to miscalculate versions.