### PR TITLE
fix(execute-dynamic-code): rename --no-wait to --fire-and-forget

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParallelExecutionTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParallelExecutionTests.cs
@@ -208,7 +208,7 @@ return ""task2"";
         }
 
         [Test]
-        public async Task NoWaitMode_ReturnsImmediatelyAfterCompile()
+        public async Task FireAndForgetMode_ReturnsImmediatelyAfterCompile()
         {
             // Use simple code that doesn't use Task.Delay (blocked by Restricted security level)
             string code = @"return ""should_not_see_this"";";
@@ -220,16 +220,16 @@ return ""task2"";
                 CancellationToken.None,
                 compileOnly: false,
                 allowParallel: false,
-                noWait: true
+                fireAndForget: true
             );
 
             Assert.IsTrue(result.Success, result.ErrorMessage);
-            Assert.IsNull(result.Result, "NoWait mode should not return execution result");
+            Assert.IsNull(result.Result, "FireAndForget mode should not return execution result");
             Assert.IsTrue(result.Logs.Exists(log => log.Contains("background")), "Logs should mention background execution");
         }
 
         [Test]
-        public async Task NoWaitMode_ReturnsCompileErrorImmediately()
+        public async Task FireAndForgetMode_ReturnsCompileErrorImmediately()
         {
             string invalidCode = @"this is not valid C# code!!!";
 
@@ -240,15 +240,15 @@ return ""task2"";
                 CancellationToken.None,
                 compileOnly: false,
                 allowParallel: false,
-                noWait: true
+                fireAndForget: true
             );
 
-            Assert.IsFalse(result.Success, "Compile error should fail even in NoWait mode");
+            Assert.IsFalse(result.Success, "Compile error should fail even in FireAndForget mode");
             Assert.IsNotNull(result.ErrorMessage, "Should have error message");
         }
 
         [Test]
-        public async Task NoWaitMode_WithAllowParallel_WorksTogether()
+        public async Task FireAndForgetMode_WithAllowParallel_WorksTogether()
         {
             // Use simple code that doesn't use Task.Delay (blocked by Restricted security level)
             string code1 = @"return ""task1"";";
@@ -261,7 +261,7 @@ return ""task2"";
                 CancellationToken.None,
                 compileOnly: false,
                 allowParallel: true,
-                noWait: true
+                fireAndForget: true
             );
 
             Task<ExecutionResult> task2 = _executor.ExecuteCodeAsync(
@@ -271,7 +271,7 @@ return ""task2"";
                 CancellationToken.None,
                 compileOnly: false,
                 allowParallel: true,
-                noWait: true
+                fireAndForget: true
             );
 
             ExecutionResult result1 = await task1;
@@ -279,12 +279,12 @@ return ""task2"";
 
             Assert.IsTrue(result1.Success, result1.ErrorMessage);
             Assert.IsTrue(result2.Success, result2.ErrorMessage);
-            Assert.IsNull(result1.Result, "NoWait should not return execution result");
-            Assert.IsNull(result2.Result, "NoWait should not return execution result");
+            Assert.IsNull(result1.Result, "FireAndForget should not return execution result");
+            Assert.IsNull(result2.Result, "FireAndForget should not return execution result");
         }
 
         [Test]
-        public async Task NoWaitMode_DefaultIsFalse()
+        public async Task FireAndForgetMode_DefaultIsFalse()
         {
             string code = @"return ""sync_result"";";
 
@@ -298,7 +298,7 @@ return ""task2"";
             );
 
             Assert.IsTrue(result.Success, result.ErrorMessage);
-            Assert.AreEqual("sync_result", result.Result, "Default (noWait=false) should return execution result");
+            Assert.AreEqual("sync_result", result.Result, "Default (fireAndForget=false) should return execution result");
         }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParallelExecutionTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParallelExecutionTests.cs
@@ -1,0 +1,211 @@
+#if ULOOPMCP_HAS_ROSLYN
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
+{
+    public class ExecuteDynamicCodeParallelExecutionTests
+    {
+        private IDynamicCodeExecutor _executor;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _executor = Factory.DynamicCodeExecutorFactory.Create(
+                DynamicCodeSecurityLevel.Restricted
+            );
+        }
+
+        [Test]
+        public async Task ExclusiveMode_SecondCallWaitsForFirst_Async()
+        {
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+
+            string blockingCode = @"
+var tcs = (System.Threading.Tasks.TaskCompletionSource<object>)parameters[""param0""];
+await tcs.Task;
+return ""first"";
+";
+
+            string quickCode = @"return ""second"";";
+
+            Task<ExecutionResult> firstTask = _executor.ExecuteCodeAsync(
+                blockingCode,
+                "DynamicCommand",
+                new object[] { tcs },
+                CancellationToken.None,
+                compileOnly: false,
+                allowParallel: false
+            );
+
+            await Task.Delay(100);
+
+            Task<ExecutionResult> secondTask = _executor.ExecuteCodeAsync(
+                quickCode,
+                "DynamicCommand",
+                null,
+                CancellationToken.None,
+                compileOnly: false,
+                allowParallel: false
+            );
+
+            await Task.Delay(100);
+
+            Assert.IsFalse(firstTask.IsCompleted, "First task should still be running");
+            Assert.IsFalse(secondTask.IsCompleted, "Second task should be waiting (exclusive mode)");
+
+            tcs.SetResult(null);
+
+            ExecutionResult firstResult = await firstTask;
+            ExecutionResult secondResult = await secondTask;
+
+            Assert.IsTrue(firstResult.Success, firstResult.ErrorMessage);
+            Assert.AreEqual("first", firstResult.Result);
+            Assert.IsTrue(secondResult.Success, secondResult.ErrorMessage);
+            Assert.AreEqual("second", secondResult.Result);
+        }
+
+        [Test]
+        public async Task ParallelMode_BothTasksRunConcurrently()
+        {
+            TaskCompletionSource<object> tcs1 = new TaskCompletionSource<object>();
+            TaskCompletionSource<object> tcs2 = new TaskCompletionSource<object>();
+
+            string code1 = @"
+var tcs = (System.Threading.Tasks.TaskCompletionSource<object>)parameters[""param0""];
+await tcs.Task;
+return ""task1"";
+";
+
+            string code2 = @"
+var tcs = (System.Threading.Tasks.TaskCompletionSource<object>)parameters[""param0""];
+await tcs.Task;
+return ""task2"";
+";
+
+            Task<ExecutionResult> task1 = _executor.ExecuteCodeAsync(
+                code1,
+                "DynamicCommand",
+                new object[] { tcs1 },
+                CancellationToken.None,
+                compileOnly: false,
+                allowParallel: true
+            );
+
+            Task<ExecutionResult> task2 = _executor.ExecuteCodeAsync(
+                code2,
+                "DynamicCommand",
+                new object[] { tcs2 },
+                CancellationToken.None,
+                compileOnly: false,
+                allowParallel: true
+            );
+
+            await Task.Delay(200);
+
+            Assert.IsFalse(task1.IsCompleted, "Task1 should still be waiting");
+            Assert.IsFalse(task2.IsCompleted, "Task2 should still be waiting (parallel mode allows both)");
+
+            tcs2.SetResult(null);
+            ExecutionResult result2 = await task2;
+
+            Assert.IsFalse(task1.IsCompleted, "Task1 should still be waiting after task2 completes");
+            Assert.IsTrue(result2.Success, result2.ErrorMessage);
+            Assert.AreEqual("task2", result2.Result);
+
+            tcs1.SetResult(null);
+            ExecutionResult result1 = await task1;
+
+            Assert.IsTrue(result1.Success, result1.ErrorMessage);
+            Assert.AreEqual("task1", result1.Result);
+        }
+
+
+        [Test]
+        public async Task ParallelMode_MixedWithExclusive_WorksCorrectly()
+        {
+            string quickCode = @"return ""done"";";
+
+            ExecutionResult result1 = await _executor.ExecuteCodeAsync(
+                quickCode,
+                "DynamicCommand",
+                null,
+                CancellationToken.None,
+                compileOnly: false,
+                allowParallel: true
+            );
+
+            ExecutionResult result2 = await _executor.ExecuteCodeAsync(
+                quickCode,
+                "DynamicCommand",
+                null,
+                CancellationToken.None,
+                compileOnly: false,
+                allowParallel: false
+            );
+
+            ExecutionResult result3 = await _executor.ExecuteCodeAsync(
+                quickCode,
+                "DynamicCommand",
+                null,
+                CancellationToken.None,
+                compileOnly: false,
+                allowParallel: true
+            );
+
+            Assert.IsTrue(result1.Success, result1.ErrorMessage);
+            Assert.IsTrue(result2.Success, result2.ErrorMessage);
+            Assert.IsTrue(result3.Success, result3.ErrorMessage);
+        }
+
+        [Test]
+        public async Task ParallelMode_MultipleSimultaneous_AllComplete()
+        {
+            const int taskCount = 5;
+            List<Task<ExecutionResult>> tasks = new List<Task<ExecutionResult>>();
+
+            for (int i = 0; i < taskCount; i++)
+            {
+                int index = i;
+                string code = $@"return ""result_{index}"";";
+
+                Task<ExecutionResult> task = _executor.ExecuteCodeAsync(
+                    code,
+                    "DynamicCommand",
+                    null,
+                    CancellationToken.None,
+                    compileOnly: false,
+                    allowParallel: true
+                );
+                tasks.Add(task);
+            }
+
+            ExecutionResult[] results = await Task.WhenAll(tasks);
+
+            for (int i = 0; i < taskCount; i++)
+            {
+                Assert.IsTrue(results[i].Success, $"Task {i} failed: {results[i].ErrorMessage}");
+                Assert.AreEqual($"result_{i}", results[i].Result);
+            }
+        }
+
+        [Test]
+        public async Task DefaultParameter_IsExclusiveMode()
+        {
+            string code = @"return ""test"";";
+
+            ExecutionResult result = await _executor.ExecuteCodeAsync(
+                code,
+                "DynamicCommand",
+                null,
+                CancellationToken.None,
+                compileOnly: false
+            );
+
+            Assert.IsTrue(result.Success, result.ErrorMessage);
+        }
+    }
+}
+#endif

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParallelExecutionTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParallelExecutionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52492dd5cfc4d4300a9f203a528425c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
+++ b/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
@@ -422,21 +422,21 @@ describe('CLI E2E Tests (requires running Unity)', () => {
       expect(result.ErrorMessage).toBeTruthy();
     });
 
-    describe('--no-wait mode', () => {
+    describe('--fire-and-forget mode', () => {
       it('should return immediately and execute in background', () => {
         // Step 1: Start background task that creates GameObject after 3 seconds (fire-and-forget)
-        const noWaitResult = runCliJson<{
+        const fireAndForgetResult = runCliJson<{
           Success: boolean;
           Result: string | null;
           Logs: string[];
         }>(
-          `execute-dynamic-code --no-wait --code "await io.github.hatayama.uLoopMCP.TimerDelay.Wait(3000); new UnityEngine.GameObject(\\"${MARKER_OBJECT_NAME}\\");"`,
+          `execute-dynamic-code --fire-and-forget --code "await io.github.hatayama.uLoopMCP.TimerDelay.Wait(3000); new UnityEngine.GameObject(\\"${MARKER_OBJECT_NAME}\\");"`,
         );
 
-        expect(noWaitResult.Success).toBe(true);
-        expect(noWaitResult.Result).toBeFalsy(); // NoWait returns null/empty result
-        // NoWait mode logs contain either "background" or standard success message
-        expect(noWaitResult.Logs.length).toBeGreaterThan(0);
+        expect(fireAndForgetResult.Success).toBe(true);
+        expect(fireAndForgetResult.Result).toBeFalsy(); // FireAndForget returns null/empty result
+        // FireAndForget mode logs contain either "background" or standard success message
+        expect(fireAndForgetResult.Logs.length).toBeGreaterThan(0);
 
         // Step 2: Monitor for the GameObject (waits for result)
         const monitorResult = runCliJson<{ Success: boolean; Result: string }>(
@@ -447,9 +447,9 @@ describe('CLI E2E Tests (requires running Unity)', () => {
         expect(monitorResult.Result).toBe('Found it!');
       });
 
-      it('should return compile error even in no-wait mode', () => {
+      it('should return compile error even in fire-and-forget mode', () => {
         const result = runCliJson<{ Success: boolean; ErrorMessage: string }>(
-          'execute-dynamic-code --no-wait --code "invalid code!!!"',
+          'execute-dynamic-code --fire-and-forget --code "invalid code!!!"',
         );
 
         expect(result.Success).toBe(false);

--- a/Packages/src/Cli~/src/default-tools.json
+++ b/Packages/src/Cli~/src/default-tools.json
@@ -325,7 +325,7 @@
             "description": "Enable parallel execution mode (use with caution - may cause race conditions)",
             "default": false
           },
-          "NoWait": {
+          "FireAndForget": {
             "type": "boolean",
             "description": "Fire-and-forget mode - return after compile, execute in background",
             "default": false

--- a/Packages/src/Cli~/src/default-tools.json
+++ b/Packages/src/Cli~/src/default-tools.json
@@ -319,6 +319,11 @@
           "AutoQualifyUnityTypesOnce": {
             "type": "boolean",
             "description": "Auto-qualify Unity types"
+          },
+          "AllowParallel": {
+            "type": "boolean",
+            "description": "Enable parallel execution mode (use with caution - may cause race conditions)",
+            "default": false
           }
         }
       }

--- a/Packages/src/Cli~/src/default-tools.json
+++ b/Packages/src/Cli~/src/default-tools.json
@@ -324,6 +324,11 @@
             "type": "boolean",
             "description": "Enable parallel execution mode (use with caution - may cause race conditions)",
             "default": false
+          },
+          "NoWait": {
+            "type": "boolean",
+            "description": "Fire-and-forget mode - return after compile, execute in background",
+            "default": false
           }
         }
       }

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeSchema.cs
@@ -95,12 +95,12 @@ Use with async code that doesn't need immediate result feedback.
 
 Behavior:
 - Compile errors ARE returned (compile check happens before return)
-- Runtime errors logged to Unity Console only (use 'uloop get-logs --search-text NoWait')
+- Runtime errors logged to Unity Console only (use 'uloop get-logs --search-text FireAndForget')
 
 Use cases:
 - Long-running monitoring tasks (wait for button to appear)
 - Scheduled actions (wait N seconds then do X)
 - Multiple independent background tasks")]
-        public bool NoWait { get; set; } = false;
+        public bool FireAndForget { get; set; } = false;
     }
 }

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeSchema.cs
@@ -67,5 +67,22 @@ NG:   ""Parameters"": ""{}""")]
   modify your source files.
 - Disable if you prefer manual control.")]
         public bool AutoQualifyUnityTypesOnce { get; set; } = false;
+
+        /// <summary>Enable parallel execution mode</summary>
+        [Description(@"Enable parallel execution mode (default: false).
+
+When false (default): Exclusive execution - safe, sequential processing.
+When true: Allows concurrent execution - faster but requires coordination.
+
+⚠️ CAUTION:
+- Parallel executions on the same GameObjects may cause race conditions
+- Each execution creates its own Undo group
+- Use only for independent operations (e.g., creating different objects in different locations)
+
+Recommended for:
+- Independent read-only operations
+- Creating objects that don't interact with each other
+- Batch operations on separate assets")]
+        public bool AllowParallel { get; set; } = false;
     }
 }

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeSchema.cs
@@ -84,5 +84,23 @@ Recommended for:
 - Creating objects that don't interact with each other
 - Batch operations on separate assets")]
         public bool AllowParallel { get; set; } = false;
+
+        /// <summary>Fire-and-forget mode</summary>
+        [Description(@"Fire-and-forget mode (default: false).
+
+When true: Returns immediately after compile succeeds.
+Execution continues in Unity background - results/errors not returned to CLI.
+
+Use with async code that doesn't need immediate result feedback.
+
+Behavior:
+- Compile errors ARE returned (compile check happens before return)
+- Runtime errors logged to Unity Console only (use 'uloop get-logs --search-text NoWait')
+
+Use cases:
+- Long-running monitoring tasks (wait for button to appear)
+- Scheduled actions (wait N seconds then do X)
+- Multiple independent background tasks")]
+        public bool NoWait { get; set; } = false;
     }
 }

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeTool.cs
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeTool.cs
@@ -107,7 +107,7 @@ See examples at {project_root}/.claude/skills/uloop-execute-dynamic-code/example
                         "Ensure operations do not modify the same GameObjects"
                     );
                 }
-                
+
                 // Level 0: Preempt with unified error (compilation and execution not allowed)
                 if (_currentSecurityLevel == DynamicCodeSecurityLevel.Disabled)
                 {
@@ -176,7 +176,8 @@ See examples at {project_root}/.claude/skills/uloop-execute-dynamic-code/example
                     parametersArray,
                     cancellationToken,
                     parameters.CompileOnly,
-                    parameters.AllowParallel
+                    parameters.AllowParallel,
+                    parameters.NoWait
                 );
 
                 // Optional: auto-insert return retry if missing return likely caused failure (unconditional)
@@ -201,7 +202,8 @@ See examples at {project_root}/.claude/skills/uloop-execute-dynamic-code/example
                             parametersArray,
                             cancellationToken,
                             parameters.CompileOnly,
-                            parameters.AllowParallel
+                            parameters.AllowParallel,
+                            parameters.NoWait
                         );
                         if (retryReturnResult.Success)
                         {
@@ -231,7 +233,8 @@ See examples at {project_root}/.claude/skills/uloop-execute-dynamic-code/example
                                 parametersArray,
                                 cancellationToken,
                                 parameters.CompileOnly,
-                                parameters.AllowParallel
+                                parameters.AllowParallel,
+                                parameters.NoWait
                             );
                             // Prefer retry result if success, otherwise keep original but merge logs
                             if (retryResult.Success)
@@ -259,6 +262,13 @@ See examples at {project_root}/.claude/skills/uloop-execute-dynamic-code/example
                 {
                     if (toolResponse.Logs == null) toolResponse.Logs = new List<string>();
                     toolResponse.Logs.Insert(0, "⚠️ PARALLEL MODE: Race conditions may occur if multiple executions modify the same GameObjects.");
+                }
+
+                // Add no-wait mode warning to response logs
+                if (parameters.NoWait)
+                {
+                    if (toolResponse.Logs == null) toolResponse.Logs = new List<string>();
+                    toolResponse.Logs.Insert(0, "⚠️ NO-WAIT MODE: Execution continues in background. Results/errors will NOT be returned. Check Unity Console: uloop get-logs --search-text NoWait");
                 }
 
                 return toolResponse;

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeTool.cs
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeTool.cs
@@ -177,7 +177,7 @@ See examples at {project_root}/.claude/skills/uloop-execute-dynamic-code/example
                     cancellationToken,
                     parameters.CompileOnly,
                     parameters.AllowParallel,
-                    parameters.NoWait
+                    parameters.FireAndForget
                 );
 
                 // Optional: auto-insert return retry if missing return likely caused failure (unconditional)
@@ -203,7 +203,7 @@ See examples at {project_root}/.claude/skills/uloop-execute-dynamic-code/example
                             cancellationToken,
                             parameters.CompileOnly,
                             parameters.AllowParallel,
-                            parameters.NoWait
+                            parameters.FireAndForget
                         );
                         if (retryReturnResult.Success)
                         {
@@ -234,7 +234,7 @@ See examples at {project_root}/.claude/skills/uloop-execute-dynamic-code/example
                                 cancellationToken,
                                 parameters.CompileOnly,
                                 parameters.AllowParallel,
-                                parameters.NoWait
+                                parameters.FireAndForget
                             );
                             // Prefer retry result if success, otherwise keep original but merge logs
                             if (retryResult.Success)
@@ -264,11 +264,11 @@ See examples at {project_root}/.claude/skills/uloop-execute-dynamic-code/example
                     toolResponse.Logs.Insert(0, "⚠️ PARALLEL MODE: Race conditions may occur if multiple executions modify the same GameObjects.");
                 }
 
-                // Add no-wait mode warning to response logs
-                if (parameters.NoWait)
+                // Add fire-and-forget mode warning to response logs
+                if (parameters.FireAndForget)
                 {
                     if (toolResponse.Logs == null) toolResponse.Logs = new List<string>();
-                    toolResponse.Logs.Insert(0, "⚠️ NO-WAIT MODE: Execution continues in background. Results/errors will NOT be returned. Check Unity Console: uloop get-logs --search-text NoWait");
+                    toolResponse.Logs.Insert(0, "⚠️ FIRE-AND-FORGET MODE: Execution continues in background. Results/errors will NOT be returned. Check Unity Console: uloop get-logs --search-text FireAndForget");
                 }
 
                 return toolResponse;

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/SKILL.md
@@ -20,6 +20,7 @@ uloop execute-dynamic-code --code '<c# code>'
 | `--code` | string | C# code to execute (direct statements, no class wrapper) |
 | `--compile-only` | boolean | Compile without execution |
 | `--auto-qualify-unity-types-once` | boolean | Auto-qualify Unity types |
+| `--allow-parallel` | boolean | Enable parallel execution (⚠️ use with caution) |
 
 ## Code Format
 
@@ -92,3 +93,29 @@ For detailed code examples, refer to these files:
   - Create ScriptableObjects, modify with SerializedObject
 - **Scene operations**: See [examples/scene-operations.md](examples/scene-operations.md)
   - Create/modify GameObjects, set parents, wire references, load scenes
+
+## Parallel Execution Mode
+
+`--allow-parallel` enables concurrent execution of multiple requests.
+
+```bash
+uloop execute-dynamic-code --code 'new GameObject("Object1");' --allow-parallel
+```
+
+### ⚠️ Risks
+
+- **Race conditions**: Simultaneous modifications to the same GameObject may cause unpredictable behavior
+- **Undo complexity**: Each parallel execution creates its own Undo group
+- **Unity API thread safety**: Some Unity APIs are not thread-safe
+
+### When to Use
+
+- Independent operations (e.g., creating objects in different locations)
+- Non-overlapping asset modifications
+- Read-only operations (queries, searches)
+
+### When NOT to Use
+
+- Modifying the same GameObject or component from multiple executions
+- Operations with sequential dependencies
+- Operations that require consistent Editor state

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/SKILL.md
@@ -21,7 +21,7 @@ uloop execute-dynamic-code --code '<c# code>'
 | `--compile-only` | boolean | Compile without execution |
 | `--auto-qualify-unity-types-once` | boolean | Auto-qualify Unity types |
 | `--allow-parallel` | boolean | Enable parallel execution (⚠️ use with caution) |
-| `--no-wait` | boolean | Fire-and-forget mode (return after compile, execute in background) |
+| `--fire-and-forget` | boolean | Fire-and-forget mode (return after compile, execute in background) |
 
 ## Code Format
 
@@ -123,11 +123,11 @@ uloop execute-dynamic-code --code 'new GameObject("Object1");' --allow-parallel
 
 ## Fire-and-Forget Mode
 
-`--no-wait` returns immediately after successful compilation. Execution continues in Unity background.
+`--fire-and-forget` returns immediately after successful compilation. Execution continues in Unity background.
 
 ```bash
 # Start a long-running monitoring task - CLI returns immediately
-uloop execute-dynamic-code --no-wait --allow-parallel --code '
+uloop execute-dynamic-code --fire-and-forget --allow-parallel --code '
 while (GameObject.Find("TargetButton") == null) {
     await Cysharp.Threading.Tasks.UniTask.Delay(100);
 }
@@ -135,7 +135,7 @@ Selection.activeGameObject = GameObject.Find("TargetButton");
 '
 
 # Check execution results in Unity Console
-uloop get-logs --search-text "NoWait"
+uloop get-logs --search-text "FireAndForget"
 ```
 
 ### Behavior
@@ -153,8 +153,8 @@ uloop get-logs --search-text "NoWait"
 ### Checking Background Execution Results
 
 ```bash
-# View recent NoWait execution logs
-uloop get-logs --search-text "NoWait"
+# View recent FireAndForget execution logs
+uloop get-logs --search-text "FireAndForget"
 
 # View all recent logs
 uloop get-logs --max-count 20

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/SKILL.md
@@ -21,6 +21,7 @@ uloop execute-dynamic-code --code '<c# code>'
 | `--compile-only` | boolean | Compile without execution |
 | `--auto-qualify-unity-types-once` | boolean | Auto-qualify Unity types |
 | `--allow-parallel` | boolean | Enable parallel execution (⚠️ use with caution) |
+| `--no-wait` | boolean | Fire-and-forget mode (return after compile, execute in background) |
 
 ## Code Format
 
@@ -119,3 +120,42 @@ uloop execute-dynamic-code --code 'new GameObject("Object1");' --allow-parallel
 - Modifying the same GameObject or component from multiple executions
 - Operations with sequential dependencies
 - Operations that require consistent Editor state
+
+## Fire-and-Forget Mode
+
+`--no-wait` returns immediately after successful compilation. Execution continues in Unity background.
+
+```bash
+# Start a long-running monitoring task - CLI returns immediately
+uloop execute-dynamic-code --no-wait --allow-parallel --code '
+while (GameObject.Find("TargetButton") == null) {
+    await Cysharp.Threading.Tasks.UniTask.Delay(100);
+}
+Selection.activeGameObject = GameObject.Find("TargetButton");
+'
+
+# Check execution results in Unity Console
+uloop get-logs --search-text "NoWait"
+```
+
+### Behavior
+
+- ✅ **Compile errors ARE returned** (compile check happens before return)
+- ⚠️ **Runtime errors logged to Unity Console only** (not returned to CLI)
+- 🔄 **Use with `--allow-parallel`** for multiple background tasks
+
+### Use Cases
+
+- Long-running monitoring tasks (wait for UI element to appear)
+- Scheduled actions (wait N seconds then perform action)
+- Multiple independent background tasks
+
+### Checking Background Execution Results
+
+```bash
+# View recent NoWait execution logs
+uloop get-logs --search-text "NoWait"
+
+# View all recent logs
+uloop get-logs --max-count 20
+```

--- a/Packages/src/Editor/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/Execution/CommandRunner.cs
@@ -127,7 +127,9 @@ namespace io.github.hatayama.uLoopMCP
         {
             foreach (CancellationTokenSource cts in _executionCts.Values)
             {
-                cts.Cancel();
+                // CTS may be disposed by finally block during iteration (race condition with cleanup)
+                try { cts.Cancel(); }
+                catch (ObjectDisposedException) { }
             }
         }
 
@@ -136,7 +138,9 @@ namespace io.github.hatayama.uLoopMCP
         {
             if (_executionCts.TryGetValue(correlationId, out CancellationTokenSource cts))
             {
-                cts.Cancel();
+                // CTS may be disposed by finally block between TryGetValue and Cancel (race condition with cleanup)
+                try { cts.Cancel(); }
+                catch (ObjectDisposedException) { }
             }
         }
 

--- a/Packages/src/Editor/Execution/DynamicCodeExecutor.cs
+++ b/Packages/src/Editor/Execution/DynamicCodeExecutor.cs
@@ -40,7 +40,7 @@ namespace io.github.hatayama.uLoopMCP
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
             bool allowParallel = false,
-            bool noWait = false)
+            bool fireAndForget = false)
         {
             string correlationId = McpConstants.GenerateCorrelationId();
             Stopwatch stopwatch = Stopwatch.StartNew();
@@ -78,8 +78,8 @@ namespace io.github.hatayama.uLoopMCP
                     return CreateCompileOnlySuccessResult(compilationResult, correlationId, stopwatch);
                 }
 
-                // Phase 4: Check NoWait Mode - fire-and-forget execution
-                if (noWait)
+                // Phase 4: Check FireAndForget Mode - fire-and-forget execution
+                if (fireAndForget)
                 {
                     _ = ExecuteInBackgroundAsync(
                         compilationResult.CompiledAssembly,
@@ -97,7 +97,7 @@ namespace io.github.hatayama.uLoopMCP
                         {
                             "✓ Compiled successfully. Execution started in background.",
                             $"CorrelationId: {correlationId}",
-                            "Check Unity Console for execution results: uloop get-logs --search-text NoWait"
+                            "Check Unity Console for execution results: uloop get-logs --search-text FireAndForget"
                         }
                     };
                 }
@@ -229,7 +229,7 @@ namespace io.github.hatayama.uLoopMCP
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
             bool allowParallel = false,
-            bool noWait = false)
+            bool fireAndForget = false)
         {
 #pragma warning restore CS1998
             // Runtime Security Check (also blocks compilation at Level 0)
@@ -265,8 +265,8 @@ namespace io.github.hatayama.uLoopMCP
                     return CreateCompileOnlySuccessResult(compilationResult, correlationId, stopwatch);
                 }
 
-                // Phase 4: Check NoWait Mode - fire-and-forget execution
-                if (noWait)
+                // Phase 4: Check FireAndForget Mode - fire-and-forget execution
+                if (fireAndForget)
                 {
                     _ = ExecuteInBackgroundAsync(
                         compilationResult.CompiledAssembly,
@@ -284,7 +284,7 @@ namespace io.github.hatayama.uLoopMCP
                         {
                             "✓ Compiled successfully. Execution started in background.",
                             $"CorrelationId: {correlationId}",
-                            "Check Unity Console for execution results: uloop get-logs --search-text NoWait"
+                            "Check Unity Console for execution results: uloop get-logs --search-text FireAndForget"
                         }
                     };
                 }
@@ -308,7 +308,7 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
-        /// <summary>Background execution for NoWait mode</summary>
+        /// <summary>Background execution for FireAndForget mode</summary>
         private async Task ExecuteInBackgroundAsync(
             System.Reflection.Assembly compiledAssembly,
             object[] parameters,
@@ -330,7 +330,7 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     VibeLogger.LogInfo(
                         "nowait_execution_complete",
-                        $"[NoWait] Background execution completed: {result.Result}",
+                        $"[FireAndForget] Background execution completed: {result.Result}",
                         new { correlationId, result = result.Result },
                         correlationId
                     );
@@ -339,7 +339,7 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     VibeLogger.LogWarning(
                         "nowait_execution_failed",
-                        $"[NoWait] Background execution failed: {result.ErrorMessage}",
+                        $"[FireAndForget] Background execution failed: {result.ErrorMessage}",
                         new { correlationId, error = result.ErrorMessage },
                         correlationId
                     );
@@ -349,7 +349,7 @@ namespace io.github.hatayama.uLoopMCP
             {
                 VibeLogger.LogError(
                     "nowait_execution_error",
-                    $"[NoWait] Background execution error: {ex.Message}",
+                    $"[FireAndForget] Background execution error: {ex.Message}",
                     new { correlationId, error = ex.Message, stackTrace = ex.StackTrace },
                     correlationId
                 );

--- a/Packages/src/Editor/Execution/DynamicCodeExecutorStub.cs
+++ b/Packages/src/Editor/Execution/DynamicCodeExecutorStub.cs
@@ -26,7 +26,8 @@ namespace io.github.hatayama.uLoopMCP
             object[] parameters = null,
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
-            bool allowParallel = false)
+            bool allowParallel = false,
+            bool noWait = false)
         {
             return CreateRoslynRequiredResult();
         }
@@ -38,7 +39,8 @@ namespace io.github.hatayama.uLoopMCP
             object[] parameters = null,
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
-            bool allowParallel = false)
+            bool allowParallel = false,
+            bool noWait = false)
         {
             return await Task.FromResult(CreateRoslynRequiredResult());
         }

--- a/Packages/src/Editor/Execution/DynamicCodeExecutorStub.cs
+++ b/Packages/src/Editor/Execution/DynamicCodeExecutorStub.cs
@@ -25,7 +25,8 @@ namespace io.github.hatayama.uLoopMCP
             string className = DynamicCodeConstants.DEFAULT_CLASS_NAME,
             object[] parameters = null,
             CancellationToken cancellationToken = default,
-            bool compileOnly = false)
+            bool compileOnly = false,
+            bool allowParallel = false)
         {
             return CreateRoslynRequiredResult();
         }
@@ -36,7 +37,8 @@ namespace io.github.hatayama.uLoopMCP
             string className = DynamicCodeConstants.DEFAULT_CLASS_NAME,
             object[] parameters = null,
             CancellationToken cancellationToken = default,
-            bool compileOnly = false)
+            bool compileOnly = false,
+            bool allowParallel = false)
         {
             return await Task.FromResult(CreateRoslynRequiredResult());
         }

--- a/Packages/src/Editor/Execution/DynamicCodeExecutorStub.cs
+++ b/Packages/src/Editor/Execution/DynamicCodeExecutorStub.cs
@@ -27,7 +27,7 @@ namespace io.github.hatayama.uLoopMCP
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
             bool allowParallel = false,
-            bool noWait = false)
+            bool fireAndForget = false)
         {
             return CreateRoslynRequiredResult();
         }
@@ -40,7 +40,7 @@ namespace io.github.hatayama.uLoopMCP
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
             bool allowParallel = false,
-            bool noWait = false)
+            bool fireAndForget = false)
         {
             return await Task.FromResult(CreateRoslynRequiredResult());
         }

--- a/Packages/src/Editor/Interfaces/IDynamicCodeExecutor.cs
+++ b/Packages/src/Editor/Interfaces/IDynamicCodeExecutor.cs
@@ -16,16 +16,18 @@ namespace io.github.hatayama.uLoopMCP
             string className = DynamicCodeConstants.DEFAULT_CLASS_NAME,
             object[] parameters = null,
             CancellationToken cancellationToken = default,
-            bool compileOnly = false
+            bool compileOnly = false,
+            bool allowParallel = false
         );
 
         /// <summary>Asynchronous code execution</summary>
         System.Threading.Tasks.Task<ExecutionResult> ExecuteCodeAsync(
             string code,
-            string className = DynamicCodeConstants.DEFAULT_CLASS_NAME, 
+            string className = DynamicCodeConstants.DEFAULT_CLASS_NAME,
             object[] parameters = null,
             CancellationToken cancellationToken = default,
-            bool compileOnly = false
+            bool compileOnly = false,
+            bool allowParallel = false
         );
 
 

--- a/Packages/src/Editor/Interfaces/IDynamicCodeExecutor.cs
+++ b/Packages/src/Editor/Interfaces/IDynamicCodeExecutor.cs
@@ -18,7 +18,7 @@ namespace io.github.hatayama.uLoopMCP
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
             bool allowParallel = false,
-            bool noWait = false
+            bool fireAndForget = false
         );
 
         /// <summary>Asynchronous code execution</summary>
@@ -29,7 +29,7 @@ namespace io.github.hatayama.uLoopMCP
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
             bool allowParallel = false,
-            bool noWait = false
+            bool fireAndForget = false
         );
 
 

--- a/Packages/src/Editor/Interfaces/IDynamicCodeExecutor.cs
+++ b/Packages/src/Editor/Interfaces/IDynamicCodeExecutor.cs
@@ -17,7 +17,8 @@ namespace io.github.hatayama.uLoopMCP
             object[] parameters = null,
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
-            bool allowParallel = false
+            bool allowParallel = false,
+            bool noWait = false
         );
 
         /// <summary>Asynchronous code execution</summary>
@@ -27,7 +28,8 @@ namespace io.github.hatayama.uLoopMCP
             object[] parameters = null,
             CancellationToken cancellationToken = default,
             bool compileOnly = false,
-            bool allowParallel = false
+            bool allowParallel = false,
+            bool noWait = false
         );
 
 


### PR DESCRIPTION
## Summary
- Renamed `--no-wait` option to `--fire-and-forget` to fix commander.js negation pattern issue

## Problem
commander.js treats `--no-*` options as negation patterns, converting `--no-wait` to `{wait: false}` instead of `{noWait: true}`. This caused the fire-and-forget mode to never be triggered.

## Solution
Renamed the option from `--no-wait` to `--fire-and-forget` to avoid commander.js special handling while keeping the same functionality.

## Files Changed
- CLI: `default-tools.json`
- C#: Schema, Tool, Interface, Executor, Stub
- Tests: Unit tests, E2E tests
- Docs: SKILL.md

## Test plan
- [x] Unity compilation succeeds
- [x] Unity unit tests pass (9 tests for parallel execution)
- [x] CLI E2E tests pass (fire-and-forget mode tests)
- [x] Manual verification: `--fire-and-forget` returns empty Result with background execution logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR renames the CLI option `--no-wait` to `--fire-and-forget` to resolve a commander.js issue where the negation pattern `--no-wait` was incorrectly converted to `{wait: false}` instead of `{noWait: true}`, preventing the fire-and-forget execution mode from being triggered.

## Changes

### Schema & Configuration
- Added two new boolean properties to `ExecuteDynamicCodeSchema`: `FireAndForget` and `AllowParallel` (both default to false)
- Updated `default-tools.json` to expose these parameters in the CLI tool definition with descriptive guidance

### Core Execution Logic
- **Fire-and-Forget Mode**: Modified `DynamicCodeExecutor` to detect when `fireAndForget=true`, immediately return after compilation (with compile errors surfaced immediately), and execute the code asynchronously in the background without blocking the caller
- **Parallel Execution Support**: Enhanced `CommandRunner` with:
  - Semaphore-based exclusive/parallel mode switching controlled by `allowParallel` parameter
  - Per-execution `CancellationTokenSource` management via correlation IDs
  - New public methods: `Cancel(string correlationId)` and `CancelAll()` for fine-grained cancellation control
  - Running execution count tracking via `RunningCount` property
  - Adaptive undo group naming: `ExecuteDynamicCode-{correlationId}` for parallel, `ExecuteDynamicCode` for exclusive

### Interface Updates
- Updated `IDynamicCodeExecutor` interface to accept `allowParallel` and `fireAndForget` parameters in `ExecuteCode` and `ExecuteCodeAsync` methods
- Updated `ExecuteDynamicCodeTool` to propagate these parameters through the execution pipeline and emit appropriate warnings in logs when modes are activated

### Testing
- Added comprehensive test suite `ExecuteDynamicCodeParallelExecutionTests` with 9 tests covering:
  - Exclusive vs. parallel execution mutual exclusivity
  - Mixed execution modes
  - Fire-and-forget immediate return with background execution
  - Fire-and-forget compile error handling
  - Default parameter behaviors
- Added CLI E2E test coverage for fire-and-forget mode with marker GameObject verification and error scenarios

### Documentation
- Updated `SKILL.md` with new CLI flags `--allow-parallel` and `--fire-and-forget`
- Added "Parallel Execution Mode" section with warnings about race conditions, Undo complexity, and thread safety
- Added "Fire-and-Forget Mode" section describing compile-time error handling, background execution, and usage examples

## Technical Details

The fire-and-forget implementation uses a private `ExecuteInBackgroundAsync` method that launches background execution without awaiting it, allowing immediate return to the caller. Compile errors are caught synchronously before the background task starts, ensuring validation occurs before return. Runtime errors and execution logs are captured asynchronously and logged to the Unity console without surfacing results to the caller.

Parallel execution leverages a `SemaphoreSlim` to conditionally permit concurrent executions when `allowParallel=true`, while maintaining exclusive execution by default. Each execution receives a unique correlation ID for targeted cancellation without affecting other running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->