### PR TITLE
fix: support Unity 6.3+ reference assembly path structure

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerUnity6PathTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerUnity6PathTests.cs
@@ -1,0 +1,144 @@
+#if ULOOPMCP_HAS_ROSLYN
+using System.Linq;
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Tests to verify RoslynCompiler works correctly with Unity 6's new folder structure.
+    /// Unity 6 moved reference assemblies from Contents/{subpath} to Contents/Resources/Scripting/{subpath}.
+    /// See: https://github.com/hatayama/uLoopMCP/issues/370
+    ///
+    /// IMPORTANT: These tests use Restricted mode because FullAccess mode falls back to
+    /// AppDomain.GetAssemblies() which masks the path resolution issue.
+    /// </summary>
+    [TestFixture]
+    public class RoslynCompilerUnity6PathTests
+    {
+        private RoslynCompiler _compiler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Use Restricted mode to test Unity folder path resolution
+            // FullAccess mode uses AppDomain.GetAssemblies() as fallback, which masks path issues
+            _compiler = new RoslynCompiler(DynamicCodeSecurityLevel.Restricted);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _compiler?.ClearCache();
+            _compiler?.Dispose();
+            _compiler = null;
+        }
+
+        [Test]
+        public void Compile_WithSystemObject_ShouldSucceed()
+        {
+            // Arrange
+            // System.Object is the most fundamental type in .NET
+            // If Unity 6 path resolution fails, this compilation will fail with "System.Object is not defined"
+            string code = @"
+                System.Object obj = new System.Object();
+                return obj.GetType().Name;";
+
+            CompilationRequest request = new CompilationRequest
+            {
+                Code = code,
+                ClassName = "SystemObjectTestClass",
+                Namespace = "TestNamespace"
+            };
+
+            // Act
+            CompilationResult result = _compiler.Compile(request);
+
+            // Assert
+            Assert.IsTrue(result.Success,
+                $"Compilation failed (System.Object not found indicates Unity path issue): " +
+                $"{string.Join(", ", result.Errors?.Select(e => e.Message) ?? new string[0])}");
+            Assert.IsNotNull(result.CompiledAssembly);
+        }
+
+        [Test]
+        public void Compile_WithBasicTypes_ShouldSucceed()
+        {
+            // Arrange
+            // Verify that basic types (string, int, bool) can be resolved
+            string code = @"
+                string text = ""Hello"";
+                int number = 42;
+                bool flag = true;
+                return $""{text} {number} {flag}"";";
+
+            CompilationRequest request = new CompilationRequest
+            {
+                Code = code,
+                ClassName = "BasicTypesTestClass",
+                Namespace = "TestNamespace"
+            };
+
+            // Act
+            CompilationResult result = _compiler.Compile(request);
+
+            // Assert
+            Assert.IsTrue(result.Success,
+                $"Compilation failed: {string.Join(", ", result.Errors?.Select(e => e.Message) ?? new string[0])}");
+            Assert.IsNotNull(result.CompiledAssembly);
+        }
+
+        [Test]
+        public void Compile_WithCollectionTypes_ShouldSucceed()
+        {
+            // Arrange
+            // Verify that System.Collections.Generic types can be resolved
+            string code = @"
+                var list = new System.Collections.Generic.List<string> { ""a"", ""b"", ""c"" };
+                var dict = new System.Collections.Generic.Dictionary<string, int>();
+                dict[""count""] = list.Count;
+                return dict[""count""];";
+
+            CompilationRequest request = new CompilationRequest
+            {
+                Code = code,
+                ClassName = "CollectionTypesTestClass",
+                Namespace = "TestNamespace"
+            };
+
+            // Act
+            CompilationResult result = _compiler.Compile(request);
+
+            // Assert
+            Assert.IsTrue(result.Success,
+                $"Compilation failed: {string.Join(", ", result.Errors?.Select(e => e.Message) ?? new string[0])}");
+            Assert.IsNotNull(result.CompiledAssembly);
+        }
+
+        [Test]
+        public void Compile_WithLinq_ShouldSucceed()
+        {
+            // Arrange
+            // Verify that System.Linq can be resolved (requires reference assemblies)
+            string code = @"
+                using System.Linq;
+                var numbers = new[] { 1, 2, 3, 4, 5 };
+                return numbers.Where(n => n > 2).Sum();";
+
+            CompilationRequest request = new CompilationRequest
+            {
+                Code = code,
+                ClassName = "LinqTestClass",
+                Namespace = "TestNamespace"
+            };
+
+            // Act
+            CompilationResult result = _compiler.Compile(request);
+
+            // Assert
+            Assert.IsTrue(result.Success,
+                $"Compilation failed: {string.Join(", ", result.Errors?.Select(e => e.Message) ?? new string[0])}");
+            Assert.IsNotNull(result.CompiledAssembly);
+        }
+    }
+}
+#endif

--- a/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerUnity6PathTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerUnity6PathTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca643fc9ab691494bba65f558a9eeba6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Compilation/RoslynCompiler.cs
+++ b/Packages/src/Editor/Compilation/RoslynCompiler.cs
@@ -352,22 +352,40 @@ namespace io.github.hatayama.uLoopMCP
             return contentsPath;
         }
 
+        /// <summary>
+        /// Get the base path for scripting-related assemblies.
+        /// Unity 6.3+ moved assemblies to Contents/Resources/Scripting/, while earlier versions use Contents/ directly.
+        /// See: https://github.com/hatayama/uLoopMCP/issues/370
+        /// </summary>
+        private string GetScriptingBasePath(string contentsPath)
+        {
+            string scriptingPath = Path.Combine(contentsPath, "Resources", "Scripting");
+            if (Directory.Exists(scriptingPath))
+            {
+                return scriptingPath;
+            }
+            return contentsPath;
+        }
+
         private List<string> BuildSearchPaths(string contentsPath)
         {
             List<string> searchPaths = new();
 
+            // Unity 6.3+ uses Contents/Resources/Scripting/, earlier versions use Contents/ directly
+            string scriptingBase = GetScriptingBasePath(contentsPath);
+
             // .NET Framework 4.x reference assemblies (use only when NetStandard 2.1 is unavailable)
-            string monoApi = Path.Combine(contentsPath, "MonoBleedingEdge", "lib", "mono", "4.7.1-api");
+            string monoApi = Path.Combine(scriptingBase, "MonoBleedingEdge", "lib", "mono", "4.7.1-api");
             string monoFacades = Path.Combine(monoApi, "Facades");
-            string monoUnityjit = Path.Combine(contentsPath, "MonoBleedingEdge", "lib", "mono", "unityjit-macos");
+            string monoUnityjit = Path.Combine(scriptingBase, "MonoBleedingEdge", "lib", "mono", "unityjit-macos");
 
             // .NET Standard reference assemblies
-            string netStandard21 = Path.Combine(contentsPath, "NetStandard", "ref", "2.1.0");
-            string netStandard20 = Path.Combine(contentsPath, "NetStandard", "ref", "2.0.0");
-            string netStandardCompat = Path.Combine(contentsPath, "NetStandard", "compat", "shims", "net472");
+            string netStandard21 = Path.Combine(scriptingBase, "NetStandard", "ref", "2.1.0");
+            string netStandard20 = Path.Combine(scriptingBase, "NetStandard", "ref", "2.0.0");
+            string netStandardCompat = Path.Combine(scriptingBase, "NetStandard", "compat", "shims", "net472");
 
             // Unity Managed assemblies
-            string managed = Path.Combine(contentsPath, "Managed");
+            string managed = Path.Combine(scriptingBase, "Managed");
             string unityEngine = Path.Combine(managed, "UnityEngine");
             string unityEditor = Path.Combine(managed, "UnityEditor");
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/hatayama/uLoopMCP/issues/370

Fixed `execute-dynamic-code` functionality for Unity 6.3+, which was failing with "System.Object is not defined" error due to Unity's reference assembly path structure change.

## Problem

Unity 6.3 moved reference assemblies from `Contents/{subpath}` to `Contents/Resources/Scripting/{subpath}`, causing compilation failures in Restricted mode:
- `BuildSearchPaths()` was looking for assemblies in old paths
- Restricted mode couldn't find basic types like `System.Object`
- FullAccess mode worked because it falls back to `AppDomain.GetAssemblies()`

## Solution

1. Added `GetScriptingBasePath()` helper method to detect Unity 6.3+ folder structure
2. Updated `BuildSearchPaths()` to use `scriptingBase` for all assembly paths
3. Added comprehensive tests using Restricted mode to verify path resolution

## Changes

**Modified:**
- `Packages/src/Editor/Compilation/RoslynCompiler.cs`
  - Added `GetScriptingBasePath()` method
  - Updated `BuildSearchPaths()` to use dynamic base path

**Added:**
- `Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerUnity6PathTests.cs`
  - 4 tests covering System.Object, basic types, collections, and LINQ
  - Tests use Restricted mode to ensure proper path resolution

## Testing

Verified on multiple Unity versions:
- ✅ Unity 2022.3 (legacy path structure)
- ✅ Unity 6.2 (legacy path structure)
- ✅ Unity 6.3 (new path structure)

All tests pass in Restricted mode, confirming proper assembly resolution across all versions.

## Backward Compatibility

Fully backward compatible - automatically detects and uses correct path structure based on Unity version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Support Unity 6.3+ Reference Assembly Path Structure

### Problem
Unity 6.3 restructured the reference assemblies location from `Contents/{subpath}` to `Contents/Resources/Scripting/{subpath}`, causing compilation failures in the execute-dynamic-code functionality. The error "Predefined type 'System.Object' is not defined or imported" occurred in Restricted mode because `RoslynCompiler.BuildSearchPaths()` was still using outdated paths. While FullAccess mode worked due to fallback mechanisms, Restricted mode had no such fallback.

### Solution
Implemented automatic path detection and resolution:

1. **New Helper Method**: Added `GetScriptingBasePath(contentsPath)` that detects the Unity 6.3+ folder structure and selects the appropriate base path:
   - Returns `Contents/Resources/Scripting` when it exists (Unity 6.3+)
   - Falls back to `Contents` for legacy versions

2. **Updated Path Resolution**: Modified `BuildSearchPaths()` to use the detected scripting base path for all Unity/.NET reference assemblies:
   - MonoBleedingEdge assemblies
   - .NET Standard (2.0, 2.1)
   - .NET Standard compatibility assemblies
   - Managed framework assemblies (UnityEngine, UnityEditor)

### Changes Made

**Modified Files:**
- `Packages/src/Editor/Compilation/RoslynCompiler.cs`: Added path detection logic and updated assembly search path construction

**New Files:**
- `Assets/Tests/Editor/DynamicCodeToolTests/RoslynCompilerUnity6PathTests.cs`: Comprehensive test suite with four Restricted-mode tests

### Testing
Added `RoslynCompilerUnity6PathTests` fixture with lifecycle management (SetUp/TearDown) validating:
- System.Object type resolution
- Basic types (string, int, bool)
- System.Collections.Generic types
- System.Linq functionality

Tests verified on Unity 2022.3 (legacy path), Unity 6.2 (legacy path), and Unity 6.3 (new path) with all tests passing in Restricted mode.

### Backward Compatibility
Fully backward compatible. The implementation automatically detects and uses the correct path structure for both legacy Unity versions and Unity 6.3+, requiring no configuration changes.

### Technical Details
The fix ensures Restricted mode can now locate core reference assemblies without relying on FullAccess mode fallbacks, enabling dynamic code compilation on modern Unity versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->