### PR TITLE
fix: check npm registry instead of release_created for publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -89,15 +89,31 @@ jobs:
           fi
 
       # ── Publish to npm when release is created ──────────────────
+      - name: 🔍 Check if npm publish needed
+        id: check_npm
+        run: |
+          # Get version from CLI package.json
+          CLI_VERSION=$(jq -r '.version' Packages/src/Cli~/package.json)
+          echo "cli_version=${CLI_VERSION}" >> $GITHUB_OUTPUT
+
+          # Check if this version exists on npm
+          if npm view "uloop-cli@${CLI_VERSION}" version 2>/dev/null; then
+            echo "Version ${CLI_VERSION} already published to npm"
+            echo "needs_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version ${CLI_VERSION} not found on npm, will publish"
+            echo "needs_publish=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: 🔧 Setup Node.js for npm publish
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.check_npm.outputs.needs_publish == 'true' }}
         uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: 📦 Publish CLI to npm
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.check_npm.outputs.needs_publish == 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -105,4 +121,4 @@ jobs:
           npm ci
           npm run build
           npm publish --access public --provenance
-          echo "✅ CLI published to npm with provenance"
+          echo "✅ CLI v${{ steps.check_npm.outputs.cli_version }} published to npm with provenance"


### PR DESCRIPTION
## Summary

- Fix npm publish step being skipped even when release exists
- Check npm registry directly instead of relying on `release_created` output

## Problem

The `release_created` output from `release-please-action` is only `true` when a release is newly created **during that specific workflow run**. However:

1. When a Release PR is merged, release-please creates the GitHub release and tag
2. The tag creation triggers another push event → workflow runs again
3. In the second run, `release_created=false` because release already exists
4. npm publish step is skipped forever

This caused `uloop-cli` to never be published to npm despite multiple releases.

## Solution

Instead of checking `release_created`, directly check if the CLI version exists on npm:

```yaml
- name: 🔍 Check if npm publish needed
  run: |
    CLI_VERSION=$(jq -r '.version' Packages/src/Cli~/package.json)
    if npm view "uloop-cli@${CLI_VERSION}" version 2>/dev/null; then
      echo "needs_publish=false" >> $GITHUB_OUTPUT
    else
      echo "needs_publish=true" >> $GITHUB_OUTPUT
    fi
```

## Test plan

After merge:
- [x] Manually published v0.44.1 to npm (verified working)
- [ ] Verify next release auto-publishes via workflow