### PR TITLE
fix(ci): use releases_created (plural) for monorepo support

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,14 +92,14 @@ jobs:
       # This ensures npm publish happens only after Release PR is merged,
       # not on every push to main (which caused version mismatch issues)
       - name: 🔧 Setup Node.js for npm publish
-        if: ${{ steps.release.outputs.release_created == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: 📦 Publish CLI to npm
-        if: ${{ steps.release.outputs.release_created == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: |
           CLI_VERSION=$(jq -r '.version' Packages/src/Cli~/package.json)
           echo "📋 Publishing CLI v${CLI_VERSION} to npm..."


### PR DESCRIPTION
## Summary

Fix npm publish not triggering after Release PR merge.

## Problem

The previous commit used `release_created` (singular) based on CodeRabbit's suggestion, but this was incorrect for our monorepo setup.

- `release_created` (singular) = Only for **root component** releases
- `releases_created` (plural) = For **any** release, including monorepo packages

Since our package is at `Packages/src` (not root), `release_created` was always `false`, causing npm publish to be skipped.

## Fix

Changed condition from:
```yaml
if: ${{ steps.release.outputs.release_created == 'true' }}
```

To:
```yaml
if: ${{ steps.release.outputs.releases_created == 'true' }}
```

## Reference

- [release-please-action outputs documentation](https://github.com/googleapis/release-please-action#outputs)

## Note

This will trigger v0.45.2 release to finally publish the multi-target skills support to npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes npm publish not triggering after a Release PR merge for packages located in a monorepo subpath (Packages/src).

## Problem

The CI workflow previously checked `steps.release.outputs.release_created` (singular), which only indicates root-component releases. For non-root packages in a monorepo, this condition always evaluated to false, causing the npm publish workflow to be skipped.

## Solution

Updated two conditional checks in `.github/workflows/release-please.yml` to use `steps.release.outputs.releases_created` (plural) instead:

1. **Setup Node.js for npm publish** step condition
2. **Publish CLI to npm** step condition

## Impact

By using the plural form `releases_created`, the workflow now responds to any release created in the repository, including releases for monorepo packages. This allows the CLI package located in `Packages/src/Cli~` to be properly published to npm when a release is created, enabling the v0.45.2 release to publish multi-target skills support to npm.

## Technical Details

- **Source of truth**: [release-please-action outputs documentation](https://github.com/googleapis/release-please-action#outputs)
- **Affected files**: `.github/workflows/release-please.yml`
- **Changes**: Conditional logic from `release_created` → `releases_created` (2 occurrences)
- **No functional impact on monorepo structure**: The change is purely a CI configuration fix to properly detect releases across all monorepo packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->