### PR TITLE
fix: invalid EditMode test requests now return a clear error during play mode

### DIFF
--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -1,0 +1,68 @@
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEditor.TestTools.TestRunner.Api;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    public class RunTestsUseCaseTests
+    {
+        [Test]
+        public async Task ExecuteAsync_WithInvalidExecutionState_ShouldFailFastWithoutRunningTests()
+        {
+            StubTestExecutionService executionService = new();
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                new StubTestExecutionStateValidationService(ValidationResult.Failure("EditMode tests cannot run during play mode"))
+            );
+            RunTestsSchema parameters = new()
+            {
+                TestMode = TestMode.EditMode
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("EditMode tests cannot run during play mode"));
+            Assert.That(response.CompletedAt, Is.Not.Empty);
+            Assert.That(response.TestCount, Is.EqualTo(0));
+            Assert.That(response.PassedCount, Is.EqualTo(0));
+            Assert.That(response.FailedCount, Is.EqualTo(0));
+            Assert.That(response.SkippedCount, Is.EqualTo(0));
+            Assert.That(executionService.WasCalled, Is.False);
+        }
+
+        private sealed class StubTestExecutionStateValidationService : TestExecutionStateValidationService
+        {
+            private readonly ValidationResult _result;
+
+            public StubTestExecutionStateValidationService(ValidationResult result)
+            {
+                _result = result;
+            }
+
+            public override ValidationResult Validate(TestMode testMode)
+            {
+                return _result;
+            }
+        }
+
+        private sealed class StubTestExecutionService : TestExecutionService
+        {
+            public bool WasCalled { get; private set; }
+
+            public override Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter)
+            {
+                WasCalled = true;
+                return Task.FromResult(new SerializableTestResult());
+            }
+
+            public override Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter)
+            {
+                WasCalled = true;
+                return Task.FromResult(new SerializableTestResult());
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ed4c1aaec85f4bd3803668a8eae6298
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
+++ b/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using UnityEditor.TestTools.TestRunner.Api;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    public class TestExecutionStateValidationServiceTests
+    {
+        [Test]
+        public void Validate_WithEditModeWhilePlaying_ShouldReturnFailure()
+        {
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(true);
+
+            ValidationResult result = service.Validate(TestMode.EditMode);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode"));
+        }
+
+        [Test]
+        public void Validate_WithEditModeWhileNotPlaying_ShouldReturnSuccess()
+        {
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(false);
+
+            ValidationResult result = service.Validate(TestMode.EditMode);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(result.ErrorMessage, Is.Null);
+        }
+
+        [Test]
+        public void Validate_WithPlayModeWhilePlaying_ShouldReturnSuccess()
+        {
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(true);
+
+            ValidationResult result = service.Validate(TestMode.PlayMode);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(result.ErrorMessage, Is.Null);
+        }
+
+        private sealed class StubTestExecutionStateValidationService : TestExecutionStateValidationService
+        {
+            private readonly bool _isPlaying;
+
+            public StubTestExecutionStateValidationService(bool isPlaying)
+            {
+                _isPlaying = isPlaying;
+            }
+
+            protected override bool IsPlaying => _isPlaying;
+        }
+    }
+}

--- a/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs.meta
+++ b/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0992eba10fa3e4b1a84fafa6ee512510
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using System.Threading;
 using UnityEditor.TestTools.TestRunner.Api;
@@ -12,6 +13,28 @@ namespace io.github.hatayama.uLoopMCP
     /// </summary>
     public class RunTestsUseCase : AbstractUseCase<RunTestsSchema, RunTestsResponse>
     {
+        private readonly TestFilterCreationService _filterService;
+        private readonly TestExecutionService _executionService;
+        private readonly TestExecutionStateValidationService _validationService;
+
+        public RunTestsUseCase()
+            : this(
+                new TestFilterCreationService(),
+                new TestExecutionService(),
+                new TestExecutionStateValidationService())
+        {
+        }
+
+        public RunTestsUseCase(
+            TestFilterCreationService filterService,
+            TestExecutionService executionService,
+            TestExecutionStateValidationService validationService)
+        {
+            _filterService = filterService ?? throw new ArgumentNullException(nameof(filterService));
+            _executionService = executionService ?? throw new ArgumentNullException(nameof(executionService));
+            _validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
+        }
+
         /// <summary>
         /// Executes test execution processing
         /// </summary>
@@ -20,17 +43,21 @@ namespace io.github.hatayama.uLoopMCP
         /// <returns>Test execution result</returns>
         public override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken cancellationToken)
         {
+            ValidationResult validation = _validationService.Validate(parameters.TestMode);
+            if (!validation.IsValid)
+            {
+                return CreateFailureResponse(validation.ErrorMessage);
+            }
+
             // 1. Test filter creation
             TestExecutionFilter filter = null;
             if (parameters.FilterType != TestFilterType.all)
             {
-                TestFilterCreationService filterService = new();
-                filter = filterService.CreateFilter(parameters.FilterType, parameters.FilterValue);
+                filter = _filterService.CreateFilter(parameters.FilterType, parameters.FilterValue);
             }
             
             // 2. Test execution
             cancellationToken.ThrowIfCancellationRequested();
-            TestExecutionService executionService = new();
             SerializableTestResult result;
             
             try
@@ -38,12 +65,12 @@ namespace io.github.hatayama.uLoopMCP
                 if (parameters.TestMode == TestMode.PlayMode)
                 {
                     // TODO: Add cancellationToken parameter when TestExecutionService supports it
-                    result = await executionService.ExecutePlayModeTestAsync(filter);
+                    result = await _executionService.ExecutePlayModeTestAsync(filter);
                 }
                 else
                 {
                     // TODO: Add cancellationToken parameter when TestExecutionService supports it
-                    result = await executionService.ExecuteEditModeTestAsync(filter);
+                    result = await _executionService.ExecuteEditModeTestAsync(filter);
                 }
             }
             catch (System.OperationCanceledException)
@@ -75,6 +102,20 @@ namespace io.github.hatayama.uLoopMCP
                 failedCount: result.failedCount,
                 skippedCount: result.skippedCount,
                 xmlPath: result.xmlPath
+            );
+        }
+
+        private static RunTestsResponse CreateFailureResponse(string message)
+        {
+            return new RunTestsResponse(
+                success: false,
+                message: message,
+                completedAt: DateTime.Now.ToString("o"),
+                testCount: 0,
+                passedCount: 0,
+                failedCount: 0,
+                skippedCount: 0,
+                xmlPath: null
             );
         }
     }

--- a/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using System.Threading;
 using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
 
 namespace io.github.hatayama.uLoopMCP
 {
@@ -30,9 +31,12 @@ namespace io.github.hatayama.uLoopMCP
             TestExecutionService executionService,
             TestExecutionStateValidationService validationService)
         {
-            _filterService = filterService ?? throw new ArgumentNullException(nameof(filterService));
-            _executionService = executionService ?? throw new ArgumentNullException(nameof(executionService));
-            _validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
+            Debug.Assert(filterService != null, "filterService must not be null");
+            Debug.Assert(executionService != null, "executionService must not be null");
+            Debug.Assert(validationService != null, "validationService must not be null");
+            _filterService = filterService;
+            _executionService = executionService;
+            _validationService = validationService;
         }
 
         /// <summary>
@@ -110,7 +114,7 @@ namespace io.github.hatayama.uLoopMCP
             return new RunTestsResponse(
                 success: false,
                 message: message,
-                completedAt: DateTime.Now.ToString("o"),
+                completedAt: DateTime.UtcNow.ToString("o"),
                 testCount: 0,
                 passedCount: 0,
                 failedCount: 0,

--- a/Packages/src/Editor/Core/ApplicationServices/TestExecutionService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/TestExecutionService.cs
@@ -15,7 +15,7 @@ namespace io.github.hatayama.uLoopMCP
         /// </summary>
         /// <param name="filter">Test execution filter</param>
         /// <returns>Test execution result</returns>
-        public async Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter)
+        public virtual async Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter)
         {
             return await PlayModeTestExecuter.ExecutePlayModeTest(filter);
         }
@@ -25,7 +25,7 @@ namespace io.github.hatayama.uLoopMCP
         /// </summary>
         /// <param name="filter">Test execution filter</param>
         /// <returns>Test execution result</returns>
-        public async Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter)
+        public virtual async Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter)
         {
             return await PlayModeTestExecuter.ExecuteEditModeTest(filter);
         }

--- a/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs
@@ -1,0 +1,20 @@
+using UnityEditor;
+using UnityEditor.TestTools.TestRunner.Api;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    public class TestExecutionStateValidationService
+    {
+        protected virtual bool IsPlaying => EditorApplication.isPlaying;
+
+        public virtual ValidationResult Validate(TestMode testMode)
+        {
+            if (testMode == TestMode.EditMode && IsPlaying)
+            {
+                return ValidationResult.Failure("EditMode tests cannot run during play mode");
+            }
+
+            return ValidationResult.Success();
+        }
+    }
+}

--- a/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs.meta
+++ b/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8dfdb70f9061248eeb326b4403df2c8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Core/CoreTools/TestRunner/SerializableTestResult.cs
+++ b/Packages/src/Editor/Core/CoreTools/TestRunner/SerializableTestResult.cs
@@ -30,7 +30,7 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     success = true,
                     message = "PlayMode test execution completed (detailed results not available)",
-                    completedAt = DateTime.Now.ToString("o"),
+                    completedAt = DateTime.UtcNow.ToString("o"),
                     testCount = 1,
                     passedCount = 1,
                     failedCount = 0,
@@ -62,7 +62,7 @@ namespace io.github.hatayama.uLoopMCP
             {
                 success = success,
                 message = message,
-                completedAt = DateTime.Now.ToString("o"),
+                completedAt = DateTime.UtcNow.ToString("o"),
                 testCount = totalTests,
                 passedCount = passedTests,
                 failedCount = failedTests,


### PR DESCRIPTION
## Summary
- Fix the case where `uloop run-tests --test-mode EditMode` could hang if Unity was already in play mode.
- Return a deterministic failure response with `EditMode tests cannot run during play mode` instead of waiting for Test Runner callbacks.

## Changes
- Add a run-tests execution-state validation service for the EditMode/play mode precondition.
- Make `RunTestsUseCase` fail fast before starting test execution and return an explicit zero-count failure result.
- Add editor tests covering the validation service and the use case fail-fast path.

## Verification
- `uloop compile`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "io.github.hatayama.uLoopMCP.TestExecutionStateValidationServiceTests"`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "io.github.hatayama.uLoopMCP.RunTestsUseCaseTests"`
- Entered play mode and confirmed that `uloop run-tests --test-mode EditMode ...` now fails immediately with the expected message.

## Issue
- Closes #934

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
EditMode test requests made during play mode now fail fast with a clear error instead of hanging. All run-tests timestamps are now UTC.

- **Bug Fixes**
  - Added TestExecutionStateValidationService to block EditMode tests while playing.
  - Updated RunTestsUseCase to validate before execution and return a failure result.
  - Standardized all run-tests timestamps to UTC.
  - Marked TestExecutionService methods virtual to enable stubbing in tests; added unit tests for validation and fail-fast behavior.

<sup>Written for commit 4bc78b859ef22923f2c3e9c6630e795a09a4ce4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR addresses a hang issue that occurred when invalid test execution requests (specifically EditMode tests) were attempted during play mode. The fix introduces an early validation check that returns a clear error response without attempting to execute the tests.

## Key Changes

### New Validation Service
- **`TestExecutionStateValidationService`**: A new application service that validates whether test execution is permitted based on the current Editor state:
  - Returns `ValidationResult.Failure` with message `"EditMode tests cannot run during play mode"` when EditMode tests are requested while the Editor is in play mode
  - Returns `ValidationResult.Success()` for all other valid combinations
  - Exposes `IsPlaying` as a protected virtual property for testability

### Enhanced `RunTestsUseCase`
- **Dependency Injection**: Constructor overload now accepts `TestFilterCreationService`, `TestExecutionService`, and `TestExecutionStateValidationService` for improved testability
- **Early Validation**: `ExecuteAsync` now validates the execution state before creating any test filter
- **Fast-Fail Response**: Invalid requests immediately return a `RunTestsResponse` with:
  - `success: false`
  - Descriptive validation error message
  - Zero test counts (`TestCount`, `PassedCount`, `FailedCount`, `SkippedCount` all 0)
  - `null` XML path
  - Current timestamp for `completedAt`
- Test execution service is never invoked for invalid requests

### Service Extensibility
- **`TestExecutionService`**: Methods `ExecutePlayModeTestAsync` and `ExecuteEditModeTestAsync` are now `virtual` to support test stubs

### Test Coverage
- **`RunTestsUseCaseTests`**: Validates that the use case returns proper failure responses when execution state validation fails
- **`TestExecutionStateValidationServiceTests`**: Comprehensive coverage of all validation scenarios:
  - EditMode tests during play mode (returns failure)
  - EditMode tests outside play mode (returns success)
  - PlayMode tests during play mode (returns success)

## Architecture

```mermaid
classDiagram
    class TestExecutionStateValidationService {
        #virtual IsPlaying: bool
        +virtual Validate(TestMode): ValidationResult
    }
    
    class RunTestsUseCase {
        -TestFilterCreationService _filterService
        -TestExecutionService _executionService
        -TestExecutionStateValidationService _validationService
        +RunTestsUseCase()
        +RunTestsUseCase(filterService, executionService, validationService)
        +ExecuteAsync(RunTestsSchema, CancellationToken): Task~RunTestsResponse~
        -CreateFailureResponse(message): RunTestsResponse
    }
    
    class TestExecutionService {
        +virtual ExecutePlayModeTestAsync(TestExecutionFilter): Task~SerializableTestResult~
        +virtual ExecuteEditModeTestAsync(TestExecutionFilter): Task~SerializableTestResult~
    }
    
    class ValidationResult {
        +Success: bool
        +ErrorMessage: string
        +static Success(): ValidationResult
        +static Failure(message): ValidationResult
    }
    
    class RunTestsSchema {
        +TestMode: TestMode
    }
    
    class TestMode {
        <<enumeration>>
        EditMode
        PlayMode
    }
    
    RunTestsUseCase --> TestExecutionStateValidationService
    RunTestsUseCase --> TestExecutionService
    RunTestsUseCase --> TestFilterCreationService
    TestExecutionStateValidationService --> ValidationResult
    RunTestsUseCase --> RunTestsSchema
    RunTestsSchema --> TestMode
```

## Impact

This change prevents the editor from hanging when EditMode tests are accidentally requested during play mode, instead providing immediate, actionable feedback to the user that the operation is not permitted in the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->