### PR TITLE
fix: add fallback when node validation fails

### DIFF
--- a/Packages/src/Editor/Utils/NodePathResolver.cs
+++ b/Packages/src/Editor/Utils/NodePathResolver.cs
@@ -40,15 +40,12 @@ namespace io.github.hatayama.uLoopMCP
 
         private static string ResolveNodePath()
         {
-            string nodePath = NodeEnvironmentResolver.FindNodePath();
-            if (string.IsNullOrEmpty(nodePath))
+            foreach (string nodePath in NodeEnvironmentResolver.FindAllNodePaths())
             {
-                return null;
-            }
-
-            if (ValidateNodeExecutable(nodePath))
-            {
-                return nodePath;
+                if (ValidateNodeExecutable(nodePath))
+                {
+                    return nodePath;
+                }
             }
 
             return null;


### PR DESCRIPTION
## Overview
Fix "Node.js Not Found" error for users with multiple Node.js installations (e.g., both `/usr/local/bin/node` and nvm).

## Details
### Problem
When a user has multiple Node.js installations, `NodePathResolver` would find the first one (e.g., `/usr/local/bin/node`) and if validation failed for any reason, it would stop and report "Node.js Not Found" - even though a working Node.js existed in nvm or other version managers.

### Solution
- Added `FindAllNodePaths()` method to `NodeEnvironmentResolver` that enumerates all candidate Node.js paths
- Modified `NodePathResolver.ResolveNodePath()` to iterate through all candidates and return the first one that passes validation
- If one candidate fails validation, it now tries the next one instead of giving up

### Changes
- `NodeEnvironmentResolver.cs`: Added `FindAllNodePaths()`, `FindAllExecutablePathsUnix()`, `FindAllExecutablePathsWindows()`, `TryWhereCommandAll()`, `EnumerateVersionManagerPaths()`
- `NodePathResolver.cs`: Modified `ResolveNodePath()` to use fallback logic

## References
- User report: nvm user with v24.12.0 getting "Node.js Not Found" error
- Root cause: `/usr/local/bin/node` existed but had issues, nvm node was not tried as fallback



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Add Fallback When Node Validation Fails

## Problem
Users with multiple Node.js installations (e.g., `/usr/local/bin/node` from a previous installation and an nvm-managed node) were encountering "Node.js Not Found" errors. The resolver would attempt the first discovered path, and if that path failed validation, it would stop immediately without trying other available Node.js installations.

## Solution
Implemented a fallback validation strategy that iterates through all candidate Node.js paths before giving up.

## Key Changes

### NodeEnvironmentResolver.cs
Added comprehensive path enumeration capabilities:

- **New Public API**: `FindAllNodePaths()` - enumerates all candidate Node.js paths across all sources
  
- **Platform-Specific Enumeration**:
  - `FindAllExecutablePathsUnix()` - searches via `which` command, common bin paths (`/usr/local/bin`, `/opt/homebrew/bin`, `/usr/bin`), and version managers
  - `FindAllExecutablePathsWindows()` - searches via `where` command and version managers

- **Command Helpers**:
  - `TryWhereCommandAll()` - returns all paths from Windows `where` command (previously only returned first match)
  - `TryWhereCommand()` - wrapper that returns first result from `TryWhereCommandAll()`

- **Version Manager Support**:
  - `EnumerateVersionManagerPaths()` - yields paths from nvm, volta, asdf, and fnm installations (sorted by version, newest first)
  - `SearchVersionManagerPaths()` - wrapper returning first path from enumerator
  - Supports version managers: `.nvm/versions/node`, `.volta/tools/image/node`, `.asdf/installs/nodejs`, `.local/share/fnm/node-versions`

- **Deduplication**: All enumeration methods use `HashSet<string>` to prevent duplicate paths across sources

### NodePathResolver.cs
Updated validation logic to support fallback:

- `ResolveNodePath()` now:
  - Iterates through all paths from `FindAllNodePaths()`
  - Validates each path by executing `node -v`
  - Returns the first path that passes validation (exit code 0 and version string)
  - Only returns null if all candidates fail validation
  - Previously would stop after first candidate failure

## Flow Architecture

```
NodePathResolver.ResolveNodePath()
  ↓
Iterate: NodeEnvironmentResolver.FindAllNodePaths()
  ├─ Windows: FindAllExecutablePathsWindows()
  │   ├─ TryWhereCommandAll() → [all paths from 'where' command]
  │   └─ EnumerateVersionManagerPaths() → [all version manager paths]
  └─ Unix: FindAllExecutablePathsUnix()
      ├─ TryWhichCommand() → [single path from 'which' command]
      ├─ SearchCommonPaths() → [paths in /usr/local/bin, /opt/homebrew/bin, /usr/bin]
      └─ EnumerateVersionManagerPaths() → [all version manager paths]
  ↓
For each candidate path:
  └─ ValidateNodeExecutable(path) → Check if 'node -v' succeeds
      ├─ Success → Return path
      └─ Failure → Continue to next candidate
  ↓
Return first valid path, or null if none found
```

## Impact
- Users with multiple Node.js installations will now have all candidates validated, preventing false "Node.js Not Found" errors
- Version manager-managed installations (nvm, volta, asdf, fnm) are prioritized within their source category and tried if system installations fail
- Platform-specific search strategies remain optimized (Windows `where`, Unix `which`) while maintaining consistency in fallback behavior
- No breaking changes to public API signatures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->