### PR TITLE
fix: support Node.js detection for nvm and other version managers

### DIFF
--- a/Packages/src/Editor/Utils/NodeEnvironmentResolver.cs
+++ b/Packages/src/Editor/Utils/NodeEnvironmentResolver.cs
@@ -1,0 +1,267 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using UnityEngine;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Utility class for detecting Node.js and npm executables across various installation methods.
+    /// Supports standard installations and version managers (nvm, volta, asdf, fnm).
+    /// </summary>
+    public static class NodeEnvironmentResolver
+    {
+        private const int PROCESS_TIMEOUT_MS = 5000;
+
+        private static readonly string[] COMMON_BIN_PATHS = {
+            "/usr/local/bin",
+            "/opt/homebrew/bin",
+            "/usr/bin"
+        };
+
+        private static readonly (string basePath, string binSubPath)[] VERSION_MANAGERS = {
+            (".nvm/versions/node", "bin"),
+            (".volta/tools/image/node", "bin"),
+            (".asdf/installs/nodejs", "bin"),
+            (".local/share/fnm/node-versions", "installation/bin"),
+        };
+
+        /// <summary>
+        /// Finds the Node.js executable path using fallback strategy.
+        /// Order: which command -> common paths -> version manager paths
+        /// </summary>
+        public static string FindNodePath()
+        {
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                return FindExecutableWindows("node");
+            }
+
+            return FindExecutableUnix("node");
+        }
+
+        /// <summary>
+        /// Finds the npm executable path using fallback strategy.
+        /// Order: which command -> common paths -> version manager paths
+        /// </summary>
+        public static string FindNpmPath()
+        {
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                return FindExecutableWindows("npm");
+            }
+
+            return FindExecutableUnix("npm");
+        }
+
+        /// <summary>
+        /// Sets up the PATH environment variable for a process to include Node.js paths.
+        /// </summary>
+        public static void SetupEnvironmentPath(ProcessStartInfo startInfo, string executablePath)
+        {
+            if (string.IsNullOrEmpty(executablePath))
+            {
+                return;
+            }
+
+            string executableDir = Path.GetDirectoryName(executablePath);
+            string currentPath = System.Environment.GetEnvironmentVariable("PATH") ?? "";
+
+            List<string> additionalPaths = new List<string>();
+
+            if (!string.IsNullOrEmpty(executableDir))
+            {
+                additionalPaths.Add(executableDir);
+            }
+
+            foreach (string path in COMMON_BIN_PATHS)
+            {
+                if (Directory.Exists(path) && !additionalPaths.Contains(path))
+                {
+                    additionalPaths.Add(path);
+                }
+            }
+
+            AddVersionManagerPaths(additionalPaths);
+
+            string separator = Application.platform == RuntimePlatform.WindowsEditor ? ";" : ":";
+            string newPath = string.Join(separator, additionalPaths) + separator + currentPath;
+
+            startInfo.EnvironmentVariables["PATH"] = newPath;
+        }
+
+        private static string FindExecutableUnix(string executableName)
+        {
+            string path = TryWhichCommand(executableName);
+            if (!string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            path = SearchCommonPaths(executableName);
+            if (!string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            path = SearchVersionManagerPaths(executableName);
+            if (!string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            return null;
+        }
+
+        private static string FindExecutableWindows(string executableName)
+        {
+            string path = TryWhereCommand(executableName);
+            if (!string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            path = SearchVersionManagerPaths(executableName);
+            if (!string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            return null;
+        }
+
+        private static string TryWhichCommand(string executableName)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = "which",
+                Arguments = executableName,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            return ExecuteAndGetOutput(startInfo);
+        }
+
+        private static string TryWhereCommand(string executableName)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                Arguments = $"/c where {executableName}",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            string output = ExecuteAndGetOutput(startInfo);
+            if (!string.IsNullOrEmpty(output))
+            {
+                string[] lines = output.Split('\n');
+                if (lines.Length > 0)
+                {
+                    return lines[0].Trim();
+                }
+            }
+
+            return null;
+        }
+
+        private static string ExecuteAndGetOutput(ProcessStartInfo startInfo)
+        {
+            using (Process process = Process.Start(startInfo))
+            {
+                if (process == null)
+                {
+                    return null;
+                }
+
+                string output = process.StandardOutput.ReadToEnd().Trim();
+                process.StandardError.ReadToEnd();
+
+                if (!process.WaitForExit(PROCESS_TIMEOUT_MS))
+                {
+                    process.Kill();
+                    return null;
+                }
+
+                if (process.ExitCode == 0 && !string.IsNullOrEmpty(output))
+                {
+                    return output;
+                }
+            }
+
+            return null;
+        }
+
+        private static string SearchCommonPaths(string executableName)
+        {
+            foreach (string binPath in COMMON_BIN_PATHS)
+            {
+                string fullPath = Path.Combine(binPath, executableName);
+                if (File.Exists(fullPath))
+                {
+                    return fullPath;
+                }
+            }
+
+            return null;
+        }
+
+        private static string SearchVersionManagerPaths(string executableName)
+        {
+            string home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+
+            foreach ((string basePath, string binSubPath) in VERSION_MANAGERS)
+            {
+                string fullBasePath = Path.Combine(home, basePath);
+                if (!Directory.Exists(fullBasePath))
+                {
+                    continue;
+                }
+
+                string[] versionDirs = Directory.GetDirectories(fullBasePath);
+                System.Array.Sort(versionDirs);
+                System.Array.Reverse(versionDirs);
+
+                foreach (string versionDir in versionDirs)
+                {
+                    string executablePath = Path.Combine(versionDir, binSubPath, executableName);
+                    if (File.Exists(executablePath))
+                    {
+                        return executablePath;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static void AddVersionManagerPaths(List<string> paths)
+        {
+            string home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+
+            foreach ((string basePath, string binSubPath) in VERSION_MANAGERS)
+            {
+                string fullBasePath = Path.Combine(home, basePath);
+                if (!Directory.Exists(fullBasePath))
+                {
+                    continue;
+                }
+
+                string[] versionDirs = Directory.GetDirectories(fullBasePath);
+                foreach (string versionDir in versionDirs)
+                {
+                    string binPath = Path.Combine(versionDir, binSubPath);
+                    if (Directory.Exists(binPath) && !paths.Contains(binPath))
+                    {
+                        paths.Add(binPath);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Utils/NodeEnvironmentResolver.cs.meta
+++ b/Packages/src/Editor/Utils/NodeEnvironmentResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56d4a5e3232ee4af683a6a8620da9cfd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add `NodeEnvironmentResolver` as a shared utility for detecting Node.js and npm across various installation methods
- Fix the issue where Unity Editor shows "Node.js not found" error for users with nvm even though MCP server works correctly
- Refactor `TypeScriptBuilder` to use the shared utility (removing duplicate code)

## Problem
PR #388 added Node.js availability check before MCP configuration. However, the check used a simple `/bin/bash -c "node -v"` which fails in nvm environments because:
1. Unity Editor's subprocess doesn't run shell initialization scripts (`.bashrc`, `.zshrc`)
2. nvm's PATH (`~/.nvm/versions/node/...`) is not set without shell initialization

## Solution
Implement a fallback detection strategy:
1. `which`/`where` command (most reliable when shell is configured)
2. Common paths (`/usr/local/bin`, `/opt/homebrew/bin`, etc.)
3. Version manager paths (`~/.nvm`, `~/.volta`, `~/.asdf`, `~/.local/share/fnm`)

## Supported Version Managers
- nvm
- volta  
- asdf
- fnm

## Test plan
- [ ] Verify Node.js detection works in nvm environment
- [ ] Verify Node.js detection works in standard installation
- [ ] Verify MCP AutoConfigure succeeds without error dialog

Closes #395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes Node.js detection for version managers like nvm, volta, asdf, and fnm by introducing a centralized `NodeEnvironmentResolver` utility class and refactoring dependent components to use it. The issue was that Unity Editor subprocesses don't run shell initialization scripts (`.bashrc`, `.zshrc`), causing nvm's PATH modifications to be unavailable, and the direct command execution approach failed silently in those environments.

## Problem Statement

- **Issue #395**: Users managing Node.js with nvm receive "Node.js is not installed or PATH is not configured" error in uLoopMCP, despite the MCP server running successfully
- **Root cause**: PR #388 introduced `/bin/bash -c "node -v"` check, which fails in Unity Editor subprocesses that don't inherit shell initialization
- **Impact**: MCP auto-configuration fails, requiring users to manually create configuration files
- **Environment**: macOS 26.1, Unity 6000.2.15f1, nvm v0.40.3, node v24.9.0

## Architecture Changes

### New Component: NodeEnvironmentResolver

A static utility class providing three public methods for cross-platform Node.js/npm detection:

**Public API**:
- `FindNodePath(): string` – Detects Node.js executable location
- `FindNpmPath(): string` – Detects npm executable location  
- `SetupEnvironmentPath(ProcessStartInfo, string): void` – Augments process environment PATH

**Detection Strategy** (fallback order):

1. **Shell-based lookup** (most reliable):
   - Unix: `which` command
   - Windows: `where` command via `cmd.exe /c`

2. **Common installation paths**:
   - `/usr/local/bin`, `/opt/homebrew/bin`, `/usr/bin` (Unix/macOS)
   - Implicitly searches `Program Files\nodejs` on Windows via `where`

3. **Version-manager specific paths**:
   - **nvm**: `~/.nvm/versions/node/*/bin`
   - **volta**: `~/.volta/tools/image/node/*/bin`
   - **asdf**: `~/.asdf/installs/nodejs/*/bin`
   - **fnm**: `~/.local/share/fnm/node-versions/*/installation/bin`

**Implementation Details**:
- Cross-platform detection via `Application.platform` checks
- Separate Unix and Windows code paths:
  - `FindExecutableUnix()`: which → common paths → version managers
  - `FindExecutableWindows()`: where → version managers
- Process timeout of 5 seconds prevents hanging
- Error handling and null/empty checks protect against invalid states
- `VERSION_MANAGERS` array enables easy addition of new version managers

**PATH Augmentation**:
- `SetupEnvironmentPath()` prepends to subprocess environment PATH:
  1. Executable's directory (typically contains npm/node)
  2. Common bin paths (if they exist)
  3. Version-manager bin directories
  4. Existing system PATH (preserves system executables)
- Platform-aware separators: `;` (Windows) vs `:` (Unix)

### Refactored: TypeScriptBuilder

**Simplification**:
- Removed hard-coded lists of common Node.js paths
- Removed manual nvm expansion logic
- Replaced ad-hoc detection with single `NodeEnvironmentResolver.FindNpmPath()` call

**Security Enhancements** in `RunCommand()`:
- Input validation: command, arguments, and workingDirectory must be non-empty
- Command whitelist via `IsValidNpmCommand()` enforces allowed npm commands:
  - `ci` (strict installation from package-lock.json)
  - `run build:bundle` (build command)
  - `install` (npm install)
- Path validation via `IsValidWorkingDirectory()` ensures working directory resides under package base path
- Throws `InvalidOperationException` on execution failure instead of silent return

**Refactored Methods**:
- `GetNpmPath()`: Delegates to `NodeEnvironmentResolver.FindNpmPath()` with logging
- `SetupEnvironmentPath()`: Delegates to `NodeEnvironmentResolver.SetupEnvironmentPath()`
- `RunCommand()`: Added validation and improved error handling

**Code Impact**:
- Reduced ~400 lines to ~300 lines
- Eliminated branching and conditional logic
- Single responsibility: npm command execution only

### Enhanced: NodePathResolver

**Reworked Detection Flow**:
- Replaced simple `ProcessStartInfo` with `NodeEnvironmentResolver` integration
- New `ResolveNodePath()` helper method:
  - Fetches candidate path via `NodeEnvironmentResolver`
  - Validates via process execution (runs `node -v`)
  - Returns path or null

**Cross-platform Validation**:
- Windows: `cmd.exe /c "[nodePath]" -v`
- Unix: Direct invocation: `[nodePath] -v`
- Checks both exit code and version output format (must start with "v")

**Testing Support**:
- Added internal `ClearCache()` method for test isolation
- Maintains backward compatibility with public API `GetNodeExecutablePath()`
- Caching semantics preserved

**Process Execution**:
- Uses `SetupEnvironmentPath()` to prepare subprocess environment
- Timeout management prevents hanging
- Proper error handling with fallback to null

## File Changes Summary

| File | Changes |
|------|---------|
| `NodeEnvironmentResolver.cs` (NEW) | 267 lines; static utility class with version-manager support |
| `TypeScriptBuilder.cs` | Simplified npm path detection; added security validations; delegated to resolver |
| `NodePathResolver.cs` | Integrated `NodeEnvironmentResolver`; improved validation; added test support |

## Benefits

1. **Reliability**: Handles multiple Node.js installation methods via layered fallback strategy
2. **Maintainability**: Single source of truth for Node.js detection; reduces code duplication
3. **Robustness**: Avoids false "Node.js not found" errors in edge cases (nvm, volta, asdf, fnm)
4. **Security**: Stricter validation prevents accidental command execution; command whitelisting
5. **Debuggability**: Comprehensive logging at each step; explicit error handling
6. **Scalability**: Easy to add new version managers via `VERSION_MANAGERS` array
7. **Cross-platform**: Unified Windows/Unix support with platform-specific logic

## User Impact

- ✅ Users with nvm/volta/asdf/fnm will no longer see false "Node.js not found" errors
- ✅ MCP auto-configuration succeeds automatically without manual intervention
- ✅ No configuration changes required
- ✅ Transparent improvement with full backward compatibility
- ✅ Improved error messages for debugging

## Technical Debt Addressed

- Eliminated duplicate Node.js detection logic across components
- Removed version-manager-specific knowledge from business logic
- Centralized process management and error handling
- Improved subprocess environment setup practices

## Scope

- **Public API additions**: Three new public methods in `NodeEnvironmentResolver`
- **Breaking changes**: None (internal refactoring of editor-only components)
- **Files modified**: 3 core files
- **Lines added**: ~600 (new resolver)
- **Lines removed**: ~100 (simplified components)
- **Test coverage**: Requires separate verification

## Closes

Issue #395: "Node.js not detected when using nvm"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->