### PR TITLE
fix(ci): Upgrade to Node.js 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: 📋 Check version

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ steps.release.outputs.pr != '' }}
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: 📦 Rebuild server bundle for Release PR
         if: ${{ steps.release.outputs.pr != '' }}


### PR DESCRIPTION
## Summary

- Upgrade `node-version` from `22` to `24` in `npm-publish.yml` and `release-please.yml`
- Only publish-related workflows are upgraded; build/test workflows stay on Node.js 22

## Why

Node.js 22 ships with npm 10.x which supports OIDC provenance signing but NOT OIDC authentication for the actual publish. Node.js 24 ships with npm 11.x which fully supports OIDC trusted publishing.

This was confirmed by comparing v1.6.3 (success, npm 11.12.1 via `npm install -g npm@latest`) with recent failures (npm 10.x).

## After Merging

Run `npm-publish` workflow with ref `v1.6.4` to publish the missing version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade publish workflows to Node.js 24 to use `npm` 11 OIDC trusted publishing and unblock releases. Updated `node-version` in `.github/workflows/npm-publish.yml` and `.github/workflows/release-please.yml`; build/test workflows stay on Node.js 22.

- **Migration**
  - After merge, run the `npm-publish` workflow with ref `v1.6.4` to publish the pending version.

<sup>Written for commit b50c2f1be1d21390b40df30e5d5ea14c57ea2dd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This pull request upgrades the Node.js runtime version from 22 to 24 in the npm publishing-related GitHub Actions workflows. The upgrade is necessary to enable full OIDC trusted publishing support, as Node.js 22 includes npm 10.x which lacks OIDC authentication capabilities, while Node.js 24 includes npm 11.x with complete OIDC support.

## Changes

### `.github/workflows/npm-publish.yml`
Updated the Node.js setup step from version `22` to `24` in the `actions/setup-node@v6` action. The workflow maintains its existing permissions (including `id-token: write` for OIDC) and publishing logic, with no other modifications to job conditions or build/publish control flow.

### `.github/workflows/release-please.yml`
Updated the Node.js setup step from version `22` to `24` in the `actions/setup-node@v6` action. All other workflow logic, release-please configuration, and rebuild commands remain unchanged.

## Scope
Only publishing-related workflows are upgraded. Build and test workflows remain on Node.js 22 to minimize unnecessary changes and maintain stability in the testing infrastructure.

## Post-Merge Action
The `npm-publish` workflow should be manually triggered with ref `v1.6.4` to publish the missing version after this change is merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->