### PR TITLE
Fix CI failure for Dependabot PRs and bump upload-artifact to v7

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -87,7 +87,7 @@ jobs:
         category: "SecurityCodeScan"
 
     - name: Upload security scan results as artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: security-scan-results

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -18,6 +18,9 @@ jobs:
   compile-check-and-test:
     name: Compile Check & Test Runner (Linux)
     runs-on: ubuntu-latest
+    # Dependabot PRs cannot access repository secrets (UNITY_LICENSE etc.)
+    env:
+      HAS_UNITY_LICENSE: ${{ secrets.UNITY_LICENSE != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -25,6 +28,7 @@ jobs:
           lfs: true
 
       - name: Cache Library folder
+        if: env.HAS_UNITY_LICENSE == 'true'
         uses: actions/cache@v5
         with:
           path: Library
@@ -33,6 +37,7 @@ jobs:
             Library-2022.3.62f1-
 
       - name: Compile Unity project
+        if: env.HAS_UNITY_LICENSE == 'true'
         id: compile
         uses: game-ci/unity-builder@v4
         timeout-minutes: 30
@@ -48,6 +53,7 @@ jobs:
         continue-on-error: true
 
       - name: Check for compile errors and warnings
+        if: env.HAS_UNITY_LICENSE == 'true'
         run: |
           LOG_FILE=$(find . -name "*.log" -path "*/build/*" -o -name "Editor.log" 2>/dev/null | head -1)
 
@@ -103,6 +109,7 @@ jobs:
           fi
 
       - name: Run EditMode tests
+        if: env.HAS_UNITY_LICENSE == 'true'
         uses: game-ci/unity-test-runner@v4
         timeout-minutes: 30
         env:
@@ -116,8 +123,8 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v6
-        if: always()
+        uses: actions/upload-artifact@v7
+        if: always() && env.HAS_UNITY_LICENSE == 'true'
         with:
           name: Unity test results
           path: artifacts


### PR DESCRIPTION
## Summary
- Gate all Unity-dependent CI steps (compile, test, upload) on `HAS_UNITY_LICENSE` env var so the job passes gracefully when secrets are unavailable (Dependabot PRs)
- Bump `actions/upload-artifact` from v6 to v7 in both `unity-compile-check-and-test-runner.yml` and `security-scan.yml`

Closes #704 (supersedes Dependabot PR)

## Test plan
- [ ] Verify this PR's CI passes (no C# files changed, so Unity workflow won't trigger on paths filter)
- [ ] After merge, close Dependabot PR #704
- [ ] Future Dependabot PRs touching workflow files should pass CI gracefully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI failures on Dependabot PRs by skipping Unity steps when secrets aren’t available. Also upgrade upload-artifact to v7 in Unity and security scan workflows.

- **Bug Fixes**
  - Gate Unity cache, compile, test, and artifact upload on HAS_UNITY_LICENSE (from secrets.UNITY_LICENSE).
  - Dependabot PRs now pass CI without Unity secrets.

- **Dependencies**
  - Bump actions/upload-artifact from v6 to v7 in unity-compile-check-and-test-runner.yml and security-scan.yml.

<sup>Written for commit f4ca39e77323c91bdd16d8eb4f7fb311e065f7c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes CI failures for Dependabot pull requests and updates the `actions/upload-artifact` GitHub Action to v7. Dependabot PRs cannot access repository secrets (including Unity license credentials), causing Unity-dependent CI steps to fail. This PR gates all Unity-dependent steps on a new environment variable and upgrades the artifact upload action.

## Changes

### `.github/workflows/unity-compile-check-and-test-runner.yml`

**Added environment-based gating for Unity-dependent steps:**
- Introduces `HAS_UNITY_LICENSE` environment variable that evaluates to `'true'` only when the `UNITY_LICENSE` secret is available (line 23)
- Conditional guards (`if: env.HAS_UNITY_LICENSE == 'true'`) added to:
  - Cache Library folder (line 31)
  - Compile Unity project (line 40)
  - Check for compile errors and warnings (line 56)
  - Run EditMode tests (line 112)
- Updated "Upload test results" step to conditionally run on both `always()` and `HAS_UNITY_LICENSE == 'true'` (line 127)

**Action upgrade:**
- Bumped `actions/upload-artifact` from v6 to v7 (line 126)

### `.github/workflows/security-scan.yml`

**Action upgrade:**
- Bumped `actions/upload-artifact` from v6 to v7 in the "Upload security scan results as artifact" step (line 90)

## Behavior Changes

- Dependabot PRs and other workflows without access to the `UNITY_LICENSE` secret will now skip all Unity compilation and testing steps gracefully instead of failing
- Upload artifact steps continue to execute regardless of Unity license availability
- The workflow will maintain checks write permissions and report test results only when Unity build succeeds
- No changes to security scanning workflows or non-Unity-dependent functionality

## Testing Strategy

- Verify this PR's own CI passes (path filters prevent Unity workflow from triggering since workflow file changes alone don't trigger the compilation check on PR targets)
- After merge, close Dependabot PR #704 (which attempted to upgrade upload-artifact)
- Future Dependabot PRs will pass CI gracefully when they modify workflow files or dependencies without impacting the Unity build system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->