### PR TITLE
fix: distinguish Downgrade CLI from Update CLI in version mismatch display

### DIFF
--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -571,7 +571,15 @@ namespace io.github.hatayama.uLoopMCP
             bool isCliInstalled = cliVersion != null;
             bool isChecking = !CliInstallationDetector.IsCheckCompleted() || _isRefreshingVersion;
             string packageVersion = McpConstants.PackageInfo.version;
-            bool needsUpdate = isCliInstalled && cliVersion != packageVersion;
+            bool needsUpdate = false;
+            bool needsDowngrade = false;
+            if (isCliInstalled)
+            {
+                System.Version cliVer = new System.Version(cliVersion);
+                System.Version pkgVer = new System.Version(packageVersion);
+                needsUpdate = cliVer < pkgVer;
+                needsDowngrade = cliVer > pkgVer;
+            }
             bool isClaudeInstalled = CliInstallationDetector.AreSkillsInstalled("claude");
             bool isCodexInstalled = CliInstallationDetector.AreSkillsInstalled("codex");
             bool isCursorInstalled = CliInstallationDetector.AreSkillsInstalled("cursor");
@@ -583,6 +591,7 @@ namespace io.github.hatayama.uLoopMCP
                 cliVersion,
                 packageVersion,
                 needsUpdate,
+                needsDowngrade,
                 _isInstallingCli,
                 isChecking,
                 isClaudeInstalled,

--- a/Packages/src/Editor/UI/McpEditorWindowViewData.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowViewData.cs
@@ -123,6 +123,7 @@ namespace io.github.hatayama.uLoopMCP
         public readonly string CliVersion;
         public readonly string PackageVersion;
         public readonly bool NeedsUpdate;
+        public readonly bool NeedsDowngrade;
         public readonly bool IsInstallingCli;
         public readonly bool IsChecking;
         public readonly bool IsClaudeSkillsInstalled;
@@ -138,6 +139,7 @@ namespace io.github.hatayama.uLoopMCP
             string cliVersion,
             string packageVersion,
             bool needsUpdate,
+            bool needsDowngrade,
             bool isInstallingCli,
             bool isChecking,
             bool isClaudeSkillsInstalled,
@@ -152,6 +154,7 @@ namespace io.github.hatayama.uLoopMCP
             CliVersion = cliVersion;
             PackageVersion = packageVersion;
             NeedsUpdate = needsUpdate;
+            NeedsDowngrade = needsDowngrade;
             IsInstallingCli = isInstallingCli;
             IsChecking = isChecking;
             IsClaudeSkillsInstalled = isClaudeSkillsInstalled;

--- a/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
@@ -107,6 +107,12 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
+            if (data.NeedsDowngrade)
+            {
+                SetCliButton($"Downgrade CLI (v{data.CliVersion} \u2192 v{data.PackageVersion})", true);
+                return;
+            }
+
             SetCliButton("Up to date", false);
         }
 


### PR DESCRIPTION
## Summary
- When CLI version is newer than Unity package version, the button now shows **Downgrade CLI** instead of **Update CLI**
- Added semantic version comparison using `System.Version` to correctly determine update direction
- Added `NeedsDowngrade` field to `CliSetupData` to distinguish downgrade from update

## Background
Previously, the version check used simple string inequality (`cliVersion != packageVersion`), which always showed "Update CLI" regardless of whether the CLI was older or newer. This confused users into unknowingly downgrading their CLI.

## Changes
- `McpEditorWindowViewData.cs`: Add `NeedsDowngrade` field to `CliSetupData`
- `McpEditorWindow.cs`: Replace string comparison with `System.Version` comparison
- `CliSetupSection.cs`: Add "Downgrade CLI (vX → vY)" button display branch

## Test plan
- [ ] Verify compilation succeeds with zero errors/warnings
- [ ] When CLI version > package version: button shows "Downgrade CLI (vX → vY)"
- [ ] When CLI version < package version: button shows "Update CLI (vX → vY)"
- [ ] When CLI version = package version: button shows "Up to date" (disabled)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI version mismatch display to correctly show “Downgrade CLI” when the installed CLI is newer than the Unity package, preventing accidental downgrades. Uses semantic version comparison for accurate update direction.

- **Bug Fixes**
  - Replace string inequality with System.Version comparison.
  - Add NeedsDowngrade to CliSetupData and update CliSetupSection to branch on downgrade vs update.

<sup>Written for commit 782b4792d735b21647d802340ecc729f8f9c6bce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Distinguish Downgrade CLI from Update CLI in Version Mismatch Display

## Overview
This PR improves the CLI installation UI by correctly distinguishing between update and downgrade scenarios. When the CLI version is newer than the Unity package version, users now see a "Downgrade CLI" button instead of "Update CLI", preventing confusion and accidental downgrades.

## Changes Made

### McpEditorWindowViewData.cs
Added a new `NeedsDowngrade` boolean field to the `CliSetupData` record to track when a downgrade is required (when CLI version > package version).

### McpEditorWindow.cs
Implemented semantic version comparison logic in `CreateCliSetupData`:
- Replaced string-based version comparison with `System.Version` for proper semantic version handling
- Added logic to set `needsDowngrade` when CLI version is greater than package version
- Set `needsUpdate` when CLI version is less than package version
- Both flags remain false when CLI is not installed

### CliSetupSection.cs
Enhanced `UpdateInstallCliButton` method:
- Added a new branch to handle downgrade scenarios
- When `data.NeedsDowngrade` is true, displays "Downgrade CLI (vX → vY)" button
- Maintains proper precedence: checks for NeedsUpdate first, then NeedsDowngrade, then defaults to "Up to date"

## User Impact
- **CLI newer than package**: Shows "Downgrade CLI (vX → vY)" button
- **CLI older than package**: Shows "Update CLI (vX → vY)" button  
- **Versions match**: Shows "Up to date" (disabled button)

## Testing Recommendations
- Verify compilation succeeds with no errors or warnings
- Test UI button display for all three version comparison scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->