### PR TITLE
fix: use portable "node" command instead of full path in mcp.json

### DIFF
--- a/Packages/src/Editor/Config/McpServerConfigFactory.cs
+++ b/Packages/src/Editor/Config/McpServerConfigFactory.cs
@@ -44,15 +44,14 @@ namespace io.github.hatayama.uLoopMCP
 #endif
             };
 
-            string nodePath = NodePathResolver.GetNodeExecutablePath();
-            if (string.IsNullOrEmpty(nodePath))
+            if (!NodePathResolver.IsNodeAvailable())
             {
                 throw new System.InvalidOperationException(
                     "Node.js is not available. Ensure Node.js is installed and accessible via PATH.");
             }
 
             return new McpServerConfigData(
-                command: nodePath,
+                command: McpConstants.NODE_COMMAND,
                 args: new[] { finalServerPath },
                 env: env
             );
@@ -117,15 +116,14 @@ namespace io.github.hatayama.uLoopMCP
 #endif
             };
             
-            string nodePath = NodePathResolver.GetNodeExecutablePath();
-            if (string.IsNullOrEmpty(nodePath))
+            if (!NodePathResolver.IsNodeAvailable())
             {
                 throw new System.InvalidOperationException(
                     "Node.js is not available. Ensure Node.js is installed and accessible via PATH.");
             }
 
             return new McpServerConfigData(
-                command: nodePath,
+                command: McpConstants.NODE_COMMAND,
                 args: new[] { serverPath },
                 env: env
             );


### PR DESCRIPTION
## Summary
- Use `McpConstants.NODE_COMMAND` ("node") instead of the resolved full path in mcp.json
- Improves portability across different environments and machines
- Full path detection is still used internally for Node.js availability validation

## Problem
After PR #398, the `mcp.json` `command` field contained the full path (e.g., `/usr/local/bin/node`), which caused issues:
- Path mismatch when sharing projects with other developers
- Stale paths when switching Node.js versions via nvm/volta
- Config breaks on machine migration

## Solution
Write `"node"` to mcp.json while keeping the full path detection for internal validation.

## Test plan
- [x] Compile succeeds with no errors or warnings
- [ ] Verify mcp.json contains `"command": "node"` after regeneration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Use Portable "node" Command Instead of Full Path in mcp.json

## Overview
This PR addresses a portability regression introduced in PR #398 where mcp.json configuration files were being generated with absolute paths to Node.js executables (e.g., `/usr/local/bin/node`). The fix replaces hardcoded full-path assignments with a portable constant command while preserving internal Node.js availability validation.

## Problem Statement
PR #398 improved Node.js detection for version managers (nvm, volta), but inadvertently caused mcp.json files to contain full paths to the Node.js executable. This creates three critical issues:
- **Portability**: Configuration files with absolute paths cannot be shared across team members or machines
- **Version Manager Compatibility**: When switching Node.js versions via nvm/volta, the stale path in mcp.json becomes invalid
- **Machine Migration**: Projects moved to different machines fail due to path mismatches

## Changes Made

**File Modified:** `Packages/src/Editor/Config/McpServerConfigFactory.cs`

### `CreateUnityMcpConfig()` Method (Lines 32-58)
- **Before**: Assigned the resolved full Node.js executable path to the command field
- **After**: 
  - Validates Node.js availability using `NodePathResolver.IsNodeAvailable()` check
  - Assigns the portable constant `McpConstants.NODE_COMMAND` ("node") to the command field
  - Preserves error handling: throws `InvalidOperationException` if Node.js is unavailable

### `CreateUnityMcpConfigWithDevelopmentMode()` Method (Lines 109-130)
- Applied identical changes for consistency across both configuration creation paths
- Maintains development mode support without affecting command portability

## Technical Details

**Configuration Output Example:**
```json
{
  "mcpServers": {
    "uLoopMCP": {
      "command": "node",
      "args": ["path/to/server.bundle.js"],
      "env": {
        "UNITY_TCP_PORT": "3000"
      }
    }
  }
}
```

**Key Architectural Decisions:**
- **Separation of Concerns**: Full-path detection remains internal via `NodePathResolver.IsNodeAvailable()` for validation only
- **Consistent Behavior**: Both configuration factory methods apply the same logic, maintaining API consistency
- **Error Semantics Preserved**: The exception message and validation flow remain unchanged
- **Server Arguments**: The TypeScript server path argument remains dynamically configured per editor type (absolute for desktop editors like Cursor/VSCode, relative for CLI-based editors like Claude Code)

## Dependencies & Related Systems

```
McpServerConfigFactory
├── NodePathResolver (validates availability)
├── McpConstants (NODE_COMMAND = "node")
├── UnityMcpPathResolver (handles server paths)
└── McpServerConfigData (value object created)
```

**Related Components:**
- `NodePathResolver`: Internally detects and caches the full Node.js path for validation
- `NodeEnvironmentResolver`: Searches for Node.js using `which` command and fallback paths, supporting nvm/volta
- `McpConfigRepository`: Persists the generated configuration to mcp.json files
- `UnityMcpPathResolver`: Manages configuration file locations for multiple editors (Cursor, Claude Code, VSCode, Windsurf, Codex, Gemini CLI, MCP Inspector)

## Impact & Benefits

✅ **Fixes Portability**: Configurations are now shareable across environments  
✅ **Version Manager Friendly**: Works seamlessly with nvm, volta, and other Node.js version managers  
✅ **Machine Migration Support**: Projects remain functional when moved to different machines  
✅ **Maintains Validation**: Robust error handling ensures Node.js availability is still verified  
✅ **No API Changes**: All public method signatures remain identical  
✅ **Backward Compatible**: Existing error handling and validation semantics preserved  

## Test Coverage

- ✅ Compilation succeeds without errors or warnings
- ⚠️ Verification that generated mcp.json contains `"command": "node"` (pending confirmation in test phase)

## Commit Reference
- Current: `39ce1b3` - fix: use portable "node" command instead of full path in mcp.json
- Previous related: `96c71c9` - fix: support Node.js detection for nvm and other version managers (#398)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->