### PR TITLE
fix: Update README docs and enable auto-start server by default

### DIFF
--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -27,7 +27,7 @@ namespace io.github.hatayama.uLoopMCP
     public record McpEditorSettingsData
     {
         public int customPort = McpServerConfig.DEFAULT_PORT;
-        public bool autoStartServer = false;
+        public bool autoStartServer = true;
         public bool showDeveloperTools = false;
         public bool enableMcpLogs = false;
         public bool enableCommunicationLogs = false;

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -514,7 +514,7 @@ All tools automatically include the following timing information:
 <img width="335" alt="image" src="https://github.com/user-attachments/assets/25f1f4f9-e3c8-40a5-a2f3-903f9ed5f45b" />
 
 3. IDE Connection Verification
-  - For example, with Cursor, check the Tools & Integrations in the settings page and find uLoopMCP. Click the toggle to enable MCP. If a red circle appears, restart Cursor.
+  - For example, with Cursor, check the Tools & MCP in the settings page and find uLoopMCP. Click the toggle to enable MCP. If a red circle appears, restart Cursor.
 
 <img width="657" height="399" alt="image" src="https://github.com/user-attachments/assets/5137491d-0396-482f-b695-6700043b3f69" />
 

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -41,7 +41,7 @@ uLoopMCPのコアとなるコンセプトは次の2つです。
 - チーム専用のMCPツールを追加し、プロジェクト固有のチェックや自動修正をAIから呼び出せるようにする
 
 # ツールwindow
-<img width="350" alt="image" src="https://github.com/user-attachments/assets/b0cd0d46-096a-49a4-adcb-cfd30beece53" />
+<img width="308" height="401" src="https://github.com/user-attachments/assets/a6beb597-363d-4816-9286-e8bdba7e4b5c" />
 
 - サーバーの状態を管理・モニターします
 - LLMツールの接続状況を把握できます
@@ -510,9 +510,9 @@ Scope(s): org.nuget
 <img width="335" alt="image" src="https://github.com/user-attachments/assets/25f1f4f9-e3c8-40a5-a2f3-903f9ed5f45b" />
 
 4. IDE接続確認
-  - 例えばCursorの場合、設定ページのTools & Integrationsを確認し、uLoopMCPを見つけてください。トグルをクリックしてMCPを有効にします。赤い円が表示される場合は、Cursorを再起動してください。  
+  - 例えばCursorの場合、設定ページのTools & MCPを確認し、uLoopMCPを見つけてください。トグルをクリックしてMCPを有効にします。赤い円が表示される場合は、Cursorを再起動してください。  
 
-<img width="545" height="481" alt="image" src="https://github.com/user-attachments/assets/2497f85d-1964-4667-92fc-a9e33a946206" />
+<img width="657" height="399" alt="image" src="https://github.com/user-attachments/assets/5137491d-0396-482f-b695-6700043b3f69" />
 
 > [!WARNING]  
 > **Codex / Windsurfについて**  


### PR DESCRIPTION
## Overview
Update uLoopMCP documentation screenshots/text and enable the MCP server auto-start option by default for new users.

## Details
- Config
  - Change `McpEditorSettingsData.autoStartServer` default value from `false` to `true`, so new environments start with **Auto Start Server** enabled by default.
  - Existing users keep their saved `autoStartServer` setting; this change only affects newly created settings files.

- README (English)
  - Tweak the main logo closing tag to remove stray spaces.
  - Update the Tool Window screenshot to the latest image and adjust its size attributes.
  - Restructure the `Microsoft.CodeAnalysis.CSharp` installation instructions into a clearer section inside the details block, with simplified wording and an explicit recommendation to use OpenUPM.
  - Update the Cursor setup description from “Tools & Integrations” to “Tools & MCP” and swap the IDE connection screenshot to the latest image.

- README_ja (Japanese)
  - Update the ツールwindow screenshot to the new image and size.
  - Update the Cursor setup description from “Tools & Integrations” to “Tools & MCP” and replace the IDE接続確認 screenshot with the latest image.

## References
- Updated files:
  - `Packages/src/Editor/Config/McpEditorSettings.cs`
  - `Packages/src/README.md`
  - `Packages/src/README_ja.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Server auto-start is now enabled by default in editor settings.

* **Documentation**
  * Simplified installation and setup instructions for improved clarity.
  * Updated IDE integration references and configuration guidance.
  * Refreshed documentation formatting and visuals across supported languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->