### PR TITLE
refactor: Add OS-specific reconnection guidance in connection error message

### DIFF
--- a/Packages/src/TypeScriptServer~/dist/server.bundle.js
+++ b/Packages/src/TypeScriptServer~/dist/server.bundle.js
@@ -7251,7 +7251,7 @@ var UnityClient = class _UnityClient {
    */
   getOsSpecificReconnectMessage() {
     const commonPrefix = "Not connected to Unity. If you just executed the compile tool, Unity reconnects automatically after compilation finishes. This can take from several seconds to tens of seconds depending on project size. Wait before your next tool call, then retry once.";
-    const platform = process.platform;
+    const platform = typeof process !== "undefined" && typeof process.platform === "string" ? process.platform : "unknown";
     if (platform === "win32") {
       return `${commonPrefix} Examples: PowerShell: Start-Sleep -Seconds <seconds>; cmd: timeout /T <seconds> /NOBREAK. Avoid repeated retries; increase <seconds> if needed.`;
     }

--- a/Packages/src/TypeScriptServer~/src/unity-client.ts
+++ b/Packages/src/TypeScriptServer~/src/unity-client.ts
@@ -492,7 +492,10 @@ export class UnityClient {
     const commonPrefix: string =
       'Not connected to Unity. If you just executed the compile tool, Unity reconnects automatically after compilation finishes. This can take from several seconds to tens of seconds depending on project size. Wait before your next tool call, then retry once.';
 
-    const platform: string = process.platform;
+    const platform: string =
+      typeof process !== 'undefined' && typeof process.platform === 'string'
+        ? process.platform
+        : 'unknown';
 
     if (platform === 'win32') {
       return `${commonPrefix} Examples: PowerShell: Start-Sleep -Seconds <seconds>; cmd: timeout /T <seconds> /NOBREAK. Avoid repeated retries; increase <seconds> if needed.`;


### PR DESCRIPTION
## Overview
Improve the connection error message displayed when Unity is temporarily unavailable after compilation, making it clearer to LLMs and users that this is expected behavior requiring patience rather than a connection failure.

## Problem
Previously, the generic error message "Please wait a few seconds and try again" could confuse LLMs into:
- Not understanding that waiting is necessary
- Retrying immediately multiple times
- Misinterpreting temporary disconnection as a permanent failure

## Solution
- Add OS-specific reconnection guidance with clear wait instructions
- Replace fixed-duration references with variable `<seconds>` placeholder  
- Provide platform-specific command examples (Windows, macOS, Linux)
- Explicitly state "do not retry immediately" to prevent rapid retries

## Changes
### TypeScript Source
- `Packages/src/TypeScriptServer~/src/unity-client.ts`:
  - Refactored `executeTool()` error message to use new `getOsSpecificReconnectMessage()` method
  - Added `getOsSpecificReconnectMessage()` private method that:
    - Detects OS platform via `process.platform`
    - Returns Windows-specific guidance (PowerShell + cmd examples)
    - Returns Unix-specific guidance (sleep command example)
    - Provides fallback message for other platforms

### Compiled Bundle
- `Packages/src/TypeScriptServer~/dist/server.bundle.js`: 
  - Rebuilt with updated error message logic

## Example Messages
- **macOS/Linux**: `... Example: sleep <seconds>. Avoid repeated retries; increase <seconds> if needed.`
- **Windows**: `... Examples: PowerShell: Start-Sleep -Seconds <seconds>; cmd: timeout /T <seconds> /NOBREAK. Avoid repeated retries; increase <seconds> if needed.`
- **Other**: Fallback message with generic wait guidance

## Testing
- ESLint/Prettier formatting passed
- TypeScript type checking passed
- Bundle rebuilt and validated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when the Unity server disconnects: reconnection guidance is now tailored to the user's operating system (Windows, macOS, Linux and others), providing clearer, platform-specific steps.
  * Removed misleading fixed wait instructions so users receive accurate, actionable guidance for re-establishing server connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->