### PR TITLE
fix: Setup no longer shows unconfigured skill targets as missing

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -154,12 +154,13 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
-        public void FilterInstallableSkillTargets_ReturnsAllDetectedTargets()
+        public void FilterInstallableSkillTargets_ExcludesTargetsWithoutSkillsDirectory()
         {
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = new()
             {
                 new("Claude Code", ".claude", "--claude", true, true),
-                new("Cursor", ".cursor", "--cursor", false, false)
+                new("Cursor", ".cursor", "--cursor", false, false),
+                new("Codex CLI", ".codex", "--codex", true, false, hasDifferentLayoutSkills: true)
             };
 
             List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets =
@@ -167,7 +168,7 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
 
             Assert.That(installableTargets.Count, Is.EqualTo(2));
             Assert.That(installableTargets[0].DirName, Is.EqualTo(".claude"));
-            Assert.That(installableTargets[1].DirName, Is.EqualTo(".cursor"));
+            Assert.That(installableTargets[1].DirName, Is.EqualTo(".codex"));
         }
 
         [Test]

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -430,7 +430,9 @@ namespace io.github.hatayama.uLoopMCP
             IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets)
         {
             Debug.Assert(targets != null, "targets must not be null");
-            return targets.ToList();
+            return targets
+                .Where(target => target.HasSkillsDirectory)
+                .ToList();
         }
 
         internal static bool ShouldUseFirstInstallSkillsUi(bool hasShownSetupWizardSkillsSelection)
@@ -575,7 +577,7 @@ namespace io.github.hatayama.uLoopMCP
 
             List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
 
-            foreach (ToolSkillSynchronizer.SkillTargetInfo target in targets)
+            foreach (ToolSkillSynchronizer.SkillTargetInfo target in installableTargets)
             {
                 VisualElement item = new VisualElement();
                 item.AddToClassList("setup-target-item");


### PR DESCRIPTION
## Summary
- Hide skill targets from the Setup Wizard update list until they explicitly opt in by creating a skills directory
- Keep the first-install flow available so users can still choose a target and install skills on demand

## User Impact
- Before this change, folders such as `.cursor/` or `.agents/` could appear in the Setup Wizard as `Missing` even when skill installation had never been enabled there
- After this change, the update list only shows targets that already opted in, so the UI no longer suggests that unconfigured targets are broken or need an update

## Changes
- Filter the Setup Wizard update list to targets that already have a skills directory
- Reuse that filtered list for rendering so non-opted-in targets are not shown with update statuses
- Add a test that locks this behavior in for targets without a skills directory

## Verification
- `uloop compile`
- `uloop run-tests --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.uLoopMCP.Tests.Editor.SetupWizardWindowTests.FilterInstallableSkillTargets_ExcludesTargetsWithoutSkillsDirectory"`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "io.github.hatayama.uLoopMCP.Tests.Editor.SetupWizardWindowTests.*"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR addresses a UX issue where unconfigured skill targets appeared as "Missing" in the Setup Wizard even though users had never enabled skill installation for those targets. The fix filters the update list to display only targets that have already opted in by creating a skills directory.

## Changes Made

### SetupWizardWindow.cs - Core Implementation
- **`FilterInstallableSkillTargets()` method**: Now filters input targets to return only those where `HasSkillsDirectory` is `true`, preventing unconfigured targets from appearing in update lists
- **`UpdateSkillsStep()` method**: Updated to iterate over the filtered `installableTargets` list instead of the original `targets` list when rendering UI target items, ensuring displayed targets match the filtered dataset

### SetupWizardWindowTests.cs - Test Coverage
- **Test renamed**: `FilterInstallableSkillTargets_ReturnsAllDetectedTargets()` → `FilterInstallableSkillTargets_ExcludesTargetsWithoutSkillsDirectory()`
- **Test data expanded**: Now includes three skill targets:
  - Claude Code: with `HasSkillsDirectory = true`
  - Cursor: with `HasSkillsDirectory = false` (excluded from results)
  - Codex CLI: with `HasSkillsDirectory = true` and different layout skills
- **Assertions updated**: Verifies that exactly 2 targets are returned, confirming targets without a skills directory are properly excluded

## Impact

- **User experience**: Skill targets like `.cursor/` or `.agents/` no longer appear as "Missing" in the Setup Wizard when they've never been configured
- **Preserved functionality**: First-install flow remains available for explicit target selection and on-demand skill installation
- **Cleaner UI**: The update list only displays targets that have already opted into skill management

## Verification

The implementation includes test validation confirming targets without a skills directory are excluded from filtered results, with assertions verifying both the count (2) and specific directory names of remaining targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->