### PR TITLE
fix: Setup now recognizes existing skill folders instead of showing them as missing

### DIFF
--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -279,6 +279,26 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public void DetectTargets_WhenGroupedLayoutRequested_DetectsEmptyFlatManagedDirectories()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            string targetRoot = Path.Combine(temporaryRoot, ".cursor");
+            Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
+
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+                    temporaryRoot,
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: true)
+                .ToArray();
+
+            Assert.That(detectedTargets.Length, Is.EqualTo(1));
+            Assert.IsFalse(detectedTargets[0].HasExistingSkills,
+                "Grouped layout should still treat empty flat directories as not installed");
+            Assert.IsTrue(detectedTargets[0].HasDifferentLayoutSkills,
+                "Empty flat managed directories should still be surfaced as a different layout");
+        }
+
+        [Test]
         public void DetectTargets_WhenFlatLayoutRequested_IgnoresGroupedInstalledSkills()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
@@ -445,6 +465,17 @@ namespace io.github.hatayama.uLoopMCP
                 "uloop-compile"));
             Assert.IsTrue(CliInstallationDetector.AreSkillsInstalled(temporaryRoot, ".codex", true));
             Assert.IsFalse(CliInstallationDetector.AreSkillsInstalled(temporaryRoot, ".codex", false));
+        }
+
+        [Test]
+        public void AreSkillsInstalled_WhenLegacyManagedDirectoryIsEmpty_StillDetectsFlatLayout()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            string targetRoot = Path.Combine(temporaryRoot, ".cursor");
+            Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
+
+            Assert.IsTrue(CliInstallationDetector.AreSkillsInstalled(temporaryRoot, ".cursor", false));
+            Assert.IsFalse(CliInstallationDetector.AreSkillsInstalled(temporaryRoot, ".cursor", true));
         }
 
         [Test]

--- a/Packages/src/Editor/Config/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Config/SkillInstallLayout.cs
@@ -90,8 +90,7 @@ namespace io.github.hatayama.uLoopMCP
 
         internal static bool HasInstalledSkills(string targetRoot)
         {
-            return EnumerateInstalledSkillDirectories(targetRoot)
-                .Any(skillDir => File.Exists(Path.Combine(skillDir, SkillFileName)));
+            return EnumerateInstalledSkillDirectories(targetRoot).Any();
         }
 
         internal static bool HasInstalledSkills(string targetRoot, bool groupSkillsUnderUnityCliLoop)
@@ -99,7 +98,7 @@ namespace io.github.hatayama.uLoopMCP
             IEnumerable<string> skillDirs = groupSkillsUnderUnityCliLoop
                 ? EnumerateManagedSkillDirectories(targetRoot)
                 : EnumerateLegacyManagedSkillDirectories(targetRoot);
-            return skillDirs.Any(skillDir => File.Exists(Path.Combine(skillDir, SkillFileName)));
+            return skillDirs.Any();
         }
 
         internal static SkillInstallState GetInstalledState(
@@ -223,6 +222,12 @@ namespace io.github.hatayama.uLoopMCP
 
         private static bool IsLegacyManagedSkillDirectory(string skillDir)
         {
+            string dirName = Path.GetFileName(skillDir);
+            if (dirName.StartsWith(CliConstants.SKILL_DIR_PREFIX, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
             string skillMdPath = Path.Combine(skillDir, SkillFileName);
             if (!File.Exists(skillMdPath))
             {
@@ -235,8 +240,7 @@ namespace io.github.hatayama.uLoopMCP
                 return true;
             }
 
-            string dirName = Path.GetFileName(skillDir);
-            return dirName.StartsWith(CliConstants.SKILL_DIR_PREFIX);
+            return false;
         }
 
         private static string GetInstalledSkillDirectoryPath(


### PR DESCRIPTION
## Summary
- Setup no longer marks existing skill folders as missing when older folder layouts are still present
- Users can still see when skills exist in a different layout and what needs attention during setup

## User Impact
- If skill folders from an older install layout are still in your workspace, Setup now recognizes them instead of incorrectly calling them missing
- This makes upgrade guidance clearer across supported tools and folder layouts

## Changes
- Recognize managed skill folders by their layout, even when older folders remain as legacy remnants
- Keep grouped vs ungrouped layout differences visible so Setup can show the right status during upgrades
- Add regression tests for legacy skill-folder detection

## Verification
- uloop compile --project-path /Users/a12115/ghq/hatayama/unity-cli-loop
- uloop run-tests --project-path /Users/a12115/ghq/hatayama/unity-cli-loop --test-mode EditMode --filter-type regex --filter-value ToolSkillSynchronizerTests
- uloop compile --project-path <EXTERNAL_PROJECT_ROOT>
