### PR TITLE
docs: add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: hatayama


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` to enable the **Sponsor** button on the repository page
- Configured with `github: hatayama` for GitHub Sponsors

## Note
GitHub Sponsors enrollment at https://github.com/sponsors must be completed separately for the button to function.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.github/FUNDING.yml` to enable the Sponsor button, configured with `github: hatayama`. GitHub Sponsors enrollment must be completed for the button to appear.

<sup>Written for commit 45d2729d8e575bd83774125f22938d2c2645a871. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

