### PR TITLE
fix: Auto-save NUnit XML on test failure

### DIFF
--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: uloop-run-tests
-description: "Execute Unity Test Runner. Use when: running unit tests, verifying code changes, checking test results, or when user asks to run tests. Returns test results with pass/fail counts."
+description: "Execute Unity Test Runner and get detailed results. Use when: (1) running unit tests (EditMode/PlayMode), (2) verifying code changes, (3) diagnosing test failures — NUnit XML with error messages and stack traces is auto-saved when tests fail."
 ---
 
 # uloop run-tests
 
-Execute Unity Test Runner.
+Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
 ## Usage
 
@@ -20,7 +20,6 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--save-xml` | boolean | `false` | Save test results as XML |
 
 ## Examples
 
@@ -40,4 +39,18 @@ uloop run-tests --filter-type regex --filter-value ".*Integration.*"
 
 ## Output
 
-Returns JSON with test results including pass/fail counts and details.
+Returns JSON with:
+- `Success` (boolean): Whether all tests passed
+- `Message` (string): Summary message
+- `TestCount` (number): Total tests executed
+- `PassedCount` (number): Passed tests
+- `FailedCount` (number): Failed tests
+- `SkippedCount` (number): Skipped tests
+- `XmlPath` (string): Path to NUnit XML result file (auto-saved when tests fail)
+
+### XML Result File
+
+When tests fail, NUnit XML results are automatically saved to `{project_root}/.uloop/outputs/TestResults/<timestamp>.xml`. The XML contains per-test-case results including:
+- Test name and full name
+- Pass/fail/skip status and duration
+- For failed tests: `<message>` (assertion error) and `<stack-trace>`

--- a/.codex/skills/uloop-run-tests/SKILL.md
+++ b/.codex/skills/uloop-run-tests/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: uloop-run-tests
-description: "Execute Unity Test Runner via uloop CLI. Use when you need to: (1) Run unit tests (EditMode tests), (2) Run integration tests (PlayMode tests), (3) Verify code changes don't break existing functionality."
+description: "Execute Unity Test Runner and get detailed results. Use when: (1) running unit tests (EditMode/PlayMode), (2) verifying code changes, (3) diagnosing test failures — NUnit XML with error messages and stack traces is auto-saved when tests fail."
 ---
 
 # uloop run-tests
 
-Execute Unity Test Runner.
+Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
 ## Usage
 
@@ -20,7 +20,6 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--save-xml` | boolean | `false` | Save test results as XML |
 
 ## Examples
 
@@ -40,4 +39,18 @@ uloop run-tests --filter-type regex --filter-value ".*Integration.*"
 
 ## Output
 
-Returns JSON with test results including pass/fail counts and details.
+Returns JSON with:
+- `Success` (boolean): Whether all tests passed
+- `Message` (string): Summary message
+- `TestCount` (number): Total tests executed
+- `PassedCount` (number): Passed tests
+- `FailedCount` (number): Failed tests
+- `SkippedCount` (number): Skipped tests
+- `XmlPath` (string): Path to NUnit XML result file (auto-saved when tests fail)
+
+### XML Result File
+
+When tests fail, NUnit XML results are automatically saved to `{project_root}/.uloop/outputs/TestResults/<timestamp>.xml`. The XML contains per-test-case results including:
+- Test name and full name
+- Pass/fail/skip status and duration
+- For failed tests: `<message>` (assertion error) and `<stack-trace>`

--- a/Assets/Editor/TestRunnerMenu.cs
+++ b/Assets/Editor/TestRunnerMenu.cs
@@ -10,51 +10,23 @@ namespace io.github.hatayama.uLoopMCP
     /// </summary>
     public static class TestRunnerMenu
     {
-        [MenuItem("uLoopMCP/Tools/Test Runner/Run EditMode Tests/All Tests (Save XML)")]
-        public static async void RunEditModeTestsAndSaveXml()
+        [MenuItem("uLoopMCP/Tools/Test Runner/Run EditMode Tests/All Tests")]
+        public static async void RunEditModeTests()
         {
-            Debug.Log("Running EditMode tests and saving to XML!");
-            
-            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(
-                null, 
-                true);
-                
-            LogTestResult(result);
-        }
-        
-        [MenuItem("uLoopMCP/Tools/Test Runner/Run EditMode Tests/All Tests (Log Only)")]
-        public static async void RunEditModeTestsAndLogOnly()
-        {
-            Debug.Log("Running EditMode tests (log only)!");
-            
-            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(
-                null, 
-                false);
-                
+            Debug.Log("Running EditMode tests!");
+
+            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest();
+
             LogTestResult(result);
         }
 
-        [MenuItem("uLoopMCP/Tools/Test Runner/Run PlayMode Tests/All Tests (Save XML)")]
-        public static async void RunPlayModeTestsAndSaveXml()
+        [MenuItem("uLoopMCP/Tools/Test Runner/Run PlayMode Tests/All Tests")]
+        public static async void RunPlayModeTests()
         {
-            Debug.Log("Running PlayMode tests and saving to XML!");
-            
-            SerializableTestResult result = await PlayModeTestExecuter.ExecutePlayModeTest(
-                null, 
-                true);
-                
-            LogTestResult(result);
-        }
-        
-        [MenuItem("uLoopMCP/Tools/Test Runner/Run PlayMode Tests/All Tests (Log Only)")]
-        public static async void RunPlayModeTestsAndLogOnly()
-        {
-            Debug.Log("Running PlayMode tests (log only)!");
-            
-            SerializableTestResult result = await PlayModeTestExecuter.ExecutePlayModeTest(
-                null, 
-                false);
-                
+            Debug.Log("Running PlayMode tests!");
+
+            SerializableTestResult result = await PlayModeTestExecuter.ExecutePlayModeTest();
+
             LogTestResult(result);
         }
         
@@ -75,9 +47,7 @@ namespace io.github.hatayama.uLoopMCP
             Debug.Log("Running only CompileCommandTests!");
             
             TestExecutionFilter filter = TestExecutionFilter.ByClassName("io.github.hatayama.uLoopMCP.CompileCommandTests");
-            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(
-                filter, 
-                false);
+            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(filter);
                 
             LogTestResult(result);
         }
@@ -88,9 +58,7 @@ namespace io.github.hatayama.uLoopMCP
             Debug.Log("Running only GetLogsCommandTests!");
             
             TestExecutionFilter filter = TestExecutionFilter.ByClassName("io.github.hatayama.uLoopMCP.GetLogsCommandTests");
-            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(
-                filter, 
-                false);
+            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(filter);
                 
             LogTestResult(result);
         }
@@ -101,9 +69,7 @@ namespace io.github.hatayama.uLoopMCP
             Debug.Log("Running only MainThreadSwitcherTests!");
             
             TestExecutionFilter filter = TestExecutionFilter.ByClassName("io.github.hatayama.uLoopMCP.MainThreadSwitcherTests");
-            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(
-                filter, 
-                false);
+            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(filter);
                 
             LogTestResult(result);
         }
@@ -114,9 +80,7 @@ namespace io.github.hatayama.uLoopMCP
             Debug.Log("Running only SampleEditModeTest!");
             
             TestExecutionFilter filter = TestExecutionFilter.ByClassName("Tests.SampleEditModeTest");
-            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(
-                filter, 
-                false);
+            SerializableTestResult result = await PlayModeTestExecuter.ExecuteEditModeTest(filter);
                 
             LogTestResult(result);
         }

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -38,14 +38,12 @@ namespace io.github.hatayama.uLoopMCP
             RunTestsSchema schema = new RunTestsSchema
             {
                 FilterType = TestFilterType.regex,
-                FilterValue = "TestClass",
-                SaveXml = true
+                FilterValue = "TestClass"
             };
 
             // Assert - Schema properties should match what we set
             Assert.That(schema.FilterType, Is.EqualTo(TestFilterType.regex));
             Assert.That(schema.FilterValue, Is.EqualTo("TestClass"));
-            Assert.That(schema.SaveXml, Is.True);
         }
 
         /// <summary>
@@ -63,7 +61,6 @@ namespace io.github.hatayama.uLoopMCP
             // Assert - Schema should have default values
             Assert.That(schema.FilterType, Is.EqualTo(TestFilterType.all));
             Assert.That(schema.FilterValue ?? string.Empty, Is.EqualTo(string.Empty));
-            Assert.That(schema.SaveXml, Is.False);
         }
 
         /// <summary>

--- a/Packages/src/Cli~/src/default-tools.json
+++ b/Packages/src/Cli~/src/default-tools.json
@@ -85,10 +85,6 @@
           "FilterValue": {
             "type": "string",
             "description": "Filter value"
-          },
-          "SaveXml": {
-            "type": "boolean",
-            "description": "Save test results as XML"
           }
         }
       }

--- a/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
@@ -41,10 +41,5 @@ namespace io.github.hatayama.uLoopMCP
         [Description("Filter value (specify when filterType is not all)\n• exact: Individual test method name (e.g.: io.github.hatayama.uLoopMCP.ConsoleLogRetrieverTests.GetAllLogs_WithMaskAllOff_StillReturnsAllLogs)\n• regex: Class name or namespace (e.g.: io.github.hatayama.uLoopMCP.ConsoleLogRetrieverTests, io.github.hatayama.uLoopMCP)\n• assembly: Assembly name (e.g.: uLoopMCP.Tests.Editor)")]
         public string FilterValue { get; set; } = "";
 
-        /// <summary>
-        /// Whether to save test results as XML file
-        /// </summary>
-        [Description("Whether to save test results as XML file. Test results are saved to external files to avoid massive token consumption when returning results directly. Please read the file if you need detailed test results.")]
-        public bool SaveXml { get; set; } = false;
     }
 } 

--- a/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: uloop-run-tests
-description: "Execute Unity Test Runner. Use when: running unit tests, verifying code changes, checking test results, or when user asks to run tests. Returns test results with pass/fail counts."
+description: "Execute Unity Test Runner and get detailed results. Use when: (1) running unit tests (EditMode/PlayMode), (2) verifying code changes, (3) diagnosing test failures — NUnit XML with error messages and stack traces is auto-saved when tests fail."
 ---
 
 # uloop run-tests
 
-Execute Unity Test Runner.
+Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
 ## Usage
 
@@ -20,7 +20,6 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--save-xml` | boolean | `false` | Save test results as XML |
 
 ## Examples
 
@@ -40,4 +39,18 @@ uloop run-tests --filter-type regex --filter-value ".*Integration.*"
 
 ## Output
 
-Returns JSON with test results including pass/fail counts and details.
+Returns JSON with:
+- `Success` (boolean): Whether all tests passed
+- `Message` (string): Summary message
+- `TestCount` (number): Total tests executed
+- `PassedCount` (number): Passed tests
+- `FailedCount` (number): Failed tests
+- `SkippedCount` (number): Skipped tests
+- `XmlPath` (string): Path to NUnit XML result file (auto-saved when tests fail)
+
+### XML Result File
+
+When tests fail, NUnit XML results are automatically saved to `{project_root}/.uloop/outputs/TestResults/<timestamp>.xml`. The XML contains per-test-case results including:
+- Test name and full name
+- Pass/fail/skip status and duration
+- For failed tests: `<message>` (assertion error) and `<stack-trace>`

--- a/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
@@ -38,14 +38,12 @@ namespace io.github.hatayama.uLoopMCP
                 if (parameters.TestMode == TestMode.PlayMode)
                 {
                     // TODO: Add cancellationToken parameter when TestExecutionService supports it
-                    // result = await executionService.ExecutePlayModeTestAsync(filter, parameters.SaveXml, cancellationToken);
-                    result = await executionService.ExecutePlayModeTestAsync(filter, parameters.SaveXml);
+                    result = await executionService.ExecutePlayModeTestAsync(filter);
                 }
                 else
                 {
                     // TODO: Add cancellationToken parameter when TestExecutionService supports it
-                    // result = await executionService.ExecuteEditModeTestAsync(filter, parameters.SaveXml, cancellationToken);
-                    result = await executionService.ExecuteEditModeTestAsync(filter, parameters.SaveXml);
+                    result = await executionService.ExecuteEditModeTestAsync(filter);
                 }
             }
             catch (System.OperationCanceledException)

--- a/Packages/src/Editor/Core/ApplicationServices/TestExecutionService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/TestExecutionService.cs
@@ -14,22 +14,20 @@ namespace io.github.hatayama.uLoopMCP
         /// Execute tests in PlayMode
         /// </summary>
         /// <param name="filter">Test execution filter</param>
-        /// <param name="saveXml">XML save flag</param>
         /// <returns>Test execution result</returns>
-        public async Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter, bool saveXml)
+        public async Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter)
         {
-            return await PlayModeTestExecuter.ExecutePlayModeTest(filter, saveXml);
+            return await PlayModeTestExecuter.ExecutePlayModeTest(filter);
         }
 
         /// <summary>
         /// Execute tests in EditMode
         /// </summary>
         /// <param name="filter">Test execution filter</param>
-        /// <param name="saveXml">XML save flag</param>
         /// <returns>Test execution result</returns>
-        public async Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter, bool saveXml)
+        public async Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter)
         {
-            return await PlayModeTestExecuter.ExecuteEditModeTest(filter, saveXml);
+            return await PlayModeTestExecuter.ExecuteEditModeTest(filter);
         }
     }
 }

--- a/Packages/src/Editor/Core/CoreTools/TestRunner/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/Core/CoreTools/TestRunner/PlayModeTestExecuter.cs
@@ -15,46 +15,41 @@ namespace io.github.hatayama.uLoopMCP
         /// Execute PlayMode tests asynchronously with domain reload control
         /// </summary>
         /// <param name="filter">Test execution filter (null for all tests)</param>
-        /// <param name="saveXml">Whether to save results as XML</param>
         /// <returns>Test execution result</returns>
         public static async Task<SerializableTestResult> ExecutePlayModeTest(
-            TestExecutionFilter filter = null, 
-            bool saveXml = false)
+            TestExecutionFilter filter = null)
         {
             using DomainReloadDisableScope scope = new();
-            return await ExecuteTestWithEventNotification(TestMode.PlayMode, filter, saveXml);
+            return await ExecuteTestWithEventNotification(TestMode.PlayMode, filter);
         }
 
         /// <summary>
         /// Execute EditMode tests asynchronously
         /// </summary>
         /// <param name="filter">Test execution filter (null for all tests)</param>
-        /// <param name="saveXml">Whether to save results as XML</param>
         /// <returns>Test execution result</returns>
         public static async Task<SerializableTestResult> ExecuteEditModeTest(
-            TestExecutionFilter filter = null, 
-            bool saveXml = false)
+            TestExecutionFilter filter = null)
         {
-            return await ExecuteTestWithEventNotification(TestMode.EditMode, filter, saveXml);
+            return await ExecuteTestWithEventNotification(TestMode.EditMode, filter);
         }
 
         /// <summary>
         /// Execute test with event-based result notification
         /// </summary>
         private static async Task<SerializableTestResult> ExecuteTestWithEventNotification(
-            TestMode testMode, 
-            TestExecutionFilter filter, 
-            bool saveXml)
+            TestMode testMode,
+            TestExecutionFilter filter)
         {
             TaskCompletionSource<SerializableTestResult> tcs = new();
-            
+
             using UnifiedTestCallback callback = new();
             callback.OnTestCompleted += (result, rawResult) =>
             {
                 if (!tcs.Task.IsCompleted)
                 {
-                    // Apply XML export if requested
-                    if (saveXml && rawResult != null)
+                    // Auto-save XML when tests fail for detailed failure diagnosis
+                    if (result.failedCount > 0 && rawResult != null)
                     {
                         result.xmlPath = NUnitXmlResultExporter.SaveTestResultAsXml(rawResult);
                     }

--- a/Packages/src/TOOL_REFERENCE.md
+++ b/Packages/src/TOOL_REFERENCE.md
@@ -67,8 +67,6 @@ All tools automatically include the following property:
     - `assembly`: Assembly name (e.g.: uLoopMCP.Tests.Editor)
   - `TestMode` (enum): Test mode - "EditMode"(0), "PlayMode"(1) (default: "EditMode")
     - **PlayMode Warning**: During PlayMode test execution, domain reload is temporarily disabled
-  - `SaveXml` (boolean): Whether to save test results as XML file (default: false)
-    - XML files are saved to `{project root}/.uloop/outputs/TestResults/` folder
 - **Response**:
   - `Success` (boolean): Whether test execution was successful
   - `Message` (string): Test execution message
@@ -77,7 +75,7 @@ All tools automatically include the following property:
   - `PassedCount` (number): Number of passed tests
   - `FailedCount` (number): Number of failed tests
   - `SkippedCount` (number): Number of skipped tests
-  - `XmlPath` (string): XML result file path (if SaveXml is true)
+  - `XmlPath` (string): NUnit XML result file path (auto-saved when tests fail). XML files are saved to `{project root}/.uloop/outputs/TestResults/` folder
 
 ### 4. clear-console
 - **Description**: Clears Unity console logs for clean development workflow

--- a/Packages/src/TOOL_REFERENCE_ja.md
+++ b/Packages/src/TOOL_REFERENCE_ja.md
@@ -67,8 +67,6 @@
     - `assembly`: アセンブリ名（例：uLoopMCP.Tests.Editor）
   - `TestMode` (enum): テストモード - "EditMode"(0), "PlayMode"(1)（デフォルト: "EditMode"）
     - **PlayMode注意**: PlayModeテスト実行時は、一時的にdomain reloadが無効化されます
-  - `SaveXml` (boolean): テスト結果をXMLファイルとして保存するかどうか（デフォルト: false）
-    - XMLファイルは `{project_root}/.uloop/outputs/TestResults/` フォルダに保存されます
 - **レスポンス**:
   - `Success` (boolean): テスト実行が成功したかどうか
   - `Message` (string): テスト実行メッセージ
@@ -77,7 +75,7 @@
   - `PassedCount` (number): 合格したテストの数
   - `FailedCount` (number): 失敗したテストの数
   - `SkippedCount` (number): スキップされたテストの数
-  - `XmlPath` (string): XML結果ファイルのパス（SaveXmlがtrueの場合）
+  - `XmlPath` (string): NUnit XML結果ファイルのパス（テスト失敗時に自動保存）。XMLファイルは `{project_root}/.uloop/outputs/TestResults/` フォルダに保存されます
 
 ### 4. clear-console
 - **説明**: クリーンな開発ワークフローのためにUnityコンソールログをクリアします

--- a/Packages/src/TypeScriptServer~/README.md
+++ b/Packages/src/TypeScriptServer~/README.md
@@ -156,7 +156,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"getLogs","params":{"logType":"All","maxC
 
 ### Run Tests
 ```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"runtests","params":{"filterType":"all","filterValue":"","saveXml":false}}' | nc localhost 7400
+echo '{"jsonrpc":"2.0","id":1,"method":"runtests","params":{"filterType":"all","filterValue":""}}' | nc localhost 7400
 ```
 
 ### Notes


### PR DESCRIPTION
## Summary

Removed the `--save-xml` option from the `run-tests` tool. Now XML results with error messages and stack traces are automatically saved when tests fail (`failedCount > 0`).

## Changes

- **Removed `SaveXml` parameter** from `RunTestsSchema.cs`
- **Updated core logic** in `PlayModeTestExecuter.cs` to auto-save XML when `failedCount > 0`
- **Updated all callers** to remove `saveXml` arguments
- **Updated documentation** (SKILL.md, TOOL_REFERENCE.md) to reflect the new behavior
- **Simplified Unity Editor menus** by removing "Save XML" / "Log Only" variants

## Why

AI agents using this tool weren't aware of the `--save-xml` option, so they couldn't retrieve detailed failure diagnostics. By auto-saving XML on failure, agents can now access error messages and stack traces without needing to know about this flag.

## Verification

- ✅ All 323 tests pass
- ✅ No compilation errors or warnings
- ✅ CLI builds successfully with `npm run lint && npm run build`
- ✅ `XmlPath` is `null` when all tests pass (no unnecessary file generation)
- ✅ XML is auto-saved to `.uloop/outputs/TestResults/` when tests fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically save NUnit XML when tests fail and remove the --save-xml option across the run-tests tool and editor menus. This simplifies usage and ensures failure diagnostics are always captured.

- **Refactors**
  - Removed SaveXml from RunTestsSchema and default-tools.json.
  - Updated PlayModeTestExecuter, TestExecutionService, and RunTestsUseCase to auto-save XML on failure (failedCount > 0).
  - Simplified Unity Editor menus to single “All Tests” entries for EditMode/PlayMode.
  - Updated docs and examples; XmlPath is returned only on failure.

- **Migration**
  - Remove any saveXml arguments in existing calls and JSON-RPC/CLI requests.
  - Expect XmlPath only when tests fail; files are written to .uloop/outputs/TestResults/.

<sup>Written for commit d09412a262ff9b4d9c9f7ecd3402cf2b6872c369. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Auto-save NUnit XML on Test Failure

### Overview
This PR removes the `--save-xml` flag from the `run-tests` tool and implements automatic saving of NUnit XML test results when tests fail. XML files containing error messages and stack traces are now generated unconditionally for any test failures and saved to `.uloop/outputs/TestResults/`, while `XmlPath` remains `null` when all tests pass.

### Changes Summary

**Configuration & Schema**
- Removed `SaveXml` property from `RunTestsSchema.cs`
- Removed `SaveXml` parameter from `default-tools.json` input schema

**Core Test Execution Logic**
- `PlayModeTestExecuter.cs`: Simplified to automatically save XML when `failedCount > 0`, removing conditional logic based on the `saveXml` flag
- `TestExecutionService.cs`: Updated method signatures to remove `saveXml` parameter from both `ExecutePlayModeTestAsync` and `ExecuteEditModeTestAsync`
- `RunTestsUseCase.cs`: Removed `saveXml` parameter passing to test execution methods

**UI & Menus**
- `TestRunnerMenu.cs`: Consolidated duplicate menu commands:
  - Removed separate "Save XML" and "Log Only" variants
  - `RunEditModeTestsAndSaveXml()`, `RunEditModeTestsAndLogOnly()` → `RunEditModeTests()`
  - `RunPlayModeTestsAndSaveXml()`, `RunPlayModeTestsAndLogOnly()` → `RunPlayModeTests()`
  - Updated specific test runners to use unified command signatures without the `saveXml` parameter

**Tests & Documentation**
- `RunTestsToolTests.cs`: Removed `SaveXml` assertions and initialization
- Updated all documentation files (`SKILL.md`, `TOOL_REFERENCE.md`, `TOOL_REFERENCE_ja.md`, `README.md`) to reflect:
  - Removal of `--save-xml` parameter
  - Automatic XML saving on test failure
  - XML result location and contents (test names, status, duration, and failure details)

### Impact
- **API Breaking Change**: `saveXml` parameter removed from public method signatures in `TestExecutionService.cs`
- **User Behavior**: XML results are now generated automatically for failures without requiring an explicit flag; no opt-out mechanism
- **AI/Automated Consumers**: Receive detailed failure diagnostics (messages, stack traces) in XML format automatically for any failed tests

### Verification
- 323 tests pass
- No compilation errors or warnings
- CLI builds successfully with `npm run lint && npm run build`

### Affected Layers
```
┌─────────────────────────────────────────────┐
│  CLI Tool Documentation & Configuration     │
│  (TOOL_REFERENCE, SKILL.md, etc.)          │
└─────────────────────────────────────────────┘
                    ↓
┌─────────────────────────────────────────────┐
│  Schema Definitions                         │
│  (RunTestsSchema.cs, default-tools.json)    │
└─────────────────────────────────────────────┘
                    ↓
┌─────────────────────────────────────────────┐
│  Use Case Layer                             │
│  (RunTestsUseCase.cs)                       │
└─────────────────────────────────────────────┘
                    ↓
┌─────────────────────────────────────────────┐
│  Service Layer                              │
│  (TestExecutionService.cs)                  │
└─────────────────────────────────────────────┘
                    ↓
┌─────────────────────────────────────────────┐
│  Core Execution Logic                       │
│  (PlayModeTestExecuter.cs)                  │
└─────────────────────────────────────────────┘
                    ↓
┌─────────────────────────────────────────────┐
│  UI & Editor Integration                    │
│  (TestRunnerMenu.cs)                        │
└─────────────────────────────────────────────┘
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->