### PR TITLE
fix(EditorUI): eliminate Texture2D background leak in MCP editor window

### DIFF
--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -55,6 +55,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private void OnDestroy()
         {
+            _view?.Dispose();
         }
 
         private void InitializeAll()
@@ -182,6 +183,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             CleanupEventHandler();
             SaveSessionState();
+            _view?.Dispose();
         }
 
         /// <summary>

--- a/Packages/src/Editor/UI/McpEditorWindowView.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowView.cs
@@ -10,30 +10,45 @@ namespace io.github.hatayama.uLoopMCP
     /// Related classes: McpEditorWindow (Presenter+Model), McpEditorWindowViewData
     /// Design document: ARCHITECTURE.md - UI layer separation pattern
     /// </summary>
-    public class McpEditorWindowView
+    public class McpEditorWindowView : IDisposable
     {
+        private GUIStyle _sectionBoxStyle;
+        private GUIStyle _clientItemBoxStyle;
+        private Texture2D _sectionBackgroundTexture;
+        private Texture2D _clientItemBackgroundTexture;
+
         private GUIStyle CreateSectionBoxStyle()
         {
-            GUIStyle style = new(EditorStyles.helpBox);
-            Texture2D backgroundTexture = new(1, 1);
-            backgroundTexture.SetPixel(0, 0, McpUIConstants.SECTION_BACKGROUND_COLOR);
-            backgroundTexture.Apply();
-            style.normal.background = backgroundTexture;
-            style.border = new RectOffset(4, 4, 4, 4);
-            style.padding = new RectOffset(8, 8, 8, 8);
-            return style;
+            if (_sectionBoxStyle != null)
+            {
+                return _sectionBoxStyle;
+            }
+
+            _sectionBoxStyle = new GUIStyle(EditorStyles.helpBox);
+            _sectionBackgroundTexture = new Texture2D(1, 1);
+            _sectionBackgroundTexture.SetPixel(0, 0, McpUIConstants.SECTION_BACKGROUND_COLOR);
+            _sectionBackgroundTexture.Apply();
+            _sectionBoxStyle.normal.background = _sectionBackgroundTexture;
+            _sectionBoxStyle.border = new RectOffset(4, 4, 4, 4);
+            _sectionBoxStyle.padding = new RectOffset(8, 8, 8, 8);
+            return _sectionBoxStyle;
         }
 
         private GUIStyle CreateClientItemBoxStyle()
         {
-            GUIStyle style = new(EditorStyles.helpBox);
-            Texture2D backgroundTexture = new(1, 1);
-            backgroundTexture.SetPixel(0, 0, McpUIConstants.CLIENT_ITEM_BACKGROUND_COLOR);
-            backgroundTexture.Apply();
-            style.normal.background = backgroundTexture;
-            style.border = new RectOffset(4, 4, 4, 4);
-            style.padding = new RectOffset(8, 8, 8, 8);
-            return style;
+            if (_clientItemBoxStyle != null)
+            {
+                return _clientItemBoxStyle;
+            }
+
+            _clientItemBoxStyle = new GUIStyle(EditorStyles.helpBox);
+            _clientItemBackgroundTexture = new Texture2D(1, 1);
+            _clientItemBackgroundTexture.SetPixel(0, 0, McpUIConstants.CLIENT_ITEM_BACKGROUND_COLOR);
+            _clientItemBackgroundTexture.Apply();
+            _clientItemBoxStyle.normal.background = _clientItemBackgroundTexture;
+            _clientItemBoxStyle.border = new RectOffset(4, 4, 4, 4);
+            _clientItemBoxStyle.padding = new RectOffset(8, 8, 8, 8);
+            return _clientItemBoxStyle;
         }
         /// <summary>
         /// Draw debug background if ULOOPMCP_DEBUG is defined
@@ -562,6 +577,24 @@ namespace io.github.hatayama.uLoopMCP
             // Only show clients with properly set names
             // Filter out empty names and the default "Unknown Client" placeholder
             return !string.IsNullOrEmpty(clientName) && clientName != McpConstants.UNKNOWN_CLIENT_NAME;
+        }
+
+        public void Dispose()
+        {
+            if (_sectionBackgroundTexture != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_sectionBackgroundTexture);
+                _sectionBackgroundTexture = null;
+            }
+
+            if (_clientItemBackgroundTexture != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_clientItemBackgroundTexture);
+                _clientItemBackgroundTexture = null;
+            }
+
+            _sectionBoxStyle = null;
+            _clientItemBoxStyle = null;
         }
     }
 } 


### PR DESCRIPTION
## Overview
Fix a memory leak in the MCP Editor Window UI where 1x1 Texture2D backgrounds were created and never destroyed, causing editor memory to grow over time.

## Details
- McpEditorWindowView
  - Implements IDisposable.
  - Caches styles and background textures: `_sectionBoxStyle`, `_clientItemBoxStyle`, `_sectionBackgroundTexture`, `_clientItemBackgroundTexture`.
  - Properly disposes and destroys textures in `Dispose()` via `UnityEngine.Object.DestroyImmediate`.
- McpEditorWindow
  - Ensures cleanup by calling `_view?.Dispose()` in `OnDisable()` and `OnDestroy()`.

## Why
Previously, background textures for section/client item boxes were created repeatedly without destruction, leading to a steady increase in Texture2D objects and memory usage in the Unity Editor.

## Testing
1. Open the MCP Editor Window repeatedly and interact with sections.
2. Observe Texture2D count and memory usage with Memory Profiler/Profiler.
3. Before fix: Texture2D count trends upward across opens/closes.
4. After fix: Texture2D count remains stable; no residual growth after closing the window.

## Impact
- No runtime API changes.
- Low risk: textures are re-created lazily when needed; disposed when the window disables/destroys.
- Editor-only change.

## References
- Unity docs: `EditorWindow.OnDisable`, `EditorWindow.OnDestroy`, `UnityEngine.Object.DestroyImmediate`.
