### PR TITLE
chore: fix markdownlint issues in README docs

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -44,24 +44,24 @@ uLoopMCP is built around two core ideas:
 <img width="350" alt="image" src="https://github.com/user-attachments/assets/b0cd0d46-096a-49a4-adcb-cfd30beece53" />
 
 
- - Manages and monitors server status
- - Provides visibility into LLM tool connection status
- - Enables easy connection to tools via the LLM tool settings button
+- Manages and monitors server status
+- Provides visibility into LLM tool connection status
+- Enables easy connection to tools via the LLM tool settings button
 
 ## Quickstart
 1. Install the uLoopMCP package into your Unity project.
-   - In Unity Package Manager, choose “Add package from git URL” and use:  
-     `https://github.com/hatayama/uLoopMCP.git?path=/Packages/src`
-   - Alternatively, you can use the OpenUPM scoped registry (see the [Installation](#installation) section for details).
+  - In Unity Package Manager, choose “Add package from git URL” and use:  
+    `https://github.com/hatayama/uLoopMCP.git?path=/Packages/src`
+  - Alternatively, you can use the OpenUPM scoped registry (see the [Installation](#installation) section for details).
 2. In Unity, open `Window > uLoopMCP` and press the `Start Server` button to launch the MCP server.
 3. In your LLM tool (Cursor, Claude Code, GitHub Copilot, etc.), enable uLoopMCP as an MCP server.
 4. For example, if you give instructions like:
-   - “Fix this project until `compile` reports no errors, using the `compile` tool as needed.”
-   - “Run tests in `uLoopMCP.Tests.Editor` with `run-tests` and keep updating the code until all tests pass.”
-   - “Use `execute-dynamic-code` to create a sample scene with 10 cubes and adjust the camera so all cubes are visible.”
+  - “Fix this project until `compile` reports no errors, using the `compile` tool as needed.”
+  - “Run tests in `uLoopMCP.Tests.Editor` with `run-tests` and keep updating the code until all tests pass.”
+  - “Use `execute-dynamic-code` to create a sample scene with 10 cubes and adjust the camera so all cubes are visible.”
 
 # Key Features
-### Development Loop Tools
+## Development Loop Tools
 #### 1. compile - Execute Compilation
 Performs AssetDatabase.Refresh() and then compiles, returning the results. Can detect errors and warnings that built-in linters cannot find.  
 You can choose between incremental compilation and forced full compilation.
@@ -141,7 +141,7 @@ Retrieve objects and examine component parameters.
 #### 10. get-hierarchy - Analyze Scene Structure
 Retrieve information about the currently active Hierarchy in nested JSON format. Works at runtime as well.
 **Automatic File Export**: Retrieved hierarchy data is always saved as JSON in `{project_root}/uLoopMCPOutputs/HierarchyResults/` directory. The MCP response only returns the file path, minimizing token consumption even for large datasets.
-```
+```text
 → Understand parent-child relationships between GameObjects, discover and fix structural issues
 → Regardless of scene size, hierarchy data is saved to a file and the path is returned instead of raw JSON
 ```
@@ -158,7 +158,7 @@ Execute C# code dynamically within Unity Editor.
 > 1. Open Project Settings window and go to the Package Manager page
 > 2. Add the following entry to the Scoped Registries list:
 
-```
+```yaml
 Name: OpenUPM
 URL: https://package.openupm.com
 Scope(s): org.nuget
@@ -175,7 +175,7 @@ Use a scoped registry in Unity Package Manager:
 1. Open Project Settings window and go to the Package Manager page  
 2. Add the following entry to the Scoped Registries list:  
 
-```
+```yaml
 Name: OpenUPM
 URL: https://package.openupm.com
 Scope(s): org.nuget

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -41,21 +41,21 @@ uLoopMCP のコアとなるコンセプトは次の 2 つです。
 # ツールwindow
 <img width="350" alt="image" src="https://github.com/user-attachments/assets/b0cd0d46-096a-49a4-adcb-cfd30beece53" />
 
- - サーバーの状態を管理・モニターします
- - LLMツールの接続状況を把握できます
- - LLMツールの設定ボタンを押すことで、簡単にツールとの接続が可能です
+- サーバーの状態を管理・モニターします
+- LLMツールの接続状況を把握できます
+- LLMツールの設定ボタンを押すことで、簡単にツールとの接続が可能です
 
 ## クイックスタート
 1. Unity プロジェクトに uLoopMCP パッケージをインストールします。
-   - Unity Package Manager の「Add package from git URL」で以下を指定します：  
-     `https://github.com/hatayama/uLoopMCP.git?path=/Packages/src`
-   - あるいは OpenUPM の Scoped Registry 経由でも利用できます。（詳しくは [インストール](#インストール) セクションを参照）。
+  - Unity Package Manager の「Add package from git URL」で以下を指定します：  
+    `https://github.com/hatayama/uLoopMCP.git?path=/Packages/src`
+  - あるいは OpenUPM の Scoped Registry 経由でも利用できます。（詳しくは [インストール](#インストール) セクションを参照）。
 2. Unity メニューから `Window > uLoopMCP` を開き、`Start Server` ボタンを押して MCP サーバーを起動します。
 3. Cursor / Claude Code / GitHub Copilot など、使用している LLM ツール側で uLoopMCP を MCP として有効化します。
 4. 例えば次のように指示すると、AIが自律的な開発ループを回し始めます。
-   - 「このプロジェクトのコンパイルが通るように直して、`compile` でエラーが 0 になるまで繰り返して」
-   - 「`run-tests` で `uLoopMCP.Tests.Editor` のテストを全部通すまで、実装とテストを更新して」
-   - 「`execute-dynamic-code` でサンプルシーンに Cube を 10 個並べて、カメラ位置も自動調整して」
+  - 「このプロジェクトのコンパイルが通るように直して、`compile` でエラーが 0 になるまで繰り返して」
+  - 「`run-tests` で `uLoopMCP.Tests.Editor` のテストを全部通すまで、実装とテストを更新して」
+  - 「`execute-dynamic-code` でサンプルシーンに Cube を 10 個並べて、カメラ位置も自動調整して」
 
 # 主要機能
 ### 自律開発ループ系ツール
@@ -138,7 +138,7 @@ UnitySearchが提供する検索プロバイダーを取得します
 #### 10. get-hierarchy - シーン構造の解析
 現在アクティブなHierarchyの情報をネストされたJSON形式で取得します。ランタイムでも動作します。
 **自動ファイル出力**: 取得したHierarchyは常に`{project_root}/uLoopMCPOutputs/HierarchyResults/`ディレクトリにJSONとして保存されます。MCPレスポンスにはファイルパスのみが返るため、大量データでもトークン消費を最小限に抑えられます。
-```
+```text
 → GameObject間の親子関係を理解。構造的な問題を発見・修正
 → シーンの規模にかかわらず、Hierarchyデータはファイルに保存され、生のJSONの代わりにパスが返されます
 ```
@@ -158,8 +158,8 @@ OpenUPM経由（推奨）で、Unity Package Manager の Scoped Registry を使�
 
 1. Project Settingsウィンドウを開き、Package Managerページに移動  
 2. Scoped Registriesリストに以下のエントリを追加：  
-
-```
+ 
+```yaml
 Name: OpenUPM
 URL: https://package.openupm.com
 Scope(s): org.nuget


### PR DESCRIPTION
## Overview
- Fix markdownlint warnings in the English and Japanese READMEs so that AI-driven workflows and documentation render cleanly.
- Address heading hierarchy, list indentation, and fenced code block language tags noted by automated review on the README PR.

## Details
- Updated `Packages/src/README.md`:
  - Changed the "Development Loop Tools" heading to `##` under "Key Features" to keep heading levels consistent (MD001).
  - Fixed top-level list indentation under "Tool Window" and nested lists in "Quickstart" so unordered lists start at column 0 and nested items use consistent spacing (MD007).
  - Added `text` and `yaml` language identifiers to fenced code blocks in the `get-hierarchy` and `execute-dynamic-code` sections so markdownlint recognizes them and syntax highlighting works as expected (MD040).
- Updated `Packages/src/README_ja.md`:
  - Fixed top-level and nested list indentation under 「ツールwindow」 and 「クイックスタート」 to follow the same unordered list indentation rules (MD007).
  - Added `text` and `yaml` language identifiers to fenced blocks in the `get-hierarchy` and Microsoft.CodeAnalysis.CSharp installation sections to align with markdownlint rules (MD040).

## References
- Follow-up to documentation improvements introduced in PR #329: https://github.com/hatayama/uLoopMCP/pull/329
- Markdownlint feedback from automated review comments on the README update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and readability in README files
  * Enhanced code block annotations and language specifications for clarity
  * Standardized header structure and organization
  * Refined quickstart instructions and examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->