### PR TITLE
fix(ci): Use OIDC trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -65,8 +65,6 @@ jobs:
 
       - name: 🚀 Publish CLI to npm
         if: ${{ inputs.dry-run == false }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd Packages/src/Cli~
           npm publish --access public --provenance

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -61,8 +61,6 @@ jobs:
 
       - name: 🚀 Publish CLI to npm
         if: steps.check.outputs.already_published == 'false'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd Packages/src/Cli~
           npm publish --access public --provenance


### PR DESCRIPTION
## Summary

- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from `publish-on-release.yml` and `npm-publish.yml`
- Both workflows already have `id-token: write` permission and `registry-url` configured, so removing the automation token lets npm authenticate via GitHub OIDC — matching `release-please.yml`

## Root Cause

The npm automation token (`NPM_TOKEN`) is rejected by npm's 2FA policy:

```
403 Forbidden - Two-factor authentication is required to publish this package
but an automation token was specified
```

## After Merging

Run the `manual-npm-publish` workflow with ref `v1.6.4` to publish the missing version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch npm publishing to GitHub OIDC trusted publishing by removing `NPM_TOKEN` usage from `npm-publish.yml` and `publish-on-release.yml`. This fixes 2FA publish failures and aligns with `release-please.yml`.

- **Bug Fixes**
  - Publishing no longer fails with 403 due to npm 2FA.
  - Uses OIDC (`id-token: write` + `registry-url`) instead of `NODE_AUTH_TOKEN`.

- **Migration**
  - After merge, run the `manual-npm-publish` workflow with ref `v1.6.4` to publish the missing version.

<sup>Written for commit 4cf626aa610278d87edaf2cbafeb72ba60f5f653. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This change removes explicit NPM token-based authentication from GitHub workflows and enables GitHub OIDC (OpenID Connect) trusted publishing instead. This aligns the `publish-on-release.yml` and `npm-publish.yml` workflows with the already-compliant `release-please.yml` workflow.

## Changes
- **`.github/workflows/npm-publish.yml`**: Removed the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` environment variable from the "🚀 Publish CLI to npm" step
- **`.github/workflows/publish-on-release.yml`**: Removed the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` environment variable from the "🚀 Publish CLI to npm" step

Both workflows already contain the necessary configuration (`id-token: write` permission and `registry-url` setup) to support OIDC authentication via `actions/setup-node`.

## Root Cause
NPM's 2FA policy rejects automation tokens with the error: "403 Forbidden - Two-factor authentication is required to publish this package but an automation token was specified." Removing the explicit token allows npm to authenticate via GitHub's OIDC provider instead.

## Impact
- Publishing will now use GitHub OIDC tokens instead of static NPM automation tokens
- No breaking changes to public APIs or entity signatures
- The `npm publish --access public --provenance` commands remain unchanged

## Next Steps
After merging, manually run the `manual-npm-publish` workflow with ref `v1.6.4` to publish the missing version that failed during the previous publish attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->