### PR TITLE
fix: Launch now waits for the correct Unity project after startup

### DIFF
--- a/Assets/Tests/Editor/McpEditorSettingsRecoveryTests.cs
+++ b/Assets/Tests/Editor/McpEditorSettingsRecoveryTests.cs
@@ -131,15 +131,18 @@ namespace io.github.hatayama.uLoopMCP
         public void UpdateSessionState_WhenStartingServerWithProjectRoot_ShouldPersistFullSessionIdentity()
         {
             McpServerStartupService service = new();
+            string projectRootPath = Path.Combine(Path.GetTempPath(), "project-root");
+            string expectedProjectRootPath = Path.GetFullPath(projectRootPath)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
             ServiceResult<bool> result = service.UpdateSessionState(
                 true,
                 18447,
-                "/tmp/project-root");
+                projectRootPath);
 
             Assert.IsTrue(result.Success, "Session update should succeed");
             Assert.AreEqual(18447, McpEditorSettings.GetCustomPort(), "customPort should be updated");
-            Assert.AreEqual("/tmp/project-root", McpEditorSettings.GetProjectRootPath(),
+            Assert.AreEqual(expectedProjectRootPath, McpEditorSettings.GetProjectRootPath(),
                 "projectRootPath should be persisted for fast project validation");
             Assert.IsFalse(string.IsNullOrWhiteSpace(McpEditorSettings.GetServerSessionId()),
                 "serverSessionId should be generated during startup state persistence");

--- a/Assets/Tests/Editor/McpEditorSettingsRecoveryTests.cs
+++ b/Assets/Tests/Editor/McpEditorSettingsRecoveryTests.cs
@@ -127,6 +127,24 @@ namespace io.github.hatayama.uLoopMCP
             Assert.IsTrue(installSkillsFlat);
         }
 
+        [Test]
+        public void UpdateSessionState_WhenStartingServerWithProjectRoot_ShouldPersistFullSessionIdentity()
+        {
+            McpServerStartupService service = new();
+
+            ServiceResult<bool> result = service.UpdateSessionState(
+                true,
+                18447,
+                "/tmp/project-root");
+
+            Assert.IsTrue(result.Success, "Session update should succeed");
+            Assert.AreEqual(18447, McpEditorSettings.GetCustomPort(), "customPort should be updated");
+            Assert.AreEqual("/tmp/project-root", McpEditorSettings.GetProjectRootPath(),
+                "projectRootPath should be persisted for fast project validation");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(McpEditorSettings.GetServerSessionId()),
+                "serverSessionId should be generated during startup state persistence");
+        }
+
         private static void RestoreFile(string path, bool existed, string content)
         {
             if (existed)

--- a/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
@@ -796,17 +796,41 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
     expect(sleepCount).toBe(6);
   });
 
-  it('does not retry project mismatch errors', async () => {
-    const mismatchClient = createMockClient([new ProjectMismatchError('/expected', '/actual')], []);
+  it('retries project mismatch errors during launch until the target project is ready', async () => {
+    const recordedMethods: string[] = [];
+    const responses: Array<MockReadinessResponse | Error> = [
+      new ProjectMismatchError('/expected', '/actual'),
+      { Success: true },
+      { Success: true },
+      { Success: true },
+      { Success: true },
+    ];
+    let sleepCount = 0;
 
-    await expect(
-      waitForDynamicCodeReadyAfterLaunch('/project', {
-        resolveUnityConnectionFn: jest.fn().mockResolvedValue(createConnection(8711)),
-        createClient: () => mismatchClient.client,
-        sleepFn: jest.fn(),
-        nowFn: () => 0,
+    await waitForDynamicCodeReadyAfterLaunch('/project', {
+      resolveUnityConnectionFn: jest.fn().mockResolvedValue(createConnection(8711)),
+      createClient: () => createMockClient(responses, recordedMethods).client,
+      sleepFn: jest.fn().mockImplementation((): Promise<void> => {
+        sleepCount++;
+        return Promise.resolve();
       }),
-    ).rejects.toThrow(ProjectMismatchError);
+      nowFn: (() => {
+        let now = 0;
+        return (): number => {
+          now += 100;
+          return now;
+        };
+      })(),
+    });
+
+    expect(recordedMethods).toEqual([
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+    ]);
+    expect(sleepCount).toBe(4);
   });
 });
 
@@ -840,8 +864,66 @@ describe('waitForLaunchReadyAfterLaunch', () => {
       isProjectBusyFn,
     });
 
-    expect(recordedMethods).toEqual([]);
+    expect(recordedMethods).toEqual(['get-version', 'get-version']);
     expect(isProjectBusyFn).toHaveBeenCalledTimes(2);
     expect(sleepCount).toBe(1);
+  });
+
+  it('retries project mismatch errors during launch until the target project responds', async () => {
+    let sleepCount = 0;
+    const responses: Array<MockReadinessResponse | Error> = [
+      new ProjectMismatchError('/expected', '/actual'),
+      {
+        DataPath: `${process.cwd()}/Assets`,
+      } as unknown as MockReadinessResponse,
+    ];
+
+    await waitForLaunchReadyAfterLaunch('/project', {
+      resolveUnityConnectionFn: jest
+        .fn()
+        .mockResolvedValue(createConnection(8711, { projectRoot: process.cwd() })),
+      createClient: () => createMockClient(responses, []).client,
+      sleepFn: jest.fn().mockImplementation((): Promise<void> => {
+        sleepCount++;
+        return Promise.resolve();
+      }),
+      nowFn: (() => {
+        let now = 0;
+        return (): number => {
+          now += 100;
+          return now;
+        };
+      })(),
+      isProjectBusyFn: jest.fn().mockReturnValue(false),
+    });
+
+    expect(sleepCount).toBe(1);
+  });
+
+  it('still validates the connected project when launch readiness uses fast session metadata', async () => {
+    const recordedMethods: string[] = [];
+    const projectRoot = process.cwd();
+
+    await waitForLaunchReadyAfterLaunch('/project', {
+      resolveUnityConnectionFn: jest
+        .fn()
+        .mockResolvedValue(
+          createConnection(8711, { shouldValidateProject: false, projectRoot }),
+        ),
+      createClient: () =>
+        createMockClient(
+          [
+            {
+              DataPath: `${projectRoot}/Assets`,
+            } as unknown as MockReadinessResponse,
+          ],
+          recordedMethods,
+        ).client,
+      sleepFn: jest.fn(),
+      nowFn: () => 0,
+      isProjectBusyFn: jest.fn().mockReturnValue(false),
+    });
+
+    expect(recordedMethods).toEqual(['get-version']);
   });
 });

--- a/Packages/src/Cli~/src/launch-readiness.ts
+++ b/Packages/src/Cli~/src/launch-readiness.ts
@@ -129,7 +129,7 @@ function isTransientCompilationProviderUnavailable(errorMessage: string): boolea
 
 function isRetryableLaunchReadinessError(error: unknown): boolean {
   if (error instanceof ProjectMismatchError) {
-    return false;
+    return true;
   }
 
   if (error instanceof UnityNotRunningError) {
@@ -319,7 +319,7 @@ export async function waitForLaunchReadyAfterLaunch(
       );
       client = dependencies.createClient(connection.port);
       await client.connect();
-      if (connection.shouldValidateProject && connection.projectRoot !== null) {
+      if (connection.projectRoot !== null) {
         await validateConnectedProject(client, connection.projectRoot);
       }
 

--- a/Packages/src/Editor/Api/McpTools/UseCases/System/McpServerInitializationUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/System/McpServerInitializationUseCase.cs
@@ -123,7 +123,9 @@ namespace io.github.hatayama.uLoopMCP
                 McpBridgeServer serverInstance = serverResult.Data;
 
                 // 5. Session state update
-                var sessionUpdateResult = _startupService.UpdateSessionState(true, availablePort);
+                string projectRootPath = UnityMcpPathResolver.GetProjectRoot();
+                var sessionUpdateResult =
+                    _startupService.UpdateSessionState(true, availablePort, projectRootPath);
                 if (!sessionUpdateResult.Success)
                 {
                     response.Success = false;

--- a/Packages/src/Editor/Core/ApplicationServices/McpServerStartupService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/McpServerStartupService.cs
@@ -60,8 +60,12 @@ namespace io.github.hatayama.uLoopMCP
         /// </summary>
         /// <param name="isRunning">Whether the server is running</param>
         /// <param name="port">Server port number (only written when isRunning=true)</param>
+        /// <param name="projectRootPath">Project root for fast project validation during startup</param>
         /// <returns>Success indicator</returns>
-        public ServiceResult<bool> UpdateSessionState(bool isRunning, int port = -1)
+        public ServiceResult<bool> UpdateSessionState(
+            bool isRunning,
+            int port = -1,
+            string projectRootPath = null)
         {
             if (!isRunning)
             {
@@ -69,11 +73,19 @@ namespace io.github.hatayama.uLoopMCP
                 return ServiceResult<bool>.SuccessResult(true);
             }
 
+            if (port > 0 && !string.IsNullOrWhiteSpace(projectRootPath))
+            {
+                string serverSessionId = System.Guid.NewGuid().ToString("N");
+                McpEditorSettings.SetRunningServerSession(port, projectRootPath, serverSessionId);
+                return ServiceResult<bool>.SuccessResult(true);
+            }
+
             McpEditorSettings.SetIsServerRunning(true);
-            if (isRunning && port > 0)
+            if (port > 0)
             {
                 McpEditorSettings.SetCustomPort(port);
             }
+
             return ServiceResult<bool>.SuccessResult(true);
         }
     }

--- a/Packages/src/Editor/Server/McpServerController.cs
+++ b/Packages/src/Editor/Server/McpServerController.cs
@@ -138,9 +138,6 @@ namespace io.github.hatayama.uLoopMCP
                 // for compatibility with existing code
                 mcpServer = result.ServerInstance;
 
-                // Sync session state with the running server to enable domain reload recovery
-                // even if mcpServer instance becomes null unexpectedly
-                SaveRunningServerSession(mcpServer.Port);
                 DynamicCodeStartupTelemetry.MarkServerReady();
                 CustomToolManager.WarmupRegistry();
                 DynamicCodeServices.ResetServerScopedServices();


### PR DESCRIPTION
## Summary
- Make `uloop launch` recover when an older Unity session answers during startup.
- Keep launch readiness tied to the intended project so the wrong editor instance is not reported as ready.

## User Impact
- Before this change, launching one project could fail with `PROJECT_MISMATCH` if another Unity project briefly responded on the saved port.
- After this change, launch retries through that startup race and confirms the connected editor still belongs to the requested project.

## Changes
- Persist the startup session identity earlier by saving the project root and server session id with the port.
- Stop regenerating the startup session immediately after launch.
- Treat launch-time project mismatches as retryable and keep non-dynamic launch readiness validating the connected project.
- Make the new recovery coverage path-neutral so it passes on Windows as well as POSIX environments.

## Verification
- `uloop compile`
- `uloop run-tests --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.uLoopMCP.McpEditorSettingsRecoveryTests.UpdateSessionState_WhenStartingServerWithProjectRoot_ShouldPersistFullSessionIdentity"`
- `npm run test:cli -- --runTestsByPath src/__tests__/launch-readiness.test.ts`
- `npm run build`