### PR TITLE
feat(execute-dynamic-code): wrap execution in single Undo group

### DIFF
--- a/Packages/src/Editor/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/Execution/CommandRunner.cs
@@ -129,7 +129,7 @@ namespace io.github.hatayama.uLoopMCP
 
                 using CancellationTokenSource combinedCts = CreateCombinedCancellationTokenSource(context);
 
-                ExecutionResult result = await ExecuteInternalAsync(context, combinedCts.Token, correlationId).ConfigureAwait(false);
+                ExecutionResult result = await ExecuteInternalAsync(context, combinedCts.Token, correlationId);
 
                 LogExecutionComplete(result, correlationId);
 
@@ -360,7 +360,7 @@ namespace io.github.hatayama.uLoopMCP
                     object[] callArgs = BuildArguments(executeAsyncMethod, context.Parameters, cancellationToken);
                     object invoked = executeAsyncMethod.Invoke(instance, callArgs);
 
-                    object awaitedResult = await io.github.hatayama.uLoopMCP.AwaitableHelper.AwaitIfNeeded(invoked).ConfigureAwait(false);
+                    object awaitedResult = await io.github.hatayama.uLoopMCP.AwaitableHelper.AwaitIfNeeded(invoked);
                     string resultString = awaitedResult?.ToString() ?? "";
 
                     return CreateSuccessResult(resultString);


### PR DESCRIPTION
## Summary
All changes made by `execute-dynamic-code` can now be undone with a single **Cmd+Z / Ctrl+Z**.

## Implementation
Wraps both `Execute()` and `ExecuteAsync()` methods in `CommandRunner.cs` with:
- `Undo.SetCurrentGroupName("ExecuteDynamicCode")` at the start
- `Undo.CollapseUndoOperations(undoGroup)` in the finally block

## Why this matters
Previously, each individual operation (create GameObject, add component, modify property) created separate Undo entries. Now they're all collapsed into a single "ExecuteDynamicCode" undo step.

## Test Plan
- [x] `uloop compile` shows 0 errors, 0 warnings
- [ ] Execute dynamic code that creates multiple objects → Cmd+Z undoes all at once
- [ ] Execute dynamic code that modifies multiple objects → Cmd+Z reverts all changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR integrates Unity's Undo system into the `CommandRunner.cs` execution flow so all modifications from dynamic code execution are recorded and collapsed into a single undo operation named "ExecuteDynamicCode". Users can now revert all changes from a single execution with one Cmd+Z / Ctrl+Z.

## Changes Made

**File Modified:** `Packages/src/Editor/Execution/CommandRunner.cs`

### Imports
- Added `using UnityEditor;` to access Unity's Undo API.

### Undo grouping
- Both `Execute()` and `ExecuteAsync()` now:
  - Capture the current undo group at the start: `int undoGroup = Undo.GetCurrentGroup();`
  - Name the group: `Undo.SetCurrentGroupName("ExecuteDynamicCode");`
  - Collapse the group's operations in the finally block: `Undo.CollapseUndoOperations(undoGroup);`

This ensures all operations performed during execution (GameObject creation, component additions, property modifications, etc.) are combined into a single undo entry.

### Async/thread-safety change
- Removed `ConfigureAwait(false)` from `await` calls in `ExecuteAsync()` and `ExecuteInternalAsync()` so continuations (and the finally block that collapses the undo group) run on Unity's main thread. This prevents invoking the Unity Undo API off the main thread.

## Implementation details
- Undo grouping is applied identically to synchronous and asynchronous execution paths.
- The collapse is executed in a finally block to guarantee grouping occurs on success, cancellation, or exception.
- No public method signatures were changed.

## Impact
- User experience: Single-step undo for all changes caused by a dynamic code execution.
- No breaking changes to public APIs.
- Ensures Undo API calls run on Unity's main thread for safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->