### PR TITLE
Change default AddConfirmationMessage to false for cleaner console clearing

### DIFF
--- a/Packages/src/Editor/Api/McpTools/ClearConsole/ClearConsoleSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/ClearConsole/ClearConsoleSchema.cs
@@ -16,6 +16,6 @@ namespace io.github.hatayama.uLoopMCP
         /// Whether to add a confirmation log message after clearing
         /// </summary>
         [Description("Whether to add a confirmation log message after clearing")]
-        public bool AddConfirmationMessage { get; set; } = true;
+        public bool AddConfirmationMessage { get; set; } = false;
     }
 } 


### PR DESCRIPTION
## Overview
Changed the default value of `AddConfirmationMessage` parameter in `ClearConsoleSchema` from `true` to `false`.

## Changes
- Modified `ClearConsoleSchema.AddConfirmationMessage` default value from `true` to `false`
- This reduces unnecessary log noise when clearing the console

## Motivation
- Clearing console logs should be a quiet operation by default
- Users can still opt-in to confirmation messages by explicitly setting the parameter to `true`
- Improves user experience by reducing console clutter

## Testing
- [x] Verified the schema change compiles successfully
- [x] Confirmed default behavior is now silent console clearing

## Impact
- **Breaking Change**: No, this only changes the default value
- **Backward Compatibility**: Yes, existing explicit `true` values will continue to work
- **Documentation**: Schema description remains accurate