### PR TITLE
fix: update repository URLs from uLoopMCP to unity-cli-loop

### DIFF
--- a/Packages/src/Cli~/package.json
+++ b/Packages/src/Cli~/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hatayama/uLoopMCP.git",
+    "url": "git+https://github.com/hatayama/unity-cli-loop.git",
     "directory": "Packages/src/Cli~"
   },
   "bugs": {

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -48,7 +48,7 @@ https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 4. Select "Add package from git URL"
 5. Enter the following URL:
 ```text
-https://github.com/hatayama/uLoopMCP.git?path=/Packages/src
+https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 ```
 
 ## Via OpenUPM (Recommended)

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -48,7 +48,7 @@ https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 4. 「Add package from git URL」を選択
 5. 以下のURLを入力：
 ```text
-https://github.com/hatayama/uLoopMCP.git?path=/Packages/src
+https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 ```
 
 ## OpenUPM経由（推奨）

--- a/Packages/src/TypeScriptServer~/package.json
+++ b/Packages/src/TypeScriptServer~/package.json
@@ -58,7 +58,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hatayama/uLoopMCP.git",
+    "url": "git+https://github.com/hatayama/unity-cli-loop.git",
     "directory": "Packages/src/TypeScriptServer~"
   },
   "bugs": {

--- a/Packages/src/package.json
+++ b/Packages/src/package.json
@@ -27,6 +27,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hatayama/uLoopMCP.git"
+    "url": "git+https://github.com/hatayama/unity-cli-loop.git"
   }
 } 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 4. Select "Add package from git URL"
 5. Enter the following URL:
 ```text
-https://github.com/hatayama/uLoopMCP.git?path=/Packages/src
+https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 ```
 
 ## Via OpenUPM (Recommended)

--- a/README_ja.md
+++ b/README_ja.md
@@ -48,7 +48,7 @@ https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 4. 「Add package from git URL」を選択
 5. 以下のURLを入力：
 ```text
-https://github.com/hatayama/uLoopMCP.git?path=/Packages/src
+https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 ```
 
 ## OpenUPM経由（推奨）


### PR DESCRIPTION
## Summary
- Update repository URLs in all package.json files and READMEs from `hatayama/uLoopMCP` to `hatayama/unity-cli-loop`
- npm provenance validation requires package.json repository.url to match the actual GitHub repository

## Context
The repository was renamed during the v1.0.0 rebrand (#769) but repository URLs were not updated. This caused npm publish to fail with E422:
```
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/hatayama/uLoopMCP.git",
expected to match "https://github.com/hatayama/unity-cli-loop"
```

## Changed files
- `Packages/src/Cli~/package.json`
- `Packages/src/TypeScriptServer~/package.json`
- `Packages/src/package.json`
- `README.md`, `README_ja.md`, `Packages/src/README.md`, `Packages/src/README_ja.md`

## Test plan
- [ ] Merge this PR
- [ ] Wait for release-please to create a release PR (this touches Packages/src/)
- [ ] Merge release PR → npm publish should succeed with provenance

Closes #775

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update repository URLs from `hatayama/uLoopMCP` to `hatayama/unity-cli-loop` to match the renamed repo and pass npm provenance validation. Prevents E422 publish failures.

- **Bug Fixes**
  - Set repository.url to `git+https://github.com/hatayama/unity-cli-loop.git` in `Packages/src/package.json`, `Packages/src/Cli~/package.json`, `Packages/src/TypeScriptServer~/package.json`.
  - Updated install docs to use `https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src` in `README.md`, `README_ja.md`, `Packages/src/README.md`, `Packages/src/README_ja.md`.

<sup>Written for commit 2cbcafee18fb073715de9b8c65b7b639e2d3e90a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates repository URLs across all package.json manifests and documentation files from `hatayama/uLoopMCP` to `hatayama/unity-cli-loop`. This change resolves npm provenance validation failures that prevented successful package publication, where the package.json repository URL must match the actual GitHub repository.

## Changes

**Package manifests updated:**
- `Packages/src/Cli~/package.json`
- `Packages/src/TypeScriptServer~/package.json`
- `Packages/src/package.json`

**Documentation files updated:**
- `README.md`
- `README_ja.md`
- `Packages/src/README.md`
- `Packages/src/README_ja.md`

All changes are URL-only updates from `git+https://github.com/hatayama/uLoopMCP.git` to `git+https://github.com/hatayama/unity-cli-loop.git`. No functional code changes.

## Impact

This PR addresses the root cause of npm publish failures with E422 error codes related to repository validation, enabling successful npm releases with provenance support. Following merge and release-please automation, npm publish should proceed without validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->