### PR TITLE
fix: Improve temporary disconnection handling for better LLM interaction

### DIFF
--- a/Packages/src/TypeScriptServer~/dist/server.bundle.js
+++ b/Packages/src/TypeScriptServer~/dist/server.bundle.js
@@ -7246,19 +7246,15 @@ var UnityClient = class _UnityClient {
     }
   }
   /**
-   * Build an OS-specific guidance message for temporary disconnection after compile.
-   * Explicitly instructs how to wait before retrying without assuming a fixed duration.
+   * Build a guidance message for temporary disconnection after compile.
    */
   getOsSpecificReconnectMessage() {
-    const commonPrefix = "A temporary disconnection from Unity has occurred. This is normal immediately after compilation. At this stage, do not report this as a persistent disconnection. Try retrying with the same tool every 3-5 seconds (e.g., sleep <seconds>), gradually increasing the wait time as needed. As a guideline, only treat it as a genuine disconnection if the connection remains unrecoverable after 1 minute or if the connection fails to establish beyond the user-specified wait time of 1 minute or more. Example: sleep <seconds>. Avoid repeated retries, and gradually increase <seconds> as needed.";
+    const baseMessage = "Waiting for Unity to be ready (normal during compilation). Wait 3 seconds then retry. If still not ready after several attempts, increase wait time (5 \u2192 10 seconds). Report as error only after 1+ minute of failures.";
     const platform = typeof process !== "undefined" && typeof process.platform === "string" ? process.platform : "unknown";
     if (platform === "win32") {
-      return `${commonPrefix} Examples: PowerShell: Start-Sleep -Seconds <seconds>; cmd: timeout /T <seconds> /NOBREAK. Avoid repeated retries; increase <seconds> if needed.`;
+      return `${baseMessage} Example: Start-Sleep -Seconds 3`;
     }
-    if (platform === "darwin" || platform === "linux") {
-      return `${commonPrefix} Example: sleep <seconds>. Avoid repeated retries; increase <seconds> if needed.`;
-    }
-    return `${commonPrefix} Wait a bit longer if needed before retrying. Avoid repeated retries.`;
+    return `${baseMessage} Example: sleep 3`;
   }
   handleToolResponse(response) {
     if (response.error) {

--- a/Packages/src/TypeScriptServer~/src/unity-client.ts
+++ b/Packages/src/TypeScriptServer~/src/unity-client.ts
@@ -485,12 +485,11 @@ export class UnityClient {
   }
 
   /**
-   * Build an OS-specific guidance message for temporary disconnection after compile.
-   * Explicitly instructs how to wait before retrying without assuming a fixed duration.
+   * Build a guidance message for temporary disconnection after compile.
    */
   private getOsSpecificReconnectMessage(): string {
-    const commonPrefix: string =
-      'A temporary disconnection from Unity has occurred. This is normal immediately after compilation. At this stage, do not report this as a persistent disconnection. Try retrying with the same tool every 3-5 seconds (e.g., sleep <seconds>), gradually increasing the wait time as needed. As a guideline, only treat it as a genuine disconnection if the connection remains unrecoverable after 1 minute or if the connection fails to establish beyond the user-specified wait time of 1 minute or more. Example: sleep <seconds>. Avoid repeated retries, and gradually increase <seconds> as needed.';
+    const baseMessage: string =
+      'Waiting for Unity to be ready (normal during compilation). Wait 3 seconds then retry. If still not ready after several attempts, increase wait time (5 → 10 seconds). Report as error only after 1+ minute of failures.';
 
     const platform: string =
       typeof process !== 'undefined' && typeof process.platform === 'string'
@@ -498,15 +497,10 @@ export class UnityClient {
         : 'unknown';
 
     if (platform === 'win32') {
-      return `${commonPrefix} Examples: PowerShell: Start-Sleep -Seconds <seconds>; cmd: timeout /T <seconds> /NOBREAK. Avoid repeated retries; increase <seconds> if needed.`;
+      return `${baseMessage} Example: Start-Sleep -Seconds 3`;
     }
 
-    if (platform === 'darwin' || platform === 'linux') {
-      return `${commonPrefix} Example: sleep <seconds>. Avoid repeated retries; increase <seconds> if needed.`;
-    }
-
-    // Fallback for other platforms
-    return `${commonPrefix} Wait a bit longer if needed before retrying. Avoid repeated retries.`;
+    return `${baseMessage} Example: sleep 3`;
   }
 
   private handleToolResponse(response: { error?: { message: string }; result?: unknown }): unknown {


### PR DESCRIPTION
## Changes

### 1. Return guidance message as success response
- Changed `executeTool()` to return reconnection guidance as a normal response instead of throwing an error when Unity is temporarily disconnected
- This allows Claude (LLM) to receive the message as a successful tool execution result, enabling better retry handling

### 2. Improved reconnection guidance message
- **Before**: Started with "A temporary disconnection from Unity has occurred..." which caused LLMs to misinterpret it as a persistent connection failure
- **After**: Starts with "Waiting for Unity to be ready (normal during compilation)" to clearly indicate this is a temporary, expected state
- Simplified the verbose message while keeping essential retry instructions
- Added gradual wait time increase guidance (3 → 5 → 10 seconds) for large projects
- Maintained OS-specific sleep command examples (sleep/Start-Sleep)

## Motivation

When Unity recompiles code, the MCP server temporarily loses connection. Previously, this triggered an error that LLMs interpreted as a critical failure. The new approach treats temporary disconnection as a normal tool response with clear retry instructions, improving LLM behavior during compilation cycles.

## Testing

- ✅ Lint passed
- ✅ Build succeeded
- ✅ Pre-commit quality checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for disconnected states: Instead of throwing an error, users now receive clear reconnection guidance with retry instructions.
  * Simplified and unified reconnection messaging across all platforms for consistency and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->