### PR TITLE
chore: README gitignore example now matches the generated .uloop registry file

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -690,7 +690,7 @@ The `.uloop/` directory at the project root stores CLI cache, tool registry, and
 > ```gitignore
 > **/.uloop/*
 > !**/.uloop/settings.permissions.json
-> !**/.uloop/settings.tools.json
+> !**/.uloop/tools.json
 > ```
 >
 > This ignores auto-generated files and runtime outputs while allowing team-shared configuration to be tracked.

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -688,7 +688,7 @@ description: "ツールの説明と使用タイミング"
 > ```gitignore
 > **/.uloop/*
 > !**/.uloop/settings.permissions.json
-> !**/.uloop/settings.tools.json
+> !**/.uloop/tools.json
 > ```
 >
 > 自動生成ファイルやランタイム出力を無視しつつ、チーム共有の設定ファイルをgit管理できます。

--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ The `.uloop/` directory at the project root stores CLI cache, tool registry, and
 > ```gitignore
 > **/.uloop/*
 > !**/.uloop/settings.permissions.json
-> !**/.uloop/settings.tools.json
+> !**/.uloop/tools.json
 > ```
 >
 > This ignores auto-generated files and runtime outputs while allowing team-shared configuration to be tracked.

--- a/README_ja.md
+++ b/README_ja.md
@@ -688,7 +688,7 @@ description: "ツールの説明と使用タイミング"
 > ```gitignore
 > **/.uloop/*
 > !**/.uloop/settings.permissions.json
-> !**/.uloop/settings.tools.json
+> !**/.uloop/tools.json
 > ```
 >
 > 自動生成ファイルやランタイム出力を無視しつつ、チーム共有の設定ファイルをgit管理できます。


### PR DESCRIPTION
## Summary
- update the root README files to ignore the generated \.uloop/tools.json file instead of the old settings.tools.json path
- sync the package README copies with the same documentation change

## Why
The documented gitignore example was still pointing at an outdated filename, which could mislead users configuring repository tracking for .uloop files.

## Testing
- not run (documentation change only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README gitignore examples to allow tracking of `.uloop/tools.json` instead of the outdated `.uloop/settings.tools.json`. Keeps root and package READMEs aligned with the generated registry file.

<sup>Written for commit f2da53f3188ce0f4db2bedb711a179bfae466a55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

