### PR TITLE
fix: Use informational dialog icon for skill installation success on Unity 6+

### DIFF
--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -906,7 +906,11 @@ namespace io.github.hatayama.uLoopMCP
 
                 if (success)
                 {
+#if UNITY_6000_0_OR_NEWER
+                    EditorDialog.DisplayAlertDialog("Skills Installed", "Skills have been installed successfully.", "OK", DialogIconType.Info);
+#else
                     EditorUtility.DisplayDialog("Skills Installed", "Skills have been installed successfully.", "OK");
+#endif
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

- **Problem**: `EditorUtility.DisplayDialog` on macOS always uses `NSAlertStyleWarning`, showing a yellow warning triangle even for success messages like "Skills Installed".
- **Solution**: On Unity 6+, use `EditorDialog.DisplayAlertDialog` with `DialogIconType.Info` to display an informational icon instead of the warning triangle.
- Pre-Unity 6 keeps the existing `EditorUtility.DisplayDialog` behavior (no change).

## Changes

- `McpEditorWindow.cs`: Add `#if UNITY_6000_0_OR_NEWER` preprocessor branch to use the new `EditorDialog` API for the skill installation success dialog.

## Test plan

- [ ] On Unity 6+: Install skills and verify the success dialog shows an info icon (not warning triangle)
- [ ] On Unity 2022.3: Verify compilation succeeds and the dialog behavior is unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On Unity 6+, the “Skills Installed” dialog now shows an info icon instead of a warning triangle on macOS. Uses EditorDialog.DisplayAlertDialog with DialogIconType.Info, and falls back to EditorUtility.DisplayDialog on earlier Unity versions.

<sup>Written for commit fe1baaba5b8019411196d52ccafc8bd3b713e5ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

