### PR TITLE
fix: show the setup wizard when the package version changes

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -1,0 +1,96 @@
+using System.IO;
+
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP.Tests.Editor
+{
+    public class SetupWizardWindowTests
+    {
+        private static readonly string SettingsFilePath =
+            Path.Combine(McpConstants.USER_SETTINGS_FOLDER, McpConstants.SETTINGS_FILE_NAME);
+
+        private bool _settingsFileExisted;
+        private string _settingsFileContent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _settingsFileExisted = File.Exists(SettingsFilePath);
+            _settingsFileContent = _settingsFileExisted ? File.ReadAllText(SettingsFilePath) : null;
+
+            if (!Directory.Exists(McpConstants.USER_SETTINGS_FOLDER))
+            {
+                Directory.CreateDirectory(McpConstants.USER_SETTINGS_FOLDER);
+            }
+
+            DeleteIfExists(SettingsFilePath);
+            McpEditorSettings.InvalidateCache();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            RestoreFile(SettingsFilePath, _settingsFileExisted, _settingsFileContent);
+            McpEditorSettings.InvalidateCache();
+        }
+
+        [TestCase("", "1.7.3", true)]
+        [TestCase("1.7.2", "1.7.3", true)]
+        [TestCase("1.7.4", "1.7.3", true)]
+        [TestCase("1.7.3", "1.7.3", false)]
+        public void ShouldAutoShowForVersion_ReturnsExpectedValue(
+            string lastSeenVersion,
+            string currentVersion,
+            bool expected)
+        {
+            bool shouldAutoShow = SetupWizardWindow.ShouldAutoShowForVersion(currentVersion, lastSeenVersion);
+
+            Assert.That(shouldAutoShow, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void MaybeRecordLastSeenVersion_WhenAutoShow_UpdatesStoredVersion()
+        {
+            McpEditorSettings.SaveSettings(new McpEditorSettingsData
+            {
+                lastSeenSetupWizardVersion = "1.7.2"
+            });
+
+            SetupWizardWindow.MaybeRecordLastSeenVersion(true, "1.7.3");
+
+            Assert.That(McpEditorSettings.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.3"));
+        }
+
+        [Test]
+        public void MaybeRecordLastSeenVersion_WhenManualShow_KeepsStoredVersion()
+        {
+            McpEditorSettings.SaveSettings(new McpEditorSettingsData
+            {
+                lastSeenSetupWizardVersion = "1.7.2"
+            });
+
+            SetupWizardWindow.MaybeRecordLastSeenVersion(false, "1.7.3");
+
+            Assert.That(McpEditorSettings.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
+        }
+
+        private static void RestoreFile(string path, bool existed, string content)
+        {
+            if (existed)
+            {
+                File.WriteAllText(path, content);
+                return;
+            }
+
+            DeleteIfExists(path);
+        }
+
+        private static void DeleteIfExists(string path)
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs.meta
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d0f04ebbffad3447e81c32fcf2d34736
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -29,6 +29,7 @@ namespace io.github.hatayama.uLoopMCP
         public bool enableCommunicationLogs = false;
         public bool enableDevelopmentMode = false;
         public string lastUsedConfigPath = "";
+        public string lastSeenSetupWizardVersion = "";
 
         // UI State Settings
         public bool showSecuritySettings = true;
@@ -213,6 +214,19 @@ namespace io.github.hatayama.uLoopMCP
         public static bool GetEnableCommunicationLogs()
         {
             return GetSettings().enableCommunicationLogs;
+        }
+
+        public static string GetLastSeenSetupWizardVersion()
+        {
+            return GetSettings().lastSeenSetupWizardVersion ?? string.Empty;
+        }
+
+        public static void SetLastSeenSetupWizardVersion(string version)
+        {
+            string normalizedVersion = version ?? string.Empty;
+            McpEditorSettingsData settings = GetSettings();
+            McpEditorSettingsData updatedSettings = settings with { lastSeenSetupWizardVersion = normalizedVersion };
+            SaveSettings(updatedSettings);
         }
 
         /// <summary>

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -57,10 +57,10 @@ namespace io.github.hatayama.uLoopMCP
 
         private static void ShowWindowInternal(bool shouldRecordVersion)
         {
-            MaybeRecordLastSeenVersion(shouldRecordVersion, McpConstants.PackageInfo.version);
             SetupWizardWindow window = GetWindow<SetupWizardWindow>(true, "Unity CLI Loop Setup");
             window.minSize = new Vector2(400, 350);
             window.ShowUtility();
+            MaybeRecordLastSeenVersion(shouldRecordVersion, McpConstants.PackageInfo.version);
         }
 
         // Prerequisite

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -79,14 +79,12 @@ namespace io.github.hatayama.uLoopMCP
         private Button _installSkillsButton;
 
         // Footer
-        private Button _skipButton;
         private Button _openSettingsButton;
         private Button _closeButton;
 
         // State
         private bool _isInstallingCli;
         private bool _isInstallingSkills;
-        private bool _isSkipped;
 
         private void CreateGUI()
         {
@@ -123,7 +121,6 @@ namespace io.github.hatayama.uLoopMCP
             _skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
             _installSkillsButton = rootVisualElement.Q<Button>("install-skills-button");
 
-            _skipButton = rootVisualElement.Q<Button>("skip-button");
             _openSettingsButton = rootVisualElement.Q<Button>("open-settings-button");
             _closeButton = rootVisualElement.Q<Button>("close-button");
         }
@@ -133,7 +130,6 @@ namespace io.github.hatayama.uLoopMCP
             _refreshButton.clicked += () => RefreshUI();
             _installCliButton.clicked += HandleInstallCli;
             _installSkillsButton.clicked += HandleInstallSkills;
-            _skipButton.clicked += HandleSkip;
             _openSettingsButton.clicked += HandleOpenSettings;
             _closeButton.clicked += HandleClose;
         }
@@ -155,7 +151,6 @@ namespace io.github.hatayama.uLoopMCP
                 _installSkillsButton.SetEnabled(false);
                 _skillsStatusLabel.text = "";
                 _skillsTargetList.Clear();
-                _skipButton.SetEnabled(false);
                 return;
             }
 
@@ -218,7 +213,6 @@ namespace io.github.hatayama.uLoopMCP
             {
                 _skillsStatusLabel.text = "";
                 _installSkillsButton.SetEnabled(false);
-                _skipButton.SetEnabled(false);
                 return;
             }
 
@@ -248,21 +242,12 @@ namespace io.github.hatayama.uLoopMCP
                 _skillsStatusLabel.text = $"Installed for {targets.Count} targets";
                 _installSkillsButton.SetEnabled(false);
                 _installSkillsButton.text = "Installed";
-                _skipButton.SetEnabled(false);
-            }
-            else if (_isSkipped)
-            {
-                _skillsStatusLabel.text = "";
-                _installSkillsButton.SetEnabled(false);
-                _installSkillsButton.text = "Skipped";
-                _skipButton.SetEnabled(false);
             }
             else
             {
                 _skillsStatusLabel.text = "";
                 _installSkillsButton.SetEnabled(!_isInstallingSkills);
                 _installSkillsButton.text = _isInstallingSkills ? "Installing..." : "Install Skills";
-                _skipButton.SetEnabled(true);
             }
         }
 
@@ -343,17 +328,6 @@ namespace io.github.hatayama.uLoopMCP
                 _isInstallingSkills = false;
                 RefreshUI();
             }
-        }
-
-        private void HandleSkip()
-        {
-            string cliVersion = CliInstallationDetector.GetCachedCliVersion();
-            Debug.Assert(IsCliVersionMatched(cliVersion), "HandleSkip requires CLI version match");
-
-            _isSkipped = true;
-            List<ToolSkillSynchronizer.SkillTargetInfo> targets = ToolSkillSynchronizer.DetectTargets();
-            UpdateSkillsStep(true, targets);
-            _openSettingsButton.SetEnabled(true);
         }
 
         private void HandleOpenSettings()

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -81,6 +81,7 @@ namespace io.github.hatayama.uLoopMCP
         // Footer
         private Button _skipButton;
         private Button _openSettingsButton;
+        private Button _closeButton;
 
         // State
         private bool _isInstallingCli;
@@ -124,6 +125,7 @@ namespace io.github.hatayama.uLoopMCP
 
             _skipButton = rootVisualElement.Q<Button>("skip-button");
             _openSettingsButton = rootVisualElement.Q<Button>("open-settings-button");
+            _closeButton = rootVisualElement.Q<Button>("close-button");
         }
 
         private void BindEvents()
@@ -133,6 +135,7 @@ namespace io.github.hatayama.uLoopMCP
             _installSkillsButton.clicked += HandleInstallSkills;
             _skipButton.clicked += HandleSkip;
             _openSettingsButton.clicked += HandleOpenSettings;
+            _closeButton.clicked += HandleClose;
         }
 
         private async void RefreshUI()
@@ -363,6 +366,11 @@ namespace io.github.hatayama.uLoopMCP
         private void HandleOpenSettings()
         {
             McpEditorWindow.ShowWindow();
+            Close();
+        }
+
+        private void HandleClose()
+        {
             Close();
         }
 

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -156,7 +156,6 @@ namespace io.github.hatayama.uLoopMCP
                 _skillsStatusLabel.text = "";
                 _skillsTargetList.Clear();
                 _skipButton.SetEnabled(false);
-                _openSettingsButton.SetEnabled(false);
                 return;
             }
 
@@ -169,12 +168,6 @@ namespace io.github.hatayama.uLoopMCP
 
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = ToolSkillSynchronizer.DetectTargets();
             UpdateSkillsStep(cliVersionMatched, targets);
-
-            bool noTargets = targets.Count == 0;
-            bool allSkillsInstalled = targets.Count > 0
-                && targets.All(t => t.HasExistingSkills);
-            bool step2Done = allSkillsInstalled || noTargets || _isSkipped;
-            _openSettingsButton.SetEnabled(cliVersionMatched && step2Done);
         }
 
         private void UpdateCliStep(bool cliInstalled, string cliVersion, bool cliVersionMatched)

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 
@@ -20,16 +19,45 @@ namespace io.github.hatayama.uLoopMCP
             if (AssetDatabase.IsAssetImportWorkerProcess()) return;
             if (Application.isBatchMode) return;
 
-            // GetSettings() auto-creates the file, so calling it first would make the check always pass
-            string settingsPath = Path.Combine(McpConstants.USER_SETTINGS_FOLDER, McpConstants.SETTINGS_FILE_NAME);
-            if (File.Exists(settingsPath)) return;
-
-            EditorApplication.delayCall += ShowWindow;
+            TryShowOnVersionChange();
         }
 
         [MenuItem("Window/Unity CLI Loop/Setup Wizard", priority = 3)]
         public static void ShowWindow()
         {
+            ShowWindowInternal(false);
+        }
+
+        internal static bool ShouldAutoShowForVersion(string currentVersion, string lastSeenVersion)
+        {
+            return !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
+        }
+
+        internal static void MaybeRecordLastSeenVersion(bool shouldRecordVersion, string version)
+        {
+            if (!shouldRecordVersion) return;
+
+            Debug.Assert(!string.IsNullOrEmpty(version), "version must not be null or empty");
+            McpEditorSettings.SetLastSeenSetupWizardVersion(version);
+        }
+
+        private static void TryShowOnVersionChange()
+        {
+            string currentVersion = McpConstants.PackageInfo.version;
+            string lastSeenVersion = McpEditorSettings.GetLastSeenSetupWizardVersion();
+            if (!ShouldAutoShowForVersion(currentVersion, lastSeenVersion)) return;
+
+            EditorApplication.delayCall += ShowWindowOnVersionChange;
+        }
+
+        private static void ShowWindowOnVersionChange()
+        {
+            ShowWindowInternal(true);
+        }
+
+        private static void ShowWindowInternal(bool shouldRecordVersion)
+        {
+            MaybeRecordLastSeenVersion(shouldRecordVersion, McpConstants.PackageInfo.version);
             SetupWizardWindow window = GetWindow<SetupWizardWindow>(true, "Unity CLI Loop Setup");
             window.minSize = new Vector2(400, 350);
             window.ShowUtility();

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
@@ -168,6 +168,15 @@
     border-top-color: var(--unity-colors-helpbox-border);
 }
 
+.setup-footer__button-row {
+    flex-direction: row;
+}
+
+.setup-footer__button-row .setup-button {
+    flex-grow: 1;
+    flex-basis: 0;
+}
+
 .setup-step__button-row {
     flex-direction: row;
 }

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
@@ -36,9 +36,18 @@
     border-color: #2e7d32;
 }
 
+.setup-prerequisite--compact {
+    justify-content: center;
+    min-height: 36px;
+}
+
 .setup-prerequisite__title {
     -unity-font-style: bold;
     margin-bottom: 4px;
+}
+
+.setup-prerequisite--compact .setup-prerequisite__title {
+    margin-bottom: 0;
 }
 
 .setup-prerequisite--warning .setup-prerequisite__title {

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -7,7 +7,7 @@
             <ui:Label text="Please install Node.js to continue." class="setup-prerequisite__message" />
             <ui:Button name="refresh-button" text="Refresh" class="setup-button setup-button--small" />
         </ui:VisualElement>
-        <ui:VisualElement name="nodejs-ok" class="setup-prerequisite setup-prerequisite--ok setup-hidden">
+        <ui:VisualElement name="nodejs-ok" class="setup-prerequisite setup-prerequisite--ok setup-prerequisite--compact setup-hidden">
             <ui:Label text="✓ Node.js detected" class="setup-prerequisite__title" />
         </ui:VisualElement>
 
@@ -31,7 +31,6 @@
                 <ui:Label name="skills-status-label" text="" class="setup-step__status-label" />
                 <ui:VisualElement class="setup-step__button-row">
                     <ui:Button name="install-skills-button" text="Install Skills" class="setup-button" />
-                    <ui:Button name="skip-button" text="Skip" class="setup-button" />
                 </ui:VisualElement>
                 <ui:Label name="skills-hint-label" text="You can install skills later from Window &gt; Unity CLI Loop &gt; Settings." class="setup-step__hint-label" />
             </ui:VisualElement>

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -39,7 +39,10 @@
 
         <!-- Footer -->
         <ui:VisualElement class="setup-footer">
-            <ui:Button name="open-settings-button" text="Open Settings" class="setup-button setup-button--primary" />
+            <ui:VisualElement class="setup-footer__button-row">
+                <ui:Button name="open-settings-button" text="Open Settings" class="setup-button setup-button--primary" />
+                <ui:Button name="close-button" text="Close" class="setup-button" />
+            </ui:VisualElement>
         </ui:VisualElement>
     </ui:ScrollView>
 </ui:UXML>


### PR DESCRIPTION
## Summary
- show the setup wizard automatically whenever the package version differs from the last seen version
- stop relying on UnityMcpSettings.json existence so startup settings writes do not suppress the wizard
- add editor tests for version-change detection and seen-version recording

## Why
The setup wizard stopped appearing after package installs or version switches because other startup services could create UnityMcpSettings.json before the wizard checked for first-run state. Comparing package versions instead makes the behavior work consistently for upgrades, downgrades, and any other version change.

## Verification
- ran \{
  "Success": true,
  "ErrorCount": 0,
  "WarningCount": 0,
  "Errors": [],
  "Warnings": [],
  "Message": null,
  "Ver": "1.7.2"
} and confirmed 0 errors / 0 warnings
- attempted \, but the current CLI/server version mismatch prevented normal test result output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Setup Wizard automatically on package version changes and decouple it from settings file writes. The UI is simpler: Open Settings is always enabled, and a Close button lets users dismiss the wizard.

- **Bug Fixes**
  - Auto-show triggers once per version by comparing the current package version to the last seen version; no reliance on UnityMcpSettings.json.
  - Records `lastSeenSetupWizardVersion` only on auto-show and only after the window is shown.
  - Editor tests cover version-change detection and seen-version recording.

- **New Features**
  - Added a Close button; footer uses a 50/50 split with Open Settings and Close.
  - Removed Skip from Step 2; simplified skills flow.
  - Centered the Node.js “detected” row with a compact style.
  - Open Settings stays enabled at all times.

<sup>Written for commit e3d0932bdfe97ba9534d6fec39a2f13bc9d91497. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR implements automatic display of the setup wizard when the Unity CLI Loop package version changes, eliminating the dependency on the existence of UnityMcpSettings.json for first-run detection. It separates manual wizard invocation (which does not update the version tracker) from automatic version-change-triggered invocation (which records the current version).

## Architecture & Key Changes

```
SetupWizardWindow                McpEditorSettings
├── TryShowOnVersionChange()     ├── lastSeenSetupWizardVersion
├── ShouldAutoShowForVersion()   ├── GetLastSeenSetupWizardVersion()
├── MaybeRecordLastSeenVersion() └── SetLastSeenSetupWizardVersion()
└── ShowWindowInternal()
```

### Core Logic Changes

- Replaced file-existence gating with version comparison logic triggered at startup: if McpConstants.PackageInfo.version != McpEditorSettings.GetLastSeenSetupWizardVersion(), schedule the wizard via EditorApplication.delayCall.
- Added internal helpers: TryShowOnVersionChange(), ShowWindowOnVersionChange(), ShowWindowInternal(bool shouldRecordVersion), ShouldAutoShowForVersion(currentVersion, lastSeenVersion), MaybeRecordLastSeenVersion(shouldRecordVersion, version).
- ShowWindowInternal now accepts a flag controlling whether to record the version. Manual opens call ShowWindowInternal(false); auto-show uses true.
- Important timing fix: recording of lastSeenSetupWizardVersion is now performed after the window is actually requested to show (GetWindow()/ShowUtility()) to avoid marking versions as seen when window creation/display fails.

### Settings Persistence

- Added lastSeenSetupWizardVersion to McpEditorSettingsData (default "").
- Added McpEditorSettings.GetLastSeenSetupWizardVersion() and McpEditorSettings.SetLastSeenSetupWizardVersion(string).
- SetLastSeen normalizes null to empty string, updates cached settings via record with-expression and persists with SaveSettings().

### UI/UX Adjustments

- Removed Step 2 "Skip" button and related skip-state logic.
- Footer restructured: new setup-footer__button-row contains "Open Settings" and new "Close" buttons laid out 50/50; Close simply closes the wizard.
- Open Settings is always enabled (removed prior conditional enabling based on Node.js/CLI/Skills).
- Simplified Step 2 flow and compacted Node.js detected UI with setup-prerequisite--compact styling.

### Tests

- Added Assets/Tests/Editor/SetupWizardWindowTests.cs which:
  - Preserves/restores user settings file state across SetUp/TearDown and invalidates McpEditorSettings cache.
  - Parameterized ShouldAutoShowForVersion_ReturnsExpectedValue covering empty/same/upgrade/downgrade cases.
  - Tests MaybeRecordLastSeenVersion behavior: updates stored version when autoShow=true; leaves stored version unchanged when autoShow=false.

### Impact Summary

- First-run detection no longer depends on external file creation; an empty lastSeenSetupWizardVersion indicates first run.
- The package version is recorded only when the wizard is auto-shown, and recording occurs after the window show request succeeds (reducing false positives when window creation fails).
- Manual wizard opens do not alter the recorded version.
- UI simplified: Step 2 streamlined, Open Settings always available, and footer provides balanced Open/Close actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->