### PR TITLE
fix: show launch progress while Unity is starting

### DIFF
--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -15,6 +15,18 @@ jest.mock('../execute-tool.js', () => ({
   prewarmDynamicCodeAfterLaunch: jest.fn(),
 }));
 
+const mockSpinnerUpdate = jest.fn<void, [string]>();
+const mockSpinnerStop = jest.fn<void, []>();
+const mockCreateSpinner = jest.fn<
+  { update: (message: string) => void; stop: () => void },
+  [string]
+>();
+
+jest.mock('../spinner.js', () => ({
+  createSpinner: (message: string): { update: (message: string) => void; stop: () => void } =>
+    mockCreateSpinner(message),
+}));
+
 jest.mock('../tool-settings-loader.js', () => ({
   isToolEnabled: jest.fn(),
 }));
@@ -40,6 +52,13 @@ describe('launch command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    mockCreateSpinner.mockReset();
+    mockCreateSpinner.mockReturnValue({
+      update: (message: string): void => mockSpinnerUpdate(message),
+      stop: (): void => mockSpinnerStop(),
+    });
+    mockSpinnerUpdate.mockReset();
+    mockSpinnerStop.mockReset();
   });
 
   afterEach(() => {
@@ -59,6 +78,9 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
+    expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
+    expect(mockSpinnerUpdate).toHaveBeenCalledWith('Waiting for Unity CLI Loop to become ready...');
+    expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForLaunchReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
     expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(prewarmDynamicCodeAfterLaunchMock).not.toHaveBeenCalled();
@@ -77,9 +99,36 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
+    expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
+    expect(mockSpinnerUpdate).toHaveBeenNthCalledWith(
+      1,
+      'Waiting for execute-dynamic-code to become ready...',
+    );
+    expect(mockSpinnerUpdate).toHaveBeenNthCalledWith(2, 'Warming up execute-dynamic-code...');
+    expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForDynamicCodeReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
     expect(prewarmDynamicCodeAfterLaunchMock).toHaveBeenCalledWith({ projectRoot: '/project' });
     expect(consoleLogSpy).not.toHaveBeenCalledWith('Waiting for execute-dynamic-code warmup...');
     expect(consoleLogSpy).not.toHaveBeenCalledWith('execute-dynamic-code is ready.');
+  });
+
+  it('stops spinner without readiness waits when Unity is already running', async () => {
+    orchestrateLaunchMock.mockResolvedValue({
+      action: 'focused',
+      projectPath: '/project',
+      pid: 4321,
+    });
+
+    const program = new Command();
+    registerLaunchCommand(program);
+
+    await program.parseAsync(['node', 'uloop', 'launch', '/project']);
+
+    expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
+    expect(mockSpinnerUpdate).not.toHaveBeenCalled();
+    expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
+    expect(waitForLaunchReadyAfterLaunchMock).not.toHaveBeenCalled();
+    expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
+    expect(prewarmDynamicCodeAfterLaunchMock).not.toHaveBeenCalled();
   });
 });

--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -79,7 +79,7 @@ describe('launch command', () => {
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
     expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
-    expect(mockSpinnerUpdate).toHaveBeenCalledWith('Waiting for Unity CLI Loop to become ready...');
+    expect(mockSpinnerUpdate).toHaveBeenCalledWith('Preparing Unity tools...');
     expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForLaunchReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
     expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
@@ -100,11 +100,8 @@ describe('launch command', () => {
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
     expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
-    expect(mockSpinnerUpdate).toHaveBeenNthCalledWith(
-      1,
-      'Waiting for execute-dynamic-code to become ready...',
-    );
-    expect(mockSpinnerUpdate).toHaveBeenNthCalledWith(2, 'Warming up execute-dynamic-code...');
+    expect(mockSpinnerUpdate).toHaveBeenNthCalledWith(1, 'Preparing Unity tools...');
+    expect(mockSpinnerUpdate).toHaveBeenNthCalledWith(2, 'Finalizing Unity startup...');
     expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForDynamicCodeReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
     expect(prewarmDynamicCodeAfterLaunchMock).toHaveBeenCalledWith({ projectRoot: '/project' });

--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -79,7 +79,7 @@ describe('launch command', () => {
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
     expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
-    expect(mockSpinnerUpdate).toHaveBeenCalledWith('Preparing Unity tools...');
+    expect(mockSpinnerUpdate).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
     expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForLaunchReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
     expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
@@ -100,8 +100,8 @@ describe('launch command', () => {
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
     expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
-    expect(mockSpinnerUpdate).toHaveBeenNthCalledWith(1, 'Preparing Unity tools...');
-    expect(mockSpinnerUpdate).toHaveBeenNthCalledWith(2, 'Finalizing Unity startup...');
+    expect(mockSpinnerUpdate).toHaveBeenCalledTimes(1);
+    expect(mockSpinnerUpdate).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
     expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForDynamicCodeReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
     expect(prewarmDynamicCodeAfterLaunchMock).toHaveBeenCalledWith({ projectRoot: '/project' });

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -91,14 +91,13 @@ async function runLaunchCommand(
       launchResult.projectPath,
     );
     if (!isDynamicCodeEnabled) {
-      spinner.update('Preparing Unity tools...');
+      spinner.update('Waiting for Unity to finish starting...');
       await waitForLaunchReadyAfterLaunch(launchResult.projectPath);
       return;
     }
 
-    spinner.update('Preparing Unity tools...');
+    spinner.update('Waiting for Unity to finish starting...');
     await waitForDynamicCodeReadyAfterLaunch(launchResult.projectPath);
-    spinner.update('Finalizing Unity startup...');
     await prewarmDynamicCodeAfterLaunch({ projectRoot: launchResult.projectPath });
   } finally {
     spinner.stop();

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -15,6 +15,7 @@ import {
   waitForDynamicCodeReadyAfterLaunch,
   waitForLaunchReadyAfterLaunch,
 } from '../launch-readiness.js';
+import { createSpinner } from '../spinner.js';
 import { isToolEnabled } from '../tool-settings-loader.js';
 
 interface LaunchCommandOptions {
@@ -65,33 +66,41 @@ async function runLaunchCommand(
   options: LaunchCommandOptions,
 ): Promise<void> {
   const maxDepth: number = parseMaxDepth(options.maxDepth);
+  const spinner = createSpinner('Launching Unity...');
 
-  const launchResult: OrchestrateResult = await orchestrateLaunch({
-    projectPath: projectPath ? resolve(projectPath) : undefined,
-    searchRoot: process.cwd(),
-    searchMaxDepth: maxDepth,
-    platform: options.platform,
-    unityArgs: [],
-    restart: options.restart === true,
-    quit: options.quit === true,
-    deleteRecovery: options.deleteRecovery === true,
-    addUnityHub: options.addUnityHub === true,
-    favoriteUnityHub: options.favorite === true,
-  });
+  try {
+    const launchResult: OrchestrateResult = await orchestrateLaunch({
+      projectPath: projectPath ? resolve(projectPath) : undefined,
+      searchRoot: process.cwd(),
+      searchMaxDepth: maxDepth,
+      platform: options.platform,
+      unityArgs: [],
+      restart: options.restart === true,
+      quit: options.quit === true,
+      deleteRecovery: options.deleteRecovery === true,
+      addUnityHub: options.addUnityHub === true,
+      favoriteUnityHub: options.favorite === true,
+    });
 
-  if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
-    return;
+    if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
+      return;
+    }
+
+    const isDynamicCodeEnabled: boolean = isToolEnabled(
+      'execute-dynamic-code',
+      launchResult.projectPath,
+    );
+    if (!isDynamicCodeEnabled) {
+      spinner.update('Waiting for Unity CLI Loop to become ready...');
+      await waitForLaunchReadyAfterLaunch(launchResult.projectPath);
+      return;
+    }
+
+    spinner.update('Waiting for execute-dynamic-code to become ready...');
+    await waitForDynamicCodeReadyAfterLaunch(launchResult.projectPath);
+    spinner.update('Warming up execute-dynamic-code...');
+    await prewarmDynamicCodeAfterLaunch({ projectRoot: launchResult.projectPath });
+  } finally {
+    spinner.stop();
   }
-
-  const isDynamicCodeEnabled: boolean = isToolEnabled(
-    'execute-dynamic-code',
-    launchResult.projectPath,
-  );
-  if (!isDynamicCodeEnabled) {
-    await waitForLaunchReadyAfterLaunch(launchResult.projectPath);
-    return;
-  }
-
-  await waitForDynamicCodeReadyAfterLaunch(launchResult.projectPath);
-  await prewarmDynamicCodeAfterLaunch({ projectRoot: launchResult.projectPath });
 }

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -91,14 +91,14 @@ async function runLaunchCommand(
       launchResult.projectPath,
     );
     if (!isDynamicCodeEnabled) {
-      spinner.update('Waiting for Unity CLI Loop to become ready...');
+      spinner.update('Preparing Unity tools...');
       await waitForLaunchReadyAfterLaunch(launchResult.projectPath);
       return;
     }
 
-    spinner.update('Waiting for execute-dynamic-code to become ready...');
+    spinner.update('Preparing Unity tools...');
     await waitForDynamicCodeReadyAfterLaunch(launchResult.projectPath);
-    spinner.update('Warming up execute-dynamic-code...');
+    spinner.update('Finalizing Unity startup...');
     await prewarmDynamicCodeAfterLaunch({ projectRoot: launchResult.projectPath });
   } finally {
     spinner.stop();


### PR DESCRIPTION
## Summary
- Show spinner feedback while uloop launch waits for Unity startup to finish
- Keep the startup message user-facing instead of exposing internal readiness terms

## User Impact
- Before this change, uloop launch could appear idle while Unity was still starting, which made the CLI feel stuck
- After this change, users see clear progress feedback until Unity is ready to use

## Changes
- Wrapped the launch wait path in the shared CLI spinner
- Added launch command coverage for launched and already-running Unity flows
- Simplified the visible wait message to a single startup-focused status

## Verification
- npm run build
- npx eslint src/commands/launch.ts src/__tests__/launch-command.test.ts
- npm run test:cli -- --runTestsByPath src/__tests__/launch-command.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix: Show launch progress while Unity is starting

## Overview
This PR improves the user experience when launching Unity by displaying interactive progress feedback (spinner) while the CLI waits for Unity to complete startup. Previously, the `uloop launch` command appeared idle while bringing an existing Unity process to the foreground or waiting for the application to become ready.

## Changes

### Launch Command Implementation (`launch.ts`)
**+33/-25 lines**

The `launch` command now provides visual feedback to users during the startup sequence:

- **Spinner Initialization**: Creates a spinner with the message "Launching Unity..." at the start of the launch flow
- **Lifecycle Management**: Wraps the entire launch orchestration and readiness checks in a `try/finally` block to guarantee spinner cleanup
- **Progressive Messaging**: Updates the spinner with appropriate status messages:
  - When dynamic code is disabled: Shows "Waiting for Unity to finish starting..." while awaiting launch readiness
  - When dynamic code is enabled: Updates the spinner before awaiting dynamic code readiness and prewarming
- **Guaranteed Cleanup**: The `spinner.stop()` method is called in the `finally` block, ensuring the spinner terminates regardless of the control flow path (including early returns)

### Test Coverage (`launch-command.test.ts`)
**+46 new lines**

Comprehensive test coverage was added for the spinner integration:

- **Spinner Mock Setup**: Mocks the CLI spinner module with typed Jest mock functions:
  - `createSpinner()` - captures spinner initialization calls
  - `mockSpinnerUpdate` - tracks all spinner message updates
  - `mockSpinnerStop` - verifies spinner termination
  
- **Launch Flow Tests**: Existing launch test cases now verify:
  - Spinner is initialized with "Launching Unity..."
  - Spinner receives expected update calls (or none, depending on configuration)
  - Spinner is stopped exactly once at completion
  
- **Already-Running Unity Test**: New test case covers the scenario where Unity is already running (`action: 'focused'`):
  - Spinner is properly stopped
  - No readiness wait operations occur
  - No dynamic code warmup is performed

## User Impact
- **Improved Feedback**: Users no longer see an apparently idle CLI when launching Unity or bringing an existing Unity process to the foreground
- **Clear Status**: Simplified messaging presents a single, user-facing "Launching Unity..." status instead of exposing internal readiness terminology
- **Better Perceived Performance**: Interactive spinner creates the impression of active work during the startup sequence

## Test Verification
All launch flows (newly-launched and already-running Unity) have been tested and verified with the new spinner lifecycle assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->