### PR TITLE
fix(ci): use npm trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -114,11 +114,10 @@ jobs:
 
       - name: 📦 Publish CLI to npm
         if: ${{ steps.check_npm.outputs.needs_publish == 'true' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd Packages/src/Cli~
           npm ci
           npm run build
+          # Uses OIDC trusted publishing - no NPM_TOKEN needed
           npm publish --access public --provenance
           echo "✅ CLI v${{ steps.check_npm.outputs.cli_version }} published to npm with provenance"


### PR DESCRIPTION
## Summary

Switch from NPM_TOKEN to OIDC trusted publishing for npm package publishing.

## Why

- NPM_TOKEN with 2FA enabled requires OTP, which doesn't work in CI
- Classic automation tokens were deprecated by npm on Dec 9, 2025
- Trusted publishing is more secure (no long-lived tokens)

## Changes

- Removed `NODE_AUTH_TOKEN` environment variable from publish step
- npm CLI automatically detects OIDC environment and uses it

## Required: npm Package Settings

**Before merging**, configure trusted publisher on npm:

1. Go to https://www.npmjs.com/package/uloop-cli/settings
2. Click "Add trusted publisher"
3. Fill in:
   - **Organization or user**: `hatayama`
   - **Repository**: `uLoopMCP`
   - **Workflow filename**: `release-please.yml`
4. Save

## Test plan

After npm settings configured and PR merged:
- [ ] Re-run failed workflow or trigger new release
- [ ] Verify npm publish succeeds without token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request switches the npm package publishing mechanism in the CI/CD workflow from using an NPM_TOKEN environment variable to OIDC (OpenID Connect) trusted publishing, which is more secure and eliminates the need for long-lived tokens.

## Changes Made

The only modification is in `.github/workflows/release-please.yml` in the "Publish CLI to npm" step:

- **Removed**: The `env:` section containing `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`
- **Added**: A comment clarifying that OIDC trusted publishing is used and no NPM_TOKEN is needed

The `npm publish --access public --provenance` command remains unchanged and now relies on npm CLI's automatic OIDC detection for authentication.

## Rationale

The shift to OIDC trusted publishing addresses several issues with the previous token-based approach:

1. **NPM Token Limitations**: NPM tokens with 2FA enabled cannot be used in CI environments due to OTP (One-Time Password) requirements
2. **Deprecated Automation Tokens**: npm deprecated classic automation tokens on December 9, 2025
3. **Enhanced Security**: OIDC trusted publishing avoids storing long-lived secrets and leverages GitHub's OIDC provider for secure, temporary credential exchange
4. **Existing Infrastructure**: The workflow already had the required `id-token: write` permission for npm provenance, which is also needed for OIDC

## Required Configuration

Before this PR can be merged and deployed, npm package settings must be manually configured:

1. Navigate to https://www.npmjs.com/package/uloop-cli/settings
2. Click "Add trusted publisher"
3. Configure with:
   - Organization or user: `hatayama`
   - Repository: `uLoopMCP`
   - Workflow filename: `release-please.yml`
4. Save the settings

## Testing

After configuration and merge, verify the fix by:
- Re-running the previously failed workflow, or
- Triggering a new release
- Confirming npm publish succeeds without requiring an NPM_TOKEN

## Impact

- **Breaking Changes**: None. The publish mechanism remains transparent to users.
- **Compatibility**: Requires npm to be updated to a version supporting OIDC (npm v9.0.0+)
- **Dependencies**: No new dependencies introduced

<!-- end of auto-generated comment: release notes by coderabbit.ai -->