### PR TITLE
docs: update READMEs with new tools and rename simulate-mouse to simulate-mouse-ui

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -27,7 +27,7 @@ Unity CLI Loop is built around three core ideas:
 
 1. **A self-hosted development loop where AI autonomously compiles, tests, inspects logs, and fixes issues.** Uses `compile`, `run-tests`, `get-logs`, `clear-console`.
 2. **AI-driven Unity Editor operation—scene building, object manipulation, menu execution, and UI refinement from screenshots.** Uses `execute-dynamic-code`, `execute-menu-item`, `screenshot`.
-3. **PlayMode automated testing—AI clicks buttons, drags elements, and verifies game behavior.** Uses `simulate-mouse-ui`, `simulate-mouse-input`, `simulate-keyboard`, `record-input`, `replay-input`, `execute-dynamic-code`, `screenshot`.
+3. **PlayMode automated testing—AI clicks buttons, drags elements, presses keys, records and replays input, and verifies game behavior.** Uses `simulate-mouse-ui`, `simulate-mouse-input`, `simulate-keyboard`, `record-input`, `replay-input`, `execute-dynamic-code`, `screenshot`.
 
 https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -27,7 +27,7 @@ Unity CLI Loopのコアとなるコンセプトは次の3つです。
 
 1. **AIが自律的にビルド・テスト・ログ解析・修正を回し続ける「自律開発ループ」** — `compile`, `run-tests`, `get-logs`, `clear-console`
 2. **シーン構築、オブジェクト操作、メニュー実行、スクリーンショットからのUI改善など、Unity Editorの操作をAIに委任** — `execute-dynamic-code`, `execute-menu-item`, `screenshot`
-3. **PlayMode中の自動テスト — ボタンクリック、ドラッグ、ゲーム動作の検証をAIが実行** — `simulate-mouse-ui`, `simulate-mouse-input`, `simulate-keyboard`, `record-input`, `replay-input`, `execute-dynamic-code`, `screenshot`
+3. **PlayMode中の自動テスト — ボタンクリック、ドラッグ、キーボード入力、入力の記録・再生、ゲーム動作の検証をAIが実行** — `simulate-mouse-ui`, `simulate-mouse-input`, `simulate-keyboard`, `record-input`, `replay-input`, `execute-dynamic-code`, `screenshot`
 
 https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Unity CLI Loop is built around three core ideas:
 
 1. **A self-hosted development loop where AI autonomously compiles, tests, inspects logs, and fixes issues.** Uses `compile`, `run-tests`, `get-logs`, `clear-console`.
 2. **AI-driven Unity Editor operation—scene building, object manipulation, menu execution, and UI refinement from screenshots.** Uses `execute-dynamic-code`, `execute-menu-item`, `screenshot`.
-3. **PlayMode automated testing—AI clicks buttons, drags elements, and verifies game behavior.** Uses `simulate-mouse-ui`, `simulate-mouse-input`, `simulate-keyboard`, `record-input`, `replay-input`, `execute-dynamic-code`, `screenshot`.
+3. **PlayMode automated testing—AI clicks buttons, drags elements, presses keys, records and replays input, and verifies game behavior.** Uses `simulate-mouse-ui`, `simulate-mouse-input`, `simulate-keyboard`, `record-input`, `replay-input`, `execute-dynamic-code`, `screenshot`.
 
 https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -27,7 +27,7 @@ Unity CLI Loopのコアとなるコンセプトは次の3つです。
 
 1. **AIが自律的にビルド・テスト・ログ解析・修正を回し続ける「自律開発ループ」** — `compile`, `run-tests`, `get-logs`, `clear-console`
 2. **シーン構築、オブジェクト操作、メニュー実行、スクリーンショットからのUI改善など、Unity Editorの操作をAIに委任** — `execute-dynamic-code`, `execute-menu-item`, `screenshot`
-3. **PlayMode中の自動テスト — ボタンクリック、ドラッグ、ゲーム動作の検証をAIが実行** — `simulate-mouse-ui`, `simulate-mouse-input`, `simulate-keyboard`, `record-input`, `replay-input`, `execute-dynamic-code`, `screenshot`
+3. **PlayMode中の自動テスト — ボタンクリック、ドラッグ、キーボード入力、入力の記録・再生、ゲーム動作の検証をAIが実行** — `simulate-mouse-ui`, `simulate-mouse-input`, `simulate-keyboard`, `record-input`, `replay-input`, `execute-dynamic-code`, `screenshot`
 
 https://github.com/user-attachments/assets/569a2110-7351-4cf3-8281-3a83fe181817
 


### PR DESCRIPTION
## Summary
- Update installation instruction images in README_ja.md to match README.md
- Rename `simulate-mouse` to `simulate-mouse-ui` across both READMEs to match actual tool name
- Add 3 missing tools to Key Features and Bundled Skills: `simulate-mouse-input`, `record-input`, `replay-input`
- Update Bundled Skills count from 17 to 20
- Add quickstart table entries for input recording/replay

## Test plan
- [ ] Verify all tool names in READMEs match actual implementations
- [ ] Verify Packages/src/ READMEs are in sync with root READMEs
- [ ] Confirm image URLs render correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update EN/JA READMEs (root and `Packages/src/`) to rename `simulate-mouse` to `simulate-mouse-ui`, add docs for new input tools, and refresh install screenshots. The concept overview now includes keyboard input and input record/replay, and the bundled skills list grows to 20.

- **New Features**
  - Added docs for `simulate-mouse-input`, `record-input`, `replay-input`; updated the Concept (idea #3) to include `simulate-keyboard` plus record/replay.
  - Clarified when to use `simulate-mouse-ui` vs `simulate-mouse-input`; updated examples, quickstart entries, bundled skills (17→20), and install screenshots.

- **Migration**
  - Replace `simulate-mouse` with `simulate-mouse-ui` in all references and scripts.

<sup>Written for commit 1a621841b106492ec67bbfd4558d4e9813aab369. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates README documentation across four files to clarify and expand the PlayMode automated testing tools. It renames the generic simulate-mouse tool to simulate-mouse-ui, adds Input System–targeted and input recording/replay tools, and synchronizes EN/JA and Packages/src READMEs and installation images.

## Changes

### Tool Updates and Additions
- Renamed: `simulate-mouse` → `simulate-mouse-ui`
  - Clarifies this tool targets UI element pointer events (EventSystem/ExecuteEvents).
  - Updated invocation examples across EN/JA root READMEs and Packages/src/ READMEs.
- New tools:
  - `simulate-mouse-input`: injects into `Mouse.current` for game logic that reads the Input System (actions: Click/LongPress/MoveDelta/SmoothDelta/Scroll; requires Input System setup).
  - `record-input`: records keyboard/mouse/input to JSON (saved under .uloop/outputs/InputRecordings/).
  - `replay-input`: replays recorded input frame-by-frame via the Input System.

### Documentation Structure Updates
- Bundled Skills count updated: 17 → 20.
- Added quickstart/table entries for input recording and replay.
- Rewrote PlayMode Automated Testing Tools section: renamed simulate-mouse section to simulate-mouse-ui, added section for simulate-mouse-input, renumbered keyboard tool, and added sections for record-input and replay-input.
- Clarified when to use simulate-mouse-ui (uGUI/EventSystem) vs simulate-mouse-input (Input System).

### Visual and Sync Updates
- Installation instruction screenshots updated in README_ja.md to match README.md; image alt text and spacing adjusted.
- Confirmed Packages/src/ READMEs synchronized with root READMEs and image URL references updated.

### Files Modified
- README.md (+57/-15)
- README_ja.md (+58/-18)
- Packages/src/README.md (+57/-15)
- Packages/src/README_ja.md (+58/-18)

## Impact
Documentation-only changes; no code or exported/public API modifications. The PR clarifies input-testing workflows and documents new input recording/replay capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->