### PR TITLE
fix: add meta

### DIFF
--- a/Packages/src/CHANGELOG.md.meta
+++ b/Packages/src/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4ca30975116b542e8867604b2096e31b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add the missing Unity .meta for Packages/src/CHANGELOG.md to restore a stable GUID and stop Unity from regenerating it. This prevents import warnings and noisy diffs in version control.

<sup>Written for commit ff2852bcc05b657b82c93a795d56897763e934cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

