### PR TITLE
feat: skip server auto-start on first launch

### DIFF
--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -74,10 +74,18 @@ namespace io.github.hatayama.uLoopMCP
     public static class McpEditorSettings
     {
         private const string ROSLYN_SYMBOL = "ULOOPMCP_HAS_ROSLYN";
-        
+
         private static string SettingsFilePath => Path.Combine(McpConstants.USER_SETTINGS_FOLDER, McpConstants.SETTINGS_FILE_NAME);
 
         private static McpEditorSettingsData _cachedSettings;
+
+        // Settings file was newly created during this session (first launch detection)
+        private static bool _isFirstLaunch;
+
+        /// <summary>
+        /// Whether this is the first launch (settings file was newly created).
+        /// </summary>
+        public static bool IsFirstLaunch => _isFirstLaunch;
 
         /// <summary>
         /// Gets the settings data.
@@ -821,22 +829,24 @@ namespace io.github.hatayama.uLoopMCP
                     {
                         throw new SecurityException("Settings file exceeds size limit");
                     }
-                    
+
                     string json = File.ReadAllText(SettingsFilePath);
-                    
+
                     // Security: Validate JSON content
                     if (string.IsNullOrWhiteSpace(json))
                     {
                         throw new InvalidDataException("Settings file contains invalid JSON content");
                     }
-                    
+
                     _cachedSettings = JsonUtility.FromJson<McpEditorSettingsData>(json);
+                    _isFirstLaunch = false;
                 }
                 else
                 {
                     // Create default settings.
                     _cachedSettings = new McpEditorSettingsData();
                     SaveSettings(_cachedSettings);
+                    _isFirstLaunch = true;
                 }
             }
             catch (Exception ex)

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -183,10 +183,12 @@ namespace io.github.hatayama.uLoopMCP
 
             // Determine if server should be started automatically (normal auto-start, not after-compile)
             // Skip auto-start if recovery is in progress to avoid conflicting with StartRecoveryIfNeededAsync
+            // Skip auto-start on first launch so users can see initial settings before server starts
             bool shouldStartAutomatically = _model.UI.AutoStartServer;
             bool serverNotRunning = !McpServerController.IsServerRunning;
             bool isRecoveryInProgress = McpServerController.IsStartupProtectionActive();
-            bool shouldStartServer = shouldStartAutomatically && serverNotRunning && !isRecoveryInProgress;
+            bool isFirstLaunch = McpEditorSettings.IsFirstLaunch;
+            bool shouldStartServer = shouldStartAutomatically && serverNotRunning && !isRecoveryInProgress && !isFirstLaunch;
 
             if (shouldStartServer)
             {


### PR DESCRIPTION
## Summary

This PR prevents the MCP server from auto-starting on first launch, allowing users to review initial settings before the server begins.

### Changes

**1. Added First Launch Detection to `McpEditorSettings`**
- Added `_isFirstLaunch` static flag to track first-time initialization
- Added `IsFirstLaunch` public property to expose the flag
- Modified `LoadSettings()` to set the flag based on settings file existence

**2. Updated Auto-Start Logic in `McpEditorWindow`**
- Modified `HandlePostCompileMode()` to skip auto-start when `IsFirstLaunch` is true
- Added explanatory comment about first-launch behavior

### Behavior

| State | Auto Start Checkbox | Server Status |
|-------|---------------------|---------------|
| **First Launch** | ✅ ON | Stopped |
| **Subsequent Launches (ON)** | ✅ ON | Auto-started |
| **Subsequent Launches (OFF)** | ☐ OFF | Stopped |

### Technical Details

- No database schema changes required
- First launch detection based on `UnityMcpSettings.json` existence
- Flag is set during `LoadSettings()` execution
- Clean, minimal implementation without persistent storage of the flag

## Test Plan

- [ ] Delete `UserSettings/UnityMcpSettings.json`
- [ ] Launch Unity and open uLoopMCP window
- [ ] Verify server does NOT auto-start (Status: Stopped)
- [ ] Verify "Auto Start Server" checkbox is ON
- [ ] Close and reopen Unity
- [ ] Verify server DOES auto-start on subsequent launches