### PR TITLE
fix: resolve GitHub Actions configuration issues for Claude workflows

### DIFF
--- a/.github/workflows/claude-architecture-update.yml
+++ b/.github/workflows/claude-architecture-update.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,7 +25,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           timeout_minutes: "60"
-          prompt: |
+          direct_prompt: |
             I need you to analyze the recent code changes and update the architecture documentation files accordingly.
             
             ## Task

--- a/.github/workflows/claude-readme-sync.yml
+++ b/.github/workflows/claude-readme-sync.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,7 +24,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           timeout_minutes: "30"
-          prompt: |
+          direct_prompt: |
             I need you to translate the Japanese README file to English and update the English README file.
             
             ## Task


### PR DESCRIPTION
## Overview
This PR fixes GitHub Actions workflow configuration issues that were preventing Claude actions from running successfully.

## Details
Fixed two critical issues in the Claude GitHub Actions workflows:

1. **Added missing OIDC token permission**: Added `id-token: write` to the permissions section of both workflows to allow OIDC token retrieval
2. **Corrected action parameter**: Changed `prompt:` to `direct_prompt:` to use the correct parameter name for the claude-code-action

### Files Modified
- `.github/workflows/claude-readme-sync.yml`
- `.github/workflows/claude-architecture-update.yml`

### Technical Details
- The OIDC token permission is required for the claude-code-action to authenticate with external services
- The `direct_prompt` parameter is the correct input parameter name for the action, not `prompt`
- Both workflows now have consistent configuration and should run without authentication errors

## Related Documents
- [Claude Code Action Documentation](https://github.com/anthropics/claude-code-action)
- [GitHub Actions OIDC Token Documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
EOF < /dev/null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configurations to enhance permissions and align input parameter names with current standards. No impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->