### PR TITLE
docs: document tracked vs local-only Unity CLI Loop files

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -678,7 +678,7 @@ For a more comprehensive example project, see [uLoopMCP-extensions-sample](https
 
 ## Other
 
-### uLoop-related Files
+### Unity CLI Loop Files
 
 `UserSettings/UnityMcpSettings.json` stores per-user editor session state and should always remain local-only.
 

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -676,7 +676,7 @@ description: "ツールの説明と使用タイミング"
 
 ## その他
 
-### uLoop関連ファイル
+### Unity CLI Loop 関連ファイル
 
 `UserSettings/UnityMcpSettings.json` はユーザー個別のエディタセッション状態を保持するため、常にローカル専用です。
 

--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ For a more comprehensive example project, see [uLoopMCP-extensions-sample](https
 
 ## Other
 
-### uLoop-related Files
+### Unity CLI Loop Files
 
 `UserSettings/UnityMcpSettings.json` stores per-user editor session state and should always remain local-only.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -676,7 +676,7 @@ description: "ツールの説明と使用タイミング"
 
 ## その他
 
-### uLoop関連ファイル
+### Unity CLI Loop 関連ファイル
 
 `UserSettings/UnityMcpSettings.json` はユーザー個別のエディタセッション状態を保持するため、常にローカル専用です。
 


### PR DESCRIPTION
## Summary

- Add a "Unity CLI Loop Files" section to all four README files (EN/JA × root/package)
- Document which `.uloop/` files can optionally be git-tracked vs which should remain local-only
- Provide a recommended `.gitignore` pattern for teams that want to share configuration

## Details

| File | Git-track? |
|------|------------|
| `settings.permissions.json` | Optional (team security policy) |
| `settings.tools.json` | Optional (tool enable/disable prefs) |
| `tools.json` | No (auto-generated) |
| `outputs/` | No (runtime outputs) |
| `UserSettings/UnityMcpSettings.json` | No (editor session state) |

Closes #844

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies which Unity CLI Loop files can be committed vs must stay local across all EN/JA READMEs (root and package). Also calls out that `UserSettings/UnityMcpSettings.json` is always local-only; closes #844.

- **Documentation**
  - Added "Unity CLI Loop Files" section with a track vs local-only table for `.uloop/` contents.
  - Provided a `.gitignore` pattern that ignores generated outputs but allows sharing `settings.permissions.json` and `settings.tools.json`.
  - Corrected the section title and placement to avoid confusion.

<sup>Written for commit 4a93d5edbd742105ab7d06dfb7a292eba4bea8d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds comprehensive documentation to four README files (English and Japanese versions at both repository root and package levels) clarifying which Unity CLI Loop (`.uloop/`) related files should be git-tracked versus kept local-only, addressing confusion when setting up worktrees and multiple environments.

## Changes Made

### Documentation Updates
Updated all four README files (`README.md`, `README_ja.md`, `Packages/src/README.md`, `Packages/src/README_ja.md`) with a new "Unity CLI Loop Files" section under the "Other" category that:

- **Specifies file tracking status** via a classification table:
  - `.uloop/settings.permissions.json` — Optional (team security policy)
  - `.uloop/settings.tools.json` — Optional (tool enable/disable preferences)  
  - `.uloop/tools.json` — Not tracked (auto-generated)
  - `.uloop/outputs/` — Not tracked (runtime outputs)
  - `UserSettings/UnityMcpSettings.json` — Not tracked (editor session state)

- **Provides recommended `.gitignore` pattern** that ignores all `.uloop/*` content by default while allowing `settings.permissions.json` and `settings.tools.json` to optionally be tracked for team policy/configuration sharing

- **Replaces prior guidance** that included generic recommendations to exclude `.uloop/` and notes about `run-tests`/`get-hierarchy` file outputs with explicit categorization and actionable configuration instructions

- **Repositions `UserSettings` documentation** to appear before the `.uloop/` section for clearer organization

### Line Changes
- `README.md`: +23/-3 lines
- `README_ja.md`: +22/-3 lines  
- `Packages/src/README.md`: +23/-3 lines
- `Packages/src/README_ja.md`: +22/-3 lines

## Impact
- Documentation-only changes with no impact on exported or public APIs
- Resolves issue #844 by providing explicit guidance on which files to track and which to keep local-only
- Reduces accidental configuration drift and simplifies multi-worktree setup for teams

<!-- end of auto-generated comment: release notes by coderabbit.ai -->