### PR TITLE
fix: Skip auto-sync for version/help flags and update command

### DIFF
--- a/Packages/src/Cli~/package-lock.json
+++ b/Packages/src/Cli~/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uloop-cli",
-  "version": "0.60.0",
+  "version": "0.62.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uloop-cli",
-      "version": "0.60.0",
+      "version": "0.62.3",
       "license": "MIT",
       "dependencies": {
         "commander": "14.0.2",


### PR DESCRIPTION
## Summary

This PR extends the auto-sync skip logic (introduced in #621) to also cover:
- Version/help flags: -v, --version, -h, --help
- update command: npm install -g uloop-cli@latest

These commands don't require Unity connection, so skipping auto-sync avoids unnecessary connection attempts and delays.

## Changes

- Add UPDATE_COMMAND and NO_SYNC_FLAGS constants
- Extract shouldSkipAutoSync() function to centralize skip logic
- Skip auto-sync for flags/commands that don't need Unity
- Remove obsolete comment (now self-documented by function)

## Test Plan

- [x] Build succeeds (npm run build)
- [x] Lint passes (npm run lint)
- [ ] Verify uloop -v / --version exits quickly without auto-sync
- [ ] Verify uloop -h / --help exits quickly without auto-sync
- [ ] Verify uloop update runs without auto-sync
- [ ] Verify uloop launch still skips auto-sync (regression check)
- [ ] Verify normal commands (e.g., uloop list) still trigger auto-sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip auto-sync for version/help flags (-v, --version, -h, --help) and the update command, so these exit immediately without trying to connect to Unity. Centralizes the skip logic in shouldSkipAutoSync, keeps launch skipped, and leaves auto-sync behavior unchanged for normal commands.

<sup>Written for commit eb7b6819810a0249bf42a403348ae85620a12194. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR extends the auto-sync skip logic introduced in PR #621 to cover additional scenarios where a Unity connection is unnecessary. It refactors the codebase to centralize skip conditions and adds support for version/help flags and the update command.

## Changes Made

### New Constants
- **`UPDATE_COMMAND`**: Constant representing the 'update' CLI subcommand (replacing the hardcoded string literal)
- **`NO_SYNC_FLAGS`**: Array defining built-in flags that exit immediately without requiring Unity connectivity: `-v`, `--version`, `-h`, `--help`

### Code Refactoring
- **`BUILTIN_COMMANDS` array**: Updated to use the new `UPDATE_COMMAND` constant instead of the string literal `'update'`
- **New function `shouldSkipAutoSync(cmdName: string | undefined, args: string[]): boolean`**: Centralizes the logic for determining when to skip auto-sync. Returns true if:
  - The command is `LAUNCH_COMMAND` or `UPDATE_COMMAND`, OR
  - The command-line arguments contain any of the `NO_SYNC_FLAGS`

### Main Function Updates
- **Auto-sync condition**: Replaced the hardcoded check `if (cmdName === LAUNCH_COMMAND)` with a call to `shouldSkipAutoSync(cmdName, args)`, making the logic more comprehensive and maintainable
- **Comment update**: Changed the inline comment from "launch starts Unity, so it cannot connect to Unity for sync" to "Main entry point with auto-sync for unknown commands"

## Rationale
The version, help, and update operations do not require a Unity connection, so skipping auto-sync avoids unnecessary connection attempts and reduces delays when users invoke these commands. The refactoring improves code maintainability by centralizing the skip logic into a dedicated function.

## Impact
- **Lines changed**: +13/-3
- **Files modified**: `Packages/src/Cli~/src/cli.ts`
- **Backward compatibility**: Fully maintained; the `launch` command continues to skip auto-sync (regression check)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->