### PR TITLE
fix: Remove HideFlags.DontSave from overlay canvas to fix PlayMode exit cleanup

### DIFF
--- a/Packages/src/Editor/Api/McpTools/Core/OverlayCanvasFactory.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/OverlayCanvasFactory.cs
@@ -33,6 +33,25 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
+            // Domain Reload resets _instance but DontDestroyOnLoad objects survive; reclaim one and destroy duplicates
+            InputVisualizationCanvas[] existing =
+                Object.FindObjectsByType<InputVisualizationCanvas>(FindObjectsSortMode.None);
+            for (int i = 0; i < existing.Length; i++)
+            {
+                if (_instance == null)
+                {
+                    _instance = existing[i];
+                }
+                else
+                {
+                    Object.DestroyImmediate(existing[i].gameObject);
+                }
+            }
+            if (_instance != null)
+            {
+                return;
+            }
+
             GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(CANVAS_PREFAB_PATH);
             Debug.Assert(prefab != null, $"InputVisualizationCanvas prefab not found at {CANVAS_PREFAB_PATH}");
 


### PR DESCRIPTION
## Summary

- Remove `HideFlags.DontSave` from `OverlayCanvasFactory` to fix input visualization overlays (mouse/keyboard) persisting after PlayMode exit
- Replace with `DontDestroyOnLoad` so the canvas survives scene transitions during PlayMode while being properly destroyed when PlayMode ends
- Simplify `EnsureExists()` and `OnPlayModeStateChanged()` by removing DontSave-dependent reclaim/cleanup logic

## Why

`HideFlags.DontSave` excluded the `InputVisualizationCanvas` from Unity's scene revert on PlayMode exit, causing overlays (especially keyboard) to persist as orphaned objects. The manual cleanup in `OnPlayModeStateChanged` was the only defense, and if it failed to run, overlays would remain indefinitely.

## Test plan

- [ ] `uloop compile` passes with 0 errors and 0 warnings
- [ ] Run keyboard simulation (`uloop simulate-keyboard`) during PlayMode
- [ ] Stop PlayMode while overlay is visible — verify overlay is destroyed
- [ ] Re-enter PlayMode and verify MCP tools still work correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes input visualization overlays sticking after exiting PlayMode by replacing HideFlags.DontSave with DontDestroyOnLoad on the overlay canvas. Adds reclaim logic to reuse a surviving canvas after Domain Reload and prevent duplicates.

- **Bug Fixes**
  - Removed PlayMode exit handler; rely on Unity to clean up DontDestroyOnLoad objects.
  - Added SubsystemRegistration reset to clear the static instance when Domain Reload is off.
  - Updated EnsureExists to find an existing canvas via FindObjectsByType, reuse it, and destroy extras.

<sup>Written for commit 64231dbe909d5e294f6c1f9f822a9a517530daf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR removes HideFlags.DontSave from overlay canvas lifecycle management and replaces it with DontDestroyOnLoad to ensure overlays are destroyed when exiting PlayMode and to simplify lifecycle handling.

## Problem

Overlay canvases were marked with HideFlags.DontSave to persist across domain reloads. That prevented Unity from reverting them on PlayMode exit, allowing input visualization overlays (notably keyboard) to persist as orphaned objects when manual cleanup failed.

## Solution

- Stop using HideFlags.DontSave. Instantiate the canvas when needed and call Object.DontDestroyOnLoad(go) so it survives scene transitions but is cleaned up by Unity on PlayMode exit.
- Remove the previous scan/reclaim/deduplication logic that searched for DontSave-marked canvases in EnsureExists().
- Remove the PlayMode exit handler that destroyed DontSave-marked canvases; instead add a static reset method:
  - Add [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)] ResetStaticFields to null the static _instance on subsystem registration (handles Domain Reload disabled scenarios).
- Simplify EnsureExists() to always instantiate when _instance is null and mark the GameObject with DontDestroyOnLoad.

## Files changed

- Packages/src/Editor/Api/McpTools/Core/OverlayCanvasFactory.cs
  - Removed InitializeOnLoad/static constructor that registered EditorApplication.playModeStateChanged and deleted the OnPlayModeStateChanged handler.
  - Replaced go.hideFlags = HideFlags.DontSave with Object.DontDestroyOnLoad(go).
  - Removed scanning of existing DontSave instances and duplicate reclamation; added SubsystemRegistration reset.
  - Net change: small reduction in complexity (lines changed: +7/-51 in the file).

## Rationale

DontSave caused overlays to persist as orphaned objects when manual cleanup failed. Relying on DontDestroyOnLoad lets Unity handle cleanup on PlayMode exit while preserving overlays across scene loads during PlayMode. The SubsystemRegistration reset prevents stale static references when Domain Reload is disabled.

## Test plan

- uloop compile passes with 0 errors and 0 warnings.
- Run keyboard simulation (uloop simulate-keyboard) during PlayMode.
- Stop PlayMode while overlay is visible — verify overlay is destroyed.
- Re-enter PlayMode and verify MCP tools still function correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->