### PR TITLE
fix: delay mcp.json update until Start Server button is pressed

### DIFF
--- a/Packages/src/Editor/UI/McpEditorModel.cs
+++ b/Packages/src/Editor/UI/McpEditorModel.cs
@@ -210,9 +210,6 @@ namespace io.github.hatayama.uLoopMCP
                 supportsRepositoryRootToggle: ui.SupportsRepositoryRootToggle,
                 showRepositoryRootToggle: ui.ShowRepositoryRootToggle));
             McpEditorSettings.SetCustomPort(port);
-
-            // Automatically update all configured MCP editor settings with new port
-            McpPortChangeUpdater.UpdateAllConfigurationsForPortChange(port, "UI port change");
         }
 
         /// <summary>

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -431,6 +431,29 @@ uloop compile --port {target-port}
 > [!NOTE]
 > You can find the port number in each Unity's uLoopMCP Window.
 
+### Claude Code Sandbox Configuration
+
+When using uloop CLI with Claude Code in sandbox mode, you need to allow localhost connections. Add the following to your project's `.claude/settings.local.json`:
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowLocalBinding": true
+    }
+  }
+}
+```
+
+> [!WARNING]
+> **Security Consideration**
+>
+> The `allowLocalBinding: true` setting allows connections to **all** localhost services, not just uloop. This means Claude Code could potentially access any service running on your machine (databases, development servers, Docker API, etc.). If you're running sensitive services on localhost, consider the implications.
+>
+> **Current limitation:** Claude Code does not support port-specific allowlists (e.g., allowing only port 8700). This is an all-or-nothing setting for localhost access.
+
 ## Installation
 
 > [!WARNING]

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -431,6 +431,29 @@ uloop compile --port {target-port}
 > [!NOTE]
 > ポート番号は各Unityの uLoopMCP Window で確認できます。
 
+### Claude Code サンドボックス設定
+
+Claude Codeのサンドボックスモードでuloop CLIを使用する場合、localhost接続を許可する必要があります。プロジェクトの `.claude/settings.local.json` に以下を追加してください：
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowLocalBinding": true
+    }
+  }
+}
+```
+
+> [!WARNING]
+> **セキュリティ上の注意点**
+>
+> `allowLocalBinding: true` 設定はuloopだけでなく、**すべての**localhostサービスへの接続を許可します。これはClaude Codeがマシン上で動作している他のサービス（データベース、開発サーバー、Docker APIなど）にもアクセスできることを意味します。localhostで機密性の高いサービスを実行している場合は、影響を検討してください。
+>
+> **現在の制限事項：** Claude Codeは特定ポートのみを許可するリスト（例：ポート8700のみ許可）をサポートしていません。localhost接続は全許可か全拒否のいずれかです。
+
 ## インストール
 
 > [!WARNING]


### PR DESCRIPTION
## Summary
- Changed port change behavior: mcp.json is now updated only when Start Server button is pressed, not immediately when port number changes in UI
- Added Claude Code sandbox configuration section to README with security considerations

## Test plan
- [ ] Change port number in uLoopMCP window and verify mcp.json is NOT updated
- [ ] Press Start Server and verify mcp.json is updated with new port
- [ ] Verify server starts correctly with updated port

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes the port change behavior in the uLoopMCP editor window and adds documentation for Claude Code sandbox configuration.

### Key Changes

#### 1. Delayed mcp.json Update (McpEditorModel.cs)
**Problem:** Previously, changing the port number in the UI immediately updated all mcp.json configuration files across all configured editors.

**Solution:** Removed the automatic call to `McpPortChangeUpdater.UpdateAllConfigurationsForPortChange()` from the `UpdateCustomPort()` method. Now:
- Port changes in the UI only update the local UI state and editor settings
- mcp.json is updated only when the **Start Server** button is pressed
- `McpConfigAutoUpdater` (already called during server startup) handles all configuration file updates with the new port

This simplifies the control flow and prevents unnecessary file writes while preserving the correct port synchronization when the server is actually started.

#### 2. Documentation Updates (README.md, README_ja.md)
Added a new "Claude Code Sandbox Configuration" section documenting:
- How to enable localhost connections in Claude Code sandbox mode
- Required JSON settings snippet for `.claude/settings.local.json`:
  ```json
  {
    "sandbox": {
      "enabled": true,
      "network": {
        "allowLocalBinding": true
      }
    }
  }
  ```
- Security warnings about the implications of allowing localhost binding to all services (databases, development servers, Docker APIs, etc.)
- Note about Claude Code's current limitation of not supporting per-port whitelisting

### Architecture Context

**Related Components:**
- `McpEditorModel`: UI state management (receives port changes from UI)
- `McpPortChangeUpdater`: Updates mcp.json for all configured editors (now only called from server startup)
- `McpConfigAutoUpdater`: Auto-updates configurations during server initialization when `UpdateAllConfiguredEditors()` is called
- `McpServerOperations`: Calls `McpConfigAutoUpdater` during server startup

```
User changes port in UI
        ↓
McpEditorModel.UpdateCustomPort()
        ├─ Updates UI state
        └─ Persists to EditorSettings
        (mcp.json NOT updated here anymore)
        ↓
User presses Start Server button
        ↓
McpServerOperations starts server
        ↓
McpConfigAutoUpdater.UpdateAllConfiguredEditors(port)
        ↓
Updates mcp.json for all configured editors
```

### Testing Recommendations
- Change port in UI → verify mcp.json is NOT modified
- Press Start Server → verify mcp.json is updated with new port
- Verify server starts correctly with the updated port
- Test with Claude Code sandbox enabled and security warnings acknowledged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->