### PR TITLE
feat(cli): auto-sync tools cache when CLI version changes

### DIFF
--- a/Packages/src/Cli~/src/cli.ts
+++ b/Packages/src/Cli~/src/cli.ts
@@ -19,7 +19,7 @@ import {
   GlobalOptions,
   syncTools,
 } from './execute-tool.js';
-import { loadToolsCache, ToolDefinition, ToolProperty } from './tool-cache.js';
+import { loadToolsCache, hasCacheFile, ToolDefinition, ToolProperty } from './tool-cache.js';
 import { pascalToKebabCase } from './arg-parser.js';
 import { registerSkillsCommand } from './skills/skills-command.js';
 import { VERSION } from './version.js';
@@ -656,6 +656,33 @@ function commandExists(cmdName: string): boolean {
 async function main(): Promise<void> {
   if (handleCompletionOptions()) {
     return;
+  }
+
+  // Check if cache version is outdated and auto-sync if needed
+  const cachedVersion = loadToolsCache().version;
+  if (hasCacheFile() && cachedVersion !== VERSION) {
+    console.log(
+      `\x1b[33mCache outdated (${cachedVersion} → ${VERSION}). Syncing tools from Unity...\x1b[0m`,
+    );
+    try {
+      await syncTools({});
+      // Re-register commands with updated cache
+      const updatedCache = loadToolsCache();
+      for (const tool of updatedCache.tools) {
+        registerToolCommand(tool);
+      }
+      console.log('\x1b[32m✓ Tools synced successfully.\x1b[0m\n');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isConnectionError(message)) {
+        console.error('\x1b[33mWarning: Failed to sync tools. Using cached definitions.\x1b[0m');
+        console.error("\x1b[33mRun 'uloop sync' manually when Unity is available.\x1b[0m\n");
+      } else {
+        console.error('\x1b[33mWarning: Failed to sync tools. Using cached definitions.\x1b[0m');
+        console.error(`\x1b[33mError: ${message}\x1b[0m`);
+        console.error("\x1b[33mRun 'uloop sync' manually when Unity is available.\x1b[0m\n");
+      }
+    }
   }
 
   const args = process.argv.slice(2);


### PR DESCRIPTION
## Summary

- CLI起動時にキャッシュバージョンとCLIバージョンを比較
- バージョン不一致の場合、自動的にUnityからツール定義をsync
- sync成功時はコマンドを再登録して最新スキーマを反映
- Unity未起動時は警告を表示して古いキャッシュで継続

## Background

PR #557 で `IncludeStackTrace` のデフォルト値を `false` に変更したが、ユーザーが別プロジェクトでパッケージを更新しても古い `.uloop/tools.json` キャッシュが残っていると、スキーマが更新されない問題があった。

## Changes

- `cli.ts`: `main()` 関数にキャッシュバージョンチェックと自動sync処理を追加
- `hasCacheFile()` をインポートしてキャッシュファイル存在確認

## Test plan

- [ ] Unity起動状態でCLI実行 → バージョン不一致時に自動syncが発動することを確認
- [ ] Unity未起動状態でCLI実行 → 警告表示後、古いキャッシュで動作することを確認

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically sync the tools cache at CLI startup when its version differs from the CLI version. Keeps tool schemas current after package updates, with a warning fallback if Unity isn’t running.

- **New Features**
  - Compare cache version with CLI version on startup.
  - If versions differ and a cache exists, sync from Unity and re-register commands.
  - On sync failure, warn and continue using the existing cache.

<sup>Written for commit 3d5cc850ac1e271e26a1c628e610aa616622138f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements automatic cache synchronization when the CLI version changes, ensuring that tool schemas remain up-to-date after package updates without requiring manual intervention.

## Problem Statement

When the CLI package is updated (e.g., via `npm update`), users may have cached tool definitions in `.uloop/tools.json` that reference outdated schemas. Previously, the cache would not automatically refresh, leading to schema mismatches. The motivating scenario occurred after PR #557 changed the `IncludeStackTrace` default to `false`—users updating their packages would retain old cache files with the outdated schema.

## Solution Overview

The implementation adds version-aware cache management at CLI startup:

1. **Version Comparison**: On startup, the CLI compares the cached tools.json version with the current CLI version
2. **Automatic Sync**: If versions differ and a cache file exists, the CLI automatically syncs tool definitions from Unity
3. **Command Re-registration**: After successful sync, all tool commands are re-registered with updated definitions
4. **Graceful Degradation**: If sync fails (e.g., Unity not running), the CLI warns the user and continues with the cached definitions, suggesting manual sync when Unity becomes available

## Technical Changes

### `cli.ts` - Core Implementation

**New import:** Added `hasCacheFile` from `tool-cache.js` to detect cache existence.

**Main function enhancement:** Inserted version-checking logic before command parsing:
- Loads cached tools version via `loadToolsCache().version`
- Checks if cache file exists and version differs from current CLI version
- On version mismatch:
  - Displays yellow progress message: "Cache outdated (old_version → new_version). Syncing tools from Unity..."
  - Attempts `syncTools({})` to refresh definitions
  - On success: reloads cache, re-registers all commands, displays green success message
  - On failure: distinguishes between connection errors (Unity unavailable) and other errors, warns user, and suggests manual `uloop sync`

**Bonus: Unknown command handling** - Added fallback logic to auto-sync when an unknown command is attempted, allowing newly added tools to be discovered without manual sync.

### `tool-cache.ts` - New Export

Exported `hasCacheFile()` function to allow CLI to detect whether a cache file exists before attempting version comparison. This prevents unnecessary sync attempts when no cache has been created yet.

## Behavior Flow

```
CLI Startup
├─ Check: hasCacheFile() && cachedVersion !== VERSION?
├─ YES → Attempt auto-sync from Unity
│   ├─ Sync succeeds → Reload cache, re-register commands ✓
│   └─ Sync fails → Show warning, continue with old cache ⚠️
└─ NO → Normal startup
```

## Backward Compatibility

- Users without a cache file: No behavior change
- Users with matching cache versions: No behavior change  
- Users with outdated cache: Automatic transparent refresh (unless Unity is unavailable)

## API Changes

- **New export in `tool-cache.ts`:** `hasCacheFile(): boolean`
- **Imported by `cli.ts`:** Uses `hasCacheFile` from tool-cache module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->