### PR TITLE
fix: Delete Unnecessary Files

### DIFF
--- a/Packages/src/Editor/Api/McpTools/CaptureUnityWindow.meta
+++ b/Packages/src/Editor/Api/McpTools/CaptureUnityWindow.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: c98e3b68742d54b6893cfdd6ea85d0d1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused Unity .meta file at Packages/src/Editor/Api/McpTools/CaptureUnityWindow.meta to clean up the project and prevent folder asset/import warnings.

<sup>Written for commit 24ec41ad7afc6612f2fed498bb2423ec2074d78b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

