### PR TITLE
fix: README pages now show the refreshed logo

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -9,9 +9,11 @@
 ![Antigravity](https://img.shields.io/badge/Antigravity-111?logo=google)
 ![GitHubCopilot](https://img.shields.io/badge/GitHub_Copilot-111?logo=githubcopilot)
 
-<img width="1000" alt="logo" align="center" src="https://github.com/user-attachments/assets/864aa12e-8fd0-4b3a-9794-15cecdf95f94" />
-<p align="right"><sub>(Logo inspired by Daft Punk's <i>Homework</i> album art)</sub></p>
-
+<p align="center">
+  <img width="600" alt="logo" src="https://github.com/user-attachments/assets/416c4452-e385-415b-bff0-9399bba3b1e0" /><br>
+  <sub>(Logo inspired by Daft Punk's <i>Discovery</i> album art)</sub>
+</p>
+  
 
 Let an AI agent compile, test, and operate your Unity project from popular LLM tools via CLI.
 

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -10,8 +10,10 @@
 ![Antigravity](https://img.shields.io/badge/Antigravity-111?logo=google)
 ![GitHubCopilot](https://img.shields.io/badge/GitHub_Copilot-111?logo=githubcopilot)
 
-<img width="1000" alt="logo" align="center" src="https://github.com/user-attachments/assets/864aa12e-8fd0-4b3a-9794-15cecdf95f94" />
-<p align="right"><sub>(Logo inspired by Daft Punk's <i>Homework</i> album art)</sub></p>
+<p align="center">
+  <img width="600" alt="logo" src="https://github.com/user-attachments/assets/416c4452-e385-415b-bff0-9399bba3b1e0" /><br>
+  <sub>(Logo inspired by Daft Punk's <i>Discovery</i> album art)</sub>
+</p>
 
 CLIを通じて、AIエージェントがUnityプロジェクトのコンパイル・テスト・操作を各種LLMツールから実行できるようにします。
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 ![Antigravity](https://img.shields.io/badge/Antigravity-111?logo=google)
 ![GitHubCopilot](https://img.shields.io/badge/GitHub_Copilot-111?logo=githubcopilot)
 
-<img width="1000" alt="logo" align="center" src="https://github.com/user-attachments/assets/864aa12e-8fd0-4b3a-9794-15cecdf95f94" />
-<p align="right"><sub>(Logo inspired by Daft Punk's <i>Homework</i> album art)</sub></p>
-
+<p align="center">
+  <img width="600" alt="logo" src="https://github.com/user-attachments/assets/416c4452-e385-415b-bff0-9399bba3b1e0" /><br>
+  <sub>(Logo inspired by Daft Punk's <i>Discovery</i> album art)</sub>
+</p>
+  
 
 Let an AI agent compile, test, and operate your Unity project from popular LLM tools via CLI.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -10,8 +10,10 @@
 ![Antigravity](https://img.shields.io/badge/Antigravity-111?logo=google)
 ![GitHubCopilot](https://img.shields.io/badge/GitHub_Copilot-111?logo=githubcopilot)
 
-<img width="1000" alt="logo" align="center" src="https://github.com/user-attachments/assets/864aa12e-8fd0-4b3a-9794-15cecdf95f94" />
-<p align="right"><sub>(Logo inspired by Daft Punk's <i>Homework</i> album art)</sub></p>
+<p align="center">
+  <img width="600" alt="logo" src="https://github.com/user-attachments/assets/416c4452-e385-415b-bff0-9399bba3b1e0" /><br>
+  <sub>(Logo inspired by Daft Punk's <i>Discovery</i> album art)</sub>
+</p>
 
 CLIを通じて、AIエージェントがUnityプロジェクトのコンパイル・テスト・操作を各種LLMツールから実行できるようにします。
 


### PR DESCRIPTION
## Summary
- refresh the root README logo block to use the centered Discovery artwork
- apply the same centered logo layout to the Japanese README
- sync the packaged README copies under Packages/src so both distributions match

## Testing
- not run (documentation-only changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR updates the README files across the repository to display a refreshed, centered "Discovery"-themed logo artwork. All changes are documentation-only, affecting four README files: the root README (English and Japanese) and their packaged copies under `Packages/src/`.

## Changes

### Logo Layout & Styling
- Replaced right-aligned `<img>` tags with centered HTML blocks (`<p align="center">`)
- Resized logo images from 1000px to 600px width for consistent, centered presentation
- Added explicit line break (`<br>`) elements within centered paragraph blocks

### Album Art Reference
- Updated logo inspiration caption from Daft Punk's *Homework* to *Discovery* across all four README files
- Applied consistent branding across English and Japanese documentation

### Files Modified
- `README.md` (+5/-3 lines)
- `README_ja.md` (+4/-2 lines)
- `Packages/src/README.md` (+5/-3 lines)
- `Packages/src/README_ja.md` (+4/-2 lines)

## Impact
Documentation-only changes with low review effort. No exported or public code entities affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the logo across all READMEs to a centered “Discovery” artwork. Applies the 600px centered image and caption to the root and Japanese READMEs and their `Packages/src/` copies, replacing the previous right-aligned “Homework” version.

<sup>Written for commit 9c4235ce39385f6e9ebbbb6239daf8c4e3f7dab6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

