### PR TITLE
fix: restore npm publish in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  # npm publish (including OIDC id-token) is handled by publish-on-release.yml
+  id-token: write  # Required for npm OIDC trusted publishing
 
 jobs:
   release:
@@ -85,6 +85,49 @@ jobs:
             echo "✅ Server bundle rebuilt and pushed to PR"
           fi
 
-      # npm publish is handled by publish-on-release.yml (triggered by GitHub Release events).
-      # This decoupling ensures publishing works regardless of whether the release was
-      # created by release-please or manually.
+      # ── Publish to npm when release is created ──────────────────
+      # GITHUB_TOKEN-created releases do NOT trigger other workflows (e.g. publish-on-release.yml),
+      # so npm publish must run inline here for release-please releases.
+      # publish-on-release.yml handles manually-created GitHub Releases.
+      - name: 🔧 Setup Node.js for npm publish
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: 📋 Validate CLI version
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        id: cli_version
+        run: |
+          CLI_VERSION=$(jq -r '.version' Packages/src/Cli~/package.json)
+          if ! echo "${CLI_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "❌ Invalid semver: ${CLI_VERSION}"
+            exit 1
+          fi
+          echo "version=${CLI_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "📋 CLI version: ${CLI_VERSION}"
+
+      - name: 📦 Build CLI
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: |
+          cd Packages/src/Cli~
+          npm ci
+          npm run build
+
+      - name: 🔍 Verify npm package contents
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: |
+          cd Packages/src/Cli~
+          npm pack --dry-run --json > /tmp/pack.json
+          jq -e '.[0].files[] | select(.path=="dist/cli.bundle.cjs")' /tmp/pack.json > /dev/null
+          echo "✅ dist/cli.bundle.cjs found in package"
+
+      - name: 🚀 Publish CLI to npm
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: |
+          cd Packages/src/Cli~
+          npm install -g npm@latest
+          echo "📋 npm version: $(npm --version)"
+          npm publish --access public --provenance
+          echo "✅ CLI v${{ steps.cli_version.outputs.version }} published to npm with provenance"


### PR DESCRIPTION
## Summary
- Restore inline npm publish steps in release-please.yml
- GITHUB_TOKEN-created releases do NOT trigger other workflows, so publish-on-release.yml never fired for release-please releases
- Added semver validation and dist/cli.bundle.cjs verification before publishing
- publish-on-release.yml remains as a fallback for manually-created GitHub Releases

## Context
PR #776 decoupled npm publish from release-please into publish-on-release.yml. However, GitHub Actions prevents GITHUB_TOKEN events from triggering other workflows (to avoid infinite loops). Since release-please uses GITHUB_TOKEN, the release event never triggered publish-on-release.yml, leaving v1.0.1 unpublished.

## Test plan
- [ ] Merge this PR
- [ ] Run manual-npm-publish workflow with ref=v1.0.1 to publish the missing version
- [ ] Verify next release-please release triggers npm publish inline

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores inline `npm` publish in `release-please` so `GITHUB_TOKEN`-created releases actually publish the CLI. Adds OIDC, version checks, and package verification; `publish-on-release.yml` stays as a fallback for manual releases.

- **Bug Fixes**
  - Move `npm publish` back into `.github/workflows/release-please.yml` to avoid workflow trigger blocking.
  - Add `id-token: write` for OIDC provenance and set up Node 22.
  - Validate semver from `Packages/src/Cli~/package.json`, build CLI, verify `dist/cli.bundle.cjs`, then publish.

<sup>Written for commit 4033f758cc8d6c7042e2f2c6604666d845e0b059. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

