### PR TITLE
fix: handle duplicate MenuItem attributes with improved warnings

### DIFF
--- a/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/ExecuteMenuItemResponse.cs
+++ b/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/ExecuteMenuItemResponse.cs
@@ -36,12 +36,18 @@ namespace io.github.hatayama.uLoopMCP
         /// </summary>
         public bool MenuItemFound { get; set; }
 
+        /// <summary>
+        /// Warning message if there are issues with this MenuItem (e.g., duplicate attributes)
+        /// </summary>
+        public string WarningMessage { get; set; }
+
         public ExecuteMenuItemResponse()
         {
             MenuItemPath = string.Empty;
             ExecutionMethod = string.Empty;
             ErrorMessage = string.Empty;
             Details = string.Empty;
+            WarningMessage = string.Empty;
         }
     }
 }

--- a/Packages/src/Editor/Api/McpTools/GetMenuItems/MenuItemDiscoveryService.cs
+++ b/Packages/src/Editor/Api/McpTools/GetMenuItems/MenuItemDiscoveryService.cs
@@ -136,8 +136,7 @@ namespace io.github.hatayama.uLoopMCP
             if (menuItemAttributes.Length > 1)
             {
                 string methodName = $"{method.DeclaringType?.FullName}.{method.Name}";
-                string duplicatePaths = string.Join(", ", menuItemAttributes.Select(attr => $"'{attr.menuItem}'"));
-                menuItemInfo.WarningMessage = $"Method '{methodName}' has multiple MenuItem attributes: {duplicatePaths}. Using the first one: '{menuItemAttributes[0].menuItem}'";
+                menuItemInfo.WarningMessage = $"Method '{methodName}' has {menuItemAttributes.Length} duplicate MenuItem attributes for '{menuItemAttribute.menuItem}'. Using the first one.";
             }
             
             return menuItemInfo;

--- a/Packages/src/Editor/Api/McpTools/GetMenuItems/MenuItemInfo.cs
+++ b/Packages/src/Editor/Api/McpTools/GetMenuItems/MenuItemInfo.cs
@@ -44,12 +44,18 @@ namespace io.github.hatayama.uLoopMCP
         /// </summary>
         public bool CanExecuteViaEditorApplication { get; set; }
 
+        /// <summary>
+        /// Warning message if there are issues with this MenuItem (e.g., duplicate attributes)
+        /// </summary>
+        public string WarningMessage { get; set; }
+
         public MenuItemInfo()
         {
             Path = string.Empty;
             MethodName = string.Empty;
             TypeName = string.Empty;
             AssemblyName = string.Empty;
+            WarningMessage = string.Empty;
         }
 
         public MenuItemInfo(string path, MethodInfo method, int priority, bool isValidateFunction)
@@ -61,6 +67,7 @@ namespace io.github.hatayama.uLoopMCP
             TypeName = method?.DeclaringType?.FullName ?? string.Empty;
             AssemblyName = method?.DeclaringType?.Assembly?.GetName()?.Name ?? string.Empty;
             CanExecuteViaEditorApplication = true; // Default to true, can be overridden
+            WarningMessage = string.Empty;
         }
 
         public override string ToString()

--- a/Packages/src/Editor/Api/McpTools/UseCases/Tools/ExecuteMenuItemUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/Tools/ExecuteMenuItemUseCase.cs
@@ -146,7 +146,17 @@ namespace io.github.hatayama.uLoopMCP
                 response.Success = true;
                 response.ExecutionMethod = "Reflection";
                 response.MenuItemFound = true;
-                response.Details = $"MenuItem executed successfully via reflection ({menuItemInfo.TypeName}.{menuItemInfo.MethodName})";
+                
+                // 基本的な実行成功メッセージ
+                string details = $"MenuItem executed successfully via reflection ({menuItemInfo.TypeName}.{menuItemInfo.MethodName})";
+                
+                // 警告メッセージがある場合は追加
+                if (!string.IsNullOrEmpty(menuItemInfo.WarningMessage))
+                {
+                    details += $"\nWarning: {menuItemInfo.WarningMessage}";
+                }
+                
+                response.Details = details;
                 return true;
             }
             catch (System.Exception ex)

--- a/Packages/src/Editor/Api/McpTools/UseCases/Tools/ExecuteMenuItemUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/Tools/ExecuteMenuItemUseCase.cs
@@ -61,6 +61,12 @@ namespace io.github.hatayama.uLoopMCP
         /// <summary>
         /// Try to execute menuItem using EditorApplication.ExecuteMenuItem
         /// </summary>
+        /// <summary>
+        /// Try to execute menuItem using EditorApplication.ExecuteMenuItem
+        /// </summary>
+        /// <summary>
+        /// Try to execute menuItem using EditorApplication.ExecuteMenuItem
+        /// </summary>
         private bool TryExecuteViaEditorApplication(string menuItemPath, ExecuteMenuItemResponse response)
         {
             bool success = EditorApplication.ExecuteMenuItem(menuItemPath);
@@ -71,6 +77,14 @@ namespace io.github.hatayama.uLoopMCP
                 response.ExecutionMethod = "EditorApplication";
                 response.MenuItemFound = true;
                 response.Details = "MenuItem executed successfully via EditorApplication.ExecuteMenuItem";
+                
+                // 重複チェックのためにMenuItemInfoを取得
+                MenuItemInfo menuItemInfo = MenuItemDiscoveryService.FindMenuItemByPath(menuItemPath);
+                if (menuItemInfo != null && !string.IsNullOrEmpty(menuItemInfo.WarningMessage))
+                {
+                    response.WarningMessage = menuItemInfo.WarningMessage;
+                }
+                
                 return true;
             }
             
@@ -147,16 +161,13 @@ namespace io.github.hatayama.uLoopMCP
                 response.ExecutionMethod = "Reflection";
                 response.MenuItemFound = true;
                 
-                // 基本的な実行成功メッセージ
-                string details = $"MenuItem executed successfully via reflection ({menuItemInfo.TypeName}.{menuItemInfo.MethodName})";
+                response.Details = $"MenuItem executed successfully via reflection ({menuItemInfo.TypeName}.{menuItemInfo.MethodName})";
                 
-                // 警告メッセージがある場合は追加
+                // 警告メッセージがある場合は専用フィールドに設定
                 if (!string.IsNullOrEmpty(menuItemInfo.WarningMessage))
                 {
-                    details += $"\nWarning: {menuItemInfo.WarningMessage}";
+                    response.WarningMessage = menuItemInfo.WarningMessage;
                 }
-                
-                response.Details = details;
                 return true;
             }
             catch (System.Exception ex)

--- a/Packages/src/Editor/Api/McpTools/UseCases/Tools/ExecuteMenuItemUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/Tools/ExecuteMenuItemUseCase.cs
@@ -57,13 +57,7 @@ namespace io.github.hatayama.uLoopMCP
             
             return Task.FromResult(response);
         }
-
-        /// <summary>
-        /// Try to execute menuItem using EditorApplication.ExecuteMenuItem
-        /// </summary>
-        /// <summary>
-        /// Try to execute menuItem using EditorApplication.ExecuteMenuItem
-        /// </summary>
+        
         /// <summary>
         /// Try to execute menuItem using EditorApplication.ExecuteMenuItem
         /// </summary>


### PR DESCRIPTION
## Summary

This PR improves the MenuItem tools to handle duplicate MenuItem attributes gracefully and provides better warning messages to MCP clients.

### Issues Fixed

- **Crash on duplicate MenuItem attributes**: Fixed `System.Attribute.GetCustomAttribute` exception when methods have multiple MenuItem attributes
- **Inconsistent warning format**: Unified warning message format between get-menu-items and execute-menu-item tools  
- **Verbose warning messages**: Improved warning messages to be more concise and informative

### Changes Made

**Core Improvements:**
- Replace `GetCustomAttribute<MenuItem>()` with `GetCustomAttributes<MenuItem>()` for safe handling of duplicate attributes
- Add `WarningMessage` property to `MenuItemInfo` and `ExecuteMenuItemResponse` for consistent warning reporting
- Detect duplicate MenuItem attributes and provide clear warning messages

**Enhanced Warning System:**
- Both `get-menu-items` and `execute-menu-item` now report warnings in dedicated `WarningMessage` fields
- Warning messages show duplicate count and affected method name for better debugging
- Warnings appear for both EditorApplication and Reflection execution methods

**Message Format Improvement:**
- Before: `"Method 'X' has multiple MenuItem attributes: 'Path', 'Path'. Using the first one: 'Path'"`  
- After: `"Method 'X' has 2 duplicate MenuItem attributes for 'Path'. Using the first one."`

### Test Plan

- [x] Verify get-menu-items returns warning messages for duplicate attributes
- [x] Verify execute-menu-item shows warnings for both execution methods  
- [x] Confirm no crashes occur with duplicate MenuItem attributes
- [x] Test warning message format is consistent and concise

### Breaking Changes

None. This is a backward-compatible enhancement that adds new warning functionality.

### Technical Details

The fix uses `GetCustomAttributes()` (plural) instead of `GetCustomAttribute()` (singular) to safely handle cases where Unity methods have multiple MenuItem attributes. The first attribute is used for execution while warnings inform about the duplication.
EOF < /dev/null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning messages to menu item information and execution responses, alerting users to potential issues such as duplicate menu item attributes.
  * Warning messages are now displayed when executing menu items if any relevant warnings exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->