### PR TITLE
fix: Remove redundant .meta files causing import warnings

### DIFF
--- a/Packages/src/Editor/Compilation.meta
+++ b/Packages/src/Editor/Compilation.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 9dc7016bc7e8a45d6b7ccf5126095d3c
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Packages/src/Editor/Core/Logging.meta
+++ b/Packages/src/Editor/Core/Logging.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 9f86dde5f0dc440dca2efad9b6080a8a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Resolved the warnings triggered during the first-time import of uLoopMCP via OpenUPM. These warnings occurred because .meta files existed without their corresponding folders.

```
A meta data file (.meta) exists but its folder 'Packages/io.github.hatayama.uloopmcp/Editor/Compilation' can't be found, and has been created. Empty directories cannot be stored in version control, so it's assumed that the meta data file is for an empty directory in version control. When moving or deleting folders outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.
A meta data file (.meta) exists but its folder 'Packages/io.github.hatayama.uloopmcp/Editor/Core/Logging' can't be found, and has been created. Empty directories cannot be stored in version control, so it's assumed that the meta data file is for an empty directory in version control. When moving or deleting folders outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed two orphaned Unity .meta files that referenced missing folders, eliminating import warnings and auto-created empty directories when installing `uLoopMCP` via OpenUPM. Deleted: `Packages/src/Editor/Compilation.meta` and `Packages/src/Editor/Core/Logging.meta`; no functional changes.

<sup>Written for commit 4c0268e6330be6c46c6f03d5635d72afecbce65e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

