### PR TITLE
improve: add uLoopMCP branding to port conflict dialog

### DIFF
--- a/Packages/src/Editor/Core/ApplicationServices/PortAllocationService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/PortAllocationService.cs
@@ -43,7 +43,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             bool userConfirmed = UnityEditor.EditorUtility.DisplayDialog(
                 "uLoopMCP - Port Conflict",
-                $"uLoopMCP Server: Port {requestedPort} is already in use.\n\nWould you like to use port {availablePort} instead?",
+                $"Port {requestedPort} is already in use.\n\nWould you like to use port {availablePort} instead?",
                 "OK",
                 "Cancel"
             );

--- a/Packages/src/Editor/Core/ApplicationServices/PortAllocationService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/PortAllocationService.cs
@@ -42,8 +42,8 @@ namespace io.github.hatayama.uLoopMCP
         public ServiceResult<bool> HandlePortConflict(int requestedPort, int availablePort)
         {
             bool userConfirmed = UnityEditor.EditorUtility.DisplayDialog(
-                "Port Conflict",
-                $"Port {requestedPort} is already in use.\n\nWould you like to use port {availablePort} instead?",
+                "uLoopMCP - Port Conflict",
+                $"uLoopMCP Server: Port {requestedPort} is already in use.\n\nWould you like to use port {availablePort} instead?",
                 "OK",
                 "Cancel"
             );


### PR DESCRIPTION
## Summary

Improved the port conflict dialog by adding uLoopMCP branding to make it clear which tool is displaying the warning.

## Changes

- Added "uLoopMCP - " prefix to the dialog title in `PortAllocationService.HandlePortConflict()`
- Changed dialog title from "Port Conflict" to "uLoopMCP - Port Conflict"

## Why This Change

The original dialog title "Port Conflict" was generic and didn't indicate which application was showing the warning. This could confuse users when multiple applications might display similar dialogs.

## Test Plan

- [ ] Verify the dialog displays with the new title when a port conflict occurs
- [ ] Confirm the dialog functionality remains unchanged
- [ ] Test that the branding appears correctly in the Unity Editor

## Impact

- Better user experience through clear tool identification
- No functional changes to the port conflict resolution logic
- Improved debugging capability for users

EOF < /dev/null