### PR TITLE
docs(readme): add Codex macOS-only notice; note global-only config

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -481,6 +481,10 @@ All tools automatically include the following timing information:
 
 <img width="545" height="481" alt="image" src="https://github.com/user-attachments/assets/2497f85d-1964-4667-92fc-a9e33a946206" />
 
+> [!WARNING]  
+> **About Codex**  
+> Currently supported on macOS only. Not available on Windows. Also, project-level configuration is not supported; only a global configuration is available.
+
 <details>
 <summary>Manual Setup (Usually Unnecessary)</summary>
 

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -474,6 +474,9 @@ Scope(s): org.nuget
 
 <img width="545" height="481" alt="image" src="https://github.com/user-attachments/assets/2497f85d-1964-4667-92fc-a9e33a946206" />
 
+> [!WARNING]  
+> **Codexについて**  
+> 現在Mac OSのみ対応です。Windowsでは利用できません。また、プロジェクト単位の設定ができず、global設定のみとなります。
 
 <details>
 <summary>手動設定（通常は不要）</summary>


### PR DESCRIPTION
## Summary
Add a warning to both READMEs clarifying that Codex is supported on macOS only (not available on Windows) and that only a global configuration is available (no per-project configuration).

## Details
- Update `Packages/src/README_ja.md`: add Codex warning under Usage > IDE connection section
- Update `Packages/src/README.md`: add Codex warning under Usage > IDE connection section
- Verified markdown rendering and diffs against `origin/main`

## References
N/A


