### PR TITLE
fix: Add uloop fix suggestion to error messages

### DIFF
--- a/Packages/src/Cli~/src/cli.ts
+++ b/Packages/src/Cli~/src/cli.ts
@@ -344,18 +344,24 @@ async function runWithErrorHandling(fn: () => Promise<void>): Promise<void> {
     if (message === 'UNITY_COMPILING') {
       console.error('\x1b[33m⏳ Unity is compiling scripts.\x1b[0m');
       console.error('Please wait for compilation to finish and try again.');
+      console.error('');
+      console.error('If the issue persists, run: uloop fix');
       process.exit(1);
     }
 
     if (message === 'UNITY_DOMAIN_RELOAD') {
       console.error('\x1b[33m⏳ Unity is reloading (Domain Reload in progress).\x1b[0m');
       console.error('Please wait a moment and try again.');
+      console.error('');
+      console.error('If the issue persists, run: uloop fix');
       process.exit(1);
     }
 
     if (message === 'UNITY_SERVER_STARTING') {
       console.error('\x1b[33m⏳ Unity server is starting.\x1b[0m');
       console.error('Please wait a moment and try again.');
+      console.error('');
+      console.error('If the issue persists, run: uloop fix');
       process.exit(1);
     }
 


### PR DESCRIPTION
## Summary

Added guidance to run `uloop fix` command in error messages when Unity is busy (compiling, domain reloading, or server starting). This helps users resolve persistent lockfile issues without manual intervention.

## Changes

- Modified `cli.ts` error handling for three Unity busy states:
  - `UNITY_COMPILING`: Added "If the issue persists, run: uloop fix"
  - `UNITY_DOMAIN_RELOAD`: Added "If the issue persists, run: uloop fix"
  - `UNITY_SERVER_STARTING`: Added "If the issue persists, run: uloop fix"

## Context

Previously, when lockfiles remained after Unity operations, users and AI would repeatedly retry commands without knowing about the `uloop fix` solution. This change makes the fix discoverable through error messages.

## Test Plan

- Verified lint passes: `npm run lint`
- Verified build succeeds: `npm run build`
- Error messages now include the fix suggestion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a suggestion to run “uloop fix” in Unity busy error messages (compiling, domain reload, server starting) to help users resolve persistent lockfile issues. This makes the fix easy to discover and reduces repeated retries.

<sup>Written for commit 3090fc20835908d587a1e0e0ad2b35778f7c989c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR enhances error handling in the CLI to improve user guidance when Unity is in busy states. When users encounter issues related to persistent lockfiles, the error messages now include a suggestion to run the `uloop fix` command as a remediation step.

## Changes

**Modified File:** `Packages/src/Cli~/src/cli.ts`

**Changes:** 
- Added user guidance to three Unity busy state error messages: `UNITY_COMPILING`, `UNITY_DOMAIN_RELOAD`, and `UNITY_SERVER_STARTING`
- Each error message now appends the text: "If the issue persists, run: uloop fix"
- The existing error handling logic and control flow remain unchanged; only the console output is extended
- Lines changed: +6/-0

## Motivation

The `uloop fix` command is an existing resolution for lockfile issues that persist after Unity operations. This change makes the resolution discoverable to users without requiring external documentation lookup, reducing frustration when encountering these states and preventing repeated retries without applying the known remedy.

## Verification

- ✓ Lint: Passed (`npm run lint`)
- ✓ Build: Passed (`npm run build`)
- ✓ Error messages verified to include the `uloop fix` suggestion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->