### PR TITLE
fix: Fix CLI port resolution when serverPort is invalid

### DIFF
--- a/Packages/src/Cli~/src/__tests__/port-resolver.test.ts
+++ b/Packages/src/Cli~/src/__tests__/port-resolver.test.ts
@@ -1,0 +1,63 @@
+import { resolvePortFromUnitySettings } from '../port-resolver.js';
+
+describe('resolvePortFromUnitySettings', () => {
+  it('returns serverPort when server is running and serverPort is valid', () => {
+    const port = resolvePortFromUnitySettings({
+      isServerRunning: true,
+      serverPort: 8711,
+      customPort: 8700,
+    });
+
+    expect(port).toBe(8711);
+  });
+
+  it('returns customPort when server is not running', () => {
+    const port = resolvePortFromUnitySettings({
+      isServerRunning: false,
+      serverPort: 8711,
+      customPort: 8700,
+    });
+
+    expect(port).toBe(8700);
+  });
+
+  it('returns customPort when serverPort is invalid', () => {
+    const port = resolvePortFromUnitySettings({
+      isServerRunning: false,
+      serverPort: 0,
+      customPort: 8711,
+    });
+
+    expect(port).toBe(8711);
+  });
+
+  it('falls back to serverPort when customPort is invalid', () => {
+    const port = resolvePortFromUnitySettings({
+      isServerRunning: false,
+      serverPort: 8711,
+      customPort: 0,
+    });
+
+    expect(port).toBe(8711);
+  });
+
+  it('returns null when both ports are invalid', () => {
+    const port = resolvePortFromUnitySettings({
+      isServerRunning: false,
+      serverPort: 0,
+      customPort: 0,
+    });
+
+    expect(port).toBeNull();
+  });
+
+  it('returns null when port is not an integer', () => {
+    const port = resolvePortFromUnitySettings({
+      isServerRunning: true,
+      serverPort: 8711.5,
+      customPort: 8700.1,
+    });
+
+    expect(port).toBeNull();
+  });
+});

--- a/Packages/src/Cli~/src/port-resolver.ts
+++ b/Packages/src/Cli~/src/port-resolver.ts
@@ -14,8 +14,44 @@ import { findUnityProjectRoot } from './project-root.js';
 const DEFAULT_PORT = 8700;
 
 interface UnityMcpSettings {
+  isServerRunning?: boolean;
   serverPort?: number;
   customPort?: number;
+}
+
+function normalizePort(port: unknown): number | null {
+  if (typeof port !== 'number') {
+    return null;
+  }
+
+  if (!Number.isInteger(port)) {
+    return null;
+  }
+
+  if (port < 1 || port > 65535) {
+    return null;
+  }
+
+  return port;
+}
+
+export function resolvePortFromUnitySettings(settings: UnityMcpSettings): number | null {
+  const serverPort = normalizePort(settings.serverPort);
+  const customPort = normalizePort(settings.customPort);
+
+  if (settings.isServerRunning === true && serverPort !== null) {
+    return serverPort;
+  }
+
+  if (customPort !== null) {
+    return customPort;
+  }
+
+  if (serverPort !== null) {
+    return serverPort;
+  }
+
+  return null;
 }
 
 export async function resolveUnityPort(explicitPort?: number): Promise<number> {
@@ -57,13 +93,5 @@ async function readPortFromSettings(projectRoot: string): Promise<number | null>
     return null;
   }
 
-  if (typeof settings.serverPort === 'number') {
-    return settings.serverPort;
-  }
-
-  if (typeof settings.customPort === 'number') {
-    return settings.customPort;
-  }
-
-  return null;
+  return resolvePortFromUnitySettings(settings);
 }


### PR DESCRIPTION
## Summary
- add robust port normalization for UnityMcpSettings values
- avoid using invalid serverPort values such as 0
- prioritize serverPort only when isServerRunning is true
- fallback to customPort, then valid serverPort, then CLI default
- add focused unit tests for port selection edge cases

## Why
UnityMcpSettings.json can contain serverPort: 0 while isServerRunning: false.
The previous logic treated any numeric serverPort as valid and attempted to connect to port 0, causing sync failures even when Unity was running on the configured custom port.

## Validation
- npm run lint in Packages/src/Cli~
- npm run build in Packages/src/Cli~
- npx jest src/__tests__/port-resolver.test.ts in Packages/src/Cli~

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI port resolution to ignore invalid UnityMcpSettings ports and pick the right port based on server status. Prevents connections to port 0 and similar invalid values.

- **Bug Fixes**
  - Normalize ports to valid integers between 1–65535; ignore others.
  - Selection order: serverPort when isServerRunning=true → customPort → valid serverPort → default 8700.
  - Added unit tests for edge cases (zero/decimal ports and fallback behavior).

<sup>Written for commit f8c02b94cbe0deff9ac1287800463372d261fe09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes CLI port resolution when `serverPort` in UnityMcpSettings.json is invalid (e.g., 0). Previously, the CLI would attempt to connect to port 0 even when the server wasn't running, causing sync failures. The fix implements robust port validation and prioritization logic that only uses `serverPort` when the server is actually running, falling back to `customPort` and other defaults as needed.

## Problem

UnityMcpSettings.json can contain `serverPort: 0` while `isServerRunning: false`. The previous implementation treated any numeric `serverPort` value as valid, attempting connection to port 0 instead of the configured custom port, resulting in sync failures even when Unity was running on the correct port.

## Solution

### Port Normalization
Added `normalizePort()` helper that validates ports against:
- Type requirement: must be a number
- Integer requirement: no decimal values
- Range requirement: 1-65535 (valid port range)

### Port Resolution Logic
Implemented `resolvePortFromUnitySettings()` with the following priority:
1. If `isServerRunning === true` AND `serverPort` is valid → use `serverPort`
2. If `customPort` is valid → use `customPort`
3. If `serverPort` is valid (fallback) → use `serverPort`
4. Otherwise → return `null` (then fall back to CLI default 8700)

### Architecture

```mermaid
classDiagram
    class UnityMcpSettings {
        +isServerRunning?: boolean
        +serverPort?: number
        +customPort?: number
    }
    
    class PortResolver {
        -normalizePort(port: unknown): number | null
        +resolvePortFromUnitySettings(settings: UnityMcpSettings): number | null
        +resolveUnityPort(explicitPort?: number): Promise~number~
        -readPortFromSettings(projectRoot: string): Promise~number | null~
    }
    
    class ValidPortRange {
        +min: 1
        +max: 65535
        +requireInteger: true
    }
    
    PortResolver --> UnityMcpSettings: uses
    PortResolver --> ValidPortRange: validates against
```

## Changes

### `port-resolver.ts` (+37/-9)
- Added `isServerRunning?: boolean` to `UnityMcpSettings` interface
- Added `normalizePort()` internal helper function
- Added exported `resolvePortFromUnitySettings()` function
- Refactored `readPortFromSettings()` to delegate port resolution to `resolvePortFromUnitySettings()`

### `port-resolver.test.ts` (+63/-0)
- New test file with comprehensive unit tests covering:
  - Server running with valid serverPort
  - Server not running (returns customPort)
  - Invalid serverPort with valid customPort
  - Invalid customPort with valid serverPort
  - Both ports invalid
  - Non-integer port values

## Testing

- Unit tests validate all port resolution scenarios including edge cases
- Tests confirm priority logic: server-running takes precedence, customPort preferred when server not running, fallback to serverPort, and null return for invalid inputs
- Validation completed: `npm run lint`, `npm run build`, and Jest tests in `Packages/src/Cli~`

## Impact

- Prevents connection attempts to invalid ports (e.g., port 0)
- Ensures CLI respects `isServerRunning` flag when determining which port to use
- Provides robust fallback chain: explicit port → server settings (with validation) → custom port → default port
- Maintains backward compatibility for existing valid configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->