### PR TITLE
fix: remove registry-url to enable OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -110,7 +110,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: 📦 Publish CLI to npm
         if: ${{ steps.check_npm.outputs.needs_publish == 'true' }}
@@ -118,6 +117,6 @@ jobs:
           cd Packages/src/Cli~
           npm ci
           npm run build
-          # Uses OIDC trusted publishing - no NPM_TOKEN needed
-          npm publish --access public --provenance
+          # Uses OIDC trusted publishing (no .npmrc or token needed)
+          npm publish --access public --provenance --registry https://registry.npmjs.org
           echo "✅ CLI v${{ steps.check_npm.outputs.cli_version }} published to npm with provenance"


### PR DESCRIPTION
## Summary
- Remove `registry-url` from setup-node step to fix OIDC trusted publishing
- Pass `--registry` option directly to npm publish command

## Problem
When `registry-url` is specified in setup-node, it creates `.npmrc` with:
```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

This placeholder conflicts with OIDC authentication, causing npm to look for `NODE_AUTH_TOKEN` instead of using the OIDC token.

## Solution
Remove `registry-url` from setup-node and specify the registry directly in the npm publish command:
```bash
npm publish --access public --provenance --registry https://registry.npmjs.org
```

## Test plan
- [ ] Merge this PR
- [ ] Re-run the release-please workflow
- [ ] Verify v0.44.2 is published to npm successfully