### PR TITLE
fix: setup wizard no longer reappears or installs skills too eagerly

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -1,7 +1,9 @@
 using System.IO;
+using System.Collections.Generic;
 
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace io.github.hatayama.uLoopMCP.Tests.Editor
 {
@@ -116,6 +118,38 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
 
             Assert.That(resizedRect.position, Is.EqualTo(initialRect.position));
             Assert.That(resizedRect.size, Is.EqualTo(contentSize + frameSize));
+        }
+
+        [Test]
+        public void FilterInstallableSkillTargets_ReturnsOnlyOptedInTargets()
+        {
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = new()
+            {
+                new("Claude Code", ".claude", true, true),
+                new("Cursor", ".cursor", false, false)
+            };
+
+            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets =
+                SetupWizardWindow.FilterInstallableSkillTargets(targets);
+
+            Assert.That(installableTargets.Count, Is.EqualTo(1));
+            Assert.That(installableTargets[0].DirName, Is.EqualTo(".claude"));
+        }
+
+        [Test]
+        public void SelectPreferredTextRight_WhenTextWraps_UsesLaidOutWidth()
+        {
+            float preferredRight = SetupWizardWindow.SelectPreferredTextRight(180f, 320f, WhiteSpace.Normal);
+
+            Assert.That(preferredRight, Is.EqualTo(180f));
+        }
+
+        [Test]
+        public void SelectPreferredTextRight_WhenTextDoesNotWrap_UsesMeasuredWidth()
+        {
+            float preferredRight = SetupWizardWindow.SelectPreferredTextRight(180f, 320f, WhiteSpace.NoWrap);
+
+            Assert.That(preferredRight, Is.EqualTo(320f));
         }
 
         private static void RestoreFile(string path, bool existed, string content)

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -137,19 +137,35 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
-        public void SelectPreferredTextRight_WhenTextWraps_UsesLaidOutWidth()
+        public void EstimateWrappedLineCount_WithPositiveHeight_ReturnsRoundedLineCount()
         {
-            float preferredRight = SetupWizardWindow.SelectPreferredTextRight(180f, 320f, WhiteSpace.Normal);
+            int lineCount = SetupWizardWindow.EstimateWrappedLineCount(35f, 12f);
 
-            Assert.That(preferredRight, Is.EqualTo(180f));
+            Assert.That(lineCount, Is.EqualTo(3));
         }
 
         [Test]
-        public void SelectPreferredTextRight_WhenTextDoesNotWrap_UsesMeasuredWidth()
+        public void SelectPreferredTextWidth_WhenWrappedAcrossManyLines_UsesTwoLineTarget()
         {
-            float preferredRight = SetupWizardWindow.SelectPreferredTextRight(180f, 320f, WhiteSpace.NoWrap);
+            float preferredWidth = SetupWizardWindow.SelectPreferredTextWidth(120f, 320f, 4, WhiteSpace.Normal);
 
-            Assert.That(preferredRight, Is.EqualTo(320f));
+            Assert.That(preferredWidth, Is.EqualTo(160f));
+        }
+
+        [Test]
+        public void SelectPreferredTextWidth_WhenWrappedAcrossTwoLines_KeepsLaidOutWidth()
+        {
+            float preferredWidth = SetupWizardWindow.SelectPreferredTextWidth(180f, 320f, 2, WhiteSpace.Normal);
+
+            Assert.That(preferredWidth, Is.EqualTo(180f));
+        }
+
+        [Test]
+        public void SelectPreferredTextWidth_WhenTextDoesNotWrap_UsesMeasuredWidth()
+        {
+            float preferredWidth = SetupWizardWindow.SelectPreferredTextWidth(180f, 320f, 1, WhiteSpace.NoWrap);
+
+            Assert.That(preferredWidth, Is.EqualTo(320f));
         }
 
         private static void RestoreFile(string path, bool existed, string content)

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 
 using NUnit.Framework;
+using UnityEngine;
 
 namespace io.github.hatayama.uLoopMCP.Tests.Editor
 {
@@ -102,6 +103,17 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             SetupWizardWindow.MaybeRecordSuppressedVersion(false, "1.7.3");
 
             Assert.That(McpEditorSettings.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
+        }
+
+        [Test]
+        public void WithFixedSize_OverridesSizeAndPreservesPosition()
+        {
+            Rect initialRect = new(123f, 456f, 789f, 321f);
+
+            Rect resizedRect = SetupWizardWindow.WithFixedSize(initialRect);
+
+            Assert.That(resizedRect.position, Is.EqualTo(initialRect.position));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(400f, 440f)));
         }
 
         private static void RestoreFile(string path, bool existed, string content)

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -113,7 +113,7 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             Rect resizedRect = SetupWizardWindow.WithFixedSize(initialRect);
 
             Assert.That(resizedRect.position, Is.EqualTo(initialRect.position));
-            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(400f, 440f)));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(400f, 410f)));
         }
 
         private static void RestoreFile(string path, bool existed, string content)

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -106,14 +106,16 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
-        public void WithFixedSize_OverridesSizeAndPreservesPosition()
+        public void WithContentSize_OverridesSizeAndPreservesPosition()
         {
             Rect initialRect = new(123f, 456f, 789f, 321f);
+            Vector2 contentSize = new(350f, 280f);
+            Vector2 frameSize = new(18f, 28f);
 
-            Rect resizedRect = SetupWizardWindow.WithFixedSize(initialRect);
+            Rect resizedRect = SetupWizardWindow.WithContentSize(initialRect, contentSize, frameSize);
 
             Assert.That(resizedRect.position, Is.EqualTo(initialRect.position));
-            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(400f, 410f)));
+            Assert.That(resizedRect.size, Is.EqualTo(contentSize + frameSize));
         }
 
         private static void RestoreFile(string path, bool existed, string content)

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -34,16 +34,20 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             McpEditorSettings.InvalidateCache();
         }
 
-        [TestCase("", "1.7.3", true)]
-        [TestCase("1.7.2", "1.7.3", true)]
-        [TestCase("1.7.4", "1.7.3", true)]
-        [TestCase("1.7.3", "1.7.3", false)]
+        [TestCase("", "1.7.3", false, true)]
+        [TestCase("1.7.2", "1.7.3", false, true)]
+        [TestCase("1.7.4", "1.7.3", false, true)]
+        [TestCase("1.7.3", "1.7.3", false, false)]
+        [TestCase("", "1.7.3", true, false)]
+        [TestCase("1.7.2", "1.7.3", true, false)]
         public void ShouldAutoShowForVersion_ReturnsExpectedValue(
             string lastSeenVersion,
             string currentVersion,
+            bool suppressAutoShow,
             bool expected)
         {
-            bool shouldAutoShow = SetupWizardWindow.ShouldAutoShowForVersion(currentVersion, lastSeenVersion);
+            bool shouldAutoShow =
+                SetupWizardWindow.ShouldAutoShowForVersion(currentVersion, lastSeenVersion, suppressAutoShow);
 
             Assert.That(shouldAutoShow, Is.EqualTo(expected));
         }
@@ -70,6 +74,32 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             });
 
             SetupWizardWindow.MaybeRecordLastSeenVersion(false, "1.7.3");
+
+            Assert.That(McpEditorSettings.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
+        }
+
+        [Test]
+        public void MaybeRecordSuppressedVersion_WhenAutoShowSuppressed_UpdatesStoredVersion()
+        {
+            McpEditorSettings.SaveSettings(new McpEditorSettingsData
+            {
+                lastSeenSetupWizardVersion = "1.7.2"
+            });
+
+            SetupWizardWindow.MaybeRecordSuppressedVersion(true, "1.7.3");
+
+            Assert.That(McpEditorSettings.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.3"));
+        }
+
+        [Test]
+        public void MaybeRecordSuppressedVersion_WhenAutoShowAllowed_KeepsStoredVersion()
+        {
+            McpEditorSettings.SaveSettings(new McpEditorSettingsData
+            {
+                lastSeenSetupWizardVersion = "1.7.2"
+            });
+
+            SetupWizardWindow.MaybeRecordSuppressedVersion(false, "1.7.3");
 
             Assert.That(McpEditorSettings.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
         }

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -100,6 +100,30 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public void DetectTargets_WhenParentDirectoryExists_ReportsTargetAsNotOptedIn()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            {
+                Directory.CreateDirectory(Path.Combine(temporaryRoot, dir));
+            }
+
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+                    temporaryRoot,
+                    requireSkillsDirectory: false)
+                .ToArray();
+
+            Assert.AreEqual(ToolSkillSynchronizer.SkillTargetDirs.Length, detectedTargets.Length);
+            foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
+            {
+                Assert.IsFalse(target.HasSkillsDirectory,
+                    $"Target '{target.DirName}' should not be opted in without a skills directory");
+                Assert.IsFalse(target.HasExistingSkills,
+                    $"Target '{target.DirName}' should not be treated as installed without a skills directory");
+            }
+        }
+
+        [Test]
         public void DetectTargets_IncludesTargetsWhenSkillsDirectoryExists()
         {
             // Arrange
@@ -119,6 +143,8 @@ namespace io.github.hatayama.uLoopMCP
 
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
             {
+                Assert.IsTrue(target.HasSkillsDirectory,
+                    $"Target '{target.DirName}' should report that its skills directory exists");
                 Assert.IsFalse(target.HasExistingSkills,
                     $"Target '{target.DirName}' should not be treated as already installed when skills directory is empty");
             }

--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -30,6 +30,7 @@ namespace io.github.hatayama.uLoopMCP
         public bool enableDevelopmentMode = false;
         public string lastUsedConfigPath = "";
         public string lastSeenSetupWizardVersion = "";
+        public bool suppressSetupWizardAutoShow = false;
 
         // UI State Settings
         public bool showSecuritySettings = true;
@@ -226,6 +227,18 @@ namespace io.github.hatayama.uLoopMCP
             string normalizedVersion = version ?? string.Empty;
             McpEditorSettingsData settings = GetSettings();
             McpEditorSettingsData updatedSettings = settings with { lastSeenSetupWizardVersion = normalizedVersion };
+            SaveSettings(updatedSettings);
+        }
+
+        public static bool GetSuppressSetupWizardAutoShow()
+        {
+            return GetSettings().suppressSetupWizardAutoShow;
+        }
+
+        public static void SetSuppressSetupWizardAutoShow(bool suppressAutoShow)
+        {
+            McpEditorSettingsData settings = GetSettings();
+            McpEditorSettingsData updatedSettings = settings with { suppressSetupWizardAutoShow = suppressAutoShow };
             SaveSettings(updatedSettings);
         }
 

--- a/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
@@ -53,12 +53,18 @@ namespace io.github.hatayama.uLoopMCP
         {
             public readonly string DisplayName;
             public readonly string DirName;
+            public readonly bool HasSkillsDirectory;
             public readonly bool HasExistingSkills;
 
-            public SkillTargetInfo(string displayName, string dirName, bool hasExistingSkills)
+            public SkillTargetInfo(
+                string displayName,
+                string dirName,
+                bool hasSkillsDirectory,
+                bool hasExistingSkills)
             {
                 DisplayName = displayName;
                 DirName = dirName;
+                HasSkillsDirectory = hasSkillsDirectory;
                 HasExistingSkills = hasExistingSkills;
             }
         }
@@ -153,15 +159,20 @@ namespace io.github.hatayama.uLoopMCP
                 }
 
                 string skillsRoot = Path.Combine(targetRoot, SkillsDirName);
-                if (requireSkillsDirectory && !Directory.Exists(skillsRoot))
+                bool hasSkillsDirectory = Directory.Exists(skillsRoot);
+                if (requireSkillsDirectory && !hasSkillsDirectory)
                 {
                     continue;
                 }
 
-                bool hasULoopSkills = Directory.Exists(skillsRoot)
+                bool hasULoopSkills = hasSkillsDirectory
                     && Directory.EnumerateDirectories(skillsRoot, CliConstants.SKILL_DIR_GLOB)
                         .Any(skillDir => File.Exists(Path.Combine(skillDir, SkillFileName)));
-                targets.Add(new SkillTargetInfo(target.DisplayName, target.DirName, hasULoopSkills));
+                targets.Add(new SkillTargetInfo(
+                    target.DisplayName,
+                    target.DirName,
+                    hasSkillsDirectory,
+                    hasULoopSkills));
             }
 
             return targets;

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -73,7 +73,7 @@ namespace io.github.hatayama.uLoopMCP
         private static void ShowWindowInternal(bool shouldRecordVersion)
         {
             SetupWizardWindow window = GetWindow<SetupWizardWindow>(true, "Unity CLI Loop Setup");
-            window.minSize = new Vector2(400, 380);
+            window.minSize = new Vector2(400, 440);
             window.ShowUtility();
             MaybeRecordLastSeenVersion(shouldRecordVersion, McpConstants.PackageInfo.version);
         }

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -28,8 +28,13 @@ namespace io.github.hatayama.uLoopMCP
             ShowWindowInternal(false);
         }
 
-        internal static bool ShouldAutoShowForVersion(string currentVersion, string lastSeenVersion)
+        internal static bool ShouldAutoShowForVersion(
+            string currentVersion,
+            string lastSeenVersion,
+            bool suppressAutoShow)
         {
+            if (suppressAutoShow) return false;
+
             return !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
         }
 
@@ -41,11 +46,21 @@ namespace io.github.hatayama.uLoopMCP
             McpEditorSettings.SetLastSeenSetupWizardVersion(version);
         }
 
+        internal static void MaybeRecordSuppressedVersion(bool suppressAutoShow, string version)
+        {
+            if (!suppressAutoShow) return;
+
+            Debug.Assert(!string.IsNullOrEmpty(version), "version must not be null or empty");
+            McpEditorSettings.SetLastSeenSetupWizardVersion(version);
+        }
+
         private static void TryShowOnVersionChange()
         {
             string currentVersion = McpConstants.PackageInfo.version;
+            bool suppressAutoShow = McpEditorSettings.GetSuppressSetupWizardAutoShow();
+            MaybeRecordSuppressedVersion(suppressAutoShow, currentVersion);
             string lastSeenVersion = McpEditorSettings.GetLastSeenSetupWizardVersion();
-            if (!ShouldAutoShowForVersion(currentVersion, lastSeenVersion)) return;
+            if (!ShouldAutoShowForVersion(currentVersion, lastSeenVersion, suppressAutoShow)) return;
 
             EditorApplication.delayCall += ShowWindowOnVersionChange;
         }
@@ -58,7 +73,7 @@ namespace io.github.hatayama.uLoopMCP
         private static void ShowWindowInternal(bool shouldRecordVersion)
         {
             SetupWizardWindow window = GetWindow<SetupWizardWindow>(true, "Unity CLI Loop Setup");
-            window.minSize = new Vector2(400, 350);
+            window.minSize = new Vector2(400, 380);
             window.ShowUtility();
             MaybeRecordLastSeenVersion(shouldRecordVersion, McpConstants.PackageInfo.version);
         }
@@ -79,6 +94,7 @@ namespace io.github.hatayama.uLoopMCP
         private Button _installSkillsButton;
 
         // Footer
+        private Toggle _suppressAutoShowToggle;
         private Button _openSettingsButton;
         private Button _closeButton;
 
@@ -121,6 +137,7 @@ namespace io.github.hatayama.uLoopMCP
             _skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
             _installSkillsButton = rootVisualElement.Q<Button>("install-skills-button");
 
+            _suppressAutoShowToggle = rootVisualElement.Q<Toggle>("suppress-auto-show-toggle");
             _openSettingsButton = rootVisualElement.Q<Button>("open-settings-button");
             _closeButton = rootVisualElement.Q<Button>("close-button");
         }
@@ -130,12 +147,20 @@ namespace io.github.hatayama.uLoopMCP
             _refreshButton.clicked += () => RefreshUI();
             _installCliButton.clicked += HandleInstallCli;
             _installSkillsButton.clicked += HandleInstallSkills;
+            _suppressAutoShowToggle.RegisterValueChangedCallback(evt => HandleSuppressAutoShowChanged(evt.newValue));
             _openSettingsButton.clicked += HandleOpenSettings;
             _closeButton.clicked += HandleClose;
         }
 
+        private void RefreshAutoShowToggle()
+        {
+            _suppressAutoShowToggle.SetValueWithoutNotify(McpEditorSettings.GetSuppressSetupWizardAutoShow());
+        }
+
         private async void RefreshUI()
         {
+            RefreshAutoShowToggle();
+
             string nodePath = NodeEnvironmentResolver.FindNodePath();
             bool nodeDetected = !string.IsNullOrEmpty(nodePath);
 
@@ -334,6 +359,12 @@ namespace io.github.hatayama.uLoopMCP
         {
             McpEditorWindow.ShowWindow();
             Close();
+        }
+
+        private void HandleSuppressAutoShowChanged(bool suppressAutoShow)
+        {
+            McpEditorSettings.SetSuppressSetupWizardAutoShow(suppressAutoShow);
+            MaybeRecordSuppressedVersion(suppressAutoShow, McpConstants.PackageInfo.version);
         }
 
         private void HandleClose()

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -12,7 +12,7 @@ namespace io.github.hatayama.uLoopMCP
     {
         private const string UXML_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uxml";
         private const string USS_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uss";
-        private static readonly Vector2 FixedWindowSize = new(400f, 440f);
+        private static readonly Vector2 FixedWindowSize = new(400f, 410f);
 
         [InitializeOnLoadMethod]
         private static void InitializeOnLoad()

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.uLoopMCP
     {
         private const string UXML_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uxml";
         private const string USS_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uss";
+        private const int PreferredWrappedTextLineCount = 2;
 
         [InitializeOnLoadMethod]
         private static void InitializeOnLoad()
@@ -468,21 +469,33 @@ namespace io.github.hatayama.uLoopMCP
                 if (string.IsNullOrEmpty(textElement.text)) continue;
 
                 float left = textElement.worldBound.xMin - contentContainer.worldBound.xMin;
-                float laidOutRight = textElement.worldBound.xMax - contentContainer.worldBound.xMin;
+                float horizontalChrome =
+                    textElement.resolvedStyle.paddingLeft
+                    + textElement.resolvedStyle.paddingRight
+                    + textElement.resolvedStyle.borderLeftWidth
+                    + textElement.resolvedStyle.borderRightWidth;
+                float verticalChrome =
+                    textElement.resolvedStyle.paddingTop
+                    + textElement.resolvedStyle.paddingBottom
+                    + textElement.resolvedStyle.borderTopWidth
+                    + textElement.resolvedStyle.borderBottomWidth;
+                float laidOutWidth = textElement.worldBound.width;
                 Vector2 measuredTextSize = textElement.MeasureTextSize(
                     textElement.text,
                     0f,
                     VisualElement.MeasureMode.Undefined,
                     0f,
                     VisualElement.MeasureMode.Undefined);
-                float measuredRight =
-                    left
-                    + measuredTextSize.x
-                    + textElement.resolvedStyle.paddingLeft
-                    + textElement.resolvedStyle.paddingRight
-                    + textElement.resolvedStyle.borderLeftWidth
-                    + textElement.resolvedStyle.borderRightWidth;
-                float right = SelectPreferredTextRight(laidOutRight, measuredRight, textElement.resolvedStyle.whiteSpace);
+                float measuredWidth = measuredTextSize.x + horizontalChrome;
+                int lineCount = EstimateWrappedLineCount(
+                    textElement.worldBound.height - verticalChrome,
+                    measuredTextSize.y);
+                float preferredWidth = SelectPreferredTextWidth(
+                    laidOutWidth,
+                    measuredWidth,
+                    lineCount,
+                    textElement.resolvedStyle.whiteSpace);
+                float right = left + preferredWidth;
                 maxRight = Mathf.Max(maxRight, right);
             }
 
@@ -492,9 +505,23 @@ namespace io.github.hatayama.uLoopMCP
                 + mainContainer.resolvedStyle.paddingRight);
         }
 
-        internal static float SelectPreferredTextRight(float laidOutRight, float measuredRight, WhiteSpace whiteSpace)
+        internal static int EstimateWrappedLineCount(float laidOutTextHeight, float singleLineTextHeight)
         {
-            return whiteSpace == WhiteSpace.Normal ? laidOutRight : measuredRight;
+            if (singleLineTextHeight <= 0f) return 1;
+
+            return Mathf.Max(1, Mathf.RoundToInt(laidOutTextHeight / singleLineTextHeight));
+        }
+
+        internal static float SelectPreferredTextWidth(
+            float laidOutWidth,
+            float measuredWidth,
+            int lineCount,
+            WhiteSpace whiteSpace)
+        {
+            if (whiteSpace != WhiteSpace.Normal) return measuredWidth;
+            if (lineCount <= PreferredWrappedTextLineCount) return laidOutWidth;
+
+            return Mathf.Max(laidOutWidth, measuredWidth / PreferredWrappedTextLineCount);
         }
 
         private static float MeasurePreferredContentHeight(VisualElement mainContainer, VisualElement contentContainer)

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -8,13 +8,13 @@ using UnityEngine.UIElements;
 
 namespace io.github.hatayama.uLoopMCP
 {
-    [InitializeOnLoad]
     public class SetupWizardWindow : EditorWindow
     {
         private const string UXML_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uxml";
         private const string USS_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uss";
 
-        static SetupWizardWindow()
+        [InitializeOnLoadMethod]
+        private static void InitializeOnLoad()
         {
             if (AssetDatabase.IsAssetImportWorkerProcess()) return;
             if (Application.isBatchMode) return;

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -446,20 +446,8 @@ namespace io.github.hatayama.uLoopMCP
                 if (!textElement.visible) continue;
                 if (string.IsNullOrEmpty(textElement.text)) continue;
 
-                float left = textElement.worldBound.xMin - contentContainer.worldBound.xMin;
-                Vector2 measuredTextSize = textElement.MeasureTextSize(
-                    textElement.text,
-                    0f,
-                    VisualElement.MeasureMode.Undefined,
-                    0f,
-                    VisualElement.MeasureMode.Undefined);
-                float preferredWidth =
-                    measuredTextSize.x
-                    + textElement.resolvedStyle.paddingLeft
-                    + textElement.resolvedStyle.paddingRight
-                    + textElement.resolvedStyle.borderLeftWidth
-                    + textElement.resolvedStyle.borderRightWidth;
-                maxRight = Mathf.Max(maxRight, left + preferredWidth);
+                float right = textElement.worldBound.xMax - contentContainer.worldBound.xMin;
+                maxRight = Mathf.Max(maxRight, right);
             }
 
             return Mathf.Ceil(

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -206,9 +206,14 @@ namespace io.github.hatayama.uLoopMCP
 
             UpdateCliStep(cliInstalled, cliVersion, cliVersionMatched);
 
-            List<ToolSkillSynchronizer.SkillTargetInfo> targets = ToolSkillSynchronizer.DetectTargets();
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectSetupWizardSkillTargets();
             UpdateSkillsStep(cliVersionMatched, targets);
             ScheduleResizeToContent();
+        }
+
+        private static List<ToolSkillSynchronizer.SkillTargetInfo> DetectSetupWizardSkillTargets()
+        {
+            return ToolSkillSynchronizer.DetectTargets(requireSkillsDirectory: true);
         }
 
         private void UpdateCliStep(bool cliInstalled, string cliVersion, bool cliVersionMatched)
@@ -264,7 +269,7 @@ namespace io.github.hatayama.uLoopMCP
 
             if (targets.Count == 0)
             {
-                _skillsStatusLabel.text = "No AI tool directories detected (.claude/, .agents/, etc.)";
+                _skillsStatusLabel.text = "No opted-in skills directories detected (.claude/skills/, .agents/skills/, etc.)";
                 _installSkillsButton.SetEnabled(false);
                 return;
             }
@@ -350,7 +355,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private async void HandleInstallSkills()
         {
-            List<ToolSkillSynchronizer.SkillTargetInfo> targets = ToolSkillSynchronizer.DetectTargets();
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectSetupWizardSkillTargets();
             if (targets.Count == 0) return;
 
             _isInstallingSkills = true;

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.uLoopMCP
     {
         private const string UXML_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uxml";
         private const string USS_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uss";
+        private static readonly Vector2 FixedWindowSize = new(400f, 440f);
 
         [InitializeOnLoadMethod]
         private static void InitializeOnLoad()
@@ -73,9 +74,24 @@ namespace io.github.hatayama.uLoopMCP
         private static void ShowWindowInternal(bool shouldRecordVersion)
         {
             SetupWizardWindow window = GetWindow<SetupWizardWindow>(true, "Unity CLI Loop Setup");
-            window.minSize = new Vector2(400, 440);
+            ApplyFixedWindowSize(window);
             window.ShowUtility();
             MaybeRecordLastSeenVersion(shouldRecordVersion, McpConstants.PackageInfo.version);
+        }
+
+        internal static Rect WithFixedSize(Rect currentRect)
+        {
+            currentRect.size = FixedWindowSize;
+            return currentRect;
+        }
+
+        private static void ApplyFixedWindowSize(SetupWizardWindow window)
+        {
+            Debug.Assert(window != null, "window must not be null");
+
+            window.minSize = FixedWindowSize;
+            window.maxSize = FixedWindowSize;
+            window.position = WithFixedSize(window.position);
         }
 
         // Prerequisite

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -206,14 +206,21 @@ namespace io.github.hatayama.uLoopMCP
 
             UpdateCliStep(cliInstalled, cliVersion, cliVersionMatched);
 
-            List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectSetupWizardSkillTargets();
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargets();
             UpdateSkillsStep(cliVersionMatched, targets);
             ScheduleResizeToContent();
         }
 
-        private static List<ToolSkillSynchronizer.SkillTargetInfo> DetectSetupWizardSkillTargets()
+        private static List<ToolSkillSynchronizer.SkillTargetInfo> DetectDisplayedSkillTargets()
         {
-            return ToolSkillSynchronizer.DetectTargets(requireSkillsDirectory: true);
+            return ToolSkillSynchronizer.DetectTargets();
+        }
+
+        internal static List<ToolSkillSynchronizer.SkillTargetInfo> FilterInstallableSkillTargets(
+            IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets)
+        {
+            Debug.Assert(targets != null, "targets must not be null");
+            return targets.Where(target => target.HasSkillsDirectory).ToList();
         }
 
         private void UpdateCliStep(bool cliInstalled, string cliVersion, bool cliVersionMatched)
@@ -269,10 +276,12 @@ namespace io.github.hatayama.uLoopMCP
 
             if (targets.Count == 0)
             {
-                _skillsStatusLabel.text = "No opted-in skills directories detected (.claude/skills/, .agents/skills/, etc.)";
+                _skillsStatusLabel.text = "No supported tool directories detected (.claude/, .agents/, etc.)";
                 _installSkillsButton.SetEnabled(false);
                 return;
             }
+
+            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
 
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in targets)
             {
@@ -287,16 +296,26 @@ namespace io.github.hatayama.uLoopMCP
                 _skillsTargetList.Add(item);
             }
 
-            bool allSkillsInstalled = targets.All(t => t.HasExistingSkills);
+            if (installableTargets.Count == 0)
+            {
+                _skillsStatusLabel.text = "Create a skills directory to opt in (.claude/skills/, .agents/skills/, etc.)";
+                _installSkillsButton.SetEnabled(false);
+                _installSkillsButton.text = "Install Skills";
+                return;
+            }
+
+            bool allSkillsInstalled = installableTargets.All(t => t.HasExistingSkills);
             if (allSkillsInstalled)
             {
-                _skillsStatusLabel.text = $"Installed for {targets.Count} targets";
+                _skillsStatusLabel.text = $"Installed for {installableTargets.Count} opted-in targets";
                 _installSkillsButton.SetEnabled(false);
                 _installSkillsButton.text = "Installed";
             }
             else
             {
-                _skillsStatusLabel.text = "";
+                _skillsStatusLabel.text = installableTargets.Count == targets.Count
+                    ? ""
+                    : "Only opted-in targets will be installed.";
                 _installSkillsButton.SetEnabled(!_isInstallingSkills);
                 _installSkillsButton.text = _isInstallingSkills ? "Installing..." : "Install Skills";
             }
@@ -355,15 +374,17 @@ namespace io.github.hatayama.uLoopMCP
 
         private async void HandleInstallSkills()
         {
-            List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectSetupWizardSkillTargets();
-            if (targets.Count == 0) return;
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargets();
+            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
+            if (installableTargets.Count == 0) return;
 
             _isInstallingSkills = true;
             UpdateSkillsStep(true, targets);
 
             try
             {
-                ToolSkillSynchronizer.SkillInstallResult result = await ToolSkillSynchronizer.InstallSkillFiles(targets);
+                ToolSkillSynchronizer.SkillInstallResult result =
+                    await ToolSkillSynchronizer.InstallSkillFiles(installableTargets);
 
                 if (!result.IsSuccessful)
                 {
@@ -446,7 +467,22 @@ namespace io.github.hatayama.uLoopMCP
                 if (!textElement.visible) continue;
                 if (string.IsNullOrEmpty(textElement.text)) continue;
 
-                float right = textElement.worldBound.xMax - contentContainer.worldBound.xMin;
+                float left = textElement.worldBound.xMin - contentContainer.worldBound.xMin;
+                float laidOutRight = textElement.worldBound.xMax - contentContainer.worldBound.xMin;
+                Vector2 measuredTextSize = textElement.MeasureTextSize(
+                    textElement.text,
+                    0f,
+                    VisualElement.MeasureMode.Undefined,
+                    0f,
+                    VisualElement.MeasureMode.Undefined);
+                float measuredRight =
+                    left
+                    + measuredTextSize.x
+                    + textElement.resolvedStyle.paddingLeft
+                    + textElement.resolvedStyle.paddingRight
+                    + textElement.resolvedStyle.borderLeftWidth
+                    + textElement.resolvedStyle.borderRightWidth;
+                float right = SelectPreferredTextRight(laidOutRight, measuredRight, textElement.resolvedStyle.whiteSpace);
                 maxRight = Mathf.Max(maxRight, right);
             }
 
@@ -454,6 +490,11 @@ namespace io.github.hatayama.uLoopMCP
                 mainContainer.resolvedStyle.paddingLeft
                 + maxRight
                 + mainContainer.resolvedStyle.paddingRight);
+        }
+
+        internal static float SelectPreferredTextRight(float laidOutRight, float measuredRight, WhiteSpace whiteSpace)
+        {
+            return whiteSpace == WhiteSpace.Normal ? laidOutRight : measuredRight;
         }
 
         private static float MeasurePreferredContentHeight(VisualElement mainContainer, VisualElement contentContainer)

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -12,7 +12,6 @@ namespace io.github.hatayama.uLoopMCP
     {
         private const string UXML_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uxml";
         private const string USS_RELATIVE_PATH = "Editor/UI/Setup/SetupWizardWindow.uss";
-        private static readonly Vector2 FixedWindowSize = new(400f, 410f);
 
         [InitializeOnLoadMethod]
         private static void InitializeOnLoad()
@@ -74,24 +73,15 @@ namespace io.github.hatayama.uLoopMCP
         private static void ShowWindowInternal(bool shouldRecordVersion)
         {
             SetupWizardWindow window = GetWindow<SetupWizardWindow>(true, "Unity CLI Loop Setup");
-            ApplyFixedWindowSize(window);
             window.ShowUtility();
+            window.ScheduleResizeToContent();
             MaybeRecordLastSeenVersion(shouldRecordVersion, McpConstants.PackageInfo.version);
         }
 
-        internal static Rect WithFixedSize(Rect currentRect)
+        internal static Rect WithContentSize(Rect currentRect, Vector2 contentSize, Vector2 frameSize)
         {
-            currentRect.size = FixedWindowSize;
+            currentRect.size = contentSize + frameSize;
             return currentRect;
-        }
-
-        private static void ApplyFixedWindowSize(SetupWizardWindow window)
-        {
-            Debug.Assert(window != null, "window must not be null");
-
-            window.minSize = FixedWindowSize;
-            window.maxSize = FixedWindowSize;
-            window.position = WithFixedSize(window.position);
         }
 
         // Prerequisite
@@ -117,13 +107,17 @@ namespace io.github.hatayama.uLoopMCP
         // State
         private bool _isInstallingCli;
         private bool _isInstallingSkills;
+        private bool _isApplyingContentSize;
+        private IVisualElementScheduledItem _resizeScheduledItem;
 
         private void CreateGUI()
         {
             LoadLayout();
             BindElements();
             BindEvents();
+            BindSizeUpdates();
             RefreshUI();
+            ScheduleResizeToContent();
         }
 
         private void LoadLayout()
@@ -168,6 +162,15 @@ namespace io.github.hatayama.uLoopMCP
             _closeButton.clicked += HandleClose;
         }
 
+        private void BindSizeUpdates()
+        {
+            rootVisualElement.RegisterCallback<GeometryChangedEvent>(_ =>
+            {
+                if (_isApplyingContentSize) return;
+                ScheduleResizeToContent();
+            });
+        }
+
         private void RefreshAutoShowToggle()
         {
             _suppressAutoShowToggle.SetValueWithoutNotify(McpEditorSettings.GetSuppressSetupWizardAutoShow());
@@ -192,6 +195,7 @@ namespace io.github.hatayama.uLoopMCP
                 _installSkillsButton.SetEnabled(false);
                 _skillsStatusLabel.text = "";
                 _skillsTargetList.Clear();
+                ScheduleResizeToContent();
                 return;
             }
 
@@ -204,6 +208,7 @@ namespace io.github.hatayama.uLoopMCP
 
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = ToolSkillSynchronizer.DetectTargets();
             UpdateSkillsStep(cliVersionMatched, targets);
+            ScheduleResizeToContent();
         }
 
         private void UpdateCliStep(bool cliInstalled, string cliVersion, bool cliVersionMatched)
@@ -381,11 +386,103 @@ namespace io.github.hatayama.uLoopMCP
         {
             McpEditorSettings.SetSuppressSetupWizardAutoShow(suppressAutoShow);
             MaybeRecordSuppressedVersion(suppressAutoShow, McpConstants.PackageInfo.version);
+            ScheduleResizeToContent();
         }
 
         private void HandleClose()
         {
             Close();
+        }
+
+        private void ScheduleResizeToContent()
+        {
+            _resizeScheduledItem?.Pause();
+            _resizeScheduledItem = rootVisualElement.schedule.Execute(ResizeToContent).StartingIn(0);
+        }
+
+        private void ResizeToContent()
+        {
+            ScrollView mainContainer = rootVisualElement.Q<ScrollView>();
+            if (mainContainer == null) return;
+            if (rootVisualElement.layout.width <= 0f || rootVisualElement.layout.height <= 0f) return;
+
+            Vector2 contentSize = MeasureContentSize(mainContainer);
+            if (contentSize.x <= 0f || contentSize.y <= 0f) return;
+
+            Vector2 frameSize = position.size - rootVisualElement.layout.size;
+            Rect targetRect = WithContentSize(position, contentSize, frameSize);
+            if (Approximately(position.size, targetRect.size))
+            {
+                minSize = targetRect.size;
+                maxSize = targetRect.size;
+                return;
+            }
+
+            _isApplyingContentSize = true;
+            minSize = targetRect.size;
+            maxSize = targetRect.size;
+            position = targetRect;
+            _isApplyingContentSize = false;
+        }
+
+        private static Vector2 MeasureContentSize(ScrollView mainContainer)
+        {
+            VisualElement contentContainer = mainContainer.contentContainer;
+            float width = MeasurePreferredContentWidth(mainContainer, contentContainer);
+            float height = MeasurePreferredContentHeight(mainContainer, contentContainer);
+            return new Vector2(width, height);
+        }
+
+        private static float MeasurePreferredContentWidth(VisualElement mainContainer, VisualElement contentContainer)
+        {
+            float maxRight = 0f;
+            foreach (TextElement textElement in contentContainer.Query<TextElement>().Build())
+            {
+                if (!textElement.visible) continue;
+                if (string.IsNullOrEmpty(textElement.text)) continue;
+
+                float left = textElement.worldBound.xMin - contentContainer.worldBound.xMin;
+                Vector2 measuredTextSize = textElement.MeasureTextSize(
+                    textElement.text,
+                    0f,
+                    VisualElement.MeasureMode.Undefined,
+                    0f,
+                    VisualElement.MeasureMode.Undefined);
+                float preferredWidth =
+                    measuredTextSize.x
+                    + textElement.resolvedStyle.paddingLeft
+                    + textElement.resolvedStyle.paddingRight
+                    + textElement.resolvedStyle.borderLeftWidth
+                    + textElement.resolvedStyle.borderRightWidth;
+                maxRight = Mathf.Max(maxRight, left + preferredWidth);
+            }
+
+            return Mathf.Ceil(
+                mainContainer.resolvedStyle.paddingLeft
+                + maxRight
+                + mainContainer.resolvedStyle.paddingRight);
+        }
+
+        private static float MeasurePreferredContentHeight(VisualElement mainContainer, VisualElement contentContainer)
+        {
+            float maxBottom = 0f;
+            foreach (VisualElement child in contentContainer.Children())
+            {
+                if (!child.visible) continue;
+                float bottom = child.worldBound.yMax - contentContainer.worldBound.yMin;
+                maxBottom = Mathf.Max(maxBottom, bottom);
+            }
+
+            return Mathf.Ceil(
+                mainContainer.resolvedStyle.paddingTop
+                + maxBottom
+                + mainContainer.resolvedStyle.paddingBottom);
+        }
+
+        private static bool Approximately(Vector2 left, Vector2 right)
+        {
+            const float Tolerance = 0.5f;
+            return Mathf.Abs(left.x - right.x) < Tolerance && Mathf.Abs(left.y - right.y) < Tolerance;
         }
 
     }

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
@@ -178,7 +178,7 @@
 }
 
 .setup-footer__toggle {
-    margin-bottom: 6px;
+    margin-top: 6px;
 }
 
 .setup-footer__button-row {

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
@@ -181,6 +181,14 @@
     margin-top: 6px;
 }
 
+.setup-footer__hint-label {
+    font-size: 11px;
+    color: var(--setup-color-muted);
+    white-space: normal;
+    margin-top: 2px;
+    margin-left: 18px;
+}
+
 .setup-footer__button-row {
     flex-direction: row;
 }

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
@@ -177,6 +177,10 @@
     border-top-color: var(--unity-colors-helpbox-border);
 }
 
+.setup-footer__toggle {
+    margin-bottom: 6px;
+}
+
 .setup-footer__button-row {
     flex-direction: row;
 }

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -38,6 +38,10 @@
 
         <!-- Footer -->
         <ui:VisualElement class="setup-footer">
+            <ui:Toggle
+                name="suppress-auto-show-toggle"
+                text="Don't show this window automatically"
+                class="setup-footer__toggle" />
             <ui:VisualElement class="setup-footer__button-row">
                 <ui:Button name="open-settings-button" text="Open Settings" class="setup-button setup-button--primary" />
                 <ui:Button name="close-button" text="Close" class="setup-button" />

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -44,7 +44,7 @@
             </ui:VisualElement>
             <ui:Toggle
                 name="suppress-auto-show-toggle"
-                text="Don't show this window automatically after updates"
+                text="Don't show this after updates"
                 class="setup-footer__toggle" />
             <ui:Label
                 text="You can re-enable it from Window &gt; Unity CLI Loop &gt; Setup Wizard."

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -47,7 +47,7 @@
                 text="Don't show this after updates"
                 class="setup-footer__toggle" />
             <ui:Label
-                text="You can re-enable it from Window &gt; Unity CLI Loop &gt; Setup Wizard."
+                text="You can reopen this from Window &gt; Unity CLI Loop &gt; Setup Wizard."
                 class="setup-footer__hint-label" />
         </ui:VisualElement>
     </ui:ScrollView>

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -38,14 +38,14 @@
 
         <!-- Footer -->
         <ui:VisualElement class="setup-footer">
-            <ui:Toggle
-                name="suppress-auto-show-toggle"
-                text="Don't show this window automatically"
-                class="setup-footer__toggle" />
             <ui:VisualElement class="setup-footer__button-row">
                 <ui:Button name="open-settings-button" text="Open Settings" class="setup-button setup-button--primary" />
                 <ui:Button name="close-button" text="Close" class="setup-button" />
             </ui:VisualElement>
+            <ui:Toggle
+                name="suppress-auto-show-toggle"
+                text="Don't show this window automatically"
+                class="setup-footer__toggle" />
         </ui:VisualElement>
     </ui:ScrollView>
 </ui:UXML>

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -44,8 +44,11 @@
             </ui:VisualElement>
             <ui:Toggle
                 name="suppress-auto-show-toggle"
-                text="Don't show this window automatically"
+                text="Don't show this window automatically after updates"
                 class="setup-footer__toggle" />
+            <ui:Label
+                text="You can re-enable it from Window &gt; Unity CLI Loop &gt; Setup Wizard."
+                class="setup-footer__hint-label" />
         </ui:VisualElement>
     </ui:ScrollView>
 </ui:UXML>


### PR DESCRIPTION
## Summary
- let users dismiss the setup wizard from future updates without losing the ability to reopen it manually
- make the setup wizard footer copy clearer and keep the dialog sized to its rendered content
- only offer skill installation for tool directories that already opted in with a skills folder

## Why
The setup wizard was reopening after updates even for users who had already finished setup, and its footer copy plus dialog sizing needed extra tuning once the dismissal option was added. On top of that, the wizard's skill installation flow was still more aggressive than the existing opt-in rule, which risked writing skill files into tool directories such as .cursor before the user had created a skills folder there.

## Changes
- persist a suppression flag in editor settings and skip auto-show on future version changes when that option is enabled
- add footer guidance that explains the setup wizard can be reopened from Window > Unity CLI Loop > Setup Wizard
- move setup wizard initialization away from the EditorWindow type initializer so opening the dialog does not trigger Unity's ScriptableObject constructor restriction
- replace hard-coded dialog sizing with content-driven sizing after layout so the window stays compact without clipping helper text
- reuse ToolSkillSynchronizer's requireSkillsDirectory path inside the setup wizard so only opted-in targets are listed and installed

## Verification
- uloop compile --force-recompile true --wait-for-domain-reload true
- uloop run-tests --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.uLoopMCP.Tests.Editor.SetupWizardWindowTests"
- uloop run-tests --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.uLoopMCP.ToolSkillSynchronizerTests"
- captured Unity window screenshots to confirm the footer copy, helper text, and final dialog size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Setup Wizard Suppression and Window Sizing Improvements

## Overview
This PR adds a user-controllable suppression option for the Setup Wizard that prevents automatic reappearance after package/version changes while preserving manual accessibility. It also refactors window sizing to use content-driven resizing so the dialog stays compact and avoids clipping helper text.

## Key Changes

### Editor Settings Persistence
- Added `suppressSetupWizardAutoShow` (default false) to `McpEditorSettingsData`.
- New accessors on `McpEditorSettings`:
  - `GetSuppressSetupWizardAutoShow()` — returns the persisted flag.
  - `SetSuppressSetupWizardAutoShow(bool)` — updates and saves the flag.

### Setup Wizard Initialization & Visibility Logic
- Replaced a class-level `[InitializeOnLoad]` static constructor with a private `[InitializeOnLoadMethod] InitializeOnLoad()` to avoid ScriptableObject constructor restrictions.
- `ShouldAutoShowForVersion` now accepts a `suppressAutoShow` parameter and returns false immediately when suppression is enabled.
- Added `MaybeRecordSuppressedVersion(bool suppressAutoShow, string version)` to record the current package version when the user suppresses auto-show, preventing suppressed prompts from resurfacing.
- `TryShowOnVersionChange()` now reads the suppression flag, records the suppressed version when applicable, and passes suppression into the auto-show check.

### Window Sizing Refactor
- Removed hard-coded `minSize` and replaced with content-driven sizing.
- New/updated sizing utilities and flows:
  - `ResizeToContent()`, `ScheduleResizeToContent()`
  - Measurement helpers and `WithContentSize(Rect, Vector2, Vector2)` that preserves window position while applying content + frame size.
  - Geometry change listener schedules content-driven resize (guarded by `_isApplyingContentSize`) so sizing occurs after layout.
- Window schedules a resize after ShowUtility() and after relevant UI refreshes to ensure text/helper content is not clipped.

### UI Changes
- Footer toggle `_suppressAutoShowToggle` added with handler `HandleSuppressAutoShowChanged`:
  - Persists suppression setting, records suppressed version when enabled, and triggers a resize.
- Footer hint updated to clarify the wizard can be reopened via Window > Unity CLI Loop > Setup Wizard.
- Stylesheet (.uss) additions to space the toggle and present the hint text in muted, wrapped form.
- UXML footer extended with the suppression toggle and hint label.

### Skills Installation Opt-in Respect
- Setup Wizard now uses `DetectSetupWizardSkillTargets()` (which calls `ToolSkillSynchronizer.DetectTargets(requireSkillsDirectory: true)`) so only tool directories that have opted in with a skills folder are listed for installation, reducing aggressive file writes.
- Empty-state copy updated to reflect "opted-in skills directories".

## Tests
- Updated `ShouldAutoShowForVersion_ReturnsExpectedValue` to include `suppressAutoShow` across six test cases.
- Added tests for `MaybeRecordSuppressedVersion`:
  - Records version when suppression is true.
  - Leaves stored version unchanged when suppression is false.
- Added `WithContentSize_OverridesSizeAndPreservesPosition` test validating position preservation and size override.

## Files Modified (summary)
- Assets/Tests/Editor/SetupWizardWindowTests.cs — tests extended/added
- Packages/src/Editor/Config/McpEditorSettings.cs — added persisted suppression flag and accessors
- Packages/src/Editor/UI/Setup/SetupWizardWindow.cs — initialization, suppression logic, UI toggle, content-driven sizing, and skills target detection adjustments
- Packages/src/Editor/UI/Setup/SetupWizardWindow.uss — footer styling additions
- Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml — footer toggle and hint label added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->