### PR TITLE
refactor: standardize VibeLogger timezone and file naming

### DIFF
--- a/Packages/src/Editor/Core/Logging/VibeLogger.cs
+++ b/Packages/src/Editor/Core/Logging/VibeLogger.cs
@@ -230,7 +230,7 @@ namespace io.github.hatayama.uLoopMCP
                 Directory.CreateDirectory(LOG_DIRECTORY);
             }
             
-            string fileName = $"{LOG_FILE_PREFIX}_{DateTime.Now:yyyyMMdd}.json";
+            string fileName = $"{LOG_FILE_PREFIX}_{DateTime.UtcNow:yyyyMMdd}.json";
             string filePath = Path.Combine(LOG_DIRECTORY, fileName);
             
             // Check file size and rotate if necessary
@@ -239,7 +239,7 @@ namespace io.github.hatayama.uLoopMCP
                 var fileInfo = new FileInfo(filePath);
                 if (fileInfo.Length > MAX_FILE_SIZE_MB * 1024 * 1024)
                 {
-                    string rotatedFileName = $"{LOG_FILE_PREFIX}_{DateTime.Now:yyyyMMdd_HHmmss}.json";
+                    string rotatedFileName = $"{LOG_FILE_PREFIX}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.json";
                     string rotatedFilePath = Path.Combine(LOG_DIRECTORY, rotatedFileName);
                     File.Move(filePath, rotatedFilePath);
                 }

--- a/Packages/src/TypeScriptServer~/dist/server.bundle.js
+++ b/Packages/src/TypeScriptServer~/dist/server.bundle.js
@@ -5690,7 +5690,7 @@ var VibeLogger = class _VibeLogger {
     OUTPUT_DIRECTORIES.ROOT,
     OUTPUT_DIRECTORIES.VIBE_LOGS
   );
-  static LOG_FILE_PREFIX = "typescript_vibe";
+  static LOG_FILE_PREFIX = "ts_vibe";
   static MAX_FILE_SIZE_MB = 10;
   static MAX_MEMORY_LOGS = 1e3;
   static memoryLogs = [];
@@ -8229,7 +8229,7 @@ var package_default = {
     "security:fix": "eslint src --ext .ts --fix",
     "security:only": "eslint src --ext .ts --config .eslintrc.security.json",
     "security:sarif": "eslint src --ext .ts -f @microsoft/eslint-formatter-sarif -o security-results.sarif",
-    "security:sarif-only": "eslint src --ext .ts --config .eslintrc.security.json -f @microsoft/eslint-formatter-sarif -o typescript-security.sarif",
+    "security:sarif-only": "eslint src --ext .ts --config .eslintrc.security.json -f @microsoft/eslint-formatter-sarif -o typescript-security.sarif --max-warnings 0",
     format: "prettier --write src/**/*.ts",
     "format:check": "prettier --check src/**/*.ts",
     "lint:check": "npm run lint && npm run format:check",

--- a/Packages/src/TypeScriptServer~/src/utils/vibe-logger.ts
+++ b/Packages/src/TypeScriptServer~/src/utils/vibe-logger.ts
@@ -56,7 +56,7 @@ export class VibeLogger {
     OUTPUT_DIRECTORIES.ROOT,
     OUTPUT_DIRECTORIES.VIBE_LOGS,
   );
-  private static readonly LOG_FILE_PREFIX = 'typescript_vibe';
+  private static readonly LOG_FILE_PREFIX = 'ts_vibe';
   private static readonly MAX_FILE_SIZE_MB = 10;
   private static readonly MAX_MEMORY_LOGS = 1000;
 


### PR DESCRIPTION
## Summary
This PR fixes timezone consistency issues and standardizes file naming conventions in the VibeLogger system.

## Changes
- **Fixed timezone inconsistency**: Changed `DateTime.Now` to `DateTime.UtcNow` in Unity VibeLogger for consistent UTC timestamps
- **Standardized file naming**: Updated TypeScript log file prefix from `typescript_vibe` to `ts_vibe` to match Unity's `unity_vibe` pattern
- **Updated build artifacts**: Regenerated TypeScript bundle with the naming changes
- **Enhanced security configuration**: Added `--max-warnings 0` to ESLint security SARIF generation

## Impact
- Log files will now use consistent UTC timestamps across Unity and TypeScript components
- File naming convention is now standardized: `unity_vibe_YYYYMMDD.json` and `ts_vibe_YYYYMMDD.json`
- Improved maintainability and debugging experience with consistent log file patterns

## Test Plan
- [x] Verified TypeScript linting passes without errors
- [x] Confirmed successful build process
- [x] Validated file naming consistency between Unity and TypeScript loggers
EOF < /dev/null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log file naming to use Coordinated Universal Time (UTC) timestamps.
  * Changed the prefix for TypeScript server log files for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->