### PR TITLE
fix: narrow EditorDialog preprocessor guard to UNITY_6000_3_OR_NEWER

### DIFF
--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -906,7 +906,7 @@ namespace io.github.hatayama.uLoopMCP
 
                 if (success)
                 {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_6000_3_OR_NEWER
                     EditorDialog.DisplayAlertDialog("Skills Installed", "Skills have been installed successfully.", "OK", DialogIconType.Info);
 #else
                     EditorUtility.DisplayDialog("Skills Installed", "Skills have been installed successfully.", "OK");


### PR DESCRIPTION
## Summary

Fixes #803 

PR #797 で導入された `EditorDialog.DisplayAlertDialog` / `DialogIconType` は
Unity **6000.3** で追加された API のようです。
ref: https://docs.unity3d.com/6000.3/Documentation/ScriptReference/EditorDialog.html

現在の `#if` 条件が `UNITY_6000_0_OR_NEWER` のため、6000.2 でコンパイルエラーになります。

```
error CS0103: The name 'EditorDialog' does not exist in the current context
error CS0103: The name 'DialogIconType' does not exist in the current context
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed the preprocessor guard for the new dialog API to `UNITY_6000_3_OR_NEWER` to match Unity’s API availability and prevent compile errors on 6000.0–6000.2; earlier versions fall back to `EditorUtility.DisplayDialog`. Fixes #803.

<sup>Written for commit b0953f09a2d7cb823b6cba3507eedf874f7592db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes issue #803 by narrowing the preprocessor condition guarding newer Unity API usage from `UNITY_6000_0_OR_NEWER` to `UNITY_6000_3_OR_NEWER`.

## Changes

**File: `Packages/src/Editor/UI/McpEditorWindow.cs`**

In the `HandleInstallSkills()` method, updated the preprocessor directive that guards the use of `EditorDialog.DisplayAlertDialog` and `DialogIconType`:

- Changed from: `#if UNITY_6000_0_OR_NEWER`
- Changed to: `#if UNITY_6000_3_OR_NEWER`

The conditional code block displays a success dialog after skills installation:
- For Unity 6.0.3+: Uses `EditorDialog.DisplayAlertDialog("Skills Installed", "Skills have been installed successfully.", "OK", DialogIconType.Info)`
- For earlier versions: Falls back to `EditorUtility.DisplayDialog("Skills Installed", "Skills have been installed successfully.", "OK")`

## Impact

This change resolves compilation errors on Unity versions 6000.0–6000.2, where `EditorDialog` and `DialogIconType` do not exist. The fix narrows the guard to the correct Unity version where these APIs were introduced, preventing "type not found" errors while maintaining backward compatibility through the fallback implementation.

**Lines changed:** +1/-1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->