### PR TITLE
fix: Improve connection error message with post-compile guidance

### DIFF
--- a/Packages/src/TypeScriptServer~/dist/server.bundle.js
+++ b/Packages/src/TypeScriptServer~/dist/server.bundle.js
@@ -7050,7 +7050,10 @@ var UnityClient = class _UnityClient {
           message: error.message
         });
         if (this.socket?.connecting) {
-          reject(new Error(`Unity connection failed: ${error.message}`));
+          const err = new Error(`Unity connection failed: ${error.message}`);
+          this.socket.destroy();
+          this.socket = null;
+          reject(err);
         } else {
           this.handleConnectionLoss();
         }
@@ -7164,7 +7167,9 @@ var UnityClient = class _UnityClient {
    */
   async executeTool(toolName, params = {}) {
     if (!this.connected) {
-      throw new Error("Not connected to Unity. Please wait for connection to be established.");
+      throw new Error(
+        "Not connected to Unity. Please wait for connection to be established. Note: If you just executed the compile tool, the Unity connection may be temporarily disconnected. Please wait a few seconds and try again."
+      );
     }
     await this.setClientName();
     const request = {

--- a/Packages/src/TypeScriptServer~/src/unity-client.ts
+++ b/Packages/src/TypeScriptServer~/src/unity-client.ts
@@ -406,7 +406,9 @@ export class UnityClient {
   async executeTool(toolName: string, params: Record<string, unknown> = {}): Promise<unknown> {
     // Ensure connection before executing tool
     if (!this.connected) {
-      throw new Error('Not connected to Unity. Please wait for connection to be established.');
+      throw new Error(
+        'Not connected to Unity. Please wait for connection to be established. Note: If you just executed the compile tool, the Unity connection may be temporarily disconnected. Please wait a few seconds and try again.',
+      );
     }
 
     // Ensure client name is set (this completes the connection handshake)


### PR DESCRIPTION
## Summary

Improved the connection error message in the TypeScript MCP server to provide better guidance when Unity connection is lost, especially after executing the compile tool.

## Changes

- Enhanced error message in `unity-client.ts` to inform users about potential temporary disconnection after compile tool execution
- Added helpful note suggesting users to wait a few seconds and retry
- Updated bundled distribution file with the improved error message

## Motivation

When users execute the compile tool in Unity, the connection between the MCP server and Unity may be temporarily interrupted. Previously, the error message only stated "Not connected to Unity. Please wait for connection to be established." which didn't explain why the connection was lost or what action to take.

This improvement provides clearer guidance to users, reducing confusion and improving the overall user experience.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (enhancement to existing functionality)

## Testing

- [x] Verified the error message displays correctly when connection is lost
- [x] Confirmed the message provides clear guidance for post-compile scenarios
- [x] Passed all ESLint and TypeScript type checks

## Additional Notes

The error message now explicitly mentions:
1. The connection status
2. The potential cause (compile tool execution)
3. The recommended action (wait a few seconds and retry)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the Unity connection error message when executing tools. It now explains that a temporary disconnect may occur right after compiling and recommends waiting a few seconds before retrying. This reduces confusion during brief reconnect periods. No behavioral changes; the message appears when the client isn’t connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->