### PR TITLE
fix: auto-rebuild server.bundle.js on release and upgrade Node.js to v22

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: 'Packages/src/TypeScriptServer~/package-lock.json'
         

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,8 +40,43 @@ jobs:
 
       # ── Execute release-please ───────────────────────────
       - name: 🚀 Run release‑please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Rebuild TypeScript bundle when Release PR is created/updated ──
+      - name: 🔧 Setup Node.js for bundle rebuild
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: 📦 Rebuild TypeScript bundle for Release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🔄 Release PR #${{ steps.release.outputs.pr }} detected, rebuilding bundle..."
+          
+          # Checkout the PR branch
+          gh pr checkout ${{ steps.release.outputs.pr }}
+          
+          # Build the bundle
+          cd Packages/src/TypeScriptServer~
+          npm ci
+          npm run build
+          
+          # Commit and push if bundle changed
+          git add dist/server.bundle.js dist/server.bundle.js.map
+          if git diff --cached --quiet; then
+            echo "✅ No changes to bundle, skipping commit"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: rebuild server.bundle.js for release"
+            git push
+            echo "✅ Bundle rebuilt and pushed to PR"
+          fi

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: 'Packages/src/TypeScriptServer~/package-lock.json'
 
@@ -147,7 +147,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '18'
+        node-version: '22'
 
     - name: Run npm audit
       working-directory: Packages/src/TypeScriptServer~

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -290,7 +290,7 @@ For detailed specifications of all tools (parameters, responses, examples), see 
 > The following software is required
 >
 > - **Unity 2022.3 or later**
-> - **Node.js 18.0 or later** - Required for MCP server execution
+> - **Node.js 22.0 or later** - Required for MCP server execution
 > - Install Node.js from [here](https://nodejs.org/en/download)
 
 ### Via Unity Package Manager

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -289,7 +289,7 @@ Scope(s): org.nuget
 > 以下のソフトウェアが必須です
 > 
 > - **Unity 2022.3以上**
-> - **Node.js 18.0以上** - MCPサーバー実行に必要
+> - **Node.js 22.0以上** - MCPサーバー実行に必要
 > - Node.jsを[こちら](https://nodejs.org/en/download)からインストールしてください
 
 ### Unity Package Manager経由

--- a/Packages/src/TypeScriptServer~/README.md
+++ b/Packages/src/TypeScriptServer~/README.md
@@ -102,7 +102,7 @@ src/
 ## Setup
 
 ### Prerequisites
-- Node.js 18 or higher
+- Node.js 22 or higher
 - Unity 2020.3 or higher
 - Unity MCP Bridge package installed.
 


### PR DESCRIPTION
## Summary
Auto-rebuild server.bundle.js when Release PR is created/updated, and upgrade Node.js from EOL v18 to Active LTS v22.

## Details

### Problem
- When release-please updated version.ts, server.bundle.js was not rebuilt
- This caused VERSION mismatch between package.json and bundle.js (e.g., package.json shows 0.43.10 but bundle.js has 0.43.9)
- Node.js 18 has reached End of Life (EOL) and no longer receives security updates

### Changes
1. **release-please.yml**: Add step to auto-rebuild and commit bundle.js when Release PR is created
2. **All workflows**: Upgrade Node.js from v18 to v22 (Active LTS)
3. **All READMEs**: Update Node.js requirement to 22.0 or later

## References
- [Node.js Release Schedule](https://github.com/nodejs/Release)
- Node.js 18: EOL (security support ended)
- Node.js 22: Active LTS (security support until April 2027)
