### PR TITLE
fix: Add TypeScript paths to Security Code Scan workflow triggers

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,11 +6,17 @@ on:
     paths:
       - 'Packages/src/**/*.cs'
       - 'Assets/**/*.cs'
+      - 'Packages/src/TypeScriptServer~/**/*.ts'
+      - 'Packages/src/TypeScriptServer~/package.json'
+      - 'Packages/src/TypeScriptServer~/package-lock.json'
   pull_request:
     branches: [ main ]
     paths:
       - 'Packages/src/**/*.cs'
       - 'Assets/**/*.cs'
+      - 'Packages/src/TypeScriptServer~/**/*.ts'
+      - 'Packages/src/TypeScriptServer~/package.json'
+      - 'Packages/src/TypeScriptServer~/package-lock.json'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Add TypeScript/npm file paths to Security Code Scan workflow triggers
- Previously only .cs file changes triggered the workflow, so TypeScript security jobs (npm ci, ESLint) only ran incidentally
- Adds: `*.ts`, `package.json`, `package-lock.json` to both push and pull_request path filters

## Context
- Run #22726845630 failed because Dependabot updated package-lock.json without syncing package.json (fixed in #735)
- But the workflow never re-ran after the fix because it only triggers on .cs changes

## Test plan
- [x] Merge will trigger the workflow on main with the latest code including lint-staged fix from #735

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Security Code Scan workflow to trigger on TypeScript and npm file changes. Ensures npm ci and ESLint run when TS code or dependencies change, not only on .cs changes.

- **Bug Fixes**
  - Added push and pull_request paths: Packages/src/TypeScriptServer~/**/*.ts, package.json, and package-lock.json.
  - Prevents missed scans when only TS or dependency files change (e.g., Dependabot updates).

<sup>Written for commit 36b009102104c10a0f273fd2ca21db1526aa9589. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

