### PR TITLE
fix: prevent port conflict dialog during startup recovery

### DIFF
--- a/Packages/src/Editor/Server/McpServerController.cs
+++ b/Packages/src/Editor/Server/McpServerController.cs
@@ -221,6 +221,9 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
+            // Block other startup paths (e.g., McpEditorWindow.HandlePostCompileMode) during recovery
+            ActivateStartupProtection(5000);
+
             // Centralized, coalesced startup request
             _ = StartRecoveryIfNeededAsync(savedPort, isAfterCompile, CancellationToken.None).ContinueWith(task =>
             {


### PR DESCRIPTION
## Problem

After installing uLoopMCP, a port conflict dialog appeared during:
1. First Unity startup
2. After compilation

This was caused by a race condition between two server startup paths running in parallel.

## Root Cause

Two server startup paths were competing:

1. **McpServerController static constructor** → `RestoreServerStateIfNeeded()` → `StartRecoveryIfNeededAsync()` (no dialog)
2. **McpEditorWindow.HandlePostCompileMode()** → `StartServerInternal()` → `McpServerInitializationUseCase` (shows dialog)

The issue: `ActivateStartupProtection()` was called **after** recovery succeeded, so `McpEditorWindow` wasn't blocked during the recovery process.

## Solution

Activate startup protection **before** starting the recovery process in `RestoreServerStateIfNeeded()`.

This blocks other startup paths (like `McpEditorWindow.HandlePostCompileMode()`) during recovery.

## Changes

**File**: `Packages/src/Editor/Server/McpServerController.cs`

Added `ActivateStartupProtection(5000)` call before `StartRecoveryIfNeededAsync()` in the `RestoreServerStateIfNeeded()` method (line 225).

## Testing

- [ ] Port conflict dialog does not appear after compilation
- [ ] Port conflict dialog does not appear on Unity startup
- [ ] Server recovers successfully
- [ ] Manual server start/stop works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Port Conflict Dialog Prevention During Startup Recovery

## Problem Statement
After installing uLoopMCP, a port conflict dialog appeared during first Unity startup and after compilation due to a race condition between two competing server startup paths executing in parallel.

## Root Cause Analysis
The issue stemmed from two concurrent startup flows:

1. **Recovery Path** (non-blocking): McpServerController static constructor → RestoreServerStateIfNeeded() → StartRecoveryIfNeededAsync()
2. **Post-Compile Path** (blocking dialog): McpEditorWindow.HandlePostCompileMode() → StartServerInternal() → McpServerInitializationUseCase

The problem occurred because `ActivateStartupProtection()` was invoked *after* recovery completed, leaving the `McpEditorWindow` unprotected during the recovery window. This allowed the post-compile path to proceed concurrently with recovery, triggering port conflict dialogs.

## Solution
Moved the `ActivateStartupProtection(5000)` call to execute **before** `StartRecoveryIfNeededAsync()` in the `RestoreServerStateIfNeeded()` method (line 225). This establishes a 5-second startup protection window that blocks competing startup paths while the centralized recovery flow executes.

## Code Changes
**File Modified**: `Packages/src/Editor/Server/McpServerController.cs`

**Change Location**: Line 225 in `RestoreServerStateIfNeeded()` method

```csharp
// Block other startup paths (e.g., McpEditorWindow.HandlePostCompileMode) during recovery
ActivateStartupProtection(5000);

// Centralized, coalesced startup request
_ = StartRecoveryIfNeededAsync(savedPort, isAfterCompile, CancellationToken.None)...
```

**How It Works**:
- The `ActivateStartupProtection(5000)` method sets `startupProtectionUntilTicks` to current UTC time + 5 seconds
- Any attempt to start the server via other paths checks this protection flag
- If protection is active, those paths are blocked from proceeding
- Only the recovery flow executes during this window
- After 5 seconds, normal startup paths become available again

## Control Flow Architecture

```
classDiagram
    class McpServerController {
        -long startupProtectionUntilTicks
        +RestoreServerStateIfNeeded()
        +ActivateStartupProtection(milliseconds)
        +StartRecoveryIfNeededAsync()
        -TryRestoreServerWithRetry()
    }
    
    class McpEditorWindow {
        +HandlePostCompileMode()
        -_serverOperations
    }
    
    class McpServerOperations {
        +StartServerInternal()
    }
    
    class McpServerInitializationUseCase {
        +ExecuteAsync()
        -Shows port conflict dialog if port unavailable
    }
    
    McpServerController --> McpServerOperations : blocks during protection window
    McpEditorWindow --> McpServerOperations : guarded by startup protection
    McpServerOperations --> McpServerInitializationUseCase : invokes on startup
```

## Behavior Changes
- **Before**: Port conflict dialogs appeared because both startup paths ran concurrently without synchronization
- **After**: The 5-second protection window ensures only the recovery path proceeds initially; competing paths are serialized after protection expires

## Testing Verification Checklist
- [ ] Port conflict dialog does not appear after compilation
- [ ] Port conflict dialog does not appear on Unity startup  
- [ ] Server recovers successfully on the original port
- [ ] Manual server start/stop works correctly after recovery completes

## Implementation Details
- **Protection Duration**: 5000 milliseconds (sufficient for recovery completion)
- **Scope**: Affects McpServerController's `RestoreServerStateIfNeeded()` flow only
- **No Breaking Changes**: Existing error handling and recovery logic remain unchanged
- **Thread-Safe**: Uses existing `StartupSemaphore` synchronization mechanism

## Code Review Effort Level
Medium - Localized single-file change in startup synchronization logic with straightforward control flow modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->