### PR TITLE
fix: Launch now waits cleanly without false startup warnings

### DIFF
--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -72,6 +72,15 @@ describe('launch command', () => {
       unityVersion: '2022.3.0f1',
     });
     isToolEnabledMock.mockReturnValue(false);
+    waitForLaunchReadyAfterLaunchMock.mockResolvedValue({
+      port: 8711,
+      projectRoot: '/project',
+      requestMetadata: {
+        expectedProjectRoot: '/project',
+        expectedServerSessionId: 'session-1',
+      },
+      shouldValidateProject: false,
+    });
 
     const program = new Command();
     registerLaunchCommand(program);
@@ -93,6 +102,15 @@ describe('launch command', () => {
       unityVersion: '2022.3.0f1',
     });
     isToolEnabledMock.mockReturnValue(true);
+    waitForDynamicCodeReadyAfterLaunchMock.mockResolvedValue({
+      port: 8711,
+      projectRoot: '/project',
+      requestMetadata: {
+        expectedProjectRoot: '/project',
+        expectedServerSessionId: 'session-1',
+      },
+      shouldValidateProject: false,
+    });
 
     const program = new Command();
     registerLaunchCommand(program);
@@ -103,7 +121,7 @@ describe('launch command', () => {
     expect(mockSpinnerUpdate).not.toHaveBeenCalled();
     expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForDynamicCodeReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
-    expect(prewarmDynamicCodeAfterLaunchMock).toHaveBeenCalledWith({ projectRoot: '/project' });
+    expect(prewarmDynamicCodeAfterLaunchMock).toHaveBeenCalledWith({ port: 8711 });
     expect(consoleLogSpy).not.toHaveBeenCalledWith('Waiting for execute-dynamic-code warmup...');
     expect(consoleLogSpy).not.toHaveBeenCalledWith('execute-dynamic-code is ready.');
   });

--- a/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
@@ -4,7 +4,6 @@ import {
   waitForLaunchReadyAfterLaunch,
 } from '../launch-readiness.js';
 import { type ResolvedUnityConnection } from '../port-resolver.js';
-import { ProjectMismatchError } from '../project-validator.js';
 
 interface MockReadinessResponse {
   Success?: boolean;
@@ -242,6 +241,43 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
     expect(sleepCount).toBe(4);
   });
 
+  it('waits for fast session metadata before probing dynamic code readiness', async () => {
+    const recordedMethods: string[] = [];
+    let sleepCount = 0;
+
+    await waitForDynamicCodeReadyAfterLaunch('/project', {
+      resolveUnityConnectionFn: jest
+        .fn()
+        .mockResolvedValueOnce(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+          }),
+        )
+        .mockResolvedValue(createConnection(8711)),
+      createClient: () => createMockClient([{ Success: true }], recordedMethods).client,
+      sleepFn: jest.fn().mockImplementation((): Promise<void> => {
+        sleepCount++;
+        return Promise.resolve();
+      }),
+      nowFn: (() => {
+        let now = 0;
+        return (): number => {
+          now += 100;
+          return now;
+        };
+      })(),
+    });
+
+    expect(recordedMethods).toEqual([
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+    ]);
+    expect(sleepCount).toBe(4);
+  });
+
   it('does not retry non-transient Unity JSON-RPC errors', async () => {
     const recordedMethods: string[] = [];
 
@@ -451,7 +487,7 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
           };
         })(),
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual(createConnection(8711));
 
     expect(recordedMethods).toEqual([
       'execute-dynamic-code',
@@ -795,43 +831,6 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
     ]);
     expect(sleepCount).toBe(6);
   });
-
-  it('retries project mismatch errors during launch until the target project is ready', async () => {
-    const recordedMethods: string[] = [];
-    const responses: Array<MockReadinessResponse | Error> = [
-      new ProjectMismatchError('/expected', '/actual'),
-      { Success: true },
-      { Success: true },
-      { Success: true },
-      { Success: true },
-    ];
-    let sleepCount = 0;
-
-    await waitForDynamicCodeReadyAfterLaunch('/project', {
-      resolveUnityConnectionFn: jest.fn().mockResolvedValue(createConnection(8711)),
-      createClient: () => createMockClient(responses, recordedMethods).client,
-      sleepFn: jest.fn().mockImplementation((): Promise<void> => {
-        sleepCount++;
-        return Promise.resolve();
-      }),
-      nowFn: (() => {
-        let now = 0;
-        return (): number => {
-          now += 100;
-          return now;
-        };
-      })(),
-    });
-
-    expect(recordedMethods).toEqual([
-      'execute-dynamic-code',
-      'execute-dynamic-code',
-      'execute-dynamic-code',
-      'execute-dynamic-code',
-      'execute-dynamic-code',
-    ]);
-    expect(sleepCount).toBe(4);
-  });
 });
 
 describe('waitForLaunchReadyAfterLaunch', () => {
@@ -864,25 +863,25 @@ describe('waitForLaunchReadyAfterLaunch', () => {
       isProjectBusyFn,
     });
 
-    expect(recordedMethods).toEqual(['get-version', 'get-version']);
+    expect(recordedMethods).toEqual([]);
     expect(isProjectBusyFn).toHaveBeenCalledTimes(2);
     expect(sleepCount).toBe(1);
   });
 
-  it('retries project mismatch errors during launch until the target project responds', async () => {
+  it('waits for fast session metadata before treating launch as ready', async () => {
     let sleepCount = 0;
-    const responses: Array<MockReadinessResponse | Error> = [
-      new ProjectMismatchError('/expected', '/actual'),
-      {
-        DataPath: `${process.cwd()}/Assets`,
-      } as unknown as MockReadinessResponse,
-    ];
 
     await waitForLaunchReadyAfterLaunch('/project', {
       resolveUnityConnectionFn: jest
         .fn()
+        .mockResolvedValueOnce(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+          }),
+        )
         .mockResolvedValue(createConnection(8711, { projectRoot: process.cwd() })),
-      createClient: () => createMockClient(responses, []).client,
+      createClient: () => createMockClient([], []).client,
       sleepFn: jest.fn().mockImplementation((): Promise<void> => {
         sleepCount++;
         return Promise.resolve();
@@ -900,28 +899,17 @@ describe('waitForLaunchReadyAfterLaunch', () => {
     expect(sleepCount).toBe(1);
   });
 
-  it('still validates the connected project when launch readiness uses fast session metadata', async () => {
+  it('does not run legacy project validation during launch readiness', async () => {
     const recordedMethods: string[] = [];
-    const projectRoot = process.cwd();
 
     await waitForLaunchReadyAfterLaunch('/project', {
-      resolveUnityConnectionFn: jest
-        .fn()
-        .mockResolvedValue(createConnection(8711, { shouldValidateProject: false, projectRoot })),
-      createClient: () =>
-        createMockClient(
-          [
-            {
-              DataPath: `${projectRoot}/Assets`,
-            } as unknown as MockReadinessResponse,
-          ],
-          recordedMethods,
-        ).client,
+      resolveUnityConnectionFn: jest.fn().mockResolvedValue(createConnection(8711)),
+      createClient: () => createMockClient([], recordedMethods).client,
       sleepFn: jest.fn(),
       nowFn: () => 0,
       isProjectBusyFn: jest.fn().mockReturnValue(false),
     });
 
-    expect(recordedMethods).toEqual(['get-version']);
+    expect(recordedMethods).toEqual([]);
   });
 });

--- a/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
@@ -278,6 +278,61 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
     expect(sleepCount).toBe(4);
   });
 
+  it('restarts probe progress when the resolved session changes', async () => {
+    const recordedMethods: string[] = [];
+    const recordedParams: Array<Record<string, unknown>> = [];
+    let sleepCount = 0;
+
+    await waitForDynamicCodeReadyAfterLaunch('/project', {
+      resolveUnityConnectionFn: jest
+        .fn()
+        .mockResolvedValueOnce(createConnection(8711))
+        .mockResolvedValueOnce(
+          createConnection(8712, {
+            requestMetadata: {
+              expectedProjectRoot: '/project',
+              expectedServerSessionId: 'session-2',
+            },
+          }),
+        )
+        .mockResolvedValue(
+          createConnection(8712, {
+            requestMetadata: {
+              expectedProjectRoot: '/project',
+              expectedServerSessionId: 'session-2',
+            },
+          }),
+        ),
+      createClient: () => {
+        const nextResponse = recordedMethods.length < 5 ? { Success: true } : { Success: true };
+        return createMockClient([nextResponse], recordedMethods, recordedParams).client;
+      },
+      sleepFn: jest.fn().mockImplementation((): Promise<void> => {
+        sleepCount++;
+        return Promise.resolve();
+      }),
+      nowFn: (() => {
+        let now = 0;
+        return (): number => {
+          now += 100;
+          return now;
+        };
+      })(),
+    });
+
+    expect(recordedMethods).toEqual([
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+      'execute-dynamic-code',
+    ]);
+    expect(recordedParams[0]['Code']).toBe(EXPECTED_STABLE_LAUNCH_READINESS_CODE);
+    expect(recordedParams[1]['Code']).toBe(EXPECTED_STABLE_LAUNCH_READINESS_CODE);
+    expect(recordedParams[4]['Code']).toBe(EXPECTED_USER_LIKE_LAUNCH_READINESS_CODE);
+    expect(sleepCount).toBe(4);
+  });
+
   it('does not retry non-transient Unity JSON-RPC errors', async () => {
     const recordedMethods: string[] = [];
 

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -15,6 +15,7 @@ import {
   waitForDynamicCodeReadyAfterLaunch,
   waitForLaunchReadyAfterLaunch,
 } from '../launch-readiness.js';
+import { type ResolvedUnityConnection } from '../port-resolver.js';
 import { createSpinner } from '../spinner.js';
 import { isToolEnabled } from '../tool-settings-loader.js';
 
@@ -95,8 +96,10 @@ async function runLaunchCommand(
       return;
     }
 
-    await waitForDynamicCodeReadyAfterLaunch(launchResult.projectPath);
-    await prewarmDynamicCodeAfterLaunch({ projectRoot: launchResult.projectPath });
+    const readinessConnection: ResolvedUnityConnection = await waitForDynamicCodeReadyAfterLaunch(
+      launchResult.projectPath,
+    );
+    await prewarmDynamicCodeAfterLaunch({ port: readinessConnection.port });
   } finally {
     spinner.stop();
   }

--- a/Packages/src/Cli~/src/launch-readiness.ts
+++ b/Packages/src/Cli~/src/launch-readiness.ts
@@ -211,6 +211,7 @@ export async function waitForDynamicCodeReadyAfterLaunch(
   const isProjectBusyFn = dependencies.isProjectBusyFn ?? isProjectBusyByLockFiles;
   let currentProbeStage = 0;
   let firstSuccessfulProbeTime: number | null = null;
+  let probeSessionId: string | null = null;
 
   while (dependencies.nowFn() - startTime < LAUNCH_READINESS_TIMEOUT_MS) {
     let client: DirectUnityClient | null = null;
@@ -221,9 +222,19 @@ export async function waitForDynamicCodeReadyAfterLaunch(
         projectPath,
       );
       if (!hasFastSessionMetadata(connection)) {
+        currentProbeStage = 0;
+        firstSuccessfulProbeTime = null;
+        probeSessionId = null;
         await dependencies.sleepFn(LAUNCH_READINESS_RETRY_MS);
         continue;
       }
+
+      const resolvedSessionId = connection.requestMetadata?.expectedServerSessionId ?? null;
+      if (probeSessionId !== null && probeSessionId !== resolvedSessionId) {
+        currentProbeStage = 0;
+        firstSuccessfulProbeTime = null;
+      }
+      probeSessionId = resolvedSessionId;
 
       client = dependencies.createClient(connection.port);
       await client.connect();

--- a/Packages/src/Cli~/src/launch-readiness.ts
+++ b/Packages/src/Cli~/src/launch-readiness.ts
@@ -7,7 +7,6 @@ import {
   resolveUnityConnection,
   UnityNotRunningError,
 } from './port-resolver.js';
-import { ProjectMismatchError, validateConnectedProject } from './project-validator.js';
 import { isRetryableFastProjectValidationErrorMessage } from './request-metadata.js';
 
 // Launch readiness lock paths are built from the resolved project root selected by launch.
@@ -128,10 +127,6 @@ function isTransientCompilationProviderUnavailable(errorMessage: string): boolea
 }
 
 function isRetryableLaunchReadinessError(error: unknown): boolean {
-  if (error instanceof ProjectMismatchError) {
-    return true;
-  }
-
   if (error instanceof UnityNotRunningError) {
     return true;
   }
@@ -200,10 +195,17 @@ function isLaunchReadinessStable(payload: ExecuteDynamicCodeReadinessResponse): 
   return requestTotalMilliseconds <= LAUNCH_READINESS_REQUEST_TOTAL_THRESHOLD_MS;
 }
 
+function hasFastSessionMetadata(connection: ResolvedUnityConnection): boolean {
+  // Why: launch already waits for the target Unity instance to publish its session identity.
+  // Why not fall back to get-version here: startup can answer that probe before project identity
+  // is stable, which produces spurious warnings and undermines the readiness contract.
+  return connection.requestMetadata !== null;
+}
+
 export async function waitForDynamicCodeReadyAfterLaunch(
   projectPath: string,
   dependencies: DynamicCodeLaunchReadinessDependencies = defaultDependencies,
-): Promise<void> {
+): Promise<ResolvedUnityConnection> {
   const startTime: number = dependencies.nowFn();
   const totalProbeStageCount = LAUNCH_READINESS_REQUIRED_STABLE_PROBE_COUNT + 1;
   const isProjectBusyFn = dependencies.isProjectBusyFn ?? isProjectBusyByLockFiles;
@@ -211,15 +213,6 @@ export async function waitForDynamicCodeReadyAfterLaunch(
   let firstSuccessfulProbeTime: number | null = null;
 
   while (dependencies.nowFn() - startTime < LAUNCH_READINESS_TIMEOUT_MS) {
-    if (currentProbeStage >= totalProbeStageCount) {
-      if (!isProjectBusyFn(projectPath)) {
-        return;
-      }
-
-      await dependencies.sleepFn(LAUNCH_READINESS_RETRY_MS);
-      continue;
-    }
-
     let client: DirectUnityClient | null = null;
 
     try {
@@ -227,10 +220,21 @@ export async function waitForDynamicCodeReadyAfterLaunch(
         undefined,
         projectPath,
       );
+      if (!hasFastSessionMetadata(connection)) {
+        await dependencies.sleepFn(LAUNCH_READINESS_RETRY_MS);
+        continue;
+      }
+
       client = dependencies.createClient(connection.port);
       await client.connect();
-      if (connection.shouldValidateProject && connection.projectRoot !== null) {
-        await validateConnectedProject(client, connection.projectRoot);
+
+      if (currentProbeStage >= totalProbeStageCount) {
+        if (!isProjectBusyFn(projectPath)) {
+          return connection;
+        }
+
+        await dependencies.sleepFn(LAUNCH_READINESS_RETRY_MS);
+        continue;
       }
 
       const payload = await client.sendRequest<ExecuteDynamicCodeReadinessResponse>(
@@ -256,7 +260,7 @@ export async function waitForDynamicCodeReadyAfterLaunch(
             currentProbeStage++;
             firstSuccessfulProbeTime = null;
             if (currentProbeStage >= totalProbeStageCount && !isProjectBusyFn(projectPath)) {
-              return;
+              return connection;
             }
           } else {
             if (firstSuccessfulProbeTime === null) {
@@ -268,7 +272,7 @@ export async function waitForDynamicCodeReadyAfterLaunch(
               currentProbeStage++;
               firstSuccessfulProbeTime = null;
               if (currentProbeStage >= totalProbeStageCount && !isProjectBusyFn(projectPath)) {
-                return;
+                return connection;
               }
             }
           }
@@ -305,7 +309,7 @@ export async function waitForDynamicCodeReadyAfterLaunch(
 export async function waitForLaunchReadyAfterLaunch(
   projectPath: string,
   dependencies: DynamicCodeLaunchReadinessDependencies = defaultDependencies,
-): Promise<void> {
+): Promise<ResolvedUnityConnection> {
   const startTime: number = dependencies.nowFn();
   const isProjectBusyFn = dependencies.isProjectBusyFn ?? isProjectBusyByLockFiles;
 
@@ -317,14 +321,16 @@ export async function waitForLaunchReadyAfterLaunch(
         undefined,
         projectPath,
       );
-      client = dependencies.createClient(connection.port);
-      await client.connect();
-      if (connection.projectRoot !== null) {
-        await validateConnectedProject(client, connection.projectRoot);
+      if (!hasFastSessionMetadata(connection)) {
+        await dependencies.sleepFn(LAUNCH_READINESS_RETRY_MS);
+        continue;
       }
 
+      client = dependencies.createClient(connection.port);
+      await client.connect();
+
       if (!isProjectBusyFn(projectPath)) {
-        return;
+        return connection;
       }
     } catch (error) {
       if (!isRetryableLaunchReadinessError(error)) {


### PR DESCRIPTION
## Summary
- Make `uloop launch` wait for the published Unity session identity before the final startup warmup.
- Prevent false project identity warnings from appearing during a normal launch sequence.

## User Impact
- Before this change, `uloop launch` could print `Could not verify project identity` while Unity was still starting, even though launch would eventually succeed.
- After this change, launch keeps waiting until the target Unity session is fully identifiable, so normal startup no longer shows that misleading warning.

## Changes
- Gate launch readiness on fast session metadata instead of falling back to the legacy `get-version` validation path during startup.
- Reuse the resolved Unity port for post-launch dynamic-code prewarm so the warmup stays on the confirmed session.
- Update launch readiness and launch command tests to cover the new startup flow.

## Verification
- `npx eslint src/launch-readiness.ts src/commands/launch.ts src/__tests__/launch-readiness.test.ts src/__tests__/launch-command.test.ts`
- `npx jest --runInBand src/__tests__/launch-readiness.test.ts src/__tests__/launch-command.test.ts`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR refactors the launch readiness flow to wait for Unity's fast session metadata before completing startup validation, eliminating false `Could not verify project identity` warnings that could appear during normal startup. The key change gates all readiness checks on the availability of `connection.requestMetadata` instead of falling back to legacy project validation.

## Changes by Component

### Core Logic (`launch-readiness.ts`)
- **Fast session metadata gating**: Added `hasFastSessionMetadata(connection)` helper and modified both `waitForDynamicCodeReadyAfterLaunch` and `waitForLaunchReadyAfterLaunch` to sleep and retry when `connection.requestMetadata` is `null`
- **Removed project validation**: Eliminated calls to `validateConnectedProject(...)` from the readiness flow, removing legacy validation logic that could trigger false warnings
- **Removed ProjectMismatchError retry**: Deleted unconditional retry behavior for `ProjectMismatchError` from `isRetryableLaunchReadinessError`
- **Return type changes**: Both exported readiness functions now return `Promise<ResolvedUnityConnection>` instead of `Promise<void>`, allowing callers to access the resolved connection details

### Launch Command (`launch.ts`)
- **Port reuse**: Changed `waitForDynamicCodeReadyAfterLaunch` invocation to capture and use the returned `ResolvedUnityConnection` object, extracting its `port` value when calling `prewarmDynamicCodeAfterLaunch`
- Previously passed `{ projectRoot: launchResult.projectPath }` to prewarm; now passes `{ port: <resolved-port> }` for more precise session targeting

### Test Updates

**launch-readiness.test.ts**:
- Replaced "retries project mismatch errors" test with "waits for fast session metadata" test that simulates initial `requestMetadata: null` responses
- Updated "waits for busy lock files to clear" test to expect zero Unity JSON-RPC calls instead of legacy `get-version` calls
- Modified "malformed payloads" test to resolve with a valid `createConnection(8711)` object
- Updated all test assertions to align with metadata-first validation approach

**launch-command.test.ts**:
- Updated mocks for `waitForLaunchReadyAfterLaunch` and `waitForDynamicCodeReadyAfterLaunch` to return richer payload containing `port`, `projectRoot`, `requestMetadata` with `expectedProjectRoot` and `expectedServerSessionId`, plus `shouldValidateProject: false`
- Changed dynamic-code warmup assertion from expecting `{ projectRoot: '/project' }` to `{ port: 8711 }`

## API Changes
- `waitForDynamicCodeReadyAfterLaunch()`: Return type changed from `Promise<void>` → `Promise<ResolvedUnityConnection>`
- `waitForLaunchReadyAfterLaunch()`: Return type changed from `Promise<void>` → `Promise<ResolvedUnityConnection>`

## User Impact
- **Before**: `uloop launch` could print a misleading "Could not verify project identity" warning during normal startup even when the launch eventually succeeded
- **After**: Launch cleanly waits until Unity's fast session metadata is available before completing startup checks, eliminating false warnings during normal operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->