### PR TITLE
docs: add git URL migration notice for repository rename

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -52,7 +52,7 @@ https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 ```
 
 > **If you installed via git URL before v1.0.0**: The repository was renamed from `uLoopMCP` to `unity-cli-loop` in v1.0.0. Please update your `manifest.json`:
-> ```
+> ```text
 > Old: https://github.com/hatayama/uLoopMCP.git?path=/Packages/src
 > New: https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 > ```

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -52,7 +52,7 @@ https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 ```
 
 > **v1.0.0以前にgit URL でインストールされていた方へ**: v1.0.0でリポジトリ名が `uLoopMCP` から `unity-cli-loop` に変更されました。`manifest.json` の URL を更新してください：
-> ```
+> ```text
 > 旧: https://github.com/hatayama/uLoopMCP.git?path=/Packages/src
 > 新: https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 > ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 ```
 
 > **If you installed via git URL before v1.0.0**: The repository was renamed from `uLoopMCP` to `unity-cli-loop` in v1.0.0. Please update your `manifest.json`:
-> ```
+> ```text
 > Old: https://github.com/hatayama/uLoopMCP.git?path=/Packages/src
 > New: https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 > ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -52,7 +52,7 @@ https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 ```
 
 > **v1.0.0以前にgit URL でインストールされていた方へ**: v1.0.0でリポジトリ名が `uLoopMCP` から `unity-cli-loop` に変更されました。`manifest.json` の URL を更新してください：
-> ```
+> ```text
 > 旧: https://github.com/hatayama/uLoopMCP.git?path=/Packages/src
 > 新: https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src
 > ```


### PR DESCRIPTION
## Summary
- Add migration notice to all README files (EN/JA, root and Packages/src/)
- Inform git URL users that the repository was renamed from uLoopMCP to unity-cli-loop in v1.0.0
- Recommend updating manifest.json while noting old URLs still work via GitHub redirect
- OpenUPM users are explicitly noted as unaffected

## Context
The repository was renamed during the v1.0.0 rebrand (#769), but existing git URL users were not informed about the URL change. While GitHub redirects keep the old URL working, users should update to the new URL for long-term reliability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a migration notice to all EN/JA READMEs (root and `Packages/src`) for git URL users, covering the v1.0.0 rename from `uLoopMCP` to `unity-cli-loop` and asking to update `manifest.json`; old URLs still work and OpenUPM users are unaffected. Also add language tags to fenced code blocks (MD040) and clarify Japanese wording.

<sup>Written for commit 14d560a36443baa43115c5c7472d984f13228273. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds migration notices to the repository's README files (English and Japanese, at root and Packages/src) to inform git-URL installers about the repository rename that took place during the v1.0.0 rebrand.

## Changes
- Packages/src/README.md — Added migration notice (+7/-0)
- Packages/src/README_ja.md — Added migration notice (+7/-0)
- README.md — Added migration notice (+7/-0)
- README_ja.md — Added migration notice (+7/-0)

## Content
Each added notice informs users that:
- The repository was renamed from `uLoopMCP` to `unity-cli-loop` in v1.0.0.
- Users who installed via git URL should update their project's `manifest.json` to point to the new repository URL.
- Both old and new git URLs are shown for reference.
- The old URLs continue to work via GitHub redirect, but updating is recommended for long-term reliability.
- Users who installed via OpenUPM are unaffected.

## Impact
- Type: Documentation only (no functional code changes)
- Scope: Four README files (English/Japanese, root and Packages/src)
- Backward compatibility: Preserved via GitHub redirects for old URLs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->