### PR TITLE
feat: improve skill scores across unity-cli-loop

### DIFF
--- a/.claude/skills/simulate-mouse-demo/SKILL.md
+++ b/.claude/skills/simulate-mouse-demo/SKILL.md
@@ -8,17 +8,6 @@ context: fork
 
 Run the SimulateMouse demo scenario: $ARGUMENTS
 
-## What
-
-Automate the SimulateMouse demo scene by clicking buttons, one-shot dragging boxes, split-dragging a box through multiple waypoints to the drop zone, and operating the virtual pad with DragStart/DragMove/DragEnd. Exercises Click, Drag, DragStart, DragMove, and DragEnd across all interactive elements.
-
-## When
-
-Use when you need to:
-1. Run the simulate-mouse demo to verify click, drag, split-drag, and virtual pad functionality
-2. Test mouse simulation on the demo scene after code changes
-3. Exercise the demo scene end-to-end (buttons + one-shot drag + split drag + virtual pad)
-
 ## How
 
 ### Prerequisites
@@ -59,26 +48,9 @@ From the `AnnotatedElements` array in the response, extract `SimX` and `SimY` fo
 
 **Phase 3 — Split drag with DragMove**: Use DragStart on GreenBox, then DragMove through 3 waypoints that zigzag across the screen, and finally DragEnd at the DropZone center. Use `--drag-speed 400` for DragMove/DragEnd so the movement is slow enough to observe the cursor overlay and trail line.
 
-Waypoint design (relative to the midpoint between GreenBox and DropZone):
-- Waypoint 1: far right, slightly above — tests horizontal sweep
-- Waypoint 2: far left, below — tests direction reversal
-- Waypoint 3: above DropZone — tests vertical approach
-- DragEnd: at DropZone center (Y offset 0)
-
 **Phase 4 — One-shot Drag**: Drag BlueBox to DropZone bottom area (Y offset +80 from center) so it doesn't overlap previous drops.
 
-**Phase 5 — Virtual Pad**: Use DragStart on VirtualPadBackground center, then DragMove through 8 random directions within padRadius (80px from center) to exercise the joystick, and DragEnd back at center. Use `--drag-speed 300` for visible movement. The direction arrow should rotate to follow each DragMove direction.
-
-Waypoint design (offsets from VirtualPadBackground center):
-- Move 1: upper-right (+60, -60 in sim coords)
-- Move 2: lower-left (-70, +50)
-- Move 3: straight up (0, -75)
-- Move 4: straight right (+80, 0)
-- Move 5: lower-right (+50, +60)
-- Move 6: straight left (-80, 0)
-- Move 7: upper-left (-55, -65)
-- Move 8: straight down (0, +75)
-- DragEnd: back to center (0, 0)
+**Phase 5 — Virtual Pad**: Use DragStart on VirtualPadBackground center, then DragMove through 8 directions within padRadius (80px from center) to exercise the joystick, and DragEnd back at center. Use `--drag-speed 300` for visible movement.
 
 ```bash
 uloop simulate-mouse --action Click --x <ClickButton1.SimX> --y <ClickButton1.SimY> && sleep 0.3 && \

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -50,6 +50,18 @@ Returns JSON:
 - `ErrorCount`: number
 - `WarningCount`: number
 
+## Typical Workflow
+
+```bash
+# 1. Compile and check for errors
+result=$(uloop compile)
+# 2. Check ErrorCount in JSON output: {"Success":true,"ErrorCount":0,"WarningCount":2}
+#    If ErrorCount > 0, fix issues and recompile
+uloop compile
+# 3. Force full recompilation when needed
+uloop compile --force-recompile true --wait-for-domain-reload true
+```
+
 ## Troubleshooting
 
 If CLI hangs or shows "Unity is busy" errors after compilation, stale lock files may be preventing connection. Run the following to clean them up:

--- a/.claude/skills/uloop-control-play-mode/SKILL.md
+++ b/.claude/skills/uloop-control-play-mode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-control-play-mode
-description: "Control Unity Editor play mode (play/stop/pause). Use when you need to: (1) Start play mode to test game behavior, (2) Stop play mode to return to edit mode, (3) Pause play mode for frame-by-frame inspection."
+description: "Control Unity Editor play mode (play/stop/pause). Use when you need to: (1) Start play mode to run or playtest the game, (2) Stop play mode to return to edit mode, (3) Pause play mode for frame-by-frame inspection. Supports run game, debug scene, and test scene workflows."
 ---
 
 # uloop control-play-mode

--- a/.claude/skills/uloop-execute-menu-item/SKILL.md
+++ b/.claude/skills/uloop-execute-menu-item/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-execute-menu-item
-description: "Execute Unity Editor menu commands programmatically. Use when you need to: (1) Trigger menu commands like save, build, or refresh, (2) Automate editor actions via menu paths, (3) Run custom menu items defined in project scripts."
+description: "Execute Unity Editor menu commands programmatically. Use when you need to: (1) Trigger Unity menu commands like save, build, or refresh, (2) Automate editor actions or toolbar operations via menu paths, (3) Run custom menu items defined in project scripts. Invoke any Unity menu item by path."
 ---
 
 # uloop execute-menu-item

--- a/.claude/skills/uloop-focus-window/SKILL.md
+++ b/.claude/skills/uloop-focus-window/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-focus-window
-description: "Bring Unity Editor window to front via uloop CLI. Use when you need to: (1) Focus Unity Editor before capturing screenshots, (2) Ensure Unity window is visible for visual checks, (3) Bring Unity to foreground for user interaction."
+description: "Bring Unity Editor window to front via uloop CLI. Use when you need to: (1) Focus or activate Unity Editor before capturing screenshots, (2) Switch to or show the Unity window for visual checks, (3) Bring Unity to foreground for user interaction. Works even during compilation or Domain Reload."
 ---
 
 # uloop focus-window

--- a/.claude/skills/uloop-get-hierarchy/SKILL.md
+++ b/.claude/skills/uloop-get-hierarchy/SKILL.md
@@ -53,4 +53,18 @@ uloop get-hierarchy --use-selection
 
 ## Output
 
-Returns JSON with hierarchical structure of GameObjects and their components.
+Returns JSON with hierarchical structure of GameObjects and their components:
+
+```json
+{
+  "Hierarchy": [
+    {
+      "Name": "Canvas",
+      "Components": ["Canvas", "CanvasScaler", "GraphicRaycaster"],
+      "Children": [
+        { "Name": "Button", "Components": ["Button", "Image"] }
+      ]
+    }
+  ]
+}
+```

--- a/.claude/skills/uloop-get-menu-items/SKILL.md
+++ b/.claude/skills/uloop-get-menu-items/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-menu-items
-description: "Discover available Unity Editor menu items. Use when you need to: (1) Find available menu commands and their paths, (2) Search for specific menu items by name, (3) Prepare menu item paths for execute-menu-item. Returns menu item list."
+description: "Discover available Unity Editor menu items and toolbar commands. Use when you need to: (1) Find available menu commands and their paths, (2) Search for specific Unity menu items by name, (3) Prepare menu item paths for execute-menu-item. Browse Unity menus and editor commands. Returns menu item list."
 ---
 
 # uloop get-menu-items

--- a/.claude/skills/uloop-get-unity-search-providers/SKILL.md
+++ b/.claude/skills/uloop-get-unity-search-providers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-unity-search-providers
-description: "Get details about available Unity Search providers. Use when you need to: (1) Discover available search providers and their IDs, (2) Understand search capabilities and filters, (3) Configure unity-search with specific provider options. Returns provider metadata."
+description: "List Unity Search provider names, IDs, and supported filter syntax. Use when you need to: (1) Discover available search providers and their IDs, (2) Understand search capabilities and filters, (3) Configure unity-search with specific provider options. Useful for asset search configuration and project search API exploration. Returns provider metadata."
 ---
 
 # uloop get-unity-search-providers

--- a/.claude/skills/uloop-hello-world/SKILL.md
+++ b/.claude/skills/uloop-hello-world/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-hello-world
-description: "Sample hello world tool via uloop CLI. Use when you need to test the MCP tool system or see an example of custom tool implementation."
+description: "Test MCP tool connectivity by sending a greeting request and verifying the response. Use when you need to: (1) Check if uloop tools work and Unity is responding, (2) Debug or troubleshoot MCP connection issues, (3) See an example of custom tool parameter handling with multi-language support."
 ---
 
 # uloop hello-world

--- a/.claude/skills/uloop-launch/SKILL.md
+++ b/.claude/skills/uloop-launch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-launch
-description: "Launch Unity project with matching Editor version via uloop CLI. Use when you need to: (1) Open a Unity project with the correct Editor version, (2) Restart Unity to apply changes, (3) Switch build target when launching."
+description: "Launch or open a Unity project with matching Editor version via uloop CLI. Use when you need to: (1) Open or start a Unity project with the correct Editor version, (2) Restart Unity to apply changes, (3) Switch build target when launching. Auto-detects the required Unity version."
 ---
 
 # uloop launch

--- a/Assets/Editor/CustomCommandSamples/HelloWorld/Skill/SKILL.md
+++ b/Assets/Editor/CustomCommandSamples/HelloWorld/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-hello-world
-description: "Sample hello world tool via uloop CLI. Use when you need to test the MCP tool system or see an example of custom tool implementation."
+description: "Test MCP tool connectivity by sending a greeting request and verifying the response. Use when you need to: (1) Check if uloop tools work and Unity is responding, (2) Debug or troubleshoot MCP connection issues, (3) See an example of custom tool parameter handling with multi-language support."
 ---
 
 # uloop hello-world

--- a/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-focus-window/Skill/SKILL.md
+++ b/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-focus-window/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-focus-window
-description: "Bring Unity Editor window to front via uloop CLI. Use when you need to: (1) Focus Unity Editor before capturing screenshots, (2) Ensure Unity window is visible for visual checks, (3) Bring Unity to foreground for user interaction."
+description: "Bring Unity Editor window to front via uloop CLI. Use when you need to: (1) Focus or activate Unity Editor before capturing screenshots, (2) Switch to or show the Unity window for visual checks, (3) Bring Unity to foreground for user interaction. Works even during compilation or Domain Reload."
 ---
 
 # uloop focus-window

--- a/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-get-project-info/Skill/SKILL.md
+++ b/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-get-project-info/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-project-info
-description: "Get Unity project information via uloop CLI. Use when you need to: (1) Check Unity Editor version, (2) Get project settings and platform info, (3) Retrieve project metadata for diagnostics."
+description: "Get Unity project information including version, build target, and platform details. Use when you need to: (1) Check what Unity version a project uses, (2) Get project settings and build target info, (3) Retrieve project metadata for diagnostics or environment checks."
 internal: true
 ---
 
@@ -28,8 +28,16 @@ uloop get-project-info
 ## Output
 
 Returns JSON with project information:
-- Unity version
-- Project name
-- Platform settings
-- Build target
-- Other project metadata
+
+```json
+{
+  "ProjectName": "MyGame",
+  "UnityVersion": "2022.3.1f1",
+  "Platform": "StandaloneOSX",
+  "CompanyName": "MyCompany",
+  "Version": "1.0.0",
+  "DataPath": "/path/to/project/Assets",
+  "IsPlaying": false,
+  "SystemMemorySize": 16384
+}
+```

--- a/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
+++ b/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-launch
-description: "Launch Unity project with matching Editor version via uloop CLI. Use when you need to: (1) Open a Unity project with the correct Editor version, (2) Restart Unity to apply changes, (3) Switch build target when launching."
+description: "Launch or open a Unity project with matching Editor version via uloop CLI. Use when you need to: (1) Open or start a Unity project with the correct Editor version, (2) Restart Unity to apply changes, (3) Switch build target when launching. Auto-detects the required Unity version."
 ---
 
 # uloop launch

--- a/Packages/src/Editor/Api/McpTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Compile/Skill/SKILL.md
@@ -50,6 +50,18 @@ Returns JSON:
 - `ErrorCount`: number
 - `WarningCount`: number
 
+## Typical Workflow
+
+```bash
+# 1. Compile and check for errors
+result=$(uloop compile)
+# 2. Check ErrorCount in JSON output: {"Success":true,"ErrorCount":0,"WarningCount":2}
+#    If ErrorCount > 0, fix issues and recompile
+uloop compile
+# 3. Force full recompilation when needed
+uloop compile --force-recompile true --wait-for-domain-reload true
+```
+
 ## Troubleshooting
 
 If CLI hangs or shows "Unity is busy" errors after compilation, stale lock files may be preventing connection. Run the following to clean them up:

--- a/Packages/src/Editor/Api/McpTools/ControlPlayMode/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ControlPlayMode/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-control-play-mode
-description: "Control Unity Editor play mode (play/stop/pause). Use when you need to: (1) Start play mode to test game behavior, (2) Stop play mode to return to edit mode, (3) Pause play mode for frame-by-frame inspection."
+description: "Control Unity Editor play mode (play/stop/pause). Use when you need to: (1) Start play mode to run or playtest the game, (2) Stop play mode to return to edit mode, (3) Pause play mode for frame-by-frame inspection. Supports run game, debug scene, and test scene workflows."
 ---
 
 # uloop control-play-mode

--- a/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-execute-menu-item
-description: "Execute Unity Editor menu commands programmatically. Use when you need to: (1) Trigger menu commands like save, build, or refresh, (2) Automate editor actions via menu paths, (3) Run custom menu items defined in project scripts."
+description: "Execute Unity Editor menu commands programmatically. Use when you need to: (1) Trigger Unity menu commands like save, build, or refresh, (2) Automate editor actions or toolbar operations via menu paths, (3) Run custom menu items defined in project scripts. Invoke any Unity menu item by path."
 ---
 
 # uloop execute-menu-item

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
@@ -53,4 +53,18 @@ uloop get-hierarchy --use-selection
 
 ## Output
 
-Returns JSON with hierarchical structure of GameObjects and their components.
+Returns JSON with hierarchical structure of GameObjects and their components:
+
+```json
+{
+  "Hierarchy": [
+    {
+      "Name": "Canvas",
+      "Components": ["Canvas", "CanvasScaler", "GraphicRaycaster"],
+      "Children": [
+        { "Name": "Button", "Components": ["Button", "Image"] }
+      ]
+    }
+  ]
+}
+```

--- a/Packages/src/Editor/Api/McpTools/GetMenuItems/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetMenuItems/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-menu-items
-description: "Discover available Unity Editor menu items. Use when you need to: (1) Find available menu commands and their paths, (2) Search for specific menu items by name, (3) Prepare menu item paths for execute-menu-item. Returns menu item list."
+description: "Discover available Unity Editor menu items and toolbar commands. Use when you need to: (1) Find available menu commands and their paths, (2) Search for specific Unity menu items by name, (3) Prepare menu item paths for execute-menu-item. Browse Unity menus and editor commands. Returns menu item list."
 ---
 
 # uloop get-menu-items

--- a/Packages/src/Editor/Api/McpTools/UnitySearchProviderDetails/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/UnitySearchProviderDetails/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-unity-search-providers
-description: "Get details about available Unity Search providers. Use when you need to: (1) Discover available search providers and their IDs, (2) Understand search capabilities and filters, (3) Configure unity-search with specific provider options. Returns provider metadata."
+description: "List Unity Search provider names, IDs, and supported filter syntax. Use when you need to: (1) Discover available search providers and their IDs, (2) Understand search capabilities and filters, (3) Configure unity-search with specific provider options. Useful for asset search configuration and project search API exploration. Returns provider metadata."
 ---
 
 # uloop get-unity-search-providers


### PR DESCRIPTION
Hullo @hatayama 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the ten most improved:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/43311c3e-56a1-4c87-9384-616c7c402f59" />

Here's the full before/after in tabular form:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| Cli~/uloop-get-project-info | 85% | 100% | +15% | 
| uloop-control-play-mode | 93% | 100% | +7% |
| uloop-execute-menu-item | 93% | 100% | +7% |
| uloop-focus-window | 93% | 100% | +7% |
| uloop-get-hierarchy | 93% | 100% | +7% |
| uloop-get-menu-items | 93% | 100% | +7% |
| uloop-launch | 93% | 100% | +7% |
| uloop-get-unity-search-providers | 88% | 93% | +5% | 
| uloop-hello-world | 88% | 93% | +5% |
| simulate-mouse-demo | 89% | 93% | +4% |

<details>
<summary>Changes summary</summary>

**Description improvements (most skills):**
- Added natural language trigger terms to skill descriptions for better AI discoverability (e.g. "run game", "playtest" for control-play-mode; "open Unity", "start Unity" for launch; "activate Unity", "switch to Unity" for focus-window)
- Made descriptions more concrete with specific actions and outputs rather than generic phrasing
- Maintained the existing "What → When → How" structure from your CLAUDE.md guidelines

**Content improvements:**
- Added a typical compile→check→fix workflow section to `uloop-compile`
- Added example JSON output snippet to `uloop-get-hierarchy` showing the tree structure
- Added concrete JSON output example to `uloop-get-project-info` with actual field names and types
- Condensed verbose waypoint design explanations in `simulate-mouse-demo` (the commands are self-documenting)
- Removed redundant "What" and "When" sections from `simulate-mouse-demo` (already covered by the frontmatter description)

**Both `.claude/skills/` and `Packages/src/` copies kept in sync.**

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved `SKILL.md` docs across `uloop` commands to boost discoverability and clarity, adding concrete examples and workflows while keeping `.claude/skills` and `Packages/src` in sync. This raises review scores across key skills (e.g., `uloop-get-project-info` 85%→100%).

- **Refactors**
  - Added natural-language trigger terms to most `uloop-*` descriptions for better searchability.
  - Added example JSON outputs for `uloop-get-hierarchy` and `uloop-get-project-info`.
  - Added a typical compile→check→fix workflow to `uloop-compile`.
  - Simplified `simulate-mouse-demo` by removing redundant sections and condensing waypoint notes.
  - Synced all changes between `.claude/skills/` and `Packages/src/` copies.

<sup>Written for commit b701d516f2eee4f690286b023a6036c2ebe13e0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Documentation-focused optimization of 10 skills in the unity-cli-loop repository to improve clarity, usability, and assessment scores. All changes were synchronized across both `.claude/skills/` and `Packages/src/` directories.

## Key Improvements

### Description Enhancements
Updated skill descriptions across the repository to be more concrete and specific:
- **uloop-control-play-mode**: Clarified scope from "test game behavior" to "run or playtest the game" and added reference to supported workflows (run game, debug scene, test scene)
- **uloop-execute-menu-item**: Expanded description to include toolbar operations and emphasized "Invoke any Unity menu item by path"
- **uloop-focus-window**: Broadened triggers to include "Focus or activate" and "Switch to or show," added note about compatibility during compilation and Domain Reload
- **uloop-get-menu-items**: Added reference to toolbar commands and clarified scope to search for "specific Unity menu items by name"
- **uloop-get-unity-search-providers**: Reworded to emphasize provider names, IDs, and filter syntax; added context about asset search configuration and project search API
- **uloop-hello-world**: Expanded from generic sample to specific use cases: testing MCP tool connectivity, checking Unity responsiveness, debugging connections, and illustrating multi-language parameter handling
- **uloop-launch**: Updated to reflect both "Launch or open" capabilities and added explicit mention of "Auto-detects the required Unity version"

### Output Documentation
Added concrete examples and workflows:
- **uloop-get-hierarchy**: Added JSON example block showing hierarchical structure with nested game objects and components
- **uloop-get-project-info**: Added JSON code block with sample project information payload (ProjectName, UnityVersion, Platform, CompanyName, Version, DataPath, IsPlaying, SystemMemorySize)
- **uloop-compile**: Added "Typical Workflow" example block outlining compile → check ErrorCount → recompile workflow, including force recompilation with domain reload

### Content Refinement
- **simulate-mouse-demo**: Removed redundant waypoint design bullet lists for Phase 3 and Phase 5 while preserving operational phase instructions and command sequences
- **uloop-focus-window**: Maintained existing functionality while expanding documentation scope

## Verification
Tessl skill review validation confirms improvements:
- Average score: 99% (up from 92%, +7% overall)
- All 10 skills improved
- Top improvements: uloop-get-project-info (85% → 100%, +15%), seven skills reached 100% (+7% each)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->