### PR TITLE
docs: Add uloop launch feature documentation

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -34,9 +34,10 @@ https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 3. Easy setup from Unity Package Manager and a few clicks to connect from LLM tools (Cursor, Claude Code, GitHub Copilot, Windsurf, etc.).
 4. Type-safe extension model for adding project-specific MCP tools that AI can implement and iterate on for you.
 5. Log and hierarchy data can be exported to files to avoid burning LLM context on large payloads.
-6. Standalone CLI tool `uloop` provided. **No MCP configuration required—just install Skills and LLM tools will automatically operate Unity**. 14 bundled Skills enable LLM tools to handle compilation, test execution, log retrieval, and more. ([Details](#cli-tool-uloop))
+6. Standalone CLI tool `uloop` provided. **No MCP configuration required—just install Skills and LLM tools will automatically operate Unity**. 15 bundled Skills enable LLM tools to handle compilation, test execution, log retrieval, and more. ([Details](#cli-tool-uloop))
 
 # Example Use Cases
+- Launch Unity with the correct Editor version from AI tools, even when Unity isn't running.
 - Let an AI keep fixing your project until compilation passes and all tests go green.
 - Ask the AI to fix bugs or refactor existing code, and verify results using `compile` / `test runner execution` / `log retrieval`.
 - After verification, enter Play Mode using `MenuItem execution` or `compile-free C# code execution`, then bring Unity Editor to the foreground with `Unity window focus`.
@@ -331,7 +332,7 @@ uLoopMCP includes a standalone CLI tool `uloop`.
 - **Multiple Unity instances**: Operate multiple Unity instances from a single AI Agent using `--port`
 - **Context-efficient**: Unlike MCP, does not consume LLM context
 
-Just install the 14 bundled Skills, and Skills-compatible LLM tools will automatically integrate with Unity.
+Just install the 15 bundled Skills, and Skills-compatible LLM tools will automatically integrate with Unity.
 
 ### Quick Start
 
@@ -357,6 +358,7 @@ After installing Skills, LLM tools can automatically handle instructions like th
 
 | Your Instruction | Skill Used by LLM Tools |
 |---|---|
+| "Launch Unity for this project" | `/uloop-launch` |
 | "Fix the compile errors" | `/uloop-compile` |
 | "Run the tests and tell me why they failed" | `/uloop-run-tests` + `/uloop-get-logs` |
 | "Check the scene hierarchy" | `/uloop-get-hierarchy` |
@@ -366,8 +368,9 @@ After installing Skills, LLM tools can automatically handle instructions like th
 > **No MCP configuration required!** As long as the server is running in the uLoopMCP Window, LLM tools communicate directly with Unity through Skills.
 
 <details>
-<summary>All 14 Bundled Skills</summary>
+<summary>All 15 Bundled Skills</summary>
 
+- `/uloop-launch` - Launch Unity with correct version
 - `/uloop-compile` - Execute compilation
 - `/uloop-get-logs` - Get console logs
 - `/uloop-run-tests` - Run tests
@@ -393,8 +396,14 @@ You can also call the CLI directly without using Skills:
 # List available tools
 uloop list
 
-# Sync tool definitions from Unity to local cache (.uloop/tools.json)
-uloop sync
+# Launch Unity project with correct version
+uloop launch
+
+# Launch with build target (Android, iOS, StandaloneOSX, etc.)
+uloop launch -p Android
+
+# Kill running Unity and restart
+uloop launch -r
 
 # Execute compilation
 uloop compile

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -34,9 +34,10 @@ https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 3. Unity Package Manager からインストールし、お使いの LLM ツール（Cursor / Claude Code / Codex / Gemini など）と数クリックで接続できます。
 4. プロジェクト固有の MCP ツールを型安全に拡張しやすく、AI に実装を任せやすい設計になっています。
 5. 大量のログや階層情報はファイルに書き出すことで、LLM のコンテキスト消費を抑える工夫をしています。
-6. スタンドアロン CLI ツール `uloop` を提供。**MCP設定不要で、Skills をインストールするだけで LLM ツールが自動的に Unity を操作できます**。14個のバンドルされた Skills により、コンパイル・テスト実行・ログ取得などをLLMツールに任せられます。（[詳細](#cli-ツール-uloop)）
+6. スタンドアロン CLI ツール `uloop` を提供。**MCP設定不要で、Skills をインストールするだけで LLM ツールが自動的に Unity を操作できます**。15個のバンドルされた Skills により、コンパイル・テスト実行・ログ取得などをLLMツールに任せられます。（[詳細](#cli-ツール-uloop)）
 
 # ユースケース例
+- Unityが起動していない状態でも、AIツールから正しいEditorバージョンでUnityを起動する
 - Unity プロジェクトの「コンパイルが通るまで」「テストが緑になるまで」を、AI に任せて自律的に回し続ける
 - 既存コードベースに対して、バグ修正やリファクタリングをAIに依頼し、`compile` / `test runnerの実行` / `log取得` で結果を検証させる
 - 検証完了後、`MenuItemの実行` または `コンパイル不要のC#コード実行` でPlay Modeに入り、`Unityウィンドウフォーカス機能` でUnity Editorを最前面に表示させる
@@ -331,7 +332,7 @@ uLoopMCPには、スタンドアロンCLIツール `uloop` が付属していま
 - **複数Unityの操作**: 1つのAI Agentから `--port` 指定で複数のUnityインスタンスを操作可能
 - **コンテキスト節約**: MCPと違い、LLMのコンテキストを消費しない
 
-14個のバンドルされたSkillsをインストールするだけで、Skills対応のLLMツールが自動的にUnityと連携します。
+15個のバンドルされたSkillsをインストールするだけで、Skills対応のLLMツールが自動的にUnityと連携します。
 
 ### クイックスタート
 
@@ -357,6 +358,7 @@ Skillsをインストールすると、LLMツールが以下のような指示�
 
 | あなたの指示 | LLMツールが使うSkill |
 |---|---|
+| 「このプロジェクトのUnityを起動して」 | `/uloop-launch` |
 | 「コンパイルエラーを直して」 | `/uloop-compile` |
 | 「テストを実行して失敗原因を教えて」 | `/uloop-run-tests` + `/uloop-get-logs` |
 | 「シーンの階層構造を確認して」 | `/uloop-get-hierarchy` |
@@ -366,8 +368,9 @@ Skillsをインストールすると、LLMツールが以下のような指示�
 > **MCP設定は不要です！** uLoopMCP Windowでサーバーを起動していれば、Skillsを通じてLLMツールが直接Unityと通信します。
 
 <details>
-<summary>バンドルされている全14個のSkills一覧</summary>
+<summary>バンドルされている全15個のSkills一覧</summary>
 
+- `/uloop-launch` - 正しいバージョンでUnityを起動
 - `/uloop-compile` - コンパイルの実行
 - `/uloop-get-logs` - Consoleログの取得
 - `/uloop-run-tests` - テストの実行
@@ -393,8 +396,14 @@ Skillsを使わずにCLIを直接呼び出すこともできます：
 # 利用可能なツール一覧を取得
 uloop list
 
-# Unityからツール定義を取得しローカルキャッシュに保存 (.uloop/tools.json)
-uloop sync
+# 正しいバージョンでUnityプロジェクトを起動
+uloop launch
+
+# ビルドターゲットを指定して起動（Android, iOS, StandaloneOSX など）
+uloop launch -p Android
+
+# 実行中のUnityを終了して再起動
+uloop launch -r
 
 # コンパイルを実行
 uloop compile


### PR DESCRIPTION
## Summary

Added documentation for the newly integrated `uloop launch` feature in both English and Japanese READMEs.

## Changes

- Updated Skills count from 14 to 15 throughout the documentation
- Added launch feature to the use cases section
- Added `/uloop-launch` to the Skills table with example usage
- Added CLI usage examples for `uloop launch` with `-p` (platform) and `-r` (restart) options
- Removed `uloop sync` from CLI examples as it's an internal auto-sync mechanism

## Details

The `launch` command allows AI tools to:
- Launch Unity projects with the correct Editor version
- Specify build targets with `-p` option (Android, iOS, StandaloneOSX, etc.)
- Restart running Unity instances with `-r` option

This feature was previously integrated from LaunchUnityCommand but wasn't documented in the READMEs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the new uloop launch feature in both READMEs so AI tools can start Unity with the correct Editor version and optionally set a build target or restart. Updated the Skills count to 15, added CLI examples for uloop launch (-p, -r), and removed the outdated uloop sync example.

<sup>Written for commit 02b36e064bd8b2cf8d4eff0457c12cc2fbcfda24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request adds comprehensive documentation for the newly integrated `uloop launch` feature to both English and Japanese README files, marking a 15th bundled Skill in the uLoopMCP standalone CLI tool.

### Key Changes

**1. Skills Count Update**
- Updated bundled Skills count from 14 to 15 across both README.md and README_ja.md
- Reflects the addition of the `launch` command to the CLI tool capabilities

**2. Feature Documentation: `uloop launch`**
- Added "Launch Unity with the correct Editor version from AI tools, even when Unity isn't running" as the first item in the Example Use Cases section
- Explains the primary value: enabling AI tools to launch Unity projects with the correct Editor version, even when Unity isn't running

**3. CLI Usage Examples**
Added new `uloop launch` command documentation with support for:
- Base command: `uloop launch` - launches Unity project with the correct version
- `-p` option: `uloop launch -p Android` - specify build targets (Android, iOS, StandaloneOSX, etc.)
- `-r` option: `uloop launch -r` - kill running Unity instances and restart

**4. Skills Table Addition**
- Added `/uloop-launch` entry to the bundled Skills reference table
- Positioned alongside other tools like `/uloop-get-menu-items`, `/uloop-execute-menu-item`, etc.

**5. Cleanup: Removed `uloop sync` Example**
- Removed `uloop sync` from CLI examples
- Added clarification that sync is an internal auto-sync mechanism (not a user-facing command)

**6. Documentation Consistency**
- Updated all references to the total number of bundled Skills from 14 to 15
- Ensured consistency between English and Japanese documentation
- All updates maintain the same structure and information across both language versions

### Technical Details

The `launch` command enables AI tools to:
- Automatically start Unity projects with the appropriate Editor version
- Specify target platforms for builds (Android, iOS, standalone variants, etc.)
- Restart Unity instances when needed (via the `-r` flag)

This feature was previously integrated from LaunchUnityCommand but had not been documented in the public-facing README files. This PR brings the documentation up to date with the actual capabilities of the uLoopMCP CLI tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->