### PR TITLE
fix: Fix submenu misrender in SkillsTarget dropdown

### DIFF
--- a/Packages/src/Editor/UI/McpEditorWindowState.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowState.cs
@@ -22,7 +22,7 @@ namespace io.github.hatayama.uLoopMCP
     public enum SkillsTarget
     {
         Claude = 0,
-        [InspectorName("Other (.agents/)")]
+        [InspectorName("Other (.agents)")]
         Agents = 1,
         Cursor = 2,
         Antigravity = 5


### PR DESCRIPTION
## Summary

Remove trailing slash from InspectorName in SkillsTarget enum.

Unity interprets a trailing slash in InspectorName as a submenu path separator, causing the dropdown item to render with an arrow as a submenu instead of a plain option.

## Root Cause

InspectorName had the value Other (.agents/) — the trailing slash made Unity UI Toolkit treat this as a submenu parent entry.

## Fix

Changed to Other (.agents) to render as a plain dropdown item.

## Test Plan

- Open Skills window in Unity Editor
- Verify the Target dropdown shows Other (.agents) without a submenu arrow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Skills Target dropdown in the Unity Editor by removing the trailing "/" from the `InspectorName` of the "Other (.agents)" option. Unity no longer treats it as a submenu, so it shows as a normal dropdown item.

<sup>Written for commit 7af7f213e92cabfaf88d24ab45f0ae405cf65697. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Removed the trailing slash from the `InspectorName` attribute of the `SkillsTarget.Agents` enum member to fix submenu misrendering in the Skills Target dropdown.

## Root Cause

Unity's UI Toolkit interprets a forward slash (`/`) in an `InspectorName` value as a submenu path separator. The original value `"Other (.agents/)"` caused Unity to render the dropdown entry with a submenu arrow, treating it as a submenu parent rather than a plain dropdown option.

## Changes

**File: `Packages/src/Editor/UI/McpEditorWindowState.cs`**

Modified the `SkillsTarget` enum:
- **Line 25**: Changed `InspectorName` attribute from `"Other (.agents/)"` to `"Other (.agents)"`

```csharp
public enum SkillsTarget
{
    Claude = 0,
    [InspectorName("Other (.agents)")]  // Removed trailing slash
    Agents = 1,
    Cursor = 2,
    Antigravity = 5
}
```

## Impact

- The "Other (.agents)" entry in the Skills Target dropdown now renders as a plain dropdown item without a submenu arrow
- No changes to enum values or control flow
- Purely a UI rendering fix with no functional behavior changes

## Testing

The fix can be verified by:
1. Opening the Skills window in the Unity Editor
2. Confirming the Target dropdown displays "Other (.agents)" without a submenu indicator

<!-- end of auto-generated comment: release notes by coderabbit.ai -->