### PR TITLE
fix: Launch progress now stays visible without leaving spinner artifacts

### DIFF
--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -78,8 +78,8 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
-    expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
-    expect(mockSpinnerUpdate).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
+    expect(mockCreateSpinner).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
+    expect(mockSpinnerUpdate).not.toHaveBeenCalled();
     expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForLaunchReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
     expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
@@ -99,9 +99,8 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
-    expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
-    expect(mockSpinnerUpdate).toHaveBeenCalledTimes(1);
-    expect(mockSpinnerUpdate).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
+    expect(mockCreateSpinner).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
+    expect(mockSpinnerUpdate).not.toHaveBeenCalled();
     expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForDynamicCodeReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
     expect(prewarmDynamicCodeAfterLaunchMock).toHaveBeenCalledWith({ projectRoot: '/project' });
@@ -121,9 +120,9 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
-    expect(mockCreateSpinner).toHaveBeenCalledWith('Launching Unity...');
+    expect(mockCreateSpinner).not.toHaveBeenCalled();
     expect(mockSpinnerUpdate).not.toHaveBeenCalled();
-    expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
+    expect(mockSpinnerStop).not.toHaveBeenCalled();
     expect(waitForLaunchReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(prewarmDynamicCodeAfterLaunchMock).not.toHaveBeenCalled();

--- a/Packages/src/Cli~/src/__tests__/spinner.test.ts
+++ b/Packages/src/Cli~/src/__tests__/spinner.test.ts
@@ -1,0 +1,93 @@
+import { createSpinner } from '../spinner.js';
+
+describe('createSpinner', () => {
+  let stderrWriteSpy: jest.SpiedFunction<typeof process.stderr.write>;
+  let stdoutWriteSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  const originalStderrIsTTY = Object.getOwnPropertyDescriptor(process.stderr, 'isTTY');
+  const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    stdoutWriteSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrWriteSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+    restoreIsTTY(process.stderr, originalStderrIsTTY);
+    restoreIsTTY(process.stdout, originalStdoutIsTTY);
+    jest.useRealTimers();
+  });
+
+  it('uses stderr when stderr is a TTY', () => {
+    setTTYState(true, true);
+
+    const spinner = createSpinner('Launching Unity...');
+
+    expect(stderrWriteSpy).toHaveBeenCalledWith('\r\x1b[K⠋ Launching Unity...');
+    expect(stdoutWriteSpy).not.toHaveBeenCalled();
+
+    spinner.stop();
+  });
+
+  it('falls back to stdout when stderr is not a TTY', () => {
+    setTTYState(false, true);
+
+    const spinner = createSpinner('Launching Unity...');
+
+    expect(stdoutWriteSpy).toHaveBeenCalledWith('\r\x1b[K⠋ Launching Unity...');
+    expect(stderrWriteSpy).not.toHaveBeenCalled();
+
+    spinner.stop();
+  });
+
+  it('re-renders immediately when the message changes', () => {
+    setTTYState(true, true);
+
+    const spinner = createSpinner('Launching Unity...');
+    spinner.update('Waiting for Unity to finish starting...');
+
+    expect(stderrWriteSpy).toHaveBeenNthCalledWith(1, '\r\x1b[K⠋ Launching Unity...');
+    expect(stderrWriteSpy).toHaveBeenNthCalledWith(
+      2,
+      '\r\x1b[K⠙ Waiting for Unity to finish starting...',
+    );
+
+    spinner.stop();
+  });
+
+  it('returns a no-op spinner when no tty output stream is available', () => {
+    setTTYState(false, false);
+
+    const spinner = createSpinner('Launching Unity...');
+    spinner.update('Waiting for Unity to finish starting...');
+    spinner.stop();
+
+    expect(stderrWriteSpy).not.toHaveBeenCalled();
+    expect(stdoutWriteSpy).not.toHaveBeenCalled();
+  });
+
+  function setTTYState(stderrIsTTY: boolean, stdoutIsTTY: boolean): void {
+    Object.defineProperty(process.stderr, 'isTTY', {
+      value: stderrIsTTY,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: stdoutIsTTY,
+      configurable: true,
+    });
+  }
+});
+
+function restoreIsTTY(
+  stream: NodeJS.WriteStream,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor === undefined) {
+    delete (stream as Partial<NodeJS.WriteStream>).isTTY;
+    return;
+  }
+
+  Object.defineProperty(stream, 'isTTY', descriptor);
+}

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -66,37 +66,35 @@ async function runLaunchCommand(
   options: LaunchCommandOptions,
 ): Promise<void> {
   const maxDepth: number = parseMaxDepth(options.maxDepth);
-  const spinner = createSpinner('Launching Unity...');
+  const launchResult: OrchestrateResult = await orchestrateLaunch({
+    projectPath: projectPath ? resolve(projectPath) : undefined,
+    searchRoot: process.cwd(),
+    searchMaxDepth: maxDepth,
+    platform: options.platform,
+    unityArgs: [],
+    restart: options.restart === true,
+    quit: options.quit === true,
+    deleteRecovery: options.deleteRecovery === true,
+    addUnityHub: options.addUnityHub === true,
+    favoriteUnityHub: options.favorite === true,
+  });
+
+  if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
+    return;
+  }
+
+  const spinner = createSpinner('Waiting for Unity to finish starting...');
 
   try {
-    const launchResult: OrchestrateResult = await orchestrateLaunch({
-      projectPath: projectPath ? resolve(projectPath) : undefined,
-      searchRoot: process.cwd(),
-      searchMaxDepth: maxDepth,
-      platform: options.platform,
-      unityArgs: [],
-      restart: options.restart === true,
-      quit: options.quit === true,
-      deleteRecovery: options.deleteRecovery === true,
-      addUnityHub: options.addUnityHub === true,
-      favoriteUnityHub: options.favorite === true,
-    });
-
-    if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
-      return;
-    }
-
     const isDynamicCodeEnabled: boolean = isToolEnabled(
       'execute-dynamic-code',
       launchResult.projectPath,
     );
     if (!isDynamicCodeEnabled) {
-      spinner.update('Waiting for Unity to finish starting...');
       await waitForLaunchReadyAfterLaunch(launchResult.projectPath);
       return;
     }
 
-    spinner.update('Waiting for Unity to finish starting...');
     await waitForDynamicCodeReadyAfterLaunch(launchResult.projectPath);
     await prewarmDynamicCodeAfterLaunch({ projectRoot: launchResult.projectPath });
   } finally {

--- a/Packages/src/Cli~/src/spinner.ts
+++ b/Packages/src/Cli~/src/spinner.ts
@@ -13,12 +13,25 @@ interface Spinner {
   stop(): void;
 }
 
+function resolveSpinnerStream(): NodeJS.WriteStream | null {
+  if (process.stderr.isTTY) {
+    return process.stderr;
+  }
+
+  if (process.stdout.isTTY) {
+    return process.stdout;
+  }
+
+  return null;
+}
+
 /**
  * Create a terminal spinner that displays a rotating animation with a message.
  * Returns a Spinner object with update() and stop() methods.
  */
 export function createSpinner(initialMessage: string): Spinner {
-  if (!process.stderr.isTTY) {
+  const outputStream = resolveSpinnerStream();
+  if (outputStream === null) {
     return {
       update: (): void => {},
       stop: (): void => {},
@@ -30,7 +43,7 @@ export function createSpinner(initialMessage: string): Spinner {
 
   const render = (): void => {
     const frame = SPINNER_FRAMES[frameIndex];
-    process.stderr.write(`\r\x1b[K${frame} ${currentMessage}`);
+    outputStream.write(`\r\x1b[K${frame} ${currentMessage}`);
     frameIndex = (frameIndex + 1) % SPINNER_FRAMES.length;
   };
 
@@ -40,10 +53,11 @@ export function createSpinner(initialMessage: string): Spinner {
   return {
     update(message: string): void {
       currentMessage = message;
+      render();
     },
     stop(): void {
       clearInterval(intervalId);
-      process.stderr.write('\r\x1b[K');
+      outputStream.write('\r\x1b[K');
     },
   };
 }


### PR DESCRIPTION
## Summary
- Keep launch progress visible when the terminal uses a different interactive output stream.
- Stop showing spinner fragments while uloop launch prints its normal startup logs.

## User Impact
- Before this change, some terminals showed no launch spinner at all, while others showed leftover spinner characters mixed into launch logs.
- After this change, launch progress stays visible during the readiness wait, and normal launch logs stay readable without spinner residue.

## Changes
- Let the spinner use an interactive output stream when stderr is unavailable and re-render immediately on message changes.
- Limit the launch spinner to the post-launch readiness phase so it no longer overlaps with launch-unity startup logs.
- Add focused CLI tests for spinner stream selection and the updated launch timing behavior.

## Verification
- npm run test:cli -- --runTestsByPath src/__tests__/spinner.test.ts src/__tests__/launch-command.test.ts
- npm run lint
- npm run build