### PR TITLE
fix: setup wizard no longer gets stuck checking skills

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -325,6 +325,24 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             Assert.That(label, Is.EqualTo(expectedLabel));
         }
 
+        [TestCase(false, false, false, "Install Skills")]
+        [TestCase(true, true, false, "Installing...")]
+        [TestCase(true, false, true, "Update Skills")]
+        [TestCase(true, false, false, "Install Skills")]
+        public void GetSkillsButtonTextForSetupWizard_ReturnsExpectedLabel(
+            bool cliInstalled,
+            bool isInstallingSkills,
+            bool hasOutdatedSkills,
+            string expectedLabel)
+        {
+            string label = SetupWizardWindow.GetSkillsButtonTextForSetupWizard(
+                cliInstalled,
+                isInstallingSkills,
+                hasOutdatedSkills);
+
+            Assert.That(label, Is.EqualTo(expectedLabel));
+        }
+
         [TestCase(SkillInstallState.Installed, false, true, "setup-target-item__status--installed")]
         [TestCase(SkillInstallState.Checking, false, true, "setup-target-item__status--checking")]
         [TestCase(SkillInstallState.Outdated, false, true, "setup-target-item__status--outdated")]

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -531,6 +531,10 @@ namespace io.github.hatayama.uLoopMCP
             {
                 UpdateSkillsStatusLabel(string.Empty);
                 _installSkillsButton.SetEnabled(false);
+                _installSkillsButton.text = GetSkillsButtonTextForSetupWizard(
+                    cliInstalled: false,
+                    _isInstallingSkills,
+                    hasOutdatedSkills: false);
                 _groupSkillsToggle.SetEnabled(false);
                 ViewDataBinder.SetVisible(_skillsTargetRow, false);
                 ViewDataBinder.SetVisible(_skillsTargetList, false);
@@ -620,10 +624,21 @@ namespace io.github.hatayama.uLoopMCP
                     t => t.InstallState == SkillInstallState.Outdated);
                 UpdateSkillsStatusLabel(string.Empty);
                 _installSkillsButton.SetEnabled(!_isInstallingSkills);
-                _installSkillsButton.text = GetInstallSkillsButtonText(
+                _installSkillsButton.text = GetSkillsButtonTextForSetupWizard(
+                    cliInstalled: true,
                     _isInstallingSkills,
                     hasOutdatedSkills);
             }
+        }
+
+        internal static string GetSkillsButtonTextForSetupWizard(
+            bool cliInstalled,
+            bool isInstallingSkills,
+            bool hasOutdatedSkills)
+        {
+            return !cliInstalled
+                ? "Install Skills"
+                : GetInstallSkillsButtonText(isInstallingSkills, hasOutdatedSkills);
         }
 
         internal static string GetInstallSkillsButtonText(


### PR DESCRIPTION
## Summary
- stop the setup wizard from leaving the skills button stuck on "Checking..." when the installed uloop-cli version does not match the package version
- keep the disabled state accurate until Step 1 is satisfied

## Cause
- the wizard initialized the skills section with a temporary "Checking..." label
- when the CLI was missing or version-mismatched, the button state was disabled but the label was not reset

## Changes
- add a setup-wizard-specific skills button text helper
- show "Install Skills" instead of the stale checking label when the CLI is unavailable for skill installation
- add EditMode tests that cover the button text selection

## Verification
- uloop compile --project-path /Users/a12115/ghq/hatayama/unity-cli-loop
- uloop run-tests --project-path /Users/a12115/ghq/hatayama/unity-cli-loop --test-mode EditMode --filter-type regex --filter-value io.github.hatayama.uLoopMCP.Tests.Editor.SetupWizardWindowTests

## User Impact
- projects that reference the package locally and still have an older global uloop-cli version now show a clear disabled skills state instead of appearing to hang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Fixed a UI issue where the setup wizard's skills install button remained stuck showing "Checking..." when the installed uloop-cli version did not match the package version. The button is now properly labeled as "Install Skills" while remaining disabled when the CLI is unavailable.

## Root Cause

The setup wizard initialized the skills section with a temporary "Checking..." label. When the CLI was missing or version-mismatched, the button was disabled but the label was not reset, resulting in a stale "Checking..." display that appeared to hang.

## Changes

### New Helper Method
- Added `GetSkillsButtonTextForSetupWizard(bool cliInstalled, bool isInstallingSkills, bool hasOutdatedSkills)` internal static method to `SetupWizardWindow`
- Returns `"Install Skills"` when `cliInstalled` is false
- Otherwise delegates to the existing `GetInstallSkillsButtonText(...)` method

### Updated Button Text Logic
- When CLI is not installed, the button text is set via the new helper to show `"Install Skills"` while keeping the button disabled
- When CLI is installed, button text assignment was migrated to use `GetSkillsButtonTextForSetupWizard(...)` instead of `GetInstallSkillsButtonText(...)`

### Test Coverage
- Added new NUnit test method `GetSkillsButtonTextForSetupWizard_ReturnsExpectedLabel` in `SetupWizardWindowTests`
- Includes four test cases covering combinations of `cliInstalled`, `isInstallingSkills`, and `hasOutdatedSkills` parameters
- Verifies correct label selection: `"Install Skills"`, `"Installing..."`, or `"Update Skills"`

## Impact

Projects that reference the package locally while using an older global uloop-cli version will now display a clear disabled skills state (`"Install Skills"`) instead of appearing to hang with a stale `"Checking..."` indicator.

## Verification

Test run passed successfully: 0 errors, 0 warnings (Ver: 1.7.3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->