### PR TITLE
fix: (execute-dynamic-code)  return optional, better Parameters guidance, and test

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParameterValidationTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParameterValidationTests.cs
@@ -65,6 +65,37 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
             Assert.IsTrue(response.Success, $"Expected success but got error: {response.ErrorMessage}");
             Assert.IsTrue(string.IsNullOrEmpty(response.ErrorMessage), "ErrorMessage should be empty on success");
         }
+
+        [Test]
+        public async Task ExecuteAsync_CodeWithoutReturn_ShouldAutoReturnAndSucceed()
+        {
+            // Arrange
+            DynamicCodeSecurityLevel prev = McpEditorSettings.GetDynamicCodeSecurityLevel();
+            McpEditorSettings.SetDynamicCodeSecurityLevel(DynamicCodeSecurityLevel.Restricted);
+            ExecuteDynamicCodeTool tool = new ExecuteDynamicCodeTool();
+            JObject paramsToken = new JObject
+            {
+                ["Code"] = "int x = 1; // no explicit return",
+                ["CompileOnly"] = false
+            };
+
+            // Act
+            BaseToolResponse baseResponse = null;
+            try
+            {
+                baseResponse = await tool.ExecuteAsync(paramsToken);
+            }
+            finally
+            {
+                McpEditorSettings.SetDynamicCodeSecurityLevel(prev);
+            }
+            ExecuteDynamicCodeResponse response = baseResponse as ExecuteDynamicCodeResponse;
+
+            // Assert
+            Assert.IsNotNull(response, "Response should be ExecuteDynamicCodeResponse");
+            Assert.IsTrue(response.Success, $"Expected success but got error: {response.ErrorMessage}");
+            Assert.IsTrue(string.IsNullOrEmpty(response.ErrorMessage), "ErrorMessage should be empty on success");
+        }
     }
 }
 #endif

--- a/Packages/src/Editor/Api/McpTools/Core/AbstractUnityTool.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/AbstractUnityTool.cs
@@ -110,7 +110,12 @@ namespace io.github.hatayama.uLoopMCP
                 // Check for specific Dictionary<string, object> conversion errors
                 if (ex.Message.Contains("Dictionary") && ex.Message.Contains("Error converting value"))
                 {
-                    errorMessage = $"Parameter 'Parameters' must be an object, not a string. Received: {paramsToken["parameters"]?.ToString() ?? paramsToken["Parameters"]?.ToString() ?? "null"}";
+                    string received = paramsToken["parameters"]?.ToString() ?? paramsToken["Parameters"]?.ToString() ?? "null";
+                    errorMessage =
+                        "Parameter 'Parameters' must be an object, not a string. " +
+                        "Do: omit 'Parameters' or use {}. " +
+                        "Don't: \"{}\" (string). " +
+                        $"Received: {received}";
                 }
                 
                 throw new ParameterValidationException(errorMessage, ex);

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeSchema.cs
@@ -12,7 +12,7 @@ namespace io.github.hatayama.uLoopMCP
         /// <summary>C# code to execute</summary>
         [Description(@"Editor automation only — no file I/O, no script authoring.
 
-Direct statements only (no classes/namespaces/methods); must return a value.
+Direct statements only (no classes/namespaces/methods); return is optional (auto 'return null;' if omitted).
 
 You may include using directives at the top; they are hoisted above the wrapper.
 Example:
@@ -40,7 +40,16 @@ Need files/dirs? Run terminal commands.")]
 - For throwaway snippets, prefer defining locals directly in code
 - Keys are not preserved; values map to parameters[""param0""], parameters[""param1""], ...
 - Use when injecting UnityEngine.Object or sensitive values, or reusing a snippet with varying data
-- Use object values supported by the Editor; prefer fully-qualified type names for ambiguous refs (e.g., UnityEngine.Object)")]
+- Use object values supported by the Editor; prefer fully-qualified type names for ambiguous refs (e.g., UnityEngine.Object)
+
+- Input type must be an OBJECT. Strings like ""{}"" are invalid.
+- Do: omit 'Parameters' entirely, or use {}
+- Don't: ""{}"" (string), ""{""a"":1}"" (string)
+
+Examples:
+OK:   ""Parameters"": {}
+OK:   (omit the 'Parameters' property)
+NG:   ""Parameters"": ""{}""")]
         public Dictionary<string, object> Parameters { get; set; } = new();
         
         /// <summary>Compile only (do not execute)</summary>


### PR DESCRIPTION
## Summary
- Make return optional for ExecuteDynamicCode; auto-insert `return null;` on missing-return failures
- Improve Parameters documentation with clear Do/Don't (object vs string)
- Enhance validation error to include explicit guidance (Do/Don't) when `Parameters` is a string
- Add EditMode test to ensure no-return snippets execute successfully

## Details
- ExecuteDynamicCodeTool: unconditional retry that appends a default return when diagnostics suggest missing return (CS0161/CS0127); keep UnityEngine auto-qualify retry as secondary
- ExecuteDynamicCodeSchema: update descriptions (return optional; Parameters Do/Don't examples)
- AbstractUnityTool: upgrade parameter type-mismatch message for `Parameters` to include actionable guidance (omit or `{}` vs `"{}"` string)
- Tests: add ExecuteAsync_CodeWithoutReturn_ShouldAutoReturnAndSucceed

## Motivation
Reduce friction for tools/agents that omit explicit return; curb common `"{}"` string misuse by providing direct, actionable error guidance.

## Notes
- Backward compatible; existing successful flows remain unchanged
- Security levels unchanged; features respect Restricted/FullAccess

## Checklist
- [x] Builds cleanly
- [x] EditMode tests pass
- [x] No security level regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Execute Dynamic Code now supports snippets without an explicit return; a safe default return is auto-applied when omitted.
  - Automatic retry on likely “missing return” errors, improving success rates.
  - Enhanced logging to indicate that returns are optional.

- Documentation
  - Updated tool and schema descriptions to clarify optional returns and valid formats for Parameters (must be an object, not a string).

- Bug Fixes
  - Clearer error message when Parameters is not an object, guiding correct usage.

- Tests
  - Added a unit test verifying successful execution when no explicit return is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->