### PR TITLE
feat: disable Skills subsection when CLI is not installed

### DIFF
--- a/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.uLoopMCP
         private readonly Button _installCliButton;
         private readonly EnumField _skillsTargetField;
         private readonly Button _installSkillsButton;
+        private readonly VisualElement _skillsSubsection;
 
         private CliSetupData _lastData;
         private bool _isTargetFieldInitialized;
@@ -29,6 +30,7 @@ namespace io.github.hatayama.uLoopMCP
             _installCliButton = root.Q<Button>("install-cli-button");
             _skillsTargetField = root.Q<EnumField>("skills-target-field");
             _installSkillsButton = root.Q<Button>("install-skills-button");
+            _skillsSubsection = root.Q<VisualElement>("skills-subsection");
         }
 
         public void SetupBindings()
@@ -51,6 +53,7 @@ namespace io.github.hatayama.uLoopMCP
             UpdateRefreshButton(data);
             UpdateInstallCliButton(data);
             InitializeTargetFieldIfNeeded(data);
+            UpdateSkillsSubsection(data);
             UpdateInstallSkillsButton(data);
         }
 
@@ -141,6 +144,12 @@ namespace io.github.hatayama.uLoopMCP
             {
                 ViewDataBinder.UpdateEnumField(_skillsTargetField, data.SelectedTarget);
             }
+        }
+
+        private void UpdateSkillsSubsection(CliSetupData data)
+        {
+            bool enabled = data.IsCliInstalled && !data.IsChecking;
+            _skillsSubsection.SetEnabled(enabled);
         }
 
         private void UpdateInstallSkillsButton(CliSetupData data)

--- a/Packages/src/Editor/UI/UIToolkit/McpEditorWindow.uxml
+++ b/Packages/src/Editor/UI/UIToolkit/McpEditorWindow.uxml
@@ -37,13 +37,14 @@
                     </ui:VisualElement>
                     <ui:Button name="install-cli-button" text="Install CLI" class="mcp-button mcp-button--configure" />
 
-                    <ui:Label text="Skills" class="mcp-cli-subsection-header" />
-                    <ui:VisualElement class="mcp-target-row">
-                        <ui:Label text="Target:" class="mcp-target-row__label" />
-                        <uie:EnumField name="skills-target-field" class="mcp-target-row__field" />
+                    <ui:VisualElement name="skills-subsection">
+                        <ui:Label text="Skills" class="mcp-cli-subsection-header" />
+                        <ui:VisualElement class="mcp-target-row">
+                            <ui:Label text="Target:" class="mcp-target-row__label" />
+                            <uie:EnumField name="skills-target-field" class="mcp-target-row__field" />
+                        </ui:VisualElement>
+                        <ui:Button name="install-skills-button" text="Install Skills" class="mcp-button mcp-button--configure" />
                     </ui:VisualElement>
-
-                    <ui:Button name="install-skills-button" text="Install Skills" class="mcp-button mcp-button--configure" />
                 </ui:VisualElement>
 
                 <!-- MCP Content -->


### PR DESCRIPTION
## Summary
- Wrap Skills UI elements (header, target dropdown, button) in a `skills-subsection` container VisualElement
- Toggle `SetEnabled` on the container based on CLI installation status
- The entire Skills subsection appears grayed out and non-interactive when CLI is unavailable or status is being checked

## Changes
- **McpEditorWindow.uxml**: Added `skills-subsection` wrapper around Skills elements
- **CliSetupSection.cs**: Added `UpdateSkillsSubsection` method that disables the container when `!IsCliInstalled || IsChecking`

## Test plan
- [ ] Open Configuration window > CLI tab with CLI installed → Skills section is fully interactive
- [ ] Uninstall CLI or simulate not-installed state → Skills section (header, dropdown, button) is grayed out
- [ ] During CLI version check → Skills section is disabled until check completes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables the Skills subsection in the CLI setup when the CLI isn’t installed or is being checked, preventing clicks and showing a grayed-out state. Improves clarity and avoids invalid actions.

- **New Features**
  - Wrapped Skills header, target dropdown, and button in a skills-subsection container.
  - Toggled SetEnabled based on IsCliInstalled and IsChecking in CliSetupSection.Update().

<sup>Written for commit 42d28c5f93f2091dd3104a8e3c1e7cada7e6b923. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds UI conditional visibility to the Skills subsection in the MCP Editor window. When the CLI is not installed or a version check is in progress, the entire Skills section (header, target dropdown, and install button) is disabled and visually grayed out, preventing user interaction.

## Changes

### McpEditorWindow.uxml
- Introduced a new `VisualElement` container named `skills-subsection` that acts as a wrapper for all Skills-related UI elements
- Nested the following elements inside the container:
  - Skills section header label (`<ui:Label text="Skills"...`)
  - Target row containing the Skills target dropdown (`<uie:EnumField name="skills-target-field"...`)
  - Install Skills button (`<ui:Button name="install-skills-button"...`)
- The container is positioned within the CLI configuration tab, after the "Install CLI" button

### CliSetupSection.cs
- Added a new private field `_skillsSubsection` to store a reference to the container VisualElement
- Retrieved the skills subsection element in the constructor via `root.Q<VisualElement>("skills-subsection")`
- Introduced `UpdateSkillsSubsection(CliSetupData data)` method that:
  - Disables the entire container when `!data.IsCliInstalled || data.IsChecking`
  - Enables the container when CLI is installed and version check is complete
  - Uses `SetEnabled()` to control both visual appearance (grayed out) and interactivity
- Invoked the new update method during the standard UI update flow

## Behavior

The Skills subsection displays in three states:

1. **CLI installed and checked**: Section is fully interactive with enabled controls
2. **CLI not installed**: Section appears grayed out and non-interactive
3. **Version check in progress**: Section appears grayed out until check completes

This provides clear visual feedback to users about the availability of Skills functionality, which depends on the CLI being installed.

## Test Coverage

The implementation can be verified by:
- Opening the Configuration window and selecting the CLI tab with CLI installed (Skills section fully interactive)
- Simulating CLI unavailability (Skills section grayed out with disabled controls)
- Monitoring the Skills section during CLI version checks (temporarily disabled during check, re-enabled upon completion)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->