### PR TITLE
fix: compile and log commands recover the Unity server more reliably

### DIFF
--- a/Assets/Tests/Editor/McpServerPortTests.cs
+++ b/Assets/Tests/Editor/McpServerPortTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using System.Reflection;
 using UnityEngine;
 
 namespace io.github.hatayama.uLoopMCP
@@ -176,6 +177,33 @@ namespace io.github.hatayama.uLoopMCP
             Assert.IsFalse(McpPortValidator.ValidatePort(0, "test"), "Port 0 should be invalid");
             Assert.IsFalse(McpPortValidator.ValidatePort(-1, "test"), "Negative port should be invalid");
             Assert.IsFalse(McpPortValidator.ValidatePort(65536, "test"), "Port 65536 should be invalid");
+        }
+
+        [Test]
+        public void ClearStartupProtection_ResetsProtectionWindow()
+        {
+            Type controllerType = typeof(McpServerController);
+            FieldInfo field = controllerType.GetField("startupProtectionUntilTicks", BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo method = controllerType.GetMethod("ClearStartupProtection", BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.IsNotNull(field, "startupProtectionUntilTicks field should exist");
+            Assert.IsNotNull(method, "ClearStartupProtection method should exist");
+
+            try
+            {
+                long futureTicks = DateTime.UtcNow.AddMinutes(1).Ticks;
+                field.SetValue(null, futureTicks);
+
+                Assert.IsTrue(McpServerController.IsStartupProtectionActive(), "Startup protection should be active after setting future ticks");
+
+                method.Invoke(null, null);
+
+                Assert.IsFalse(McpServerController.IsStartupProtectionActive(), "Startup protection should be cleared by recovery path");
+            }
+            finally
+            {
+                field.SetValue(null, 0L);
+            }
         }
 
     }

--- a/Assets/Tests/Editor/McpServerPortTests.cs
+++ b/Assets/Tests/Editor/McpServerPortTests.cs
@@ -206,5 +206,35 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
+        [Test]
+        public void OnBeforeAssemblyReload_ShouldClearStartupProtectionBeforeRecovery()
+        {
+            Type controllerType = typeof(McpServerController);
+            FieldInfo field = controllerType.GetField("startupProtectionUntilTicks", BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo method = controllerType.GetMethod("OnBeforeAssemblyReload", BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.IsNotNull(field, "startupProtectionUntilTicks field should exist");
+            Assert.IsNotNull(method, "OnBeforeAssemblyReload method should exist");
+
+            try
+            {
+                long futureTicks = DateTime.UtcNow.AddMinutes(1).Ticks;
+                field.SetValue(null, futureTicks);
+
+                Assert.IsTrue(McpServerController.IsStartupProtectionActive(), "Startup protection should be active before reload");
+
+                method.Invoke(null, null);
+
+                Assert.IsFalse(
+                    McpServerController.IsStartupProtectionActive(),
+                    "Assembly reload recovery should clear startup protection so the server can restart"
+                );
+            }
+            finally
+            {
+                field.SetValue(null, 0L);
+            }
+        }
+
     }
 }

--- a/Assets/Tests/Editor/McpServerPortTests.cs
+++ b/Assets/Tests/Editor/McpServerPortTests.cs
@@ -211,13 +211,24 @@ namespace io.github.hatayama.uLoopMCP
         {
             Type controllerType = typeof(McpServerController);
             FieldInfo field = controllerType.GetField("startupProtectionUntilTicks", BindingFlags.NonPublic | BindingFlags.Static);
+            FieldInfo serverField = controllerType.GetField("mcpServer", BindingFlags.NonPublic | BindingFlags.Static);
             MethodInfo method = controllerType.GetMethod("OnBeforeAssemblyReload", BindingFlags.NonPublic | BindingFlags.Static);
 
             Assert.IsNotNull(field, "startupProtectionUntilTicks field should exist");
+            Assert.IsNotNull(serverField, "mcpServer field should exist");
             Assert.IsNotNull(method, "OnBeforeAssemblyReload method should exist");
+
+            object originalServer = serverField.GetValue(null);
+            bool originalIsServerRunning = McpEditorSettings.GetIsServerRunning();
+            bool originalIsAfterCompile = McpEditorSettings.GetIsAfterCompile();
+            bool originalIsDomainReloadInProgress = McpEditorSettings.GetIsDomainReloadInProgress();
+            bool originalIsReconnecting = McpEditorSettings.GetIsReconnecting();
+            bool originalShowReconnectingUi = McpEditorSettings.GetShowReconnectingUI();
+            bool originalShowPostCompileReconnectingUi = McpEditorSettings.GetShowPostCompileReconnectingUI();
 
             try
             {
+                serverField.SetValue(null, new McpBridgeServer());
                 long futureTicks = DateTime.UtcNow.AddMinutes(1).Ticks;
                 field.SetValue(null, futureTicks);
 
@@ -232,6 +243,63 @@ namespace io.github.hatayama.uLoopMCP
             }
             finally
             {
+                serverField.SetValue(null, originalServer);
+                McpEditorSettings.SetIsServerRunning(originalIsServerRunning);
+                McpEditorSettings.SetIsAfterCompile(originalIsAfterCompile);
+                McpEditorSettings.SetIsDomainReloadInProgress(originalIsDomainReloadInProgress);
+                McpEditorSettings.SetIsReconnecting(originalIsReconnecting);
+                McpEditorSettings.SetShowReconnectingUI(originalShowReconnectingUi);
+                McpEditorSettings.SetShowPostCompileReconnectingUI(originalShowPostCompileReconnectingUi);
+                DomainReloadDetectionService.DeleteLockFile();
+                field.SetValue(null, 0L);
+            }
+        }
+
+        [Test]
+        public async System.Threading.Tasks.Task StopServerWithUseCaseAsync_ShouldClearStartupProtectionBeforeShutdown()
+        {
+            Type controllerType = typeof(McpServerController);
+            FieldInfo field = controllerType.GetField("startupProtectionUntilTicks", BindingFlags.NonPublic | BindingFlags.Static);
+            FieldInfo serverField = controllerType.GetField("mcpServer", BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo method = controllerType.GetMethod("StopServerWithUseCaseAsync", BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.IsNotNull(field, "startupProtectionUntilTicks field should exist");
+            Assert.IsNotNull(serverField, "mcpServer field should exist");
+            Assert.IsNotNull(method, "StopServerWithUseCaseAsync method should exist");
+
+            object originalServer = serverField.GetValue(null);
+            bool originalIsServerRunning = McpEditorSettings.GetIsServerRunning();
+            bool originalIsAfterCompile = McpEditorSettings.GetIsAfterCompile();
+            bool originalIsDomainReloadInProgress = McpEditorSettings.GetIsDomainReloadInProgress();
+            bool originalIsReconnecting = McpEditorSettings.GetIsReconnecting();
+            bool originalShowReconnectingUi = McpEditorSettings.GetShowReconnectingUI();
+            bool originalShowPostCompileReconnectingUi = McpEditorSettings.GetShowPostCompileReconnectingUI();
+
+            try
+            {
+                serverField.SetValue(null, new McpBridgeServer());
+                long futureTicks = DateTime.UtcNow.AddMinutes(1).Ticks;
+                field.SetValue(null, futureTicks);
+
+                Assert.IsTrue(McpServerController.IsStartupProtectionActive(), "Startup protection should be active before shutdown");
+
+                System.Threading.Tasks.Task task = (System.Threading.Tasks.Task)method.Invoke(null, null);
+                await task;
+
+                Assert.IsFalse(
+                    McpServerController.IsStartupProtectionActive(),
+                    "Shutdown path should clear startup protection so recovery can restart the server"
+                );
+            }
+            finally
+            {
+                serverField.SetValue(null, originalServer);
+                McpEditorSettings.SetIsServerRunning(originalIsServerRunning);
+                McpEditorSettings.SetIsAfterCompile(originalIsAfterCompile);
+                McpEditorSettings.SetIsDomainReloadInProgress(originalIsDomainReloadInProgress);
+                McpEditorSettings.SetIsReconnecting(originalIsReconnecting);
+                McpEditorSettings.SetShowReconnectingUI(originalShowReconnectingUi);
+                McpEditorSettings.SetShowPostCompileReconnectingUI(originalShowPostCompileReconnectingUi);
                 field.SetValue(null, 0L);
             }
         }

--- a/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
+++ b/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
@@ -445,6 +445,7 @@ describe('CLI E2E Tests (requires running Unity)', () => {
 
       expect(exitCode).toBe(0);
       expect(stdout).toContain('--force-recompile');
+      expect(stdout).toContain('--wait-for-domain-reload');
     });
 
     it('should display grouped help with category headings', () => {
@@ -712,6 +713,16 @@ describe('CLI E2E Tests (requires running Unity)', () => {
 
       // Domain Reload causes connection to be lost, so we just verify the command runs
       // The exit code may be non-zero due to connection being dropped during reload
+      expect(typeof exitCode).toBe('number');
+    });
+  });
+
+  describe('compile --wait-for-domain-reload', () => {
+    it('should support --wait-for-domain-reload option', () => {
+      const { exitCode } = runCli('compile --wait-for-domain-reload');
+
+      // This option is intended to survive domain reload and return once the
+      // compile result is available again.
       expect(typeof exitCode).toBe('number');
     });
   });

--- a/Packages/src/Cli~/src/__tests__/execute-tool-recovery.test.ts
+++ b/Packages/src/Cli~/src/__tests__/execute-tool-recovery.test.ts
@@ -1,0 +1,130 @@
+const mockResolveUnityPort = jest.fn<Promise<number>, [number | undefined, string | undefined]>();
+const mockValidateProjectPath = jest.fn<string, [string]>();
+const mockFindUnityProjectRoot = jest.fn<string | null, []>();
+const mockExistsSync = jest.fn<boolean, [string]>();
+const mockFindRunningUnityProcessForProject = jest.fn<
+  Promise<{ pid: number } | null>,
+  [string]
+>();
+const mockSleep = jest.fn<Promise<void>, [number]>();
+const mockSpinnerUpdate = jest.fn<void, [string]>();
+const mockSpinnerStop = jest.fn<void, []>();
+const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+const constructedPorts: number[] = [];
+
+class MockDirectUnityClient {
+  public readonly port: number;
+
+  public constructor(port: number) {
+    this.port = port;
+    constructedPorts.push(port);
+  }
+
+  public async connect(): Promise<void> {
+    if (this.port === 8711) {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:8711');
+    }
+  }
+
+  public disconnect(): void {}
+
+  public async sendRequest<T>(): Promise<T> {
+    return {
+      Logs: [],
+      Ver: '1.7.3',
+    } as T;
+  }
+}
+
+jest.mock('../port-resolver.js', () => ({
+  resolveUnityPort: (explicitPort?: number, projectPath?: string): Promise<number> =>
+    mockResolveUnityPort(explicitPort, projectPath),
+  validateProjectPath: (projectPath: string): string => mockValidateProjectPath(projectPath),
+  UnityNotRunningError: class UnityNotRunningError extends Error {},
+  UnityServerNotRunningError: class UnityServerNotRunningError extends Error {},
+}));
+
+jest.mock('../project-root.js', () => ({
+  findUnityProjectRoot: (): string | null => mockFindUnityProjectRoot(),
+}));
+
+jest.mock('fs', () => ({
+  existsSync: (path: string): boolean => mockExistsSync(path),
+}));
+
+jest.mock('../unity-process.js', () => ({
+  findRunningUnityProcessForProject: (projectRoot: string): Promise<{ pid: number } | null> =>
+    mockFindRunningUnityProcessForProject(projectRoot),
+}));
+
+jest.mock('../compile-helpers.js', () => ({
+  ensureCompileRequestId: (params: Record<string, unknown>): string =>
+    (params['RequestId'] as string | undefined) ?? 'request-id',
+  resolveCompileExecutionOptions: (): { forceRecompile: boolean; waitForDomainReload: boolean } =>
+    ({
+      forceRecompile: false,
+      waitForDomainReload: false,
+    }),
+  sleep: (delayMs: number): Promise<void> => mockSleep(delayMs),
+  waitForCompileCompletion: jest.fn(),
+}));
+
+jest.mock('../spinner.js', () => ({
+  createSpinner: (): { update: (message: string) => void; stop: () => void } => ({
+    update: (message: string): void => mockSpinnerUpdate(message),
+    stop: (): void => mockSpinnerStop(),
+  }),
+}));
+
+jest.mock('../project-validator.js', () => ({
+  validateConnectedProject: jest.fn(),
+  ProjectMismatchError: class ProjectMismatchError extends Error {},
+}));
+
+jest.mock('../direct-unity-client.js', () => ({
+  DirectUnityClient: MockDirectUnityClient,
+}));
+
+import { executeToolCommand } from '../execute-tool.js';
+
+describe('executeToolCommand recovery', () => {
+  beforeEach(() => {
+    mockResolveUnityPort.mockReset();
+    mockResolveUnityPort.mockResolvedValueOnce(8711).mockResolvedValueOnce(8712);
+
+    mockValidateProjectPath.mockReset();
+    mockValidateProjectPath.mockReturnValue('/project');
+
+    mockFindUnityProjectRoot.mockReset();
+    mockFindUnityProjectRoot.mockReturnValue('/project');
+
+    mockExistsSync.mockReset();
+    mockExistsSync.mockReturnValue(false);
+
+    mockFindRunningUnityProcessForProject.mockReset();
+    mockFindRunningUnityProcessForProject.mockResolvedValue({ pid: 1234 });
+
+    mockSleep.mockReset();
+    mockSleep.mockResolvedValue();
+
+    mockSpinnerUpdate.mockReset();
+    mockSpinnerStop.mockReset();
+
+    mockConsoleLog.mockClear();
+    constructedPorts.length = 0;
+  });
+
+  afterAll(() => {
+    mockConsoleLog.mockRestore();
+  });
+
+  it('re-resolves the Unity port before retrying recovery while Unity is still running', async () => {
+    await expect(executeToolCommand('get-logs', {}, { projectPath: '/project' })).resolves.toBe(
+      undefined,
+    );
+
+    expect(mockResolveUnityPort).toHaveBeenCalledTimes(2);
+    expect(constructedPorts).toEqual([8711, 8712]);
+  });
+});

--- a/Packages/src/Cli~/src/__tests__/execute-tool.test.ts
+++ b/Packages/src/Cli~/src/__tests__/execute-tool.test.ts
@@ -1,6 +1,7 @@
 import {
   diagnoseRetryableProjectConnectionError,
   isTransportDisconnectError,
+  resolveRecoveryPortOrKeepCurrent,
   shouldRetryWhenUnityProcessIsRunning,
 } from '../execute-tool.js';
 import { UnityNotRunningError, UnityServerNotRunningError } from '../port-resolver.js';
@@ -131,5 +132,24 @@ describe('shouldRetryWhenUnityProcessIsRunning', () => {
         },
       ),
     ).resolves.toBe(false);
+  });
+});
+
+describe('resolveRecoveryPortOrKeepCurrent', () => {
+  it('keeps the current port when recovery settings are temporarily unreadable', async () => {
+    await expect(
+      resolveRecoveryPortOrKeepCurrent(8711, undefined, '/project', jest.fn().mockRejectedValue(new Error('busy'))),
+    ).resolves.toBe(8711);
+  });
+
+  it('re-resolves the port when recovery settings are available', async () => {
+    await expect(
+      resolveRecoveryPortOrKeepCurrent(
+        8711,
+        undefined,
+        '/project',
+        jest.fn().mockResolvedValue(8712),
+      ),
+    ).resolves.toBe(8712);
   });
 });

--- a/Packages/src/Cli~/src/__tests__/execute-tool.test.ts
+++ b/Packages/src/Cli~/src/__tests__/execute-tool.test.ts
@@ -1,6 +1,7 @@
 import {
   diagnoseRetryableProjectConnectionError,
   isTransportDisconnectError,
+  shouldRetryWhenUnityProcessIsRunning,
 } from '../execute-tool.js';
 import { UnityNotRunningError, UnityServerNotRunningError } from '../port-resolver.js';
 import { ProjectMismatchError } from '../project-validator.js';
@@ -102,5 +103,33 @@ describe('diagnoseRetryableProjectConnectionError', () => {
     });
 
     expect(error).toBe(originalError);
+  });
+});
+
+describe('shouldRetryWhenUnityProcessIsRunning', () => {
+  it('returns true for retryable failures when Unity is still running', async () => {
+    await expect(
+      shouldRetryWhenUnityProcessIsRunning(
+        new Error('UNITY_NO_RESPONSE'),
+        '/project',
+        true,
+        {
+          findRunningUnityProcessForProjectFn: jest.fn().mockResolvedValue({ pid: 1234 }),
+        },
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it('returns false for non-retryable Unity errors even when Unity is still running', async () => {
+    await expect(
+      shouldRetryWhenUnityProcessIsRunning(
+        new Error('Unity error: compilation failed'),
+        '/project',
+        true,
+        {
+          findRunningUnityProcessForProjectFn: jest.fn().mockResolvedValue({ pid: 1234 }),
+        },
+      ),
+    ).resolves.toBe(false);
   });
 });

--- a/Packages/src/Cli~/src/__tests__/stress-script.test.ts
+++ b/Packages/src/Cli~/src/__tests__/stress-script.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
@@ -79,6 +79,7 @@ function runStressScript(pathEntries: string[]): Promise<ScriptRunResult> {
 
 describe('uloop compile/get-logs stress script', () => {
   let tempDir: string;
+  const scriptPath = resolve(process.cwd(), '../../../scripts/uloop-compile-get-logs-stress.sh');
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'uloop-stress-test-'));
@@ -97,5 +98,13 @@ describe('uloop compile/get-logs stress script', () => {
     expect(result.stdout).toContain('bootstrap failed');
     expect(result.stdout).toContain('ready timeout after 1s');
     expect(result.durationMs).toBeLessThan(4000);
+  });
+
+  it('guards timeout marker creation with a liveness check before killing the child', () => {
+    const script = readFileSync(scriptPath, 'utf8');
+
+    expect(script).toMatch(
+      /if kill -0 "\$CURRENT_CHILD_PID" 2>\/dev\/null; then\s+: > "\$timeout_marker"\s+kill -TERM "\$CURRENT_CHILD_PID" 2>\/dev\/null \|\| :/m,
+    );
   });
 });

--- a/Packages/src/Cli~/src/__tests__/stress-script.test.ts
+++ b/Packages/src/Cli~/src/__tests__/stress-script.test.ts
@@ -1,0 +1,101 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+interface ScriptRunResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+}
+
+function createFakeUloopCommand(tempDir: string): string {
+  const uloopPath = join(tempDir, 'uloop');
+  writeFileSync(
+    uloopPath,
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "get-logs" ]; then',
+      '    sleep 10',
+      '    exit 1',
+      'fi',
+      'printf \'{"Success":true}\\n\'',
+    ].join('\n'),
+    'utf8',
+  );
+  chmodSync(uloopPath, 0o755);
+  return uloopPath;
+}
+
+function runStressScript(pathEntries: string[]): Promise<ScriptRunResult> {
+  return new Promise((resolvePromise) => {
+    const startMs = Date.now();
+    const scriptPath = resolve(process.cwd(), '../../../scripts/uloop-compile-get-logs-stress.sh');
+    const child = spawn(scriptPath, [], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        PATH: `${pathEntries.join(':')}:${process.env.PATH ?? ''}`,
+        ULOOP_STRESS_WAIT_FOR_READY_SECONDS: '1',
+        ULOOP_STRESS_INTERVAL_SECONDS: '1',
+        ULOOP_STRESS_MAX_ROUNDS: '1',
+      },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error: Error) => {
+      stderr += error.message;
+      resolvePromise({
+        code: null,
+        signal: null,
+        stdout,
+        stderr,
+        durationMs: Date.now() - startMs,
+      });
+    });
+
+    child.on('close', (code, signal) => {
+      resolvePromise({
+        code,
+        signal,
+        stdout,
+        stderr,
+        durationMs: Date.now() - startMs,
+      });
+    });
+  });
+}
+
+describe('uloop compile/get-logs stress script', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'uloop-stress-test-'));
+    createFakeUloopCommand(tempDir);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('fails within the configured ready timeout when a readiness probe hangs', async () => {
+    const result = await runStressScript([tempDir]);
+
+    expect(result.signal).toBeNull();
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain('bootstrap failed');
+    expect(result.stdout).toContain('ready timeout after 1s');
+    expect(result.durationMs).toBeLessThan(4000);
+  });
+});

--- a/Packages/src/Cli~/src/execute-tool.ts
+++ b/Packages/src/Cli~/src/execute-tool.ts
@@ -288,7 +288,7 @@ export async function executeToolCommand(
     portNumber = parsed;
   }
   checkUnityBusyStateBeforeProjectResolution(globalOptions);
-  const port = await resolveUnityPort(portNumber, globalOptions.projectPath);
+  let port = await resolveUnityPort(portNumber, globalOptions.projectPath);
   const compileOptions = getCompileExecutionOptions(toolName, params);
   const shouldWaitForDomainReload = compileOptions.waitForDomainReload;
   const compileRequestId = shouldWaitForDomainReload ? ensureCompileRequestId(params) : undefined;
@@ -374,6 +374,9 @@ export async function executeToolCommand(
       if (await shouldRetryWhenUnityProcessIsRunning(error, projectRoot, shouldValidateProject)) {
         spinner.update('Unity Editor is running, waiting for CLI Loop server to recover...');
         await sleep(RETRY_DELAY_MS);
+        if (portNumber === undefined) {
+          port = await resolveUnityPort(undefined, globalOptions.projectPath);
+        }
         continue;
       }
 

--- a/Packages/src/Cli~/src/execute-tool.ts
+++ b/Packages/src/Cli~/src/execute-tool.ts
@@ -158,6 +158,23 @@ export async function shouldRetryWhenUnityProcessIsRunning(
   return runningProcess !== null && runningProcess !== undefined;
 }
 
+export async function resolveRecoveryPortOrKeepCurrent(
+  currentPort: number,
+  explicitPort: number | undefined,
+  projectPath: string | undefined,
+  resolveUnityPortFn: typeof resolveUnityPort = resolveUnityPort,
+): Promise<number> {
+  if (explicitPort !== undefined) {
+    return currentPort;
+  }
+
+  try {
+    return await resolveUnityPortFn(undefined, projectPath);
+  } catch {
+    return currentPort;
+  }
+}
+
 async function throwFinalToolError(
   error: unknown,
   projectRoot: string | null,
@@ -374,9 +391,11 @@ export async function executeToolCommand(
       if (await shouldRetryWhenUnityProcessIsRunning(error, projectRoot, shouldValidateProject)) {
         spinner.update('Unity Editor is running, waiting for CLI Loop server to recover...');
         await sleep(RETRY_DELAY_MS);
-        if (portNumber === undefined) {
-          port = await resolveUnityPort(undefined, globalOptions.projectPath);
-        }
+        port = await resolveRecoveryPortOrKeepCurrent(
+          port,
+          portNumber,
+          globalOptions.projectPath,
+        );
         continue;
       }
 

--- a/Packages/src/Cli~/src/execute-tool.ts
+++ b/Packages/src/Cli~/src/execute-tool.ts
@@ -142,15 +142,17 @@ export async function diagnoseRetryableProjectConnectionError(
   return new UnityServerNotRunningError(projectRoot);
 }
 
-async function shouldRetryWhenUnityProcessIsRunning(
+export async function shouldRetryWhenUnityProcessIsRunning(
+  error: unknown,
   projectRoot: string | null,
   shouldDiagnoseProjectState: boolean,
+  dependencies: ConnectionFailureDiagnosisDependencies = defaultConnectionFailureDiagnosisDependencies,
 ): Promise<boolean> {
-  if (!shouldDiagnoseProjectState || projectRoot === null) {
+  if (!isRetryableError(error) || !shouldDiagnoseProjectState || projectRoot === null) {
     return false;
   }
 
-  const runningProcess = await findRunningUnityProcessForProject(projectRoot).catch(
+  const runningProcess = await dependencies.findRunningUnityProcessForProjectFn(projectRoot).catch(
     () => undefined,
   );
   return runningProcess !== null && runningProcess !== undefined;
@@ -369,7 +371,7 @@ export async function executeToolCommand(
         throw error instanceof Error ? error : new Error(String(error));
       }
 
-      if (await shouldRetryWhenUnityProcessIsRunning(projectRoot, shouldValidateProject)) {
+      if (await shouldRetryWhenUnityProcessIsRunning(error, projectRoot, shouldValidateProject)) {
         spinner.update('Unity Editor is running, waiting for CLI Loop server to recover...');
         await sleep(RETRY_DELAY_MS);
         continue;

--- a/Packages/src/Cli~/src/execute-tool.ts
+++ b/Packages/src/Cli~/src/execute-tool.ts
@@ -142,6 +142,20 @@ export async function diagnoseRetryableProjectConnectionError(
   return new UnityServerNotRunningError(projectRoot);
 }
 
+async function shouldRetryWhenUnityProcessIsRunning(
+  projectRoot: string | null,
+  shouldDiagnoseProjectState: boolean,
+): Promise<boolean> {
+  if (!shouldDiagnoseProjectState || projectRoot === null) {
+    return false;
+  }
+
+  const runningProcess = await findRunningUnityProcessForProject(projectRoot).catch(
+    () => undefined,
+  );
+  return runningProcess !== null && runningProcess !== undefined;
+}
+
 async function throwFinalToolError(
   error: unknown,
   projectRoot: string | null,
@@ -353,6 +367,12 @@ export async function executeToolCommand(
         spinner.stop();
         restoreStdin();
         throw error instanceof Error ? error : new Error(String(error));
+      }
+
+      if (await shouldRetryWhenUnityProcessIsRunning(projectRoot, shouldValidateProject)) {
+        spinner.update('Unity Editor is running, waiting for CLI Loop server to recover...');
+        await sleep(RETRY_DELAY_MS);
+        continue;
       }
 
       if (!isRetryableError(error) || attempt >= MAX_RETRIES) {

--- a/Packages/src/Editor/Server/McpServerController.cs
+++ b/Packages/src/Editor/Server/McpServerController.cs
@@ -155,6 +155,8 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
+            ClearStartupProtection();
+
             // Execute shutdown UseCase
             McpServerShutdownUseCase useCase = new(new McpServerStartupService());
             ServerShutdownSchema schema = new() { ForceShutdown = false };
@@ -182,6 +184,8 @@ namespace io.github.hatayama.uLoopMCP
         /// </summary>
         private static void OnBeforeAssemblyReload()
         {
+            ClearStartupProtection();
+
             // Create and execute DomainReloadRecoveryUseCase instance
             DomainReloadRecoveryUseCase useCase = new();
             ServiceResult<string> result = useCase.ExecuteBeforeDomainReload(mcpServer);
@@ -361,6 +365,8 @@ namespace io.github.hatayama.uLoopMCP
             // OnServerLoopExited fires from thread pool — marshal to main thread for Unity API safety
             EditorApplication.delayCall += () =>
             {
+                ClearStartupProtection();
+
                 VibeLogger.LogWarning(
                     "server_loop_exit_detected",
                     "Detected unexpected server loop exit. Initiating automatic recovery.",
@@ -619,6 +625,14 @@ namespace io.github.hatayama.uLoopMCP
             long untilTicks = DateTime.UtcNow.AddMilliseconds(milliseconds).Ticks;
             System.Threading.Volatile.Write(ref startupProtectionUntilTicks, untilTicks);
             VibeLogger.LogInfo("startup_protection_active", $"window={milliseconds}ms");
+        }
+
+        /// <summary>
+        /// Clears startup protection so recovery paths can restart the server immediately.
+        /// </summary>
+        private static void ClearStartupProtection()
+        {
+            System.Threading.Volatile.Write(ref startupProtectionUntilTicks, 0L);
         }
 
         /// <summary>

--- a/scripts/uloop-compile-get-logs-stress.sh
+++ b/scripts/uloop-compile-get-logs-stress.sh
@@ -9,6 +9,7 @@ INTERVAL_SECONDS="${ULOOP_STRESS_INTERVAL_SECONDS:-2}"
 LOG_DIR="${ULOOP_STRESS_LOG_DIR:-.uloop/stress-tests}"
 MAX_ROUNDS="${ULOOP_STRESS_MAX_ROUNDS:-0}"
 WAIT_FOR_READY_SECONDS="${ULOOP_STRESS_WAIT_FOR_READY_SECONDS:-15}"
+CURRENT_CHILD_PID=''
 mkdir -p "$LOG_DIR"
 
 timestamp() {
@@ -27,7 +28,7 @@ wait_for_ready() {
     round="$1"
     deadline=$(( $(date +%s) + WAIT_FOR_READY_SECONDS ))
     while :; do
-        if uloop_cmd get-logs --max-count 1 >/dev/null 2>&1; then
+        if run_quiet uloop_cmd get-logs --max-count 1; then
             printf '%s [%s] ready\n' "$(timestamp)" "$round"
             return 0
         fi
@@ -38,7 +39,7 @@ wait_for_ready() {
             return 1
         fi
 
-        sleep 2
+        sleep_interruptible 2
     done
 }
 
@@ -46,7 +47,48 @@ cleanup() {
     printf '%s cleanup\n' "$(timestamp)"
 }
 
-trap cleanup INT TERM
+run_quiet() {
+    "$@" >/dev/null 2>&1 &
+    CURRENT_CHILD_PID="$!"
+    wait "$CURRENT_CHILD_PID"
+    status="$?"
+    CURRENT_CHILD_PID=''
+    return "$status"
+}
+
+run_with_logs() {
+    stdout_path="$1"
+    stderr_path="$2"
+    shift 2
+
+    "$@" >"$stdout_path" 2>"$stderr_path" &
+    CURRENT_CHILD_PID="$!"
+    wait "$CURRENT_CHILD_PID"
+    status="$?"
+    CURRENT_CHILD_PID=''
+    return "$status"
+}
+
+sleep_interruptible() {
+    duration_seconds="$1"
+
+    sleep "$duration_seconds" &
+    CURRENT_CHILD_PID="$!"
+    wait "$CURRENT_CHILD_PID"
+    status="$?"
+    CURRENT_CHILD_PID=''
+    return "$status"
+}
+
+handle_interrupt() {
+    cleanup
+    if [ -n "$CURRENT_CHILD_PID" ]; then
+        kill -TERM "$CURRENT_CHILD_PID" 2>/dev/null || :
+    fi
+    exit 130
+}
+
+trap handle_interrupt INT TERM
 
 echo "=== uloop compile/get-logs stress test ==="
 echo "log_dir=$LOG_DIR"
@@ -66,7 +108,8 @@ while :; do
         exit 0
     fi
 
-    if ! uloop_cmd compile --wait-for-domain-reload true >"$LOG_DIR/${round}_compile.out" 2>"$LOG_DIR/${round}_compile.err"; then
+    if ! run_with_logs "$LOG_DIR/${round}_compile.out" "$LOG_DIR/${round}_compile.err" \
+        uloop_cmd compile --wait-for-domain-reload true; then
         echo "compile failed at round $round"
         exit 1
     fi
@@ -76,12 +119,13 @@ while :; do
         exit 1
     fi
 
-    if ! uloop_cmd get-logs --max-count 1 >"$LOG_DIR/${round}_get-logs.out" 2>"$LOG_DIR/${round}_get-logs.err"; then
+    if ! run_with_logs "$LOG_DIR/${round}_get-logs.out" "$LOG_DIR/${round}_get-logs.err" \
+        uloop_cmd get-logs --max-count 1; then
         echo "get-logs failed at round $round"
         exit 1
     fi
 
     echo "$(timestamp) [$round] round complete"
     round=$((round + 1))
-    sleep "$INTERVAL_SECONDS"
+    sleep_interruptible "$INTERVAL_SECONDS"
 done

--- a/scripts/uloop-compile-get-logs-stress.sh
+++ b/scripts/uloop-compile-get-logs-stress.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Stress test: repeatedly run uloop compile and uloop get-logs in sequence.
+# Designed for long-running Unity server restart/recovery verification.
+
+set -eu
+
+PROJECT_PATH="${ULOOP_PROJECT_PATH:-}"
+INTERVAL_SECONDS="${ULOOP_STRESS_INTERVAL_SECONDS:-2}"
+LOG_DIR="${ULOOP_STRESS_LOG_DIR:-.uloop/stress-tests}"
+MAX_ROUNDS="${ULOOP_STRESS_MAX_ROUNDS:-0}"
+WAIT_FOR_READY_SECONDS="${ULOOP_STRESS_WAIT_FOR_READY_SECONDS:-15}"
+mkdir -p "$LOG_DIR"
+
+timestamp() {
+    date +"%Y-%m-%dT%H:%M:%S%z"
+}
+
+uloop_cmd() {
+    if [ -n "$PROJECT_PATH" ]; then
+        uloop "$@" --project-path "$PROJECT_PATH"
+    else
+        uloop "$@"
+    fi
+}
+
+wait_for_ready() {
+    round="$1"
+    deadline=$(( $(date +%s) + WAIT_FOR_READY_SECONDS ))
+    while :; do
+        if uloop_cmd get-logs --max-count 1 >/dev/null 2>&1; then
+            printf '%s [%s] ready\n' "$(timestamp)" "$round"
+            return 0
+        fi
+
+        now="$(date +%s)"
+        if [ "$now" -ge "$deadline" ]; then
+            printf '%s [%s] ready timeout after %ss\n' "$(timestamp)" "$round" "$WAIT_FOR_READY_SECONDS"
+            return 1
+        fi
+
+        sleep 2
+    done
+}
+
+cleanup() {
+    printf '%s cleanup\n' "$(timestamp)"
+}
+
+trap cleanup INT TERM
+
+echo "=== uloop compile/get-logs stress test ==="
+echo "log_dir=$LOG_DIR"
+echo "interval_seconds=$INTERVAL_SECONDS"
+echo "max_rounds=$MAX_ROUNDS"
+echo "wait_for_ready_seconds=$WAIT_FOR_READY_SECONDS"
+
+if ! wait_for_ready "bootstrap"; then
+    echo "bootstrap failed"
+    exit 1
+fi
+
+round=1
+while :; do
+    if [ "$MAX_ROUNDS" -gt 0 ] && [ "$round" -gt "$MAX_ROUNDS" ]; then
+        echo "reached max rounds: $MAX_ROUNDS"
+        exit 0
+    fi
+
+    if ! uloop_cmd compile >"$LOG_DIR/${round}_compile.out" 2>"$LOG_DIR/${round}_compile.err"; then
+        echo "compile failed at round $round"
+        exit 1
+    fi
+
+    if ! wait_for_ready "$round"; then
+        echo "server did not become ready after compile at round $round"
+        exit 1
+    fi
+
+    if ! uloop_cmd get-logs --max-count 1 >"$LOG_DIR/${round}_get-logs.out" 2>"$LOG_DIR/${round}_get-logs.err"; then
+        echo "get-logs failed at round $round"
+        exit 1
+    fi
+
+    echo "$(timestamp) [$round] round complete"
+    round=$((round + 1))
+    sleep "$INTERVAL_SECONDS"
+done

--- a/scripts/uloop-compile-get-logs-stress.sh
+++ b/scripts/uloop-compile-get-logs-stress.sh
@@ -66,7 +66,7 @@ while :; do
         exit 0
     fi
 
-    if ! uloop_cmd compile >"$LOG_DIR/${round}_compile.out" 2>"$LOG_DIR/${round}_compile.err"; then
+    if ! uloop_cmd compile --wait-for-domain-reload true >"$LOG_DIR/${round}_compile.out" 2>"$LOG_DIR/${round}_compile.err"; then
         echo "compile failed at round $round"
         exit 1
     fi

--- a/scripts/uloop-compile-get-logs-stress.sh
+++ b/scripts/uloop-compile-get-logs-stress.sh
@@ -89,10 +89,12 @@ run_quiet_with_timeout() {
 
     (
         sleep "$timeout_seconds"
-        : > "$timeout_marker"
-        kill -TERM "$CURRENT_CHILD_PID" 2>/dev/null || :
-        sleep 1
-        kill -KILL "$CURRENT_CHILD_PID" 2>/dev/null || :
+        if kill -0 "$CURRENT_CHILD_PID" 2>/dev/null; then
+            : > "$timeout_marker"
+            kill -TERM "$CURRENT_CHILD_PID" 2>/dev/null || :
+            sleep 1
+            kill -KILL "$CURRENT_CHILD_PID" 2>/dev/null || :
+        fi
     ) &
     CURRENT_TIMEOUT_PID="$!"
 

--- a/scripts/uloop-compile-get-logs-stress.sh
+++ b/scripts/uloop-compile-get-logs-stress.sh
@@ -10,6 +10,7 @@ LOG_DIR="${ULOOP_STRESS_LOG_DIR:-.uloop/stress-tests}"
 MAX_ROUNDS="${ULOOP_STRESS_MAX_ROUNDS:-0}"
 WAIT_FOR_READY_SECONDS="${ULOOP_STRESS_WAIT_FOR_READY_SECONDS:-15}"
 CURRENT_CHILD_PID=''
+CURRENT_TIMEOUT_PID=''
 mkdir -p "$LOG_DIR"
 
 timestamp() {
@@ -28,7 +29,13 @@ wait_for_ready() {
     round="$1"
     deadline=$(( $(date +%s) + WAIT_FOR_READY_SECONDS ))
     while :; do
-        if run_quiet uloop_cmd get-logs --max-count 1; then
+        remaining_seconds=$(( deadline - $(date +%s) ))
+        if [ "$remaining_seconds" -le 0 ]; then
+            printf '%s [%s] ready timeout after %ss\n' "$(timestamp)" "$round" "$WAIT_FOR_READY_SECONDS"
+            return 1
+        fi
+
+        if run_quiet_with_timeout "$remaining_seconds" uloop_cmd get-logs --max-count 1; then
             printf '%s [%s] ready\n' "$(timestamp)" "$round"
             return 0
         fi
@@ -44,6 +51,20 @@ wait_for_ready() {
 }
 
 cleanup() {
+    if [ -n "$CURRENT_TIMEOUT_PID" ]; then
+        kill -TERM "$CURRENT_TIMEOUT_PID" 2>/dev/null || :
+        wait "$CURRENT_TIMEOUT_PID" 2>/dev/null || :
+        CURRENT_TIMEOUT_PID=''
+    fi
+
+    if [ -n "$CURRENT_CHILD_PID" ]; then
+        kill -TERM "$CURRENT_CHILD_PID" 2>/dev/null || :
+        sleep 1
+        kill -KILL "$CURRENT_CHILD_PID" 2>/dev/null || :
+        wait "$CURRENT_CHILD_PID" 2>/dev/null || :
+        CURRENT_CHILD_PID=''
+    fi
+
     printf '%s cleanup\n' "$(timestamp)"
 }
 
@@ -53,6 +74,45 @@ run_quiet() {
     wait "$CURRENT_CHILD_PID"
     status="$?"
     CURRENT_CHILD_PID=''
+    return "$status"
+}
+
+run_quiet_with_timeout() {
+    timeout_seconds="$1"
+    shift
+
+    "$@" >/dev/null 2>&1 &
+    CURRENT_CHILD_PID="$!"
+
+    timeout_marker="${LOG_DIR}/.timeout-${CURRENT_CHILD_PID}"
+    rm -f "$timeout_marker"
+
+    (
+        sleep "$timeout_seconds"
+        : > "$timeout_marker"
+        kill -TERM "$CURRENT_CHILD_PID" 2>/dev/null || :
+        sleep 1
+        kill -KILL "$CURRENT_CHILD_PID" 2>/dev/null || :
+    ) &
+    CURRENT_TIMEOUT_PID="$!"
+
+    if wait "$CURRENT_CHILD_PID"; then
+        status=0
+    else
+        status="$?"
+    fi
+
+    kill -TERM "$CURRENT_TIMEOUT_PID" 2>/dev/null || :
+    wait "$CURRENT_TIMEOUT_PID" 2>/dev/null || :
+    CURRENT_TIMEOUT_PID=''
+    CURRENT_CHILD_PID=''
+
+    if [ -e "$timeout_marker" ]; then
+        rm -f "$timeout_marker"
+        return 124
+    fi
+
+    rm -f "$timeout_marker"
     return "$status"
 }
 
@@ -82,9 +142,6 @@ sleep_interruptible() {
 
 handle_interrupt() {
     cleanup
-    if [ -n "$CURRENT_CHILD_PID" ]; then
-        kill -TERM "$CURRENT_CHILD_PID" 2>/dev/null || :
-    fi
     exit 130
 }
 


### PR DESCRIPTION
## Summary
- improve Unity-side server recovery so the Unity CLI Loop server can restart reliably across shutdown, assembly reload, and unexpected loop exits
- reduce false "Unity Editor is running, but Unity CLI Loop server is not" reports while the Unity server is still recovering
- add regression coverage for startup-protection recovery paths and make those tests safe to run against a live Unity Editor
- add stress tooling and CLI coverage for repeated `compile` / `get-logs` recovery verification, including `--wait-for-domain-reload`

## Testing
- `uloop compile --wait-for-domain-reload true`
- `uloop run-tests --filter-type regex --filter-value "McpServerPortTests\.(OnBeforeAssemblyReload_ShouldClearStartupProtectionBeforeRecovery|StopServerWithUseCaseAsync_ShouldClearStartupProtectionBeforeShutdown)"`
- `ULOOP_PROJECT_PATH=/Users/a12115/ghq/hatayama/unity-cli-loop3 ULOOP_STRESS_MAX_ROUNDS=10 ULOOP_STRESS_INTERVAL_SECONDS=1 ULOOP_STRESS_WAIT_FOR_READY_SECONDS=20 ./scripts/uloop-compile-get-logs-stress.sh`

## Notes
- local Unity-generated changes in `ProjectSettings/ProjectSettings.asset` are intentionally left out of this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Unity server recovery so `uloop compile` and `uloop get-logs` work reliably through shutdowns, domain reloads, and unexpected exits. Further reduces false “Unity Editor is running, but Unity CLI Loop server is not” messages by gating retries to safe cases and improving the stress test’s timeout handling.

- **Bug Fixes**
  - Clear startup protection before shutdown, before domain reload, and after unexpected loop exit so restarts aren’t dropped.
  - Retry only when Unity is still running; update spinner, wait, and refresh the port before retry (keep current if settings are busy). Adds tests for retry gating and port refresh.
  - Stress script guards the timeout marker with a liveness check before killing the child process; adds readiness-timeout and liveness tests.

- **New Features**
  - Expose and verify `compile --wait-for-domain-reload`; waits through domain reload and returns once the compile result is available.
  - Add `scripts/uloop-compile-get-logs-stress.sh` to loop `compile` and `get-logs`, auto-wait for readiness, save per-round logs, and handle INT/TERM for clean shutdown.

<sup>Written for commit ce0e3821a0340d8d6c5744269ca31ed99e1b2647. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR improves Unity CLI Loop server recovery reliability by ensuring startup-protection windows are cleared during shutdown, domain reload, and unexpected exit scenarios. It adds regression and unit test coverage, exposes the `--wait-for-domain-reload` compile option, enhances CLI retry/recovery behavior (including port refresh), and introduces stress testing tooling to validate recovery paths under load.

## Key Changes

### Startup Protection Recovery (Packages/src/Editor/Server/McpServerController.cs)
- Added ClearStartupProtection() helper that atomically resets the internal startup-protection window (`startupProtectionUntilTicks`) to 0.
- Call sites added to clear startup protection in three recovery/shutdown flows:
  1. Before executing the shutdown UseCase in StopServerWithUseCaseAsync.
  2. At the start of OnBeforeAssemblyReload (domain reload recovery).
  3. Inside the main-thread EditorApplication.delayCall handler for OnServerLoopUnexpectedlyExited.
- Ensures MCP server restart requests are not silently dropped while Unity is recovering.

### Retry Logic and Port Refresh (Packages/src/Cli~/src/execute-tool.ts)
- Added two exported helpers:
  - shouldRetryWhenUnityProcessIsRunning(...) — returns true only for retryable failures when project-state diagnosis is enabled and a Unity process is detected.
  - resolveRecoveryPortOrKeepCurrent(...) — refreshes the Unity server port for recovery unless an explicit port override was provided; falls back to current port on failure.
- Modified executeToolCommand retry loop to:
  - Retry only on retryable failures and only while a Unity process is still running.
  - Update spinner message and sleep (RETRY_DELAY_MS) while waiting for recovery.
  - Refresh the server port before retrying (keeping current port if settings are busy or resolution fails).
  - Limit retries to appropriate conditions so recovery attempts are not wasted.

### Compile Command Exposure (Packages/src/Cli~/src/__tests__/cli-e2e.test.ts)
- Exposed and tested `compile --wait-for-domain-reload` behavior.
- Updated `compile --help` assertions to require the `--wait-for-domain-reload` flag.
- Added an end-to-end test that invokes `compile --wait-for-domain-reload` and verifies successful execution.

### Tests: Startup Protection & Retry Behavior
- Assets/Tests/Editor/McpServerPortTests.cs
  - Added three NUnit tests (using reflection) that validate clearing of startup protection through:
    1. Direct ClearStartupProtection invocation.
    2. OnBeforeAssemblyReload recovery path.
    3. StopServerWithUseCaseAsync shutdown path (awaited).
  - Tests restore modified controller/editor state and clean domain-reload lock file in finally blocks; designed to be safe to run against a live Unity Editor.
- Packages/src/Cli~/src/__tests__/execute-tool-recovery.test.ts
  - New test suite that mocks port resolution and Unity liveness to verify executeToolCommand retries and that resolveUnityPort is invoked again during recovery (e.g., fails on first port 8711 then succeeds on 8712).
- Packages/src/Cli~/src/__tests__/execute-tool.test.ts
  - Added unit tests for the two new helpers (shouldRetryWhenUnityProcessIsRunning and resolveRecoveryPortOrKeepCurrent) covering retryable vs non-retryable errors and port resolution fallback/update behaviors.

### Stress Testing Tooling
- scripts/uloop-compile-get-logs-stress.sh
  - New POSIX shell stress script to repeatedly run `uloop compile --wait-for-domain-reload true` and `uloop get-logs --max-count 1`, capturing per-round logs.
  - Configurable via environment variables: ULOOP_PROJECT_PATH, ULOOP_STRESS_INTERVAL_SECONDS, ULOOP_STRESS_LOG_DIR, ULOOP_STRESS_MAX_ROUNDS, ULOOP_STRESS_WAIT_FOR_READY_SECONDS.
  - Performs a bootstrap readiness probe before the stress loop, enforces a readiness timeout, timestamps outputs, and saves per-round stdout/stderr.
  - Installs INT/TERM trap and handles child/timeout process cleanup so the script exits cleanly (code 130) on interrupts.
- Packages/src/Cli~/src/__tests__/stress-script.test.ts
  - Added tests that run the stress script under controlled conditions (fake uloop executable), asserting bootstrap/readiness failure behavior and that the script guards timeout-marker creation with a liveness check.

## Commit-level Notes
- Fixes include handling signal shutdown in the stress script, limiting recovery retries to retryable failures while Unity is live, ensuring port refresh happens inside retry cleanup to probe the correct port, and guarding stress-test timeout marker creation with a liveness check to avoid false timeouts during Unity recovery.

## Testing / How to Exercise
- Run regression/unit tests added (NUnit and Jest suites).
- CLI examples:
  - uloop compile --wait-for-domain-reload true
  - uloop run-tests --filter-type regex --filter-value "McpServerPortTests\.(OnBeforeAssemblyReload_ShouldClearStartupProtectionBeforeRecovery|StopServerWithUseCaseAsync_ShouldClearStartupProtectionBeforeShutdown)"
- Stress run example:
  - ULOOP_PROJECT_PATH=... ULOOP_STRESS_MAX_ROUNDS=10 ULOOP_STRESS_INTERVAL_SECONDS=1 ULOOP_STRESS_WAIT_FOR_READY_SECONDS=20 ./scripts/uloop-compile-get-logs-stress.sh

## Impact
- Reduces false "Unity Editor is running, but Unity CLI Loop server is not" reports while the server recovers.
- Improves reliability of MCP server restarts across shutdown, assembly reloads, and unexpected loop exits.
- Provides tooling and tests to validate recovery behavior under repeated stress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->