### PR TITLE
fix: clarify execute-dynamic-code skill parameters

### DIFF
--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -16,17 +16,22 @@ Execute the following request using `uloop execute-dynamic-code`: $ARGUMENTS
 4. If execution fails, adjust code and retry
 5. Report the execution result
 
+## Parameters
+
+- `--code '<code>'` (required): Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
+- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`).
+- `--parameters {}` (advanced, optional): Pass an object when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets, and pass an object instead of a JSON string.
+- `--compile-only true` (optional): Compile the snippet without executing it. Use this when you want Roslyn diagnostics before running new code.
+
 ## Code Rules
 
 Write direct statements only — no class/namespace/method wrappers. Return is optional.
 
 ```csharp
 using UnityEngine;
-var x = Mathf.PI;
+float x = Mathf.PI;
 return x;
 ```
-
-**Shell quoting**: bash/zsh uses single quotes (`'Debug.Log("Hello!");'`), PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`).
 
 **Forbidden** — these will be rejected at compile time: `System.IO.*`, `AssetDatabase.CreateFolder`, creating/editing `.cs`/`.asmdef` files. Use terminal commands for file operations instead.
 

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation.md
@@ -252,7 +252,7 @@ uloop clear-console
 **Step 1**: Start Play mode
 
 ```bash
-uloop control-play-mode --action play
+uloop control-play-mode --action Play
 ```
 
 **Step 2**: Wait for scene initialization, then find and click a button
@@ -285,5 +285,5 @@ uloop get-logs --log-type Error
 **Step 5**: Stop Play mode
 
 ```bash
-uloop control-play-mode --action stop
+uloop control-play-mode --action Stop
 ```

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -16,17 +16,22 @@ Execute the following request using `uloop execute-dynamic-code`: $ARGUMENTS
 4. If execution fails, adjust code and retry
 5. Report the execution result
 
+## Parameters
+
+- `--code '<code>'` (required): Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
+- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`).
+- `--parameters {}` (advanced, optional): Pass an object when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets, and pass an object instead of a JSON string.
+- `--compile-only true` (optional): Compile the snippet without executing it. Use this when you want Roslyn diagnostics before running new code.
+
 ## Code Rules
 
 Write direct statements only — no class/namespace/method wrappers. Return is optional.
 
 ```csharp
 using UnityEngine;
-var x = Mathf.PI;
+float x = Mathf.PI;
 return x;
 ```
-
-**Shell quoting**: bash/zsh uses single quotes (`'Debug.Log("Hello!");'`), PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`).
 
 **Forbidden** — these will be rejected at compile time: `System.IO.*`, `AssetDatabase.CreateFolder`, creating/editing `.cs`/`.asmdef` files. Use terminal commands for file operations instead.
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation.md
@@ -252,7 +252,7 @@ uloop clear-console
 **Step 1**: Start Play mode
 
 ```bash
-uloop control-play-mode --action play
+uloop control-play-mode --action Play
 ```
 
 **Step 2**: Wait for scene initialization, then find and click a button
@@ -285,5 +285,5 @@ uloop get-logs --log-type Error
 **Step 5**: Stop Play mode
 
 ```bash
-uloop control-play-mode --action stop
+uloop control-play-mode --action Stop
 ```


### PR DESCRIPTION
## Summary
- add a Parameters section to the execute-dynamic-code skill docs
- clarify how to use --code, --parameters, and --compile-only
- normalize PlayMode control examples to use Play/Stop casing

## Testing
- verified the updated markdown diff locally
- confirmed no lowercase play/stop actions remain in the execute-dynamic-code skill references

## Notes
- docs-only change; no Unity compile or automated tests were run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Parameters section to the `execute-dynamic-code` skill docs and clarified how to use `--code`, `--parameters`, and `--compile-only`. Also standardized PlayMode control examples to use `Play`/`Stop` casing.

<sup>Written for commit d421171d2a2d17d7fa44dd4b7e463c746aef7d6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request clarifies the parameters and usage of the `execute-dynamic-code` skill across multiple documentation files.

## Changes Made

**Documentation Updates:**
- Added a dedicated "Parameters" section to the execute-dynamic-code skill documentation, documenting:
  - `--code` flag: Inline C# statements with guidance on direct-statement format and optional `return` keyword; `using` statements allowed at the top
  - `--parameters {}` flag: Advanced object-based parameterization allowing external values to be passed via `parameters["paramN"]`
  - `--compile-only true` flag: Optional compilation mode that skips execution

**Code Examples:**
- Updated C# sample snippet from `var x = Mathf.PI;` to explicit type declaration `float x = Mathf.PI;`
- Reorganized "Shell quoting" guidance, integrating it into the new Parameters section

**PlayMode Control Normalization:**
- Updated `control-play-mode` command examples across two playmode-automation references:
  - Changed `--action play` to `--action Play`
  - Changed `--action stop` to `--action Stop`

## Files Modified

- `.claude/skills/uloop-execute-dynamic-code/SKILL.md` (+8/-3 lines)
- `.claude/skills/uloop-execute-dynamic-code/references/playmode-automation.md` (+2/-2 lines)
- `Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md` (+8/-3 lines)
- `Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation.md` (+2/-2 lines)

## Testing

- Documentation changes verified locally through markdown diff review
- Confirmed no lowercase play/stop actions remain in execute-dynamic-code skill references

## Notes

Documentation-only changes; no Unity compilation or automated tests were executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->