### PR TITLE
feat: Windows users can follow PowerShell-specific PlayMode automation examples

### DIFF
--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -57,8 +57,10 @@ For detailed code examples, refer to these files:
   - Undo-aware operations: RecordObject, AddComponent, SetParent, grouping
 - **Selection operations**: See [references/selection-operations.md](references/selection-operations.md)
   - Get/set selection, multi-select, filter by type/editability
-- **PlayMode automation**: See [references/playmode-automation.md](references/playmode-automation.md)
-  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows
+- **PlayMode automation (zsh)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
+  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows for zsh users
+- **PlayMode automation (PowerShell)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
+  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows for PowerShell users
 - **PlayMode UI controls**: See [references/playmode-ui-controls.md](references/playmode-ui-controls.md)
   - InputField, Slider, Toggle, Dropdown, drag & drop simulation, list all UI controls
 - **PlayMode inspection**: See [references/playmode-inspection.md](references/playmode-inspection.md)

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-execute-dynamic-code
-description: "Execute C# code dynamically in Unity Editor. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) PlayMode automation (click buttons, raycast, invoke methods), (5) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (6) PlayMode inspection (scene info, reflection, physics state). NOT for file I/O or script authoring."
+description: "Execute C# code dynamically in Unity Editor. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) PlayMode automation (click buttons, invoke methods, tweak runtime state), (5) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (6) PlayMode inspection (scene info, reflection, physics state, raycast checks). NOT for file I/O or script authoring."
 context: fork
 ---
 
@@ -58,10 +58,10 @@ For detailed code examples, refer to these files:
 - **Selection operations**: See [references/selection-operations.md](references/selection-operations.md)
   - Get/set selection, multi-select, filter by type/editability
 - **PlayMode automation (zsh)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
-  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows for zsh users
+  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
 - **PlayMode automation (PowerShell)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
-  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows for PowerShell users
+  - Click UI buttons, invoke methods, set fields, tool combination workflows for PowerShell users
 - **PlayMode UI controls**: See [references/playmode-ui-controls.md](references/playmode-ui-controls.md)
   - InputField, Slider, Toggle, Dropdown, drag & drop simulation, list all UI controls
 - **PlayMode inspection**: See [references/playmode-inspection.md](references/playmode-inspection.md)
-  - Scene info, game state via reflection, physics state, GameObject search, position/rotation
+  - Scene info, game state via reflection, physics state, raycast checks, GameObject search, position/rotation

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -4,6 +4,21 @@ Code examples for runtime automation during Play mode using `execute-dynamic-cod
 These examples manipulate live scene objects while the game is running.
 Shell command examples in this file target `PowerShell`.
 
+## When to use dedicated mouse simulation tools instead
+
+The examples in this file call UI handlers or runtime methods from C#.
+That is useful for targeted automation, but it is not the same as simulating a real mouse input path.
+
+Use dedicated mouse tools when you want input behavior closer to what a human player produces:
+
+| Scenario | Recommended tool | Why |
+|----------|------------------|-----|
+| Click or drag a uGUI element through the EventSystem path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of calling handlers from custom C# directly. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
+| Jump straight to a known button callback or inspect internal state | `execute-dynamic-code` | Best when you intentionally want a direct method call, reflection, or state tweak without reproducing the full input pipeline. |
+
+In short: `execute-dynamic-code` is best for direct automation, while `simulate-mouse-ui` and `simulate-mouse-input` are better when you need the actual input route to be part of the test.
+
 ## PowerShell Quoting Notes
 
 Use these patterns when you need shell-safe inline code:

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). If that is not available in the target project, prefer `execute-dynamic-code` for a project-specific workaround instead of changing project settings just to use this tool. |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. Requires Active Input Handling set to `Input System Package (New)` or `Both`. |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. Requires Active Input Handling set to `Input System Package (New)` or `Both`. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -1,7 +1,67 @@
-# PlayMode Automation
+# PlayMode Automation (PowerShell)
 
 Code examples for runtime automation during Play mode using `execute-dynamic-code`.
 These examples manipulate live scene objects while the game is running.
+Shell command examples in this file target `PowerShell`.
+
+## PowerShell Quoting Notes
+
+Use these patterns when you need shell-safe inline code:
+
+### Double quotes inside C# strings
+
+Single-quote the whole snippet and keep C# string literals unchanged.
+
+```powershell
+uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
+```
+
+### Single quotes inside inline C# code
+
+If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
+
+```powershell
+uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
+```
+
+### JSON-like values passed via `--parameters`
+
+Wrap the whole expression in single quotes so PowerShell passes the inner double quotes through unchanged.
+
+```powershell
+uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
+```
+
+### Multi-line C# snippets
+
+Use a here-string when the snippet spans multiple lines.
+
+```powershell
+$code = @'
+using UnityEngine;
+
+GameObject obj = GameObject.Find("Player");
+if (obj == null) return "Player not found";
+
+return obj.name;
+'@
+
+uloop execute-dynamic-code --code $code
+```
+
+You can combine multi-line code with multi-line parameters the same way.
+
+```powershell
+$code = @'
+return parameters["param0"];
+'@
+
+$parameters = @'
+{"param0":"Hello from PowerShell"}
+'@
+
+uloop execute-dynamic-code --code $code --parameters $parameters
+```
 
 ## Click UI Button by Path
 
@@ -135,7 +195,7 @@ Use `find-game-objects` to discover buttons with their hierarchy paths, then cli
 
 **Step 1**: Find all GameObjects with Button component
 
-```bash
+```powershell
 uloop find-game-objects --required-components UnityEngine.UI.Button --include-inactive false
 ```
 
@@ -161,8 +221,8 @@ Use `get-hierarchy` to explore the UI tree structure, then target the right elem
 
 **Step 1**: Get Canvas hierarchy to understand UI structure
 
-```bash
-uloop get-hierarchy --root-path "Canvas" --max-depth 3 --include-components true
+```powershell
+uloop get-hierarchy --root-path 'Canvas' --max-depth 3 --include-components true
 ```
 
 **Step 2**: Based on the hierarchy JSON, click the desired button
@@ -201,7 +261,7 @@ return "Clicked PlayButton";
 
 **Step 2**: Capture Game View to verify the result
 
-```bash
+```powershell
 uloop screenshot --window-name Game
 ```
 
@@ -211,7 +271,7 @@ Run an action then inspect Unity Console logs to verify expected behavior.
 
 **Step 1**: Clear console before the action
 
-```bash
+```powershell
 uloop clear-console
 ```
 
@@ -235,8 +295,8 @@ return "Invoked TakeDamage(50)";
 
 **Step 3**: Check logs for expected output
 
-```bash
-uloop get-logs --log-type Log --search-text "damage"
+```powershell
+uloop get-logs --log-type Log --search-text 'damage'
 ```
 
 ## Full Automation: Play → Act → Capture → Stop
@@ -245,13 +305,13 @@ End-to-end test flow: start Play mode, perform actions, capture evidence, stop.
 
 **Step 0**: Clear console to isolate this run
 
-```bash
+```powershell
 uloop clear-console
 ```
 
 **Step 1**: Start Play mode
 
-```bash
+```powershell
 uloop control-play-mode --action Play
 ```
 
@@ -272,18 +332,18 @@ return $"Clicked {startBtn.gameObject.name}";
 
 **Step 3**: Capture screenshot as evidence
 
-```bash
+```powershell
 uloop screenshot --window-name Game
 ```
 
 **Step 4**: Check logs for errors
 
-```bash
+```powershell
 uloop get-logs --log-type Error
 ```
 
 **Step 5**: Stop Play mode
 
-```bash
+```powershell
 uloop control-play-mode --action Stop
 ```

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -7,17 +7,20 @@ Shell command examples in this file target `PowerShell`.
 ## When to use dedicated mouse simulation tools instead
 
 The examples in this file call UI handlers or runtime methods from C#.
-That is useful for targeted automation, but it is not the same as simulating a real mouse input path.
+That remains the better choice when you want targeted automation, direct state control, or a quick diagnostic path.
+Use dedicated mouse tools only when the input route itself is part of what you need to verify.
 
-Use dedicated mouse tools when you want input behavior closer to what a human player produces:
+Choose the tool based on what you are trying to validate:
 
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
-| Click or drag a uGUI element through the EventSystem path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of calling handlers from custom C# directly. |
+| Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
 | Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
-| Jump straight to a known button callback or inspect internal state | `execute-dynamic-code` | Best when you intentionally want a direct method call, reflection, or state tweak without reproducing the full input pipeline. |
+| Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
+| Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 
-In short: `execute-dynamic-code` is best for direct automation, while `simulate-mouse-ui` and `simulate-mouse-input` are better when you need the actual input route to be part of the test.
+In short: do not default everything to mouse simulation.
+Use `execute-dynamic-code` for direct automation and diagnostics, and switch to `simulate-mouse-ui` or `simulate-mouse-input` when reproducing the real input path is the thing you need to test.
 
 ## PowerShell Quoting Notes
 
@@ -102,43 +105,6 @@ if (target == null) return $"PlayButton not found. Available: {string.Join(", ",
 
 target.onClick.Invoke();
 return $"Clicked {target.gameObject.name}";
-```
-
-## Raycast from Camera Center
-
-```csharp
-Camera cam = Camera.main;
-if (cam == null) return "Main camera not found";
-
-Ray ray = cam.ScreenPointToRay(new Vector3(Screen.width / 2f, Screen.height / 2f, 0));
-if (Physics.Raycast(ray, out RaycastHit hit, 100f))
-{
-    return $"Hit: {hit.collider.gameObject.name} at {hit.point}";
-}
-return "No hit";
-```
-
-## Raycast Click at Screen Position
-
-```csharp
-using UnityEngine.EventSystems;
-using System.Collections.Generic;
-
-if (EventSystem.current == null) return "EventSystem not found";
-
-PointerEventData pointerData = new PointerEventData(EventSystem.current)
-{
-    position = new Vector2(Screen.width / 2f, Screen.height / 2f)
-};
-
-List<RaycastResult> results = new List<RaycastResult>();
-EventSystem.current.RaycastAll(pointerData, results);
-
-if (results.Count == 0) return "No UI element at screen center";
-
-GameObject target = results[0].gameObject;
-ExecuteEvents.ExecuteHierarchy(target, pointerData, ExecuteEvents.pointerClickHandler);
-return $"Clicked UI element: {target.name}";
 ```
 
 ## Toggle GameObject Active State

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). If that is not available in the target project, prefer `execute-dynamic-code` for a project-specific workaround instead of changing project settings just to use this tool. |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
@@ -7,17 +7,20 @@ Shell command examples in this file target `zsh`-style usage.
 ## When to use dedicated mouse simulation tools instead
 
 The examples in this file call UI handlers or runtime methods from C#.
-That is useful for targeted automation, but it is not the same as simulating a real mouse input path.
+That remains the better choice when you want targeted automation, direct state control, or a quick diagnostic path.
+Use dedicated mouse tools only when the input route itself is part of what you need to verify.
 
-Use dedicated mouse tools when you want input behavior closer to what a human player produces:
+Choose the tool based on what you are trying to validate:
 
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
-| Click or drag a uGUI element through the EventSystem path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of calling handlers from custom C# directly. |
+| Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
 | Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
-| Jump straight to a known button callback or inspect internal state | `execute-dynamic-code` | Best when you intentionally want a direct method call, reflection, or state tweak without reproducing the full input pipeline. |
+| Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
+| Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 
-In short: `execute-dynamic-code` is best for direct automation, while `simulate-mouse-ui` and `simulate-mouse-input` are better when you need the actual input route to be part of the test.
+In short: do not default everything to mouse simulation.
+Use `execute-dynamic-code` for direct automation and diagnostics, and switch to `simulate-mouse-ui` or `simulate-mouse-input` when reproducing the real input path is the thing you need to test.
 
 ## zsh Quoting Notes
 
@@ -71,43 +74,6 @@ if (target == null) return $"PlayButton not found. Available: {string.Join(", ",
 
 target.onClick.Invoke();
 return $"Clicked {target.gameObject.name}";
-```
-
-## Raycast from Camera Center
-
-```csharp
-Camera cam = Camera.main;
-if (cam == null) return "Main camera not found";
-
-Ray ray = cam.ScreenPointToRay(new Vector3(Screen.width / 2f, Screen.height / 2f, 0));
-if (Physics.Raycast(ray, out RaycastHit hit, 100f))
-{
-    return $"Hit: {hit.collider.gameObject.name} at {hit.point}";
-}
-return "No hit";
-```
-
-## Raycast Click at Screen Position
-
-```csharp
-using UnityEngine.EventSystems;
-using System.Collections.Generic;
-
-if (EventSystem.current == null) return "EventSystem not found";
-
-PointerEventData pointerData = new PointerEventData(EventSystem.current)
-{
-    position = new Vector2(Screen.width / 2f, Screen.height / 2f)
-};
-
-List<RaycastResult> results = new List<RaycastResult>();
-EventSystem.current.RaycastAll(pointerData, results);
-
-if (results.Count == 0) return "No UI element at screen center";
-
-GameObject target = results[0].gameObject;
-ExecuteEvents.ExecuteHierarchy(target, pointerData, ExecuteEvents.pointerClickHandler);
-return $"Clicked UI element: {target.name}";
 ```
 
 ## Toggle GameObject Active State

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. Requires Active Input Handling set to `Input System Package (New)` or `Both`. |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
@@ -4,6 +4,21 @@ Code examples for runtime automation during Play mode using `execute-dynamic-cod
 These examples manipulate live scene objects while the game is running.
 Shell command examples in this file target `zsh`-style usage.
 
+## When to use dedicated mouse simulation tools instead
+
+The examples in this file call UI handlers or runtime methods from C#.
+That is useful for targeted automation, but it is not the same as simulating a real mouse input path.
+
+Use dedicated mouse tools when you want input behavior closer to what a human player produces:
+
+| Scenario | Recommended tool | Why |
+|----------|------------------|-----|
+| Click or drag a uGUI element through the EventSystem path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of calling handlers from custom C# directly. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
+| Jump straight to a known button callback or inspect internal state | `execute-dynamic-code` | Best when you intentionally want a direct method call, reflection, or state tweak without reproducing the full input pipeline. |
+
+In short: `execute-dynamic-code` is best for direct automation, while `simulate-mouse-ui` and `simulate-mouse-input` are better when you need the actual input route to be part of the test.
+
 ## zsh Quoting Notes
 
 Use these patterns when you need shell-safe inline code:

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. Requires Active Input Handling set to `Input System Package (New)` or `Both`. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md
@@ -1,0 +1,318 @@
+# PlayMode Automation (zsh)
+
+Code examples for runtime automation during Play mode using `execute-dynamic-code`.
+These examples manipulate live scene objects while the game is running.
+Shell command examples in this file target `zsh`-style usage.
+
+## zsh Quoting Notes
+
+Use these patterns when you need shell-safe inline code:
+
+### Double quotes inside C# strings
+
+Single-quote the whole snippet and keep C# string literals unchanged.
+
+```zsh
+uloop execute-dynamic-code --code 'return "Hello from zsh";'
+```
+
+### Single quotes inside inline C# code
+
+If the C# snippet itself contains a single quote, close and reopen the shell string with `'\''`.
+
+```zsh
+uloop execute-dynamic-code --code 'char initial = '\''A'\''; return initial.ToString();'
+```
+
+### JSON-like values passed via `--parameters`
+
+Wrap the whole expression in single quotes so the shell does not interpret double quotes.
+
+```zsh
+uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from zsh"}'
+```
+
+## Click UI Button by Path
+
+```csharp
+using UnityEngine.UI;
+
+Button btn = GameObject.Find("Canvas/StartButton")?.GetComponent<Button>();
+if (btn == null) return "Button not found";
+
+btn.onClick.Invoke();
+return $"Clicked {btn.gameObject.name}";
+```
+
+## Click UI Button by Search
+
+```csharp
+using UnityEngine.UI;
+using System.Linq;
+
+Button[] buttons = Object.FindObjectsByType<Button>(FindObjectsSortMode.None);
+Button target = buttons.FirstOrDefault(b => b.gameObject.name == "PlayButton");
+if (target == null) return $"PlayButton not found. Available: {string.Join(", ", buttons.Select(b => b.gameObject.name))}";
+
+target.onClick.Invoke();
+return $"Clicked {target.gameObject.name}";
+```
+
+## Raycast from Camera Center
+
+```csharp
+Camera cam = Camera.main;
+if (cam == null) return "Main camera not found";
+
+Ray ray = cam.ScreenPointToRay(new Vector3(Screen.width / 2f, Screen.height / 2f, 0));
+if (Physics.Raycast(ray, out RaycastHit hit, 100f))
+{
+    return $"Hit: {hit.collider.gameObject.name} at {hit.point}";
+}
+return "No hit";
+```
+
+## Raycast Click at Screen Position
+
+```csharp
+using UnityEngine.EventSystems;
+using System.Collections.Generic;
+
+if (EventSystem.current == null) return "EventSystem not found";
+
+PointerEventData pointerData = new PointerEventData(EventSystem.current)
+{
+    position = new Vector2(Screen.width / 2f, Screen.height / 2f)
+};
+
+List<RaycastResult> results = new List<RaycastResult>();
+EventSystem.current.RaycastAll(pointerData, results);
+
+if (results.Count == 0) return "No UI element at screen center";
+
+GameObject target = results[0].gameObject;
+ExecuteEvents.ExecuteHierarchy(target, pointerData, ExecuteEvents.pointerClickHandler);
+return $"Clicked UI element: {target.name}";
+```
+
+## Toggle GameObject Active State
+
+```csharp
+GameObject obj = GameObject.Find("Enemy");
+if (obj == null) return "Enemy not found";
+
+obj.SetActive(!obj.activeSelf);
+return $"{obj.name} is now {(obj.activeSelf ? "active" : "inactive")}";
+```
+
+## Invoke Method on MonoBehaviour
+
+```csharp
+using System.Reflection;
+
+GameObject player = GameObject.Find("Player");
+if (player == null) return "Player not found";
+
+MonoBehaviour script = player.GetComponent("PlayerController") as MonoBehaviour;
+if (script == null) return "PlayerController not found";
+
+MethodInfo method = script.GetType().GetMethod("TakeDamage");
+if (method == null) return "TakeDamage method not found";
+
+method.Invoke(script, new object[] { 10f });
+return $"Invoked TakeDamage(10) on {player.name}";
+```
+
+## Set Field Value at Runtime
+
+```csharp
+using System.Reflection;
+
+GameObject player = GameObject.Find("Player");
+if (player == null) return "Player not found";
+
+MonoBehaviour script = player.GetComponent("PlayerController") as MonoBehaviour;
+if (script == null) return "PlayerController not found";
+
+FieldInfo field = script.GetType().GetField("moveSpeed", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+if (field == null) return "moveSpeed field not found";
+
+field.SetValue(script, 20f);
+return $"Set moveSpeed to 20 on {player.name}";
+```
+
+## Move Player to Position
+
+```csharp
+GameObject player = GameObject.Find("Player");
+if (player == null) return "Player not found";
+
+Vector3 targetPos = new Vector3(5f, 0f, 10f);
+player.transform.position = targetPos;
+return $"Moved {player.name} to {targetPos}";
+```
+
+---
+
+# Tool Combination Workflows
+
+Examples of combining `execute-dynamic-code` with other uloop tools for multi-step PlayMode automation.
+
+## find-game-objects → Click Button
+
+Use `find-game-objects` to discover buttons with their hierarchy paths, then click one via `execute-dynamic-code`.
+
+**Step 1**: Find all GameObjects with Button component
+
+```zsh
+uloop find-game-objects --required-components UnityEngine.UI.Button --include-inactive false
+```
+
+**Step 2**: Click the target button using the path from Step 1
+
+```csharp
+using UnityEngine.UI;
+
+// Use the path returned by find-game-objects (e.g. "Canvas/MainMenu/StartButton")
+GameObject btnObj = GameObject.Find("Canvas/MainMenu/StartButton");
+if (btnObj == null) return "Button not found at path";
+
+Button btn = btnObj.GetComponent<Button>();
+if (btn == null) return "No Button component";
+
+btn.onClick.Invoke();
+return $"Clicked {btnObj.name}";
+```
+
+## get-hierarchy → Navigate UI and Click
+
+Use `get-hierarchy` to explore the UI tree structure, then target the right element.
+
+**Step 1**: Get Canvas hierarchy to understand UI structure
+
+```zsh
+uloop get-hierarchy --root-path "Canvas" --max-depth 3 --include-components true
+```
+
+**Step 2**: Based on the hierarchy JSON, click the desired button
+
+```csharp
+using UnityEngine.UI;
+
+// Path identified from hierarchy output
+GameObject btnObj = GameObject.Find("Canvas/SettingsPanel/AudioTab/MuteToggle");
+if (btnObj == null) return "MuteToggle not found";
+
+Toggle toggle = btnObj.GetComponent<Toggle>();
+if (toggle != null)
+{
+    toggle.isOn = !toggle.isOn;
+    return $"Toggled {btnObj.name} to {toggle.isOn}";
+}
+return "No Toggle component found";
+```
+
+## Execute Action → Screenshot to Verify
+
+Run an action then capture a screenshot to visually confirm the result.
+
+**Step 1**: Perform the action
+
+```csharp
+using UnityEngine.UI;
+
+Button btn = GameObject.Find("Canvas/PlayButton")?.GetComponent<Button>();
+if (btn == null) return "PlayButton not found";
+
+btn.onClick.Invoke();
+return "Clicked PlayButton";
+```
+
+**Step 2**: Capture Game View to verify the result
+
+```zsh
+uloop screenshot --window-name Game
+```
+
+## Execute Action → Check Logs for Side Effects
+
+Run an action then inspect Unity Console logs to verify expected behavior.
+
+**Step 1**: Clear console before the action
+
+```zsh
+uloop clear-console
+```
+
+**Step 2**: Perform the action
+
+```csharp
+using System.Reflection;
+
+GameObject player = GameObject.Find("Player");
+if (player == null) return "Player not found";
+
+MonoBehaviour script = player.GetComponent("PlayerController") as MonoBehaviour;
+if (script == null) return "PlayerController not found";
+
+MethodInfo method = script.GetType().GetMethod("TakeDamage");
+if (method == null) return "TakeDamage method not found";
+
+method.Invoke(script, new object[] { 50f });
+return "Invoked TakeDamage(50)";
+```
+
+**Step 3**: Check logs for expected output
+
+```zsh
+uloop get-logs --log-type Log --search-text "damage"
+```
+
+## Full Automation: Play → Act → Capture → Stop
+
+End-to-end test flow: start Play mode, perform actions, capture evidence, stop.
+
+**Step 0**: Clear console to isolate this run
+
+```zsh
+uloop clear-console
+```
+
+**Step 1**: Start Play mode
+
+```zsh
+uloop control-play-mode --action Play
+```
+
+**Step 2**: Wait for scene initialization, then find and click a button
+
+```csharp
+using UnityEngine.UI;
+using System.Linq;
+
+// Scene may need a moment to initialize after Play starts
+Button[] buttons = Object.FindObjectsByType<Button>(FindObjectsSortMode.None);
+Button startBtn = buttons.FirstOrDefault(b => b.gameObject.name.Contains("Start"));
+if (startBtn == null) return $"Start button not found. Available: {string.Join(", ", buttons.Select(b => b.gameObject.name))}";
+
+startBtn.onClick.Invoke();
+return $"Clicked {startBtn.gameObject.name}";
+```
+
+**Step 3**: Capture screenshot as evidence
+
+```zsh
+uloop screenshot --window-name Game
+```
+
+**Step 4**: Check logs for errors
+
+```zsh
+uloop get-logs --log-type Error
+```
+
+**Step 5**: Stop Play mode
+
+```zsh
+uloop control-play-mode --action Stop
+```

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-inspection.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-inspection.md
@@ -126,6 +126,20 @@ if (rb == null) return "Rigidbody not found on TargetCube";
 return $"velocity={rb.velocity}, angularVelocity={rb.angularVelocity}, isKinematic={rb.isKinematic}, useGravity={rb.useGravity}, isSleeping={rb.IsSleeping()}";
 ```
 
+## Raycast from Camera Center
+
+```csharp
+Camera cam = Camera.main;
+if (cam == null) return "Main camera not found";
+
+Ray ray = cam.ScreenPointToRay(new Vector3(Screen.width / 2f, Screen.height / 2f, 0));
+if (Physics.Raycast(ray, out RaycastHit hit, 100f))
+{
+    return $"Hit: {hit.collider.gameObject.name} at {hit.point}";
+}
+return "No hit";
+```
+
 ## Find GameObjects by Tag
 
 ```csharp
@@ -135,4 +149,3 @@ string tag = "Enemy";
 GameObject[] enemies = GameObject.FindGameObjectsWithTag(tag);
 return $"Found {enemies.Length} objects with tag '{tag}': {string.Join(", ", enemies.Select(e => $"{e.name} at {e.transform.position}"))}";
 ```
-

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-simulate-mouse-input
-description: "Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into Mouse.current. Use when you need to: (1) Click in games that read Mouse.current.leftButton.wasPressedThisFrame, (2) Right-click for actions like block placement, (3) Inject mouse delta for FPS camera control, (4) Inject scroll wheel for hotbar switching or zoom. Assumes the project uses the New Input System. For UI elements with IPointerClickHandler, use simulate-mouse-ui instead."
+description: "Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into Mouse.current. Use when you need to: (1) Click in games that read Mouse.current.leftButton.wasPressedThisFrame, (2) Right-click for actions like block placement, (3) Inject mouse delta for FPS camera control, (4) Inject scroll wheel for hotbar switching or zoom. Assumes the project uses the New Input System. If the project cannot use it, prefer execute-dynamic-code for a project-specific workaround. For UI elements with IPointerClickHandler, use simulate-mouse-ui instead."
 context: fork
 ---
 

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -93,6 +93,5 @@ uloop simulate-mouse-input --action SmoothDelta --delta-x 300 --delta-y 0 --dura
 
 - Unity must be in **PlayMode**
 - **Input System package** must be installed (`com.unity.inputsystem`)
-- This tool assumes Active Input Handling uses the New Input System (`Input System Package (New)` or `Both`)
 - Game code must read input via Input System API (e.g. `Mouse.current.leftButton.wasPressedThisFrame`)
 - If the target project cannot use the New Input System, prefer `execute-dynamic-code` for a project-specific workaround instead of changing project settings just to use this tool

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-simulate-mouse-input
-description: "Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into Mouse.current. Use when you need to: (1) Click in games that read Mouse.current.leftButton.wasPressedThisFrame, (2) Right-click for actions like block placement, (3) Inject mouse delta for FPS camera control, (4) Inject scroll wheel for hotbar switching or zoom. For UI elements with IPointerClickHandler, use simulate-mouse-ui instead."
+description: "Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into Mouse.current. Use when you need to: (1) Click in games that read Mouse.current.leftButton.wasPressedThisFrame, (2) Right-click for actions like block placement, (3) Inject mouse delta for FPS camera control, (4) Inject scroll wheel for hotbar switching or zoom. Assumes the project uses the New Input System. For UI elements with IPointerClickHandler, use simulate-mouse-ui instead."
 context: fork
 ---
 
@@ -58,11 +58,11 @@ uloop simulate-mouse-input --action <action> [options]
 | Scenario | Tool |
 |----------|------|
 | Click a Unity UI Button (IPointerClickHandler) | `simulate-mouse-ui` |
-| Destroy a block in Minecraft (reads `Mouse.current.leftButton`) | `simulate-mouse-input` |
-| Place a block with right-click | `simulate-mouse-input --button Right` |
+| Destroy a block in Minecraft (reads `Mouse.current.leftButton`) | `simulate-mouse-input` when the project uses the New Input System; otherwise prefer `execute-dynamic-code` for a project-specific workaround |
+| Place a block with right-click | `simulate-mouse-input --button Right` when the project uses the New Input System |
 | Drag a UI slider | `simulate-mouse-ui --action Drag` |
-| Look around with mouse (FPS camera) | `simulate-mouse-input --action MoveDelta` |
-| Scroll hotbar slots | `simulate-mouse-input --action Scroll` |
+| Look around with mouse (FPS camera) | `simulate-mouse-input --action MoveDelta` when the project uses the New Input System |
+| Scroll hotbar slots | `simulate-mouse-input --action Scroll` when the project uses the New Input System |
 
 ## Examples
 
@@ -93,5 +93,6 @@ uloop simulate-mouse-input --action SmoothDelta --delta-x 300 --delta-y 0 --dura
 
 - Unity must be in **PlayMode**
 - **Input System package** must be installed (`com.unity.inputsystem`)
-- Active Input Handling must be set to `Input System Package (New)` or `Both` in Player Settings
+- This tool assumes Active Input Handling uses the New Input System (`Input System Package (New)` or `Both`)
 - Game code must read input via Input System API (e.g. `Mouse.current.leftButton.wasPressedThisFrame`)
+- If the target project cannot use the New Input System, prefer `execute-dynamic-code` for a project-specific workaround instead of changing project settings just to use this tool

--- a/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-simulate-mouse-ui
-description: "Simulate mouse click, long-press, and drag on PlayMode UI elements via EventSystem screen coordinates. Use when you need to: (1) Click buttons or interactive UI elements during PlayMode testing, (2) Drag UI elements from one position to another, (3) Hold a drag at a position for inspection before releasing, (4) Long-press UI elements that respond to sustained pointer-down. For game logic that reads Input System (e.g. WasPressedThisFrame), use simulate-mouse-input instead."
+description: "Simulate mouse click, long-press, and drag on PlayMode UI elements via EventSystem screen coordinates. Use when you need to: (1) Click buttons or interactive UI elements during PlayMode testing, (2) Drag UI elements from one position to another, (3) Hold a drag at a position for inspection before releasing, (4) Long-press UI elements that respond to sustained pointer-down. For game logic that reads Input System (e.g. WasPressedThisFrame), use simulate-mouse-input when the project uses the New Input System; otherwise prefer execute-dynamic-code."
 context: fork
 ---
 
@@ -95,3 +95,4 @@ uloop simulate-mouse-ui --action DragEnd --x 600 --y 300
 - Unity must be in **PlayMode**
 - Target scene must have an **EventSystem** GameObject
 - UI elements must have a **GraphicRaycaster** on their Canvas
+- If you need gameplay mouse input rather than UI pointer events, `simulate-mouse-input` assumes the project uses the New Input System; otherwise prefer `execute-dynamic-code`

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -57,8 +57,10 @@ For detailed code examples, refer to these files:
   - Undo-aware operations: RecordObject, AddComponent, SetParent, grouping
 - **Selection operations**: See [references/selection-operations.md](references/selection-operations.md)
   - Get/set selection, multi-select, filter by type/editability
-- **PlayMode automation**: See [references/playmode-automation.md](references/playmode-automation.md)
-  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows
+- **PlayMode automation (zsh)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
+  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows for zsh users
+- **PlayMode automation (PowerShell)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
+  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows for PowerShell users
 - **PlayMode UI controls**: See [references/playmode-ui-controls.md](references/playmode-ui-controls.md)
   - InputField, Slider, Toggle, Dropdown, drag & drop simulation, list all UI controls
 - **PlayMode inspection**: See [references/playmode-inspection.md](references/playmode-inspection.md)

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-execute-dynamic-code
-description: "Execute C# code dynamically in Unity Editor. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) PlayMode automation (click buttons, raycast, invoke methods), (5) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (6) PlayMode inspection (scene info, reflection, physics state). NOT for file I/O or script authoring."
+description: "Execute C# code dynamically in Unity Editor. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) PlayMode automation (click buttons, invoke methods, tweak runtime state), (5) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (6) PlayMode inspection (scene info, reflection, physics state, raycast checks). NOT for file I/O or script authoring."
 context: fork
 ---
 
@@ -58,10 +58,10 @@ For detailed code examples, refer to these files:
 - **Selection operations**: See [references/selection-operations.md](references/selection-operations.md)
   - Get/set selection, multi-select, filter by type/editability
 - **PlayMode automation (zsh)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
-  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows for zsh users
+  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
 - **PlayMode automation (PowerShell)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
-  - Click UI buttons, raycast interaction, invoke methods, set fields, tool combination workflows for PowerShell users
+  - Click UI buttons, invoke methods, set fields, tool combination workflows for PowerShell users
 - **PlayMode UI controls**: See [references/playmode-ui-controls.md](references/playmode-ui-controls.md)
   - InputField, Slider, Toggle, Dropdown, drag & drop simulation, list all UI controls
 - **PlayMode inspection**: See [references/playmode-inspection.md](references/playmode-inspection.md)
-  - Scene info, game state via reflection, physics state, GameObject search, position/rotation
+  - Scene info, game state via reflection, physics state, raycast checks, GameObject search, position/rotation

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -4,6 +4,21 @@ Code examples for runtime automation during Play mode using `execute-dynamic-cod
 These examples manipulate live scene objects while the game is running.
 Shell command examples in this file target `PowerShell`.
 
+## When to use dedicated mouse simulation tools instead
+
+The examples in this file call UI handlers or runtime methods from C#.
+That is useful for targeted automation, but it is not the same as simulating a real mouse input path.
+
+Use dedicated mouse tools when you want input behavior closer to what a human player produces:
+
+| Scenario | Recommended tool | Why |
+|----------|------------------|-----|
+| Click or drag a uGUI element through the EventSystem path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of calling handlers from custom C# directly. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
+| Jump straight to a known button callback or inspect internal state | `execute-dynamic-code` | Best when you intentionally want a direct method call, reflection, or state tweak without reproducing the full input pipeline. |
+
+In short: `execute-dynamic-code` is best for direct automation, while `simulate-mouse-ui` and `simulate-mouse-input` are better when you need the actual input route to be part of the test.
+
 ## PowerShell Quoting Notes
 
 Use these patterns when you need shell-safe inline code:

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). If that is not available in the target project, prefer `execute-dynamic-code` for a project-specific workaround instead of changing project settings just to use this tool. |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. Requires Active Input Handling set to `Input System Package (New)` or `Both`. |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. Requires Active Input Handling set to `Input System Package (New)` or `Both`. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -1,7 +1,67 @@
-# PlayMode Automation
+# PlayMode Automation (PowerShell)
 
 Code examples for runtime automation during Play mode using `execute-dynamic-code`.
 These examples manipulate live scene objects while the game is running.
+Shell command examples in this file target `PowerShell`.
+
+## PowerShell Quoting Notes
+
+Use these patterns when you need shell-safe inline code:
+
+### Double quotes inside C# strings
+
+Single-quote the whole snippet and keep C# string literals unchanged.
+
+```powershell
+uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
+```
+
+### Single quotes inside inline C# code
+
+If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
+
+```powershell
+uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
+```
+
+### JSON-like values passed via `--parameters`
+
+Wrap the whole expression in single quotes so PowerShell passes the inner double quotes through unchanged.
+
+```powershell
+uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
+```
+
+### Multi-line C# snippets
+
+Use a here-string when the snippet spans multiple lines.
+
+```powershell
+$code = @'
+using UnityEngine;
+
+GameObject obj = GameObject.Find("Player");
+if (obj == null) return "Player not found";
+
+return obj.name;
+'@
+
+uloop execute-dynamic-code --code $code
+```
+
+You can combine multi-line code with multi-line parameters the same way.
+
+```powershell
+$code = @'
+return parameters["param0"];
+'@
+
+$parameters = @'
+{"param0":"Hello from PowerShell"}
+'@
+
+uloop execute-dynamic-code --code $code --parameters $parameters
+```
 
 ## Click UI Button by Path
 
@@ -135,7 +195,7 @@ Use `find-game-objects` to discover buttons with their hierarchy paths, then cli
 
 **Step 1**: Find all GameObjects with Button component
 
-```bash
+```powershell
 uloop find-game-objects --required-components UnityEngine.UI.Button --include-inactive false
 ```
 
@@ -161,8 +221,8 @@ Use `get-hierarchy` to explore the UI tree structure, then target the right elem
 
 **Step 1**: Get Canvas hierarchy to understand UI structure
 
-```bash
-uloop get-hierarchy --root-path "Canvas" --max-depth 3 --include-components true
+```powershell
+uloop get-hierarchy --root-path 'Canvas' --max-depth 3 --include-components true
 ```
 
 **Step 2**: Based on the hierarchy JSON, click the desired button
@@ -201,7 +261,7 @@ return "Clicked PlayButton";
 
 **Step 2**: Capture Game View to verify the result
 
-```bash
+```powershell
 uloop screenshot --window-name Game
 ```
 
@@ -211,7 +271,7 @@ Run an action then inspect Unity Console logs to verify expected behavior.
 
 **Step 1**: Clear console before the action
 
-```bash
+```powershell
 uloop clear-console
 ```
 
@@ -235,8 +295,8 @@ return "Invoked TakeDamage(50)";
 
 **Step 3**: Check logs for expected output
 
-```bash
-uloop get-logs --log-type Log --search-text "damage"
+```powershell
+uloop get-logs --log-type Log --search-text 'damage'
 ```
 
 ## Full Automation: Play → Act → Capture → Stop
@@ -245,13 +305,13 @@ End-to-end test flow: start Play mode, perform actions, capture evidence, stop.
 
 **Step 0**: Clear console to isolate this run
 
-```bash
+```powershell
 uloop clear-console
 ```
 
 **Step 1**: Start Play mode
 
-```bash
+```powershell
 uloop control-play-mode --action Play
 ```
 
@@ -272,18 +332,18 @@ return $"Clicked {startBtn.gameObject.name}";
 
 **Step 3**: Capture screenshot as evidence
 
-```bash
+```powershell
 uloop screenshot --window-name Game
 ```
 
 **Step 4**: Check logs for errors
 
-```bash
+```powershell
 uloop get-logs --log-type Error
 ```
 
 **Step 5**: Stop Play mode
 
-```bash
+```powershell
 uloop control-play-mode --action Stop
 ```

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -7,17 +7,20 @@ Shell command examples in this file target `PowerShell`.
 ## When to use dedicated mouse simulation tools instead
 
 The examples in this file call UI handlers or runtime methods from C#.
-That is useful for targeted automation, but it is not the same as simulating a real mouse input path.
+That remains the better choice when you want targeted automation, direct state control, or a quick diagnostic path.
+Use dedicated mouse tools only when the input route itself is part of what you need to verify.
 
-Use dedicated mouse tools when you want input behavior closer to what a human player produces:
+Choose the tool based on what you are trying to validate:
 
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
-| Click or drag a uGUI element through the EventSystem path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of calling handlers from custom C# directly. |
+| Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
 | Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
-| Jump straight to a known button callback or inspect internal state | `execute-dynamic-code` | Best when you intentionally want a direct method call, reflection, or state tweak without reproducing the full input pipeline. |
+| Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
+| Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 
-In short: `execute-dynamic-code` is best for direct automation, while `simulate-mouse-ui` and `simulate-mouse-input` are better when you need the actual input route to be part of the test.
+In short: do not default everything to mouse simulation.
+Use `execute-dynamic-code` for direct automation and diagnostics, and switch to `simulate-mouse-ui` or `simulate-mouse-input` when reproducing the real input path is the thing you need to test.
 
 ## PowerShell Quoting Notes
 
@@ -102,43 +105,6 @@ if (target == null) return $"PlayButton not found. Available: {string.Join(", ",
 
 target.onClick.Invoke();
 return $"Clicked {target.gameObject.name}";
-```
-
-## Raycast from Camera Center
-
-```csharp
-Camera cam = Camera.main;
-if (cam == null) return "Main camera not found";
-
-Ray ray = cam.ScreenPointToRay(new Vector3(Screen.width / 2f, Screen.height / 2f, 0));
-if (Physics.Raycast(ray, out RaycastHit hit, 100f))
-{
-    return $"Hit: {hit.collider.gameObject.name} at {hit.point}";
-}
-return "No hit";
-```
-
-## Raycast Click at Screen Position
-
-```csharp
-using UnityEngine.EventSystems;
-using System.Collections.Generic;
-
-if (EventSystem.current == null) return "EventSystem not found";
-
-PointerEventData pointerData = new PointerEventData(EventSystem.current)
-{
-    position = new Vector2(Screen.width / 2f, Screen.height / 2f)
-};
-
-List<RaycastResult> results = new List<RaycastResult>();
-EventSystem.current.RaycastAll(pointerData, results);
-
-if (results.Count == 0) return "No UI element at screen center";
-
-GameObject target = results[0].gameObject;
-ExecuteEvents.ExecuteHierarchy(target, pointerData, ExecuteEvents.pointerClickHandler);
-return $"Clicked UI element: {target.name}";
 ```
 
 ## Toggle GameObject Active State

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md.meta
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 86022f911600881458e40f35e562a5db
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). If that is not available in the target project, prefer `execute-dynamic-code` for a project-specific workaround instead of changing project settings just to use this tool. |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
@@ -7,17 +7,20 @@ Shell command examples in this file target `zsh`-style usage.
 ## When to use dedicated mouse simulation tools instead
 
 The examples in this file call UI handlers or runtime methods from C#.
-That is useful for targeted automation, but it is not the same as simulating a real mouse input path.
+That remains the better choice when you want targeted automation, direct state control, or a quick diagnostic path.
+Use dedicated mouse tools only when the input route itself is part of what you need to verify.
 
-Use dedicated mouse tools when you want input behavior closer to what a human player produces:
+Choose the tool based on what you are trying to validate:
 
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
-| Click or drag a uGUI element through the EventSystem path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of calling handlers from custom C# directly. |
+| Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
 | Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
-| Jump straight to a known button callback or inspect internal state | `execute-dynamic-code` | Best when you intentionally want a direct method call, reflection, or state tweak without reproducing the full input pipeline. |
+| Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
+| Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 
-In short: `execute-dynamic-code` is best for direct automation, while `simulate-mouse-ui` and `simulate-mouse-input` are better when you need the actual input route to be part of the test.
+In short: do not default everything to mouse simulation.
+Use `execute-dynamic-code` for direct automation and diagnostics, and switch to `simulate-mouse-ui` or `simulate-mouse-input` when reproducing the real input path is the thing you need to test.
 
 ## zsh Quoting Notes
 
@@ -71,43 +74,6 @@ if (target == null) return $"PlayButton not found. Available: {string.Join(", ",
 
 target.onClick.Invoke();
 return $"Clicked {target.gameObject.name}";
-```
-
-## Raycast from Camera Center
-
-```csharp
-Camera cam = Camera.main;
-if (cam == null) return "Main camera not found";
-
-Ray ray = cam.ScreenPointToRay(new Vector3(Screen.width / 2f, Screen.height / 2f, 0));
-if (Physics.Raycast(ray, out RaycastHit hit, 100f))
-{
-    return $"Hit: {hit.collider.gameObject.name} at {hit.point}";
-}
-return "No hit";
-```
-
-## Raycast Click at Screen Position
-
-```csharp
-using UnityEngine.EventSystems;
-using System.Collections.Generic;
-
-if (EventSystem.current == null) return "EventSystem not found";
-
-PointerEventData pointerData = new PointerEventData(EventSystem.current)
-{
-    position = new Vector2(Screen.width / 2f, Screen.height / 2f)
-};
-
-List<RaycastResult> results = new List<RaycastResult>();
-EventSystem.current.RaycastAll(pointerData, results);
-
-if (results.Count == 0) return "No UI element at screen center";
-
-GameObject target = results[0].gameObject;
-ExecuteEvents.ExecuteHierarchy(target, pointerData, ExecuteEvents.pointerClickHandler);
-return $"Clicked UI element: {target.name}";
 ```
 
 ## Toggle GameObject Active State

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. Requires Active Input Handling set to `Input System Package (New)` or `Both`. |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
@@ -4,6 +4,21 @@ Code examples for runtime automation during Play mode using `execute-dynamic-cod
 These examples manipulate live scene objects while the game is running.
 Shell command examples in this file target `zsh`-style usage.
 
+## When to use dedicated mouse simulation tools instead
+
+The examples in this file call UI handlers or runtime methods from C#.
+That is useful for targeted automation, but it is not the same as simulating a real mouse input path.
+
+Use dedicated mouse tools when you want input behavior closer to what a human player produces:
+
+| Scenario | Recommended tool | Why |
+|----------|------------------|-----|
+| Click or drag a uGUI element through the EventSystem path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of calling handlers from custom C# directly. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. |
+| Jump straight to a known button callback or inspect internal state | `execute-dynamic-code` | Best when you intentionally want a direct method call, reflection, or state tweak without reproducing the full input pipeline. |
+
+In short: `execute-dynamic-code` is best for direct automation, while `simulate-mouse-ui` and `simulate-mouse-input` are better when you need the actual input route to be part of the test.
+
 ## zsh Quoting Notes
 
 Use these patterns when you need shell-safe inline code:

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
@@ -15,7 +15,7 @@ Choose the tool based on what you are trying to validate:
 | Scenario | Recommended tool | Why |
 |----------|------------------|-----|
 | Verify that a uGUI element responds through the real EventSystem pointer path | `simulate-mouse-ui` | Fires `PointerDown` / `PointerUp` / `PointerClick` / drag events through EventSystem raycasts instead of bypassing the UI input route. |
-| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. Requires Active Input Handling set to `Input System Package (New)` or `Both`. |
+| Test gameplay that reads `Mouse.current`, button state, delta, or scroll | `simulate-mouse-input` | Injects Input System mouse state into `Mouse.current`, so game code can observe `wasPressedThisFrame`, movement delta, and scroll like player input. This assumes the project uses the New Input System (`Input System Package (New)` or `Both`). |
 | Jump straight to a known button callback, invoke a method, inspect state, or set up a test precondition | `execute-dynamic-code` | Best when you intentionally want direct automation without reproducing the full input pipeline. |
 | Drive custom runtime behavior that does not map cleanly to the built-in mouse tools | `execute-dynamic-code` | Lets you call project-specific methods, inspect scene objects, and prototype one-off flows immediately. |
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
@@ -1,0 +1,318 @@
+# PlayMode Automation (zsh)
+
+Code examples for runtime automation during Play mode using `execute-dynamic-code`.
+These examples manipulate live scene objects while the game is running.
+Shell command examples in this file target `zsh`-style usage.
+
+## zsh Quoting Notes
+
+Use these patterns when you need shell-safe inline code:
+
+### Double quotes inside C# strings
+
+Single-quote the whole snippet and keep C# string literals unchanged.
+
+```zsh
+uloop execute-dynamic-code --code 'return "Hello from zsh";'
+```
+
+### Single quotes inside inline C# code
+
+If the C# snippet itself contains a single quote, close and reopen the shell string with `'\''`.
+
+```zsh
+uloop execute-dynamic-code --code 'char initial = '\''A'\''; return initial.ToString();'
+```
+
+### JSON-like values passed via `--parameters`
+
+Wrap the whole expression in single quotes so the shell does not interpret double quotes.
+
+```zsh
+uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from zsh"}'
+```
+
+## Click UI Button by Path
+
+```csharp
+using UnityEngine.UI;
+
+Button btn = GameObject.Find("Canvas/StartButton")?.GetComponent<Button>();
+if (btn == null) return "Button not found";
+
+btn.onClick.Invoke();
+return $"Clicked {btn.gameObject.name}";
+```
+
+## Click UI Button by Search
+
+```csharp
+using UnityEngine.UI;
+using System.Linq;
+
+Button[] buttons = Object.FindObjectsByType<Button>(FindObjectsSortMode.None);
+Button target = buttons.FirstOrDefault(b => b.gameObject.name == "PlayButton");
+if (target == null) return $"PlayButton not found. Available: {string.Join(", ", buttons.Select(b => b.gameObject.name))}";
+
+target.onClick.Invoke();
+return $"Clicked {target.gameObject.name}";
+```
+
+## Raycast from Camera Center
+
+```csharp
+Camera cam = Camera.main;
+if (cam == null) return "Main camera not found";
+
+Ray ray = cam.ScreenPointToRay(new Vector3(Screen.width / 2f, Screen.height / 2f, 0));
+if (Physics.Raycast(ray, out RaycastHit hit, 100f))
+{
+    return $"Hit: {hit.collider.gameObject.name} at {hit.point}";
+}
+return "No hit";
+```
+
+## Raycast Click at Screen Position
+
+```csharp
+using UnityEngine.EventSystems;
+using System.Collections.Generic;
+
+if (EventSystem.current == null) return "EventSystem not found";
+
+PointerEventData pointerData = new PointerEventData(EventSystem.current)
+{
+    position = new Vector2(Screen.width / 2f, Screen.height / 2f)
+};
+
+List<RaycastResult> results = new List<RaycastResult>();
+EventSystem.current.RaycastAll(pointerData, results);
+
+if (results.Count == 0) return "No UI element at screen center";
+
+GameObject target = results[0].gameObject;
+ExecuteEvents.ExecuteHierarchy(target, pointerData, ExecuteEvents.pointerClickHandler);
+return $"Clicked UI element: {target.name}";
+```
+
+## Toggle GameObject Active State
+
+```csharp
+GameObject obj = GameObject.Find("Enemy");
+if (obj == null) return "Enemy not found";
+
+obj.SetActive(!obj.activeSelf);
+return $"{obj.name} is now {(obj.activeSelf ? "active" : "inactive")}";
+```
+
+## Invoke Method on MonoBehaviour
+
+```csharp
+using System.Reflection;
+
+GameObject player = GameObject.Find("Player");
+if (player == null) return "Player not found";
+
+MonoBehaviour script = player.GetComponent("PlayerController") as MonoBehaviour;
+if (script == null) return "PlayerController not found";
+
+MethodInfo method = script.GetType().GetMethod("TakeDamage");
+if (method == null) return "TakeDamage method not found";
+
+method.Invoke(script, new object[] { 10f });
+return $"Invoked TakeDamage(10) on {player.name}";
+```
+
+## Set Field Value at Runtime
+
+```csharp
+using System.Reflection;
+
+GameObject player = GameObject.Find("Player");
+if (player == null) return "Player not found";
+
+MonoBehaviour script = player.GetComponent("PlayerController") as MonoBehaviour;
+if (script == null) return "PlayerController not found";
+
+FieldInfo field = script.GetType().GetField("moveSpeed", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+if (field == null) return "moveSpeed field not found";
+
+field.SetValue(script, 20f);
+return $"Set moveSpeed to 20 on {player.name}";
+```
+
+## Move Player to Position
+
+```csharp
+GameObject player = GameObject.Find("Player");
+if (player == null) return "Player not found";
+
+Vector3 targetPos = new Vector3(5f, 0f, 10f);
+player.transform.position = targetPos;
+return $"Moved {player.name} to {targetPos}";
+```
+
+---
+
+# Tool Combination Workflows
+
+Examples of combining `execute-dynamic-code` with other uloop tools for multi-step PlayMode automation.
+
+## find-game-objects → Click Button
+
+Use `find-game-objects` to discover buttons with their hierarchy paths, then click one via `execute-dynamic-code`.
+
+**Step 1**: Find all GameObjects with Button component
+
+```zsh
+uloop find-game-objects --required-components UnityEngine.UI.Button --include-inactive false
+```
+
+**Step 2**: Click the target button using the path from Step 1
+
+```csharp
+using UnityEngine.UI;
+
+// Use the path returned by find-game-objects (e.g. "Canvas/MainMenu/StartButton")
+GameObject btnObj = GameObject.Find("Canvas/MainMenu/StartButton");
+if (btnObj == null) return "Button not found at path";
+
+Button btn = btnObj.GetComponent<Button>();
+if (btn == null) return "No Button component";
+
+btn.onClick.Invoke();
+return $"Clicked {btnObj.name}";
+```
+
+## get-hierarchy → Navigate UI and Click
+
+Use `get-hierarchy` to explore the UI tree structure, then target the right element.
+
+**Step 1**: Get Canvas hierarchy to understand UI structure
+
+```zsh
+uloop get-hierarchy --root-path "Canvas" --max-depth 3 --include-components true
+```
+
+**Step 2**: Based on the hierarchy JSON, click the desired button
+
+```csharp
+using UnityEngine.UI;
+
+// Path identified from hierarchy output
+GameObject btnObj = GameObject.Find("Canvas/SettingsPanel/AudioTab/MuteToggle");
+if (btnObj == null) return "MuteToggle not found";
+
+Toggle toggle = btnObj.GetComponent<Toggle>();
+if (toggle != null)
+{
+    toggle.isOn = !toggle.isOn;
+    return $"Toggled {btnObj.name} to {toggle.isOn}";
+}
+return "No Toggle component found";
+```
+
+## Execute Action → Screenshot to Verify
+
+Run an action then capture a screenshot to visually confirm the result.
+
+**Step 1**: Perform the action
+
+```csharp
+using UnityEngine.UI;
+
+Button btn = GameObject.Find("Canvas/PlayButton")?.GetComponent<Button>();
+if (btn == null) return "PlayButton not found";
+
+btn.onClick.Invoke();
+return "Clicked PlayButton";
+```
+
+**Step 2**: Capture Game View to verify the result
+
+```zsh
+uloop screenshot --window-name Game
+```
+
+## Execute Action → Check Logs for Side Effects
+
+Run an action then inspect Unity Console logs to verify expected behavior.
+
+**Step 1**: Clear console before the action
+
+```zsh
+uloop clear-console
+```
+
+**Step 2**: Perform the action
+
+```csharp
+using System.Reflection;
+
+GameObject player = GameObject.Find("Player");
+if (player == null) return "Player not found";
+
+MonoBehaviour script = player.GetComponent("PlayerController") as MonoBehaviour;
+if (script == null) return "PlayerController not found";
+
+MethodInfo method = script.GetType().GetMethod("TakeDamage");
+if (method == null) return "TakeDamage method not found";
+
+method.Invoke(script, new object[] { 50f });
+return "Invoked TakeDamage(50)";
+```
+
+**Step 3**: Check logs for expected output
+
+```zsh
+uloop get-logs --log-type Log --search-text "damage"
+```
+
+## Full Automation: Play → Act → Capture → Stop
+
+End-to-end test flow: start Play mode, perform actions, capture evidence, stop.
+
+**Step 0**: Clear console to isolate this run
+
+```zsh
+uloop clear-console
+```
+
+**Step 1**: Start Play mode
+
+```zsh
+uloop control-play-mode --action Play
+```
+
+**Step 2**: Wait for scene initialization, then find and click a button
+
+```csharp
+using UnityEngine.UI;
+using System.Linq;
+
+// Scene may need a moment to initialize after Play starts
+Button[] buttons = Object.FindObjectsByType<Button>(FindObjectsSortMode.None);
+Button startBtn = buttons.FirstOrDefault(b => b.gameObject.name.Contains("Start"));
+if (startBtn == null) return $"Start button not found. Available: {string.Join(", ", buttons.Select(b => b.gameObject.name))}";
+
+startBtn.onClick.Invoke();
+return $"Clicked {startBtn.gameObject.name}";
+```
+
+**Step 3**: Capture screenshot as evidence
+
+```zsh
+uloop screenshot --window-name Game
+```
+
+**Step 4**: Check logs for errors
+
+```zsh
+uloop get-logs --log-type Error
+```
+
+**Step 5**: Stop Play mode
+
+```zsh
+uloop control-play-mode --action Stop
+```

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md.meta
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3b1bffe936a214bc49398ce92705ba66
+guid: 0d40893521e758a4997b2352987ab719
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-inspection.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-inspection.md
@@ -126,6 +126,20 @@ if (rb == null) return "Rigidbody not found on TargetCube";
 return $"velocity={rb.velocity}, angularVelocity={rb.angularVelocity}, isKinematic={rb.isKinematic}, useGravity={rb.useGravity}, isSleeping={rb.IsSleeping()}";
 ```
 
+## Raycast from Camera Center
+
+```csharp
+Camera cam = Camera.main;
+if (cam == null) return "Main camera not found";
+
+Ray ray = cam.ScreenPointToRay(new Vector3(Screen.width / 2f, Screen.height / 2f, 0));
+if (Physics.Raycast(ray, out RaycastHit hit, 100f))
+{
+    return $"Hit: {hit.collider.gameObject.name} at {hit.point}";
+}
+return "No hit";
+```
+
 ## Find GameObjects by Tag
 
 ```csharp
@@ -135,4 +149,3 @@ string tag = "Enemy";
 GameObject[] enemies = GameObject.FindGameObjectsWithTag(tag);
 return $"Found {enemies.Length} objects with tag '{tag}': {string.Join(", ", enemies.Select(e => $"{e.name} at {e.transform.position}"))}";
 ```
-

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseInput/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-simulate-mouse-input
-description: "Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into Mouse.current. Use when you need to: (1) Click in games that read Mouse.current.leftButton.wasPressedThisFrame, (2) Right-click for actions like block placement, (3) Inject mouse delta for FPS camera control, (4) Inject scroll wheel for hotbar switching or zoom. Assumes the project uses the New Input System. For UI elements with IPointerClickHandler, use simulate-mouse-ui instead."
+description: "Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into Mouse.current. Use when you need to: (1) Click in games that read Mouse.current.leftButton.wasPressedThisFrame, (2) Right-click for actions like block placement, (3) Inject mouse delta for FPS camera control, (4) Inject scroll wheel for hotbar switching or zoom. Assumes the project uses the New Input System. If the project cannot use it, prefer execute-dynamic-code for a project-specific workaround. For UI elements with IPointerClickHandler, use simulate-mouse-ui instead."
 context: fork
 ---
 

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseInput/Skill/SKILL.md
@@ -93,6 +93,5 @@ uloop simulate-mouse-input --action SmoothDelta --delta-x 300 --delta-y 0 --dura
 
 - Unity must be in **PlayMode**
 - **Input System package** must be installed (`com.unity.inputsystem`)
-- This tool assumes Active Input Handling uses the New Input System (`Input System Package (New)` or `Both`)
 - Game code must read input via Input System API (e.g. `Mouse.current.leftButton.wasPressedThisFrame`)
 - If the target project cannot use the New Input System, prefer `execute-dynamic-code` for a project-specific workaround instead of changing project settings just to use this tool

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseInput/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-simulate-mouse-input
-description: "Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into Mouse.current. Use when you need to: (1) Click in games that read Mouse.current.leftButton.wasPressedThisFrame, (2) Right-click for actions like block placement, (3) Inject mouse delta for FPS camera control, (4) Inject scroll wheel for hotbar switching or zoom. For UI elements with IPointerClickHandler, use simulate-mouse-ui instead."
+description: "Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into Mouse.current. Use when you need to: (1) Click in games that read Mouse.current.leftButton.wasPressedThisFrame, (2) Right-click for actions like block placement, (3) Inject mouse delta for FPS camera control, (4) Inject scroll wheel for hotbar switching or zoom. Assumes the project uses the New Input System. For UI elements with IPointerClickHandler, use simulate-mouse-ui instead."
 context: fork
 ---
 
@@ -58,11 +58,11 @@ uloop simulate-mouse-input --action <action> [options]
 | Scenario | Tool |
 |----------|------|
 | Click a Unity UI Button (IPointerClickHandler) | `simulate-mouse-ui` |
-| Destroy a block in Minecraft (reads `Mouse.current.leftButton`) | `simulate-mouse-input` |
-| Place a block with right-click | `simulate-mouse-input --button Right` |
+| Destroy a block in Minecraft (reads `Mouse.current.leftButton`) | `simulate-mouse-input` when the project uses the New Input System; otherwise prefer `execute-dynamic-code` for a project-specific workaround |
+| Place a block with right-click | `simulate-mouse-input --button Right` when the project uses the New Input System |
 | Drag a UI slider | `simulate-mouse-ui --action Drag` |
-| Look around with mouse (FPS camera) | `simulate-mouse-input --action MoveDelta` |
-| Scroll hotbar slots | `simulate-mouse-input --action Scroll` |
+| Look around with mouse (FPS camera) | `simulate-mouse-input --action MoveDelta` when the project uses the New Input System |
+| Scroll hotbar slots | `simulate-mouse-input --action Scroll` when the project uses the New Input System |
 
 ## Examples
 
@@ -93,5 +93,6 @@ uloop simulate-mouse-input --action SmoothDelta --delta-x 300 --delta-y 0 --dura
 
 - Unity must be in **PlayMode**
 - **Input System package** must be installed (`com.unity.inputsystem`)
-- Active Input Handling must be set to `Input System Package (New)` or `Both` in Player Settings
+- This tool assumes Active Input Handling uses the New Input System (`Input System Package (New)` or `Both`)
 - Game code must read input via Input System API (e.g. `Mouse.current.leftButton.wasPressedThisFrame`)
+- If the target project cannot use the New Input System, prefer `execute-dynamic-code` for a project-specific workaround instead of changing project settings just to use this tool

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-simulate-mouse-ui
-description: "Simulate mouse click, long-press, and drag on PlayMode UI elements via EventSystem screen coordinates. Use when you need to: (1) Click buttons or interactive UI elements during PlayMode testing, (2) Drag UI elements from one position to another, (3) Hold a drag at a position for inspection before releasing, (4) Long-press UI elements that respond to sustained pointer-down. For game logic that reads Input System (e.g. WasPressedThisFrame), use simulate-mouse-input instead."
+description: "Simulate mouse click, long-press, and drag on PlayMode UI elements via EventSystem screen coordinates. Use when you need to: (1) Click buttons or interactive UI elements during PlayMode testing, (2) Drag UI elements from one position to another, (3) Hold a drag at a position for inspection before releasing, (4) Long-press UI elements that respond to sustained pointer-down. For game logic that reads Input System (e.g. WasPressedThisFrame), use simulate-mouse-input when the project uses the New Input System; otherwise prefer execute-dynamic-code."
 context: fork
 ---
 
@@ -95,3 +95,4 @@ uloop simulate-mouse-ui --action DragEnd --x 600 --y 300
 - Unity must be in **PlayMode**
 - Target scene must have an **EventSystem** GameObject
 - UI elements must have a **GraphicRaycaster** on their Canvas
+- If you need gameplay mouse input rather than UI pointer events, `simulate-mouse-input` assumes the project uses the New Input System; otherwise prefer `execute-dynamic-code`


### PR DESCRIPTION
## Summary
- split the PlayMode automation reference into zsh and PowerShell variants
- add validated PowerShell quoting examples for inline snippets, parameters, and multi-line here-strings
- keep the packaged skill source and generated Codex skill files aligned

## Why
PowerShell users need different quoting guidance from zsh users when they run execute-dynamic-code examples on Windows. Separating the references keeps each shell's examples copy-pasteable and reduces trial and error.

## Testing
- uloop compile
- verified inline PowerShell execute-dynamic-code examples
- verified PowerShell parameters example with param0
- verified PowerShell here-string examples for multi-line code and parameters

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split PlayMode automation docs into `zsh` and `PowerShell` with copy‑pasteable quoting and a simple tool‑choice guide between `simulate-mouse-ui`, `simulate-mouse-input`, and `execute-dynamic-code`, including a clear fallback when the New Input System isn’t available. Moved raycast checks to the PlayMode inspection guide and softened mouse‑input prerequisites to avoid implying Player Settings changes.

- New Features
  - Added `playmode-automation-powershell.md` with validated `execute-dynamic-code` examples, `--parameters`, and here-strings.
  - Shell-specific guides include quoting rules and a quick matrix for choosing `simulate-mouse-ui`, `simulate-mouse-input`, or `execute-dynamic-code`.

- Refactors
  - Renamed and aligned the zsh guide; removed UI raycast click from automation; added camera-center raycast to `playmode-inspection.md`.
  - Updated `uloop-simulate-mouse-input` and `uloop-simulate-mouse-ui` to assume the New Input System and recommend `execute-dynamic-code` as the fallback.
  - Removed the explicit “Active Input Handling = Input System/New or Both” prerequisite; linked shell-specific guides in `uloop-execute-dynamic-code` and synced docs.

<sup>Written for commit 1878aeade50a7848f9781232b152f16bcf5f3f5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR splits the PlayMode automation documentation for `execute-dynamic-code` into shell-specific variants so examples are copy-pasteable for both zsh and PowerShell users, and clarifies when to prefer dedicated mouse-simulation tools vs direct C#-driven automation.

## Changes Made

### Documentation Structure
- Replaced the single generic PlayMode automation reference with two shell-specific references:
  - `playmode-automation-zsh.md` — zsh-specific guidance and examples
  - `playmode-automation-powershell.md` — PowerShell-specific guidance and examples

### Shell-Specific Guidance
- PowerShell examples:
  - PowerShell-safe quoting rules for embedding C# snippets
  - Handling nested double/single quotes in C# code
  - JSON-like `--parameters` payload formatting
  - Multi-line C# snippets via here-strings
  - Validated inline examples, parameter usage (including `param0`), and here-string multi-line examples
- zsh examples:
  - zsh single-quote patterns for safe C# snippet passing
  - Escaping embedded single quotes in parameters
  - Code fences updated to `zsh` and zsh-specific notes added

### Tooling / Guidance Clarification
- Documented when to prefer dedicated mouse simulation tools (`simulate-mouse-ui`, `simulate-mouse-input`) versus `execute-dynamic-code`:
  - Prefer `simulate-mouse-ui` for EventSystem-driven UI interaction and `simulate-mouse-input` for Input System gameplay input.
  - Added guidance to choose the appropriate approach for PlayMode testing scenarios.

### Code Examples Retained
Both shell documents preserve the same automation use cases:
- Locating UI buttons by hierarchy or component search
- Click interactions via `onClick` and EventSystem raycasts
- Physics raycasting from camera and screen positions
- Toggling GameObject active state
- Invoking MonoBehaviour methods via reflection
- Setting MonoBehaviour field values
- Moving GameObjects to positions
- Multi-step workflows combining `execute-dynamic-code` with other uloop commands (e.g., find → act → screenshot → verify → stop)

## Files Updated (line counts)
- .claude/skills/uloop-execute-dynamic-code/SKILL.md (67 lines)
- .claude/skills/uloop-execute-dynamic-code/references/playmode-automation-zsh.md (333 lines)
- .claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md (364 lines)
- Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md (67 lines)
- Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md (333 lines)
- Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md (364 lines)

## Testing
- Ran `uloop compile`
- Verified inline PowerShell `execute-dynamic-code` examples
- Verified PowerShell parameter handling including `param0`
- Verified PowerShell here-string multi-line examples

## Impact
- Documentation-only changes; no exported/public code entities modified.
- Estimated review effort: Low
<!-- end of auto-generated comment: release notes by coderabbit.ai -->