### PR TITLE
docs: update outdated menu path references in READMEs

### DIFF
--- a/Packages/src/Cli~/README.md
+++ b/Packages/src/Cli~/README.md
@@ -423,7 +423,7 @@ uloop completion --shell powershell --install  # PowerShell
 
 - **Node.js 22.0 or later**
 - **Unity 2022.3 or later** with [uLoopMCP](https://github.com/hatayama/uLoopMCP) installed
-- uLoopMCP server running (Window > uLoopMCP > Start Server)
+- uLoopMCP server running (Window > Unity CLI Loop > Start Server)
 
 ## Links
 

--- a/Packages/src/Cli~/README_ja.md
+++ b/Packages/src/Cli~/README_ja.md
@@ -423,7 +423,7 @@ uloop completion --shell powershell --install  # PowerShell
 
 - **Node.js 22.0 以降**
 - **Unity 2022.3 以降**（[uLoopMCP](https://github.com/hatayama/uLoopMCP) がインストール済みであること）
-- uLoopMCP サーバーが起動していること（Window > uLoopMCP > Start Server）
+- uLoopMCP サーバーが起動していること（Window > Unity CLI Loop > Start Server）
 
 ## リンク
 

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -75,7 +75,7 @@ Scope(s): io.github.hatayama.uloopmcp
 
 ## Step 1: Install the CLI
 
-Select Window > uLoop. A dedicated window will open — confirm that the **CLI** button is highlighted in blue.
+Select Window > Unity CLI Loop > Settings. A dedicated window will open — confirm that the **CLI** button is highlighted in blue.
 
 Press the **Install CLI** button.  
 <img width="277" height="327" alt="CleanShot 2026-02-26 at 20 14 25" src="https://github.com/user-attachments/assets/680b9586-6323-4bde-a2f0-1c3166f0c224" />
@@ -238,7 +238,7 @@ You can also connect via MCP (Model Context Protocol). CLI and Skills installati
 
 ### MCP Connection Steps
 
-1. Select Window > uLoop. A dedicated window will open — press the **MCP** button.
+1. Select Window > Unity CLI Loop > Settings. A dedicated window will open — press the **MCP** button.
 <img width="274" height="289" alt="CleanShot 2026-02-26 at 20 37 16" src="https://github.com/user-attachments/assets/5f2fc5db-fd33-4b5d-9f0e-3e2e0d134cf6" />
 
 2. Next, select the target IDE in the LLM Tool Settings section. Press the yellow "Configure {LLM Tool Name}" button to automatically connect to the IDE.

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -76,7 +76,7 @@ Scope(s): io.github.hatayama.uloopmcp
 
 ## ステップ1: CLIのインストール
 
-Window > uLoopを選択します。専用ウィンドウが開くので **CLI** ボタンが青くなっている事を確認します。
+Window > Unity CLI Loop > Settingsを選択します。専用ウィンドウが開くので **CLI** ボタンが青くなっている事を確認します。
 
 **Install CLI** ボタンを押します。  
 <img width="277" height="327" alt="CleanShot 2026-02-26 at 20 14 25" src="https://github.com/user-attachments/assets/680b9586-6323-4bde-a2f0-1c3166f0c224" />
@@ -239,7 +239,7 @@ MCP（Model Context Protocol）経由でも接続できます。MCPの場合、C
 
 ### MCP接続の手順
 
-1. Window > uLoopを選択します。専用ウィンドウが開くので **MCP** ボタンを押してください。
+1. Window > Unity CLI Loop > Settingsを選択します。専用ウィンドウが開くので **MCP** ボタンを押してください。
 <img width="274" height="289" alt="CleanShot 2026-02-26 at 20 37 16" src="https://github.com/user-attachments/assets/5f2fc5db-fd33-4b5d-9f0e-3e2e0d134cf6" />
 
 2. 次に、LLM Tool SettingsセクションでターゲットIDEを選択します。黄色い「Configure {LLM Tool名}」ボタンを押してIDEに自動接続してください。

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Scope(s): io.github.hatayama.uloopmcp
 
 ## Step 1: Install the CLI
 
-Select Window > uLoop. A dedicated window will open — confirm that the **CLI** button is highlighted in blue.
+Select Window > Unity CLI Loop > Settings. A dedicated window will open — confirm that the **CLI** button is highlighted in blue.
 
 Press the **Install CLI** button.  
 <img width="277" height="327" alt="CleanShot 2026-02-26 at 20 14 25" src="https://github.com/user-attachments/assets/680b9586-6323-4bde-a2f0-1c3166f0c224" />
@@ -238,7 +238,7 @@ You can also connect via MCP (Model Context Protocol). CLI and Skills installati
 
 ### MCP Connection Steps
 
-1. Select Window > uLoop. A dedicated window will open — press the **MCP** button.
+1. Select Window > Unity CLI Loop > Settings. A dedicated window will open — press the **MCP** button.
 <img width="274" height="289" alt="CleanShot 2026-02-26 at 20 37 16" src="https://github.com/user-attachments/assets/5f2fc5db-fd33-4b5d-9f0e-3e2e0d134cf6" />
 
 2. Next, select the target IDE in the LLM Tool Settings section. Press the yellow "Configure {LLM Tool Name}" button to automatically connect to the IDE.

--- a/README_ja.md
+++ b/README_ja.md
@@ -76,7 +76,7 @@ Scope(s): io.github.hatayama.uloopmcp
 
 ## ステップ1: CLIのインストール
 
-Window > uLoopを選択します。専用ウィンドウが開くので **CLI** ボタンが青くなっている事を確認します。
+Window > Unity CLI Loop > Settingsを選択します。専用ウィンドウが開くので **CLI** ボタンが青くなっている事を確認します。
 
 **Install CLI** ボタンを押します。  
 <img width="277" height="327" alt="CleanShot 2026-02-26 at 20 14 25" src="https://github.com/user-attachments/assets/680b9586-6323-4bde-a2f0-1c3166f0c224" />
@@ -239,7 +239,7 @@ MCP（Model Context Protocol）経由でも接続できます。MCPの場合、C
 
 ### MCP接続の手順
 
-1. Window > uLoopを選択します。専用ウィンドウが開くので **MCP** ボタンを押してください。
+1. Window > Unity CLI Loop > Settingsを選択します。専用ウィンドウが開くので **MCP** ボタンを押してください。
 <img width="274" height="289" alt="CleanShot 2026-02-26 at 20 37 16" src="https://github.com/user-attachments/assets/5f2fc5db-fd33-4b5d-9f0e-3e2e0d134cf6" />
 
 2. 次に、LLM Tool SettingsセクションでターゲットIDEを選択します。黄色い「Configure {LLM Tool名}」ボタンを押してIDEに自動接続してください。


### PR DESCRIPTION
## Summary
- Updated Unity Editor menu path from `Window > uLoop` / `Window > uLoopMCP` to `Window > Unity CLI Loop > Settings` across all README files
- The menu was renamed when the MenuItem was moved to `Window/Unity CLI Loop/Settings`, but the documentation still referenced the old path

## Changed files
- `README.md` (2 places)
- `README_ja.md` (2 places)
- `Packages/src/README.md` (2 places)
- `Packages/src/README_ja.md` (2 places)
- `Packages/src/Cli~/README.md` (1 place)
- `Packages/src/Cli~/README_ja.md` (1 place)

## Test plan
- [ ] Verify menu path matches actual Unity Editor menu item

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated all READMEs to use the current Unity Editor menu paths. Replaced “Window > uLoop” and “Window > uLoopMCP” with “Window > Unity CLI Loop > Settings,” and updated the server path to “Window > Unity CLI Loop > Start Server.”

<sup>Written for commit 68bfb1174ea9c04e5bf2040c86d5c6673dd21d0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

