### PR TITLE
fix: Add missing .meta files for playmode skill references

### DIFF
--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation.md.meta
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3b1bffe936a214bc49398ce92705ba66
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-inspection.md.meta
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-inspection.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 54bdd16e7f97c42198b472ac9bc4aa14
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-ui-controls.md.meta
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-ui-controls.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 84096b299132946e9ae4bba41cd210b0
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add 3 missing .meta files for playmode skill reference documents
  - playmode-automation.md.meta
  - playmode-inspection.md.meta
  - playmode-ui-controls.md.meta

## Test plan
- [ ] Verify Unity imports the .meta files without regenerating new GUIDs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing Unity `.meta` files for playmode skill reference docs to preserve GUIDs and prevent broken references. Includes `playmode-automation.md.meta`, `playmode-inspection.md.meta`, and `playmode-ui-controls.md.meta`.

<sup>Written for commit aea125e857d255ff28303d1ce914d03ad0fc7487. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

