### PR TITLE
fix: prevent installation errors when the Unity Test Framework package is missing

### DIFF
--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -197,6 +197,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
+        "com.unity.test-framework": "1.3.9",
         "com.unity.ugui": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.2.1"
       }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -197,7 +197,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.unity.test-framework": "1.3.9",
+        "com.unity.test-framework": "1.1.33",
         "com.unity.ugui": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.2.1"
       }

--- a/Packages/src/package.json
+++ b/Packages/src/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/hatayama/uLoopMCP"
   },
   "dependencies": {
+    "com.unity.test-framework": "1.3.9",
     "com.unity.ugui": "1.0.0",
     "com.unity.nuget.newtonsoft-json": "3.2.1"
   },

--- a/Packages/src/package.json
+++ b/Packages/src/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/hatayama/uLoopMCP"
   },
   "dependencies": {
-    "com.unity.test-framework": "1.3.9",
+    "com.unity.test-framework": "1.1.33",
     "com.unity.ugui": "1.0.0",
     "com.unity.nuget.newtonsoft-json": "3.2.1"
   },


### PR DESCRIPTION
## Summary
- add the missing `com.unity.test-framework` dependency to the package manifest
- prevent package import errors in projects that use the bundled Run Tests tool

## Changes
- add `com.unity.test-framework` version `1.1.33` to `Packages/src/package.json`
- update `Packages/packages-lock.json` so the embedded package dependency matches the manifest

## Verification
- `uloop compile --force-recompile true --wait-for-domain-reload true`
- `uloop get-logs --log-type Error --max-count 50`
- `uloop get-logs --log-type Warning --max-count 50`
- `uloop run-tests --test-mode EditMode --filter-type exact --filter-value io.github.hatayama.uLoopMCP.RunTestsToolTests.ToolName_ShouldReturnRunTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds the missing `com.unity.test-framework` package dependency to prevent installation errors when projects use the bundled Run Tests tool.

## Changes

- **Packages/src/package.json**: Added `com.unity.test-framework` version `1.1.33` to the `dependencies` section
- **Packages/packages-lock.json**: Added corresponding dependency entry to the embedded package `io.github.hatayama.uloopmcp`

## Context

The Unity Test Framework package is required for the bundled Run Tests tool to function properly in projects that consume this package. Without this explicit dependency declaration, Unity package resolution would fail, causing import errors.

## Testing

Verification steps have been provided:
- Force recompilation with domain reload
- Log validation for errors and warnings
- Run Tests tool functional test targeting the `ToolName_ShouldReturnRunTests` test case

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing `com.unity.test-framework` dependency (v1.1.33) to prevent installation/import errors when using the bundled Run Tests tool. Updates `Packages/src/package.json` and `Packages/packages-lock.json` so the embedded package resolves correctly.

<sup>Written for commit 0d66269ab2219b19c7eb1bb89da7fb5cb45bf5c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


