### PR TITLE
docs: add (Optional) label to shell completion section

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -399,7 +399,7 @@ uloop run-tests --filter-type all
 uloop execute-dynamic-code --code 'using UnityEngine; Debug.Log("Hello from CLI!");'
 ```
 
-### Shell Completion
+### Shell Completion (Optional)
 
 You can install Bash/Zsh/PowerShell completion:
 

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -399,7 +399,7 @@ uloop run-tests --filter-type all
 uloop execute-dynamic-code --code 'using UnityEngine; Debug.Log("Hello from CLI!");'
 ```
 
-### シェル補完
+### シェル補完（オプション）
 
 Bash/Zsh/PowerShell の補完機能をインストールできます：
 


### PR DESCRIPTION
## Overview
Add "(Optional)" label to the shell completion section heading in both English and Japanese README files to clarify that this feature is not required.

## Details
- Updated `README.md`: Changed "### Shell Completion" to "### Shell Completion (Optional)"
- Updated `README_ja.md`: Changed "### シェル補完" to "### シェル補完（オプション）"

## References
N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation Update: Shell Completion Section Labeling and Japanese README Expansion

This PR adds an "(Optional)" label to the Shell Completion section headings in both English and Japanese README files to clarify that this feature is not required for users. Additionally, the Japanese README files are expanded with more detailed usage examples and a new Port Specification section.

### Changes Made

**README.md and Packages/src/README.md (English):**
- Updated the Shell Completion section heading from `### Shell Completion` to `### Shell Completion (Optional)`
- Updated all corresponding table of contents entries to reflect the new heading

**README_ja.md and Packages/src/README_ja.md (Japanese):**
- Updated the Shell Completion section heading from `### シェル補完` to `### シェル補完（オプション）`
- Expanded the shell completion section with explicit installation commands:
  - Auto-detection of shell for completion installation
  - Explicit shell specification for cases where auto-detection fails (e.g., MINGW64)
  - Completion script verification commands
- Added a new "ポート指定" (Port Specification) section describing the use of the `--port` option to manage multiple Unity instances

### Impact

This is a documentation-only change that improves user clarity by:
1. Explicitly indicating that shell completion setup is optional
2. Providing more detailed and practical examples for Japanese documentation users
3. Documenting port configuration for managing multiple instances

No functional code, logic, behavior, or public API declarations were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->