### PR TITLE
fix: auto-detect Unity project root from subdirectories

### DIFF
--- a/Packages/src/Cli~/src/cli.ts
+++ b/Packages/src/Cli~/src/cli.ts
@@ -19,6 +19,7 @@ import { loadToolsCache, ToolDefinition, ToolProperty } from './tool-cache.js';
 import { pascalToKebabCase } from './arg-parser.js';
 import { registerSkillsCommand } from './skills/skills-command.js';
 import { VERSION } from './version.js';
+import { findUnityProjectRoot } from './project-root.js';
 
 interface CliOptions extends GlobalOptions {
   [key: string]: unknown;
@@ -202,7 +203,11 @@ function extractGlobalOptions(options: Record<string, unknown>): GlobalOptions {
 }
 
 function isDomainReloadLockFilePresent(): boolean {
-  const lockPath = join(process.cwd(), 'Temp', 'domainreload.lock');
+  const projectRoot = findUnityProjectRoot();
+  if (projectRoot === null) {
+    return false;
+  }
+  const lockPath = join(projectRoot, 'Temp', 'domainreload.lock');
   return existsSync(lockPath);
 }
 

--- a/Packages/src/Cli~/src/port-resolver.ts
+++ b/Packages/src/Cli~/src/port-resolver.ts
@@ -5,6 +5,7 @@
 
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { findUnityProjectRoot } from './project-root.js';
 
 const DEFAULT_PORT = 8700;
 
@@ -27,7 +28,11 @@ export async function resolveUnityPort(explicitPort?: number): Promise<number> {
 }
 
 async function readPortFromSettings(): Promise<number | null> {
-  const settingsPath = join(process.cwd(), 'UserSettings/UnityMcpSettings.json');
+  const projectRoot = findUnityProjectRoot();
+  if (projectRoot === null) {
+    return null;
+  }
+  const settingsPath = join(projectRoot, 'UserSettings/UnityMcpSettings.json');
 
   let content: string;
   try {

--- a/Packages/src/Cli~/src/project-root.ts
+++ b/Packages/src/Cli~/src/project-root.ts
@@ -1,0 +1,31 @@
+/**
+ * Unity project root detection utility.
+ * Searches upward from current directory to find Unity project markers.
+ */
+
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+
+/**
+ * Find Unity project root by searching upward from start path.
+ * A Unity project is identified by having both Assets/ and ProjectSettings/ directories.
+ * Returns null if not inside a Unity project.
+ */
+export function findUnityProjectRoot(startPath: string = process.cwd()): string | null {
+  let currentPath = startPath;
+
+  while (true) {
+    const hasAssets = existsSync(join(currentPath, 'Assets'));
+    const hasProjectSettings = existsSync(join(currentPath, 'ProjectSettings'));
+
+    if (hasAssets && hasProjectSettings) {
+      return currentPath;
+    }
+
+    const parentPath = dirname(currentPath);
+    if (parentPath === currentPath) {
+      return null;
+    }
+    currentPath = parentPath;
+  }
+}

--- a/Packages/src/Cli~/src/tool-cache.ts
+++ b/Packages/src/Cli~/src/tool-cache.ts
@@ -6,6 +6,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import defaultToolsData from './default-tools.json';
+import { findUnityProjectRoot } from './project-root.js';
 
 export interface ToolProperty {
   type: string;
@@ -37,7 +38,11 @@ const CACHE_DIR = '.uloop';
 const CACHE_FILE = 'tools.json';
 
 function getCacheDir(): string {
-  return join(process.cwd(), CACHE_DIR);
+  const projectRoot = findUnityProjectRoot();
+  if (projectRoot === null) {
+    return join(process.cwd(), CACHE_DIR);
+  }
+  return join(projectRoot, CACHE_DIR);
 }
 
 function getCachePath(): string {


### PR DESCRIPTION
## Summary

- Add `findUnityProjectRoot()` function to detect Unity project root by searching upward for `Assets/` and `ProjectSettings/` directories
- Update domain reload detection, port settings, and tool cache to use project root detection
- CLI now works correctly when executed from any subdirectory within a Unity project

## Problem

Previously, the CLI assumed it was always executed from the Unity project root directory. When run from subdirectories (e.g., `Assets/Scripts/`), paths became invalid:
- Domain reload detection failed silently
- Port settings couldn't be read
- Tool cache was created in wrong location

## Changes

| File | Change |
|------|--------|
| `project-root.ts` | New module with `findUnityProjectRoot()` |
| `cli.ts` | Use project root for domain reload lock detection |
| `port-resolver.ts` | Use project root for settings file path |
| `tool-cache.ts` | Use project root for `.uloop/` cache directory |

## Test plan

- [x] Run `uloop get-version` from project root - works
- [x] Run `uloop get-version` from `Assets/` subdirectory - works  
- [x] Run `uloop get-version` from `Packages/src/` subdirectory - works
- [x] Run `uloop get-version` from outside project (`/tmp`) - graceful fallback

## References

- Design document: `docs/plans/cli-project-root-detection.md`
- CodeRabbit review comment on PR #443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Auto-Detect Unity Project Root from Subdirectories

## Overview
This PR introduces automatic detection of the Unity project root directory, allowing the CLI to function correctly when executed from project subdirectories rather than requiring execution from the project root. A new utility module searches upward through the directory tree to locate the project root by identifying the presence of `Assets/` and `ProjectSettings/` directories.

## Problem Addressed
Previously, the CLI assumed execution from the Unity project root, causing multiple issues when invoked from subdirectories:
- Domain reload lock detection failed silently (incorrect file path)
- Port settings file was not found (invalid path construction)
- Cache directory was created in the wrong location

## Changes Made

### New File: `project-root.ts`
- Introduces `findUnityProjectRoot(startPath?: string): string | null`
- Traverses upward from a given starting point (defaults to `process.cwd()`)
- Identifies the project root when both `Assets/` and `ProjectSettings/` directories are found
- Returns `null` if no Unity project is detected (graceful fallback)

### Updated Files

**`cli.ts`**
- Replaces hardcoded `process.cwd()` with project root lookup for domain reload lock detection
- Falls back to returning `false` for domain reload checks if project root cannot be determined
- Changes domain reload lock path resolution from CWD to `<projectRoot>/Temp/domainreload.lock`

**`port-resolver.ts`**
- Integrates `findUnityProjectRoot()` to locate the port settings file
- `readPortFromSettings()` now:
  - Returns `null` if project root cannot be determined
  - Constructs the settings path relative to the detected project root instead of CWD
  - Maintains existing behavior for missing/invalid settings files

**`tool-cache.ts`**
- Uses `findUnityProjectRoot()` to locate the `.uloop/` cache directory
- Falls back to CWD if project root is not found
- Cache directory is now created at `<projectRoot>/.uloop/` when possible

## Test Coverage
- ✅ `uloop get-version` executes successfully from:
  - Project root
  - `Assets/` subdirectory
  - `Packages/src/` subdirectory
- ✅ Graceful fallback when executed outside a project (e.g., `/tmp`)

## Impact
- **User Experience**: CLI now works seamlessly from any location within a Unity project
- **Robustness**: Reduces silent failures by establishing explicit project context
- **Backward Compatibility**: Existing project-root execution remains unaffected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->