### PR TITLE
feat: add Windows npm install permission pre-check and error classification

### DIFF
--- a/Assets/Tests/Editor/NpmInstallDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/NpmInstallDiagnosticsTests.cs
@@ -1,0 +1,103 @@
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    [TestFixture]
+    public class NpmInstallDiagnosticsTests
+    {
+        // --- ClassifyInstallError ---
+
+        [Test]
+        public void ClassifyInstallError_NullInput_ReturnsNull()
+        {
+            string result = NpmInstallDiagnostics.ClassifyInstallError(null);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ClassifyInstallError_EmptyInput_ReturnsNull()
+        {
+            string result = NpmInstallDiagnostics.ClassifyInstallError("");
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ClassifyInstallError_WithEPERM_ReturnsPermissionGuidance()
+        {
+            string stderr = "npm ERR! Error: EPERM: operation not permitted, rename 'C:\\Users\\test'";
+
+            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr);
+
+            Assert.IsNotNull(result);
+            Assert.That(result, Does.Contain("permission"));
+        }
+
+        [Test]
+        public void ClassifyInstallError_WithEACCES_ReturnsPermissionGuidance()
+        {
+            string stderr = "npm ERR! Error: EACCES: permission denied, access '/usr/lib/node_modules'";
+
+            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr);
+
+            Assert.IsNotNull(result);
+            Assert.That(result, Does.Contain("permission"));
+        }
+
+        [Test]
+        public void ClassifyInstallError_WithOperationNotPermitted_ReturnsPermissionGuidance()
+        {
+            string stderr = "npm ERR! Error: operation not permitted, mkdir 'C:\\Program Files\\nodejs'";
+
+            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr);
+
+            Assert.IsNotNull(result);
+            Assert.That(result, Does.Contain("permission"));
+        }
+
+        [Test]
+        public void ClassifyInstallError_UnrecognizedError_ReturnsNull()
+        {
+            string stderr = "npm ERR! 404 Not Found - GET https://registry.npmjs.org/nonexistent";
+
+            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr);
+
+            Assert.IsNull(result);
+        }
+
+        // --- IsPermissionError ---
+
+        [Test]
+        public void IsPermissionError_WithEPERM_ReturnsTrue()
+        {
+            bool result = NpmInstallDiagnostics.IsPermissionError("EPERM: operation not permitted");
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsPermissionError_WithEACCES_ReturnsTrue()
+        {
+            bool result = NpmInstallDiagnostics.IsPermissionError("EACCES: permission denied");
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsPermissionError_CaseInsensitiveOperationNotPermitted_ReturnsTrue()
+        {
+            bool result = NpmInstallDiagnostics.IsPermissionError("Operation Not Permitted");
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsPermissionError_NoPermissionPattern_ReturnsFalse()
+        {
+            bool result = NpmInstallDiagnostics.IsPermissionError("404 Not Found");
+
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/Assets/Tests/Editor/NpmInstallDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/NpmInstallDiagnosticsTests.cs
@@ -5,12 +5,14 @@ namespace io.github.hatayama.uLoopMCP
     [TestFixture]
     public class NpmInstallDiagnosticsTests
     {
+        private const string DUMMY_COMMAND = "npm install -g uloop-cli@1.0.0";
+
         // --- ClassifyInstallError ---
 
         [Test]
         public void ClassifyInstallError_NullInput_ReturnsNull()
         {
-            string result = NpmInstallDiagnostics.ClassifyInstallError(null);
+            string result = NpmInstallDiagnostics.ClassifyInstallError(null, DUMMY_COMMAND);
 
             Assert.IsNull(result);
         }
@@ -18,7 +20,7 @@ namespace io.github.hatayama.uLoopMCP
         [Test]
         public void ClassifyInstallError_EmptyInput_ReturnsNull()
         {
-            string result = NpmInstallDiagnostics.ClassifyInstallError("");
+            string result = NpmInstallDiagnostics.ClassifyInstallError("", DUMMY_COMMAND);
 
             Assert.IsNull(result);
         }
@@ -28,7 +30,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             string stderr = "npm ERR! Error: EPERM: operation not permitted, rename 'C:\\Users\\test'";
 
-            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr);
+            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr, DUMMY_COMMAND);
 
             Assert.IsNotNull(result);
             Assert.That(result, Does.Contain("permission"));
@@ -39,7 +41,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             string stderr = "npm ERR! Error: EACCES: permission denied, access '/usr/lib/node_modules'";
 
-            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr);
+            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr, DUMMY_COMMAND);
 
             Assert.IsNotNull(result);
             Assert.That(result, Does.Contain("permission"));
@@ -50,7 +52,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             string stderr = "npm ERR! Error: operation not permitted, mkdir 'C:\\Program Files\\nodejs'";
 
-            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr);
+            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr, DUMMY_COMMAND);
 
             Assert.IsNotNull(result);
             Assert.That(result, Does.Contain("permission"));
@@ -61,9 +63,20 @@ namespace io.github.hatayama.uLoopMCP
         {
             string stderr = "npm ERR! 404 Not Found - GET https://registry.npmjs.org/nonexistent";
 
-            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr);
+            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr, DUMMY_COMMAND);
 
             Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ClassifyInstallError_EmbedsManualCommandInline()
+        {
+            string stderr = "npm ERR! Error: EPERM: operation not permitted";
+            string command = "npm install -g uloop-cli@2.0.0";
+
+            string result = NpmInstallDiagnostics.ClassifyInstallError(stderr, command);
+
+            Assert.That(result, Does.Contain(command));
         }
 
         // --- IsPermissionError ---

--- a/Assets/Tests/Editor/NpmInstallDiagnosticsTests.cs
+++ b/Assets/Tests/Editor/NpmInstallDiagnosticsTests.cs
@@ -99,5 +99,44 @@ namespace io.github.hatayama.uLoopMCP
 
             Assert.IsFalse(result);
         }
+
+        // --- IsGlobalPrefixWritable ---
+
+        [Test]
+        public void IsGlobalPrefixWritable_MalformedPath_ReturnsTrue()
+        {
+            // Malformed paths cause ArgumentException/NotSupportedException from File APIs;
+            // indeterminate result should fall through (true) to let npm attempt the install
+            bool result = NpmInstallDiagnostics.IsGlobalPrefixWritable("invalid<>path|with:illegal*chars");
+
+            Assert.IsTrue(result);
+        }
+
+        // --- BuildInstallErrorMessage ---
+
+        [Test]
+        public void BuildInstallErrorMessage_ContainsBothGuidanceAndStderr()
+        {
+            string guidance = "npm does not have permission to write to the global directory.";
+            string rawStderr = "npm ERR! code EPERM\nnpm ERR! syscall rename";
+
+            string result = NpmInstallDiagnostics.BuildInstallErrorMessage(guidance, rawStderr);
+
+            Assert.That(result, Does.Contain(guidance));
+            Assert.That(result, Does.Contain(rawStderr));
+        }
+
+        [Test]
+        public void BuildInstallErrorMessage_GuidanceAppearsBeforeStderr()
+        {
+            string guidance = "Permission denied guidance";
+            string rawStderr = "npm ERR! EPERM";
+
+            string result = NpmInstallDiagnostics.BuildInstallErrorMessage(guidance, rawStderr);
+
+            int guidanceIndex = result.IndexOf(guidance, System.StringComparison.Ordinal);
+            int stderrIndex = result.IndexOf(rawStderr, System.StringComparison.Ordinal);
+            Assert.That(guidanceIndex, Is.LessThan(stderrIndex));
+        }
     }
 }

--- a/Assets/Tests/Editor/NpmInstallDiagnosticsTests.cs.meta
+++ b/Assets/Tests/Editor/NpmInstallDiagnosticsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77b0c80b714ef4c858ca05c27410a354
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
+++ b/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
@@ -119,6 +119,18 @@ namespace io.github.hatayama.uLoopMCP
             {
                 return false;
             }
+            // npm prefix -g output is external input — malformed paths throw these exceptions
+            // Return true (indeterminate) to skip pre-flight and let npm attempt the actual install
+            catch (System.ArgumentException e)
+            {
+                UnityEngine.Debug.LogWarning("[uLoopMCP] Cannot validate npm global prefix path: " + e.Message);
+                return true;
+            }
+            catch (System.NotSupportedException e)
+            {
+                UnityEngine.Debug.LogWarning("[uLoopMCP] Cannot validate npm global prefix path: " + e.Message);
+                return true;
+            }
         }
 
         /// <summary>
@@ -143,6 +155,18 @@ namespace io.github.hatayama.uLoopMCP
                  + "2. Or change npm's global prefix to a user-writable directory:\n"
                  + "   npm config set prefix \"%USERPROFILE%\\.npm-global\"\n"
                  + "   Then add %USERPROFILE%\\.npm-global to your system PATH";
+        }
+
+        /// <summary>
+        /// Combines classified guidance with the raw npm stderr so users see both
+        /// the actionable suggestion and the original error details.
+        /// </summary>
+        public static string BuildInstallErrorMessage(string guidance, string rawStderr)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(guidance), "guidance must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(rawStderr), "rawStderr must not be null or empty");
+
+            return guidance + "\n\n--- npm output ---\n" + rawStderr;
         }
 
         internal static bool IsPermissionError(string stderrOutput)

--- a/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
+++ b/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
@@ -94,16 +94,18 @@ namespace io.github.hatayama.uLoopMCP
         {
             UnityEngine.Debug.Assert(!string.IsNullOrEmpty(globalPrefixPath), "globalPrefixPath must not be null or empty");
 
-            if (!Directory.Exists(globalPrefixPath))
-            {
-                return false;
-            }
-
-            string testFilePath = Path.Combine(
-                globalPrefixPath,
-                ".uloop_write_test_" + System.Guid.NewGuid().ToString("N").Substring(0, 8));
             try
             {
+                // npm creates the prefix directory on first install, so a non-existent directory
+                // does not mean non-writable — test by creating it (no-op if it already exists)
+                if (!Directory.Exists(globalPrefixPath))
+                {
+                    Directory.CreateDirectory(globalPrefixPath);
+                }
+
+                string testFilePath = Path.Combine(
+                    globalPrefixPath,
+                    ".uloop_write_test_" + System.Guid.NewGuid().ToString("N").Substring(0, 8));
                 File.WriteAllText(testFilePath, "");
                 File.Delete(testFilePath);
                 return true;

--- a/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
+++ b/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
@@ -1,0 +1,154 @@
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using UnityEngine;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Pre-flight diagnostics and error classification for npm global install.
+    /// Windows npm installs often fail silently due to directory permissions
+    /// (e.g. C:\Program Files\nodejs requires admin elevation).
+    /// </summary>
+    public static class NpmInstallDiagnostics
+    {
+        private const int PREFIX_CHECK_TIMEOUT_MS = 5000;
+
+        private const string ERROR_PATTERN_EPERM = "EPERM";
+        private const string ERROR_PATTERN_EACCES = "EACCES";
+        private const string ERROR_PATTERN_OPERATION_NOT_PERMITTED = "operation not permitted";
+
+        /// <summary>
+        /// Returns the npm global prefix path by running `npm prefix -g`, or null if resolution fails.
+        /// </summary>
+        public static string GetGlobalPrefix(string npmPath)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(npmPath), "npmPath must not be null or empty");
+
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = npmPath,
+                Arguments = "prefix -g",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            NodeEnvironmentResolver.SetupEnvironmentPath(startInfo, NodeEnvironmentResolver.FindNodePath());
+
+            using (Process process = Process.Start(startInfo))
+            {
+                if (process == null)
+                {
+                    return null;
+                }
+
+                StringBuilder stdoutBuilder = new StringBuilder();
+
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if (e.Data != null)
+                    {
+                        stdoutBuilder.AppendLine(e.Data);
+                    }
+                };
+                process.ErrorDataReceived += (sender, e) => { };
+
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
+                if (!process.WaitForExit(PREFIX_CHECK_TIMEOUT_MS))
+                {
+                    // Process may exit between WaitForExit(timeout) and Kill() (TOCTOU race)
+                    try
+                    {
+                        process.Kill();
+                        process.WaitForExit(1000);
+                    }
+                    catch (System.InvalidOperationException)
+                    {
+                        UnityEngine.Debug.Log("Process already exited before Kill() was called");
+                    }
+
+                    return null;
+                }
+
+                process.WaitForExit();
+
+                string output = stdoutBuilder.ToString().Trim();
+                if (process.ExitCode == 0 && !string.IsNullOrEmpty(output))
+                {
+                    return output;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks whether the npm global prefix directory is writable by creating and deleting a temp file.
+        /// Returns true if writable, false otherwise.
+        /// </summary>
+        public static bool IsGlobalPrefixWritable(string globalPrefixPath)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(globalPrefixPath), "globalPrefixPath must not be null or empty");
+
+            if (!Directory.Exists(globalPrefixPath))
+            {
+                return false;
+            }
+
+            string testFilePath = Path.Combine(
+                globalPrefixPath,
+                ".uloop_write_test_" + System.Guid.NewGuid().ToString("N").Substring(0, 8));
+            try
+            {
+                File.WriteAllText(testFilePath, "");
+                File.Delete(testFilePath);
+                return true;
+            }
+            // OS permission denial cannot be pre-checked with assertions; must attempt the operation
+            catch (System.UnauthorizedAccessException)
+            {
+                return false;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Analyzes npm stderr output and returns a user-friendly guidance message.
+        /// Returns null if no specific pattern is matched (caller falls back to raw error).
+        /// </summary>
+        public static string ClassifyInstallError(string stderrOutput)
+        {
+            if (string.IsNullOrEmpty(stderrOutput))
+            {
+                return null;
+            }
+
+            if (!IsPermissionError(stderrOutput))
+            {
+                return null;
+            }
+
+            return "npm does not have permission to write to the global directory.\n\n"
+                 + "Solutions:\n"
+                 + "1. Open a terminal as Administrator and run the manual command below\n"
+                 + "2. Or change npm's global prefix to a user-writable directory:\n"
+                 + "   npm config set prefix \"%USERPROFILE%\\.npm-global\"";
+        }
+
+        internal static bool IsPermissionError(string stderrOutput)
+        {
+            UnityEngine.Debug.Assert(stderrOutput != null, "stderrOutput must not be null");
+
+            return stderrOutput.Contains(ERROR_PATTERN_EPERM)
+                || stderrOutput.Contains(ERROR_PATTERN_EACCES)
+                || stderrOutput.IndexOf(ERROR_PATTERN_OPERATION_NOT_PERMITTED, System.StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}

--- a/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
+++ b/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
@@ -141,7 +141,8 @@ namespace io.github.hatayama.uLoopMCP
                  + "Solutions:\n"
                  + "1. Open a terminal as Administrator and run the manual command below\n"
                  + "2. Or change npm's global prefix to a user-writable directory:\n"
-                 + "   npm config set prefix \"%USERPROFILE%\\.npm-global\"";
+                 + "   npm config set prefix \"%USERPROFILE%\\.npm-global\"\n"
+                 + "   Then add %USERPROFILE%\\.npm-global to your system PATH";
         }
 
         internal static bool IsPermissionError(string stderrOutput)

--- a/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
+++ b/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs
@@ -137,8 +137,10 @@ namespace io.github.hatayama.uLoopMCP
         /// Analyzes npm stderr output and returns a user-friendly guidance message.
         /// Returns null if no specific pattern is matched (caller falls back to raw error).
         /// </summary>
-        public static string ClassifyInstallError(string stderrOutput)
+        public static string ClassifyInstallError(string stderrOutput, string manualCommand)
         {
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(manualCommand), "manualCommand must not be null or empty");
+
             if (string.IsNullOrEmpty(stderrOutput))
             {
                 return null;
@@ -151,7 +153,8 @@ namespace io.github.hatayama.uLoopMCP
 
             return "npm does not have permission to write to the global directory.\n\n"
                  + "Solutions:\n"
-                 + "1. Open a terminal as Administrator and run the manual command below\n"
+                 + "1. Open a terminal as Administrator and run:\n"
+                 + "   " + manualCommand + "\n\n"
                  + "2. Or change npm's global prefix to a user-writable directory:\n"
                  + "   npm config set prefix \"%USERPROFILE%\\.npm-global\"\n"
                  + "   Then add %USERPROFILE%\\.npm-global to your system PATH";

--- a/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs.meta
+++ b/Packages/src/Editor/CLI/NpmInstallDiagnostics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: faa6f3b29439b4cb484ad289fb21247e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -698,9 +698,12 @@ namespace io.github.hatayama.uLoopMCP
                     string manualCommand = $"npm install -g {installTarget}";
 
                     // Classifier emits Windows-specific remediation; on other platforms show raw stderr
-                    string errorDetail = Application.platform == RuntimePlatform.WindowsEditor
-                        ? (NpmInstallDiagnostics.ClassifyInstallError(errorOutput) ?? errorOutput)
-                        : errorOutput;
+                    string guidance = Application.platform == RuntimePlatform.WindowsEditor
+                        ? NpmInstallDiagnostics.ClassifyInstallError(errorOutput)
+                        : null;
+                    string errorDetail = (guidance != null && !string.IsNullOrEmpty(errorOutput))
+                        ? NpmInstallDiagnostics.BuildInstallErrorMessage(guidance, errorOutput)
+                        : (guidance ?? errorOutput);
 
                     EditorUtility.DisplayDialog(
                         "Installation Failed",

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -697,18 +697,24 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     string manualCommand = $"npm install -g {installTarget}";
 
-                    // Classifier emits Windows-specific remediation; on other platforms show raw stderr
+                    // Classifier emits Windows-specific remediation with the command embedded;
+                    // on other platforms (or unrecognized errors) show raw stderr + manual command footer
                     string guidance = Application.platform == RuntimePlatform.WindowsEditor
-                        ? NpmInstallDiagnostics.ClassifyInstallError(errorOutput)
+                        ? NpmInstallDiagnostics.ClassifyInstallError(errorOutput, manualCommand)
                         : null;
-                    string errorDetail = (guidance != null && !string.IsNullOrEmpty(errorOutput))
-                        ? NpmInstallDiagnostics.BuildInstallErrorMessage(guidance, errorOutput)
-                        : (guidance ?? errorOutput);
 
-                    EditorUtility.DisplayDialog(
-                        "Installation Failed",
-                        $"Failed to install uLoop CLI.\n\n{errorDetail}\n\nYou can try manually:\n{manualCommand}",
-                        "OK");
+                    string message;
+                    if (guidance != null && !string.IsNullOrEmpty(errorOutput))
+                    {
+                        message = "Failed to install uLoop CLI.\n\n"
+                            + NpmInstallDiagnostics.BuildInstallErrorMessage(guidance, errorOutput);
+                    }
+                    else
+                    {
+                        message = $"Failed to install uLoop CLI.\n\n{errorOutput}\n\nYou can try manually:\n{manualCommand}";
+                    }
+
+                    EditorUtility.DisplayDialog("Installation Failed", message, "OK");
                 }
             }
             finally

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -618,6 +618,25 @@ namespace io.github.hatayama.uLoopMCP
             string packageVersion = McpConstants.PackageInfo.version;
             string installTarget = $"{CliConstants.NPM_PACKAGE_NAME}@{packageVersion}";
 
+            // Windows: npm global prefix often points to admin-only directories (e.g. C:\Program Files\nodejs)
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                string globalPrefix = NpmInstallDiagnostics.GetGlobalPrefix(npmPath);
+                if (!string.IsNullOrEmpty(globalPrefix) && !NpmInstallDiagnostics.IsGlobalPrefixWritable(globalPrefix))
+                {
+                    string manualCommand = $"npm install -g {installTarget}";
+                    EditorUtility.DisplayDialog(
+                        "Permission Issue Detected",
+                        $"npm's global directory ({globalPrefix}) requires elevated permissions.\n\n"
+                        + "Solutions:\n"
+                        + $"1. Open a terminal as Administrator and run:\n   {manualCommand}\n\n"
+                        + "2. Or change npm's global prefix to a user-writable directory:\n"
+                        + "   npm config set prefix \"%USERPROFILE%\\.npm-global\"",
+                        "OK");
+                    return;
+                }
+            }
+
             _isInstallingCli = true;
             RefreshCliSetupSection();
 
@@ -676,9 +695,14 @@ namespace io.github.hatayama.uLoopMCP
                 else
                 {
                     string manualCommand = $"npm install -g {installTarget}";
+                    string classifiedGuidance = NpmInstallDiagnostics.ClassifyInstallError(errorOutput);
+                    string errorDetail = classifiedGuidance != null
+                        ? classifiedGuidance
+                        : errorOutput;
+
                     EditorUtility.DisplayDialog(
                         "Installation Failed",
-                        $"Failed to install uLoop CLI.\n\n{errorOutput}\n\nYou can try manually:\n{manualCommand}",
+                        $"Failed to install uLoop CLI.\n\n{errorDetail}\n\nYou can try manually:\n{manualCommand}",
                         "OK");
                 }
             }

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -631,7 +631,8 @@ namespace io.github.hatayama.uLoopMCP
                         + "Solutions:\n"
                         + $"1. Open a terminal as Administrator and run:\n   {manualCommand}\n\n"
                         + "2. Or change npm's global prefix to a user-writable directory:\n"
-                        + "   npm config set prefix \"%USERPROFILE%\\.npm-global\"",
+                        + "   npm config set prefix \"%USERPROFILE%\\.npm-global\"\n"
+                        + "   Then add %USERPROFILE%\\.npm-global to your system PATH",
                         "OK");
                     return;
                 }
@@ -695,9 +696,10 @@ namespace io.github.hatayama.uLoopMCP
                 else
                 {
                     string manualCommand = $"npm install -g {installTarget}";
-                    string classifiedGuidance = NpmInstallDiagnostics.ClassifyInstallError(errorOutput);
-                    string errorDetail = classifiedGuidance != null
-                        ? classifiedGuidance
+
+                    // Classifier emits Windows-specific remediation; on other platforms show raw stderr
+                    string errorDetail = Application.platform == RuntimePlatform.WindowsEditor
+                        ? (NpmInstallDiagnostics.ClassifyInstallError(errorOutput) ?? errorOutput)
                         : errorOutput;
 
                     EditorUtility.DisplayDialog(


### PR DESCRIPTION
## Summary

- Add pre-flight permission check before `npm install -g` on Windows: detect unwritable global prefix directories (e.g. `C:\Program Files\nodejs`) and show actionable guidance before attempting a doomed 30-second install
- Classify EPERM/EACCES errors in npm stderr on install failure to provide specific solutions (run as Administrator, or change npm prefix)
- Add `NpmInstallDiagnostics` utility with unit tests for error classification logic

## Test plan

- [ ] Unit tests pass for `ClassifyInstallError` / `IsPermissionError` (macOS/Windows)
- [ ] On Windows: set `npm config set prefix "C:\Program Files\test-npm-global"`, click Install CLI → "Permission Issue Detected" dialog appears
- [ ] On Windows: restore prefix with `npm config delete prefix`, click Install CLI → installs successfully
- [ ] On Windows: verify error classification by simulating npm failure with EPERM in stderr

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents slow, failing npm install -g runs on Windows by checking permissions first and showing clear guidance. Also surfaces raw npm errors and the exact manual command for quick fixes.

- **New Features**
  - Windows pre-flight: check writability of npm’s global prefix and show solutions if unwritable.
  - Error classification: detect EPERM/EACCES/“operation not permitted” and combine guidance with raw stderr via BuildInstallErrorMessage.
  - NpmInstallDiagnostics utility with unit tests; McpEditorWindow updated to use it.

- **Bug Fixes**
  - Create missing prefix directory before the write probe to avoid false “not writable.”
  - Windows-only guidance now embeds the manual command and includes PATH steps when recommending a custom prefix.
  - Handle malformed npm prefix paths by skipping the pre-flight check (let npm attempt the install).

<sup>Written for commit 42ad2ab8b560098e816b6cafbe028fe52ab2de9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Windows npm Install Permission Pre-check and Error Classification

## Overview
This PR improves the uLoop CLI installation experience on Windows by adding a Windows-focused pre-flight permission check for npm global installs and classifying npm install permission errors to present clear, actionable remediation (run as Administrator or change npm prefix). It avoids long, failing installs against protected directories (e.g., C:\Program Files\nodejs) and surfaces platform-appropriate guidance alongside raw npm stderr.

## Key Changes

### New Utility: NpmInstallDiagnostics
A new static utility class (`NpmInstallDiagnostics`) provides:

- GetGlobalPrefix(npmPath: string) — Runs `npm prefix -g` with a 5s guarded timeout and safe process cleanup; returns trimmed prefix or null on failure. Protects against malformed npm prefix output by returning indeterminate so npm can attempt the install.
- IsGlobalPrefixWritable(globalPrefixPath: string) — Probes write access by creating the directory if missing and writing/deleting a temp file to avoid false "not writable" results; returns false on explicit permission errors, and true (indeterminate) on malformed path input.
- ClassifyInstallError(stderrOutput: string, manualCommand: string) — Detects permission-related errors and, when a permission pattern is found, returns Windows-specific, actionable guidance that embeds the provided manualCommand inline (so the remediation appears before raw npm output). Returns null for non-permission errors.
- BuildInstallErrorMessage(guidance: string, rawStderr: string) — Composes a structured message combining guidance (if any) with the raw npm stderr (guidance appears before raw output).
- IsPermissionError(stderrOutput: string) — Internal helper detecting permission patterns (EPERM, EACCES, case-insensitive "operation not permitted").

Notes:
- Recommendations for a custom npm prefix include PATH update instructions.
- Raw npm stderr is preserved and displayed alongside guidance so other errors remain visible.
- The pre-flight writability probe creates the prefix directory if missing to avoid false negatives.
- The pre-flight check is skipped (treated indeterminate) for malformed npm prefix paths so npm can attempt the install.

### Enhanced Installation Flow in McpEditorWindow
- Windows pre-install check: before running `npm install -g`, the code queries the npm global prefix and verifies writability. If non-writable, it shows a permission-issue dialog with targeted remediation (manual command and guidance) and aborts the installation early.
- Improved failure dialog: on install failures, Windows uses NpmInstallDiagnostics.ClassifyInstallError(stderr, manualCommand) to show classified guidance when available; otherwise falls back to raw stderr with a manual command footer.

### Tests
- Added NUnit test suite `NpmInstallDiagnosticsTests` covering:
  - ClassifyInstallError: null/empty input, EPERM, EACCES, "operation not permitted" (case-insensitive), unrecognized errors, and embedding the manual command inline.
  - IsPermissionError: EPERM, EACCES, case-insensitive "operation not permitted", and non-permission errors.
  - IsGlobalPrefixWritable: malformed path behavior (returns indeterminate/true to allow npm to proceed).
  - BuildInstallErrorMessage: ensures guidance and raw stderr are present and that guidance appears before stderr.

## Commit detail
- ClassifyInstallError now accepts a manualCommand parameter and embeds it at the top of guidance so the actionable command is visible before raw npm output.
- Pre-flight writability probe now creates the prefix directory if missing.
- Malformed npm prefix outputs are handled conservatively (treated indeterminate so npm will try the install).
- Preserve raw npm stderr in dialogs so non-permission errors remain visible.

## Class Diagram

```
classDiagram
    class NpmInstallDiagnostics {
        +GetGlobalPrefix(npmPath: string) string
        +IsGlobalPrefixWritable(globalPrefixPath: string) bool
        +ClassifyInstallError(stderrOutput: string, manualCommand: string) string
        +BuildInstallErrorMessage(guidance: string, rawStderr: string) string
        -IsPermissionError(stderrOutput: string) bool
        -PREFIX_CHECK_TIMEOUT_MS: int
    }

    class McpEditorWindow {
        -HandleInstallCli() void
    }

    McpEditorWindow --|> NpmInstallDiagnostics : uses
```

## Test/Manual verification
- Unit tests for ClassifyInstallError, IsPermissionError, IsGlobalPrefixWritable, and BuildInstallErrorMessage should pass.
- Manual Windows checks:
  - With npm prefix set to an unwritable location (e.g., C:\Program Files\test-npm-global), clicking Install CLI shows a permission dialog with remediation.
  - Restoring prefix (npm config delete prefix) or running as Administrator allows the install to proceed.
  - Simulated npm stderr containing EPERM/EACCES/operation not permitted is classified and guidance (including PATH instructions when recommending a custom prefix) is shown above the raw stderr.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->