### PR TITLE
docs: Add SKILL.md files for Device Agent CLI commands

### DIFF
--- a/.claude/skills/uloop-device-connect/SKILL.md
+++ b/.claude/skills/uloop-device-connect/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: uloop-device-connect
+description: "Connect to a Device Agent running on a physical device over USB. Use when you need to: (1) establish connection to Android/iOS device for automated testing, (2) set up ADB port forwarding, (3) authenticate with the Device Agent. Performs ADB forward (Android) or iproxy (iOS) and auth.login handshake."
+---
+
+# uloop device-connect
+
+Connect to a Device Agent running on a physical Android or iOS device over USB.
+
+## Usage
+
+```bash
+uloop device-connect [options]
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--port` | integer | `8800` | Device Agent TCP port |
+| `--token` | string | - | Authentication token for the Device Agent |
+| `--platform` | string | - | Target platform: `android` or `ios` |
+
+## Examples
+
+```bash
+# Connect to Android device with default port
+uloop device-connect --platform android
+
+# Connect to iOS device with default port
+uloop device-connect --platform ios
+
+# Connect with a specific port
+uloop device-connect --platform android --port 9900
+
+# Connect with authentication token
+uloop device-connect --platform android --token my-secret-token
+```
+
+## Output
+
+Returns JSON with:
+- `Connected`: Whether the connection was established successfully
+- `DeviceSerial`: Serial number of the connected device
+- `Capabilities`: List of supported Device Agent capabilities
+
+## Notes
+
+- For Android, ADB port forwarding is set up automatically
+- For iOS, iproxy is used for USB tunneling
+- An auth.login handshake is performed after the connection is established
+- The default Device Agent port is 8800

--- a/.claude/skills/uloop-device-find-game-objects/SKILL.md
+++ b/.claude/skills/uloop-device-find-game-objects/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: uloop-device-find-game-objects
+description: "Search for GameObjects in a running app on a physical device. Use when you need to: (1) find UI elements by name, tag, or component type, (2) discover interactive elements for automated testing, (3) get objectIds for use with device-tap-object or other device commands. Queries the Device Agent over TCP on port 8800."
+---
+
+# uloop device-find-game-objects
+
+Search for GameObjects in a running app on a connected physical device.
+
+## Usage
+
+```bash
+uloop device-find-game-objects [options]
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--name` | string | - | GameObject name to search for |
+| `--tag` | string | - | Tag filter |
+| `--component-type` | string | - | Required component type (e.g., `Button`, `Text`) |
+| `--active-only` | boolean | `false` | Only return active GameObjects |
+
+## Examples
+
+```bash
+# Find GameObjects by name
+uloop device-find-game-objects --name "StartButton"
+
+# Find GameObjects by tag
+uloop device-find-game-objects --tag "Player"
+
+# Find GameObjects with a specific component
+uloop device-find-game-objects --component-type Button
+
+# Find only active GameObjects by name
+uloop device-find-game-objects --name "Panel" --active-only
+```
+
+## Output
+
+Returns JSON with matching GameObjects, each containing:
+- `ObjectId`: Session-scoped identifier for use with other device commands (e.g., `device-tap-object`)
+- `Name`: GameObject name
+- `Path`: Hierarchy path
+- `Components`: List of attached components
+
+## Notes
+
+- The `ObjectId` is session-scoped and valid only for the current Device Agent session
+- Use the returned `ObjectId` with `device-tap-object` to interact with found elements

--- a/.claude/skills/uloop-device-get-screenshot/SKILL.md
+++ b/.claude/skills/uloop-device-get-screenshot/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: uloop-device-get-screenshot
+description: "Capture a screenshot from a running app on a physical device. Use when you need to: (1) see current state of the app on device, (2) verify UI layout or visual state, (3) capture evidence of test results. Retrieves the screenshot via the Device Agent over TCP on port 8800."
+---
+
+# uloop device-get-screenshot
+
+Capture a screenshot from a running app on a connected physical device.
+
+## Usage
+
+```bash
+uloop device-get-screenshot [options]
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--format` | string | `png` | Image format: `png` or `jpg` |
+| `--quality` | integer | - | JPEG quality (1-100, only applicable when format is `jpg`) |
+| `--output` | string | - | File path to save the screenshot. When omitted, returns Base64-encoded image data. |
+
+## Examples
+
+```bash
+# Capture screenshot as PNG (default)
+uloop device-get-screenshot
+
+# Capture screenshot as JPEG with quality setting
+uloop device-get-screenshot --format jpg --quality 80
+
+# Save screenshot to a specific file
+uloop device-get-screenshot --output /tmp/device-screenshot.png
+
+# Save as JPEG to a specific file
+uloop device-get-screenshot --format jpg --quality 90 --output /tmp/screenshot.jpg
+```
+
+## Output
+
+Returns JSON with:
+- `ImageData`: Base64-encoded image data (when `--output` is not specified)
+- `ImagePath`: Absolute path to the saved file (when `--output` is specified)
+- `Width`: Image width in pixels
+- `Height`: Image height in pixels
+- `Format`: Image format used (`png` or `jpg`)
+
+## Notes
+
+- Default format is PNG for lossless quality
+- The maximum long side of the image defaults to 1568 pixels

--- a/.claude/skills/uloop-device-list/SKILL.md
+++ b/.claude/skills/uloop-device-list/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: uloop-device-list
+description: "List connected physical devices available for Device Agent. Use when you need to: (1) discover connected Android/iOS devices, (2) check device connection status, (3) find device serial numbers for targeting. Shows connected devices with serial, model, and status."
+---
+
+# uloop device-list
+
+List connected physical devices available for Device Agent.
+
+## Usage
+
+```bash
+uloop device-list
+```
+
+## Parameters
+
+This command takes no parameters.
+
+## Examples
+
+```bash
+# List all connected devices
+uloop device-list
+```
+
+## Output
+
+Returns JSON with an array of connected devices, each containing:
+- `Serial`: Device serial number
+- `Model`: Device model name
+- `Status`: Connection status (e.g., connected, offline)

--- a/.claude/skills/uloop-device-tap-object/SKILL.md
+++ b/.claude/skills/uloop-device-tap-object/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: uloop-device-tap-object
+description: "Tap a GameObject on a physical device via EventSystem. Use when you need to: (1) tap UI buttons or interactive elements, (2) automate user interactions on device, (3) simulate touch input on specific GameObjects. Sends tap events through the Device Agent over TCP on port 8800."
+---
+
+# uloop device-tap-object
+
+Tap a GameObject on a connected physical device via the Unity EventSystem.
+
+## Usage
+
+```bash
+uloop device-tap-object [options]
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--object-id` | string | - | Session-scoped objectId from `device-find-game-objects` (preferred) |
+| `--object-path` | string | - | Hierarchy path to the target GameObject (fallback) |
+
+## Object Targeting
+
+- **Preferred**: Use `--object-id` obtained from `device-find-game-objects` for reliable targeting
+- **Fallback**: Use `--object-path` with the full hierarchy path (e.g., `Canvas/Panel/Button`)
+- **Same-name siblings**: Append `[n]` index to disambiguate (e.g., `Canvas/Panel/Button[2]` for the third Button)
+
+## Examples
+
+```bash
+# Tap by objectId (preferred)
+uloop device-tap-object --object-id "abc123"
+
+# Tap by hierarchy path
+uloop device-tap-object --object-path "Canvas/MainMenu/StartButton"
+
+# Tap a specific sibling by index
+uloop device-tap-object --object-path "Canvas/Panel/Button[2]"
+```
+
+## Output
+
+Returns JSON with:
+- `Success`: Whether the tap was delivered
+- `TargetObject`: Name of the tapped GameObject
+
+## Notes
+
+- The tap is delivered through Unity's EventSystem, simulating a real touch event
+- `--object-id` is preferred over `--object-path` for reliability, as IDs are unambiguous within a session
+- Use `device-find-game-objects` first to discover available objects and obtain their `ObjectId`
+- The `[n]` index for same-name siblings is zero-based


### PR DESCRIPTION
## Summary
- Add SKILL.md documentation for 5 new Device Agent CLI commands: `device-connect`, `device-list`, `device-find-game-objects`, `device-tap-object`, and `device-get-screenshot`
- Follows the existing "What → When → How" structure from CLAUDE.md Skill Description Guidelines
- Enables AI agents (Claude Code etc.) to discover and use Device Agent commands

## Test plan
- [x] All 5 files exist at correct paths under `.claude/skills/`
- [x] Frontmatter YAML is valid with `name` and `description` fields
- [x] Format matches existing SKILL.md files (Usage, Parameters, Examples, Output, Notes sections)
- [x] Content is in English per project conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds SKILL.md documentation files for five Device Agent CLI commands to enable AI agents to discover and utilize these commands. The documentation follows the established "What → When → How" structure defined in CLAUDE.md Skill Description Guidelines.

## Changes

Five new SKILL.md files have been added under `.claude/skills/`:

| Skill | File | Details |
|-------|------|---------|
| **uloop-device-connect** | `.claude/skills/uloop-device-connect/SKILL.md` | Documents connecting to a Device Agent over USB for Android/iOS platforms. Includes port and token parameters, platform selection, sample commands, and JSON output structure with Connected, DeviceSerial, and Capabilities fields. Notes platform-specific setup (ADB port forwarding for Android, iproxy for iOS) and authentication handshake. (+52 lines) |
| **uloop-device-list** | `.claude/skills/uloop-device-list/SKILL.md` | Documents listing connected physical devices for Device Agent. Specifies JSON array output format where each device object contains Serial, Model, and Status fields. (+32 lines) |
| **uloop-device-find-game-objects** | `.claude/skills/uloop-device-find-game-objects/SKILL.md` | Documents searching for GameObjects on a running app on a connected device. Includes parameters (name, tag, component-type, active-only) and JSON output structure (ObjectId, Name, Path, Components). Notes that ObjectIds are session-scoped and used with device-tap-object. (+52 lines) |
| **uloop-device-tap-object** | `.claude/skills/uloop-device-tap-object/SKILL.md` | Documents tapping a target GameObject on a physical device via Unity's EventSystem. Includes parameters (--object-id and --object-path), targeting guidance, example commands, and notes on reliability and object discovery. (+53 lines) |
| **uloop-device-get-screenshot** | `.claude/skills/uloop-device-get-screenshot/SKILL.md` | Documents capturing screenshots from a running app on a physical device. Includes parameters (--format, --quality, --output), examples (PNG, JPEG with quality, file output), and JSON output schema (ImageData, ImagePath, Width, Height, Format). Notes default format (PNG) and max image dimension constraint (long side 1568px). (+52 lines) |

## Documentation Format

Each SKILL.md file includes:
- Frontmatter YAML with name and description fields
- Usage section with command syntax
- Parameters section describing available options
- Examples section with sample commands
- Output section specifying JSON response structure
- Notes section with platform-specific setup or usage guidance

**Total lines added:** 241

<!-- end of auto-generated comment: release notes by coderabbit.ai -->