### PR TITLE
fix: Fix incomplete property serialization in ComponentPropertySerializer

### DIFF
--- a/Packages/src/Editor/Core/CoreTools/GameObjectFinder/ComponentPropertySerializer.cs
+++ b/Packages/src/Editor/Core/CoreTools/GameObjectFinder/ComponentPropertySerializer.cs
@@ -24,12 +24,15 @@ namespace io.github.hatayama.uLoopMCP
             // Use SerializedObject to get only Inspector-visible properties
             SerializedObject serializedObject = new SerializedObject(component);
             SerializedProperty iterator = serializedObject.GetIterator();
-            
-            // Skip the first property (m_Script)
+
             if (iterator.NextVisible(true))
             {
-                while (iterator.NextVisible(false))
+                do
                 {
+                    // m_Script is an internal reference, not a user-facing property
+                    if (iterator.name == "m_Script")
+                        continue;
+
                     object value = GetSerializedPropertyValue(iterator);
                     if (value != null)
                     {
@@ -39,10 +42,10 @@ namespace io.github.hatayama.uLoopMCP
                             type = iterator.propertyType.ToString(),
                             value = SerializeValue(value)
                         };
-                        
+
                         propertyInfos.Add(info);
                     }
-                }
+                } while (iterator.NextVisible(false));
             }
             
             return propertyInfos.ToArray();
@@ -79,6 +82,8 @@ namespace io.github.hatayama.uLoopMCP
                     return property.quaternionValue;
                 case SerializedPropertyType.Enum:
                     return property.enumNames[property.enumValueIndex];
+                case SerializedPropertyType.LayerMask:
+                    return property.intValue;
                 case SerializedPropertyType.ObjectReference:
                     UnityEngine.Object obj = property.objectReferenceValue;
                     if (obj == null)


### PR DESCRIPTION
## Summary
- Fix first SerializedProperty being unconditionally skipped in ComponentPropertySerializer. The previous code assumed the first property was always `m_Script`, but native Unity components (Canvas, Camera, Transform, Rigidbody, etc.) don't have `m_Script`. This caused their first data property (e.g., Canvas's Render Mode, Camera's Clear Flags) to be silently dropped.
- Add `SerializedPropertyType.LayerMask` handling so properties like `GraphicRaycaster.blockingMask` are now correctly serialized.

## Changes
- Changed iteration logic from blind skip to explicit `m_Script` name check using `do-while` loop
- Added `case SerializedPropertyType.LayerMask` returning `property.intValue`

## Affected Components
All native Unity components were affected (18+ types verified), including:
Transform, RectTransform, Canvas, Camera, Light, Rigidbody, Colliders, Renderers, AudioSource, Animator, ParticleSystem, etc.

## Test Plan
- [x] Verified Canvas now returns Render Mode (Enum) as first property
- [x] Verified GraphicRaycaster returns Blocking Mask (LayerMask, value=-1 for Everything)
- [x] Verified RectTransform returns Local Rotation as first property
- [x] Verified CanvasGroup (native) returns Alpha as first property
- [x] Compilation passes with 0 errors and 0 warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes property serialization for native Unity components by not skipping the first visible property. Adds LayerMask serialization so fields like GraphicRaycaster.blockingMask are included.

- **Bug Fixes**
  - Stop blindly skipping the first property; now explicitly ignore only m_Script.
  - Native components (e.g., Canvas, Camera, RectTransform) now include their true first property.

- **New Features**
  - Handle SerializedPropertyType.LayerMask by returning intValue.

<sup>Written for commit de7dab1d757002a4361cae873a2fc42236c535bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixed property serialization in `ComponentPropertySerializer` to correctly handle native Unity components and added support for LayerMask properties.

### Changes

**File Modified:** `Packages/src/Editor/Core/CoreTools/GameObjectFinder/ComponentPropertySerializer.cs`

#### 1. Property Iteration Logic Fix
- **Problem:** The original code unconditionally skipped the first SerializedProperty returned by the iterator, assuming it would always be `m_Script`. However, native Unity components (Transform, RectTransform, Canvas, Camera, Light, etc.) do not include `m_Script` as their first property, causing the actual first data property to be incorrectly dropped.
- **Solution:** Changed from a `while` loop to a `do-while` loop with an explicit name check: `if (iterator.name == "m_Script") continue;`
- **Impact:** Now correctly serializes the first property of native components while still filtering out `m_Script` when present.

#### 2. LayerMask Type Support
- **Addition:** Added handling for `SerializedPropertyType.LayerMask` in the `GetSerializedPropertyValue()` method, returning `property.intValue`
- **Impact:** Properties like `GraphicRaycaster.blockingMask` (LayerMask type) are now correctly serialized instead of being skipped.

### Verified Components
The fix enables proper serialization for 18+ verified native Unity component types:
- Transform, RectTransform
- Canvas (now returns Render Mode as first property)
- Camera, Light
- Rigidbody, Colliders (various types)
- Renderers (various types)
- AudioSource, Animator
- ParticleSystem
- CanvasGroup (returns Alpha as first property)
- GraphicRaycaster (returns Blocking Mask with LayerMask value = -1 for Everything)

### Build Status
- Compilation: 0 errors, 0 warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->