### PR TITLE
fix: Setup updates no longer show the first-run skills screen

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -172,17 +172,31 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
-        public void ShouldUseFirstInstallSkillsUi_WhenSelectionHasNotBeenShown_ReturnsTrue()
+        public void ShouldUseFirstInstallSkillsUi_WhenSelectionHasNotBeenShownAndVersionWasNeverSeen_ReturnsTrue()
         {
-            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(false);
+            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(
+                hasShownSetupWizardSkillsSelection: false,
+                lastSeenSetupWizardVersion: "");
 
             Assert.That(shouldUseFirstInstallUi, Is.True);
         }
 
         [Test]
+        public void ShouldUseFirstInstallSkillsUi_WhenSelectionHasNotBeenShownButVersionWasSeen_ReturnsFalse()
+        {
+            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(
+                hasShownSetupWizardSkillsSelection: false,
+                lastSeenSetupWizardVersion: "1.9.0");
+
+            Assert.That(shouldUseFirstInstallUi, Is.False);
+        }
+
+        [Test]
         public void ShouldUseFirstInstallSkillsUi_WhenSelectionHasAlreadyBeenShown_ReturnsFalse()
         {
-            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(true);
+            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(
+                hasShownSetupWizardSkillsSelection: true,
+                lastSeenSetupWizardVersion: "");
 
             Assert.That(shouldUseFirstInstallUi, Is.False);
         }

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -172,31 +172,17 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
-        public void ShouldUseFirstInstallSkillsUi_WhenSelectionHasNotBeenShownAndVersionWasNeverSeen_ReturnsTrue()
+        public void ShouldUseFirstInstallSkillsUi_WhenVersionWasNeverSeen_ReturnsTrue()
         {
-            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(
-                hasShownSetupWizardSkillsSelection: false,
-                lastSeenSetupWizardVersion: "");
+            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi("");
 
             Assert.That(shouldUseFirstInstallUi, Is.True);
         }
 
         [Test]
-        public void ShouldUseFirstInstallSkillsUi_WhenSelectionHasNotBeenShownButVersionWasSeen_ReturnsFalse()
+        public void ShouldUseFirstInstallSkillsUi_WhenVersionWasSeen_ReturnsFalse()
         {
-            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(
-                hasShownSetupWizardSkillsSelection: false,
-                lastSeenSetupWizardVersion: "1.9.0");
-
-            Assert.That(shouldUseFirstInstallUi, Is.False);
-        }
-
-        [Test]
-        public void ShouldUseFirstInstallSkillsUi_WhenSelectionHasAlreadyBeenShown_ReturnsFalse()
-        {
-            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(
-                hasShownSetupWizardSkillsSelection: true,
-                lastSeenSetupWizardVersion: "");
+            bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi("1.9.0");
 
             Assert.That(shouldUseFirstInstallUi, Is.False);
         }

--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -33,7 +33,6 @@ namespace io.github.hatayama.uLoopMCP
         public string lastUsedConfigPath = "";
         public string lastSeenSetupWizardVersion = "";
         public bool suppressSetupWizardAutoShow = false;
-        public bool hasShownSetupWizardSkillsSelection = false;
 
         // UI State Settings
         public bool showSecuritySettings = true;
@@ -269,18 +268,6 @@ namespace io.github.hatayama.uLoopMCP
         {
             McpEditorSettingsData settings = GetSettings();
             McpEditorSettingsData updatedSettings = settings with { suppressSetupWizardAutoShow = suppressAutoShow };
-            SaveSettings(updatedSettings);
-        }
-
-        public static bool GetHasShownSetupWizardSkillsSelection()
-        {
-            return GetSettings().hasShownSetupWizardSkillsSelection;
-        }
-
-        public static void SetHasShownSetupWizardSkillsSelection(bool hasShown)
-        {
-            McpEditorSettingsData settings = GetSettings();
-            McpEditorSettingsData updatedSettings = settings with { hasShownSetupWizardSkillsSelection = hasShown };
             SaveSettings(updatedSettings);
         }
 

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -78,7 +78,9 @@ namespace io.github.hatayama.uLoopMCP
 
         private static void ShowWindowInternal(bool shouldRecordVersion)
         {
+            string lastSeenSetupWizardVersionBeforeOpen = McpEditorSettings.GetLastSeenSetupWizardVersion();
             SetupWizardWindow window = GetWindow<SetupWizardWindow>(true, "Unity CLI Loop Setup");
+            window._lastSeenSetupWizardVersionBeforeOpen = lastSeenSetupWizardVersionBeforeOpen;
             window.position = CreateCenteredRect(EditorGUIUtility.GetMainWindowPosition(), MinimumWindowSize);
             window.ShowUtility();
             window.ScheduleResizeToContent();
@@ -142,6 +144,7 @@ namespace io.github.hatayama.uLoopMCP
         private bool _isSkillsTargetFieldInitialized;
         private bool _shouldUseFirstInstallSkillsUi;
         private bool _installSkillsFlat;
+        private string _lastSeenSetupWizardVersionBeforeOpen = string.Empty;
         private IVisualElementScheduledItem _initialRefreshScheduledItem;
         private IVisualElementScheduledItem _resizeScheduledItem;
         private CancellationTokenSource _skillInstallStateRefreshCts;
@@ -162,7 +165,8 @@ namespace io.github.hatayama.uLoopMCP
         private void InitializeFirstInstallSkillsUiState()
         {
             _shouldUseFirstInstallSkillsUi = ShouldUseFirstInstallSkillsUi(
-                McpEditorSettings.GetHasShownSetupWizardSkillsSelection());
+                McpEditorSettings.GetHasShownSetupWizardSkillsSelection(),
+                _lastSeenSetupWizardVersionBeforeOpen);
             McpEditorSettings.SetHasShownSetupWizardSkillsSelection(true);
         }
 
@@ -435,9 +439,16 @@ namespace io.github.hatayama.uLoopMCP
                 .ToList();
         }
 
-        internal static bool ShouldUseFirstInstallSkillsUi(bool hasShownSetupWizardSkillsSelection)
+        internal static bool ShouldUseFirstInstallSkillsUi(
+            bool hasShownSetupWizardSkillsSelection,
+            string lastSeenSetupWizardVersion)
         {
-            return !hasShownSetupWizardSkillsSelection;
+            if (hasShownSetupWizardSkillsSelection)
+            {
+                return false;
+            }
+
+            return string.IsNullOrEmpty(lastSeenSetupWizardVersion);
         }
 
         internal static bool CanManageSkills(bool cliInstalled)

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -165,9 +165,7 @@ namespace io.github.hatayama.uLoopMCP
         private void InitializeFirstInstallSkillsUiState()
         {
             _shouldUseFirstInstallSkillsUi = ShouldUseFirstInstallSkillsUi(
-                McpEditorSettings.GetHasShownSetupWizardSkillsSelection(),
                 _lastSeenSetupWizardVersionBeforeOpen);
-            McpEditorSettings.SetHasShownSetupWizardSkillsSelection(true);
         }
 
         private void OnDisable()
@@ -439,15 +437,8 @@ namespace io.github.hatayama.uLoopMCP
                 .ToList();
         }
 
-        internal static bool ShouldUseFirstInstallSkillsUi(
-            bool hasShownSetupWizardSkillsSelection,
-            string lastSeenSetupWizardVersion)
+        internal static bool ShouldUseFirstInstallSkillsUi(string lastSeenSetupWizardVersion)
         {
-            if (hasShownSetupWizardSkillsSelection)
-            {
-                return false;
-            }
-
             return string.IsNullOrEmpty(lastSeenSetupWizardVersion);
         }
 


### PR DESCRIPTION
## Summary
- Setup updates now keep existing users on the upgrade flow instead of showing the first-install skills screen.
- Setup state is simplified so the upgrade check uses the previously seen Setup Wizard version.

## User Impact
- Before this change, users who installed the package before the new selection flag existed could be treated as first-time users after updating.
- After this change, upgrading keeps the expected Setup flow and avoids showing brand-new onboarding UI to existing users.

## Changes
- Capture the previously seen Setup Wizard version before opening the window and use it to decide whether first-install UI should appear.
- Remove the obsolete `hasShownSetupWizardSkillsSelection` setting and align the Setup Wizard tests with version-based detection.

## Verification
- `uloop launch -r`
- `uloop compile`
- `uloop run-tests --filter-type regex --filter-value "SetupWizardWindowTests"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes an issue where users upgrading from older package versions were incorrectly shown the first-run skills selection screen. The fix replaces a dedicated boolean flag with version-based detection, ensuring the upgrade flow is preserved for existing users while still showing first-run UI to genuinely new installations.

## Technical Changes

### Architecture Change
The detection mechanism for first-run setup shifted from a persistent boolean flag (`hasShownSetupWizardSkillsSelection`) to version-based detection using the previously recorded Setup Wizard version.

```
classDiagram
    class McpEditorSettings {
        -GetHasShownSetupWizardSkillsSelection() : bool [REMOVED]
        -SetHasShownSetupWizardSkillsSelection(bool) : void [REMOVED]
        -GetLastSeenSetupWizardVersion() : string [USED]
    }
    
    class McpEditorSettingsData {
        -hasShownSetupWizardSkillsSelection : bool [REMOVED]
    }
    
    class SetupWizardWindow {
        -_lastSeenSetupWizardVersionBeforeOpen : string [ADDED]
        -ShouldUseFirstInstallSkillsUi(string lastSeenSetupWizardVersion) : bool [MODIFIED]
    }
    
    SetupWizardWindow --> McpEditorSettings: reads version
    McpEditorSettings --> McpEditorSettingsData: manages
```

### Detailed Changes

**SetupWizardWindow.cs**
- Added `_lastSeenSetupWizardVersionBeforeOpen` field to capture the Setup Wizard version at window creation time
- Modified `ShowWindowInternal` to read and store the last seen version before opening the window
- Updated `ShouldUseFirstInstallSkillsUi` method signature:
  - **Before**: `ShouldUseFirstInstallSkillsUi(bool hasShownSetupWizardSkillsSelection)`
  - **After**: `ShouldUseFirstInstallSkillsUi(string lastSeenSetupWizardVersion)`
- Logic now returns `true` (show first-install UI) only when the version string is `null` or empty

**McpEditorSettings.cs**
- Removed `hasShownSetupWizardSkillsSelection` field from `McpEditorSettingsData`
- Removed public accessors: `GetHasShownSetupWizardSkillsSelection()` and `SetHasShownSetupWizardSkillsSelection(bool)`
- The last seen version is now the sole source of truth for determining first-run status

**SetupWizardWindowTests.cs**
- Updated test cases to reflect the new parameter type:
  - "no prior version" test: changed from `false` (boolean) to `""` (empty string) while expecting `true`
  - "version already exists" test: changed from `true` (boolean) to `"1.9.0"` (version string) while expecting `false`

## API Changes
- **Removed**: `McpEditorSettings.GetHasShownSetupWizardSkillsSelection()` and `SetHasShownSetupWizardSkillsSelection(bool)`
- **Modified**: `SetupWizardWindow.ShouldUseFirstInstallSkillsUi(string)` signature changed from boolean to string parameter

## User Impact
- Existing users upgrading the package will now be kept on the upgrade flow instead of being shown brand-new onboarding UI
- Truly new installations (where no previous Setup Wizard version exists) will still see the first-install skills selection screen
- The obsolete `hasShownSetupWizardSkillsSelection` setting is removed from the configuration system

## Testing
Test updates ensure the new version-based detection works correctly for both first-run (empty/null version) and upgrade scenarios (existing version).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->