### PR TITLE
fix: use Node.js 24 and registry-url for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -110,6 +110,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: 📦 Publish CLI to npm
         if: ${{ steps.check_npm.outputs.needs_publish == 'true' }}
@@ -117,6 +118,8 @@ jobs:
           cd Packages/src/Cli~
           npm ci
           npm run build
-          # Uses OIDC trusted publishing (no .npmrc or token needed)
-          npm publish --access public --provenance --registry https://registry.npmjs.org
+          npm install -g npm@latest
+          echo "📋 npm version: $(npm --version)"
+          # Uses OIDC trusted publishing - npm automatically detects OIDC environment
+          npm publish --access public --provenance
           echo "✅ CLI v${{ steps.check_npm.outputs.cli_version }} published to npm with provenance"


### PR DESCRIPTION
## Summary
- Re-add `registry-url` to setup-node for proper OIDC configuration
- Upgrade npm to latest (11.5.1+) required for OIDC trusted publishing
- Keep Node.js 22 (stable LTS)

## Problem
The previous attempt failed with `ENEEDAUTH` error because:
1. **npm version**: OIDC trusted publishing requires npm 11.5.1+, but Node.js 22 ships with npm 10.x
2. **Missing registry-url**: `setup-node`'s `registry-url` is required for OIDC to properly configure npm

Reference: Same approach used in [UnityHubCli](https://github.com/hatayama/UnityHubCli/blob/main/.github/workflows/release-please.yml)

## Changes
- Re-added `registry-url: 'https://registry.npmjs.org'`
- Added `npm install -g npm@latest` to upgrade npm before publish
- Added npm version logging for debugging

## Test plan
- [ ] Merge this PR
- [ ] Re-run the release-please workflow
- [ ] Verify v0.44.2 is published to npm successfully