### PR TITLE
feat: support CS0103 auto-using resolution

### DIFF
--- a/Packages/src/Editor/Compilation/RoslynCompiler.cs
+++ b/Packages/src/Editor/Compilation/RoslynCompiler.cs
@@ -612,12 +612,12 @@ namespace io.github.hatayama.uLoopMCP
                 if (!diagnostics.Any()) break;
 
                 Diagnostic[] unresolvedTypeDiagnostics = diagnostics
-                    .Where(d => d.Id == "CS0246")
+                    .Where(d => d.Id == "CS0246" || d.Id == "CS0103")
                     .ToArray();
 
                 if (!unresolvedTypeDiagnostics.Any()) break;
 
-                List<UsingResolutionResult> resolutions = resolver.ResolveUnresolvedTypes(
+                List<UsingResolutionResult> resolutions = resolver.ResolveMissingSymbols(
                     compilation, unresolvedTypeDiagnostics);
 
                 HashSet<string> namespacesToAdd = new();


### PR DESCRIPTION
## Summary
- extend auto-using resolution to also process CS0103 diagnostics in addition to CS0246
- detect type-like member access patterns (for example Debug.Log) and resolve candidate namespaces only when the target type has a matching public static member
- improve CS0103 error hints when multiple namespace candidates are found and add focused EditMode tests for these behaviors

## Validation
- uloop compile
- uloop run-tests --test-mode EditMode --filter-type regex --filter-value AutoUsingResolutionTests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CS0103 auto-using resolution to automatically add the correct using for type-like member access (e.g., Debug.Log) and improve ambiguity hints. This extends the resolver beyond CS0246 and adds focused tests.

- **New Features**
  - Auto-resolve CS0103 by detecting Type.Member patterns and adding a using only if the type has a public static member with that name.
  - Handles cases like Debug.Log by adding using UnityEngine and suppressing CS0103.
  - If multiple namespaces match, show a hint listing candidates and suggest fully-qualified forms.
  - EditMode tests added for success, non-PascalCase identifiers, and ambiguous Debug (UnityEngine vs System.Diagnostics).

- **Refactors**
  - Generalized UsingDirectiveResolver to ResolveMissingSymbols (handles CS0246 and CS0103) with caching and static-member lookup.
  - Added FindNamespacesForTypeWithStaticMember and syntax-based CS0103 extraction; ignores value-like symbols to avoid false positives.
  - RoslynCompiler now includes CS0103 in the fix loop; ExecuteDynamicCodeTool surfaces candidate lists in hints.

<sup>Written for commit 7d4fc08e72e57cf1d378359bc721f4486b815e43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# CS0103 Auto-Using Resolution Support

## Overview
This PR extends the auto-using resolution feature to handle CS0103 (name does not exist in the current context) diagnostics in addition to the existing CS0246 (type or namespace not found) support. The implementation intelligently detects type-like member access patterns (e.g., `Debug.Log`) and resolves candidate namespaces only when the target type exposes a matching public static member.

## Key Features

### 1. Extended Diagnostic Support
- **RoslynCompiler.cs**: Broadened the diagnostic filter in `ApplyDiagnosticFixes` to capture both CS0246 and CS0103 errors
- Changed the symbol resolution entry point from `ResolveUnresolvedTypes` to `ResolveMissingSymbols` to handle the expanded set of diagnostics

### 2. Enhanced Symbol Resolution with Deduplication
- **UsingDirectiveResolver.cs**: Introduces new public method `ResolveMissingSymbols` that replaces `ResolveUnresolvedTypes` (maintained as a compatibility wrapper)
- Adds `FindNamespacesForTypeWithStaticMember` API to resolve namespaces for type-member pairs
- Implements diagnostic preprocessing with smart deduplication using composite keys:
  - `CS0246:{type}` for type-only resolution
  - `CS0103:{type}.{member}` for member access pattern resolution
- Collects unresolved CS0246 types upfront via `CollectUnresolvedTypes` to avoid processing CS0103 errors for types that are already unresolved

### 3. CS0103-Specific Resolution Logic
- Extracts type and static member candidates from CS0103 diagnostic messages using `TryExtractCs0103TypeMemberCandidate`
- Validates candidates through Pascal case identifier checks (`IsPascalCaseIdentifier`) to avoid false positives on non-type-like patterns
- Searches namespaces for types exposing the target public static member via `SearchNamespaceForTypeWithStaticMember`
- Filters out value-like symbols (`IsValueLikeSymbol`) to prevent primitive types and value structs from being incorrectly resolved as candidates

### 4. Improved Error Handling and Hints
- **ExecuteDynamicCodeTool.cs**: Enhanced CS0103 error hints when Roslyn is available
- When multiple ambiguous candidates exist, dynamically generates suggestions in the format `Use {Namespace}.{Identifier}` for each candidate namespace
- Falls back to original static hint and two static suggestions when ambiguity data is unavailable

### 5. Caching Optimization
- Introduces separate cache dictionaries:
  - `_typeNameToNamespacesCache`: for CS0246 type lookups
  - `_typeNameMemberToNamespacesCache`: for CS0103 type-member lookups
- Reduces redundant namespace searches during compilation

## Real-World Example
For code like `Debug.Log("hello");` without a `using UnityEngine;` directive:
- Compiler reports CS0103: "Debug does not exist"
- Feature extracts `Debug` as type and `Log` as member
- Searches for namespaces containing a type `Debug` with public static member `Log`
- Finds `UnityEngine` namespace and auto-injects `using UnityEngine;`
- Compilation succeeds without user intervention

## Test Coverage
Four new EditMode test cases in **AutoUsingResolutionTests.cs** validate:
1. **Should_AutoResolve_UnityEngine_When_DebugLogUsed**: Verifies that `Debug.Log()` triggers auto-resolution of UnityEngine namespace
2. **Should_NotReportCs0103_When_DebugLogUsedWithoutUsingDirective**: Confirms CS0103 error is eliminated after auto-using resolution
3. **Should_NotAutoResolve_When_Cs0103TargetIsNotPascalCase**: Ensures non-Pascal case identifiers don't trigger false auto-resolution
4. **Should_ReportAmbiguousCandidates_When_Cs0103HasMultipleTypeMatches**: Validates correct handling when multiple namespaces contain matching type-member combinations (e.g., both UnityEngine and System.Diagnostics have Debug types)

## Code Changes Summary
| File | Changes | Complexity |
|------|---------|-----------|
| UsingDirectiveResolver.cs | +284/-13 | High |
| AutoUsingResolutionTests.cs | +61/-0 | Medium |
| ExecuteDynamicCodeTool.cs | +22/-3 | Medium |
| RoslynCompiler.cs | +2/-2 | Low |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->