### PR TITLE
fix: Prevent toggle ChangeEvent from collapsing parent Foldout

### DIFF
--- a/Packages/src/Editor/UI/UIToolkit/Components/EditorConfigSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/EditorConfigSection.cs
@@ -42,7 +42,13 @@ namespace io.github.hatayama.uLoopMCP
 
         private void SetupBindings()
         {
-            _repositoryRootToggle.RegisterValueChangedCallback(evt => OnRepositoryRootChanged?.Invoke(evt.newValue));
+            _repositoryRootToggle.RegisterValueChangedCallback(evt =>
+            {
+                // Foldout uses an internal Toggle that listens for ChangeEvent<bool>.
+                // Without StopPropagation, this event bubbles up and collapses the Foldout.
+                evt.StopPropagation();
+                OnRepositoryRootChanged?.Invoke(evt.newValue);
+            });
             _configureButton.clicked += () => OnConfigureClicked?.Invoke();
             _deleteConfigButton.clicked += () => OnDeleteConfigClicked?.Invoke();
             _openSettingsButton.clicked += () => OnOpenSettingsClicked?.Invoke();

--- a/Packages/src/Editor/UI/UIToolkit/Components/SecuritySettingsSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/SecuritySettingsSection.cs
@@ -48,9 +48,23 @@ namespace io.github.hatayama.uLoopMCP
         private void SetupBindings()
         {
             _foldout.RegisterValueChangedCallback(evt => OnFoldoutChanged?.Invoke(evt.newValue));
-            _enableTestsToggle.RegisterValueChangedCallback(evt => OnEnableTestsChanged?.Invoke(evt.newValue));
-            _allowMenuToggle.RegisterValueChangedCallback(evt => OnAllowMenuChanged?.Invoke(evt.newValue));
-            _allowThirdPartyToggle.RegisterValueChangedCallback(evt => OnAllowThirdPartyChanged?.Invoke(evt.newValue));
+            _enableTestsToggle.RegisterValueChangedCallback(evt =>
+            {
+                // Foldout uses an internal Toggle that listens for ChangeEvent<bool>.
+                // Without StopPropagation, this event bubbles up and collapses the Foldout.
+                evt.StopPropagation();
+                OnEnableTestsChanged?.Invoke(evt.newValue);
+            });
+            _allowMenuToggle.RegisterValueChangedCallback(evt =>
+            {
+                evt.StopPropagation();
+                OnAllowMenuChanged?.Invoke(evt.newValue);
+            });
+            _allowThirdPartyToggle.RegisterValueChangedCallback(evt =>
+            {
+                evt.StopPropagation();
+                OnAllowThirdPartyChanged?.Invoke(evt.newValue);
+            });
 
             // Labels need click handlers because UI Toolkit toggles don't natively support label clicks
             _enableTestsLabel.RegisterCallback<ClickEvent>(evt => ToggleValue(_enableTestsToggle, OnEnableTestsChanged));


### PR DESCRIPTION
## Summary
- Stop `ChangeEvent<bool>` from bubbling up to parent Foldout when toggling checkboxes inside Security Settings and Editor Configuration sections
- Toggling a checkbox OFF inside a Foldout caused the Foldout itself to collapse, because the `ChangeEvent<bool>` with `newValue=false` propagated to the parent Foldout which interpreted it as a collapse request
- Add `evt.StopPropagation()` to toggle callbacks in `SecuritySettingsSection` (3 toggles) and `EditorConfigSection` (1 toggle), matching the existing pattern in `ToolSettingsSection`

## Changed Files
- `Packages/src/Editor/UI/UIToolkit/Components/SecuritySettingsSection.cs` — Add StopPropagation to Allow Tests / Allow Menu / Allow Third Party toggle callbacks
- `Packages/src/Editor/UI/UIToolkit/Components/EditorConfigSection.cs` — Add StopPropagation to Repository Root toggle callback

## Test Plan
- [ ] Open uLoop window in Unity Editor
- [ ] Expand Security Settings foldout
- [ ] Toggle each checkbox ON then OFF — verify the foldout stays open
- [ ] Expand Configuration foldout
- [ ] Toggle Repository Root checkbox ON then OFF — verify the foldout stays open

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented foldouts from collapsing when toggling checkboxes by stopping ChangeEvent<bool> from bubbling to the parent Foldout. Toggling in Security Settings and Editor Configuration no longer collapses the section.

- **Bug Fixes**
  - Added evt.StopPropagation() to toggle callbacks: Allow Tests, Allow Menu, Allow Third Party (SecuritySettingsSection) and Repository Root (EditorConfigSection).
  - Aligns behavior with ToolSettingsSection to avoid false foldout collapse on newValue=false.

<sup>Written for commit 0a98314df95e9d65848dd0fccc7bcb8b31f2fb9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Prevent Toggle ChangeEvent from Collapsing Parent Foldout

## Problem
When toggling checkboxes inside a Foldout control, the `ChangeEvent<bool>` event propagated to the parent Foldout, causing it to collapse when a toggle was turned OFF. This occurs because the Foldout control internally listens for `ChangeEvent<bool>` on child elements.

## Solution
Add `evt.StopPropagation()` to toggle value-changed callbacks to prevent events from bubbling up to parent Foldout controls. This follows the existing pattern already implemented in `ToolSettingsSection`.

## Changes

### SecuritySettingsSection.cs
Added event propagation blocking to three toggle callbacks in `SetupBindings()`:
- **Enable Tests Toggle** (line 51-57): Added `evt.StopPropagation()` before invoking `OnEnableTestsChanged`
- **Allow Menu Toggle** (line 58-62): Added `evt.StopPropagation()` before invoking `OnAllowMenuChanged`
- **Allow Third Party Toggle** (line 63-67): Added `evt.StopPropagation()` before invoking `OnAllowThirdPartyChanged`

Each callback now includes an explanatory comment: "Foldout uses an internal Toggle that listens for ChangeEvent<bool>. Without StopPropagation, this event bubbles up and collapses the Foldout."

### EditorConfigSection.cs
Added event propagation blocking to the Repository Root toggle callback in `SetupBindings()`:
- **Repository Root Toggle** (line 45-51): Added `evt.StopPropagation()` before invoking `OnRepositoryRootChanged`

Includes the same explanatory comment as SecuritySettingsSection.

## Impact
- **Scope**: UI event handling only; no changes to public signatures or data flow
- **Behavior**: Toggles inside Foldouts now maintain the parent Foldout's expanded state when toggled ON or OFF
- **Consistency**: Aligns SecuritySettingsSection and EditorConfigSection with the existing pattern in ToolSettingsSection
- **Testing**: Manual verification in Unity Editor by toggling each affected checkbox while verifying parent Foldout remains open

## Architecture Diagram

```
┌─────────────────────────────────────────────────────┐
│                 uLoop UI Window                      │
├─────────────────────────────────────────────────────┤
│                                                     │
│  ┌──────────────────────────────────────────────┐  │
│  │  SecuritySettingsSection                     │  │
│  ├──────────────────────────────────────────────┤  │
│  │ - _foldout: Foldout (parent)                 │  │
│  │ - _enableTestsToggle: Toggle ◄─StopProp      │  │
│  │ - _allowMenuToggle: Toggle ◄─StopProp        │  │
│  │ - _allowThirdPartyToggle: Toggle ◄─StopProp  │  │
│  │ - _securityLevelField: EnumField             │  │
│  └──────────────────────────────────────────────┘  │
│                                                     │
│  ┌──────────────────────────────────────────────┐  │
│  │  EditorConfigSection                         │  │
│  ├──────────────────────────────────────────────┤  │
│  │ - _editorTypeField: EnumField                │  │
│  │ - _repositoryRootToggle: Toggle ◄─StopProp   │  │
│  │ - _configureButton: Button                   │  │
│  │ - _deleteConfigButton: Button                │  │
│  │ - _openSettingsButton: Button                │  │
│  └──────────────────────────────────────────────┘  │
│                                                     │
│  ┌──────────────────────────────────────────────┐  │
│  │  ToolSettingsSection                         │  │
│  ├──────────────────────────────────────────────┤  │
│  │ - _foldout: Foldout (parent)                 │  │
│  │ - Toggle controls (already use StopProp)     │  │
│  └──────────────────────────────────────────────┘  │
│                                                     │
└─────────────────────────────────────────────────────┘

Legend: ◄─StopProp = evt.StopPropagation() added
```

## Code Example

**Before:**
```csharp
_enableTestsToggle.RegisterValueChangedCallback(evt =>
{
    OnEnableTestsChanged?.Invoke(evt.newValue);  // Event bubbles to parent Foldout
});
```

**After:**
```csharp
_enableTestsToggle.RegisterValueChangedCallback(evt =>
{
    evt.StopPropagation();  // Event stopped here
    OnEnableTestsChanged?.Invoke(evt.newValue);
});
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->