### PR TITLE
chore(deps): bump GitHub Actions versions

### DIFF
--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Cache Library folder
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Library
           key: Library-2022.3.62f1-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs') }}
@@ -116,7 +116,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: Unity test results


### PR DESCRIPTION
## Summary

Update GitHub Actions to their latest versions:
- actions/checkout: v4 → v6
- actions/cache: v4 → v5
- actions/upload-artifact: v4 → v6

## Closes

Closes #585, #586, #587

## Note

The individual dependabot PRs were failing CI due to missing Unity license (dependabot PRs cannot access repository secrets). This PR combines all three updates into one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated GitHub Actions in the Unity CI workflow to the latest versions to keep CI secure and compatible. Combined the Dependabot updates into one PR so CI can access repository secrets (Unity license) and pass.

- **Dependencies**
  - actions/checkout: v4 → v6
  - actions/cache: v4 → v5
  - actions/upload-artifact: v4 → v6

<sup>Written for commit cf223074b7c9bc2962d0b9f3588ef1301c66f02a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

