### PR TITLE
feat: Add CLI device infrastructure for Device Agent

### DIFF
--- a/Packages/src/Cli~/src/cli.ts
+++ b/Packages/src/Cli~/src/cli.ts
@@ -33,6 +33,8 @@ import { pascalToKebabCase } from './arg-parser.js';
 import { registerSkillsCommand } from './skills/skills-command.js';
 import { registerLaunchCommand } from './commands/launch.js';
 import { registerFocusWindowCommand } from './commands/focus-window.js';
+import { registerDeviceConnectCommand } from './commands/device-connect.js';
+import { registerDeviceListCommand } from './commands/device-list.js';
 import { VERSION } from './version.js';
 import { findUnityProjectRoot } from './project-root.js';
 import { validateProjectPath } from './port-resolver.js';
@@ -45,6 +47,8 @@ interface CliOptions extends GlobalOptions {
 const FOCUS_WINDOW_COMMAND = 'focus-window' as const;
 const LAUNCH_COMMAND = 'launch' as const;
 const UPDATE_COMMAND = 'update' as const;
+const DEVICE_CONNECT_COMMAND = 'device-connect' as const;
+const DEVICE_LIST_COMMAND = 'device-list' as const;
 
 const HELP_GROUP_BUILTIN_TOOLS = 'Built-in Tools:' as const;
 const HELP_GROUP_THIRD_PARTY_TOOLS = 'Third-party Tools:' as const;
@@ -68,6 +72,8 @@ const BUILTIN_COMMANDS = [
   'skills',
   LAUNCH_COMMAND,
   FOCUS_WINDOW_COMMAND,
+  DEVICE_CONNECT_COMMAND,
+  DEVICE_LIST_COMMAND,
 ] as const;
 
 const program = new Command();
@@ -179,6 +185,10 @@ registerSkillsCommand(program);
 
 // Register launch subcommand
 registerLaunchCommand(program);
+
+// Register device commands
+registerDeviceConnectCommand(program);
+registerDeviceListCommand(program);
 
 // focus-window is registered conditionally in main() based on tool settings,
 // since it corresponds to an MCP tool that can be disabled via Tool Settings UI
@@ -841,7 +851,12 @@ function commandExists(cmdName: string, projectPath?: string): boolean {
 }
 
 function shouldSkipAutoSync(cmdName: string | undefined, args: string[]): boolean {
-  if (cmdName === LAUNCH_COMMAND || cmdName === UPDATE_COMMAND) {
+  if (
+    cmdName === LAUNCH_COMMAND ||
+    cmdName === UPDATE_COMMAND ||
+    cmdName === DEVICE_CONNECT_COMMAND ||
+    cmdName === DEVICE_LIST_COMMAND
+  ) {
     return true;
   }
   return args.some((arg) => (NO_SYNC_FLAGS as readonly string[]).includes(arg));
@@ -915,7 +930,12 @@ async function main(): Promise<void> {
   const cmdName = findCommandName(args);
 
   // No command name = no Unity operation; skip project detection
-  const NO_PROJECT_COMMANDS = [UPDATE_COMMAND, 'completion'] as const;
+  const NO_PROJECT_COMMANDS = [
+    UPDATE_COMMAND,
+    'completion',
+    DEVICE_CONNECT_COMMAND,
+    DEVICE_LIST_COMMAND,
+  ] as const;
   const skipProjectDetection =
     cmdName === undefined || (NO_PROJECT_COMMANDS as readonly string[]).includes(cmdName);
 

--- a/Packages/src/Cli~/src/commands/device-connect.ts
+++ b/Packages/src/Cli~/src/commands/device-connect.ts
@@ -1,0 +1,142 @@
+/**
+ * CLI command for connecting to a Device Agent on a physical device.
+ * Sets up USB port forwarding and establishes an authenticated connection.
+ */
+
+// CLI commands output to console by design
+/* eslint-disable no-console */
+
+import assert from 'node:assert';
+import { execSync } from 'child_process';
+import { Command } from 'commander';
+import { DeviceClient, DEVICE_DEFAULT_PORT } from '../device-client.js';
+
+type Platform = 'android' | 'ios';
+
+interface DeviceConnectOptions {
+  port?: string;
+  token?: string;
+  platform?: string;
+}
+
+export function registerDeviceConnectCommand(program: Command): void {
+  program
+    .command('device-connect')
+    .description('Connect to a Device Agent running on a physical device over USB')
+    .option('--port <port>', `Device Agent port (default: ${DEVICE_DEFAULT_PORT})`)
+    .option('--token <token>', 'Authentication token for Device Agent')
+    .option('--platform <platform>', 'Device platform: android or ios (default: auto-detect)')
+    .action(async (options: DeviceConnectOptions) => {
+      await runDeviceConnect(options);
+    });
+}
+
+function parsePort(portStr: string | undefined): number {
+  if (portStr === undefined) {
+    return DEVICE_DEFAULT_PORT;
+  }
+  const parsed: number = parseInt(portStr, 10);
+  if (Number.isNaN(parsed) || parsed < 1 || parsed > 65535) {
+    console.error(`Error: Invalid port "${portStr}". Must be an integer between 1 and 65535.`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
+function detectPlatform(): Platform {
+  const adbAvailable: boolean = isCommandAvailable('adb');
+  if (adbAvailable) {
+    return 'android';
+  }
+
+  const iproxyAvailable: boolean = isCommandAvailable('iproxy');
+  if (iproxyAvailable) {
+    return 'ios';
+  }
+
+  console.error('Error: Could not detect device platform.');
+  console.error('Make sure either "adb" (Android) or "iproxy" (iOS) is available on your PATH.');
+  process.exit(1);
+}
+
+function resolvePlatform(platformStr: string | undefined): Platform {
+  if (platformStr === undefined) {
+    return detectPlatform();
+  }
+
+  const normalized: string = platformStr.toLowerCase();
+  if (normalized === 'android' || normalized === 'ios') {
+    return normalized;
+  }
+
+  console.error(`Error: Invalid platform "${platformStr}". Must be "android" or "ios".`);
+  process.exit(1);
+}
+
+function isCommandAvailable(command: string): boolean {
+  const whichCmd: string = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    execSync(`${whichCmd} ${command}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function setupAndroidPortForward(port: number): void {
+  console.log(`Setting up ADB port forwarding: tcp:${port} -> tcp:${port}`);
+  try {
+    execSync(`adb forward tcp:${port} tcp:${port}`, { stdio: 'inherit' });
+  } catch {
+    console.error('Error: Failed to set up ADB port forwarding.');
+    console.error('Make sure a device is connected and ADB is working: adb devices');
+    process.exit(1);
+  }
+}
+
+function setupIosPortForward(port: number): void {
+  // iproxy runs as a background process; full implementation deferred to future work
+  console.log(`iOS port forwarding via iproxy is not yet fully supported.`);
+  console.log(`To manually forward: iproxy ${port} ${port}`);
+  console.log('Attempting to connect assuming port forwarding is already set up...');
+}
+
+async function runDeviceConnect(options: DeviceConnectOptions): Promise<void> {
+  const port: number = parsePort(options.port);
+  const platform: Platform = resolvePlatform(options.platform);
+  const token: string = options.token ?? '';
+
+  assert(port >= 1 && port <= 65535, 'port must be in valid range');
+
+  if (platform === 'android') {
+    setupAndroidPortForward(port);
+  } else {
+    setupIosPortForward(port);
+  }
+
+  console.log(`\nConnecting to Device Agent at 127.0.0.1:${port}...`);
+
+  const client = new DeviceClient(port);
+
+  await client.connect();
+  console.log('TCP connection established.');
+
+  if (token.length > 0) {
+    console.log('Authenticating...');
+    const authResult = await client.authenticate(token);
+    console.log('Authentication successful.');
+
+    if (authResult.capabilities && Object.keys(authResult.capabilities).length > 0) {
+      console.log('\nDevice capabilities:');
+      for (const [key, value] of Object.entries(authResult.capabilities)) {
+        console.log(`  ${key}: ${JSON.stringify(value)}`);
+      }
+    }
+  } else {
+    console.log('No token provided, skipping authentication.');
+  }
+
+  console.log(`\nConnected to ${platform} Device Agent on port ${port}.`);
+
+  client.disconnect();
+}

--- a/Packages/src/Cli~/src/commands/device-list.ts
+++ b/Packages/src/Cli~/src/commands/device-list.ts
@@ -1,0 +1,126 @@
+/**
+ * CLI command for listing connected physical devices.
+ * Queries ADB for Android devices and idevice_id for iOS devices (future).
+ */
+
+// CLI commands output to console by design
+/* eslint-disable no-console */
+
+import { execSync } from 'child_process';
+import { Command } from 'commander';
+
+interface DeviceInfo {
+  serial: string;
+  model: string;
+  status: string;
+  platform: string;
+}
+
+export function registerDeviceListCommand(program: Command): void {
+  program
+    .command('device-list')
+    .description('List connected physical devices (Android via ADB, iOS planned)')
+    .action(() => {
+      runDeviceList();
+    });
+}
+
+function runDeviceList(): void {
+  const devices: DeviceInfo[] = listAndroidDevices();
+
+  if (devices.length === 0) {
+    console.log('No devices found.');
+    console.log('Make sure a device is connected and USB debugging is enabled.');
+    return;
+  }
+
+  console.log(`Found ${devices.length} device(s):\n`);
+
+  const serialWidth: number = Math.max('SERIAL'.length, ...devices.map((d) => d.serial.length));
+  const modelWidth: number = Math.max('MODEL'.length, ...devices.map((d) => d.model.length));
+  const statusWidth: number = Math.max('STATUS'.length, ...devices.map((d) => d.status.length));
+  const platformWidth: number = Math.max(
+    'PLATFORM'.length,
+    ...devices.map((d) => d.platform.length),
+  );
+
+  const header: string = [
+    'SERIAL'.padEnd(serialWidth),
+    'MODEL'.padEnd(modelWidth),
+    'STATUS'.padEnd(statusWidth),
+    'PLATFORM'.padEnd(platformWidth),
+  ].join('  ');
+
+  const separator: string = [
+    '-'.repeat(serialWidth),
+    '-'.repeat(modelWidth),
+    '-'.repeat(statusWidth),
+    '-'.repeat(platformWidth),
+  ].join('  ');
+
+  console.log(header);
+  console.log(separator);
+
+  for (const device of devices) {
+    const row: string = [
+      device.serial.padEnd(serialWidth),
+      device.model.padEnd(modelWidth),
+      device.status.padEnd(statusWidth),
+      device.platform.padEnd(platformWidth),
+    ].join('  ');
+    console.log(row);
+  }
+}
+
+function listAndroidDevices(): DeviceInfo[] {
+  let output: string;
+  try {
+    output = execSync('adb devices -l', { encoding: 'utf-8', timeout: 10000 });
+  } catch {
+    return [];
+  }
+
+  const lines: string[] = output.split('\n');
+  const devices: DeviceInfo[] = [];
+
+  for (const line of lines) {
+    // Skip the header line ("List of devices attached") and empty lines
+    if (line.startsWith('List of') || line.trim().length === 0) {
+      continue;
+    }
+
+    const parsed: DeviceInfo | null = parseAdbDeviceLine(line);
+    if (parsed !== null) {
+      devices.push(parsed);
+    }
+  }
+
+  return devices;
+}
+
+function parseAdbDeviceLine(line: string): DeviceInfo | null {
+  // Format: "<serial> <status> <properties...>"
+  // Example: "ABCDEF123456 device usb:1-1 product:oriole model:Pixel_6 device:oriole transport_id:1"
+  const parts: string[] = line.trim().split(/\s+/);
+  if (parts.length < 2) {
+    return null;
+  }
+
+  const serial: string = parts[0];
+  const status: string = parts[1];
+
+  let model: string = 'unknown';
+  for (const part of parts.slice(2)) {
+    if (part.startsWith('model:')) {
+      model = part.substring('model:'.length);
+      break;
+    }
+  }
+
+  return {
+    serial,
+    model,
+    status,
+    platform: 'android',
+  };
+}

--- a/Packages/src/Cli~/src/device-client.ts
+++ b/Packages/src/Cli~/src/device-client.ts
@@ -1,0 +1,180 @@
+/**
+ * TCP client for Device Agent communication.
+ * Connects to a Device Agent running on a physical Android/iOS device over USB
+ * via ADB port forwarding (Android) or iproxy (iOS).
+ */
+
+// Non-null assertions are used after TCP frame parsing where data existence is guaranteed by protocol
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import assert from 'node:assert';
+import * as net from 'net';
+import { createFrame, parseFrameFromBuffer, extractFrameFromBuffer } from './simple-framer.js';
+import { JsonRpcRequest, JsonRpcResponse } from './direct-unity-client.js';
+import { VERSION } from './version.js';
+
+const JSONRPC_VERSION = '2.0';
+
+export const DEVICE_DEFAULT_HOST = '127.0.0.1';
+export const DEVICE_DEFAULT_PORT = 8800;
+
+const DEVICE_NETWORK_TIMEOUT_MS = 30000;
+
+const AUTH_ERROR_CODE = -32001;
+const INCOMPATIBLE_VERSION_ERROR_CODE = -32005;
+
+export interface DeviceCapabilities {
+  [key: string]: unknown;
+}
+
+export interface AuthLoginResult {
+  capabilities: DeviceCapabilities;
+}
+
+export class DeviceClient {
+  private socket: net.Socket | null = null;
+  private requestId: number = 0;
+  private receiveBuffer: Buffer = Buffer.alloc(0);
+  private capabilities: DeviceCapabilities | null = null;
+
+  constructor(
+    private readonly port: number = DEVICE_DEFAULT_PORT,
+    private readonly host: string = DEVICE_DEFAULT_HOST,
+  ) {}
+
+  async connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.socket = new net.Socket();
+
+      this.socket.on('error', (error: Error) => {
+        reject(new Error(`Device connection error: ${error.message}`));
+      });
+
+      this.socket.connect(this.port, this.host, () => {
+        resolve();
+      });
+    });
+  }
+
+  async authenticate(token: string): Promise<AuthLoginResult> {
+    assert(token.length > 0, 'token must not be empty');
+
+    const result = await this.sendRequest<AuthLoginResult>('auth.login', {
+      token,
+      cliVersion: VERSION,
+    });
+
+    assert(result !== null && result !== undefined, 'auth.login response must not be null');
+    this.capabilities = result.capabilities ?? {};
+    return result;
+  }
+
+  async sendRequest<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+    if (!this.socket) {
+      throw new Error('Not connected to Device Agent');
+    }
+
+    const request: JsonRpcRequest = {
+      jsonrpc: JSONRPC_VERSION,
+      method,
+      params: params ?? {},
+      id: ++this.requestId,
+    };
+
+    const requestJson: string = JSON.stringify(request);
+    const framedMessage: string = createFrame(requestJson);
+
+    return new Promise((resolve, reject) => {
+      const socket = this.socket!;
+
+      const cleanup = (): void => {
+        clearTimeout(timeoutId);
+        socket.off('data', onData);
+        socket.off('error', onError);
+        socket.off('close', onClose);
+      };
+
+      const timeoutId = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(
+            `Device request timed out after ${DEVICE_NETWORK_TIMEOUT_MS}ms. Device Agent may be unresponsive.`,
+          ),
+        );
+      }, DEVICE_NETWORK_TIMEOUT_MS);
+
+      const onData = (chunk: Buffer): void => {
+        this.receiveBuffer = Buffer.concat([this.receiveBuffer, chunk]);
+
+        const parseResult = parseFrameFromBuffer(this.receiveBuffer);
+        if (!parseResult.isComplete) {
+          return;
+        }
+
+        const extractResult = extractFrameFromBuffer(
+          this.receiveBuffer,
+          parseResult.contentLength,
+          parseResult.headerLength,
+        );
+
+        if (extractResult.jsonContent === null) {
+          return;
+        }
+
+        cleanup();
+        this.receiveBuffer = extractResult.remainingData;
+
+        const response = JSON.parse(extractResult.jsonContent) as JsonRpcResponse;
+
+        if (response.error) {
+          const errorMessage: string = buildDeviceErrorMessage(response.error);
+          reject(new Error(errorMessage));
+          return;
+        }
+
+        resolve(response.result as T);
+      };
+
+      const onError = (error: Error): void => {
+        cleanup();
+        reject(new Error(`Device connection lost: ${error.message}`));
+      };
+
+      const onClose = (): void => {
+        cleanup();
+        reject(new Error('DEVICE_NO_RESPONSE'));
+      };
+
+      socket.on('data', onData);
+      socket.on('error', onError);
+      socket.on('close', onClose);
+      socket.write(framedMessage);
+    });
+  }
+
+  disconnect(): void {
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = null;
+    }
+    this.receiveBuffer = Buffer.alloc(0);
+  }
+
+  isConnected(): boolean {
+    return this.socket !== null && !this.socket.destroyed;
+  }
+
+  getCapabilities(): DeviceCapabilities | null {
+    return this.capabilities;
+  }
+}
+
+function buildDeviceErrorMessage(error: { code: number; message: string; data?: unknown }): string {
+  if (error.code === AUTH_ERROR_CODE) {
+    return `Device auth failed: ${error.message}`;
+  }
+  if (error.code === INCOMPATIBLE_VERSION_ERROR_CODE) {
+    return `Incompatible version: ${error.message}`;
+  }
+  return `Device Agent error: ${error.message}`;
+}


### PR DESCRIPTION
## Summary
- Add `DeviceClient` TCP client (`device-client.ts`) for communicating with Device Agent running on physical Android/iOS devices over USB, reusing `SimpleFramer` and `JsonRpcRequest`/`JsonRpcResponse` types from existing `direct-unity-client.ts`
- Add `device-connect` command that sets up ADB port forwarding (Android) or stubs iproxy (iOS), connects to the Device Agent, and optionally performs `auth.login` handshake
- Add `device-list` command that parses `adb devices -l` output and displays connected devices in a table format
- Register both commands in `cli.ts` as built-in commands that skip Unity project detection and auto-sync

## Test plan
- [x] `npm run lint` passes with 0 errors (only pre-existing warnings)
- [x] `npm run build` succeeds
- [x] All 50 existing unit tests pass (no regressions)
- [ ] Manual testing with a running Device Agent on a physical Android device (requires device)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DeviceClient and two CLI commands to connect to a Device Agent over USB and list connected devices. These commands run without Unity project detection and skip auto-sync to streamline device workflows.

- **New Features**
  - DeviceClient: TCP JSON-RPC client using SimpleFramer; supports auth.login and capability discovery.
  - device-connect: sets up ADB port forwarding (Android), shows iproxy instructions (iOS), connects to 127.0.0.1:<port>, optional token-based auth.
  - device-list: parses `adb devices -l` and prints a simple table of connected Android devices.
  - CLI integration: registers both commands and excludes them from project detection and auto-sync.

<sup>Written for commit 3899e3e10b60d85e93ad24be5087b05729405d78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

