### PR TITLE
fix: restore server bundle rebuild step in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,8 +49,43 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # ── Rebuild bundles when Release PR is created/updated ──
+      # GITHUB_TOKEN-created PRs do not trigger pull_request events,
+      # so build-and-test.yml cannot handle this — must rebuild here.
+      - name: 🔧 Setup Node.js for bundle rebuild
+        if: ${{ steps.release.outputs.pr != '' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: 📦 Rebuild server bundle for Release PR
+        if: ${{ steps.release.outputs.pr != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')
+          echo "🔄 Release PR #${PR_NUMBER} detected, rebuilding server bundle..."
+
+          gh pr checkout "${PR_NUMBER}"
+
+          cd Packages/src/TypeScriptServer~
+          npm ci --ignore-scripts=false
+          ULOOPMCP_PRODUCTION=true NODE_ENV=production npm run build:production
+          cd "$GITHUB_WORKSPACE"
+
+          git add Packages/src/TypeScriptServer~/dist/server.bundle.js Packages/src/TypeScriptServer~/dist/server.bundle.js.map
+          if git diff --cached --quiet; then
+            echo "✅ No changes to bundle, skipping commit"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: rebuild server bundle for release"
+            git push
+            echo "✅ Server bundle rebuilt and pushed to PR"
+          fi
+
       # ── Publish to npm ONLY when release is created ──────────────────
-      # Bundle rebuild is handled by build-and-test.yml on PR events (including Release PRs)
       # This ensures npm publish happens only after Release PR is merged,
       # not on every push to main (which caused version mismatch issues)
       - name: 🔧 Setup Node.js for npm publish


### PR DESCRIPTION
## Summary
- Restore the server bundle rebuild step in `release-please.yml` that was removed in PR #597
- PR #597 assumed `build-and-test.yml` would handle bundle rebuilds for Release PRs via `pull_request` events, but `GITHUB_TOKEN`-created PRs do not trigger other workflows (GitHub's infinite loop prevention)
- This caused release 0.62.1 to ship with `server.bundle.js` containing the old version (`0.62.0`)

## Changes
- Added bundle rebuild step (Node.js setup + `npm run build:production`) that runs when a Release PR is created/updated
- Updated comments to accurately describe the workflow behavior
- Used `build:production` (matching `build-and-test.yml`) instead of the original `build`

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] After merging, confirm that the next `push to main` triggers the release-please workflow and the bundle rebuild step executes on the Release PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the server bundle rebuild in the release-please workflow so Release PRs regenerate server.bundle.js with the correct version. Fixes stale bundles caused by GITHUB_TOKEN-created PRs not triggering other workflows.

- **Bug Fixes**
  - Rebuild runs when a Release PR is created or updated.
  - Uses Node 22 and npm run build:production, then commits changes back to the PR.
  - Updated comments to clarify workflow behavior.

<sup>Written for commit 8d12d0f90d456843da1974c4cfe38f932b378482. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR restores a server bundle rebuild step in the release-please workflow to address a critical issue where release 0.62.1 shipped with server.bundle.js still showing version 0.62.0.

## Problem
PR #597 removed the bundle rebuild step from release-please.yml, assuming the build-and-test.yml workflow would handle bundle rebuilding via pull_request events. However, workflows triggered by GITHUB_TOKEN-created PRs do not trigger other workflows as a GitHub infinite loop prevention mechanism. This caused the Release PR to ship without updated bundles.

## Solution
The PR reintroduces an inline bundle rebuild step in release-please.yml that executes when a Release PR is created or updated. The rebuild process:
- Detects when a PR exists (Release PR number)
- Checks out the Release PR
- Sets up Node.js environment
- Runs `npm run build:production` to rebuild server bundle
- Stages and commits dist artifacts if modified
- Pushes changes back to the Release PR

## Changes
**File: `.github/workflows/release-please.yml`**
- Added Node.js setup step
- Added bundle rebuild step with conditional logic (only runs when PR exists)
- Replaced implicit external dependency on build-and-test.yml with explicit inline rebuild
- Switched to `npm run build:production` (matching build-and-test.yml configuration)
- Updated workflow comments for clarity
- The npm publish section remains gated on `releases_created` events

**Stats:** +36 lines / -1 line

<!-- end of auto-generated comment: release notes by coderabbit.ai -->