### PR TITLE
fix: Update hono and @hono/node-server to resolve high severity vulnerabilities

### DIFF
--- a/Packages/src/TypeScriptServer~/package-lock.json
+++ b/Packages/src/TypeScriptServer~/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uloopmcp-server",
-  "version": "0.68.3",
+  "version": "0.69.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uloopmcp-server",
-      "version": "0.68.3",
+      "version": "0.69.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -28,7 +28,7 @@
         "eslint-plugin-security": "4.0.0",
         "husky": "9.1.7",
         "jest": "30.2.0",
-        "knip": "^5.85.0",
+        "knip": "5.85.0",
         "lint-staged": "16.3.1",
         "prettier": "3.8.1",
         "ts-jest": "29.4.6",
@@ -1156,9 +1156,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -4829,9 +4829,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
-      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

- Update `hono` from 4.12.2 to 4.12.5
- Update `@hono/node-server` from 1.19.9 to 1.19.11
- Fixes 2 high severity vulnerabilities detected by `npm audit`

## Vulnerabilities Fixed

### hono <= 4.12.3
- [GHSA-5pq2-9x2x-5p6w](https://github.com/advisories/GHSA-5pq2-9x2x-5p6w) - Cookie Attribute Injection via unsanitized domain/path in setCookie()
- [GHSA-p6xx-57qc-3wxr](https://github.com/advisories/GHSA-p6xx-57qc-3wxr) - SSE Control Field Injection via CR/LF in writeSSE()
- [GHSA-q5qw-h33p-qvwr](https://github.com/advisories/GHSA-q5qw-h33p-qvwr) - Arbitrary file access via serveStatic vulnerability

### @hono/node-server < 1.19.10
- [GHSA-wc8c-qw6v-h7f6](https://github.com/advisories/GHSA-wc8c-qw6v-h7f6) - Authorization bypass for protected static paths via encoded slashes

## Changes

- Only `Packages/src/TypeScriptServer~/package-lock.json` is modified (transitive dependency update via `@modelcontextprotocol/sdk`)

## Test plan

- [x] `npm audit --audit-level=moderate` reports 0 vulnerabilities
- [x] No changes to direct dependencies or application code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Hono and @hono/node-server to patch high-severity vulnerabilities flagged by npm audit. Only the TypeScriptServer package-lock was changed; npm audit (moderate) now reports 0 vulnerabilities.

- **Dependencies**
  - hono: 4.12.2 -> 4.12.5
  - @hono/node-server: 1.19.9 -> 1.19.11

- **Bug Fixes**
  - hono: fixes cookie attribute injection, SSE control field injection, and arbitrary file access
  - @hono/node-server: fixes authorization bypass via encoded slashes

<sup>Written for commit 5a2bbd832cbcd8ae19792640a1d3faa363efc96e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

