### PR TITLE
chore: update readme

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -412,7 +412,6 @@ public class MyCustomTool : AbstractUnityTool<MyCustomSchema, MyCustomResponse>
 
 > [!IMPORTANT]  
 > **Important Notes**:
-> - **Timeout Handling**: All tools inherit `TimeoutSeconds` parameter from `BaseToolSchema`. Implement `cancellationToken.ThrowIfCancellationRequested()` checks in long-running operations to ensure proper timeout behavior.
 > - **Thread Safety**: Tools execute on Unity's main thread, so Unity API calls are safe without additional synchronization.
 
 Please also refer to [Custom Tool Samples](/Assets/Editor/CustomToolSamples).
@@ -425,19 +424,6 @@ Please also refer to [Custom Tool Samples](/Assets/Editor/CustomToolSamples).
 > 
 > The `run-tests`, `unity-search`, and `get-hierarchy` tools can save results to the `{project_root}/uLoopMCPOutputs/` directory to avoid massive token consumption when dealing with large datasets.
 > **Recommendation**: Add `uLoopMCPOutputs/` to `.gitignore` to exclude from version control.
-
-> [!TIP]
-> **Automatic MCP Execution in Cursor**  
-> 
-> By default, Cursor requires user permission when executing MCP.
-> To disable this, go to Cursor Settings > Chat > MCP Tools Protection and turn it Off.
-> Note that this cannot be controlled per MCP type or tool, so all MCPs will no longer require permission. This is a security tradeoff, so please configure it with that in mind.
-
-> [!WARNING]
-> **Windows Claude Code**  
-> 
-> When using Claude Code on Windows, version 1.0.51 or higher is recommended. (Git for Windows is required)  
-> Please refer to [Claude Code CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md).
 
 ## License
 MIT License

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -410,7 +410,6 @@ public class MyCustomTool : AbstractUnityTool<MyCustomSchema, MyCustomResponse>
 
 > [!IMPORTANT]  
 > **重要事項**：
-> - **タイムアウト処理**: 全てのツールは`BaseToolSchema`から`TimeoutSeconds`パラメータを継承します。長時間実行される処理では`cancellationToken.ThrowIfCancellationRequested()`チェックを実装して、適切なタイムアウト動作を保証してください。
 > - **スレッドセーフティ**: ツールはUnityのメインスレッドで実行されるため、追加の同期なしにUnity APIを安全に呼び出せます。
 
 [カスタムツールのサンプル](/Assets/Editor/CustomToolSamples)も参考にして下さい。
@@ -424,19 +423,6 @@ public class MyCustomTool : AbstractUnityTool<MyCustomSchema, MyCustomResponse>
 > 
 > `run-tests`、`unity-search`、`get-hierarchy`の各ツールは、大量のデータによるトークン消費を避けるため、結果を`{project_root}/uLoopMCPOutputs/`ディレクトリにファイル保存する機能があります。
 > **推奨**: `.gitignore`に`uLoopMCPOutputs/`を追加してバージョン管理から除外してください。
-
-> [!TIP]
-> **Cursorでmcpの実行を自動で行う**  
-> 
-> CursorはデフォルトでMCP実行時にユーザーの許可を必要とします。
-> これを無効にするには、Cursor Settings > Chat > MCP Tools ProtectionをOffにします。
-> MCPの種類・ツール事に制御できず、全てのMCPが許可不要になってしまうため、セキュリティとのトレードオフになります。そこを留意して設定してください。
-
-> [!WARNING]
-> **Windows板 Claude Code**  
-> 
-> WindowsでClaude Codeを使う場合、1.0.51以上のバージョンを推奨します。(Git for Windows が必要です)  
-> [Claude CodeのCHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md) を参照して下さい。
 
 ## ライセンス
 MIT License


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# README Documentation Cleanup

This PR removes three informational sections from both English and Japanese README files in the uLoopMCP project documentation.

## Removed Content:

### 1. Timeout Handling Guidance
Removed the note about `TimeoutSeconds` parameter inheritance from `BaseToolSchema` and recommendations for implementing cancellation checks in long-running custom tool operations.

### 2. Cursor MCP Permission Configuration Tip
Removed the tip explaining how to disable MCP permission prompts in Cursor via Settings > Chat > MCP Tools Protection, along with the security tradeoff warning.

### 3. Windows Claude Code Platform Warning
Removed the Windows-specific warning about Claude Code version requirements (1.0.51+) and Git for Windows dependency.

## Files Modified:
- `Packages/src/README.md` (English) - 14 lines removed
- `Packages/src/README_ja.md` (Japanese) - 14 lines removed  

## Impact:
Streamlined documentation by removing implementation-specific guidance, tool configuration details, and platform-specific warnings. No functional code changes; documentation simplification only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->