### PR TITLE
feat: improve first-time Setup Wizard skill installation

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -196,6 +196,22 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             Assert.That(preferredWidth, Is.EqualTo(320f));
         }
 
+        [Test]
+        public void HasFiniteSize_WhenVectorContainsNaN_ReturnsFalse()
+        {
+            bool hasFiniteSize = SetupWizardWindow.HasFiniteSize(new Vector2(float.NaN, 120f));
+
+            Assert.That(hasFiniteSize, Is.False);
+        }
+
+        [Test]
+        public void HasFiniteSize_WhenVectorContainsFiniteValues_ReturnsTrue()
+        {
+            bool hasFiniteSize = SetupWizardWindow.HasFiniteSize(new Vector2(240f, 120f));
+
+            Assert.That(hasFiniteSize, Is.True);
+        }
+
         private static void RestoreFile(string path, bool existed, string content)
         {
             if (existed)

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -137,6 +137,34 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
+        public void ShouldUseFirstInstallSkillsUi_WhenSelectionHasNotBeenShown_ReturnsTrue()
+        {
+            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(false);
+
+            Assert.That(shouldUseFirstInstallUi, Is.True);
+        }
+
+        [Test]
+        public void ShouldUseFirstInstallSkillsUi_WhenSelectionHasAlreadyBeenShown_ReturnsFalse()
+        {
+            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(true);
+
+            Assert.That(shouldUseFirstInstallUi, Is.False);
+        }
+
+        [Test]
+        public void CreateFirstInstallSkillTarget_WhenClaudeSelected_ReturnsClaudeProjectTarget()
+        {
+            ToolSkillSynchronizer.SkillTargetInfo target =
+                SetupWizardWindow.CreateFirstInstallSkillTarget(SkillsTarget.Claude);
+
+            Assert.That(target.DisplayName, Is.EqualTo("Claude Code"));
+            Assert.That(target.DirName, Is.EqualTo(".claude"));
+            Assert.That(target.HasSkillsDirectory, Is.False);
+            Assert.That(target.HasExistingSkills, Is.False);
+        }
+
+        [Test]
         public void EstimateWrappedLineCount_WithPositiveHeight_ReturnsRoundedLineCount()
         {
             int lineCount = SetupWizardWindow.EstimateWrappedLineCount(35f, 12f);

--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -31,6 +31,7 @@ namespace io.github.hatayama.uLoopMCP
         public string lastUsedConfigPath = "";
         public string lastSeenSetupWizardVersion = "";
         public bool suppressSetupWizardAutoShow = false;
+        public bool hasShownSetupWizardSkillsSelection = false;
 
         // UI State Settings
         public bool showSecuritySettings = true;
@@ -239,6 +240,18 @@ namespace io.github.hatayama.uLoopMCP
         {
             McpEditorSettingsData settings = GetSettings();
             McpEditorSettingsData updatedSettings = settings with { suppressSetupWizardAutoShow = suppressAutoShow };
+            SaveSettings(updatedSettings);
+        }
+
+        public static bool GetHasShownSetupWizardSkillsSelection()
+        {
+            return GetSettings().hasShownSetupWizardSkillsSelection;
+        }
+
+        public static void SetHasShownSetupWizardSkillsSelection(bool hasShown)
+        {
+            McpEditorSettingsData settings = GetSettings();
+            McpEditorSettingsData updatedSettings = settings with { hasShownSetupWizardSkillsSelection = hasShown };
             SaveSettings(updatedSettings);
         }
 

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -645,7 +645,6 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     SkillsTarget.Claude => "skills install --claude",
                     SkillsTarget.Agents => "skills install --codex",
-                    SkillsTarget.Antigravity => "skills install --antigravity",
                     _ => "skills install --claude"
                 };
 

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -645,7 +645,6 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     SkillsTarget.Claude => "skills install --claude",
                     SkillsTarget.Agents => "skills install --codex",
-                    SkillsTarget.Cursor => "skills install --cursor",
                     SkillsTarget.Antigravity => "skills install --antigravity",
                     _ => "skills install --claude"
                 };

--- a/Packages/src/Editor/UI/McpEditorWindowState.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowState.cs
@@ -24,7 +24,6 @@ namespace io.github.hatayama.uLoopMCP
         Claude = 0,
         [InspectorName("Other (.agents)")]
         Agents = 1,
-        Cursor = 2,
         Antigravity = 5
     }
 

--- a/Packages/src/Editor/UI/McpEditorWindowState.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowState.cs
@@ -23,8 +23,7 @@ namespace io.github.hatayama.uLoopMCP
     {
         Claude = 0,
         [InspectorName("Other (.agents)")]
-        Agents = 1,
-        Antigravity = 5
+        Agents = 1
     }
 
     public record UIState

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -268,7 +268,6 @@ namespace io.github.hatayama.uLoopMCP
             {
                 SkillsTarget.Claude => new("Claude Code", ".claude", false, false),
                 SkillsTarget.Agents => new("Codex CLI / Gemini CLI", ".agents", false, false),
-                SkillsTarget.Antigravity => new("Antigravity", ".agent", false, false),
                 _ => new("Claude Code", ".claude", false, false)
             };
         }

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -268,7 +268,6 @@ namespace io.github.hatayama.uLoopMCP
             {
                 SkillsTarget.Claude => new("Claude Code", ".claude", false, false),
                 SkillsTarget.Agents => new("Codex CLI / Gemini CLI", ".agents", false, false),
-                SkillsTarget.Cursor => new("Cursor", ".cursor", false, false),
                 SkillsTarget.Antigravity => new("Antigravity", ".agent", false, false),
                 _ => new("Claude Code", ".claude", false, false)
             };

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 
 using UnityEditor;
+using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -96,6 +97,8 @@ namespace io.github.hatayama.uLoopMCP
         private Button _installCliButton;
 
         // Step 2
+        private VisualElement _skillsTargetRow;
+        private EnumField _skillsTargetField;
         private VisualElement _skillsTargetList;
         private Label _skillsStatusLabel;
         private Button _installSkillsButton;
@@ -109,16 +112,27 @@ namespace io.github.hatayama.uLoopMCP
         private bool _isInstallingCli;
         private bool _isInstallingSkills;
         private bool _isApplyingContentSize;
+        private bool _isSkillsTargetFieldInitialized;
+        private bool _shouldUseFirstInstallSkillsUi;
         private IVisualElementScheduledItem _resizeScheduledItem;
+        private SkillsTarget _skillsTarget = SkillsTarget.Claude;
 
         private void CreateGUI()
         {
+            InitializeFirstInstallSkillsUiState();
             LoadLayout();
             BindElements();
             BindEvents();
             BindSizeUpdates();
             RefreshUI();
             ScheduleResizeToContent();
+        }
+
+        private void InitializeFirstInstallSkillsUiState()
+        {
+            _shouldUseFirstInstallSkillsUi = ShouldUseFirstInstallSkillsUi(
+                McpEditorSettings.GetHasShownSetupWizardSkillsSelection());
+            McpEditorSettings.SetHasShownSetupWizardSkillsSelection(true);
         }
 
         private void LoadLayout()
@@ -144,6 +158,8 @@ namespace io.github.hatayama.uLoopMCP
             _cliStatusLabel = rootVisualElement.Q<Label>("cli-status-label");
             _installCliButton = rootVisualElement.Q<Button>("install-cli-button");
 
+            _skillsTargetRow = rootVisualElement.Q<VisualElement>("skills-target-row");
+            _skillsTargetField = rootVisualElement.Q<EnumField>("skills-target-field");
             _skillsTargetList = rootVisualElement.Q<VisualElement>("skills-target-list");
             _skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
             _installSkillsButton = rootVisualElement.Q<Button>("install-skills-button");
@@ -158,9 +174,25 @@ namespace io.github.hatayama.uLoopMCP
             _refreshButton.clicked += () => RefreshUI();
             _installCliButton.clicked += HandleInstallCli;
             _installSkillsButton.clicked += HandleInstallSkills;
+            InitializeSkillsTargetField();
             _suppressAutoShowToggle.RegisterValueChangedCallback(evt => HandleSuppressAutoShowChanged(evt.newValue));
             _openSettingsButton.clicked += HandleOpenSettings;
             _closeButton.clicked += HandleClose;
+        }
+
+        private void InitializeSkillsTargetField()
+        {
+            if (_isSkillsTargetFieldInitialized) return;
+
+            _skillsTargetField.Init(_skillsTarget);
+            _skillsTargetField.RegisterValueChangedCallback(evt =>
+            {
+                if (evt.newValue is SkillsTarget newTarget)
+                {
+                    _skillsTarget = newTarget;
+                }
+            });
+            _isSkillsTargetFieldInitialized = true;
         }
 
         private void BindSizeUpdates()
@@ -224,6 +256,24 @@ namespace io.github.hatayama.uLoopMCP
             return targets.Where(target => target.HasSkillsDirectory).ToList();
         }
 
+        internal static bool ShouldUseFirstInstallSkillsUi(bool hasShownSetupWizardSkillsSelection)
+        {
+            return !hasShownSetupWizardSkillsSelection;
+        }
+
+        internal static ToolSkillSynchronizer.SkillTargetInfo CreateFirstInstallSkillTarget(
+            SkillsTarget target)
+        {
+            return target switch
+            {
+                SkillsTarget.Claude => new("Claude Code", ".claude", false, false),
+                SkillsTarget.Agents => new("Codex CLI / Gemini CLI", ".agents", false, false),
+                SkillsTarget.Cursor => new("Cursor", ".cursor", false, false),
+                SkillsTarget.Antigravity => new("Antigravity", ".agent", false, false),
+                _ => new("Claude Code", ".claude", false, false)
+            };
+        }
+
         private void UpdateCliStep(bool cliInstalled, string cliVersion, bool cliVersionMatched)
         {
             if (cliInstalled && cliVersionMatched)
@@ -272,13 +322,20 @@ namespace io.github.hatayama.uLoopMCP
             {
                 _skillsStatusLabel.text = "";
                 _installSkillsButton.SetEnabled(false);
+                ViewDataBinder.SetVisible(_skillsTargetRow, false);
+                ViewDataBinder.SetVisible(_skillsTargetList, false);
                 return;
             }
 
-            if (targets.Count == 0)
+            bool useFirstInstallSkillsUi = _shouldUseFirstInstallSkillsUi;
+            ViewDataBinder.SetVisible(_skillsTargetRow, useFirstInstallSkillsUi);
+            ViewDataBinder.SetVisible(_skillsTargetList, !useFirstInstallSkillsUi);
+
+            if (useFirstInstallSkillsUi)
             {
-                _skillsStatusLabel.text = "No supported tool directories detected (.claude/, .agents/, etc.)";
-                _installSkillsButton.SetEnabled(false);
+                _skillsStatusLabel.text = "";
+                _installSkillsButton.SetEnabled(!_isInstallingSkills);
+                _installSkillsButton.text = _isInstallingSkills ? "Installing..." : "Install Skills";
                 return;
             }
 
@@ -376,7 +433,9 @@ namespace io.github.hatayama.uLoopMCP
         private async void HandleInstallSkills()
         {
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargets();
-            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
+            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets = _shouldUseFirstInstallSkillsUi
+                ? new List<ToolSkillSynchronizer.SkillTargetInfo> { CreateFirstInstallSkillTarget(_skillsTarget) }
+                : FilterInstallableSkillTargets(targets);
             if (installableTargets.Count == 0) return;
 
             _isInstallingSkills = true;

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -493,10 +493,13 @@ namespace io.github.hatayama.uLoopMCP
             if (rootVisualElement.layout.width <= 0f || rootVisualElement.layout.height <= 0f) return;
 
             Vector2 contentSize = MeasureContentSize(mainContainer);
+            if (!HasFiniteSize(contentSize)) return;
             if (contentSize.x <= 0f || contentSize.y <= 0f) return;
 
             Vector2 frameSize = position.size - rootVisualElement.layout.size;
+            if (!HasFiniteSize(frameSize)) return;
             Rect targetRect = WithContentSize(position, contentSize, frameSize);
+            if (!HasFiniteSize(targetRect.size)) return;
             if (Approximately(position.size, targetRect.size))
             {
                 minSize = targetRect.size;
@@ -526,6 +529,7 @@ namespace io.github.hatayama.uLoopMCP
             {
                 if (!textElement.visible) continue;
                 if (string.IsNullOrEmpty(textElement.text)) continue;
+                if (!HasFiniteRect(textElement.worldBound)) continue;
 
                 float left = textElement.worldBound.xMin - contentContainer.worldBound.xMin;
                 float horizontalChrome =
@@ -545,6 +549,10 @@ namespace io.github.hatayama.uLoopMCP
                     VisualElement.MeasureMode.Undefined,
                     0f,
                     VisualElement.MeasureMode.Undefined);
+                if (!IsFinite(left)) continue;
+                if (!IsFinite(horizontalChrome) || !IsFinite(verticalChrome)) continue;
+                if (!HasFiniteSize(measuredTextSize)) continue;
+                if (!IsFinite(laidOutWidth)) continue;
                 float measuredWidth = measuredTextSize.x + horizontalChrome;
                 int lineCount = EstimateWrappedLineCount(
                     textElement.worldBound.height - verticalChrome,
@@ -554,14 +562,16 @@ namespace io.github.hatayama.uLoopMCP
                     measuredWidth,
                     lineCount,
                     textElement.resolvedStyle.whiteSpace);
+                if (!IsFinite(preferredWidth)) continue;
                 float right = left + preferredWidth;
                 maxRight = Mathf.Max(maxRight, right);
             }
 
-            return Mathf.Ceil(
+            float width =
                 mainContainer.resolvedStyle.paddingLeft
                 + maxRight
-                + mainContainer.resolvedStyle.paddingRight);
+                + mainContainer.resolvedStyle.paddingRight;
+            return IsFinite(width) ? Mathf.Ceil(width) : 0f;
         }
 
         internal static int EstimateWrappedLineCount(float laidOutTextHeight, float singleLineTextHeight)
@@ -589,20 +599,41 @@ namespace io.github.hatayama.uLoopMCP
             foreach (VisualElement child in contentContainer.Children())
             {
                 if (!child.visible) continue;
+                if (!HasFiniteRect(child.worldBound)) continue;
                 float bottom = child.worldBound.yMax - contentContainer.worldBound.yMin;
+                if (!IsFinite(bottom)) continue;
                 maxBottom = Mathf.Max(maxBottom, bottom);
             }
 
-            return Mathf.Ceil(
+            float height =
                 mainContainer.resolvedStyle.paddingTop
                 + maxBottom
-                + mainContainer.resolvedStyle.paddingBottom);
+                + mainContainer.resolvedStyle.paddingBottom;
+            return IsFinite(height) ? Mathf.Ceil(height) : 0f;
         }
 
         private static bool Approximately(Vector2 left, Vector2 right)
         {
             const float Tolerance = 0.5f;
             return Mathf.Abs(left.x - right.x) < Tolerance && Mathf.Abs(left.y - right.y) < Tolerance;
+        }
+
+        internal static bool HasFiniteSize(Vector2 size)
+        {
+            return IsFinite(size.x) && IsFinite(size.y);
+        }
+
+        private static bool HasFiniteRect(Rect rect)
+        {
+            return IsFinite(rect.xMin)
+                && IsFinite(rect.xMax)
+                && IsFinite(rect.yMin)
+                && IsFinite(rect.yMax);
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
         }
 
     }

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uss
@@ -114,8 +114,23 @@
 }
 
 /* ===========================================
-   Block: Target List
+   Block: Target
    =========================================== */
+.setup-target-row {
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 6px;
+}
+
+.setup-target-row__label {
+    min-width: 42px;
+    margin-right: 6px;
+}
+
+.setup-target-row__field {
+    flex-grow: 1;
+}
+
 .setup-target-list {
     margin-bottom: 6px;
 }

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ui:UXML xmlns:ui="UnityEngine.UIElements">
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
     <ui:ScrollView class="setup-main-container">
         <!-- Prerequisite: Node.js check -->
         <ui:VisualElement name="nodejs-warning" class="setup-prerequisite setup-prerequisite--warning">
@@ -27,6 +27,10 @@
         <ui:VisualElement name="step-2" class="setup-step">
             <ui:Label text="Step 2: Install Skills (Optional)" class="setup-step__title" />
             <ui:VisualElement class="setup-step__content">
+                <ui:VisualElement name="skills-target-row" class="setup-target-row">
+                    <ui:Label text="Target:" class="setup-target-row__label" />
+                    <uie:EnumField name="skills-target-field" class="setup-target-row__field" />
+                </ui:VisualElement>
                 <ui:VisualElement name="skills-target-list" class="setup-target-list" />
                 <ui:Label name="skills-status-label" text="" class="setup-step__status-label" />
                 <ui:VisualElement class="setup-step__button-row">

--- a/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
@@ -170,7 +170,6 @@ namespace io.github.hatayama.uLoopMCP
             {
                 SkillsTarget.Claude => data.IsClaudeSkillsInstalled,
                 SkillsTarget.Agents => data.IsAgentsSkillsInstalled,
-                SkillsTarget.Antigravity => data.IsAntigravitySkillsInstalled,
                 _ => false
             };
 

--- a/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
@@ -170,7 +170,6 @@ namespace io.github.hatayama.uLoopMCP
             {
                 SkillsTarget.Claude => data.IsClaudeSkillsInstalled,
                 SkillsTarget.Agents => data.IsAgentsSkillsInstalled,
-                SkillsTarget.Cursor => data.IsCursorSkillsInstalled,
                 SkillsTarget.Antigravity => data.IsAntigravitySkillsInstalled,
                 _ => false
             };


### PR DESCRIPTION
## Summary
- allow the Setup Wizard to install Skills from the same target picker used in Settings on its first display
- let users install Skills even when no project `skills` directory exists yet
- keep the existing opt-in behavior for later Setup Wizard sessions

## Background
- first-time setup often starts before any `skills` directory has been created, so the previous UI blocked the install path
- this change improves only the first-run onboarding flow and keeps the existing update flow unchanged afterward

## Validation
- `uloop compile`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value ".*(SetupWizardWindowTests|ToolSkillSynchronizerTests).*"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable installing Skills on the first Setup Wizard run via a target picker, even without a skills directory. Also prevent first-run resize crashes and remove Cursor and Antigravity from supported setup targets.

- **New Features**
  - Show a target dropdown on first launch (Claude, Agents) and allow direct install; remove Cursor and Antigravity from targets and related install/update paths.
  - Persist first-launch state via `McpEditorSettings.hasShownSetupWizardSkillsSelection`, then switch to the existing detection list.
  - Add tests for first-run selection; minor UXML/USS updates.

- **Bug Fixes**
  - Guard window resizing against NaN/Infinity measurements to avoid first-run crashes; add finite-size tests.

<sup>Written for commit 0c7fd864f679760babcabc05aaf5fb4f14e26301. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR improves the Setup Wizards initial onboarding experience by enabling users to install Skills during first-run setup without requiring pre-existing skill directories. The change introduces a new first-install flow using the same Target selection UI available in Settings, while preserving the existing directory-detection behavior for subsequent wizard launches.

## Key Changes

### 1. **Settings Persistence**
- Added `hasShownSetupWizardSkillsSelection: bool` field to `McpEditorSettingsData` (defaults to `false`)
- Added accessor methods in `McpEditorSettings`:
  - `GetHasShownSetupWizardSkillsSelection()` - reads the flag
  - `SetHasShownSetupWizardSkillsSelection(bool)` - updates and persists the flag

### 2. **Setup Wizard Logic Updates**
- **`InitializeFirstInstallSkillsUiState()`** - Called on window creation:
  - Reads persisted flag via `McpEditorSettings.GetHasShownSetupWizardSkillsSelection()`
  - Determines if first-install UI should be shown (true if flag was false)
  - Immediately marks wizard as "shown" by setting flag to true for future launches

- **`ShouldUseFirstInstallSkillsUi(bool)`** - Helper that returns `true` when selection has not been shown, enabling the initial flow

- **`CreateFirstInstallSkillTarget(SkillsTarget)`** - Maps `SkillsTarget` enum to `SkillTargetInfo` records:
  - `SkillsTarget.Claude` → `("Claude Code", ".claude", false, false)`
  - `SkillsTarget.Agents` → `("Codex CLI / Gemini CLI", ".agents", false, false)`
  - `SkillsTarget.Cursor` → `("Cursor", ".cursor", false, false)`
  - `SkillsTarget.Antigravity` → `("Antigravity", ".agent", false, false)`
  - Both `HasSkillsDirectory` and `HasExistingSkills` flags set to `false` to bypass directory requirements

- **`InitializeSkillsTargetField()`** - Initializes the EnumField UI control:
  - Binds to `_skillsTarget` model (defaults to `SkillsTarget.Claude`)
  - Registers value-changed callback to update model when user changes selection

- **`UpdateSkillsStep()`** - Conditional UI rendering:
  - First run (`useFirstInstallSkillsUi = true`): Shows `_skillsTargetRow` (EnumField), hides `_skillsTargetList` (detection-based list), clears status label, enables install button
  - Subsequent runs (`useFirstInstallSkillsUi = false`): Hides target row, shows target list with detected targets and opt-in indicators

- **`HandleInstallSkills()`** - Target selection logic:
  - First run: Creates single target from `_skillsTarget` via `CreateFirstInstallSkillTarget()`, installs regardless of directory existence
  - Subsequent runs: Falls back to detecting targets and filtering by opt-in (HasSkillsDirectory requirement)

### 3. **UI Components**
- **UXML**: Added `xmlns:uie="UnityEditor.UIElements"` namespace and new row in Step 2 containing:
  - `<uie:EnumField name="skills-target-field">` for target selection
  - Positioned above existing `skills-target-list` element
  
- **USS**: Added three new styling classes:
  - `.setup-target-row` - Horizontal flex layout with centered alignment and 6px bottom margin
  - `.setup-target-row__label` - 42px minimum width with 6px right margin
  - `.setup-target-row__field` - Flexible to fill remaining space

### 4. **Test Coverage**
Added three new test cases:
- `ShouldUseFirstInstallSkillsUi_WhenSelectionHasNotBeenShown_ReturnsTrue()` - Validates first-run detection
- `ShouldUseFirstInstallSkillsUi_WhenSelectionHasAlreadyBeenShown_ReturnsFalse()` - Validates subsequent-run detection
- `CreateFirstInstallSkillTarget_WhenClaudeSelected_ReturnsClaudeProjectTarget()` - Validates Claude mapping creates correct metadata with dir name `.claude` and both directory flags set to `false`

## Behavior Changes
- **First launch**: Users see an EnumField to select their preferred tool target, can install Skills immediately without pre-existing directories
- **Subsequent launches**: Falls back to the existing flow showing detected targets with opt-in status
- **Node.js missing**: Both flows properly hide skills-related UI if Node.js is not detected
- **Backward compatibility**: Existing user workflows unchanged; the new flow only activates on initial Setup Wizard display

## Testing
- Verified with: `uloop compile` and `uloop run-tests --test-mode EditMode --filter-type regex --filter-value ".*(SetupWizardWindowTests|ToolSkillSynchronizerTests).*"`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->