### PR TITLE
fix: Prevent rename migration from shadowing legacy settings migration

### DIFF
--- a/Assets/Tests/Editor/ULoopSettingsTests.cs
+++ b/Assets/Tests/Editor/ULoopSettingsTests.cs
@@ -456,6 +456,86 @@ namespace io.github.hatayama.uLoopMCP
                 "dynamicCodeSecurityLevel should be migrated");
         }
 
+        // ── Test 12: Plain legacy migration via McpEditorSettings first ──
+
+        [Test]
+        public void Migration_WhenLegacyHasSecurityValuesAndNoSpecialFields_ShouldInheritValues()
+        {
+            DeleteIfExists(SettingsFilePath);
+
+            // Plain legacy JSON: security fields only, no autoStartServer or isAfterCompile
+            string legacyJson = JsonUtility.ToJson(new LegacySettingsFixture
+            {
+                enableTestsExecution = true,
+                allowMenuItemExecution = true,
+                allowThirdPartyTools = true,
+                dynamicCodeSecurityLevel = (int)DynamicCodeSecurityLevel.Restricted,
+                customPort = 18080
+            }, true);
+            File.WriteAllText(LegacySettingsFilePath, legacyJson);
+            InvalidateBothCaches();
+
+            // Real-world order: McpEditorSettings loads first during domain reload
+            McpEditorSettings.GetSettings();
+
+            ULoopSettingsData result = ULoopSettings.GetSettings();
+
+            Assert.IsTrue(result.enableTestsExecution, "enableTestsExecution should be inherited from legacy");
+            Assert.IsTrue(result.allowMenuItemExecution, "allowMenuItemExecution should be inherited from legacy");
+            Assert.IsTrue(result.allowThirdPartyTools, "allowThirdPartyTools should be inherited from legacy");
+            Assert.AreEqual((int)DynamicCodeSecurityLevel.Restricted, result.dynamicCodeSecurityLevel,
+                "dynamicCodeSecurityLevel should be inherited from legacy");
+
+            // Verify file contents directly (not just cache)
+            Assert.IsTrue(File.Exists(SettingsFilePath), "settings.permissions.json should be created");
+            string permissionsJson = File.ReadAllText(SettingsFilePath);
+            ULoopSettingsData fileData = JsonUtility.FromJson<ULoopSettingsData>(permissionsJson);
+            Assert.IsTrue(fileData.enableTestsExecution, "File should persist enableTestsExecution=true");
+            Assert.IsTrue(fileData.allowMenuItemExecution, "File should persist allowMenuItemExecution=true");
+            Assert.IsTrue(fileData.allowThirdPartyTools, "File should persist allowThirdPartyTools=true");
+            Assert.AreEqual((int)DynamicCodeSecurityLevel.Restricted, fileData.dynamicCodeSecurityLevel,
+                "File should persist correct dynamicCodeSecurityLevel");
+        }
+
+        // ── Test 13: Rename migration should not shadow legacy migration ──
+
+        [Test]
+        public void Migration_WhenOldSecurityJsonHasDefaultsAndLegacyHasValues_ShouldNotLoseValues()
+        {
+            DeleteIfExists(SettingsFilePath);
+
+            // settings.security.json exists with DEFAULT values (v0.68 created it but user
+            // never changed defaults, OR v0.68 migration extracted defaults)
+            ULoopSettingsData defaultSecurityData = new ULoopSettingsData();
+            File.WriteAllText(OldSettingsFilePath, JsonUtility.ToJson(defaultSecurityData, true));
+
+            // Legacy file has non-default security values that the user actually configured
+            string legacyJson = JsonUtility.ToJson(new LegacySettingsFixture
+            {
+                enableTestsExecution = true,
+                allowMenuItemExecution = true,
+                allowThirdPartyTools = true,
+                dynamicCodeSecurityLevel = (int)DynamicCodeSecurityLevel.Restricted,
+                customPort = 18080
+            }, true);
+            File.WriteAllText(LegacySettingsFilePath, legacyJson);
+            InvalidateBothCaches();
+
+            ULoopSettingsData result = ULoopSettings.GetSettings();
+
+            // The rename migration converts settings.security.json (defaults) to
+            // settings.permissions.json, then returns early — legacy values are lost.
+            // This test documents the expected behavior: legacy values should be preserved.
+            Assert.IsTrue(result.enableTestsExecution,
+                "enableTestsExecution should not be reset to default by rename migration");
+            Assert.IsTrue(result.allowMenuItemExecution,
+                "allowMenuItemExecution should not be reset to default by rename migration");
+            Assert.IsTrue(result.allowThirdPartyTools,
+                "allowThirdPartyTools should not be reset to default by rename migration");
+            Assert.AreEqual((int)DynamicCodeSecurityLevel.Restricted, result.dynamicCodeSecurityLevel,
+                "dynamicCodeSecurityLevel should not be reset to default by rename migration");
+        }
+
         /// <summary>
         /// Fixture that includes both security and non-security fields,
         /// matching the legacy UserSettings/UnityMcpSettings.json structure.

--- a/Packages/src/Editor/Config/ULoopSettings.cs
+++ b/Packages/src/Editor/Config/ULoopSettings.cs
@@ -128,10 +128,23 @@ namespace io.github.hatayama.uLoopMCP
 
         private static void LoadSettings()
         {
-            // v0.68.0 used "settings.security.json"; rename once so existing users keep their settings.
-            // This migration block can be removed after a few releases.
             string oldSettingsPath = Path.Combine(McpConstants.ULOOP_DIR, "settings.security.json");
             string oldBackupPath = oldSettingsPath + ".bak";
+
+            // When upgrading directly from v0.67 (or earlier) to v0.69+, the legacy
+            // file still contains security fields because v0.68's extraction never ran.
+            // Legacy file takes priority over any settings.security.json which may hold
+            // stale default values.
+            if (!File.Exists(SettingsFilePath) && LegacyFileHasSecurityFields())
+            {
+                MigrateFromLegacySettings();
+                DeleteIfExists(oldSettingsPath);
+                DeleteIfExists(oldBackupPath);
+                return;
+            }
+
+            // v0.68.0 used "settings.security.json"; rename once so existing users keep their settings.
+            // This migration block can be removed after a few releases.
             if (!File.Exists(SettingsFilePath))
             {
                 if (File.Exists(oldSettingsPath))
@@ -171,6 +184,25 @@ namespace io.github.hatayama.uLoopMCP
 
             // .uloop/settings.permissions.json does not exist yet — attempt migration from legacy file
             MigrateFromLegacySettings();
+        }
+
+        private static bool LegacyFileHasSecurityFields()
+        {
+            if (!File.Exists(LegacySettingsFilePath))
+            {
+                return false;
+            }
+
+            string json = File.ReadAllText(LegacySettingsFilePath);
+            return json.Contains($"\"{nameof(LegacySecuritySettingsProbe.enableTestsExecution)}\"");
+        }
+
+        private static void DeleteIfExists(string path)
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

When upgrading directly from v0.67 (or earlier) to v0.69+, the rename migration (`settings.security.json` → `settings.permissions.json`) ran before the legacy migration (`UnityMcpSettings.json` → `settings.permissions.json`). This caused all security settings to be reset to defaults because the stale `settings.security.json` was promoted to `settings.permissions.json`, and the legacy migration was never executed.

## Changes

- Add `LegacyFileHasSecurityFields()` to detect un-migrated legacy files before the rename migration runs
- Prioritize legacy migration over rename migration when security fields are still present in `UnityMcpSettings.json`
- Clean up stale `settings.security.json` after successful legacy migration
- Use `nameof()` instead of magic string for field name check

## Test plan

- [x] Test 12: Plain legacy migration via McpEditorSettings-first order (no autoStartServer/isAfterCompile)
- [x] Test 13: Rename migration does not shadow legacy migration when both files exist
- [x] All 13 existing + new tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the upgrade path so legacy security settings are preserved when jumping from v0.67 (or earlier) to v0.69+. The legacy migration now runs before the settings.security.json → settings.permissions.json rename when security fields exist, preventing defaults from overwriting user values.

- **Bug Fixes**
  - Detect un-migrated legacy settings via LegacyFileHasSecurityFields().
  - Prioritize legacy migration and delete stale settings.security.json/.bak after success.
  - Use nameof() instead of hard-coded field names in the probe.

<sup>Written for commit 6cd1381b3fa9a6e985bd6c615c2ad8711bc0ce7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Prevent Rename Migration from Shadowing Legacy Settings Migration

### Problem

When upgrading directly from v0.67 (or earlier) to v0.69+, the rename migration (settings.security.json → settings.permissions.json) ran before the legacy migration (UnityMcpSettings.json → settings.permissions.json), causing security settings to be reset to defaults. This occurred because a stale settings.security.json file (possibly containing only default values from v0.68) was promoted to the new location, preventing the legacy file's actual user-configured security values from being migrated.

### Solution

The fix implements a prioritization system that ensures legacy migration takes precedence when security fields are detected in the legacy file:

**Changes to `Packages/src/Editor/Config/ULoopSettings.cs`:**

1. **New detection method `LegacyFileHasSecurityFields()`**: Inspects the legacy JSON file to determine if it contains any security-related fields (`enableTestsExecution`, `allowMenuItemExecution`, `allowThirdPartyTools`, `dynamicCodeSecurityLevel`) using `nameof()` instead of magic strings for maintainability.

2. **New utility method `DeleteIfExists()`**: Safely removes files if they exist, used for cleanup of stale migration artifacts.

3. **Enhanced `LoadSettings()` migration logic**: 
   - Added an early-exit migration path (lines 138-144): When the current settings file doesn't exist AND the legacy file contains security fields, the legacy migration runs first, creates settings.permissions.json, and deletes the old settings.security.json files.
   - Preserves existing rename migration (v0.68.0 settings.security.json → settings.permissions.json) as a fallback for cases where the legacy file has no security fields.
   - Maintains backward compatibility with atomic write recovery.

**Changes to `Assets/Tests/Editor/ULoopSettingsTests.cs`:**

Two new regression tests validate the fix:

1. **Test 12 - "Migration_WhenLegacyHasSecurityValuesAndNoSpecialFields_ShouldInheritValues"**: 
   - Verifies that when McpEditorSettings loads first (typical domain reload scenario) and the legacy file contains only plain security fields, those values are correctly inherited by ULoopSettings and persisted to settings.permissions.json.

2. **Test 13 - "Migration_WhenOldSecurityJsonHasDefaultsAndLegacyHasValues_ShouldNotLoseValues"**: 
   - Regression test for the core issue: Confirms that when settings.security.json contains default values and the legacy file contains user-configured non-default security values, the legacy values are preserved through the migration path rather than being lost to the stale defaults.

### Impact

- Security settings are now reliably preserved during direct upgrades from v0.67 to v0.69+
- Legacy file cleanup properly occurs after migration, preventing stale defaults from interfering with subsequent migrations
- All 13 existing tests plus 2 new tests pass
- No changes to public API signatures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->