### PR TITLE
fix: correct SKILL.md file format

### DIFF
--- a/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-get-project-info/SKILL.md
+++ b/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-get-project-info/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-project-info
-description: Get Unity project information via uloop CLI. Use when you need to: (1) Check Unity Editor version, (2) Get project settings and platform info, (3) Retrieve project metadata for diagnostics.
+description: "Get Unity project information via uloop CLI. Use when you need to: (1) Check Unity Editor version, (2) Get project settings and platform info, (3) Retrieve project metadata for diagnostics."
 internal: true
 ---
 

--- a/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-get-version/SKILL.md
+++ b/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-get-version/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-version
-description: Get Unity and project information via uloop CLI. Use when you need to verify Unity version, check project settings (ProductName, CompanyName, Version), or troubleshoot environment issues.
+description: "Get Unity and project information via uloop CLI. Use when you need to verify Unity version, check project settings (ProductName, CompanyName, Version), or troubleshoot environment issues."
 internal: true
 ---
 

--- a/Packages/src/Editor/Api/McpTools/CaptureWindow/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/CaptureWindow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-screenshot
-description: Take a screenshot of Unity Editor windows and save as PNG image. Use when you need to: (1) Screenshot the Game View, Scene View, Console, Inspector, or other windows, (2) Capture current visual state for debugging or documentation, (3) Save what the Editor looks like as an image file.
+description: "Take a screenshot of Unity Editor windows and save as PNG image. Use when you need to: (1) Screenshot the Game View, Scene View, Console, Inspector, or other windows, (2) Capture current visual state for debugging or documentation, (3) Save what the Editor looks like as an image file."
 ---
 
 # uloop capture-window

--- a/Packages/src/Editor/Api/McpTools/ClearConsole/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ClearConsole/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-clear-console
-description: Clear Unity console logs via uloop CLI. Use when you need to: (1) Clear the console before running tests, (2) Start a fresh debugging session, (3) Clean up log output for better readability.
+description: "Clear Unity console logs via uloop CLI. Use when you need to: (1) Clear the console before running tests, (2) Start a fresh debugging session, (3) Clean up log output for better readability."
 ---
 
 # uloop clear-console

--- a/Packages/src/Editor/Api/McpTools/Compile/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Compile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-compile
-description: Compile Unity project via uloop CLI. Use when you need to: (1) Verify C# code compiles successfully after editing scripts, (2) Check for compile errors or warnings, (3) Validate script changes before running tests.
+description: "Compile Unity project via uloop CLI. Use when you need to: (1) Verify C# code compiles successfully after editing scripts, (2) Check for compile errors or warnings, (3) Validate script changes before running tests."
 ---
 
 # uloop compile

--- a/Packages/src/Editor/Api/McpTools/ControlPlayMode/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ControlPlayMode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-control-play-mode
-description: Control Unity Editor play mode via uloop CLI. Use when you need to: (1) Start play mode for testing, (2) Stop play mode after testing, (3) Pause play mode for debugging.
+description: "Control Unity Editor play mode via uloop CLI. Use when you need to: (1) Start play mode for testing, (2) Stop play mode after testing, (3) Pause play mode for debugging."
 ---
 
 # uloop control-play-mode

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-execute-dynamic-code
-description: Execute C# code dynamically in Unity Editor via uloop CLI. Use for editor automation: (1) Prefab/material wiring and AddComponent operations, (2) Reference wiring with SerializedObject, (3) Scene/hierarchy edits and batch operations. NOT for file I/O or script authoring.
+description: "Execute C# code dynamically in Unity Editor via uloop CLI. Use for editor automation: (1) Prefab/material wiring and AddComponent operations, (2) Reference wiring with SerializedObject, (3) Scene/hierarchy edits and batch operations. NOT for file I/O or script authoring."
 ---
 
 # uloop execute-dynamic-code

--- a/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-execute-menu-item
-description: Execute Unity MenuItem via uloop CLI. Use when you need to: (1) Trigger menu commands programmatically, (2) Automate editor actions (save, build, refresh), (3) Run custom menu items defined in scripts.
+description: "Execute Unity MenuItem via uloop CLI. Use when you need to: (1) Trigger menu commands programmatically, (2) Automate editor actions (save, build, refresh), (3) Run custom menu items defined in scripts."
 ---
 
 # uloop execute-menu-item

--- a/Packages/src/Editor/Api/McpTools/FindGameObjects/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/FindGameObjects/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-find-game-objects
-description: Find GameObjects with search criteria via uloop CLI. Use when you need to: (1) Locate GameObjects by name pattern, (2) Find objects by tag or layer, (3) Search for objects with specific component types.
+description: "Find GameObjects with search criteria via uloop CLI. Use when you need to: (1) Locate GameObjects by name pattern, (2) Find objects by tag or layer, (3) Search for objects with specific component types."
 ---
 
 # uloop find-game-objects

--- a/Packages/src/Editor/Api/McpTools/FocusUnityWindow/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/FocusUnityWindow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-focus-window
-description: Bring Unity Editor window to front via uloop CLI. Use when you need to: (1) Focus Unity Editor before capturing screenshots, (2) Ensure Unity window is visible for visual checks, (3) Bring Unity to foreground for user interaction.
+description: "Bring Unity Editor window to front via uloop CLI. Use when you need to: (1) Focus Unity Editor before capturing screenshots, (2) Ensure Unity window is visible for visual checks, (3) Bring Unity to foreground for user interaction."
 ---
 
 # uloop focus-window

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-hierarchy
-description: Get Unity Hierarchy structure via uloop CLI. Use when you need to: (1) Inspect scene structure and GameObject tree, (2) Find GameObjects and their parent-child relationships, (3) Check component attachments on objects.
+description: "Get Unity Hierarchy structure via uloop CLI. Use when you need to: (1) Inspect scene structure and GameObject tree, (2) Find GameObjects and their parent-child relationships, (3) Check component attachments on objects."
 ---
 
 # uloop get-hierarchy

--- a/Packages/src/Editor/Api/McpTools/GetLogs/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetLogs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-logs
-description: Get Unity Console output including errors, warnings, and Debug.Log messages. Use when you need to: (1) Check for compile errors or runtime exceptions after code changes, (2) See what Debug.Log printed during execution, (3) Find NullReferenceException, MissingComponentException, or other error messages, (4) Investigate why something failed in Unity Editor.
+description: "Get Unity Console output including errors, warnings, and Debug.Log messages. Use when you need to: (1) Check for compile errors or runtime exceptions after code changes, (2) See what Debug.Log printed during execution, (3) Find NullReferenceException, MissingComponentException, or other error messages, (4) Investigate why something failed in Unity Editor."
 ---
 
 # uloop get-logs

--- a/Packages/src/Editor/Api/McpTools/GetMenuItems/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetMenuItems/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-menu-items
-description: Retrieve Unity MenuItems via uloop CLI. Use when you need to: (1) Discover available menu commands in Unity Editor, (2) Find menu paths for automation, (3) Prepare for executing menu items programmatically.
+description: "Retrieve Unity MenuItems via uloop CLI. Use when you need to: (1) Discover available menu commands in Unity Editor, (2) Find menu paths for automation, (3) Prepare for executing menu items programmatically."
 ---
 
 # uloop get-menu-items

--- a/Packages/src/Editor/Api/McpTools/RunTests/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/RunTests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-run-tests
-description: Execute Unity Test Runner via uloop CLI. Use when you need to: (1) Run unit tests (EditMode tests), (2) Run integration tests (PlayMode tests), (3) Verify code changes don't break existing functionality.
+description: "Execute Unity Test Runner via uloop CLI. Use when you need to: (1) Run unit tests (EditMode tests), (2) Run integration tests (PlayMode tests), (3) Verify code changes don't break existing functionality."
 ---
 
 # uloop run-tests

--- a/Packages/src/Editor/Api/McpTools/UnitySearch/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/UnitySearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-unity-search
-description: Search Unity project via uloop CLI. Use when you need to: (1) Find assets by name or type (scenes, prefabs, scripts, materials), (2) Search for project resources using Unity's search system, (3) Locate files within the Unity project.
+description: "Search Unity project via uloop CLI. Use when you need to: (1) Find assets by name or type (scenes, prefabs, scripts, materials), (2) Search for project resources using Unity's search system, (3) Locate files within the Unity project."
 ---
 
 # uloop unity-search

--- a/Packages/src/Editor/Api/McpTools/UnitySearchProviderDetails/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/UnitySearchProviderDetails/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-provider-details
-description: Get Unity Search provider details via uloop CLI. Use when you need to: (1) Discover available search providers, (2) Understand search capabilities and filters, (3) Configure searches with specific provider options.
+description: "Get Unity Search provider details via uloop CLI. Use when you need to: (1) Discover available search providers, (2) Understand search capabilities and filters, (3) Configure searches with specific provider options."
 ---
 
 # uloop get-provider-details


### PR DESCRIPTION
## Summary
- Fix formatting issues in SKILL.md files across 16 skill definitions
- Ensures consistent format for skill discoverability

## Changes
- CLI-only skills: uloop-get-project-info, uloop-get-version
- MCP tools: CaptureWindow, ClearConsole, Compile, ControlPlayMode, ExecuteDynamicCode, ExecuteMenuItem, FindGameObjects, FocusUnityWindow, GetHierarchy, GetLogs, GetMenuItems, RunTests, UnitySearch, UnitySearchProviderDetails

## Test Plan
- [x] Verify SKILL.md files are properly formatted
- [ ] Confirm skills are correctly discovered by Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quoted the description field in SKILL.md front matter across 16 skills to fix parsing issues. This makes skill discovery consistent and reliable.

- **Bug Fixes**
  - Updated 16 SKILL.md files (2 CLI-only, 14 MCP tools) to quote description values.
  - Prevents YAML parse errors from colons/parentheses and restores skill discoverability.

<sup>Written for commit 4bccdb959630d260f34df4531799f4a8fee8444a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR corrects formatting inconsistencies in SKILL.md files across 16 skill definitions to ensure consistent format for skill discoverability by Claude Code.

## Changes

All changes involve converting the `description` field in YAML front matter from unquoted strings to properly quoted strings. This affects:

**CLI-only skills (2 files):**
- `uloop-get-project-info`
- `uloop-get-version`

**MCP tools (14 files):**
- CaptureWindow
- ClearConsole
- Compile
- ControlPlayMode
- ExecuteDynamicCode
- ExecuteMenuItem
- FindGameObjects
- FocusUnityWindow
- GetHierarchy
- GetLogs
- GetMenuItems
- RunTests
- UnitySearch
- UnitySearchProviderDetails

## Technical Details

Each SKILL.md file has exactly one line changed: the `description` field value was converted from an unquoted scalar to a double-quoted string in the YAML front matter. For example:

**Before:**
```yaml
description: Get Unity...
```

**After:**
```yaml
description: "Get Unity..."
```

The actual description text content remains unchanged—only the YAML syntax/formatting has been corrected. This ensures consistent parsing and proper metadata formatting for skill discovery mechanisms.

## Impact

- **No semantic changes:** Description content is identical before and after
- **Metadata standardization:** Ensures all SKILL.md files follow consistent YAML formatting conventions
- **Skill discoverability:** Corrects formatting to enable proper skill discovery by Claude Code
- **16 files affected:** +16/-16 lines across all skill definition files

## Test Plan Status

- ✓ SKILL.md files formatting verified
- ⏳ Pending confirmation of proper skill discovery by Claude Code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->