### PR TITLE
feat(cli): auto-sync tools cache when CLI version changes

### DIFF
--- a/Packages/src/Cli~/src/cli.ts
+++ b/Packages/src/Cli~/src/cli.ts
@@ -87,12 +87,6 @@ program
 // Register skills subcommand
 registerSkillsCommand(program);
 
-// Load tools from cache and register commands dynamically
-const toolsCache = loadToolsCache();
-for (const tool of toolsCache.tools) {
-  registerToolCommand(tool);
-}
-
 /**
  * Register a tool as a CLI command dynamically.
  */
@@ -666,11 +660,6 @@ async function main(): Promise<void> {
     );
     try {
       await syncTools({});
-      // Re-register commands with updated cache
-      const updatedCache = loadToolsCache();
-      for (const tool of updatedCache.tools) {
-        registerToolCommand(tool);
-      }
       console.log('\x1b[32m✓ Tools synced successfully.\x1b[0m\n');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -683,6 +672,12 @@ async function main(): Promise<void> {
         console.error("\x1b[33mRun 'uloop sync' manually when Unity is available.\x1b[0m\n");
       }
     }
+  }
+
+  // Register tool commands from cache (after potential auto-sync)
+  const toolsCache = loadToolsCache();
+  for (const tool of toolsCache.tools) {
+    registerToolCommand(tool);
   }
 
   const args = process.argv.slice(2);


### PR DESCRIPTION
## Summary

- Compare cache version with CLI version on startup
- Auto-sync tool definitions from Unity when versions differ
- Re-register commands with updated schema after sync
- On sync failure (Unity not running), warn user and continue with old cache

## Background

PR #557 changed the default value of `IncludeStackTrace` to `false`, but users updating the package in another project would still have the old `.uloop/tools.json` cache, causing the schema to not update.

## Changes

- `cli.ts`: Add cache version check and auto-sync logic in `main()` function
- Import `hasCacheFile()` to check cache file existence

## Test plan

- [ ] With Unity running: Verify auto-sync triggers when version mismatch detected
- [ ] Without Unity running: Verify warning is shown and CLI continues with old cache

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-sync the tools cache at CLI startup when the CLI version changes, so tool schemas stay up to date without manual steps. Also prevents duplicate command registration by moving tool registration inside main.

- **New Features**
  - Compare cached tools.json version to CLI version; if mismatch and cache exists, sync from Unity.
  - Re-register tool commands using the updated schema after a successful sync.
  - On sync failure (e.g., Unity not running), warn and continue with the old cache.

- **Bug Fixes**
  - Defer tool registration to after the auto-sync check to avoid duplicate Commander.js command registrations.

<sup>Written for commit 33fe36a72dd5b74000c702ae8d9414effdd0cf9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Auto-Sync Tools Cache on CLI Version Change

## Overview
This PR implements automatic tools cache synchronization on CLI startup when a cached tools schema version differs from the CLI VERSION. It prevents stale `.uloop/tools.json` caches from retaining old schemas after package upgrades (notably after PR #557 changed the default of IncludeStackTrace).

## Changes Made

### New Public API Export
- **tool-cache.js**: Adds and exports `hasCacheFile()` to detect if a local tools cache exists before attempting auto-sync.

### CLI Startup Logic (cli.ts)
- **Import Addition**: Imports `hasCacheFile` from tool-cache.js.
- **Cache Version Check & Auto-Sync**: In main(), if a cache file exists and its schema version differs from the CLI VERSION constant, the CLI automatically calls `syncTools({})`.
- **Deferred Tool Registration**: Tool command registration was moved out of module load time and into main(), after the auto-sync check, to avoid duplicate Commander.js registrations and related issues.
- **Post-Sync Behavior**: After a successful sync, the updated cache is loaded and tool commands are re-registered via `registerToolCommand()` for each tool.
- **Graceful Error Handling**:
  - Connection errors (ECONNREFUSED, EADDRNOTAVAIL): warn the user and recommend manual `uloop sync`; continue using existing cached definitions.
  - Other errors: warn with error details and recommend manual sync; continue using existing cached definitions.
- **Observability**: Logs status messages for outdated cache, successful sync, and failures.

## Behavior Flow

CLI Startup (main)
  ├─ Check for cache file (hasCacheFile)
  ├─ Load cached tools version
  ├─ Compare cached version vs current VERSION
  ├─ If mismatch:
  │  ├─ Notify user
  │  ├─ Attempt syncTools()
  │  ├─ On success: reload cache and re-register tool commands
  │  └─ On failure: warn (connection vs other), continue with cached definitions
  └─ Continue normal CLI flow

## Rationale
- Prevents stale schemas from causing inconsistent tool behavior after package updates.
- Avoids duplicate command registrations by deferring registration until after any potential cache update.

## Test Plan
- With Unity running: verify auto-sync triggers on version mismatch, cache updates, and commands re-register.
- Without Unity running: verify warning is shown and CLI continues using the existing cache.

## Lines Changed
+29/-7 (changes concentrated in cli.ts and tool-cache.js)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->