### PR TITLE
docs(examples): add missing null checks in original example files

### DIFF
--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/examples/prefab-operations.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/examples/prefab-operations.md
@@ -39,6 +39,10 @@ using UnityEditor;
 
 string prefabPath = "Assets/Prefabs/MyCube.prefab";
 GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+if (prefab == null)
+{
+    return $"Prefab not found at {prefabPath}";
+}
 string assetPath = AssetDatabase.GetAssetPath(prefab);
 
 using (PrefabUtility.EditPrefabContentsScope scope = new PrefabUtility.EditPrefabContentsScope(assetPath))
@@ -59,6 +63,10 @@ using UnityEditor;
 
 string prefabPath = "Assets/Prefabs/MyCube.prefab";
 GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+if (prefab == null)
+{
+    return $"Prefab not found at {prefabPath}";
+}
 
 using (PrefabUtility.EditPrefabContentsScope scope = new PrefabUtility.EditPrefabContentsScope(prefabPath))
 {

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/examples/scriptableobject.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/examples/scriptableobject.md
@@ -65,6 +65,10 @@ using UnityEditor;
 
 string path = "Assets/Data/GameSettings.asset";
 ScriptableObject so = AssetDatabase.LoadAssetAtPath<ScriptableObject>(path);
+if (so == null)
+{
+    return $"Asset not found at {path}";
+}
 
 SerializedObject serializedObj = new SerializedObject(so);
 


### PR DESCRIPTION
## Summary
Same fix as PR #524 but for the original files in `Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/examples/`.

The `.claude/skills/` copies were fixed in #524 but the originals were missed.

## Files Changed
- `prefab-operations.md`: Added null checks for "Add Component to Prefab" and "Modify Prefab Properties" examples
- `scriptableobject.md`: Added null check for "Set Int/Float/Bool Properties" example

## Test plan
- [x] Verified changes match the fixes in #524

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing null checks to the original Unity ExecuteDynamicCode examples to prevent errors when prefabs or assets aren’t found. Aligns the originals with the fixes already applied to the .claude/skills copies.

- **Bug Fixes**
  - prefab-operations.md: Added null checks to “Add Component to Prefab” and “Modify Prefab Properties”.
  - scriptableobject.md: Added null check to “Set Int/Float/Bool Properties”.

<sup>Written for commit 17840c7e91cae06cf438f77433f886d17a12cfca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

