### PR TITLE
fix: add explicit github_token to claude actions for authentication

### DIFF
--- a/.github/workflows/claude-architecture-update.yml
+++ b/.github/workflows/claude-architecture-update.yml
@@ -25,6 +25,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           timeout_minutes: "60"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           direct_prompt: |
             I need you to analyze the recent code changes and update the architecture documentation files accordingly.
             

--- a/.github/workflows/claude-readme-sync.yml
+++ b/.github/workflows/claude-readme-sync.yml
@@ -24,6 +24,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           timeout_minutes: "30"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           direct_prompt: |
             I need you to translate the Japanese README file to English and update the English README file.
             


### PR DESCRIPTION
## Overview
This PR completes the fix for Claude GitHub Actions authentication by adding explicit GitHub token configuration to both workflows.

## Details
Added `github_token: ${{ secrets.GITHUB_TOKEN }}` to both Claude action workflows to resolve OIDC token authentication issues:

### Changes Made
- **claude-readme-sync.yml**: Added explicit GitHub token parameter to the claude-code-action step
- **claude-architecture-update.yml**: Added explicit GitHub token parameter to the claude-code-action step

### Technical Background
The previous attempts to fix OIDC token authentication issues were partially successful but still resulted in "Invalid OIDC token" errors during app token exchange. By explicitly providing the GitHub token, the actions can bypass the OIDC token exchange process and use direct GitHub authentication.

### Previous Fixes Included
1. Added `id-token: write` permission (already in place)
2. Changed `prompt:` to `direct_prompt:` parameter (already in place)
3. Now added explicit `github_token` configuration (this PR)

## Related Documents
- [Claude Code Action Documentation](https://github.com/anthropics/claude-code-action)
- [GitHub Actions Authentication Documentation](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
EOF < /dev/null