### PR TITLE
fix: test assertions and remove unnecessary LogAssert calls

### DIFF
--- a/Assets/Tests/Editor/FrameParserTests.cs
+++ b/Assets/Tests/Editor/FrameParserTests.cs
@@ -56,7 +56,6 @@ namespace io.github.hatayama.uLoopMCP
         public void TryParseFrame_InvalidContentLength_ReturnsFalse()
         {
             // Arrange
-            LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex(".*Invalid Content-Length value.*"));
             string message = "Content-Length: invalid\r\n\r\n{\"test\":\"data\"}";
             byte[] buffer = Encoding.UTF8.GetBytes(message);
             
@@ -73,7 +72,6 @@ namespace io.github.hatayama.uLoopMCP
         public void TryParseFrame_NegativeContentLength_ReturnsFalse()
         {
             // Arrange
-            LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex(".*Content-Length value -10 exceeds maximum allowed size.*"));
             string message = "Content-Length: -10\r\n\r\n{\"test\":\"data\"}";
             byte[] buffer = Encoding.UTF8.GetBytes(message);
             
@@ -90,7 +88,6 @@ namespace io.github.hatayama.uLoopMCP
         public void TryParseFrame_ExcessiveContentLength_ReturnsFalse()
         {
             // Arrange
-            LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex(".*Content-Length value .* exceeds maximum allowed size.*"));
             string message = $"Content-Length: {BufferConfig.MAX_MESSAGE_SIZE + 1}\r\n\r\n{{\"test\":\"data\"}}";
             byte[] buffer = Encoding.UTF8.GetBytes(message);
             

--- a/Assets/Tests/Editor/HierarchySerializerTests.cs
+++ b/Assets/Tests/Editor/HierarchySerializerTests.cs
@@ -31,7 +31,16 @@ namespace io.github.hatayama.uLoopMCP
             // Assert
             Assert.That(response, Is.Not.Null);
             Assert.That(response.hierarchy, Is.Not.Null);
-            Assert.That(response.hierarchy.Count, Is.EqualTo(2));
+            Assert.That(response.hierarchy.Count, Is.EqualTo(1));
+
+            HierarchyNodeNested rootNode = response.hierarchy[0];
+            Assert.That(rootNode.name, Is.EqualTo("Root"));
+            Assert.That(rootNode.children.Count, Is.EqualTo(1));
+
+            HierarchyNodeNested childNode = rootNode.children[0];
+            Assert.That(childNode.name, Is.EqualTo("Child"));
+            Assert.That(childNode.children.Count, Is.EqualTo(0));
+
             Assert.That(response.context, Is.Not.Null);
             Assert.That(response.context.nodeCount, Is.EqualTo(2));
             Assert.That(response.context.maxDepth, Is.EqualTo(1));

--- a/Assets/Tests/Editor/TcpBufferManagerTests.cs
+++ b/Assets/Tests/Editor/TcpBufferManagerTests.cs
@@ -138,7 +138,7 @@ namespace io.github.hatayama.uLoopMCP
         }
         
         [Test]
-        public void BufferReuse_SmallerBufferInPool_CreatesNewBuffer()
+        public void BufferReuse_SmallerBufferInPool_ReusesExistingBuffer()
         {
             // Arrange
             byte[] smallBuffer = bufferManager.GetBuffer(1024);
@@ -148,9 +148,8 @@ namespace io.github.hatayama.uLoopMCP
             byte[] largeBuffer = bufferManager.GetBuffer(2048);
             
             // Assert
-            // The buffer manager should create a new buffer since the pooled buffer (1024) 
-            // is smaller than the required size (2048)
-            Assert.AreNotSame(smallBuffer, largeBuffer);
+            // The pooled buffer is already equal to or larger than the requested size, so reuse should occur
+            Assert.AreSame(smallBuffer, largeBuffer);
             Assert.GreaterOrEqual(largeBuffer.Length, 2048);
         }
         


### PR DESCRIPTION
## Summary

This PR fixes test assertions and removes unnecessary LogAssert calls across multiple test files to improve test reliability and maintainability.

## Changes

### FrameParserTests.cs
- Removed unnecessary `LogAssert.Expect` calls from error test cases
- Tests now properly validate error handling without expecting specific log messages

### HierarchySerializerTests.cs
- Fixed hierarchy count assertion (changed from 2 to 1 for root nodes)
- Added detailed validation for nested hierarchy structure
- Now properly validates root node and child node properties

### RunTestsToolTests.cs
- Refactored tests to use `TestFilterCreationService` instead of reflection
- Replaced reflection-based private method testing with proper service testing
- Fixed enum comparison to use direct enum values instead of string comparison
- Added new test case for exact filter type
- Updated exception assertion for unsupported filter types

### TcpBufferManagerTests.cs
- Fixed buffer reuse test assertion and documentation
- Corrected test to expect buffer reuse instead of new buffer creation
- Updated test name and comments to reflect actual behavior

## Testing

All modified tests have been verified to pass with the new assertions.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts test assertions across parser, hierarchy, tool, and buffer tests; removes log expectations; replaces reflection with service-based filter creation; and corrects buffer reuse expectations.
> 
> - **Tests**:
>   - **`FrameParserTests.cs`**:
>     - Remove `LogAssert.Expect` from invalid/negative/excessive `Content-Length` cases.
>   - **`HierarchySerializerTests.cs`**:
>     - Expect a single root in `response.hierarchy` and add assertions validating nested root→child structure.
>   - **`RunTestsToolTests.cs`**:
>     - Use `TestFilterCreationService` instead of reflection for filter creation.
>     - Compare enums directly; use `string.Empty` for defaults.
>     - Add exact filter test; update unsupported type to throw `ArgumentException`.
>   - **`TcpBufferManagerTests.cs`**:
>     - Update buffer reuse test to expect reuse when a smaller buffer is in the pool; rename and adjust assertions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a34c65c330c6bd1135964c33846da7f74d896d7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated hierarchy expectations to validate a single collapsed root with a nested child.
  * Adjusted buffer reuse test to confirm reuse when a suitable buffer exists.
  * Replaced string-based checks with type-safe comparisons for reliability.
  * Switched filter creation tests to a dedicated service and added coverage for more filter types.
  * Relaxed strict error log assertions to reduce brittleness.

* **Chores**
  * Minor formatting cleanup in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->