### PR TITLE
fix: Add Directory.Exists check before creating config directory

### DIFF
--- a/Packages/src/Editor/Config/McpConfigRepository.cs
+++ b/Packages/src/Editor/Config/McpConfigRepository.cs
@@ -34,10 +34,12 @@ namespace io.github.hatayama.uLoopMCP
         public void CreateConfigDirectory(string configPath)
         {
             string configDir = Path.GetDirectoryName(configPath);
-            if (!string.IsNullOrEmpty(configDir))
+            if (string.IsNullOrEmpty(configDir) || Directory.Exists(configDir))
             {
-                Directory.CreateDirectory(configDir);
+                return;
             }
+
+            Directory.CreateDirectory(configDir);
         }
 
         /// <summary>


### PR DESCRIPTION
Prevents IOException when a symbolic link to a directory already exists at the config directory path.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration directory initialization to skip unnecessary creation attempts when the directory already exists or when an invalid path is provided, reducing redundant file system operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->