### PR TITLE
fix: Prevent CLI from connecting to wrong Unity instance via stale port

### DIFF
--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Security;
 
-using UnityEditor;
 using UnityEngine;
 
 namespace io.github.hatayama.uLoopMCP
@@ -755,8 +754,6 @@ namespace io.github.hatayama.uLoopMCP
                     // If SaveSettings runs first, legacy security fields are stripped from JSON
                     // because McpEditorSettingsData no longer defines them.
                     ULoopSettings.GetSettings();
-
-                    MigrateLegacyAutoStartIfNeeded(json);
                 }
                 else
                 {
@@ -769,37 +766,6 @@ namespace io.github.hatayama.uLoopMCP
                 throw new InvalidOperationException(
                     $"Failed to load MCP Editor settings from: {SettingsFilePath}. Settings file may be corrupted.", ex);
             }
-        }
-        
-        /// <summary>
-        /// One-time migration for legacy autoStartServer field.
-        /// Old versions persisted autoStartServer (true/false) and always set
-        /// isServerRunning=false on quit. New logic relies solely on isServerRunning,
-        /// so we translate the legacy intent: autoStartServer=true → isServerRunning=true.
-        /// After SaveSettings the legacy field disappears from JSON, preventing re-trigger.
-        /// </summary>
-        [Serializable]
-        private class LegacyAutoStartProbe
-        {
-            // Default matches old code's default (true), so missing field → true
-            public bool autoStartServer = true;
-        }
-
-        private static void MigrateLegacyAutoStartIfNeeded(string json)
-        {
-            LegacyAutoStartProbe probe = JsonUtility.FromJson<LegacyAutoStartProbe>(json);
-
-            // Field absent in JSON → probe uses default (true), but no legacy data exists
-            // Field present in JSON → real legacy value
-            bool hasLegacyField = json.Contains("\"autoStartServer\"");
-            if (!hasLegacyField)
-            {
-                return;
-            }
-
-            _cachedSettings.isServerRunning = probe.autoStartServer;
-
-            SaveSettings(_cachedSettings);
         }
 
         /// <summary>

--- a/Packages/src/Editor/Server/McpServerController.cs
+++ b/Packages/src/Editor/Server/McpServerController.cs
@@ -234,14 +234,11 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            bool wasRunning = McpEditorSettings.GetIsServerRunning();
             int savedPort = McpEditorSettings.GetCustomPort();
             bool isAfterCompile = McpEditorSettings.GetIsAfterCompile();
 
-            // If the server is already running (e.g., started from McpEditorWindow).
             if (mcpServer?.IsRunning == true)
             {
-                // Just clear the post-compilation flag and exit.
                 if (isAfterCompile)
                 {
                     McpEditorSettings.ClearAfterCompileFlag();
@@ -250,21 +247,9 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            // Clear the post-compilation flag.
             if (isAfterCompile)
             {
                 McpEditorSettings.ClearAfterCompileFlag();
-            }
-
-            if (mcpServer != null && mcpServer.IsRunning)
-            {
-                return;
-            }
-
-            if (!wasRunning && !isAfterCompile)
-            {
-                DeleteAllLockFiles();
-                return;
             }
 
             int portToUse = savedPort;
@@ -347,8 +332,8 @@ namespace io.github.hatayama.uLoopMCP
 
         /// <summary>
         /// Cleanup on Unity exit.
-        /// Disposes the TCP listener but preserves isServerRunning
-        /// so the server state can be restored on next Unity launch.
+        /// Disposes the TCP listener and marks the server as stopped so the CLI
+        /// does not attempt to connect to a stale port after the editor closes.
         /// </summary>
         private static void OnEditorQuitting()
         {
@@ -363,6 +348,7 @@ namespace io.github.hatayama.uLoopMCP
                     mcpServer = null;
                 }
             }
+            McpEditorSettings.ClearServerSession();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- `OnEditorQuitting()` now sets `isServerRunning=false` so the CLI immediately detects that the server is stopped, instead of trying a stale port that may have been reassigned to a different Unity instance
- `RestoreServerStateIfNeeded()` no longer checks `isServerRunning` — the MCP server always auto-starts on editor launch, removing the dual-purpose overload of `isServerRunning` (runtime state vs auto-start intent)
- Removed legacy `autoStartServer` migration code that was only needed for the old dual-purpose design

## Problem

When a user closes Unity for Project A, `isServerRunning` stays `true` (preserved for auto-restore). If another Unity instance (Project B) later binds to the same port, the CLI reads Project A's stale settings and connects to Project B — causing a confusing `ProjectMismatchError`.

## Test plan

- [ ] `uloop compile` succeeds with Unity running
- [ ] After closing Unity, `uloop compile` shows `UnityNotRunningError` (not `ProjectMismatchError`)
- [ ] Reopening Unity auto-starts the MCP server without issues
- [ ] Domain reload preserves server state correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the CLI from connecting to the wrong Unity project by clearing MCP server state on editor quit and always auto-starting the server on launch. This avoids stale port reuse and removes confusing project mismatch errors.

- **Bug Fixes**
  - On Unity exit, OnEditorQuitting() now clears the server session (`isServerRunning=false`) so the CLI won’t probe a reassigned port.
  - Simplified RestoreServerStateIfNeeded() to always start the MCP server on editor launch; removed legacy `autoStartServer` migration code.
  - After closing Unity, the CLI now reports UnityNotRunningError instead of ProjectMismatchError.

<sup>Written for commit f46c523fafaba96276f09051330ff6eafb906f91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Prevent CLI from Connecting to Wrong Unity Instance via Stale Port

## Problem
When Unity closes, the persisted `isServerRunning` flag could remain `true` for auto-restore purposes. If a different Unity instance (Project B) later binds to the same port number that was previously used by Project A, the CLI would read Project A's stale settings and attempt to connect to Project B's server, resulting in a `ProjectMismatchError`.

## Root Cause
The `isServerRunning` field served two conflicting purposes:
1. **Runtime State**: Indicates whether the server is currently running
2. **Auto-start Intent**: Signals whether the server should auto-start on editor launch

This dual purpose meant the persisted runtime state could cause incorrect connection attempts after editor closure.

## Solution

### 1. McpEditorSettings.cs (-34 lines)
**Removed legacy migration code**
- Deleted `MigrateLegacyAutoStartIfNeeded()` method that translated deprecated `autoStartServer` field to `isServerRunning`
- Removed `LegacyAutoStartProbe` internal probe type
- Eliminated migration invocation from `LoadSettings()`
- Removed unused `using UnityEditor;` directive

The migration code is no longer needed since the new design decouples runtime state from auto-start behavior.

### 2. McpServerController.cs (+3/-17 lines)
**Explicit server state management on editor quit**

**OnEditorQuitting():**
- Added `McpEditorSettings.ClearServerSession()` call after disposing the server instance
- Ensures the server is immediately marked as stopped when the editor closes
- Prevents CLI from reading stale port information after editor exit

**RestoreServerStateIfNeeded():**
- Removed dependency on persisted `wasRunning` flag and conditional early-return logic
- Removed conditional lock file cleanup based on previous server state
- Now unconditionally triggers `StartRecoveryIfNeededAsync()`
- MCP server always auto-starts on editor launch regardless of previous persistent state

## Architecture Impact
The changes separate two previously conflated responsibilities:
- **Runtime State** (`isServerRunning`): Now explicitly cleared on editor quit
- **Auto-start Intent**: Always enabled, ensuring MCP server auto-starts on every editor launch

This ensures the CLI sees the server as stopped when the editor closes, preventing stale port misconnection even if the state is preserved internally during the same session.

## Verification
- `uloop compile` succeeds when Unity is running
- After closing Unity, `uloop compile` shows `UnityNotRunningError` (not `ProjectMismatchError`)
- Reopening Unity auto-starts the MCP server without issues
- Domain reload preserves server state correctly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->