### PR TITLE
fix: use jq to parse PR JSON instead of fromJson in env block

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,8 +58,10 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
+          # Extract PR number from JSON using jq
+          PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')
           echo "🔄 Release PR #${PR_NUMBER} detected, rebuilding bundle..."
           
           # Checkout the PR branch


### PR DESCRIPTION
## Summary
Fix the release-please workflow template parsing error when the step's if condition is false.

## Details

### Problem
GitHub Actions evaluates `env` expressions **even when the step's `if` condition is false**. When the Release PR is merged (2nd workflow run), `steps.release.outputs.pr` is empty, causing `fromJson()` to fail:

```
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

### Fix
Move JSON parsing from the `env` block to the shell script using `jq`:

```yaml
# Before (fails when outputs.pr is empty)
env:
  PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}

# After (safe - only evaluated when step runs)
env:
  PR_JSON: ${{ steps.release.outputs.pr }}
run: |
  PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')
```

## References
- Failed workflow: https://github.com/hatayama/uLoopMCP/actions/runs/20205282375/job/58002918471