### PR TITLE
fix: consolidate serverPort and customPort into single customPort field

### DIFF
--- a/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
+++ b/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
@@ -28,7 +28,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             // Save original session state
             _originalIsServerRunning = McpEditorSettings.GetIsServerRunning();
-            _originalServerPort = McpEditorSettings.GetServerPort();
+            _originalServerPort = McpEditorSettings.GetCustomPort();
         }
 
         [TearDown]
@@ -36,7 +36,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             // Restore original session state
             McpEditorSettings.SetIsServerRunning(_originalIsServerRunning);
-            McpEditorSettings.SetServerPort(_originalServerPort);
+            McpEditorSettings.SetCustomPort(_originalServerPort);
             McpEditorSettings.SetIsAfterCompile(false);
             McpEditorSettings.SetIsDomainReloadInProgress(false);
             McpEditorSettings.SetIsReconnecting(false);
@@ -53,7 +53,7 @@ namespace io.github.hatayama.uLoopMCP
             // Arrange
             int expectedPort = 7499;
             McpEditorSettings.SetIsServerRunning(true);
-            McpEditorSettings.SetServerPort(expectedPort);
+            McpEditorSettings.SetCustomPort(expectedPort);
 
             DomainReloadRecoveryUseCase useCase = new();
 
@@ -63,7 +63,7 @@ namespace io.github.hatayama.uLoopMCP
             // Assert
             Assert.IsTrue(result.Success, "ExecuteBeforeDomainReload should succeed");
             Assert.IsTrue(McpEditorSettings.GetIsAfterCompile(), "IsAfterCompile should be set to true");
-            Assert.AreEqual(expectedPort, McpEditorSettings.GetServerPort(), "Server port should be preserved from session state");
+            Assert.AreEqual(expectedPort, McpEditorSettings.GetCustomPort(), "Server port should be preserved from session state");
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             // Arrange
             McpEditorSettings.SetIsServerRunning(false);
-            McpEditorSettings.SetServerPort(7400);
+            McpEditorSettings.SetCustomPort(7400);
             McpEditorSettings.SetIsAfterCompile(false);
 
             DomainReloadRecoveryUseCase useCase = new();
@@ -91,7 +91,7 @@ namespace io.github.hatayama.uLoopMCP
             int sessionPort = GetFreePort();
             int instancePort = GetFreePort();
             McpEditorSettings.SetIsServerRunning(true);
-            McpEditorSettings.SetServerPort(sessionPort);
+            McpEditorSettings.SetCustomPort(sessionPort);
 
             // Create a running server instance
             McpBridgeServer server = null;
@@ -107,7 +107,7 @@ namespace io.github.hatayama.uLoopMCP
 
                 // Assert
                 Assert.IsTrue(result.Success, "ExecuteBeforeDomainReload should succeed");
-                Assert.AreEqual(instancePort, McpEditorSettings.GetServerPort(),
+                Assert.AreEqual(instancePort, McpEditorSettings.GetCustomPort(),
                     "Server port should be from running instance, not session state");
             }
             finally

--- a/Packages/src/Cli~/src/__tests__/port-resolver.test.ts
+++ b/Packages/src/Cli~/src/__tests__/port-resolver.test.ts
@@ -6,51 +6,36 @@ import {
 } from '../port-resolver.js';
 
 describe('resolvePortFromUnitySettings', () => {
-  it('returns serverPort when server is running and serverPort is valid', () => {
+  it('returns customPort when valid', () => {
     const port = resolvePortFromUnitySettings({
       isServerRunning: true,
-      serverPort: 8711,
-      customPort: 8700,
-    });
-
-    expect(port).toBe(8711);
-  });
-
-  it('returns customPort when server is not running', () => {
-    const port = resolvePortFromUnitySettings({
-      isServerRunning: false,
-      serverPort: 8711,
       customPort: 8700,
     });
 
     expect(port).toBe(8700);
   });
 
-  it('returns customPort when serverPort is invalid', () => {
+  it('returns customPort regardless of isServerRunning flag', () => {
     const port = resolvePortFromUnitySettings({
       isServerRunning: false,
-      serverPort: 0,
       customPort: 8711,
     });
 
     expect(port).toBe(8711);
   });
 
-  it('falls back to serverPort when customPort is invalid', () => {
+  it('returns null when customPort is invalid', () => {
     const port = resolvePortFromUnitySettings({
-      isServerRunning: false,
-      serverPort: 8711,
+      isServerRunning: true,
       customPort: 0,
     });
 
-    expect(port).toBe(8711);
+    expect(port).toBeNull();
   });
 
-  it('returns null when both ports are invalid', () => {
+  it('returns null when customPort is missing', () => {
     const port = resolvePortFromUnitySettings({
-      isServerRunning: false,
-      serverPort: 0,
-      customPort: 0,
+      isServerRunning: true,
     });
 
     expect(port).toBeNull();
@@ -59,7 +44,6 @@ describe('resolvePortFromUnitySettings', () => {
   it('returns null when port is not an integer', () => {
     const port = resolvePortFromUnitySettings({
       isServerRunning: true,
-      serverPort: 8711.5,
       customPort: 8700.1,
     });
 

--- a/Packages/src/Cli~/src/port-resolver.ts
+++ b/Packages/src/Cli~/src/port-resolver.ts
@@ -15,7 +15,6 @@ const DEFAULT_PORT = 8700;
 
 interface UnityMcpSettings {
   isServerRunning?: boolean;
-  serverPort?: number;
   customPort?: number;
 }
 
@@ -36,19 +35,10 @@ function normalizePort(port: unknown): number | null {
 }
 
 export function resolvePortFromUnitySettings(settings: UnityMcpSettings): number | null {
-  const serverPort = normalizePort(settings.serverPort);
   const customPort = normalizePort(settings.customPort);
-
-  if (settings.isServerRunning === true && serverPort !== null) {
-    return serverPort;
-  }
 
   if (customPort !== null) {
     return customPort;
-  }
-
-  if (serverPort !== null) {
-    return serverPort;
   }
 
   return null;

--- a/Packages/src/Editor/Api/McpTools/UseCases/System/DomainReloadRecoveryUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/System/DomainReloadRecoveryUseCase.cs
@@ -29,7 +29,7 @@ namespace io.github.hatayama.uLoopMCP
             // Handles case where mcpServer instance became null unexpectedly
             if (currentServer == null && McpEditorSettings.GetIsServerRunning())
             {
-                int sessionPort = McpEditorSettings.GetServerPort();
+                int sessionPort = McpEditorSettings.GetCustomPort();
                 if (NetworkUtility.IsValidPort(sessionPort))
                 {
                     serverRunning = true;

--- a/Packages/src/Editor/Api/McpTools/UseCases/System/McpServerShutdownUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/System/McpServerShutdownUseCase.cs
@@ -54,7 +54,7 @@ namespace io.github.hatayama.uLoopMCP
                 cancellationToken.ThrowIfCancellationRequested();
                 
                 // 3. Session state clear
-                var sessionUpdateResult = _startupService.UpdateSessionState(false, 0);
+                var sessionUpdateResult = _startupService.UpdateSessionState(false);
                 if (!sessionUpdateResult.Success)
                 {
                     response.Success = false;

--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -51,7 +51,6 @@ namespace io.github.hatayama.uLoopMCP
         // Session State Settings (moved from McpSessionManager)
         // Default to true so the server starts automatically on fresh install
         public bool isServerRunning = true;
-        public int serverPort = McpServerConfig.DEFAULT_PORT;
         public bool isAfterCompile = false;
         public bool isDomainReloadInProgress = false;
         public bool isReconnecting = false;
@@ -324,24 +323,6 @@ namespace io.github.hatayama.uLoopMCP
         {
             McpEditorSettingsData settings = GetSettings();
             McpEditorSettingsData newSettings = settings with { isServerRunning = isServerRunning };
-            SaveSettings(newSettings);
-        }
-
-        /// <summary>
-        /// Gets the server port.
-        /// </summary>
-        public static int GetServerPort()
-        {
-            return GetSettings().serverPort;
-        }
-
-        /// <summary>
-        /// Sets the server port.
-        /// </summary>
-        public static void SetServerPort(int serverPort)
-        {
-            McpEditorSettingsData settings = GetSettings();
-            McpEditorSettingsData newSettings = settings with { serverPort = serverPort };
             SaveSettings(newSettings);
         }
 
@@ -898,19 +879,6 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             _cachedSettings.isServerRunning = probe.autoStartServer;
-
-            // Old McpServerShutdownUseCase.ExecuteAsync always called
-            // UpdateSessionState(false, 0), persisting serverPort=0 on every quit.
-            // Without normalization, recovery binds port 0 and becomes unreachable.
-            if (!McpPortValidator.ValidatePort(_cachedSettings.serverPort))
-            {
-                int fallbackPort = McpPortValidator.ValidatePort(_cachedSettings.customPort)
-                    ? _cachedSettings.customPort
-                    : McpServerConfig.DEFAULT_PORT;
-                Debug.LogWarning(
-                    $"[{McpConstants.PROJECT_NAME}] Legacy migration: serverPort={_cachedSettings.serverPort} is invalid, using {fallbackPort}");
-                _cachedSettings.serverPort = fallbackPort;
-            }
 
             SaveSettings(_cachedSettings);
         }

--- a/Packages/src/Editor/Core/ApplicationServices/DomainReloadDetectionService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/DomainReloadDetectionService.cs
@@ -75,7 +75,7 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     isDomainReloadInProgress = true,
                     isServerRunning = true,
-                    serverPort = port,
+                    customPort = port,
                     isAfterCompile = true,
                     isReconnecting = true,
                     showReconnectingUI = true,
@@ -122,7 +122,7 @@ namespace io.github.hatayama.uLoopMCP
             VibeLogger.LogInfo(
                 "domain_reload_complete",
                 "Domain reload completed - starting server recovery process",
-                new { session_server_port = McpEditorSettings.GetServerPort() },
+                new { session_server_port = McpEditorSettings.GetCustomPort() },
                 correlationId
             );
         }

--- a/Packages/src/Editor/Core/ApplicationServices/McpServerStartupService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/McpServerStartupService.cs
@@ -53,14 +53,19 @@ namespace io.github.hatayama.uLoopMCP
 
         /// <summary>
         /// Updates session manager with server state.
+        /// On shutdown (isRunning=false), only the running flag is cleared — customPort is preserved
+        /// so recovery can rebind to the same port after domain reload or editor restart.
         /// </summary>
         /// <param name="isRunning">Whether the server is running</param>
-        /// <param name="port">Server port number</param>
+        /// <param name="port">Server port number (only written when isRunning=true)</param>
         /// <returns>Success indicator</returns>
-        public ServiceResult<bool> UpdateSessionState(bool isRunning, int port)
+        public ServiceResult<bool> UpdateSessionState(bool isRunning, int port = -1)
         {
             McpEditorSettings.SetIsServerRunning(isRunning);
-            McpEditorSettings.SetServerPort(port);
+            if (isRunning && port > 0)
+            {
+                McpEditorSettings.SetCustomPort(port);
+            }
             return ServiceResult<bool>.SuccessResult(true);
         }
     }

--- a/Packages/src/Editor/Core/ApplicationServices/SessionRecoveryService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/SessionRecoveryService.cs
@@ -21,7 +21,7 @@ namespace io.github.hatayama.uLoopMCP
         public static ValidationResult RestoreServerStateIfNeeded()
         {
             bool wasRunning = McpEditorSettings.GetIsServerRunning();
-            int savedPort = McpEditorSettings.GetServerPort();
+            int savedPort = McpEditorSettings.GetCustomPort();
             bool isAfterCompile = McpEditorSettings.GetIsAfterCompile();
 
             // If server is already running
@@ -89,7 +89,7 @@ namespace io.github.hatayama.uLoopMCP
                 // Update session state
                 McpEditorSettings.UpdateSettings(s => s with
                 {
-                    serverPort = availablePort,
+                    customPort = availablePort,
                     isReconnecting = false
                 });
 

--- a/Packages/src/Editor/Server/McpServerController.cs
+++ b/Packages/src/Editor/Server/McpServerController.cs
@@ -122,7 +122,7 @@ namespace io.github.hatayama.uLoopMCP
                 // Sync session state with the running server to enable domain reload recovery
                 // even if mcpServer instance becomes null unexpectedly
                 McpEditorSettings.SetIsServerRunning(true);
-                McpEditorSettings.SetServerPort(mcpServer.Port);
+                McpEditorSettings.SetCustomPort(mcpServer.Port);
 
             }
             else
@@ -231,7 +231,7 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             bool wasRunning = McpEditorSettings.GetIsServerRunning();
-            int savedPort = McpEditorSettings.GetServerPort();
+            int savedPort = McpEditorSettings.GetCustomPort();
             bool isAfterCompile = McpEditorSettings.GetIsAfterCompile();
 
             // If the server is already running (e.g., started from McpEditorWindow).
@@ -263,7 +263,7 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            int portToUse = wasRunning ? savedPort : McpEditorSettings.GetCustomPort();
+            int portToUse = savedPort;
 
             // Centralized, coalesced startup request
             // Store the task so McpEditorWindow can await it to prevent race conditions
@@ -301,9 +301,9 @@ namespace io.github.hatayama.uLoopMCP
                 mcpServer.StartServer(port);
 
                 // Update settings with the actual port used (same as requested)
-                if (McpEditorSettings.GetServerPort() != port)
+                if (McpEditorSettings.GetCustomPort() != port)
                 {
-                    McpEditorSettings.SetServerPort(port);
+                    McpEditorSettings.SetCustomPort(port);
                 }
 
                 // Clear server-side reconnecting flag on successful restoration
@@ -682,10 +682,9 @@ namespace io.github.hatayama.uLoopMCP
 
                 // Mark running and update settings
                 McpEditorSettings.SetIsServerRunning(true);
-                if (McpEditorSettings.GetServerPort() != chosenPort)
+                if (McpEditorSettings.GetCustomPort() != chosenPort)
                 {
-                    // Defer aggressive external updates; only update internal setting here
-                    McpEditorSettings.SetServerPort(chosenPort);
+                    McpEditorSettings.SetCustomPort(chosenPort);
                 }
 
                 // Clear reconnection-related flags on successful recovery

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -147,7 +147,7 @@ namespace io.github.hatayama.uLoopMCP
             {
                 McpEditorSettings.ClearAfterCompileFlag();
 
-                int savedPort = McpEditorSettings.GetServerPort();
+                int savedPort = McpEditorSettings.GetCustomPort();
                 bool portNeedsUpdate = savedPort != _model.UI.CustomPort;
 
                 if (portNeedsUpdate)


### PR DESCRIPTION
## Summary

- Remove the redundant `serverPort` field from `McpEditorSettingsData`, keeping only `customPort` as the single source of truth for port configuration
- Fix the shutdown path that persisted `serverPort=0` via `UpdateSessionState(false, 0)`, which broke server recovery on next startup
- `UpdateSessionState` now only writes the port when `isRunning=true`, preserving the last-known good port across restarts and domain reloads
- Simplify CLI port resolution to use only `customPort` (full backward compatibility since the JSON field name is unchanged)

## Changes

### C# (Unity)
- **McpEditorSettings.cs**: Remove `serverPort` field, `GetServerPort()`/`SetServerPort()` accessors, and legacy migration code
- **McpServerStartupService.cs**: Change `UpdateSessionState` to skip port update on shutdown (`isRunning=false`)
- **McpServerShutdownUseCase.cs**: Call `UpdateSessionState(false)` instead of `UpdateSessionState(false, 0)`
- **McpServerController.cs**: Replace all `GetServerPort`/`SetServerPort` with `GetCustomPort`/`SetCustomPort`
- **DomainReloadRecoveryUseCase.cs**, **DomainReloadDetectionService.cs**, **SessionRecoveryService.cs**: Same replacement
- **McpEditorWindow.cs**: Same replacement

### TypeScript (CLI)
- **port-resolver.ts**: Remove `serverPort` from `UnityMcpSettings` interface, simplify resolution to `customPort` only
- **port-resolver.test.ts**: Update tests for single-port model

### Tests
- **DomainReloadRecoveryUseCaseTests.cs**: Update all `SetServerPort`/`GetServerPort` to `SetCustomPort`/`GetCustomPort`

## Test plan
- [x] C# compilation: 0 errors, 0 warnings
- [x] TypeScript lint + build: pass
- [x] port-resolver unit tests: 9/9 pass
- [x] Unity EditMode tests: 351/351 pass
- [ ] E2E: Start server -> stop server -> verify `customPort` is preserved (not reset to 0) in settings JSON

Closes #665

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated Unity MCP port configuration to a single customPort and stopped writing port=0 on shutdown, fixing broken server recovery. CLI and Editor now consistently use customPort, preserving the last known port across restarts and domain reloads. Closes #665.

- **Bug Fixes**
  - UpdateSessionState no longer writes the port on shutdown; recovery uses the saved customPort.

- **Refactors**
  - Removed serverPort from settings; replaced Get/SetServerPort with Get/SetCustomPort across Editor and tests.
  - Simplified CLI port resolver to read customPort only; updated tests.

<sup>Written for commit 81cdd75e64ce26432fc0d8aed07084d84d3c5ddd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Consolidate serverPort and customPort into single customPort field

## Overview
This PR consolidates two redundant port configuration fields (`serverPort` and `customPort`) in the MCP Editor Settings into a single `customPort` field. This eliminates confusion about which port field to use in different contexts and prevents bugs from stale or inconsistent persisted port state, particularly fixing recovery failures after migrations.

## Key Changes

### Data Model (C#)
**File: `Packages/src/Editor/Config/McpEditorSettings.cs`**
- **Removed** the `serverPort` field from `McpEditorSettingsData` 
- **Removed** public accessors `GetServerPort()` and `SetServerPort(int)`
- **Retained** `customPort` as the single source of truth for port configuration
- **Removed** legacy migration logic that validated serverPort and applied port fallback logic

### Port State Management (C#)
**File: `Packages/src/Editor/Core/ApplicationServices/McpServerStartupService.cs`**
- **Updated** `UpdateSessionState()` signature from `UpdateSessionState(bool isRunning, int port)` to `UpdateSessionState(bool isRunning, int port = -1)`
- **Critical behavior change**: Port is now only written to settings when `isRunning=true` AND `port > 0`
  - Startup: `UpdateSessionState(true, portNumber)` → writes customPort and sets server running
  - Shutdown: `UpdateSessionState(false)` → clears running flag while **preserving customPort** for recovery
- **Effect**: Prevents invalid `serverPort=0` from persisting during shutdown, which was causing recovery failures

### Service Layer Updates (C#)
All services now use `GetCustomPort()/SetCustomPort()` instead of `GetServerPort()/SetServerPort()`:

| File | Change |
|------|--------|
| `McpServerController.cs` | Port initialization, restoration, and recovery paths |
| `DomainReloadRecoveryUseCase.cs` | Session port retrieval before domain reload |
| `DomainReloadDetectionService.cs` | Pre/post domain reload port tracking |
| `SessionRecoveryService.cs` | Stored port retrieval and session state updates |
| `McpEditorWindow.cs` | Port comparison for UI model updates |
| `McpServerShutdownUseCase.cs` | Changed from `UpdateSessionState(false, 0)` to `UpdateSessionState(false)` |

### CLI Port Resolution (TypeScript)
**Files: `Packages/src/Cli~/src/port-resolver.ts` and tests**
- **Removed** `serverPort` property from `UnityMcpSettings` interface
- **Simplified** `resolvePortFromUnitySettings()` to only check `customPort`
- **Removed** `isServerRunning` fallback logic that previously used serverPort as a backup
- **Behavior**: Returns `null` if `customPort` is missing or invalid (no fallback mechanism)
- **Test updates**: Port-resolver tests rewritten to validate customPort-only scenarios with all edge cases

### Test Coverage Updates
**Files: `Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs` and port-resolver tests**
- Updated all port accessor calls from `GetServerPort/SetServerPort` to `GetCustomPort/SetCustomPort`
- Rewrote port-resolver tests to verify customPort behavior without serverPort fallback
- Test logic preserved; only port field references updated

## Test Status
✓ C# compilation: Pass  
✓ TypeScript lint + build: Pass  
✓ port-resolver unit tests: 9/9 pass  
✓ Unity EditMode tests: 351/351 pass  
⏳ E2E (customPort preservation on stop/start): Pending verification

## Benefits
- **Simplified mental model**: Single port field eliminates confusion about which field to read/write
- **Improved reliability**: Prevents invalid port values from persisting after shutdown
- **Cleaner recovery**: Port is now preserved across domain reloads and editor restarts without special logic
- **Reduced bug surface**: No more inconsistent state between two port fields
- **Backward compatible**: JSON serialization field name remains unchanged

## Architecture
```
Before:
McpEditorSettingsData
├── serverPort (persisted on shutdown, caused issues)
└── customPort (user-configured port)
     ↓ (confusion about which to use)

After:
McpEditorSettingsData
└── customPort (single source of truth)
     ↓ preserved across shutdown
     → ready for recovery
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->