### PR TITLE
feat: add manual trigger support to all workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,7 @@ on:
     tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/claude-architecture-update.yml
+++ b/.github/workflows/claude-architecture-update.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'Packages/src/Editor/**'
       - 'Packages/src/TypeScriptServer~/**'
+  workflow_dispatch:
 
 jobs:
   architecture-update:

--- a/.github/workflows/claude-readme-sync.yml
+++ b/.github/workflows/claude-readme-sync.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'Packages/src/README_ja.md'
+  workflow_dispatch:
 
 jobs:
   readme-sync:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'Packages/src/**/*.cs'
       - 'Assets/**/*.cs'
+  workflow_dispatch:
 
 jobs:
   security-scan:


### PR DESCRIPTION
## Overview
This PR adds manual trigger support to all GitHub Actions workflows, enabling developers to run any workflow on-demand from the GitHub Actions UI.

## Details
Added `workflow_dispatch:` trigger to all four main workflows to enable manual execution:

### Modified Workflows
- **build-and-test.yml**: Added manual trigger support for building and testing the project
- **claude-architecture-update.yml**: Added manual trigger to run architecture documentation updates
- **claude-readme-sync.yml**: Added manual trigger to run README translation synchronization
- **security-scan.yml**: Added manual trigger to run security code analysis

### Benefits
- **On-demand execution**: Developers can now trigger any workflow manually without waiting for automatic conditions
- **Testing workflows**: Easy to test workflow changes without needing to create commits or tags
- **Emergency runs**: Ability to run security scans or builds immediately when needed
- **Flexibility**: All workflows maintain their existing automatic triggers while adding manual capability

### Usage
After merging, workflows can be triggered manually by:
1. Going to the "Actions" tab in GitHub
2. Selecting the desired workflow
3. Clicking "Run workflow" button
4. Confirming the execution

## Related Documents
- [GitHub Actions Manual Triggers Documentation](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
- [Workflow Dispatch Event Documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
EOF < /dev/null