### PR TITLE
fix: resolve lockfile-lint mutually exclusive options error in CI

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -168,6 +168,5 @@ jobs:
         lockfile-lint \
           --path package-lock.json \
           --type npm \
-          --validate-https \
           --allowed-hosts npm \
           --allowed-schemes "https:" "git+https:"


### PR DESCRIPTION
## Summary

This PR fixes a CI failure in the "NPM Supply Chain Security" job caused by mutually exclusive command-line options in `lockfile-lint`.

## Problem

The `lockfile-lint` command was configured with both `--validate-https` and `--allowed-schemes` options, which are mutually exclusive. This caused the CI to fail with the error:
```
Arguments allowed-schemes and validate-https are mutually exclusive
```

## Solution

Removed the `--validate-https` option while keeping `--allowed-schemes "https:" "git+https:"`. This maintains the same HTTPS validation behavior while resolving the conflict.

## Changes

- Removed `--validate-https` option from the lockfile-lint command in `.github/workflows/security-scan.yml`
- HTTPS validation is still enforced through `--allowed-schemes "https:" "git+https:"`

## Testing

- CI should now pass the lockfile-lint validation step
- The security requirements remain unchanged (only HTTPS and git+https schemes are allowed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Resolve lockfile-lint mutually exclusive options error in CI

## Overview
This PR resolves a CI failure in the "NPM Supply Chain Security" job caused by conflicting command-line arguments passed to lockfile-lint. The tool was receiving both `--validate-https` and `--allowed-schemes` options simultaneously, which are mutually exclusive parameters, resulting in the error: `"Arguments allowed-schemes and validate-https are mutually exclusive"`.

## Changes Made
**File: `.github/workflows/security-scan.yml`**

Modified the "Run lockfile-lint" step in the `npm-supply-chain-security` job:
- **Removed**: `--validate-https` flag from the lockfile-lint command
- **Retained**: `--allowed-schemes "https:" "git+https:"` configuration for HTTPS validation
- Other parameters (`--path`, `--type`, `--allowed-hosts`) remain unchanged

The updated command now reads:
```yaml
lockfile-lint \
  --path package-lock.json \
  --type npm \
  --allowed-hosts npm \
  --allowed-schemes "https:" "git+https:"
```

## Technical Details
The lockfile-lint tool does not support simultaneous use of `--validate-https` and `--allowed-schemes` parameters. By removing the redundant `--validate-https` flag and relying solely on `--allowed-schemes "https:" "git+https:"`, the tool achieves the same security validation goal—enforcing that only HTTPS-based package sources are allowed in dependencies—without the conflicting options.

## Impact
- **CI/CD**: Resolves the lockfile-lint validation failure, allowing the "NPM Supply Chain Security" job to complete successfully
- **Security**: Maintains identical security requirements by restricting dependencies to HTTPS and git+https protocols
- **No Breaking Changes**: All other security validations and allowed hosts configurations remain in place

## Testing & Validation
The security scan workflow should now pass the lockfile-lint validation step while continuing to enforce supply chain security by allowing only HTTPS-based package sources in the package-lock.json file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->