### PR TITLE
fix: add --no-xxx options for default-true boolean parameters in CLI

### DIFF
--- a/.claude/skills/uloop-execute-menu-item/SKILL.md
+++ b/.claude/skills/uloop-execute-menu-item/SKILL.md
@@ -18,7 +18,7 @@ uloop execute-menu-item --menu-item-path "<path>"
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--menu-item-path` | string | - | Menu item path (e.g., "GameObject/Create Empty") |
-| `--use-reflection-fallback` | boolean | `true` | Use reflection fallback |
+| `--use-reflection-fallback` | boolean | `true` | Use reflection fallback (use `--no-use-reflection-fallback` to disable) |
 
 ## Examples
 

--- a/.claude/skills/uloop-get-hierarchy/SKILL.md
+++ b/.claude/skills/uloop-get-hierarchy/SKILL.md
@@ -19,8 +19,8 @@ uloop get-hierarchy [options]
 |-----------|------|---------|-------------|
 | `--root-path` | string | - | Root GameObject path to start from |
 | `--max-depth` | integer | `-1` | Maximum depth (-1 for unlimited) |
-| `--include-components` | boolean | `true` | Include component information |
-| `--include-inactive` | boolean | `true` | Include inactive GameObjects |
+| `--include-components` | boolean | `true` | Include component information (use `--no-include-components` to disable) |
+| `--include-inactive` | boolean | `true` | Include inactive GameObjects (use `--no-include-inactive` to disable) |
 | `--include-paths` | boolean | `false` | Include full path information |
 
 ## Examples
@@ -36,7 +36,10 @@ uloop get-hierarchy --root-path "Canvas/UI"
 uloop get-hierarchy --max-depth 2
 
 # Without components
-uloop get-hierarchy --include-components false
+uloop get-hierarchy --no-include-components
+
+# Exclude inactive GameObjects
+uloop get-hierarchy --no-include-inactive
 ```
 
 ## Output

--- a/.claude/skills/uloop-get-provider-details/SKILL.md
+++ b/.claude/skills/uloop-get-provider-details/SKILL.md
@@ -19,8 +19,8 @@ uloop get-provider-details [options]
 |-----------|------|---------|-------------|
 | `--provider-id` | string | - | Specific provider ID to query |
 | `--active-only` | boolean | `false` | Only show active providers |
-| `--include-descriptions` | boolean | `true` | Include descriptions |
-| `--sort-by-priority` | boolean | `true` | Sort by priority |
+| `--include-descriptions` | boolean | `true` | Include descriptions (use `--no-include-descriptions` to disable) |
+| `--sort-by-priority` | boolean | `true` | Sort by priority (use `--no-sort-by-priority` to disable) |
 
 ## Examples
 

--- a/.claude/skills/uloop-hello-world/SKILL.md
+++ b/.claude/skills/uloop-hello-world/SKILL.md
@@ -19,7 +19,7 @@ uloop hello-world [options]
 |-----------|------|---------|-------------|
 | `--name` | string | `World` | Name to greet |
 | `--language` | string | `english` | Language for greeting: `english`, `japanese`, `spanish`, `french` |
-| `--include-timestamp` | boolean | `true` | Whether to include timestamp in response |
+| `--include-timestamp` | boolean | `true` | Whether to include timestamp in response (use `--no-include-timestamp` to disable) |
 
 ## Examples
 
@@ -34,7 +34,7 @@ uloop hello-world --name "Alice"
 uloop hello-world --name "太郎" --language japanese
 
 # Spanish greeting without timestamp
-uloop hello-world --name "Carlos" --language spanish --include-timestamp false
+uloop hello-world --name "Carlos" --language spanish --no-include-timestamp
 ```
 
 ## Output

--- a/.codex/skills/uloop-execute-menu-item/SKILL.md
+++ b/.codex/skills/uloop-execute-menu-item/SKILL.md
@@ -18,7 +18,7 @@ uloop execute-menu-item --menu-item-path "<path>"
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--menu-item-path` | string | - | Menu item path (e.g., "GameObject/Create Empty") |
-| `--use-reflection-fallback` | boolean | `true` | Use reflection fallback |
+| `--use-reflection-fallback` | boolean | `true` | Use reflection fallback (use `--no-use-reflection-fallback` to disable) |
 
 ## Examples
 

--- a/.codex/skills/uloop-get-hierarchy/SKILL.md
+++ b/.codex/skills/uloop-get-hierarchy/SKILL.md
@@ -19,8 +19,8 @@ uloop get-hierarchy [options]
 |-----------|------|---------|-------------|
 | `--root-path` | string | - | Root GameObject path to start from |
 | `--max-depth` | integer | `-1` | Maximum depth (-1 for unlimited) |
-| `--include-components` | boolean | `true` | Include component information |
-| `--include-inactive` | boolean | `true` | Include inactive GameObjects |
+| `--include-components` | boolean | `true` | Include component information (use `--no-include-components` to disable) |
+| `--include-inactive` | boolean | `true` | Include inactive GameObjects (use `--no-include-inactive` to disable) |
 | `--include-paths` | boolean | `false` | Include full path information |
 
 ## Examples
@@ -36,7 +36,10 @@ uloop get-hierarchy --root-path "Canvas/UI"
 uloop get-hierarchy --max-depth 2
 
 # Without components
-uloop get-hierarchy --include-components false
+uloop get-hierarchy --no-include-components
+
+# Exclude inactive GameObjects
+uloop get-hierarchy --no-include-inactive
 ```
 
 ## Output

--- a/.codex/skills/uloop-get-provider-details/SKILL.md
+++ b/.codex/skills/uloop-get-provider-details/SKILL.md
@@ -19,8 +19,8 @@ uloop get-provider-details [options]
 |-----------|------|---------|-------------|
 | `--provider-id` | string | - | Specific provider ID to query |
 | `--active-only` | boolean | `false` | Only show active providers |
-| `--include-descriptions` | boolean | `true` | Include descriptions |
-| `--sort-by-priority` | boolean | `true` | Sort by priority |
+| `--include-descriptions` | boolean | `true` | Include descriptions (use `--no-include-descriptions` to disable) |
+| `--sort-by-priority` | boolean | `true` | Sort by priority (use `--no-sort-by-priority` to disable) |
 
 ## Examples
 

--- a/.codex/skills/uloop-hello-world/SKILL.md
+++ b/.codex/skills/uloop-hello-world/SKILL.md
@@ -19,7 +19,7 @@ uloop hello-world [options]
 |-----------|------|---------|-------------|
 | `--name` | string | `World` | Name to greet |
 | `--language` | string | `english` | Language for greeting: `english`, `japanese`, `spanish`, `french` |
-| `--include-timestamp` | boolean | `true` | Whether to include timestamp in response |
+| `--include-timestamp` | boolean | `true` | Whether to include timestamp in response (use `--no-include-timestamp` to disable) |
 
 ## Examples
 
@@ -34,7 +34,7 @@ uloop hello-world --name "Alice"
 uloop hello-world --name "太郎" --language japanese
 
 # Spanish greeting without timestamp
-uloop hello-world --name "Carlos" --language spanish --include-timestamp false
+uloop hello-world --name "Carlos" --language spanish --no-include-timestamp
 ```
 
 ## Output

--- a/Assets/Editor/CustomCommandSamples/HelloWorld/Skill/SKILL.md
+++ b/Assets/Editor/CustomCommandSamples/HelloWorld/Skill/SKILL.md
@@ -19,7 +19,7 @@ uloop hello-world [options]
 |-----------|------|---------|-------------|
 | `--name` | string | `World` | Name to greet |
 | `--language` | string | `english` | Language for greeting: `english`, `japanese`, `spanish`, `french` |
-| `--include-timestamp` | boolean | `true` | Whether to include timestamp in response |
+| `--include-timestamp` | boolean | `true` | Whether to include timestamp in response (use `--no-include-timestamp` to disable) |
 
 ## Examples
 
@@ -34,7 +34,7 @@ uloop hello-world --name "Alice"
 uloop hello-world --name "太郎" --language japanese
 
 # Spanish greeting without timestamp
-uloop hello-world --name "Carlos" --language spanish --include-timestamp false
+uloop hello-world --name "Carlos" --language spanish --no-include-timestamp
 ```
 
 ## Output

--- a/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
+++ b/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
@@ -212,6 +212,24 @@ describe('CLI E2E Tests (requires running Unity)', () => {
       expect(typeof result.hierarchyFilePath).toBe('string');
       expect(result.hierarchyFilePath).toContain('hierarchy_');
     });
+
+    it('should support --no-include-components to disable components', () => {
+      const result = runCliJson<{ hierarchyFilePath: string }>(
+        'get-hierarchy --max-depth 1 --no-include-components',
+      );
+
+      expect(typeof result.hierarchyFilePath).toBe('string');
+      expect(result.hierarchyFilePath).toContain('hierarchy_');
+    });
+
+    it('should support --no-include-inactive to exclude inactive objects', () => {
+      const result = runCliJson<{ hierarchyFilePath: string }>(
+        'get-hierarchy --max-depth 1 --no-include-inactive',
+      );
+
+      expect(typeof result.hierarchyFilePath).toBe('string');
+      expect(result.hierarchyFilePath).toContain('hierarchy_');
+    });
   });
 
   describe('get-menu-items', () => {
@@ -257,6 +275,14 @@ describe('CLI E2E Tests (requires running Unity)', () => {
       const messages = logs.Logs.map((log) => log.Message);
       expect(messages.some((m) => m.includes('LogGetter test complete'))).toBe(true);
     });
+
+    it('should support --no-use-reflection-fallback option', () => {
+      const result = runCliJson<{ Success: boolean }>(
+        `execute-menu-item --menu-item-path "${TEST_LOG_MENU_PATH}" --no-use-reflection-fallback`,
+      );
+
+      expect(result.Success).toBe(true);
+    });
   });
 
   describe('unity-search', () => {
@@ -284,6 +310,22 @@ describe('CLI E2E Tests (requires running Unity)', () => {
 
       expect(Array.isArray(result.Providers)).toBe(true);
     });
+
+    it('should support --no-include-descriptions to exclude descriptions', () => {
+      const result = runCliJson<{ Providers: unknown[] }>(
+        'get-provider-details --no-include-descriptions',
+      );
+
+      expect(Array.isArray(result.Providers)).toBe(true);
+    });
+
+    it('should support --no-sort-by-priority to disable priority sorting', () => {
+      const result = runCliJson<{ Providers: unknown[] }>(
+        'get-provider-details --no-sort-by-priority',
+      );
+
+      expect(Array.isArray(result.Providers)).toBe(true);
+    });
   });
 
   describe('--help', () => {
@@ -301,6 +343,23 @@ describe('CLI E2E Tests (requires running Unity)', () => {
 
       expect(exitCode).toBe(0);
       expect(stdout).toContain('--force-recompile');
+    });
+
+    it('should display --no-xxx options for default-true booleans in get-hierarchy help', () => {
+      const { stdout, exitCode } = runCli('get-hierarchy --help');
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('--no-include-components');
+      expect(stdout).toContain('--no-include-inactive');
+      expect(stdout).toContain('Disable:');
+    });
+
+    it('should display --no-xxx options for default-true booleans in get-provider-details help', () => {
+      const { stdout, exitCode } = runCli('get-provider-details --help');
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('--no-include-descriptions');
+      expect(stdout).toContain('--no-sort-by-priority');
     });
   });
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/Skill/SKILL.md
@@ -18,7 +18,7 @@ uloop execute-menu-item --menu-item-path "<path>"
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--menu-item-path` | string | - | Menu item path (e.g., "GameObject/Create Empty") |
-| `--use-reflection-fallback` | boolean | `true` | Use reflection fallback |
+| `--use-reflection-fallback` | boolean | `true` | Use reflection fallback (use `--no-use-reflection-fallback` to disable) |
 
 ## Examples
 

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
@@ -19,8 +19,8 @@ uloop get-hierarchy [options]
 |-----------|------|---------|-------------|
 | `--root-path` | string | - | Root GameObject path to start from |
 | `--max-depth` | integer | `-1` | Maximum depth (-1 for unlimited) |
-| `--include-components` | boolean | `true` | Include component information |
-| `--include-inactive` | boolean | `true` | Include inactive GameObjects |
+| `--include-components` | boolean | `true` | Include component information (use `--no-include-components` to disable) |
+| `--include-inactive` | boolean | `true` | Include inactive GameObjects (use `--no-include-inactive` to disable) |
 | `--include-paths` | boolean | `false` | Include full path information |
 
 ## Examples
@@ -36,7 +36,10 @@ uloop get-hierarchy --root-path "Canvas/UI"
 uloop get-hierarchy --max-depth 2
 
 # Without components
-uloop get-hierarchy --include-components false
+uloop get-hierarchy --no-include-components
+
+# Exclude inactive GameObjects
+uloop get-hierarchy --no-include-inactive
 ```
 
 ## Output

--- a/Packages/src/Editor/Api/McpTools/UnitySearchProviderDetails/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/UnitySearchProviderDetails/Skill/SKILL.md
@@ -19,8 +19,8 @@ uloop get-provider-details [options]
 |-----------|------|---------|-------------|
 | `--provider-id` | string | - | Specific provider ID to query |
 | `--active-only` | boolean | `false` | Only show active providers |
-| `--include-descriptions` | boolean | `true` | Include descriptions |
-| `--sort-by-priority` | boolean | `true` | Sort by priority |
+| `--include-descriptions` | boolean | `true` | Include descriptions (use `--no-include-descriptions` to disable) |
+| `--sort-by-priority` | boolean | `true` | Sort by priority (use `--no-sort-by-priority` to disable) |
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- Add `--no-xxx` options for boolean parameters with `default=true` in CLI
- This fixes the issue where users couldn't set default-true booleans to false (commander.js limitation)
- Also adds `--no-xxx` options to shell completion suggestions

## Affected tools
| Tool | New Options |
|------|-------------|
| `get-hierarchy` | `--no-include-components`, `--no-include-inactive` |
| `execute-menu-item` | `--no-use-reflection-fallback` |
| `get-provider-details` | `--no-include-descriptions`, `--no-sort-by-priority` |

## Usage example
```bash
# Before: couldn't disable include-components (always true)
uloop get-hierarchy

# After: can now disable with --no-xxx
uloop get-hierarchy --no-include-components
```

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm run test:cli` passes (46 tests)
- [x] Verify `--help` shows `--no-xxx` options with "Disable:" prefix
- [x] Verify shell completion includes `--no-xxx` options

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds --no-xxx options for CLI booleans that default to true, so users can disable them. Also updates shell completion and --help to list these negatable flags.

- **Bug Fixes**
  - get-hierarchy: --no-include-components, --no-include-inactive
  - execute-menu-item: --no-use-reflection-fallback
  - get-provider-details: --no-include-descriptions, --no-sort-by-priority
  - hello-world: --no-include-timestamp

<sup>Written for commit b392680a427f91d05fd7b0206c9ec9130a82300a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a commander.js limitation by adding negatable `--no-xxx` CLI options for boolean parameters with `default=true`, enabling users to explicitly disable these options from the command line.

## Problem

Commander.js flag-style options (e.g., `--include-components`) cannot be set to `false` when the default value is `true`. Users had no way to override these default-true booleans through the CLI, limiting flexibility.

## Solution

The implementation adds corresponding `--no-xxx` negatable options for each boolean parameter with `default=true`:

1. In `registerToolCommand()`: Before registering each tool's standard option, a `--no-<flag>` option is registered first (required by commander.js ordering). This option includes a "Disable:" prefix in its description and displays in both shell completion and `--help` output.

2. In `listOptionsForCommand()`: Shell completion logic now lists both `--<flag>` and `--no-<flag>` options for default-true booleans, ensuring completion suggestions are comprehensive.

3. Documentation updates: SKILL.md/help examples for affected tools and samples updated to show `--no-xxx` usage (including hello-world sample).

## Affected Tools and New Options

- get-hierarchy: `--no-include-components`, `--no-include-inactive`
- execute-menu-item: `--no-use-reflection-fallback`
- get-provider-details: `--no-include-descriptions`, `--no-sort-by-priority`
- hello-world docs updated: `--no-include-timestamp`

## Usage Example

Before: `uloop get-hierarchy` (could not disable include-components)  
After: `uloop get-hierarchy --no-include-components --no-include-inactive`

## Implementation Architecture

┌─────────────────────────────────────────────────────┐
│                    CLI Entry Point                   │
│              (cli.ts - main program)                 │
└──────────────────────┬──────────────────────────────┘
                       │
                       │ For each tool definition
                       ▼
        ┌──────────────────────────────┐
        │  registerToolCommand()        │
        │  (Tool Registration Logic)    │
        └──────────────┬───────────────┘
                       │
        ┌──────────────┴───────────────┐
        │                              │
        ▼                              ▼
┌──────────────────────┐    ┌──────────────────────┐
│  For each Property   │    │  For each Property   │
│  (in tool schema)    │    │  (in tool schema)    │
└──────────┬───────────┘    └──────────┬───────────┘
           │                           │
           ▼                           ▼
    ┌─────────────────┐       ┌─────────────────┐
    │ Is boolean with │       │ Register options│
    │ default=true?   │       │ in Command      │
    └────────┬────────┘       └─────────────────┘
    Yes      │      No
             │
    ┌────────▼────────┐
    │ Register        │
    │ --no-<kebab>    │
    │ (Disable: ...)  │
    │ FIRST (order!)  │
    └────────┬────────┘
             │
    ┌────────▼────────────────┐
    │ Then register           │
    │ --<kebab> option        │
    │ (standard flag)         │
    └────────────────────────┘

## Test Coverage

- Added E2E tests (Packages/src/Cli~/src/__tests__/cli-e2e.test.ts) verifying:
  - Functional execution with `--no-xxx` flags (get-hierarchy, execute-menu-item, get-provider-details).
  - `--help` output includes `--no-xxx` options with "Disable:" prefix.
  - Shell completion includes `--no-xxx` options.
- All CLI tests pass (46 tests). Lint/build also pass.

## Key Technical Details

- Option registration order matters: `--no-<flag>` must be registered before `--<flag>` for commander.js to parse correctly.
- Shell completion and help listing updated to include negated options.
- Documentation and examples updated across SKILL.md files and samples to prefer `--no-xxx` for disabling default-true booleans.
- Backward compatible; no breaking changes to APIs or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->