### PR TITLE
fix: change CLI boolean options to value format for MCP consistency

### DIFF
--- a/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
+++ b/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
@@ -212,6 +212,24 @@ describe('CLI E2E Tests (requires running Unity)', () => {
       expect(typeof result.hierarchyFilePath).toBe('string');
       expect(result.hierarchyFilePath).toContain('hierarchy_');
     });
+
+    it('should support --include-components false to disable components', () => {
+      const result = runCliJson<{ hierarchyFilePath: string }>(
+        'get-hierarchy --max-depth 1 --include-components false',
+      );
+
+      expect(typeof result.hierarchyFilePath).toBe('string');
+      expect(result.hierarchyFilePath).toContain('hierarchy_');
+    });
+
+    it('should support --include-inactive false to exclude inactive objects', () => {
+      const result = runCliJson<{ hierarchyFilePath: string }>(
+        'get-hierarchy --max-depth 1 --include-inactive false',
+      );
+
+      expect(typeof result.hierarchyFilePath).toBe('string');
+      expect(result.hierarchyFilePath).toContain('hierarchy_');
+    });
   });
 
   describe('get-menu-items', () => {
@@ -257,6 +275,14 @@ describe('CLI E2E Tests (requires running Unity)', () => {
       const messages = logs.Logs.map((log) => log.Message);
       expect(messages.some((m) => m.includes('LogGetter test complete'))).toBe(true);
     });
+
+    it('should support --use-reflection-fallback false option', () => {
+      const result = runCliJson<{ Success: boolean }>(
+        `execute-menu-item --menu-item-path "${TEST_LOG_MENU_PATH}" --use-reflection-fallback false`,
+      );
+
+      expect(result.Success).toBe(true);
+    });
   });
 
   describe('unity-search', () => {
@@ -270,7 +296,7 @@ describe('CLI E2E Tests (requires running Unity)', () => {
   describe('find-game-objects', () => {
     it('should find game objects with name pattern', () => {
       const result = runCliJson<{ results: unknown[]; totalFound: number }>(
-        'find-game-objects --name-pattern "*" --include-inactive',
+        'find-game-objects --name-pattern "*" --include-inactive true',
       );
 
       expect(Array.isArray(result.results)).toBe(true);
@@ -281,6 +307,22 @@ describe('CLI E2E Tests (requires running Unity)', () => {
   describe('get-provider-details', () => {
     it('should retrieve search providers', () => {
       const result = runCliJson<{ Providers: unknown[] }>('get-provider-details');
+
+      expect(Array.isArray(result.Providers)).toBe(true);
+    });
+
+    it('should support --include-descriptions false to exclude descriptions', () => {
+      const result = runCliJson<{ Providers: unknown[] }>(
+        'get-provider-details --include-descriptions false',
+      );
+
+      expect(Array.isArray(result.Providers)).toBe(true);
+    });
+
+    it('should support --sort-by-priority false to disable priority sorting', () => {
+      const result = runCliJson<{ Providers: unknown[] }>(
+        'get-provider-details --sort-by-priority false',
+      );
 
       expect(Array.isArray(result.Providers)).toBe(true);
     });
@@ -301,6 +343,16 @@ describe('CLI E2E Tests (requires running Unity)', () => {
 
       expect(exitCode).toBe(0);
       expect(stdout).toContain('--force-recompile');
+    });
+
+    it('should display boolean options with value format in get-hierarchy help', () => {
+      const { stdout, exitCode } = runCli('get-hierarchy --help');
+
+      expect(exitCode).toBe(0);
+      // Boolean options should show <value> format
+      expect(stdout).toContain('--include-components <value>');
+      expect(stdout).toContain('--include-inactive <value>');
+      expect(stdout).toContain('(default: "true")');
     });
   });
 


### PR DESCRIPTION
## Summary
- Change boolean parameters from flag format (`--flag`) to value format (`--flag <value>`)
- This allows users to explicitly pass `true` or `false`, matching the MCP interface behavior

## Problem
Previously, boolean options used commander.js flag format:
- `--include-components` → sets to `true`
- (no option) → uses default value

**This made it impossible to set a default-true boolean to false.**

## Solution
Changed to value format for all options:
- `--include-components true` → sets to `true`
- `--include-components false` → sets to `false`
- (no option) → uses default value

This is consistent with:
- MCP interface (JSON: `{ "IncludeComponents": false }`)
- SKILL.md documentation (already used `--xxx false` format)

## Usage example
```bash
# Disable components in hierarchy output
uloop get-hierarchy --include-components false

# Disable inactive objects
uloop get-hierarchy --include-inactive false

# Disable reflection fallback
uloop execute-menu-item --menu-item-path "File/Save" --use-reflection-fallback false
```

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes  
- [x] `npm run test:cli` passes (45 tests)
- [x] Verify `--help` shows `<value>` format for boolean options
- [x] Verify `--xxx false` works for default-true booleans

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches all CLI boolean options from flag-only to value format (--option <value>) so users can pass true or false explicitly. Aligns the CLI with MCP behavior and fixes the inability to set default-true options to false.

- **Refactors**
  - All CLI options now use --option <value> for MCP consistency.
  - Added string-to-boolean parsing with validation (accepts "true"/"false").
  - Registered defaults as strings so --help shows <value> and defaults; updated E2E tests.

- **Migration**
  - Replace flag usage with explicit values (e.g., --include-inactive true).
  - Use false to override default-true options (e.g., --include-components false).

<sup>Written for commit 4d96f759b572de05ae0a72b246d1e1124cd31c62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Change CLI Boolean Options to Value Format for MCP Consistency

## Overview
This PR converts CLI boolean options from flag format (`--flag`) to value format (`--flag <value>`) to enable explicit `true` or `false` values and align with MCP interface specifications.

## Changes

### Main Implementation (`cli.ts`)

**New Helper Function:**
- `convertDefaultToString(value: unknown): string` - Normalizes default values to strings for CLI registration (strings returned as-is; booleans/numbers converted via `String()`; others via `JSON.stringify()`)

**Updated Core Functions:**
- `generateOptionString(propName: string, propInfo: ToolProperty): string`
  - Changed from conditional logic (booleans using flag format, others using value format) to consistent value format for all types
  - Now always generates `--option <value>` format

- `convertValue(value: unknown, propInfo: ToolProperty): unknown`
  - Added explicit boolean string parsing that converts `'true'` → `true` and `'false'` → `false`
  - Throws error for invalid boolean strings
  - Retained existing handling for arrays, integers, and numbers

- `registerToolCommand(tool: ToolDefinition): void`
  - Modified option registration to extract default values and convert them to strings via `convertDefaultToString()` before passing to `cmd.option()`
  - Maintains undefined/null defaults for options without defaults

### Test Coverage (`cli-e2e.test.ts`)

**New test cases:**
- `get-hierarchy`: Tests for `--include-components false` and `--include-inactive false` with default-true options
- `execute-menu-item`: Test for `--use-reflection-fallback false`
- `find-game-objects`: Updated to use `--include-inactive true`
- `get-provider-details`: Tests for `--include-descriptions false` and `--sort-by-priority false`
- `--help` verification: Tests confirm boolean options display as `--option <value>` in help text

## Behavior Changes

**Before:**
- `--include-components` (flag only - enabled/disabled with presence)
- Default-true options could not be explicitly disabled

**After:**
- `--include-components true` - explicitly enables
- `--include-components false` - explicitly disables
- Omitted option uses configured default value

## Technical Details

The conversion pipeline for boolean CLI options:
1. User provides: `--include-components false`
2. Commander.js parses as string: `value = "false"`
3. `convertValue()` converts to boolean: `false`
4. Tool receives properly typed boolean parameter

Default value handling:
- Default values from tool definitions are converted to strings during option registration
- Allows commander.js to display defaults in help text (e.g., `(default: "true")`)
- Maintains type safety through `convertValue()` during command execution

## Verification

- All 45 CLI tests pass (lint, build, e2e)
- Help output correctly shows `<value>` format for all options
- Boolean parsing correctly handles explicit true/false values
- Default values properly handled for both enabled and disabled defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->