### PR TITLE
fix: stabilize npm publishing and remove CLI bin warning

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,20 +11,6 @@ on:
         description: 'Dry run (skip actual publish)'
         type: boolean
         default: false
-  workflow_call:
-    inputs:
-      ref:
-        type: string
-        required: false
-        default: ''
-      dry-run:
-        type: boolean
-        required: false
-        default: false
-    secrets:
-      NPM_TOKEN:
-        description: 'npm authentication token for publishing'
-        required: true
 
 permissions:
   contents: read
@@ -84,8 +70,6 @@ jobs:
 
       - name: 🚀 Publish CLI to npm
         if: steps.version.outputs.already_published == 'false' && inputs.dry-run != true
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd Packages/src/Cli~
           npm publish --access public --provenance

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -5,18 +5,21 @@ on:
     types: [published]
 
 permissions:
+  actions: write
   contents: read
-  id-token: write  # Passed to npm-publish workflow for OIDC trusted publishing
 
 jobs:
-  publish:
+  dispatch-publish:
     if: startsWith(github.event.release.tag_name, 'v')
-    uses: ./.github/workflows/npm-publish.yml
-    with:
-      ref: ${{ github.event.release.tag_name }}
-      dry-run: false
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    permissions:
-      contents: read
-      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🚀 Dispatch npm-publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh workflow run npm-publish.yml \
+            --ref main \
+            -f ref="${RELEASE_TAG}" \
+            -f dry-run=false \
+            --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,6 @@ on:
         required: false
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
   issues: write
@@ -95,13 +94,49 @@ jobs:
     needs: release
     if: needs.release.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: 🚀 Dispatch npm-publish workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
           gh workflow run npm-publish.yml \
             --ref main \
             -f ref="${GITHUB_SHA}" \
             -f dry-run=false \
             --repo "${GITHUB_REPOSITORY}"
+
+          RUN_ID=""
+          for _ in 1 2 3 4 5; do
+            sleep 3
+            RUN_ID=$(
+              gh run list \
+                --workflow npm-publish.yml \
+                --event workflow_dispatch \
+                --commit "${GITHUB_SHA}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --limit 10 \
+                --json databaseId,createdAt \
+              | jq -r --arg started_at "${STARTED_AT}" '
+                  map(select(.createdAt >= $started_at))
+                  | sort_by(.createdAt)
+                  | last
+                  | .databaseId // empty
+                '
+            )
+
+            if [ -n "${RUN_ID}" ]; then
+              break
+            fi
+          done
+
+          if [ -z "${RUN_ID}" ]; then
+            echo "Failed to find the dispatched npm-publish workflow run." >&2
+            exit 1
+          fi
+
+          gh run watch "${RUN_ID}" --exit-status --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,10 +12,10 @@ on:
         required: false
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
   issues: write
-  id-token: write  # Passed to npm-publish workflow for OIDC trusted publishing
 
 jobs:
   release:
@@ -87,19 +87,21 @@ jobs:
             echo "✅ Server bundle rebuilt and pushed to PR"
           fi
 
-  # ── Publish to npm when release is created ──────────────────
-  # GITHUB_TOKEN-created releases do NOT trigger other workflows (e.g. publish-on-release.yml),
-  # so we call npm-publish.yml here for release-please releases.
-  # publish-on-release.yml handles manually-created GitHub Releases.
-  publish:
+  # ── Dispatch npm-publish when release is created ────────────
+  # Keep npm-publish.yml as the single trusted publisher entrypoint.
+  # GITHUB_TOKEN-created releases do not trigger publish-on-release.yml,
+  # so release-please must explicitly dispatch npm-publish.yml here.
+  dispatch-publish:
     needs: release
     if: needs.release.outputs.releases_created == 'true'
-    uses: ./.github/workflows/npm-publish.yml
-    with:
-      ref: ${{ github.sha }}
-      dry-run: false
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    permissions:
-      contents: read
-      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🚀 Dispatch npm-publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run npm-publish.yml \
+            --ref main \
+            -f ref="${GITHUB_SHA}" \
+            -f dry-run=false \
+            --repo "${GITHUB_REPOSITORY}"

--- a/Packages/src/Cli~/package.json
+++ b/Packages/src/Cli~/package.json
@@ -5,7 +5,7 @@
   "description": "CLI tool for Unity Editor communication via Unity CLI Loop",
   "main": "dist/cli.bundle.cjs",
   "bin": {
-    "uloop": "./dist/cli.bundle.cjs"
+    "uloop": "dist/cli.bundle.cjs"
   },
   "type": "module",
   "scripts": {

--- a/Packages/src/Cli~/src/__tests__/package-metadata.test.ts
+++ b/Packages/src/Cli~/src/__tests__/package-metadata.test.ts
@@ -1,5 +1,4 @@
 // Test reads the checked-in manifest through a stable relative path during Jest execution.
-/* eslint-disable security/detect-non-literal-fs-filename */
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -10,6 +9,7 @@ type PackageManifest = {
 
 function loadPackageManifest(): PackageManifest {
   const packageJsonPath = join(__dirname, '..', '..', 'package.json');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
   const packageJsonText = readFileSync(packageJsonPath, 'utf8');
   return JSON.parse(packageJsonText) as PackageManifest;
 }

--- a/Packages/src/Cli~/src/__tests__/package-metadata.test.ts
+++ b/Packages/src/Cli~/src/__tests__/package-metadata.test.ts
@@ -1,0 +1,28 @@
+// Test reads the checked-in manifest through a stable relative path during Jest execution.
+/* eslint-disable security/detect-non-literal-fs-filename */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+type PackageManifest = {
+  readonly bin?: Record<string, string>;
+};
+
+function loadPackageManifest(): PackageManifest {
+  const packageJsonPath = join(__dirname, '..', '..', 'package.json');
+  const packageJsonText = readFileSync(packageJsonPath, 'utf8');
+  return JSON.parse(packageJsonText) as PackageManifest;
+}
+
+describe('package metadata', () => {
+  it('avoids bin target prefixes that npm normalizes during publish', () => {
+    const packageManifest = loadPackageManifest();
+    const binEntries = Object.entries(packageManifest.bin ?? {});
+
+    expect(binEntries.length).toBeGreaterThan(0);
+
+    for (const [, binTarget] of binEntries) {
+      expect(binTarget).not.toMatch(/^(?:\.{1,2}[\\/]|[\\/])/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- keep npm-publish as the single trusted publishing entrypoint by dispatching it from the release workflows instead of reusing it as a callable workflow
- remove the leading ./ from the CLI bin path so npm publish no longer normalizes it with a warning
- add a regression test that guards the CLI package metadata against publish-time bin path rewrites

## Testing
- npm run lint
- npm run build
- npx jest --runTestsByPath src/__tests__/package-metadata.test.ts --runInBand
- npm publish --dry-run

## Issues
- Closes #915

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes npm publishing by dispatching a single trusted `npm-publish.yml` and making `release-please.yml` wait for the publish to finish. Also removes the CLI bin warning by aligning the bin path with npm’s normalized form. Closes #915.

- **Refactors**
  - Dispatch `npm-publish.yml` via `gh workflow run` from both `release-please.yml` and `publish-on-release.yml`, keeping one publisher entrypoint.
  - Remove the reusable workflow path and token wiring; use minimal permissions for dispatch and move `actions: write` to the dispatch job.
  - In `release-please.yml`, locate the dispatched run and `gh run watch` it so publish failures fail the release job.

- **Bug Fixes**
  - Change CLI `bin` from "./dist/cli.bundle.cjs" to "dist/cli.bundle.cjs" to avoid npm 11 publish warnings.
  - Add a regression test to prevent publish-time bin path rewrites.

<sup>Written for commit eef5cdb994d9e041e2049d15583b161c6c988de5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR stabilizes npm publishing by converting from a reusable workflow pattern to an explicit workflow dispatch mechanism, and eliminates an npm publish normalization warning by removing the leading `./` prefix from the CLI `bin` path.

## Changes

### Workflow Architecture Refactoring

The npm publishing workflow now operates as a single trusted entrypoint triggered via explicit dispatch rather than reusable workflow invocations:

- **npm-publish.yml**: Transitioned from `workflow_call` (reusable workflow) to `workflow_dispatch` (manual trigger). Retains support for optional `ref` (git ref, defaults to main branch) and `dry-run` inputs. Maintains OIDC-based npm authentication via `id-token: write` permission.

- **publish-on-release.yml**: Replaced direct reusable workflow invocation (`uses:`) with GitHub CLI dispatch (`gh workflow run npm-publish.yml`). The job now uses `GITHUB_TOKEN` for authorization instead of passing `NPM_TOKEN` directly, and adds `permissions: actions: write` to enable workflow dispatch capability.

- **release-please.yml**: Similarly updated to dispatch `npm-publish.yml` via `gh workflow run` instead of directly invoking the reusable workflow. The dispatch targets `main` branch and passes the release `GITHUB_SHA` as the `ref` input.

### Package Metadata Fix

**Packages/src/Cli~/package.json**: Removed the leading `./` from the CLI executable path, changing `bin.uloop` from `./dist/cli.bundle.cjs` to `dist/cli.bundle.cjs`. This aligns the metadata with npm 11's path normalization behavior, which previously caused npm to warn that the entry was invalid and remove it during publish.

### Regression Test

**Packages/src/Cli~/src/__tests__/package-metadata.test.ts**: Added a Jest test suite that validates the package manifest's `bin` entries do not contain problematic path prefixes (`./`, `../`, `/`, or `\`). This guards against reintroducing the leading `./` prefix in future changes and ensures compliance with npm's publish-time path normalization expectations.

## Impact

- Eliminates the npm publish warning: `npm warn publish "bin[uloop]" script name was invalid and removed`
- Centralizes publishing logic in a single workflow, reducing configuration complexity and potential drift
- Ensures the CLI remains globally executable after npm normalization
- Prevents regression through automated test coverage of package metadata constraints

## Validation

PR includes standard testing (lint, build, unit tests) and `npm publish --dry-run` verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->