### PR TITLE
chore: ignore ESLint v10 major updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,12 @@ updates:
       - "dependencies"
       - "npm"
       - "security"
+    # typescript-eslint does not yet support ESLint v10 (see typescript-eslint/typescript-eslint#11952)
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
     # Group minor/patch updates to reduce PR noise
     groups:
       dev-dependencies:


### PR DESCRIPTION
## Summary
- Ignore major version updates for `eslint` and `@eslint/js` in Dependabot config
- `typescript-eslint` does not yet support ESLint v10 (see [typescript-eslint#11952](https://github.com/typescript-eslint/typescript-eslint/issues/11952)), causing peer dependency conflicts and runtime crashes
- Closed PR #607 and PR #606 which were failing CI due to this incompatibility

## Test plan
- [ ] Verify `dependabot.yml` YAML syntax is valid
- [ ] Confirm Dependabot does not recreate ESLint v10 major update PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Dependabot from opening ESLint v10 major upgrade PRs. typescript-eslint doesn’t support ESLint v10 yet, which causes peer dependency conflicts and CI failures.

- **Dependencies**
  - Add ignore rules for semver-major updates to eslint and @eslint/js in dependabot.yml.

<sup>Written for commit 29f7634322fddf30abf6bc60b00be6776137496d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR updates the Dependabot configuration to prevent automatic major version updates for `eslint` and `@eslint/js` packages. This addresses a compatibility issue where `typescript-eslint` does not yet support ESLint v10, which has been causing peer dependency conflicts and runtime crashes in the project.

## Changes Made
**File: `.github/dependabot.yml`**
- Added an ignore block under the npm updater for semver-major version updates
- Configured to ignore major version updates for:
  - `eslint`
  - `@eslint/js`
- Includes explanatory comments documenting the ESLint v10 compatibility limitations

**Impact:**
- Prevents Dependabot from automatically creating PRs for ESLint v10 major version releases
- Preserves existing grouping and update-type behavior for other dependencies
- Maintains the ability to receive minor and patch updates for these packages

## Context
This change resolves issues encountered in PR #607 and PR #606, which failed CI due to ESLint v10 incompatibility with the current typescript-eslint setup (reference: typescript-eslint/typescript-eslint#11952).

## Testing
- Dependabot configuration YAML syntax validation required
- Verification that Dependabot will not recreate PRs for ESLint v10 major updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->