### PR TITLE
fix: revert Cursor MCP server path change from #327

### DIFF
--- a/Packages/src/Editor/Config/McpServerConfigFactory.cs
+++ b/Packages/src/Editor/Config/McpServerConfigFactory.cs
@@ -59,14 +59,9 @@ namespace io.github.hatayama.uLoopMCP
         /// <returns>The processed server path</returns>
         private static string GetServerPathForEditor(string serverPath, McpEditorType editorType)
         {
-            // Cursor uses a path relative to the configuration root (Unity project root or Git root)
-            if (editorType == McpEditorType.Cursor)
-            {
-                return UnityMcpPathResolver.MakeRelativeToConfigurationRoot(serverPath);
-            }
-
-            // Desktop editors (VSCode, Windsurf, Codex) require absolute path for proper connection
-            if (editorType == McpEditorType.VSCode || 
+            // Desktop editors (Cursor, VSCode, Windsurf, Codex) require absolute path for proper connection
+            if (editorType == McpEditorType.Cursor || 
+                editorType == McpEditorType.VSCode || 
                 editorType == McpEditorType.Windsurf ||
                 editorType == McpEditorType.Codex)
             {

--- a/Packages/src/Editor/Config/UnityMcpPathResolver.cs
+++ b/Packages/src/Editor/Config/UnityMcpPathResolver.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
-using System.Linq; // Added for .Concat()
 using UnityEngine;
+using System.Linq; // Added for .Concat()
 
 namespace io.github.hatayama.uLoopMCP
 {
@@ -68,10 +68,9 @@ namespace io.github.hatayama.uLoopMCP
     /// - Windsurf: "uLoopMCP-{port}" (includes port number)
     /// - Other editors: "uLoopMCP" (no port number)
     /// 
-        /// #### Server Path Format:
-        /// - Cursor: Path relative to the configuration root (Unity project root or Git root)
-        /// - Desktop editors (VSCode, Windsurf, Codex): Absolute path
-        /// - CLI editors (Claude Code, Gemini CLI): Relative path from configuration root (project/Git root)
+    /// #### Server Path Format:
+    /// - Desktop editors (Cursor, VSCode, Windsurf): Absolute path
+    /// - CLI editors (Claude Code, Gemini CLI): Relative path from project root
     /// 
     /// #### Environment Variables:
     /// ```json
@@ -155,8 +154,6 @@ namespace io.github.hatayama.uLoopMCP
         /// If the absolutePath is under the configuration root, returns relative path with '/' separators.
         /// Otherwise returns the original absolutePath.
         /// </summary>
-        /// <param name="absolutePath">The absolute path to convert.</param>
-        /// <returns>Path relative to configuration root or the original absolute path.</returns>
         public static string MakeRelativeToConfigurationRoot(string absolutePath)
         {
             if (string.IsNullOrEmpty(absolutePath))
@@ -170,42 +167,24 @@ namespace io.github.hatayama.uLoopMCP
                 return absolutePath;
             }
 
-            string normalizedRoot = NormalizeDirectoryPath(root);
-            string normalizedPath = NormalizePath(absolutePath);
+            // Ensure both have consistent trailing separators for comparison
+            string normalizedRoot = root.Replace('\\', '/');
+            string normalizedPath = absolutePath.Replace('\\', '/');
 
-            if (!normalizedPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase))
+            if (!normalizedRoot.EndsWith("/"))
             {
-                return absolutePath;
+                normalizedRoot += "/";
             }
 
-            string relative = normalizedPath.Substring(normalizedRoot.Length);
-            return relative.Replace('\\', '/');
-        }
-
-        /// <summary>
-        /// Normalizes a directory path to use forward slashes and ensures it ends with a slash.
-        /// </summary>
-        /// <param name="path">The directory path to normalize.</param>
-        /// <returns>Normalized directory path ending with '/'.</returns>
-        private static string NormalizeDirectoryPath(string path)
-        {
-            string normalized = path.Replace('\\', '/');
-            if (!normalized.EndsWith("/"))
+            // Use case-insensitive comparison to support Windows file systems
+            if (normalizedPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase))
             {
-                normalized += "/";
+                string relative = normalizedPath.Substring(normalizedRoot.Length);
+                // Ensure forward slashes
+                return relative.Replace('\\', '/');
             }
 
-            return normalized;
-        }
-
-        /// <summary>
-        /// Normalizes a file system path to use forward slashes.
-        /// </summary>
-        /// <param name="path">The path to normalize.</param>
-        /// <returns>Normalized path with forward slashes.</returns>
-        private static string NormalizePath(string path)
-        {
-            return path.Replace('\\', '/');
+            return absolutePath;
         }
 
         private static string _cachedGitRepositoryRoot;

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.68f1
-m_EditorVersionWithRevision: 2022.3.68f1 (5dfc353c715b)
+m_EditorVersion: 2022.3.62f3
+m_EditorVersionWithRevision: 2022.3.62f3 (96770f904ca7)


### PR DESCRIPTION
## Overview

Revert the MCP server path changes introduced in #327 and restore the previous behavior and documentation.

## Details

- Revert the change in `McpServerConfigFactory.GetServerPathForEditor` so that `McpEditorType.Cursor` is treated as a desktop editor again and uses an absolute server path, in line with VSCode, Windsurf, and Codex.
- Update the "Server Path Format" XML documentation in `UnityMcpPathResolver` to describe Cursor as a desktop editor that uses an absolute path, and keep CLI editors (Claude Code, Gemini CLI) on project-root-relative paths.
- Restore the earlier `MakeRelativeToConfigurationRoot` behavior by removing the extra normalization helpers that were added in #327 and simplifying the path comparison logic while preserving case-insensitive checks and forward-slash normalization.
- Adjust `ProjectSettings/ProjectVersion.txt` so the Unity editor version is set to `2022.3.62f3` for this rollback.

## References

- Reverts: [fix: resolve Cursor MCP server path relative to configuration root #327](https://github.com/hatayama/uLoopMCP/pull/327)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cursor editor integration by aligning its path configuration with other supported editors (VSCode, Windsurf).

* **Chores**
  * Rolled back Unity project version to 2022.3.62f3.
  * Enhanced server path resolution logic for better compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->