### PR TITLE
fix: CLI lint now gets past existing prettier formatting issues

### DIFF
--- a/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
+++ b/Packages/src/Cli~/src/__tests__/cli-e2e.test.ts
@@ -718,7 +718,6 @@ describe('CLI E2E Tests (requires running Unity)', () => {
       // Should mention project skills were installed
       expect(stdout).toMatch(/project|installed/i);
     });
-
   });
 
   describe('execute-dynamic-code', () => {

--- a/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
@@ -907,9 +907,7 @@ describe('waitForLaunchReadyAfterLaunch', () => {
     await waitForLaunchReadyAfterLaunch('/project', {
       resolveUnityConnectionFn: jest
         .fn()
-        .mockResolvedValue(
-          createConnection(8711, { shouldValidateProject: false, projectRoot }),
-        ),
+        .mockResolvedValue(createConnection(8711, { shouldValidateProject: false, projectRoot })),
       createClient: () =>
         createMockClient(
           [

--- a/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
+++ b/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
@@ -269,7 +269,9 @@ describe('skill install layout', () => {
     expect(searchRoots).toContain(join(projectRoot, 'Assets'));
     expect(searchRoots).toContain(join(projectRoot, 'Packages', 'src'));
     expect(searchRoots).toContain(join(projectRoot, 'Packages', 'com.example.embedded'));
-    expect(searchRoots).toContain(join(projectRoot, 'Library', 'PackageCache', 'com.example.cached@1.0.0'));
+    expect(searchRoots).toContain(
+      join(projectRoot, 'Library', 'PackageCache', 'com.example.cached@1.0.0'),
+    );
     expect(searchRoots).toContain(localPackageRoot);
     expect(searchRoots).not.toContain(
       join(projectRoot, 'Library', 'PackageCache', 'com.example.unused@1.0.0'),

--- a/Packages/src/Cli~/src/skills/skills-manager.ts
+++ b/Packages/src/Cli~/src/skills/skills-manager.ts
@@ -241,7 +241,10 @@ function isSkillOutdated(
 
   const installedFiles = collectSkillFolderFiles(skillDir);
   const expectedFileCount =
-    1 + ('additionalFiles' in skill && skill.additionalFiles ? Object.keys(skill.additionalFiles).length : 0);
+    1 +
+    ('additionalFiles' in skill && skill.additionalFiles
+      ? Object.keys(skill.additionalFiles).length
+      : 0);
   const installedFileCount = 1 + (installedFiles ? Object.keys(installedFiles).length : 0);
   if (installedFileCount !== expectedFileCount) {
     return true;
@@ -718,7 +721,11 @@ function uninstallSkill(
   return removed;
 }
 
-function uninstallSkillFromAllLayouts(skill: SkillDefinition, target: TargetConfig, global: boolean): boolean {
+function uninstallSkillFromAllLayouts(
+  skill: SkillDefinition,
+  target: TargetConfig,
+  global: boolean,
+): boolean {
   const baseDir = getSkillsBaseDir(target, global);
   const candidateDirs = [
     getManagedSkillDir(baseDir, skill.dirName),


### PR DESCRIPTION
## Summary
- Remove the remaining CLI prettier formatting errors that were already present on `main`.
- Let `npm run lint` complete with warnings only instead of failing on formatting noise.

## User Impact
- Before this change, contributors could hit lint failures even when they had not introduced any new behavior changes, because a few existing CLI files were still misformatted.
- After this change, the CLI lint step no longer stops on those old prettier violations, which makes routine verification clearer and less noisy.

## Changes
- Reformat the remaining offending CLI test and implementation files to match the repository's prettier rules.
- Keep the patch limited to whitespace, wrapping, and blank-line cleanup without changing runtime behavior.

## Verification
- `npm run lint`
- `npm run build`