### PR TITLE
fix: stabilize Tool Settings toggle interaction during UI refresh

### DIFF
--- a/Assets/Tests/Editor/ToolSettingsSectionTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsSectionTests.cs
@@ -1,0 +1,141 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    [TestFixture]
+    public class ToolSettingsSectionTests
+    {
+        [Test]
+        public void Update_SameLayout_DoesNotReplaceToggleElements()
+        {
+            VisualElement root = CreateRootElement();
+            ToolSettingsSection section = new ToolSettingsSection(root);
+            ToolSettingsSectionData data = CreateData(compileEnabled: true, includeGetLogs: false);
+            VisualElement container = root.Q<VisualElement>("tool-list-container");
+
+            section.Update(data);
+            Toggle beforeToggle = FindToggleByToolName(container, "compile");
+
+            section.Update(data);
+            Toggle afterToggle = FindToggleByToolName(container, "compile");
+
+            Assert.IsNotNull(beforeToggle);
+            Assert.AreSame(beforeToggle, afterToggle);
+        }
+
+        [Test]
+        public void Update_SameLayout_UpdatesToggleStateWithoutRebuild()
+        {
+            VisualElement root = CreateRootElement();
+            ToolSettingsSection section = new ToolSettingsSection(root);
+            ToolSettingsSectionData enabledData = CreateData(compileEnabled: true, includeGetLogs: false);
+            ToolSettingsSectionData disabledData = CreateData(compileEnabled: false, includeGetLogs: false);
+            VisualElement container = root.Q<VisualElement>("tool-list-container");
+
+            section.Update(enabledData);
+            Toggle beforeToggle = FindToggleByToolName(container, "compile");
+            Assert.IsNotNull(beforeToggle);
+            Assert.IsTrue(beforeToggle.value);
+
+            section.Update(disabledData);
+            Toggle afterToggle = FindToggleByToolName(container, "compile");
+
+            Assert.AreSame(beforeToggle, afterToggle);
+            Assert.IsFalse(afterToggle.value);
+        }
+
+        [Test]
+        public void Update_LayoutChanged_RebuildsToggleElements()
+        {
+            VisualElement root = CreateRootElement();
+            ToolSettingsSection section = new ToolSettingsSection(root);
+            ToolSettingsSectionData initialData = CreateData(compileEnabled: true, includeGetLogs: false);
+            ToolSettingsSectionData changedLayoutData = CreateData(compileEnabled: true, includeGetLogs: true);
+            VisualElement container = root.Q<VisualElement>("tool-list-container");
+
+            section.Update(initialData);
+            Toggle beforeToggle = FindToggleByToolName(container, "compile");
+
+            section.Update(changedLayoutData);
+            Toggle afterToggle = FindToggleByToolName(container, "compile");
+            Toggle getLogsToggle = FindToggleByToolName(container, "get-logs");
+
+            Assert.IsNotNull(beforeToggle);
+            Assert.IsNotNull(afterToggle);
+            Assert.AreNotSame(beforeToggle, afterToggle);
+            Assert.IsNotNull(getLogsToggle);
+        }
+
+        private static VisualElement CreateRootElement()
+        {
+            VisualElement root = new VisualElement();
+            Foldout foldout = new Foldout
+            {
+                name = "tool-settings-foldout"
+            };
+            VisualElement container = new VisualElement
+            {
+                name = "tool-list-container"
+            };
+
+            foldout.Add(container);
+            root.Add(foldout);
+            return root;
+        }
+
+        private static ToolSettingsSectionData CreateData(bool compileEnabled, bool includeGetLogs)
+        {
+            ToolToggleItem compile = new ToolToggleItem(
+                toolName: "compile",
+                description: "Compile project",
+                isEnabled: compileEnabled,
+                isThirdParty: false);
+
+            if (!includeGetLogs)
+            {
+                return new ToolSettingsSectionData(
+                    showToolSettings: true,
+                    builtInTools: new[] { compile },
+                    thirdPartyTools: System.Array.Empty<ToolToggleItem>(),
+                    isRegistryAvailable: true);
+            }
+
+            ToolToggleItem getLogs = new ToolToggleItem(
+                toolName: "get-logs",
+                description: "Read Unity logs",
+                isEnabled: true,
+                isThirdParty: false);
+
+            return new ToolSettingsSectionData(
+                showToolSettings: true,
+                builtInTools: new[] { compile, getLogs },
+                thirdPartyTools: System.Array.Empty<ToolToggleItem>(),
+                isRegistryAvailable: true);
+        }
+
+        private static Toggle FindToggleByToolName(VisualElement container, string toolName)
+        {
+            for (int i = 0; i < container.childCount; i++)
+            {
+                VisualElement row = container[i];
+                bool isToggleRow = row.ClassListContains("mcp-tool-toggle-row");
+                if (!isToggleRow || row.childCount < 2)
+                {
+                    continue;
+                }
+
+                Toggle toggle = row[0] as Toggle;
+                Label label = row[1] as Label;
+                bool isTargetRow = label != null && label.text == toolName;
+
+                if (isTargetRow)
+                {
+                    return toggle;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/Tests/Editor/ToolSettingsSectionTests.cs.meta
+++ b/Assets/Tests/Editor/ToolSettingsSectionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 082177c568da245338820ec2b20b2411
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -483,13 +483,15 @@ namespace io.github.hatayama.uLoopMCP
 
         private void HandleToolToggled(string toolName, bool enabled)
         {
-            // Let the UI repaint the toggle visual immediately before running heavy work
-            EditorApplication.delayCall += () => ApplyToolToggle(toolName, enabled);
+            _model.UpdateToolEnabled(toolName, enabled);
+            _view?.UpdateSingleToolToggle(toolName, enabled);
+
+            // Skill synchronization can touch many files, so defer it to keep UI input responsive.
+            EditorApplication.delayCall += () => ApplyToolToggleSideEffects(toolName, enabled);
         }
 
-        private async void ApplyToolToggle(string toolName, bool enabled)
+        private async void ApplyToolToggleSideEffects(string toolName, bool enabled)
         {
-            _model.UpdateToolEnabled(toolName, enabled);
             ClientNotificationService.TriggerToolChangeNotification();
 
             if (!enabled)

--- a/Packages/src/Editor/UI/UIToolkit/Components/ToolSettingsSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/ToolSettingsSection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using UnityEngine.UIElements;
 
 namespace io.github.hatayama.uLoopMCP
@@ -14,6 +15,9 @@ namespace io.github.hatayama.uLoopMCP
         private readonly Foldout _foldout;
         private readonly VisualElement _toolListContainer;
         private readonly Dictionary<string, Toggle> _togglesByToolName = new();
+        private bool _isRegistryAvailable;
+        private bool _isUnavailableStateShown;
+        private string _layoutSignature = string.Empty;
 
         public event Action<bool> OnFoldoutChanged;
         public event Action<string, bool> OnToolToggled;
@@ -37,11 +41,11 @@ namespace io.github.hatayama.uLoopMCP
 
             if (!data.IsRegistryAvailable)
             {
-                RebuildUnavailable();
+                UpdateUnavailableState();
                 return;
             }
 
-            Rebuild(data);
+            UpdateToolList(data);
         }
 
         /// <summary>
@@ -53,6 +57,38 @@ namespace io.github.hatayama.uLoopMCP
             {
                 toggle.SetValueWithoutNotify(enabled);
             }
+        }
+
+        private void UpdateUnavailableState()
+        {
+            if (_isRegistryAvailable || !_isUnavailableStateShown)
+            {
+                RebuildUnavailable();
+            }
+
+            _isRegistryAvailable = false;
+            _isUnavailableStateShown = true;
+            _layoutSignature = string.Empty;
+        }
+
+        private void UpdateToolList(ToolSettingsSectionData data)
+        {
+            string layoutSignature = CreateLayoutSignature(data);
+            bool shouldRebuild = !_isRegistryAvailable || _layoutSignature != layoutSignature;
+
+            if (shouldRebuild)
+            {
+                Rebuild(data);
+                _layoutSignature = layoutSignature;
+            }
+            else
+            {
+                UpdateToggleStates(data.BuiltInTools);
+                UpdateToggleStates(data.ThirdPartyTools);
+            }
+
+            _isRegistryAvailable = true;
+            _isUnavailableStateShown = false;
         }
 
         private void RebuildUnavailable()
@@ -86,6 +122,38 @@ namespace io.github.hatayama.uLoopMCP
                     AddToolToggle(item);
                 }
             }
+        }
+
+        private void UpdateToggleStates(IReadOnlyList<ToolToggleItem> items)
+        {
+            for (int i = 0; i < items.Count; i++)
+            {
+                ToolToggleItem item = items[i];
+                UpdateSingleToggle(item.ToolName, item.IsEnabled);
+            }
+        }
+
+        private static string CreateLayoutSignature(ToolSettingsSectionData data)
+        {
+            StringBuilder builder = new StringBuilder();
+            AppendGroupSignature(builder, data.BuiltInTools, "B");
+            AppendGroupSignature(builder, data.ThirdPartyTools, "T");
+            return builder.ToString();
+        }
+
+        private static void AppendGroupSignature(StringBuilder builder, IReadOnlyList<ToolToggleItem> items, string group)
+        {
+            builder.Append(group);
+            builder.Append(':');
+
+            for (int i = 0; i < items.Count; i++)
+            {
+                ToolToggleItem item = items[i];
+                builder.Append(item.ToolName);
+                builder.Append('|');
+            }
+
+            builder.Append(';');
         }
 
         private void AddGroupHeader(string text)


### PR DESCRIPTION
## Summary
- prevent Tool Settings toggles from becoming unclickable when the editor window refreshes repeatedly
- update tool toggle handling so settings are persisted immediately and heavy side effects are deferred
- add edit mode tests that verify differential update behavior for Tool Settings UI

## Changes
- add layout-signature based differential rendering in ToolSettingsSection and rebuild only when the tool list shape changes
- keep existing toggle elements for same-layout updates and apply value changes without rebuilding rows
- update McpEditorWindow.HandleToolToggled to save tool state immediately and defer skill synchronization side effects
- add ToolSettingsSectionTests covering no-rebuild, state-update-without-rebuild, and rebuild-on-layout-change scenarios

## Validation
- uloop compile (Success: true, ErrorCount: 0, WarningCount: 0)
- uloop run-tests --test-mode EditMode --filter-type regex --filter-value ToolSettingsSectionTests (Passed: 3/3)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Tool Settings toggles so they stay clickable during frequent UI refreshes. State changes are applied instantly, while heavy side effects are deferred to keep the editor responsive.

- **Bug Fixes**
  - Added layout-signature based differential rendering to reuse existing toggle elements when the tool list shape is unchanged.
  - Updated McpEditorWindow to save tool state immediately and defer skill sync side effects via delayCall.
  - Added edit mode tests covering no-rebuild, state updates without rebuild, and rebuild on layout change (3/3 passing).

<sup>Written for commit 439ed158df693d4c912e25f1df3b16fcdbf15f16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes Tool Settings toggle interaction stability by implementing differential UI rendering based on tool layout signatures, preventing toggles from becoming unclickable during repeated editor window refreshes.

## Technical Approach

The solution uses a two-layered fix:

1. **Deferred Side Effects**: Tool toggle state is persisted immediately to the UI, while heavy operations (skill synchronization) are deferred to a later update cycle, keeping UI interactions responsive.

2. **Differential Rendering**: The ToolSettingsSection now computes a deterministic layout signature from the tool list shape and only rebuilds UI elements when the signature changes. For same-layout updates, existing toggle elements are preserved and only their state values are updated.

## Changes by File

### ToolSettingsSection.cs
Refactored to support layout-signature-based differential rendering:

- **New State Fields**: Added `_isRegistryAvailable`, `_isUnavailableStateShown`, and `_layoutSignature` to track registry state and UI layout.

- **Conditional Rebuild Logic**: 
  - `UpdateUnavailableState()`: Rebuilds unavailable UI once and resets layout tracking when registry is not available.
  - `UpdateToolList(data)`: Computes layout signature and conditionally rebuilds or updates toggles based on signature changes.
  - `UpdateToggleStates(items)`: Updates existing toggles' enabled states without full rebuild.
  - `CreateLayoutSignature(data)` and `AppendGroupSignature(...)`: Generate deterministic layout fingerprints from tool lists to detect structural changes.

- **Behavior**: When registry becomes available, the method checks if the tool list shape (Built-in and Third Party tools) has changed via layout signature. Matching signatures preserve existing toggle elements while applying new state values; changed signatures trigger full rebuild.

### McpEditorWindow.cs
Modified `HandleToolToggled` to split immediate state persistence from deferred side effects:

- **Immediate Updates**: Calls `_model.UpdateToolEnabled()` and `_view?.UpdateSingleToolToggle()` synchronously for instant UI feedback.

- **Deferred Work**: Renamed `ApplyToolToggle` to `ApplyToolToggleSideEffects` and defers its execution. The method now handles tool change notifications and skill file synchronization (InstallSkillFiles when enabling, RemoveSkillFiles when disabling).

- **Removal of Duplicate State Update**: The deferred side-effects method no longer calls `_model.UpdateToolEnabled()` since this occurs in the immediate path.

### ToolSettingsSectionTests.cs
New NUnit test suite validating differential update behavior:

- **Update_SameLayout_DoesNotReplaceToggleElements**: Verifies that repeated updates with identical data retain the same Toggle element instances, avoiding unnecessary DOM mutations.

- **Update_SameLayout_UpdatesToggleStateWithoutRebuild**: Confirms that toggling enabled/disabled state updates toggles without rebuilding the entire row structure.

- **Update_LayoutChanged_RebuildsToggleElements**: Validates that adding a new tool (changing layout signature) triggers full rebuild, producing new Toggle instances.

Test infrastructure includes helpers to construct minimal VisualElement hierarchies, create test data with compile and optional get-logs tools, and locate toggles by tool name within the container.

## Validation

- Project compiled successfully (0 errors, 0 warnings).
- All 3 ToolSettingsSectionTests passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->