### PR TITLE
fix: Sync lint-staged version in package.json with package-lock.json

### DIFF
--- a/Packages/src/TypeScriptServer~/package.json
+++ b/Packages/src/TypeScriptServer~/package.json
@@ -85,7 +85,7 @@
     "husky": "9.1.7",
     "jest": "30.2.0",
     "knip": "5.85.0",
-    "lint-staged": "16.3.1",
+    "lint-staged": "16.3.2",
     "prettier": "3.8.1",
     "ts-jest": "29.4.6",
     "tsx": "4.21.0",


### PR DESCRIPTION
## Summary
- Fix lint-staged version mismatch between package.json (16.3.1) and package-lock.json (16.3.2)
- Dependabot PR #727 updated the lock file but left package.json out of sync
- This caused npm ci to fail in CI (Security Code Scan workflow)

## Test plan
- [x] Verified npm ci succeeds locally with the updated version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated lint-staged in Packages/src/TypeScriptServer~/package.json from 16.3.1 to 16.3.2 to match package-lock.json and fix npm ci failures in the Security Code Scan workflow.

<sup>Written for commit 2947ed4e8d14b34877a6e228ee06a9ee78cfde69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

