### PR TITLE
fix: Correct npm script name in Security Code Scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Run TypeScript security-only check
       working-directory: Packages/src/TypeScriptServer~
       run: |
-        npm run security:sarif-only || echo "Security ESLint completed with issues - SARIF file generated"
+        npm run security:sarif || echo "Security ESLint completed with issues - SARIF file generated"
 
         # Filter out suppressed warnings from SARIF to prevent false positives in GitHub Security tab
         if [ -f typescript-security.sarif ]; then


### PR DESCRIPTION
## Summary
- Fix incorrect npm script name: `security:sarif-only` -> `security:sarif`
- The workflow referenced a non-existent script, which was silently ignored due to `|| echo ...`

## Context
Fixes the remaining issue from run #22726845630. Combined with #735 (lint-staged version sync) and #736 (path triggers), this should make the Security Code Scan workflow fully functional.

## Test plan
- [x] Verified `security:sarif` exists in package.json
- [ ] Merging this PR will trigger the Security Code Scan workflow on main (path filter now includes .yml changes from #736)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Security Code Scan workflow by calling the correct npm script (security:sarif) instead of the non-existent security:sarif-only. This ensures the TypeScript security check runs and produces SARIF, rather than being silently skipped.

<sup>Written for commit 528b093bcb82061ebb37712021a8ad0a6f0d8ee3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

