### PR TITLE
fix: Prevent SetupWizardWindow from showing on package upgrade

### DIFF
--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -759,7 +759,6 @@ namespace io.github.hatayama.uLoopMCP
                     ULoopSettings.GetSettings();
 
                     MigrateLegacyAutoStartIfNeeded(json);
-                    MigrateLastSkillPromptVersionIfNeeded(json);
                 }
                 else
                 {
@@ -804,24 +803,6 @@ namespace io.github.hatayama.uLoopMCP
 
             _cachedSettings.isServerRunning = probe.autoStartServer;
 
-            SaveSettings(_cachedSettings);
-        }
-
-        /// Existing users upgrading from before the SetupWizardWindow (PR #855) have a settings
-        /// file that lacks lastSkillPromptVersion. The field deserializes to "" and causes the
-        /// wizard to show spuriously. Stamp the current version so the wizard is suppressed.
-        private static void MigrateLastSkillPromptVersionIfNeeded(string json)
-        {
-            bool hasField = json.Contains($"\"{nameof(McpEditorSettingsData.lastSkillPromptVersion)}\"");
-            if (hasField)
-            {
-                return;
-            }
-
-            _cachedSettings = _cachedSettings with
-            {
-                lastSkillPromptVersion = McpVersion.VERSION
-            };
             SaveSettings(_cachedSettings);
         }
 

--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -759,6 +759,7 @@ namespace io.github.hatayama.uLoopMCP
                     ULoopSettings.GetSettings();
 
                     MigrateLegacyAutoStartIfNeeded(json);
+                    MigrateLastSkillPromptVersionIfNeeded(json);
                 }
                 else
                 {
@@ -803,6 +804,24 @@ namespace io.github.hatayama.uLoopMCP
 
             _cachedSettings.isServerRunning = probe.autoStartServer;
 
+            SaveSettings(_cachedSettings);
+        }
+
+        /// Existing users upgrading from before the SetupWizardWindow (PR #855) have a settings
+        /// file that lacks lastSkillPromptVersion. The field deserializes to "" and causes the
+        /// wizard to show spuriously. Stamp the current version so the wizard is suppressed.
+        private static void MigrateLastSkillPromptVersionIfNeeded(string json)
+        {
+            bool hasField = json.Contains($"\"{nameof(McpEditorSettingsData.lastSkillPromptVersion)}\"");
+            if (hasField)
+            {
+                return;
+            }
+
+            _cachedSettings = _cachedSettings with
+            {
+                lastSkillPromptVersion = McpVersion.VERSION
+            };
             SaveSettings(_cachedSettings);
         }
 

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -24,16 +24,10 @@ namespace io.github.hatayama.uLoopMCP
 
             // Static constructors cannot run async I/O, but CLI version check requires
             // spawning a process. Defer to delayCall so we can await the result.
-            if (string.IsNullOrEmpty(lastVersion))
-            {
-                EditorApplication.delayCall += CheckLegacySetupAndMaybeShowWindow;
-                return;
-            }
-
-            EditorApplication.delayCall += ShowWindow;
+            EditorApplication.delayCall += CheckSetupAndMaybeShowWindow;
         }
 
-        private static async void CheckLegacySetupAndMaybeShowWindow()
+        private static async void CheckSetupAndMaybeShowWindow()
         {
             await CliInstallationDetector.ForceRefreshCliVersionAsync(CancellationToken.None);
 
@@ -195,8 +189,8 @@ namespace io.github.hatayama.uLoopMCP
 
         private static bool IsSetupComplete()
         {
-            string cliVersion = CliInstallationDetector.GetCachedCliVersion();
-            if (!IsCliVersionMatched(cliVersion)) return false;
+            // Version mismatch alone should not trigger the wizard — McpEditorWindow handles CLI update prompts
+            if (!CliInstallationDetector.IsCliInstalled()) return false;
 
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = ToolSkillSynchronizer.DetectTargets();
             if (targets.Count == 0) return true;

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -22,7 +22,28 @@ namespace io.github.hatayama.uLoopMCP
             string lastVersion = McpEditorSettings.GetSettings().lastSkillPromptVersion;
             if (lastVersion == McpVersion.VERSION) return;
 
+            // Static constructors cannot run async I/O, but CLI version check requires
+            // spawning a process. Defer to delayCall so we can await the result.
+            if (string.IsNullOrEmpty(lastVersion))
+            {
+                EditorApplication.delayCall += CheckLegacySetupAndMaybeShowWindow;
+                return;
+            }
+
             EditorApplication.delayCall += ShowWindow;
+        }
+
+        private static async void CheckLegacySetupAndMaybeShowWindow()
+        {
+            await CliInstallationDetector.RefreshCliVersionAsync(CancellationToken.None);
+
+            if (IsSetupComplete())
+            {
+                SavePromptVersion();
+                return;
+            }
+
+            ShowWindow();
         }
 
         [MenuItem("Window/Unity CLI Loop/Setup Wizard", priority = 3)]
@@ -170,6 +191,17 @@ namespace io.github.hatayama.uLoopMCP
             ViewDataBinder.ToggleClass(_cliStatusIcon, "setup-status-icon--pending", true);
             _installCliButton.SetEnabled(!_isInstallingCli);
             _installCliButton.text = _isInstallingCli ? "Installing..." : "Install CLI";
+        }
+
+        private static bool IsSetupComplete()
+        {
+            string cliVersion = CliInstallationDetector.GetCachedCliVersion();
+            if (!IsCliVersionMatched(cliVersion)) return false;
+
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = ToolSkillSynchronizer.DetectTargets();
+            if (targets.Count == 0) return true;
+
+            return targets.All(t => t.HasExistingSkills);
         }
 
         private static bool IsCliVersionMatched(string cliVersion)
@@ -342,21 +374,12 @@ namespace io.github.hatayama.uLoopMCP
         private void OnDestroy()
         {
             if (_isSkipped) return;
+            if (!IsSetupComplete()) return;
 
-            string cliVersion = CliInstallationDetector.GetCachedCliVersion();
-            if (!IsCliVersionMatched(cliVersion)) return;
-
-            List<ToolSkillSynchronizer.SkillTargetInfo> targets = ToolSkillSynchronizer.DetectTargets();
-            bool noTargets = targets.Count == 0;
-            bool allSkillsInstalled = targets.Count > 0
-                && targets.All(t => t.HasExistingSkills);
-            if (noTargets || allSkillsInstalled)
-            {
-                SavePromptVersion();
-            }
+            SavePromptVersion();
         }
 
-        private void SavePromptVersion()
+        private static void SavePromptVersion()
         {
             McpEditorSettings.UpdateSettings(s => s with
             {

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -35,7 +35,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private static async void CheckLegacySetupAndMaybeShowWindow()
         {
-            await CliInstallationDetector.RefreshCliVersionAsync(CancellationToken.None);
+            await CliInstallationDetector.ForceRefreshCliVersionAsync(CancellationToken.None);
 
             if (IsSetupComplete())
             {


### PR DESCRIPTION
## Summary

- Unify the static constructor's two startup paths (empty and mismatched `lastSkillPromptVersion`) into a single async readiness check (`CheckSetupAndMaybeShowWindow`)
- Relax `IsSetupComplete()` to use `IsCliInstalled()` instead of `IsCliVersionMatched()` — the wizard is for initial setup, not version updates
- CLI version update prompts remain handled by `McpEditorWindow`

## Problem

When upgrading the package (e.g., v1.5.1 → v1.6.1), the setup wizard appeared even for fully configured users. Two root causes:

1. The version-bump path in the static constructor called `ShowWindow()` directly without checking CLI/skills readiness
2. `IsSetupComplete()` required exact CLI version match, which always fails right after a package upgrade (CLI still at old version)

## Test plan

- [ ] Set `lastSkillPromptVersion` to `"1.5.1"` with CLI+Skills configured → wizard should NOT appear
- [ ] Delete `UnityMcpSettings.json` entirely → wizard should appear (new user)
- [ ] Set `lastSkillPromptVersion` to `""` with CLI not installed → wizard should appear
- [ ] Set `lastSkillPromptVersion` to `""` with CLI+Skills configured → wizard should NOT appear
- [ ] `uloop compile` passes with no errors or warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing the Setup Wizard after package upgrades for already-configured users. We now check CLI and skills readiness before opening the window.

- **Bug Fixes**
  - Unified startup path: static constructor defers to a single async check that refreshes CLI version and decides whether to show the wizard.
  - Relaxed completion check: setup is complete when the CLI is installed and there are no targets or all targets have skills; CLI version mismatch no longer triggers the wizard.
  - Saved prompt version immediately after confirming setup, preventing repeat prompts.
  - Avoided cache race by using a forced CLI version refresh and simplified OnDestroy to only persist when setup is complete.

<sup>Written for commit 4ca5553e30eac12d4b6216590d12aca5439e0466. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR prevents the SetupWizardWindow from appearing on package upgrades by consolidating the startup logic and relaxing the setup completion check to account for CLI version mismatches. The fix unifies two startup paths into a single async readiness check and separates concerns: the setup wizard handles initial setup, while CLI version update prompts remain the responsibility of McpEditorWindow.

## Key Changes

### Startup Logic Consolidation (Static Constructor)

**Before:** The static constructor had two separate paths (empty and mismatched `lastSkillPromptVersion`) that both called `ShowWindow()` directly without async CLI version checks.

**After:** Replaced with a single unified path:
```
Static Constructor
  → CheckSetupAndMaybeShowWindow (deferred via delayCall)
    → ForceRefreshCliVersionAsync (ensures cache is populated)
    → IsSetupComplete() check (gated window display)
```

### Setup Completion Logic

**New `IsSetupComplete()` method** (lines 190-199):
- Checks only if CLI is installed (`IsCliInstalled()`) — not exact version match
- Returns `true` if no skill targets are configured (minimal setup needed)
- Returns `true` only if all detected skill targets have existing skills installed
- Separates concerns: version mismatches no longer trigger the wizard

**Previous logic** required exact CLI version match via `IsCliVersionMatched()`, causing the wizard to appear immediately after upgrades when the CLI was still at the old version.

### Version Persistence

**`SavePromptVersion()` refactoring** (line 283):
- Changed from instance method to `private static void`
- Called from three locations:
  1. `CheckSetupAndMaybeShowWindow` (setup complete, skipping wizard)
  2. `HandleSkip` (user explicitly skipped)
  3. `HandleOpenSettings` (user completed setup)
  4. `OnDestroy` (cleanup, gated by `IsSetupComplete()`)

**`OnDestroy` simplification** (lines 275-280):
- Removed duplicate "no targets/all skills installed" checks
- Now delegates setup completeness to `IsSetupComplete()`
- Only persists version timestamp when setup is actually complete

### CLI Version Detection

**New `ForceRefreshCliVersionAsync` call** (line 32):
- Ensures the CLI version cache is always populated before making setup decisions
- Bypasses the early-return guard in `RefreshCliVersionAsync`, preventing stale cache issues during rapid checks

## Architecture

```
┌─────────────────────────────────────────┐
│     SetupWizardWindow                    │
├─────────────────────────────────────────┤
│ [InitializeOnLoad] Static Constructor   │
│  - Check: lastVersion ≠ VERSION?        │
│  - Defer: CheckSetupAndMaybeShowWindow  │
├─────────────────────────────────────────┤
│ async CheckSetupAndMaybeShowWindow()    │
│  - Await ForceRefreshCliVersionAsync()  │
│  - Check IsSetupComplete()              │
│  - Maybe call ShowWindow()              │
├─────────────────────────────────────────┤
│ static IsSetupComplete(): bool          │
│  ├─ IsCliInstalled() [gate]             │
│  ├─ DetectTargets()                     │
│  └─ All targets have skills? OR         │
│     No targets exist?                   │
├─────────────────────────────────────────┤
│ static SavePromptVersion()              │
│  - McpEditorSettings.UpdateSettings()   │
│  - Set lastSkillPromptVersion =         │
│    McpVersion.VERSION                   │
└─────────────────────────────────────────┘
        ↓ delegates to ↓
┌─────────────────────────────────────────┐
│  CliInstallationDetector                │
├─────────────────────────────────────────┤
│ ForceRefreshCliVersionAsync(ct)         │
│  - Always refresh cache, ignoring       │
│    _cacheInitialized flag               │
│                                         │
│ IsCliInstalled(): bool                  │
│  - GetCachedCliVersion() != null        │
│                                         │
│ GetCachedCliVersion(): string           │
│  - Return _cachedCliVersion if          │
│    _cacheInitialized                    │
└─────────────────────────────────────────┘
```

## Impact

- **Prevents spurious wizard display:** Package upgrades no longer trigger the wizard for fully configured users
- **Separates concerns:** CLI version mismatches no longer affect setup wizard logic; McpEditorWindow handles version-update prompts
- **Cleaner state management:** Consolidated startup into a single async path with clear readiness gates
- **Line changes:** +30/-13 in SetupWizardWindow.cs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->