### PR TITLE
fix: use generic type for TypeScript package.json version sync

### DIFF
--- a/Packages/src/TypeScriptServer~/package.json
+++ b/Packages/src/TypeScriptServer~/package.json
@@ -1,6 +1,7 @@
 {
   "name": "uloopmcp-server",
   "version": "0.43.9",
+  "//version": "x-release-please-version",
   "description": "TypeScript MCP Server for Unity-Cursor integration",
   "main": "dist/server.bundle.js",
   "type": "module",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,9 +6,9 @@
       "include-component-in-tag": false,
       "extra-files": [
         {
-          "type": "json",
+          "type": "generic",
           "path": "Packages/src/TypeScriptServer~/package.json",
-          "jsonpath": "$.version"
+          "glob": "Packages/src/TypeScriptServer~/package.json"
         },
         {
           "type": "generic",


### PR DESCRIPTION
## Summary

- Use generic type with `x-release-please-version` marker for TypeScript package.json
- The json type with jsonpath was not updating the file

## Problem

In PR #419, the TypeScript `package.json` version was not updated despite the extra-files configuration.

The `json` type with `jsonpath: "$.version"` did not work, while `generic` type with marker worked for `version.ts`.

## Solution

1. Add `"//version": "x-release-please-version"` marker to TypeScript package.json
2. Change extra-files config from `json` type to `generic` type

This approach is proven to work (same pattern as version.ts).

## Files Changed

- `Packages/src/TypeScriptServer~/package.json` - Added version marker
- `release-please-config.json` - Changed to generic type

## Test Plan

- [ ] After merging, verify next release-please PR updates TypeScript package.json version