### PR TITLE
fix: use simple v-prefixed tags for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
     "Packages/src": {
       "release-type": "node",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

- Add `include-component-in-tag: false` to release-please config to fix tag detection

## Problem

After merging #416, release-please created PR #417 with version 0.1.1 instead of continuing from 0.43.9.

Root cause: release-please was looking for tags with component prefix (`io.github.hatayama.uloopmcp-v0.43.9`) but actual tags use simple format (`v0.43.9`).

## Solution

Add `include-component-in-tag: false` to tell release-please to use simple v-prefixed tags without the package name prefix.

| Before | After |
|--------|-------|
| Looking for: `io.github.hatayama.uloopmcp-v0.43.9` | Looking for: `v0.43.9` |

## Test Plan

- [ ] After merging, close PR #417 (DO NOT MERGE IT)
- [ ] Verify release-please creates correct release PR with v0.43.10 or v0.44.0