### PR TITLE
fix: Prevent SetupWizardWindow from showing for existing users on upgrade

### DIFF
--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -35,7 +35,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private static async void CheckLegacySetupAndMaybeShowWindow()
         {
-            await CliInstallationDetector.RefreshCliVersionAsync(CancellationToken.None);
+            await CliInstallationDetector.ForceRefreshCliVersionAsync(CancellationToken.None);
 
             if (IsSetupComplete())
             {


### PR DESCRIPTION
## Summary

- Existing users upgrading to v1.6.0 see the SetupWizardWindow spuriously because their `UnityMcpSettings.json` predates PR #855 and lacks the `lastSkillPromptVersion` field
- The missing field deserializes to `""`, which never matches `McpVersion.VERSION`, triggering the wizard on every editor startup
- Add a one-time migration in `LoadSettings()` that stamps the current version when the field is absent, following the same pattern as `MigrateLegacyAutoStartIfNeeded`

## Test plan

- [ ] Remove `lastSkillPromptVersion` from `UnityMcpSettings.json` and restart editor — wizard should NOT appear
- [ ] Delete `UnityMcpSettings.json` entirely and restart editor — wizard SHOULD appear (new user flow)
- [ ] Verify `lastSkillPromptVersion` is written to JSON after migration runs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Setup Wizard from showing for existing users after upgrading by deferring a one-time legacy check and stamping `lastSkillPromptVersion` only when setup is complete. New users still see the wizard; CLI detection now uses a forced refresh to avoid races.

- **Bug Fixes**
  - Moved legacy user check from settings migration to `SetupWizardWindow` static init via `EditorApplication.delayCall`; use `CliInstallationDetector.ForceRefreshCliVersionAsync` to populate the cache and avoid race conditions.
  - Added `IsSetupComplete()` and save prompt version only when CLI matches and skills exist (or no targets); made `SavePromptVersion()` static and removed the old migration.

<sup>Written for commit 960d75fe870003ae038b18b840d407736545387d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Fix: Prevent SetupWizardWindow from showing for existing users on upgrade

## Problem
When upgrading to v1.6.0 existing users saw the SetupWizardWindow on every editor startup because:
- Their UnityMcpSettings.json predated PR #855 and lacked lastSkillPromptVersion.
- The missing field deserialized as an empty string ("") which never equaled McpVersion.VERSION.
- The static-constructor logic therefore treated these users as "not prompted" and showed the wizard repeatedly.

## Solution
Introduce a one-time asynchronous migration in SetupWizardWindow that stamps lastSkillPromptVersion when the field is absent, following the existing MigrateLegacyAutoStartIfNeeded pattern and moving legacy readiness checks into the delayed async initialization.

### Key changes
- Static constructor: if lastSkillPromptVersion == McpVersion.VERSION → return; if lastSkillPromptVersion is empty → schedule CheckLegacySetupAndMaybeShowWindow via EditorApplication.delayCall; otherwise schedule ShowWindow. This defers async work off editor startup.
- New async CheckLegacySetupAndMaybeShowWindow():
  - Forces CLI version cache population using ForceRefreshCliVersionAsync (guarantees cache is populated before evaluation).
  - Calls IsSetupComplete() to decide whether to save the prompt version or show the setup window.
  - If setup is complete → SavePromptVersion() writes lastSkillPromptVersion = McpVersion.VERSION (migration done) and returns; if incomplete → opens the setup wizard.
- New IsSetupComplete() (static): centralizes setup-complete logic. It requires an exact cached CLI version match and treats "no detected targets" as complete; otherwise it verifies all detected targets already have skills.
- SavePromptVersion() converted from instance to static to allow invocation from the async migration path.
- OnDestroy() simplified: it now calls SavePromptVersion() only when IsSetupComplete() is true (and respects _isSkipped) to avoid unnecessary writes.
- Removed an obsolete migration and moved legacy readiness checks into SetupWizardWindow initialization.

### Behavior guarantees / migration effects
- Existing users whose settings file lacks lastSkillPromptVersion will have that field stamped to McpVersion.VERSION automatically (one-time) if their setup is already complete; the wizard will NOT appear for them after migration.
- New users (no settings file) still see the wizard as before.
- The change uses ForceRefreshCliVersionAsync to avoid races where the CLI version cache could be null if a non-forcing refresh returned early.

### Tests
- Remove lastSkillPromptVersion from UnityMcpSettings.json and restart editor — wizard should NOT appear (migration stamps version).
- Delete UnityMcpSettings.json entirely and restart editor — wizard SHOULD appear (new user flow).
- Verify lastSkillPromptVersion is written to JSON after migration runs.

### Surface changes
- File: Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
  - Added: CheckLegacySetupAndMaybeShowWindow(), IsSetupComplete()
  - Modified: static constructor, OnDestroy()
  - Changed: SavePromptVersion() from private instance method → private static method

Lines changed: +35 / -12
Estimated review effort: High (async flow, CLI cache guarantees, and setup-logic consolidation)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->