### PR TITLE
fix: remove unnecessary timing properties from BaseToolResponse

### DIFF
--- a/Packages/src/Editor/Api/McpTools/Core/BaseToolResponse.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/BaseToolResponse.cs
@@ -9,31 +9,17 @@ namespace io.github.hatayama.uLoopMCP
     public abstract class BaseToolResponse
     {
         /// <summary>
-        /// Tool execution start time (UTC)
-        /// </summary>
-        public string StartedAt { get; set; }
-
-        /// <summary>
-        /// Tool execution end time (UTC)
-        /// </summary>
-        public string EndedAt { get; set; }
-
-        /// <summary>
         /// Tool execution duration in milliseconds
         /// </summary>
+#pragma warning disable IDE0051 // Remove unused private members
         public long ExecutionTimeMs { get; set; }
+#pragma warning restore IDE0051
 
         /// <summary>
         /// Set timing information automatically
         /// </summary>
         public void SetTimingInfo(DateTime startTime, DateTime endTime)
         {
-            // Convert UTC to local time for display
-            DateTime localStartTime = startTime.ToLocalTime();
-            DateTime localEndTime = endTime.ToLocalTime();
-            
-            StartedAt = localStartTime.ToString("yyyy-MM-ddTHH:mm:ss.fff");
-            EndedAt = localEndTime.ToString("yyyy-MM-ddTHH:mm:ss.fff");
             ExecutionTimeMs = (long)(endTime - startTime).TotalMilliseconds;
         }
     }

--- a/Packages/src/Editor/Api/McpTools/Core/BaseToolResponse.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/BaseToolResponse.cs
@@ -11,9 +11,7 @@ namespace io.github.hatayama.uLoopMCP
         /// <summary>
         /// Tool execution duration in milliseconds
         /// </summary>
-#pragma warning disable IDE0051 // Remove unused private members
         public long ExecutionTimeMs { get; set; }
-#pragma warning restore IDE0051
 
         /// <summary>
         /// Set timing information automatically


### PR DESCRIPTION
## Summary
- Remove StartedAt and EndedAt properties from BaseToolResponse
- Keep only ExecutionTimeMs for tool response timing information
- Simplify SetTimingInfo method to calculate ExecutionTimeMs only

## Test plan
- [x] Compile Unity project successfully
- [x] Verify no warnings or errors
- [x] Confirm ExecutionTimeMs still functions correctly in tool responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed display of tool execution start and end times; only execution duration in milliseconds is now provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->