### PR TITLE
fix: extract PR number from release-please JSON output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,11 +58,12 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
         run: |
-          echo "🔄 Release PR #${{ steps.release.outputs.pr }} detected, rebuilding bundle..."
+          echo "🔄 Release PR #${PR_NUMBER} detected, rebuilding bundle..."
           
           # Checkout the PR branch
-          gh pr checkout ${{ steps.release.outputs.pr }}
+          gh pr checkout "${PR_NUMBER}"
           
           # Build the bundle
           cd Packages/src/TypeScriptServer~


### PR DESCRIPTION
## Summary
Fix the release-please workflow that failed due to incorrect parsing of the PR output.

## Details

### Problem
The `release-please-action@v4` outputs a full JSON object for the PR (not just the number), causing a shell syntax error when used directly in `gh pr checkout`.

```
gh pr checkout {"headBranchName":"...", "number":425, ...}
# Results in: syntax error near unexpected token `('
```

### Fix
Use `fromJson()` to extract the PR number from the JSON output:

```yaml
env:
  PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
run: |
  gh pr checkout "${PR_NUMBER}"
```

## References
- Failed workflow: https://github.com/hatayama/uLoopMCP/actions/runs/20205162383/job/58002634490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Extract PR Number from release-please JSON Output

### Overview
This pull request fixes a failing release-please workflow that was unable to properly parse the PR output from the `googleapis/release-please-action@v4` action.

### Problem
The release-please action emits a full JSON object for the PR field (e.g., `{"headBranchName":"...", "number":425, "title":"...", ...}`), not just a numeric PR number. When this JSON object was used directly in shell commands like `gh pr checkout ${{ steps.release.outputs.pr }}`, it caused a shell syntax error because the shell received invalid input.

### Solution
The fix extracts the numeric PR number from the JSON output using GitHub Actions' `fromJson()` function:

**Key Change in `.github/workflows/release-please.yml`:**
- Added `PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}` to the environment variables of the "Rebuild TypeScript bundle for Release PR" step
- Updated the echo statement to use `${PR_NUMBER}` instead of the raw JSON output
- Updated the `gh pr checkout` command to use `"${PR_NUMBER}"` for proper shell execution

### Workflow Impact
- The workflow now correctly extracts the numeric PR identifier from the JSON object
- The release PR branch can be properly checked out for bundle rebuilding
- The TypeScript bundle can be rebuilt, committed, and pushed to the release PR
- Fixes the failing workflow run previously referenced: https://github.com/hatayama/uLoopMCP/actions/runs/20205162383/job/58002634490

### Technical Details
The workflow follows this sequence:
1. Release-please action creates or updates a release PR and outputs JSON metadata
2. `fromJson()` function extracts the `number` field from the JSON object
3. Extracted PR number is stored in `PR_NUMBER` environment variable
4. Subsequent commands use `PR_NUMBER` for shell operations that require a numeric identifier

<!-- end of auto-generated comment: release notes by coderabbit.ai -->