### PR TITLE
fix: Setup Wizard now shows skill status during CLI updates

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -187,6 +187,22 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
+        public void CanManageSkills_WhenCliIsMissing_ReturnsFalse()
+        {
+            bool canManageSkills = SetupWizardWindow.CanManageSkills(cliInstalled: false);
+
+            Assert.That(canManageSkills, Is.False);
+        }
+
+        [Test]
+        public void CanManageSkills_WhenCliIsInstalled_ReturnsTrue()
+        {
+            bool canManageSkills = SetupWizardWindow.CanManageSkills(cliInstalled: true);
+
+            Assert.That(canManageSkills, Is.True);
+        }
+
+        [Test]
         public void CreateFirstInstallSkillTarget_WhenClaudeSelected_ReturnsClaudeProjectTarget()
         {
             ToolSkillSynchronizer.SkillTargetInfo target =

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -326,11 +326,12 @@ namespace io.github.hatayama.uLoopMCP
         private void RefreshSkillsSection()
         {
             string cachedCliVersion = CliInstallationDetector.GetCachedCliVersion();
-            bool cliVersionMatched = IsCliVersionMatched(cachedCliVersion);
+            bool cliInstalled = !string.IsNullOrEmpty(cachedCliVersion);
             string projectRoot = UnityMcpPathResolver.GetProjectRoot();
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
-            UpdateSkillsStep(cliVersionMatched, targets);
-            BeginRefreshDisplayedSkillTargets(cliVersionMatched);
+            bool canManageSkills = CanManageSkills(cliInstalled);
+            UpdateSkillsStep(canManageSkills, targets);
+            BeginRefreshDisplayedSkillTargets(canManageSkills);
             ScheduleResizeToContent();
         }
 
@@ -370,8 +371,9 @@ namespace io.github.hatayama.uLoopMCP
 
             string projectRoot = UnityMcpPathResolver.GetProjectRoot();
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
-            UpdateSkillsStep(cliVersionMatched, targets);
-            BeginRefreshDisplayedSkillTargets(cliVersionMatched);
+            bool canManageSkills = CanManageSkills(cliInstalled);
+            UpdateSkillsStep(canManageSkills, targets);
+            BeginRefreshDisplayedSkillTargets(canManageSkills);
             ScheduleResizeToContent();
         }
 
@@ -385,10 +387,10 @@ namespace io.github.hatayama.uLoopMCP
             return ToolSkillSynchronizer.DetectTargetsForLayoutFastAtProjectRoot(projectRoot, !_installSkillsFlat);
         }
 
-        private void BeginRefreshDisplayedSkillTargets(bool cliVersionMatched)
+        private void BeginRefreshDisplayedSkillTargets(bool canManageSkills)
         {
             CancelSkillInstallStateRefresh();
-            if (!cliVersionMatched || _isInstallingSkills)
+            if (!canManageSkills || _isInstallingSkills)
             {
                 return;
             }
@@ -408,7 +410,7 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            UpdateSkillsStep(cliInstalled: true, targets);
+            UpdateSkillsStep(canManageSkills: true, targets);
             ScheduleResizeToContent();
         }
 
@@ -434,6 +436,11 @@ namespace io.github.hatayama.uLoopMCP
         internal static bool ShouldUseFirstInstallSkillsUi(bool hasShownSetupWizardSkillsSelection)
         {
             return !hasShownSetupWizardSkillsSelection;
+        }
+
+        internal static bool CanManageSkills(bool cliInstalled)
+        {
+            return cliInstalled;
         }
 
         internal static ToolSkillSynchronizer.SkillTargetInfo CreateFirstInstallSkillTarget(
@@ -522,12 +529,12 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         private void UpdateSkillsStep(
-            bool cliInstalled,
+            bool canManageSkills,
             List<ToolSkillSynchronizer.SkillTargetInfo> targets)
         {
             _skillsTargetList.Clear();
 
-            if (!cliInstalled)
+            if (!canManageSkills)
             {
                 UpdateSkillsStatusLabel(string.Empty);
                 _installSkillsButton.SetEnabled(false);


### PR DESCRIPTION
## Summary
- Keep Setup Wizard Step 2 available even when the installed CLI version does not match the package version
- Surface grouped vs flat skill layout differences during upgrades, just like the Settings window

## Changes
- Change Setup Wizard skill-management gating to depend on whether the CLI is installed
- Use the same gating for the async skill-status refresh so layout mismatches stay visible during updates
- Add focused SetupWizardWindowTests for the new gating behavior

## Verification
- uloop compile --project-path /Users/a12115/ghq/hatayama/unity-cli-loop
- uloop run-tests --project-path /Users/a12115/ghq/hatayama/unity-cli-loop --test-mode EditMode --filter-type regex --filter-value SetupWizardWindowTests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves the Setup Wizard to keep skill status detection available whenever the CLI is installed, even when the installed CLI version is behind the package version. This ensures layout mismatches between grouped and flat skill organization are surfaced during CLI updates, consistent with the Settings window behavior.

## Changes

### Core Logic Refactoring

**SetupWizardWindow.cs**

- Added new internal helper method `CanManageSkills(bool cliInstalled)` that gates skill management based on CLI installation status rather than version matching
- Unified skill management gating logic: replaced CLI version matching checks (`cliVersionMatched`) with CLI installation checks (`cliInstalled`) across skill refresh operations
- Updated `BeginRefreshDisplayedSkillTargets()` to proceed when `canManageSkills` is true (instead of requiring matched CLI version), while still respecting the `_isInstallingSkills` block
- Modified `UpdateSkillsStep()` to gate skill UI updates based on `canManageSkills` instead of raw CLI installation
- Updated `RefreshSkillsSection()` and `RefreshUI()` to compute and use `canManageSkills` for both synchronous fast detection and asynchronous detailed detection
- Aligned `RefreshDisplayedSkillTargetsAsync()` to pass `canManageSkills: true` to maintain consistency

### Test Coverage

**SetupWizardWindowTests.cs**

- Added `CanManageSkills_WhenCliIsMissing_ReturnsFalse()`: asserts false when CLI is not installed
- Added `CanManageSkills_WhenCliIsInstalled_ReturnsTrue()`: asserts true when CLI is installed

These new tests lock in the skill management gating behavior, ensuring the Setup Wizard correctly enables/disables skill operations based on CLI presence alone.

## Impact

- Users can now observe grouped/flat skill layout mismatches in the Setup Wizard Step 2 during CLI version upgrades
- Skill state detection becomes available immediately after CLI installation, independent of version alignment
- Behavior aligns between Setup Wizard and Settings window for skill layout detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->