### PR TITLE
fix: prevent port conflict dialog during domain reload recovery

### DIFF
--- a/Packages/src/Editor/Server/McpServerController.cs
+++ b/Packages/src/Editor/Server/McpServerController.cs
@@ -470,7 +470,7 @@ namespace io.github.hatayama.uLoopMCP
             // Note: Port availability and system port conflicts are handled by FindAvailablePort
         }
 
-        private static bool IsStartupProtectionActive()
+        public static bool IsStartupProtectionActive()
         {
             long nowTicks = DateTime.UtcNow.Ticks;
             return nowTicks < System.Threading.Volatile.Read(ref startupProtectionUntilTicks);

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -182,9 +182,11 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             // Determine if server should be started automatically (normal auto-start, not after-compile)
+            // Skip auto-start if recovery is in progress to avoid conflicting with StartRecoveryIfNeededAsync
             bool shouldStartAutomatically = _model.UI.AutoStartServer;
             bool serverNotRunning = !McpServerController.IsServerRunning;
-            bool shouldStartServer = shouldStartAutomatically && serverNotRunning;
+            bool isRecoveryInProgress = McpServerController.IsStartupProtectionActive();
+            bool shouldStartServer = shouldStartAutomatically && serverNotRunning && !isRecoveryInProgress;
 
             if (shouldStartServer)
             {


### PR DESCRIPTION
## Problem

After Unity domain reload, a dialog appeared asking "Port X is already in use. Would you like to use port Y instead?" even though PR #318 implemented a 5-second retry mechanism to wait for the port to be released.

## Root Cause

Three recovery paths existed after domain reload, but path #3 bypassed the recovery coordination:

1. **McpServerController static constructor** → `StartRecoveryIfNeededAsync()` ✓ (5s retry, semaphore)
2. **OnAfterAssemblyReload** → Same as above ✓
3. **McpEditorWindow.OnEnable** → `McpServerInitializationUseCase` ✗ (no semaphore, immediate port check)

Path #3 called `FindAvailablePort()` immediately and showed a dialog if the port was in use, bypassing the 5-second retry logic from PR #318.

## Solution

Prevent `McpEditorWindow` auto-start when recovery is in progress:

1. **McpServerController.cs**: Made `IsStartupProtectionActive()` public
2. **McpEditorWindow.cs**: Added recovery check in `HandlePostCompileMode()`
   - Skip auto-start if `IsStartupProtectionActive()` returns true
   - This ensures the 5-second retry completes before attempting auto-start

## Changes

- `Packages/src/Editor/Server/McpServerController.cs`: Change `IsStartupProtectionActive()` visibility to public
- `Packages/src/Editor/UI/McpEditorWindow.cs`: Add recovery check before auto-start

## Testing

- Domain reload should no longer show the port conflict dialog
- Manual "Start Server" button still shows dialog if port is actually in use

## Related

- Builds on PR #318 which implemented the 5-second retry mechanism
- Fixes regression where multiple recovery paths could interfere with each other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Prevent Port Conflict Dialog During Domain Reload Recovery

## Overview
This PR fixes a race condition that occurs during Unity domain reload where a port-conflict dialog could prematurely appear despite the existing 5-second recovery retry mechanism from PR #318. The issue stems from `McpEditorWindow` bypassing the coordinated recovery semaphore by directly invoking startup logic without checking if recovery is already in progress.

## Problem Description
The MCP server controller has three recovery entry points during domain reload:
1. `OnBeforeAssemblyReload()` - Uses coordinated recovery with semaphore
2. `OnAfterAssemblyReload()` → `StartRecoveryIfNeededAsync()` - Uses coordinated recovery with semaphore
3. `McpEditorWindow.OnEnable()` → `HandlePostCompileMode()` - Previously bypassed coordination entirely

When `McpEditorWindow.HandlePostCompileMode()` automatically started the server, it would immediately call port detection without waiting for the existing 5-second recovery window, causing the port conflict dialog to display prematurely even though the port would become available within seconds.

## Solution
The fix prevents automatic server startup when recovery is already in progress by introducing a recovery state check at the UI layer.

**Changes made:**

1. **`McpServerController.cs`** - Made `IsStartupProtectionActive()` public
   - Changed visibility from `private static` to `public static`
   - This method checks if startup protection (recovery) is currently active using a volatile timestamp
   - Allows external components to query the recovery state

2. **`McpEditorWindow.cs`** - Added recovery check in `HandlePostCompileMode()`
   - Added `bool isRecoveryInProgress = McpServerController.IsStartupProtectionActive();` check
   - Updated auto-start condition: `bool shouldStartServer = shouldStartAutomatically && serverNotRunning && !isRecoveryInProgress;`
   - Prevents auto-start when `IsStartupProtectionActive()` returns true (during the 5-second recovery window)

## Expected Behavior
- **Domain reload**: No longer triggers the port conflict dialog during the 5-second recovery window
- **Manual "Start Server"**: Still displays the port conflict dialog if the port is actually in use
- **Auto-start disabled**: Respects existing auto-start settings
- **Recovery coordination**: All three recovery paths now use the same semaphore-based protection mechanism

## Testing
The PR includes `McpEditorWindowPortWarningTests.cs` which validates:
- Port warning detection when ports are occupied
- No warning when ports are available
- Default data creation for server controls

## Architecture Impact
```
classDiagram
    class McpServerController {
        +IsStartupProtectionActive() bool
        -startupProtectionUntilTicks: long
        -ActivateStartupProtection(int) void
        +StartRecoveryIfNeededAsync() Task
    }
    
    class McpEditorWindow {
        -HandlePostCompileMode() void
    }
    
    McpEditorWindow --> McpServerController : checks IsStartupProtectionActive()
    McpServerController --> McpServerController : coordinated via semaphore
```

## Related Issues
- Builds on PR #318 which introduced the 5-second retry mechanism with startup protection
- Fixes a regression where multiple recovery paths interfered with each other

<!-- end of auto-generated comment: release notes by coderabbit.ai -->