### PR TITLE
chore: add unicon

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "com.boxqkrtm.ide.cursor": "https://github.com/boxqkrtm/com.unity.ide.cursor.git",
+    "com.mattun.unicon": "1.2.5",
     "com.unity.ext.nunit": "2.0.3",
     "com.unity.ide.rider": "3.0.36",
     "com.unity.ide.visualstudio": "2.0.23",
@@ -14,7 +15,8 @@
       "name": "OpenUPM",
       "url": "https://package.openupm.com",
       "scopes": [
-        "org.nuget"
+        "org.nuget",
+        "com.mattun.unicon"
       ]
     }
   ]

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -9,6 +9,13 @@
       },
       "hash": "38fecf55e4fd94ccfe58a92ed8ad1a529ba1694e"
     },
+    "com.mattun.unicon": {
+      "version": "1.2.5",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
     "com.unity.ext.nunit": {
       "version": "2.0.3",
       "depth": 0,

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -31,6 +31,7 @@ MonoBehaviour:
     m_Url: https://package.openupm.com
     m_Scopes:
     - org.nuget
+    - com.mattun.unicon
     m_IsDefault: 0
     m_Capabilities: 0
     m_ConfigSource: 4


### PR DESCRIPTION
Unicon
https://github.com/AtaruMatsudaira/Unicon

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the Unicon package to the Unity project via OpenUPM so it’s available for use.

- **Dependencies**
  - Added com.mattun.unicon 1.2.5 to manifest.json.
  - Added com.mattun.unicon scope to the OpenUPM registry in PackageManagerSettings.asset.
  - Updated packages-lock.json.

<sup>Written for commit 4b38364da2f570701f849ba0a4980fa4be1b6d15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds the Unicon package as a new dependency to the project. Unicon (version 1.2.5) is sourced from OpenUPM and is a Unity package available at https://github.com/AtaruMatsudaira/Unicon.

## Changes

### Package Configuration Updates
- **Packages/manifest.json**: Added `com.mattun.unicon` (v1.2.5) as a new dependency and included it in the OpenUPM scoped registries scopes
- **Packages/packages-lock.json**: Added corresponding package lock entry for `com.mattun.unicon` with version 1.2.5, pointing to the OpenUPM registry (https://package.openupm.com)

### Impact
- Introduces a new runtime dependency to the project
- No changes to exported/public API declarations
- Lock file updated to ensure reproducible builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->