### PR TITLE
fix: change IncludeStackTrace default value from true to false in get-logs

### DIFF
--- a/.claude/skills/uloop-get-logs/SKILL.md
+++ b/.claude/skills/uloop-get-logs/SKILL.md
@@ -20,7 +20,7 @@ uloop get-logs [options]
 | `--log-type` | string | `All` | Log type filter: `Error`, `Warning`, `Log`, `All` |
 | `--max-count` | integer | `100` | Maximum number of logs to retrieve |
 | `--search-text` | string | - | Text to search within logs |
-| `--include-stack-trace` | boolean | `true` | Include stack trace in output |
+| `--include-stack-trace` | boolean | `false` | Include stack trace in output |
 | `--use-regex` | boolean | `false` | Use regex for search |
 | `--search-in-stack-trace` | boolean | `false` | Search within stack trace |
 

--- a/.codex/skills/uloop-get-logs/SKILL.md
+++ b/.codex/skills/uloop-get-logs/SKILL.md
@@ -20,7 +20,7 @@ uloop get-logs [options]
 | `--log-type` | string | `All` | Log type filter: `Error`, `Warning`, `Log`, `All` |
 | `--max-count` | integer | `100` | Maximum number of logs to retrieve |
 | `--search-text` | string | - | Text to search within logs |
-| `--include-stack-trace` | boolean | `true` | Include stack trace in output |
+| `--include-stack-trace` | boolean | `false` | Include stack trace in output |
 | `--use-regex` | boolean | `false` | Use regex for search |
 | `--search-in-stack-trace` | boolean | `false` | Search within stack trace |
 

--- a/Packages/src/Cli~/src/default-tools.json
+++ b/Packages/src/Cli~/src/default-tools.json
@@ -43,7 +43,7 @@
           "IncludeStackTrace": {
             "type": "boolean",
             "description": "Include stack trace in output",
-            "default": true
+            "default": false
           },
           "UseRegex": {
             "type": "boolean",

--- a/Packages/src/Editor/Api/McpTools/GetLogs/GetLogsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/GetLogs/GetLogsSchema.cs
@@ -53,6 +53,6 @@ namespace io.github.hatayama.uLoopMCP
         /// Whether to display stack trace
         /// </summary>
         [Description("Whether to display stack trace")]
-        public bool IncludeStackTrace { get; set; } = true;
+        public bool IncludeStackTrace { get; set; } = false;
     }
 } 

--- a/Packages/src/Editor/Api/McpTools/GetLogs/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetLogs/Skill/SKILL.md
@@ -20,7 +20,7 @@ uloop get-logs [options]
 | `--log-type` | string | `All` | Log type filter: `Error`, `Warning`, `Log`, `All` |
 | `--max-count` | integer | `100` | Maximum number of logs to retrieve |
 | `--search-text` | string | - | Text to search within logs |
-| `--include-stack-trace` | boolean | `true` | Include stack trace in output |
+| `--include-stack-trace` | boolean | `false` | Include stack trace in output |
 | `--use-regex` | boolean | `false` | Use regex for search |
 | `--search-in-stack-trace` | boolean | `false` | Search within stack trace |
 


### PR DESCRIPTION
## Summary
- Change `IncludeStackTrace` default value from `true` to `false` in `get-logs` command
- Stack traces are verbose and often unnecessary for routine log checking
- Users can still enable them with `--include-stack-trace` option when needed

## Changed files
- `GetLogsSchema.cs` - C# schema default value
- `default-tools.json` - CLI tool definition
- `SKILL.md` (3 files) - Documentation updates

## Test plan
- [x] Unity compilation passes with no errors/warnings
- [x] CLI build and lint pass
- [x] CLI E2E tests pass (39 tests)
- [x] Unity Test Runner: `GetLogsUseCaseTests` (16 tests pass)
- [x] Unity Test Runner: `ConsoleLogRetrieverTests` (11 tests pass)
- [x] MCP tool verification: default returns `IncludeStackTrace: false` with `StackTrace: null`
- [x] MCP tool verification: `IncludeStackTrace: true` returns full stack traces

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set IncludeStackTrace default to false in get-logs to reduce noisy output during routine log checks. Users can still opt in with --include-stack-trace; schema, CLI tool config, and docs updated.

<sup>Written for commit a95f07221f464dd77a560090b861d9060c7dce80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR Summary: Change IncludeStackTrace Default from true to false in get-logs

## Overview
This PR changes the default behavior of the `get-logs` command by setting the `IncludeStackTrace` parameter default from `true` to `false`. Stack traces are verbose and often unnecessary for routine log checking; users can now explicitly enable them using the `--include-stack-trace` flag when needed.

## Changes Made

### Schema & Configuration Updates
- **GetLogsSchema.cs**: Modified the `IncludeStackTrace` property default value from `true` to `false`
- **default-tools.json**: Updated the `get-logs` tool's `IncludeStackTrace` parameter default from `true` to `false`

### Documentation Updates
- **.claude/skills/uloop-get-logs/SKILL.md**: Updated parameter table to reflect new default (`false`)
- **.codex/skills/uloop-get-logs/SKILL.md**: Updated parameter table to reflect new default (`false`)
- **Packages/src/Editor/Api/McpTools/GetLogs/Skill/SKILL.md**: Updated parameter table to reflect new default (`false`)

## Impact
- **Behavior Change**: When users call `get-logs` without explicitly specifying `--include-stack-trace`, stack traces will no longer be included in the output
- **User Experience**: Reduced verbosity in routine log retrieval, making logs more concise and easier to scan
- **Opt-in Enhancement**: Users requiring stack traces can explicitly enable them by passing `--include-stack-trace true`

## Testing Status
All tests pass successfully:
- Unity compilation: No errors/warnings
- CLI build and lint: Pass
- CLI E2E tests: 39 tests pass
- Unity Test Runner (GetLogsUseCaseTests): 16 tests pass
- Unity Test Runner (ConsoleLogRetrieverTests): 11 tests pass
- MCP tool verification: Confirmed default returns `IncludeStackTrace: false` with `StackTrace: null`
- MCP tool verification: Confirmed `IncludeStackTrace: true` still returns full stack traces when explicitly requested

<!-- end of auto-generated comment: release notes by coderabbit.ai -->