### PR TITLE
feat: add CaptureGameView MCP tool for Unity screenshot capture

### DIFF
--- a/Packages/src/Editor/Api/McpTools/CaptureGameView.meta
+++ b/Packages/src/Editor/Api/McpTools/CaptureGameView.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e4a2aa1ec3174660bf733ab4b10809b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewResponse.cs
+++ b/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewResponse.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// GameViewキャプチャツールのレスポンス
+    /// 関連クラス: CaptureGameViewTool, CaptureGameViewSchema
+    /// 設計ドキュメント: docs/design/gameview-capture-tool-design.md
+    /// </summary>
+    public class CaptureGameViewResponse : BaseToolResponse
+    {
+        /// <summary>
+        /// 保存された画像ファイルの絶対パス（キャプチャ失敗時はnull）
+        /// </summary>
+        public string? ImagePath { get; set; }
+
+        /// <summary>
+        /// 保存されたファイルのサイズ（バイト単位、キャプチャ失敗時はnull）
+        /// </summary>
+        public long? FileSizeBytes { get; set; }
+
+        /// <summary>
+        /// 成功レスポンス生成用コンストラクタ
+        /// </summary>
+        public CaptureGameViewResponse(string imagePath, long fileSizeBytes)
+        {
+            ImagePath = imagePath;
+            FileSizeBytes = fileSizeBytes;
+        }
+
+        /// <summary>
+        /// 失敗レスポンス生成用コンストラクタ
+        /// </summary>
+        public CaptureGameViewResponse(bool failure)
+        {
+            ImagePath = null;
+            FileSizeBytes = null;
+        }
+
+        /// <summary>
+        /// デフォルトコンストラクタ（JSON デシリアライゼーション用）
+        /// </summary>
+        public CaptureGameViewResponse()
+        {
+        }
+    }
+}

--- a/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewResponse.cs.meta
+++ b/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewResponse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 135deda06741a4ec0a5954352633f8ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewSchema.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// GameViewキャプチャツールのパラメータスキーマ
+    /// 関連クラス: CaptureGameViewTool, CaptureGameViewResponse
+    /// 設計ドキュメント: docs/design/gameview-capture-tool-design.md
+    /// </summary>
+    public class CaptureGameViewSchema : BaseToolSchema
+    {
+        /// <summary>
+        /// 解像度倍率 (0.1 - 1.0, デフォルト: 1.0)
+        /// 1.0で等倍、0.5で半分の解像度、0.1で10%の解像度
+        /// </summary>
+        [Description("Resolution scale multiplier (0.1 to 1.0, where 1.0 is original size)")]
+        public float ResolutionScale { get; set; } = 1.0f;
+    }
+}

--- a/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewSchema.cs.meta
+++ b/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewSchema.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5818b25fb893049828536f09aaf9155d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewTool.cs
+++ b/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewTool.cs
@@ -1,0 +1,281 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEditor;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Unity Game Viewをキャプチャしてファイルに保存するMCPツール
+    /// 関連クラス: CaptureGameViewSchema, CaptureGameViewResponse
+    /// 設計ドキュメント: docs/design/gameview-capture-tool-design.md
+    /// </summary>
+    [McpTool(Description = "Capture Unity Game View and save as PNG image")]
+    public class CaptureGameViewTool : AbstractUnityTool<CaptureGameViewSchema, CaptureGameViewResponse>
+    {
+        public override string ToolName => "capture-gameview";
+
+        private const string OUTPUT_DIRECTORY_NAME = "GameViewCaptures";
+
+        protected override async Task<CaptureGameViewResponse> ExecuteAsync(
+            CaptureGameViewSchema parameters, 
+            CancellationToken cancellationToken)
+        {
+            string correlationId = Guid.NewGuid().ToString("N")[..8];
+            
+            // VibeLogger開始ログ
+            VibeLogger.LogInfo(
+                "capture_gameview_start",
+                "Game view capture started",
+                new { ResolutionScale = parameters.ResolutionScale },
+                correlationId: correlationId,
+                humanNote: "User requested Game View screenshot",
+                aiTodo: "Monitor capture performance and file size"
+            );
+
+            try
+            {
+                // パラメータ検証
+                ValidateParameters(parameters);
+                
+                // 出力ディレクトリ作成
+                string outputDirectory = EnsureOutputDirectoryExists();
+                
+                // Unity ScreenCapture API直接呼び出し
+                Texture2D texture = await CaptureGameViewAsync(parameters.ResolutionScale, cancellationToken);
+                
+                try
+                {
+                    // ファイル保存
+                    string savedPath = SaveTextureAsPng(texture, outputDirectory);
+                    
+                    // レスポンス生成
+                    var fileInfo = new FileInfo(savedPath);
+                    var response = new CaptureGameViewResponse(savedPath, fileInfo.Length);
+                    
+                    // VibeLogger成功ログ
+                    VibeLogger.LogInfo(
+                        "capture_gameview_success",
+                        "Game view captured successfully",
+                        new { 
+                            ImagePath = response.ImagePath,
+                            FileSizeBytes = response.FileSizeBytes,
+                            ResolutionScale = parameters.ResolutionScale
+                        },
+                        correlationId: correlationId,
+                        humanNote: "Screenshot saved successfully",
+                        aiTodo: "Analyze capture quality if needed"
+                    );
+                    
+                    return response;
+                }
+                finally
+                {
+                    // テクスチャのメモリ解放
+                    if (texture != null)
+                    {
+                        UnityEngine.Object.DestroyImmediate(texture);
+                    }
+                    texture = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                // VibeLoggerエラーログ
+                VibeLogger.LogError(
+                    "capture_gameview_error",
+                    "Game view capture failed",
+                    new { Error = ex.Message, ResolutionScale = parameters.ResolutionScale },
+                    correlationId: correlationId,
+                    humanNote: "Screenshot capture encountered an error",
+                    aiTodo: "Investigate capture failure cause"
+                );
+                
+                // 例外を投げずに失敗レスポンスを返す
+                return new CaptureGameViewResponse(failure: true);
+            }
+            finally
+            {
+                // VibeLogger完了ログ
+                VibeLogger.LogInfo(
+                    "capture_gameview_complete", 
+                    "GameView capture operation completed",
+                    correlationId: correlationId
+                );
+            }
+        }
+
+        /// <summary>
+        /// パラメータを検証する
+        /// </summary>
+        private void ValidateParameters(CaptureGameViewSchema parameters)
+        {
+            if (parameters.ResolutionScale < 0.1f || parameters.ResolutionScale > 1.0f)
+            {
+                throw new ArgumentException(
+                    $"ResolutionScale must be between 0.1 and 1.0, got: {parameters.ResolutionScale}");
+            }
+        }
+
+        /// <summary>
+        /// 出力ディレクトリが存在することを確認し、なければ作成する
+        /// </summary>
+        private string EnsureOutputDirectoryExists()
+        {
+            string projectRoot = Application.dataPath.Replace("/Assets", "");
+            string outputDirectory = Path.Combine(projectRoot, "uLoopMCPOutputs", OUTPUT_DIRECTORY_NAME);
+            
+            if (!Directory.Exists(outputDirectory))
+            {
+                Directory.CreateDirectory(outputDirectory);
+            }
+            
+            return outputDirectory;
+        }
+
+        /// <summary>
+        /// Game Viewをキャプチャしてテクスチャとして返す
+        /// </summary>
+        private async Task<Texture2D> CaptureGameViewAsync(float resolutionScale, CancellationToken cancellationToken)
+        {
+            // キャンセレーション確認
+            cancellationToken.ThrowIfCancellationRequested();
+            
+            string tempFileName = $"temp_screenshot_{System.DateTime.Now:yyyyMMdd_HHmmss_fff}.png";
+            string fullPath = Path.Combine(Application.dataPath.Replace("/Assets", ""), tempFileName);
+            
+            try
+            {
+                // Unity再生中と停止中の両対応（万能キャプチャ処理）
+                ScreenCapture.CaptureScreenshot(tempFileName, 1);
+                
+                if (!Application.isPlaying)
+                {
+                    // 停止中：GameView を1フレーム強制再描画
+                    Assembly asm = typeof(EditorWindow).Assembly;
+                    EditorWindow gameView = EditorWindow.GetWindow(asm.GetType("UnityEditor.GameView"));
+                    gameView.Repaint();
+                }
+                else
+                {
+                    // Play中：次フレームで保存完了するようキューを回す
+                    EditorApplication.QueuePlayerLoopUpdate();
+                }
+                
+                // ファイルが作成されるまで待機（最大5秒）
+                int maxAttempts = 50;
+                int attempts = 0;
+                while (!File.Exists(fullPath) && attempts < maxAttempts)
+                {
+                    await TimerDelay.Wait(100, cancellationToken);
+                    attempts++;
+                }
+                
+                if (!File.Exists(fullPath))
+                {
+                    throw new InvalidOperationException($"Failed to capture Game View - screenshot file was not created at: {fullPath}");
+                }
+                
+                // ファイルサイズ確認
+                var fileInfo = new FileInfo(fullPath);
+                if (fileInfo.Length == 0)
+                {
+                    throw new InvalidOperationException("Failed to capture Game View - screenshot file is empty");
+                }
+                
+                // PNGファイルからテクスチャを読み込み
+                byte[] fileData = File.ReadAllBytes(fullPath);
+                Texture2D texture = new(2, 2);
+                
+                if (!texture.LoadImage(fileData))
+                {
+                    UnityEngine.Object.DestroyImmediate(texture);
+                    throw new InvalidOperationException("Failed to load captured screenshot as texture");
+                }
+                
+                // 解像度スケーリング適用
+                if (!Mathf.Approximately(resolutionScale, 1.0f))
+                {
+                    texture = ApplyResolutionScaling(texture, resolutionScale);
+                }
+                
+                return texture;
+            }
+            finally
+            {
+                // 一時ファイルを削除
+                if (File.Exists(fullPath))
+                {
+                    File.Delete(fullPath);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 解像度スケーリングを適用する
+        /// </summary>
+        private Texture2D ApplyResolutionScaling(Texture2D originalTexture, float scale)
+        {
+            if (Mathf.Approximately(scale, 1.0f))
+                return originalTexture;
+            
+            int newWidth = Mathf.RoundToInt(originalTexture.width * scale);
+            int newHeight = Mathf.RoundToInt(originalTexture.height * scale);
+            
+            Texture2D scaledTexture = new(newWidth, newHeight, originalTexture.format, false);
+            
+            // RenderTextureを使用してスケーリング
+            RenderTexture rt = RenderTexture.GetTemporary(newWidth, newHeight);
+            try
+            {
+                Graphics.Blit(originalTexture, rt);
+                
+                RenderTexture.active = rt;
+                scaledTexture.ReadPixels(new Rect(0, 0, newWidth, newHeight), 0, 0);
+                scaledTexture.Apply();
+                RenderTexture.active = null;
+            }
+            finally
+            {
+                RenderTexture.ReleaseTemporary(rt);
+            }
+            
+            // 元のテクスチャは破棄
+            UnityEngine.Object.DestroyImmediate(originalTexture);
+            
+            return scaledTexture;
+        }
+
+        /// <summary>
+        /// テクスチャをPNGファイルとして保存する
+        /// </summary>
+        private string SaveTextureAsPng(Texture2D texture, string outputDirectory)
+        {
+            // ファイル名生成
+            string fileName = GenerateFileName();
+            string fullPath = Path.Combine(outputDirectory, fileName);
+            
+            // PNG エンコード
+            byte[] pngData = texture.EncodeToPNG();
+            
+            // ファイル書き込み
+            File.WriteAllBytes(fullPath, pngData);
+            
+            return fullPath;
+        }
+
+        /// <summary>
+        /// 一意のファイル名を生成する
+        /// </summary>
+        private string GenerateFileName()
+        {
+            DateTime now = DateTime.Now;
+            string baseFileName = $"gameview_{now:yyyyMMdd_HHmmss_fff}.png";
+            
+            return baseFileName;
+        }
+    }
+}

--- a/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewTool.cs.meta
+++ b/Packages/src/Editor/Api/McpTools/CaptureGameView/CaptureGameViewTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15a647cdb3d9b4ce385e190c33ece005
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

This PR adds a new MCP tool `CaptureGameView` that captures Unity Game View screenshots and saves them as PNG files with configurable resolution scaling.

## Changes Made

### New Files Added
- `CaptureGameViewTool.cs` - Main tool implementation with async screenshot capture
- `CaptureGameViewSchema.cs` - Parameter schema with resolution scale support (0.1-1.0)
- `CaptureGameViewResponse.cs` - Response schema with nullable fields for failure handling

### Key Features
- **Game View Screenshot Capture**: Uses Unity's `ScreenCapture.CaptureScreenshot()` API
- **Resolution Scaling**: Configurable scale from 0.1x to 1.0x using RenderTexture and Graphics.Blit
- **Dual Mode Support**: Works in both Unity Play mode and Edit mode with proper frame timing
- **Unity Editor Compatibility**: Uses `TimerDelay` instead of `Task.Delay` to prevent editor freezing
- **Robust Error Handling**: Returns nullable response fields instead of throwing exceptions
- **Structured Logging**: Integrated with VibeLogger for debugging and monitoring

### Technical Implementation
- Proper Game View window focusing and frame synchronization
- Temporary file management with automatic cleanup
- Memory management with texture disposal
- Cancellation token support for async operations
- Validation for resolution scale parameters (0.1-1.0 range)

## Testing

- ✅ Compiles without errors or warnings
- ✅ Works in Unity Play mode
- ✅ Works in Unity Edit mode  
- ✅ Resolution scaling functions correctly
- ✅ Proper error handling with nullable responses
- ✅ VibeLogger integration working

## Output

Screenshots are saved to `uLoopMCPOutputs/GameViewCaptures/` directory with timestamp-based filenames.

Example response:
```json
{
  "ImagePath": "/path/to/project/uLoopMCPOutputs/GameViewCaptures/gameview_20250806_143052_123.png",
  "FileSizeBytes": 245760
}
```

## Breaking Changes

None - this is a new feature addition.
EOF < /dev/null