### PR TITLE
test: reproduce CS0246 compile error on Linux CI

### DIFF
--- a/.github/workflows/unity-compile-check.yml
+++ b/.github/workflows/unity-compile-check.yml
@@ -1,0 +1,47 @@
+name: Unity Compile Check
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Packages/src/Editor/**/*.cs'
+      - 'Packages/src/Runtime/**/*.cs'
+      - 'Assets/**/*.cs'
+  workflow_dispatch:
+
+jobs:
+  compile-linux:
+    name: Compile Check (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Library folder
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs') }}
+          restore-keys: |
+            Library-
+
+      - name: Run EditMode tests (compile check)
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          unityVersion: 2022.3.62f1
+          testMode: EditMode
+          checkName: Unity Compile Check Results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Test results (EditMode)
+          path: artifacts


### PR DESCRIPTION
## Purpose
This PR tests the Unity compile check CI workflow **BEFORE** applying the fix.

## Expected Result
**CI should FAIL** with CS0246 errors:
```
error CS0246: The type or namespace name 'FocusUnityWindowSchema' could not be found
error CS0246: The type or namespace name 'FocusUnityWindowResponse' could not be found
```

## Root Cause
`FocusUnityWindowSchema.cs` and `FocusUnityWindowResponse.cs` have `#if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN` preprocessor directives, but `FocusUnityWindowTool.cs` references them unconditionally.

On Linux (where neither `UNITY_EDITOR_OSX` nor `UNITY_EDITOR_WIN` is defined), the Schema/Response classes are not compiled, causing the reference error.

## Next Steps
After confirming CI failure, merge #513 which contains the fix.

---
**DO NOT MERGE** - This is for testing purposes only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions workflow to run Unity EditMode compile checks on Linux and intentionally reproduce CS0246 errors. This exposes the Linux-only issue where FocusUnityWindowSchema and FocusUnityWindowResponse are gated by UNITY_EDITOR_OSX/WIN but still referenced.

<sup>Written for commit 378338aa6814b71c93b677dd1b63abd2d2f1afde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds a GitHub Actions workflow to reproduce a CS0246 compile error on Linux CI. It is intentionally marked "DO NOT MERGE" and exists solely to validate the failing CI before applying a fix in a separate PR.

## Changes

**Added file:** `.github/workflows/unity-compile-check.yml`

A new GitHub Actions workflow that performs Unity compile checks:
- **Trigger:** Pull requests targeting `main` branch that modify C# files in `Packages/src/`, or manual workflow dispatch
- **Environment:** Runs on `ubuntu-latest` (Linux)
- **Key steps:**
  1. Checks out repository with Git LFS support
  2. Caches the Unity Library folder based on hash of C# source files
  3. Runs Unity EditMode tests via `game-ci/unity-test-runner` (v4) with:
     - Unity version: `2022.3.62f1`
     - Test mode: `EditMode` (acts as compile check)
     - Uses Unity license from GitHub secrets
  4. Uploads test results as artifact named "Test results (EditMode)"

## Problem Statement

A compile error exists in the FocusUnityWindow module:
- `FocusUnityWindowSchema.cs` and `FocusUnityWindowResponse.cs` are conditionally compiled under `#if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN`
- `FocusUnityWindowTool.cs` references these types unconditionally as generic parameters: `AbstractUnityTool<FocusUnityWindowSchema, FocusUnityWindowResponse>`
- On Linux CI (where neither symbol is defined), the Schema and Response files are not compiled, causing:
  - `error CS0246: The type or namespace name 'FocusUnityWindowSchema' could not be found`
  - `error CS0246: The type or namespace name 'FocusUnityWindowResponse' could not be found`

## Expected Outcome

This workflow is expected to **fail on Linux** with the above CS0246 errors, validating that the CI can detect platform-specific compilation issues. Once the failure is confirmed, PR #513 (containing the fix) will be merged.

## Impact

- No code logic changes
- No impact on production; this is a CI testing infrastructure addition
- Enables detection of platform-specific compilation issues in future PRs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->