### PR TITLE
docs: clarify Windows shell completion examples in README

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -407,9 +407,9 @@ You can install Bash/Zsh/PowerShell completion:
 # Add completion script to shell config (auto-detects shell)
 uloop completion --install
 
-# Explicitly specify shell (when auto-detection fails, e.g., MINGW64)
-uloop completion --shell bash --install
-uloop completion --shell powershell --install
+# Explicitly specify shell (when auto-detection fails on Windows)
+uloop completion --shell bash --install        # Git Bash / MINGW64
+uloop completion --shell powershell --install  # PowerShell
 
 # Check completion script
 uloop completion

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -407,9 +407,9 @@ Bash/Zsh/PowerShell の補完機能をインストールできます：
 # 補完スクリプトをシェル設定に追加（シェル自動検出）
 uloop completion --install
 
-# シェルを明示的に指定（MINGW64等で自動検出が失敗する場合）
-uloop completion --shell bash --install
-uloop completion --shell powershell --install
+# シェルを明示的に指定（Windows環境で自動検出が失敗する場合）
+uloop completion --shell bash --install        # Git Bash / MINGW64
+uloop completion --shell powershell --install  # PowerShell
 
 # 補完スクリプトを確認
 uloop completion


### PR DESCRIPTION
## Overview
Improve shell completion documentation in README to clarify Windows-specific instructions.

## Details
- Updated both English and Japanese README files
- Clarified that the explicit shell specification is for Windows environments
- Added inline comments to distinguish Git Bash/MINGW64 and PowerShell usage

## Reference
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Shell Completion Documentation Clarification

This PR improves the shell completion setup documentation in both English and Japanese README files to make Windows-specific instructions clearer.

### Changes Made

**README.md (English)**
- Updated the shell completion section comment from generic wording to explicitly state "(when auto-detection fails on Windows)"
- Added inline comments for the explicit shell invocations to clearly identify each command's purpose:
  - `# Git Bash / MINGW64` for the bash shell option
  - `# PowerShell` for the powershell shell option

**README_ja.md (Japanese)**
- Updated the comment to "Windows環境で自動検出が失敗する場合" (when auto-detection fails on Windows environments)
- Added matching inline comments in Japanese context to distinguish:
  - `# Git Bash / MINGW64` for bash installation
  - `# PowerShell` for PowerShell installation

### Documentation Impact

The changes enhance clarity for Windows users by:
1. Explicitly stating that the shell specification examples apply to Windows environments
2. Clearly labeling which command applies to which shell/environment (Git Bash vs PowerShell)
3. Maintaining consistency across both language versions of the documentation

The underlying functionality remains unchanged—only the documentation text and comments were updated to reduce confusion during shell completion setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->