### PR TITLE
fix: prioritize .cmd/.exe over extensionless shims in Windows executable detection

### DIFF
--- a/Packages/src/Editor/Utils/NodeEnvironmentResolver.cs
+++ b/Packages/src/Editor/Utils/NodeEnvironmentResolver.cs
@@ -145,10 +145,30 @@ namespace io.github.hatayama.uLoopMCP
             return ExtractAbsolutePathLine(block);
         }
 
+        /// <summary>
+        /// Finds the first executable path for the given name using the Windows 'where' command.
+        /// Prioritizes .cmd/.exe over extensionless entries because npm generates both a bash shim
+        /// (extensionless) and a Windows cmd shim (.cmd); the bash shim cannot be launched via Process.Start.
+        /// </summary>
         private static string TryWhereCommand(string executableName)
         {
             string[] paths = TryWhereCommandAll(executableName);
-            return paths != null && paths.Length > 0 ? paths[0] : null;
+            if (paths == null || paths.Length == 0)
+            {
+                return null;
+            }
+
+            foreach (string path in paths)
+            {
+                string extension = Path.GetExtension(path);
+                if (string.Equals(extension, ".cmd", System.StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(extension, ".exe", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return path;
+                }
+            }
+
+            return paths[0];
         }
 
         private static string[] TryWhereCommandAll(string executableName)


### PR DESCRIPTION
## Summary

- On Windows, `where uloop` returns both an extensionless bash shim and a `.cmd` shim. `TryWhereCommand` was returning the extensionless one first, which `Process.Start` cannot execute (`Win32Exception`), causing the CLI to appear as "Not installed".
- Fix `TryWhereCommand` to prioritize `.cmd`/`.exe` entries over extensionless paths.

## Test plan

- [x] Verified `FindExecutablePath("uloop")` returns `.cmd` path in Unity Editor on Windows
- [x] Verified `CliInstallationDetector.IsCliInstalled` returns `true` after fix
- [x] Verified `CachedVersion` correctly returns version string (`0.61.1`)
- [x] All 23 existing `NodeEnvironmentResolverTests` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows executable detection to return .cmd/.exe from 'where' instead of extensionless shims, so the uloop CLI is correctly detected and launches in the Unity Editor.

- **Bug Fixes**
  - Updated TryWhereCommand to prioritize .cmd/.exe and fall back to the first path when none are found.

<sup>Written for commit 2253147518558e382150291e8d9a3352f27e25c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixes a Windows executable detection issue where `Process.Start` fails to execute extensionless bash shims. On Windows, the `where` command returns both an extensionless bash shim and a `.cmd`/`.exe` shim for package managers like npm and uLoop CLI. The previous implementation returned the extensionless entry first, which is not executable by `Process.Start`, causing a `Win32Exception` and making the CLI appear as "Not installed".

## Changes
**File: `Packages/src/Editor/Utils/NodeEnvironmentResolver.cs`**

Enhanced the `TryWhereCommand` method to intelligently select executable paths on Windows:
- **Null/empty validation**: Added explicit check for null or empty path arrays before processing
- **Extension prioritization**: Implemented logic to scan the list of paths returned by `where` and return the first path with a `.cmd` or `.exe` extension (case-insensitive comparison)
- **Fallback behavior**: If no `.cmd`/`.exe` path is found, falls back to returning the first path in the list
- **Documentation**: Added XML summary documenting the Windows-specific behavior and the rationale for prioritizing extensions

**Code change summary:**
- Old: `return paths != null && paths.Length > 0 ? paths[0] : null;`
- New: Explicit loop through paths filtering for `.cmd`/`.exe` extensions, with fallback to `paths[0]`

Lines changed: +21/-1

## Testing
- Verified `FindExecutablePath("uloop")` returns the `.cmd` path in Unity Editor on Windows
- Verified `CliInstallationDetector.IsCliInstalled` returns `true` after the fix
- Verified `CachedVersion` correctly returns the version string (0.61.1)
- All 23 existing `NodeEnvironmentResolverTests` pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->