### PR TITLE
feat: スキルの発見可能性を改善

### DIFF
--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -20,8 +20,6 @@ uloop execute-dynamic-code --code '<c# code>'
 | `--code` | string | C# code to execute (direct statements, no class wrapper) |
 | `--compile-only` | boolean | Compile without execution |
 | `--auto-qualify-unity-types-once` | boolean | Auto-qualify Unity types |
-| `--allow-parallel` | boolean | Enable parallel execution (⚠️ use with caution) |
-| `--fire-and-forget` | boolean | Fire-and-forget mode (return after compile, execute in background) |
 
 ## Code Format
 
@@ -94,68 +92,3 @@ For detailed code examples, refer to these files:
   - Create ScriptableObjects, modify with SerializedObject
 - **Scene operations**: See [examples/scene-operations.md](examples/scene-operations.md)
   - Create/modify GameObjects, set parents, wire references, load scenes
-
-## Parallel Execution Mode
-
-`--allow-parallel` enables concurrent execution of multiple requests.
-
-```bash
-uloop execute-dynamic-code --code 'new GameObject("Object1");' --allow-parallel
-```
-
-### ⚠️ Risks
-
-- **Race conditions**: Simultaneous modifications to the same GameObject may cause unpredictable behavior
-- **Undo complexity**: Each parallel execution creates its own Undo group
-- **Unity API thread safety**: Some Unity APIs are not thread-safe
-
-### When to Use
-
-- Independent operations (e.g., creating objects in different locations)
-- Non-overlapping asset modifications
-- Read-only operations (queries, searches)
-
-### When NOT to Use
-
-- Modifying the same GameObject or component from multiple executions
-- Operations with sequential dependencies
-- Operations that require consistent Editor state
-
-## Fire-and-Forget Mode
-
-`--fire-and-forget` returns immediately after successful compilation. Execution continues in Unity background.
-
-```bash
-# Start a long-running monitoring task - CLI returns immediately
-uloop execute-dynamic-code --fire-and-forget --allow-parallel --code '
-while (GameObject.Find("TargetButton") == null) {
-    await Cysharp.Threading.Tasks.UniTask.Delay(100);
-}
-Selection.activeGameObject = GameObject.Find("TargetButton");
-'
-
-# Check execution results in Unity Console
-uloop get-logs --search-text "FireAndForget"
-```
-
-### Behavior
-
-- ✅ **Compile errors ARE returned** (compile check happens before return)
-- ⚠️ **Runtime errors logged to Unity Console only** (not returned to CLI)
-- 🔄 **Use with `--allow-parallel`** for multiple background tasks
-
-### Use Cases
-
-- Long-running monitoring tasks (wait for UI element to appear)
-- Scheduled actions (wait N seconds then perform action)
-- Multiple independent background tasks
-
-### Checking Background Execution Results
-
-```bash
-# View recent FireAndForget execution logs
-uloop get-logs --search-text "FireAndForget"
-
-# View all recent logs
-uloop get-logs --max-count 20
-```

--- a/.claude/skills/uloop-execute-dynamic-code/examples/prefab-operations.md
+++ b/.claude/skills/uloop-execute-dynamic-code/examples/prefab-operations.md
@@ -39,10 +39,6 @@ using UnityEditor;
 
 string prefabPath = "Assets/Prefabs/MyCube.prefab";
 GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
-if (prefab == null)
-{
-    return $"Prefab not found at {prefabPath}";
-}
 string assetPath = AssetDatabase.GetAssetPath(prefab);
 
 using (PrefabUtility.EditPrefabContentsScope scope = new PrefabUtility.EditPrefabContentsScope(assetPath))
@@ -63,10 +59,6 @@ using UnityEditor;
 
 string prefabPath = "Assets/Prefabs/MyCube.prefab";
 GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
-if (prefab == null)
-{
-    return $"Prefab not found at {prefabPath}";
-}
 
 using (PrefabUtility.EditPrefabContentsScope scope = new PrefabUtility.EditPrefabContentsScope(prefabPath))
 {

--- a/.claude/skills/uloop-execute-dynamic-code/examples/scriptableobject.md
+++ b/.claude/skills/uloop-execute-dynamic-code/examples/scriptableobject.md
@@ -65,10 +65,6 @@ using UnityEditor;
 
 string path = "Assets/Data/GameSettings.asset";
 ScriptableObject so = AssetDatabase.LoadAssetAtPath<ScriptableObject>(path);
-if (so == null)
-{
-    return $"Asset not found at {path}";
-}
 
 SerializedObject serializedObj = new SerializedObject(so);
 

--- a/.claude/skills/uloop-screenshot/SKILL.md
+++ b/.claude/skills/uloop-screenshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: uloop-capture-window
-description: Capture Unity EditorWindow and save as PNG. Use when you need to: (1) Take a screenshot of Game View, Scene View, Console, Inspector, etc., (2) Capture visual state for debugging or verification, (3) Save editor output as an image file.
+name: uloop-screenshot
+description: Take a screenshot of Unity Editor windows and save as PNG image. Use when you need to: (1) Screenshot the Game View, Scene View, Console, Inspector, or other windows, (2) Capture current visual state for debugging or documentation, (3) Save what the Editor looks like as an image file.
 ---
 
 # uloop capture-window

--- a/Packages/src/Cli~/src/skills/bundled-skills.ts
+++ b/Packages/src/Cli~/src/skills/bundled-skills.ts
@@ -11,7 +11,6 @@
  * To exclude a skill from bundling, add `internal: true` to its frontmatter.
  */
 
-import captureWindowSkill from '../../../Editor/Api/McpTools/CaptureWindow/SKILL.md';
 import clearConsoleSkill from '../../../Editor/Api/McpTools/ClearConsole/SKILL.md';
 import compileSkill from '../../../Editor/Api/McpTools/Compile/SKILL.md';
 import controlPlayModeSkill from '../../../Editor/Api/McpTools/ControlPlayMode/SKILL.md';
@@ -24,6 +23,7 @@ import getLogsSkill from '../../../Editor/Api/McpTools/GetLogs/SKILL.md';
 import getMenuItemsSkill from '../../../Editor/Api/McpTools/GetMenuItems/SKILL.md';
 import getProviderDetailsSkill from '../../../Editor/Api/McpTools/UnitySearchProviderDetails/SKILL.md';
 import runTestsSkill from '../../../Editor/Api/McpTools/RunTests/SKILL.md';
+import screenshotSkill from '../../../Editor/Api/McpTools/CaptureWindow/SKILL.md';
 import unitySearchSkill from '../../../Editor/Api/McpTools/UnitySearch/SKILL.md';
 
 export interface BundledSkill {
@@ -34,11 +34,6 @@ export interface BundledSkill {
 }
 
 export const BUNDLED_SKILLS: BundledSkill[] = [
-  {
-    name: 'uloop-capture-window',
-    dirName: 'uloop-capture-window',
-    content: captureWindowSkill,
-  },
   {
     name: 'uloop-clear-console',
     dirName: 'uloop-clear-console',
@@ -1232,6 +1227,10 @@ using UnityEditor;
 
 string prefabPath = "Assets/Prefabs/MyCube.prefab";
 GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+if (prefab == null)
+{
+    return $"Prefab not found at {prefabPath}";
+}
 string assetPath = AssetDatabase.GetAssetPath(prefab);
 
 using (PrefabUtility.EditPrefabContentsScope scope = new PrefabUtility.EditPrefabContentsScope(assetPath))
@@ -1252,6 +1251,10 @@ using UnityEditor;
 
 string prefabPath = "Assets/Prefabs/MyCube.prefab";
 GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+if (prefab == null)
+{
+    return $"Prefab not found at {prefabPath}";
+}
 
 using (PrefabUtility.EditPrefabContentsScope scope = new PrefabUtility.EditPrefabContentsScope(prefabPath))
 {
@@ -1614,6 +1617,10 @@ using UnityEditor;
 
 string path = "Assets/Data/GameSettings.asset";
 ScriptableObject so = AssetDatabase.LoadAssetAtPath<ScriptableObject>(path);
+if (so == null)
+{
+    return $"Asset not found at {path}";
+}
 
 SerializedObject serializedObj = new SerializedObject(so);
 
@@ -2312,6 +2319,11 @@ return "Changed material color (Undo available)";
     name: 'uloop-run-tests',
     dirName: 'uloop-run-tests',
     content: runTestsSkill,
+  },
+  {
+    name: 'uloop-screenshot',
+    dirName: 'uloop-screenshot',
+    content: screenshotSkill,
   },
   {
     name: 'uloop-unity-search',

--- a/Packages/src/Editor/Api/McpTools/CaptureWindow/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/CaptureWindow/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: uloop-capture-window
-description: Capture Unity EditorWindow and save as PNG. Use when you need to: (1) Take a screenshot of Game View, Scene View, Console, Inspector, etc., (2) Capture visual state for debugging or verification, (3) Save editor output as an image file.
+name: uloop-screenshot
+description: Take a screenshot of Unity Editor windows and save as PNG image. Use when you need to: (1) Screenshot the Game View, Scene View, Console, Inspector, or other windows, (2) Capture current visual state for debugging or documentation, (3) Save what the Editor looks like as an image file.
 ---
 
 # uloop capture-window

--- a/Packages/src/Editor/Api/McpTools/GetLogs/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetLogs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-logs
-description: Retrieve Unity Console logs via uloop CLI. Use when you need to: (1) Check for errors or warnings after operations, (2) Debug runtime issues in Unity Editor, (3) Investigate unexpected behavior or exceptions.
+description: Get Unity Console output including errors, warnings, and Debug.Log messages. Use when you need to: (1) Check for compile errors or runtime exceptions after code changes, (2) See what Debug.Log printed during execution, (3) Find NullReferenceException, MissingComponentException, or other error messages, (4) Investigate why something failed in Unity Editor.
 ---
 
 # uloop get-logs


### PR DESCRIPTION
## 概要

AIがスキルを発見しやすくするため、スキル名と説明文を改善しました。

## 変更内容

### 1. uloop-capture-window → uloop-screenshot にリネーム
- スキル名を一般的な「screenshot」に変更
- description も「Take a screenshot」に変更し、キーワードを追加

### 2. uloop-get-logs の description 改善
- 「Debug.Log」「NullReferenceException」「compile errors」などの具体的なキーワードを追加
- ユーザーが「エラーを確認して」と言った時に発見されやすくなる

## 影響範囲

- CLIコマンド名は変更なし（`uloop capture-window`, `uloop get-logs` のまま）
- スキル名のみ変更（AI向けの表示名）

## 検証方法

新しいClaude Codeセッションで以下を試す：
- 「Unityのスクリーンショットを撮って」→ uloop-screenshot が使用される
- 「Unityのエラーを確認して」→ uloop-get-logs が使用される

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves skill discoverability by renaming the screenshot skill and sharpening descriptions. Helps match common requests like “take a screenshot” and “check errors.”

- **Refactors**
  - Renamed skill name from uloop-capture-window to uloop-screenshot; CLI command stays uloop capture-window.
  - Updated screenshot SKILL descriptions to emphasize “screenshot” and Unity Editor windows.
  - Expanded uloop-get-logs description with keywords like Debug.Log, NullReferenceException, and compile errors.
  - Regenerated bundled-skills.ts to register the new uloop-screenshot skill name.

- **Migration**
  - No CLI changes or breaking updates.

<sup>Written for commit d4b65655345d3bec15c1c0fed2c09150cef7406e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves skill discoverability for AI agents by renaming and enhancing descriptions of two bundled skills.

### Changes Made

1. **Renamed screenshot skill**: `uloop-capture-window` → `uloop-screenshot`
   - Updated skill name and AI-facing metadata in `Packages/src/Editor/Api/McpTools/CaptureWindow/SKILL.md`
   - Updated bundled skill registry in `Packages/src/Cli~/src/skills/bundled-skills.ts` to reference the new name
   - CLI command name (`uloop capture-window`) remains unchanged; only the AI-facing skill identifier changed

2. **Enhanced get-logs skill description**: Updated `Packages/src/Editor/Api/McpTools/GetLogs/SKILL.md`
   - Added specific error-related keywords to the description: "compile errors", "Debug.Log", "NullReferenceException", "MissingComponentException"
   - Expanded use cases to explicitly mention error investigation scenarios
   - Helps AI agents discover this skill when users mention checking errors, exceptions, or logs

### Impact

- **No breaking changes**: CLI command names remain the same; only AI-facing skill names and descriptions are updated
- **Improved AI discoverability**: More natural skill names and keywords help Claude and other AI agents better understand when to use these tools
- **User experience**: AI agents will more naturally suggest taking screenshots and checking logs when appropriate

### Files Modified

- `.claude/skills/uloop-screenshot/SKILL.md` - New skill definition with updated metadata
- `.claude/skills/uloop-get-logs/SKILL.md` - Enhanced description with specific error keywords
- `Packages/src/Cli~/src/skills/bundled-skills.ts` - Updated skill registry entry
- `Packages/src/Editor/Api/McpTools/CaptureWindow/SKILL.md` - Updated skill name field
- `Packages/src/Editor/Api/McpTools/GetLogs/SKILL.md` - Enhanced description

<!-- end of auto-generated comment: release notes by coderabbit.ai -->