### PR TITLE
fix: Prevent SetupWizardWindow from showing on package upgrade

### DIFF
--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -24,16 +24,10 @@ namespace io.github.hatayama.uLoopMCP
 
             // Static constructors cannot run async I/O, but CLI version check requires
             // spawning a process. Defer to delayCall so we can await the result.
-            if (string.IsNullOrEmpty(lastVersion))
-            {
-                EditorApplication.delayCall += CheckLegacySetupAndMaybeShowWindow;
-                return;
-            }
-
-            EditorApplication.delayCall += ShowWindow;
+            EditorApplication.delayCall += CheckSetupAndMaybeShowWindow;
         }
 
-        private static async void CheckLegacySetupAndMaybeShowWindow()
+        private static async void CheckSetupAndMaybeShowWindow()
         {
             await CliInstallationDetector.ForceRefreshCliVersionAsync(CancellationToken.None);
 
@@ -195,8 +189,8 @@ namespace io.github.hatayama.uLoopMCP
 
         private static bool IsSetupComplete()
         {
-            string cliVersion = CliInstallationDetector.GetCachedCliVersion();
-            if (!IsCliVersionMatched(cliVersion)) return false;
+            // Version mismatch alone should not trigger the wizard — McpEditorWindow handles CLI update prompts
+            if (!CliInstallationDetector.IsCliInstalled()) return false;
 
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = ToolSkillSynchronizer.DetectTargets();
             if (targets.Count == 0) return true;


### PR DESCRIPTION
## Summary

- Unify the static constructor's two startup paths (empty and mismatched `lastSkillPromptVersion`) into a single async readiness check (`CheckSetupAndMaybeShowWindow`)
- Relax `IsSetupComplete()` to use `IsCliInstalled()` instead of `IsCliVersionMatched()` — the wizard is for initial setup, not version updates
- CLI version update prompts remain handled by `McpEditorWindow`

## Problem

When upgrading the package (e.g., v1.5.1 → v1.6.1), the setup wizard appeared even for fully configured users. Two root causes:

1. The version-bump path in the static constructor called `ShowWindow()` directly without checking CLI/skills readiness
2. `IsSetupComplete()` required exact CLI version match, which always fails right after a package upgrade (CLI still at old version)

## Test plan

- [ ] Set `lastSkillPromptVersion` to `"1.5.1"` with CLI+Skills configured → wizard should NOT appear
- [ ] Delete `UnityMcpSettings.json` entirely → wizard should appear (new user)
- [ ] Set `lastSkillPromptVersion` to `""` with CLI not installed → wizard should appear
- [ ] Set `lastSkillPromptVersion` to `""` with CLI+Skills configured → wizard should NOT appear
- [ ] `uloop compile` passes with no errors or warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the setup wizard from appearing after package upgrades by running a single async readiness check and only showing the window when initial setup is needed. Users with CLI and skills already configured will no longer see the wizard on version bumps; CLI update prompts remain in McpEditorWindow.

- **Bug Fixes**
  - Unified both startup paths to use CheckSetupAndMaybeShowWindow via EditorApplication.delayCall instead of calling ShowWindow on version mismatch.
  - Loosened IsSetupComplete to require that the CLI is installed, not version-matched; version mismatches are handled by McpEditorWindow.

<sup>Written for commit c1ee0b29dd77f64efdf5df78e1749ae20836d316. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a regression where the SetupWizardWindow appeared on package upgrades for fully configured users.

### Problem
On package upgrades (e.g., v1.5.1 → v1.6.1), the setup wizard incorrectly appeared because:
1. The version-bump path in the static constructor called `ShowWindow()` directly without checking CLI/skills readiness
2. `IsSetupComplete()` required an exact CLI version match, which fails immediately after package upgrades while the CLI may still be at the old version

### Solution
- **Unified startup paths**: The static constructor now consistently defers to a single async readiness check function (`CheckSetupAndMaybeShowWindow`) for all cases—both when `lastSkillPromptVersion` is empty and when it's mismatched
- **Relaxed setup completion criteria**: `IsSetupComplete()` now checks only `IsCliInstalled()` instead of requiring an exact version match via `IsCliVersionMatched()`
- **Separated concerns**: CLI version update prompts are now exclusively handled by `McpEditorWindow`, while the setup wizard targets initial setup only

### Changes
- Updated static constructor to always use `EditorApplication.delayCall` with `CheckSetupAndMaybeShowWindow`
- Renamed async check method from `CheckLegacySetupAndMaybeShowWindow` to `CheckSetupAndMaybeShowWindow`
- Modified `IsSetupComplete()` to return `false` only when CLI is not installed, with a clarifying comment that version mismatch alone should not trigger the wizard
- Lines changed: +4/-10

### Testing Plan
- Verify wizard does not appear when `lastSkillPromptVersion` is set to an older version and CLI+Skills are configured
- Verify wizard appears for new users (deleted `UnityMcpSettings.json`) and when `lastSkillPromptVersion` is empty with CLI not installed
- Verify wizard does not appear when `lastSkillPromptVersion` is empty but CLI+Skills are already configured
- Verify `uloop compile` passes with no errors or warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->