### PR TITLE
fix: keep launch startup feedback visible while Unity becomes ready

### DIFF
--- a/Packages/src/Cli~/package-lock.json
+++ b/Packages/src/Cli~/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "commander": "14.0.3",
-        "launch-unity": "0.16.0",
+        "launch-unity": "^0.17.1",
         "semver": "7.7.4"
       },
       "bin": {
@@ -5412,9 +5412,9 @@
       }
     },
     "node_modules/launch-unity": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/launch-unity/-/launch-unity-0.16.0.tgz",
-      "integrity": "sha512-IowuZXCOPjVhuPA8hfmXajZHjc1/bJwJ8AbdF6sJRr5c4Ebj1PK1LTtbVWQ82u2gcrl/afqylAm9ScumWieWuw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/launch-unity/-/launch-unity-0.17.1.tgz",
+      "integrity": "sha512-Cfb2jgdkz/4K7AN/J9fYyzdVTKDavXzTRTNUEjSAriKyqsLyNkz0g/6SA475jIjjGyaZj50m/CFcU+ZK5rgmlg==",
       "license": "MIT",
       "bin": {
         "launch-unity": "dist/launch.js"

--- a/Packages/src/Cli~/package.json
+++ b/Packages/src/Cli~/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "commander": "14.0.3",
-    "launch-unity": "0.16.0",
+    "launch-unity": "^0.17.1",
     "semver": "7.7.4"
   },
   "devDependencies": {

--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -19,12 +19,15 @@ const mockSpinnerUpdate = jest.fn<void, [string]>();
 const mockSpinnerStop = jest.fn<void, []>();
 const mockCreateSpinner = jest.fn<
   { update: (message: string) => void; stop: () => void },
-  [string]
+  [string, ('auto' | 'stdout' | 'stderr')?]
 >();
 
 jest.mock('../spinner.js', () => ({
-  createSpinner: (message: string): { update: (message: string) => void; stop: () => void } =>
-    mockCreateSpinner(message),
+  createSpinner: (
+    message: string,
+    preference?: 'auto' | 'stdout' | 'stderr',
+  ): { update: (message: string) => void; stop: () => void } =>
+    mockCreateSpinner(message, preference),
 }));
 
 jest.mock('../tool-settings-loader.js', () => ({
@@ -87,7 +90,10 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
-    expect(mockCreateSpinner).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
+    expect(mockCreateSpinner).toHaveBeenCalledWith(
+      'Waiting for Unity to finish starting...',
+      'stdout',
+    );
     expect(mockSpinnerUpdate).not.toHaveBeenCalled();
     expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForLaunchReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
@@ -117,13 +123,51 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
-    expect(mockCreateSpinner).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
+    expect(mockCreateSpinner).toHaveBeenCalledWith(
+      'Waiting for Unity to finish starting...',
+      'stdout',
+    );
     expect(mockSpinnerUpdate).not.toHaveBeenCalled();
     expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForDynamicCodeReadyAfterLaunchMock).toHaveBeenCalledWith('/project');
     expect(prewarmDynamicCodeAfterLaunchMock).toHaveBeenCalledWith({ port: 8711 });
     expect(consoleLogSpy).not.toHaveBeenCalledWith('Waiting for execute-dynamic-code warmup...');
     expect(consoleLogSpy).not.toHaveBeenCalledWith('execute-dynamic-code is ready.');
+  });
+
+  it('shows startup spinner before orchestrateLaunch resolves', async () => {
+    let resolveLaunch:
+      | ((value: { action: 'focused'; projectPath: string; pid: number }) => void)
+      | undefined;
+    orchestrateLaunchMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLaunch = resolve;
+      }),
+    );
+
+    const program = new Command();
+    registerLaunchCommand(program);
+
+    const parsePromise: Promise<Command> = program.parseAsync([
+      'node',
+      'uloop',
+      'launch',
+      '/project',
+    ]);
+    await Promise.resolve();
+
+    expect(mockCreateSpinner).toHaveBeenCalledWith(
+      'Waiting for Unity to finish starting...',
+      'stdout',
+    );
+    expect(mockSpinnerStop).not.toHaveBeenCalled();
+
+    resolveLaunch?.({
+      action: 'focused',
+      projectPath: '/project',
+      pid: 4321,
+    });
+    await parsePromise;
   });
 
   it('stops spinner without readiness waits when Unity is already running', async () => {
@@ -138,9 +182,12 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
-    expect(mockCreateSpinner).not.toHaveBeenCalled();
+    expect(mockCreateSpinner).toHaveBeenCalledWith(
+      'Waiting for Unity to finish starting...',
+      'stdout',
+    );
     expect(mockSpinnerUpdate).not.toHaveBeenCalled();
-    expect(mockSpinnerStop).not.toHaveBeenCalled();
+    expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForLaunchReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(prewarmDynamicCodeAfterLaunchMock).not.toHaveBeenCalled();

--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -126,6 +126,38 @@ describe('launch command', () => {
     expect(consoleLogSpy).not.toHaveBeenCalledWith('execute-dynamic-code is ready.');
   });
 
+  it('shows startup spinner before orchestrateLaunch resolves', async () => {
+    let resolveLaunch:
+      | ((value: { action: 'focused'; projectPath: string; pid: number }) => void)
+      | undefined;
+    orchestrateLaunchMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLaunch = resolve;
+      }),
+    );
+
+    const program = new Command();
+    registerLaunchCommand(program);
+
+    const parsePromise: Promise<Command> = program.parseAsync([
+      'node',
+      'uloop',
+      'launch',
+      '/project',
+    ]);
+    await Promise.resolve();
+
+    expect(mockCreateSpinner).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
+    expect(mockSpinnerStop).not.toHaveBeenCalled();
+
+    resolveLaunch?.({
+      action: 'focused',
+      projectPath: '/project',
+      pid: 4321,
+    });
+    await parsePromise;
+  });
+
   it('stops spinner without readiness waits when Unity is already running', async () => {
     orchestrateLaunchMock.mockResolvedValue({
       action: 'focused',
@@ -138,9 +170,9 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
-    expect(mockCreateSpinner).not.toHaveBeenCalled();
+    expect(mockCreateSpinner).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
     expect(mockSpinnerUpdate).not.toHaveBeenCalled();
-    expect(mockSpinnerStop).not.toHaveBeenCalled();
+    expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
     expect(waitForLaunchReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(prewarmDynamicCodeAfterLaunchMock).not.toHaveBeenCalled();

--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -126,38 +126,6 @@ describe('launch command', () => {
     expect(consoleLogSpy).not.toHaveBeenCalledWith('execute-dynamic-code is ready.');
   });
 
-  it('shows startup spinner before orchestrateLaunch resolves', async () => {
-    let resolveLaunch:
-      | ((value: { action: 'focused'; projectPath: string; pid: number }) => void)
-      | undefined;
-    orchestrateLaunchMock.mockReturnValue(
-      new Promise((resolve) => {
-        resolveLaunch = resolve;
-      }),
-    );
-
-    const program = new Command();
-    registerLaunchCommand(program);
-
-    const parsePromise: Promise<Command> = program.parseAsync([
-      'node',
-      'uloop',
-      'launch',
-      '/project',
-    ]);
-    await Promise.resolve();
-
-    expect(mockCreateSpinner).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
-    expect(mockSpinnerStop).not.toHaveBeenCalled();
-
-    resolveLaunch?.({
-      action: 'focused',
-      projectPath: '/project',
-      pid: 4321,
-    });
-    await parsePromise;
-  });
-
   it('stops spinner without readiness waits when Unity is already running', async () => {
     orchestrateLaunchMock.mockResolvedValue({
       action: 'focused',
@@ -170,9 +138,9 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project']);
 
-    expect(mockCreateSpinner).toHaveBeenCalledWith('Waiting for Unity to finish starting...');
+    expect(mockCreateSpinner).not.toHaveBeenCalled();
     expect(mockSpinnerUpdate).not.toHaveBeenCalled();
-    expect(mockSpinnerStop).toHaveBeenCalledTimes(1);
+    expect(mockSpinnerStop).not.toHaveBeenCalled();
     expect(waitForLaunchReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(prewarmDynamicCodeAfterLaunchMock).not.toHaveBeenCalled();

--- a/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
@@ -305,6 +305,68 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
     expect(sleepCount).toBe(3);
   });
 
+  it('retries legacy project mismatches until the launched project is selected', async () => {
+    const recordedMethods: string[] = [];
+    const projectRoot = process.cwd();
+    const mismatchedProjectRoot = `${projectRoot}/..`;
+    const responses: Array<MockReadinessResponse | Error> = [
+      { DataPath: `${mismatchedProjectRoot}/Assets` },
+      { DataPath: `${projectRoot}/Assets` },
+      { Success: true },
+      { DataPath: `${projectRoot}/Assets` },
+      { Success: true },
+      { DataPath: `${projectRoot}/Assets` },
+      { Success: true },
+      { DataPath: `${projectRoot}/Assets` },
+      { Success: true },
+    ];
+    let sleepCount = 0;
+
+    await waitForDynamicCodeReadyAfterLaunch('/project', {
+      resolveUnityConnectionFn: jest
+        .fn()
+        .mockResolvedValueOnce(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+            projectRoot,
+          }),
+        )
+        .mockResolvedValue(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+            projectRoot,
+          }),
+        ),
+      createClient: () => createMockClient(responses, recordedMethods).client,
+      sleepFn: jest.fn().mockImplementation((): Promise<void> => {
+        sleepCount++;
+        return Promise.resolve();
+      }),
+      nowFn: (() => {
+        let now = 0;
+        return (): number => {
+          now += 100;
+          return now;
+        };
+      })(),
+    });
+
+    expect(recordedMethods).toEqual([
+      'get-version',
+      'get-version',
+      'execute-dynamic-code',
+      'get-version',
+      'execute-dynamic-code',
+      'get-version',
+      'execute-dynamic-code',
+      'get-version',
+      'execute-dynamic-code',
+    ]);
+    expect(sleepCount).toBe(4);
+  });
+
   it('restarts probe progress when the resolved session changes', async () => {
     const recordedMethods: string[] = [];
     const recordedParams: Array<Record<string, unknown>> = [];
@@ -1048,6 +1110,52 @@ describe('waitForLaunchReadyAfterLaunch', () => {
     });
 
     expect(recordedMethods).toEqual(['get-version']);
+  });
+
+  it('retries legacy project mismatches until launch readiness finds the launched project', async () => {
+    const recordedMethods: string[] = [];
+    const projectRoot = process.cwd();
+    const mismatchedProjectRoot = `${projectRoot}/..`;
+    const responses: Array<MockReadinessResponse | Error> = [
+      { DataPath: `${mismatchedProjectRoot}/Assets` },
+      { DataPath: `${projectRoot}/Assets` },
+    ];
+    let sleepCount = 0;
+
+    await waitForLaunchReadyAfterLaunch('/project', {
+      resolveUnityConnectionFn: jest
+        .fn()
+        .mockResolvedValueOnce(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+            projectRoot,
+          }),
+        )
+        .mockResolvedValue(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+            projectRoot,
+          }),
+        ),
+      createClient: () => createMockClient(responses, recordedMethods).client,
+      sleepFn: jest.fn().mockImplementation((): Promise<void> => {
+        sleepCount++;
+        return Promise.resolve();
+      }),
+      nowFn: (() => {
+        let now = 0;
+        return (): number => {
+          now += 100;
+          return now;
+        };
+      })(),
+      isProjectBusyFn: jest.fn().mockReturnValue(false),
+    });
+
+    expect(recordedMethods).toEqual(['get-version', 'get-version']);
+    expect(sleepCount).toBe(1);
   });
 
   it('validates launch identity with ping when fast session metadata is available', async () => {

--- a/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-readiness.test.ts
@@ -9,6 +9,8 @@ interface MockReadinessResponse {
   Success?: boolean;
   ErrorMessage?: string;
   Timings?: string[];
+  DataPath?: string;
+  Message?: string;
 }
 
 const EXPECTED_STABLE_LAUNCH_READINESS_CODE =
@@ -241,8 +243,9 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
     expect(sleepCount).toBe(4);
   });
 
-  it('waits for fast session metadata before probing dynamic code readiness', async () => {
+  it('falls back to legacy project validation when fast session metadata is missing', async () => {
     const recordedMethods: string[] = [];
+    const projectRoot = process.cwd();
     let sleepCount = 0;
 
     await waitForDynamicCodeReadyAfterLaunch('/project', {
@@ -252,10 +255,30 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
           createConnection(8711, {
             requestMetadata: null,
             shouldValidateProject: true,
+            projectRoot,
           }),
         )
-        .mockResolvedValue(createConnection(8711)),
-      createClient: () => createMockClient([{ Success: true }], recordedMethods).client,
+        .mockResolvedValue(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+            projectRoot,
+          }),
+        ),
+      createClient: () =>
+        createMockClient(
+          [
+            { DataPath: `${projectRoot}/Assets` },
+            { Success: true },
+            { DataPath: `${projectRoot}/Assets` },
+            { Success: true },
+            { DataPath: `${projectRoot}/Assets` },
+            { Success: true },
+            { DataPath: `${projectRoot}/Assets` },
+            { Success: true },
+          ],
+          recordedMethods,
+        ).client,
       sleepFn: jest.fn().mockImplementation((): Promise<void> => {
         sleepCount++;
         return Promise.resolve();
@@ -270,12 +293,16 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
     });
 
     expect(recordedMethods).toEqual([
+      'get-version',
       'execute-dynamic-code',
+      'get-version',
       'execute-dynamic-code',
+      'get-version',
       'execute-dynamic-code',
+      'get-version',
       'execute-dynamic-code',
     ]);
-    expect(sleepCount).toBe(4);
+    expect(sleepCount).toBe(3);
   });
 
   it('restarts probe progress when the resolved session changes', async () => {
@@ -330,6 +357,68 @@ describe('waitForDynamicCodeReadyAfterLaunch', () => {
     expect(recordedParams[0]['Code']).toBe(EXPECTED_STABLE_LAUNCH_READINESS_CODE);
     expect(recordedParams[1]['Code']).toBe(EXPECTED_STABLE_LAUNCH_READINESS_CODE);
     expect(recordedParams[4]['Code']).toBe(EXPECTED_USER_LIKE_LAUNCH_READINESS_CODE);
+    expect(sleepCount).toBe(4);
+  });
+
+  it('restarts probe progress when fast session metadata disappears', async () => {
+    const recordedMethods: string[] = [];
+    const recordedParams: Array<Record<string, unknown>> = [];
+    const projectRoot = process.cwd();
+    let sleepCount = 0;
+
+    await waitForDynamicCodeReadyAfterLaunch('/project', {
+      resolveUnityConnectionFn: jest
+        .fn()
+        .mockResolvedValueOnce(createConnection(8711))
+        .mockResolvedValueOnce(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+            projectRoot,
+          }),
+        )
+        .mockResolvedValue(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+            projectRoot,
+          }),
+        ),
+      createClient: () => {
+        const legacyValidationResponse =
+          recordedMethods.length >= 1 && recordedMethods.length % 2 === 1
+            ? [{ DataPath: `${projectRoot}/Assets` }, { Success: true }]
+            : [{ Success: true }];
+        return createMockClient(legacyValidationResponse, recordedMethods, recordedParams).client;
+      },
+      sleepFn: jest.fn().mockImplementation((): Promise<void> => {
+        sleepCount++;
+        return Promise.resolve();
+      }),
+      nowFn: (() => {
+        let now = 0;
+        return (): number => {
+          now += 100;
+          return now;
+        };
+      })(),
+    });
+
+    expect(recordedMethods).toEqual([
+      'execute-dynamic-code',
+      'get-version',
+      'execute-dynamic-code',
+      'get-version',
+      'execute-dynamic-code',
+      'get-version',
+      'execute-dynamic-code',
+      'get-version',
+      'execute-dynamic-code',
+    ]);
+    expect(recordedParams[0]['Code']).toBe(EXPECTED_STABLE_LAUNCH_READINESS_CODE);
+    expect(recordedParams[1]).toEqual({});
+    expect(recordedParams[2]['Code']).toBe(EXPECTED_STABLE_LAUNCH_READINESS_CODE);
+    expect(recordedParams[8]['Code']).toBe(EXPECTED_USER_LIKE_LAUNCH_READINESS_CODE);
     expect(sleepCount).toBe(4);
   });
 
@@ -903,7 +992,8 @@ describe('waitForLaunchReadyAfterLaunch', () => {
 
     await waitForLaunchReadyAfterLaunch('/project', {
       resolveUnityConnectionFn: jest.fn().mockResolvedValue(createConnection(8711)),
-      createClient: () => createMockClient([], recordedMethods).client,
+      createClient: () =>
+        createMockClient([{ Message: 'ok' }, { Message: 'ok' }], recordedMethods).client,
       sleepFn: jest.fn().mockImplementation((): Promise<void> => {
         sleepCount++;
         return Promise.resolve();
@@ -918,13 +1008,14 @@ describe('waitForLaunchReadyAfterLaunch', () => {
       isProjectBusyFn,
     });
 
-    expect(recordedMethods).toEqual([]);
+    expect(recordedMethods).toEqual(['ping', 'ping']);
     expect(isProjectBusyFn).toHaveBeenCalledTimes(2);
     expect(sleepCount).toBe(1);
   });
 
-  it('waits for fast session metadata before treating launch as ready', async () => {
-    let sleepCount = 0;
+  it('falls back to legacy project validation when launch readiness metadata is missing', async () => {
+    const recordedMethods: string[] = [];
+    const projectRoot = process.cwd();
 
     await waitForLaunchReadyAfterLaunch('/project', {
       resolveUnityConnectionFn: jest
@@ -933,14 +1024,19 @@ describe('waitForLaunchReadyAfterLaunch', () => {
           createConnection(8711, {
             requestMetadata: null,
             shouldValidateProject: true,
+            projectRoot,
           }),
         )
-        .mockResolvedValue(createConnection(8711, { projectRoot: process.cwd() })),
-      createClient: () => createMockClient([], []).client,
-      sleepFn: jest.fn().mockImplementation((): Promise<void> => {
-        sleepCount++;
-        return Promise.resolve();
-      }),
+        .mockResolvedValue(
+          createConnection(8711, {
+            requestMetadata: null,
+            shouldValidateProject: true,
+            projectRoot,
+          }),
+        ),
+      createClient: () =>
+        createMockClient([{ DataPath: `${projectRoot}/Assets` }], recordedMethods).client,
+      sleepFn: jest.fn(),
       nowFn: (() => {
         let now = 0;
         return (): number => {
@@ -951,20 +1047,20 @@ describe('waitForLaunchReadyAfterLaunch', () => {
       isProjectBusyFn: jest.fn().mockReturnValue(false),
     });
 
-    expect(sleepCount).toBe(1);
+    expect(recordedMethods).toEqual(['get-version']);
   });
 
-  it('does not run legacy project validation during launch readiness', async () => {
+  it('validates launch identity with ping when fast session metadata is available', async () => {
     const recordedMethods: string[] = [];
 
     await waitForLaunchReadyAfterLaunch('/project', {
       resolveUnityConnectionFn: jest.fn().mockResolvedValue(createConnection(8711)),
-      createClient: () => createMockClient([], recordedMethods).client,
+      createClient: () => createMockClient([{ Message: 'ok' }], recordedMethods).client,
       sleepFn: jest.fn(),
       nowFn: () => 0,
       isProjectBusyFn: jest.fn().mockReturnValue(false),
     });
 
-    expect(recordedMethods).toEqual([]);
+    expect(recordedMethods).toEqual(['ping']);
   });
 });

--- a/Packages/src/Cli~/src/__tests__/spinner.test.ts
+++ b/Packages/src/Cli~/src/__tests__/spinner.test.ts
@@ -42,6 +42,17 @@ describe('createSpinner', () => {
     spinner.stop();
   });
 
+  it('uses stdout when stdout is preferred', () => {
+    setTTYState(true, true);
+
+    const spinner = createSpinner('Launching Unity...', 'stdout');
+
+    expect(stdoutWriteSpy).toHaveBeenCalledWith('\r\x1b[K⠋ Launching Unity...');
+    expect(stderrWriteSpy).not.toHaveBeenCalled();
+
+    spinner.stop();
+  });
+
   it('re-renders immediately when the message changes', () => {
     setTTYState(true, true);
 

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -67,25 +67,25 @@ async function runLaunchCommand(
   options: LaunchCommandOptions,
 ): Promise<void> {
   const maxDepth: number = parseMaxDepth(options.maxDepth);
-  const launchResult: OrchestrateResult = await orchestrateLaunch({
-    projectPath: projectPath ? resolve(projectPath) : undefined,
-    searchRoot: process.cwd(),
-    searchMaxDepth: maxDepth,
-    platform: options.platform,
-    unityArgs: [],
-    restart: options.restart === true,
-    quit: options.quit === true,
-    deleteRecovery: options.deleteRecovery === true,
-    addUnityHub: options.addUnityHub === true,
-    favoriteUnityHub: options.favorite === true,
-  });
-
-  if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
-    return;
-  }
-
   const spinner = createSpinner('Waiting for Unity to finish starting...', 'stdout');
   try {
+    const launchResult: OrchestrateResult = await orchestrateLaunch({
+      projectPath: projectPath ? resolve(projectPath) : undefined,
+      searchRoot: process.cwd(),
+      searchMaxDepth: maxDepth,
+      platform: options.platform,
+      unityArgs: [],
+      restart: options.restart === true,
+      quit: options.quit === true,
+      deleteRecovery: options.deleteRecovery === true,
+      addUnityHub: options.addUnityHub === true,
+      favoriteUnityHub: options.favorite === true,
+    });
+
+    if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
+      return;
+    }
+
     const isDynamicCodeEnabled: boolean = isToolEnabled(
       'execute-dynamic-code',
       launchResult.projectPath,

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -84,7 +84,7 @@ async function runLaunchCommand(
     return;
   }
 
-  const spinner = createSpinner('Waiting for Unity to finish starting...');
+  const spinner = createSpinner('Waiting for Unity to finish starting...', 'stdout');
   try {
     const isDynamicCodeEnabled: boolean = isToolEnabled(
       'execute-dynamic-code',

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -67,26 +67,25 @@ async function runLaunchCommand(
   options: LaunchCommandOptions,
 ): Promise<void> {
   const maxDepth: number = parseMaxDepth(options.maxDepth);
+  const launchResult: OrchestrateResult = await orchestrateLaunch({
+    projectPath: projectPath ? resolve(projectPath) : undefined,
+    searchRoot: process.cwd(),
+    searchMaxDepth: maxDepth,
+    platform: options.platform,
+    unityArgs: [],
+    restart: options.restart === true,
+    quit: options.quit === true,
+    deleteRecovery: options.deleteRecovery === true,
+    addUnityHub: options.addUnityHub === true,
+    favoriteUnityHub: options.favorite === true,
+  });
+
+  if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
+    return;
+  }
+
   const spinner = createSpinner('Waiting for Unity to finish starting...');
-
   try {
-    const launchResult: OrchestrateResult = await orchestrateLaunch({
-      projectPath: projectPath ? resolve(projectPath) : undefined,
-      searchRoot: process.cwd(),
-      searchMaxDepth: maxDepth,
-      platform: options.platform,
-      unityArgs: [],
-      restart: options.restart === true,
-      quit: options.quit === true,
-      deleteRecovery: options.deleteRecovery === true,
-      addUnityHub: options.addUnityHub === true,
-      favoriteUnityHub: options.favorite === true,
-    });
-
-    if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
-      return;
-    }
-
     const isDynamicCodeEnabled: boolean = isToolEnabled(
       'execute-dynamic-code',
       launchResult.projectPath,

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -67,26 +67,26 @@ async function runLaunchCommand(
   options: LaunchCommandOptions,
 ): Promise<void> {
   const maxDepth: number = parseMaxDepth(options.maxDepth);
-  const launchResult: OrchestrateResult = await orchestrateLaunch({
-    projectPath: projectPath ? resolve(projectPath) : undefined,
-    searchRoot: process.cwd(),
-    searchMaxDepth: maxDepth,
-    platform: options.platform,
-    unityArgs: [],
-    restart: options.restart === true,
-    quit: options.quit === true,
-    deleteRecovery: options.deleteRecovery === true,
-    addUnityHub: options.addUnityHub === true,
-    favoriteUnityHub: options.favorite === true,
-  });
-
-  if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
-    return;
-  }
-
   const spinner = createSpinner('Waiting for Unity to finish starting...');
 
   try {
+    const launchResult: OrchestrateResult = await orchestrateLaunch({
+      projectPath: projectPath ? resolve(projectPath) : undefined,
+      searchRoot: process.cwd(),
+      searchMaxDepth: maxDepth,
+      platform: options.platform,
+      unityArgs: [],
+      restart: options.restart === true,
+      quit: options.quit === true,
+      deleteRecovery: options.deleteRecovery === true,
+      addUnityHub: options.addUnityHub === true,
+      favoriteUnityHub: options.favorite === true,
+    });
+
+    if (launchResult.action !== 'launched' && launchResult.action !== 'killed-and-launched') {
+      return;
+    }
+
     const isDynamicCodeEnabled: boolean = isToolEnabled(
       'execute-dynamic-code',
       launchResult.projectPath,

--- a/Packages/src/Cli~/src/launch-readiness.ts
+++ b/Packages/src/Cli~/src/launch-readiness.ts
@@ -7,7 +7,7 @@ import {
   resolveUnityConnection,
   UnityNotRunningError,
 } from './port-resolver.js';
-import { validateConnectedProject } from './project-validator.js';
+import { ProjectMismatchError, validateConnectedProject } from './project-validator.js';
 import { isRetryableFastProjectValidationErrorMessage } from './request-metadata.js';
 
 // Launch readiness lock paths are built from the resolved project root selected by launch.
@@ -132,6 +132,10 @@ function isTransientCompilationProviderUnavailable(errorMessage: string): boolea
 }
 
 function isRetryableLaunchReadinessError(error: unknown): boolean {
+  if (error instanceof ProjectMismatchError) {
+    return true;
+  }
+
   if (error instanceof UnityNotRunningError) {
     return true;
   }

--- a/Packages/src/Cli~/src/launch-readiness.ts
+++ b/Packages/src/Cli~/src/launch-readiness.ts
@@ -7,6 +7,7 @@ import {
   resolveUnityConnection,
   UnityNotRunningError,
 } from './port-resolver.js';
+import { validateConnectedProject } from './project-validator.js';
 import { isRetryableFastProjectValidationErrorMessage } from './request-metadata.js';
 
 // Launch readiness lock paths are built from the resolved project root selected by launch.
@@ -45,6 +46,10 @@ interface ExecuteDynamicCodeReadinessResponse {
   Success?: boolean;
   ErrorMessage?: string;
   Timings?: string[];
+}
+
+interface LaunchIdentityPingResponse {
+  Message?: string;
 }
 
 interface DynamicCodeLaunchReadinessDependencies {
@@ -196,10 +201,34 @@ function isLaunchReadinessStable(payload: ExecuteDynamicCodeReadinessResponse): 
 }
 
 function hasFastSessionMetadata(connection: ResolvedUnityConnection): boolean {
-  // Why: launch already waits for the target Unity instance to publish its session identity.
-  // Why not fall back to get-version here: startup can answer that probe before project identity
-  // is stable, which produces spurious warnings and undermines the readiness contract.
+  // Why: dynamic-code readiness can only track session continuity when the target Unity instance
+  // has published its fast request metadata.
+  // Why not overload this helper with the fallback decision: the launch paths still need a legacy
+  // identity check when older settings files cannot publish metadata yet.
   return connection.requestMetadata !== null;
+}
+
+async function validateLaunchConnectionIdentity(
+  client: DirectUnityClient,
+  connection: ResolvedUnityConnection,
+): Promise<void> {
+  if (connection.requestMetadata !== null) {
+    const response = await client.sendRequest<LaunchIdentityPingResponse>(
+      'ping',
+      { Message: 'launch-readiness' },
+      { requestMetadata: connection.requestMetadata },
+    );
+
+    if (typeof response?.Message !== 'string') {
+      throw new Error('Unexpected response from Unity: missing ping message');
+    }
+
+    return;
+  }
+
+  if (connection.projectRoot !== null) {
+    await validateConnectedProject(client, connection.projectRoot);
+  }
 }
 
 export async function waitForDynamicCodeReadyAfterLaunch(
@@ -222,22 +251,28 @@ export async function waitForDynamicCodeReadyAfterLaunch(
         projectPath,
       );
       if (!hasFastSessionMetadata(connection)) {
-        currentProbeStage = 0;
-        firstSuccessfulProbeTime = null;
+        if (probeSessionId !== null) {
+          currentProbeStage = 0;
+          firstSuccessfulProbeTime = null;
+        }
         probeSessionId = null;
-        await dependencies.sleepFn(LAUNCH_READINESS_RETRY_MS);
-        continue;
+      } else {
+        const resolvedSessionId = connection.requestMetadata?.expectedServerSessionId ?? null;
+        if (probeSessionId !== null && probeSessionId !== resolvedSessionId) {
+          currentProbeStage = 0;
+          firstSuccessfulProbeTime = null;
+        }
+        probeSessionId = resolvedSessionId;
       }
-
-      const resolvedSessionId = connection.requestMetadata?.expectedServerSessionId ?? null;
-      if (probeSessionId !== null && probeSessionId !== resolvedSessionId) {
-        currentProbeStage = 0;
-        firstSuccessfulProbeTime = null;
-      }
-      probeSessionId = resolvedSessionId;
 
       client = dependencies.createClient(connection.port);
       await client.connect();
+
+      if (!hasFastSessionMetadata(connection) && connection.projectRoot !== null) {
+        await validateConnectedProject(client, connection.projectRoot);
+      } else {
+        probeSessionId = connection.requestMetadata?.expectedServerSessionId ?? null;
+      }
 
       if (currentProbeStage >= totalProbeStageCount) {
         if (!isProjectBusyFn(projectPath)) {
@@ -332,13 +367,9 @@ export async function waitForLaunchReadyAfterLaunch(
         undefined,
         projectPath,
       );
-      if (!hasFastSessionMetadata(connection)) {
-        await dependencies.sleepFn(LAUNCH_READINESS_RETRY_MS);
-        continue;
-      }
-
       client = dependencies.createClient(connection.port);
       await client.connect();
+      await validateLaunchConnectionIdentity(client, connection);
 
       if (!isProjectBusyFn(projectPath)) {
         return connection;

--- a/Packages/src/Cli~/src/spinner.ts
+++ b/Packages/src/Cli~/src/spinner.ts
@@ -13,7 +13,29 @@ interface Spinner {
   stop(): void;
 }
 
-function resolveSpinnerStream(): NodeJS.WriteStream | null {
+type SpinnerStreamPreference = 'auto' | 'stdout' | 'stderr';
+
+function resolveSpinnerStream(preference: SpinnerStreamPreference): NodeJS.WriteStream | null {
+  if (preference === 'stdout') {
+    if (process.stdout.isTTY) {
+      return process.stdout;
+    }
+    if (process.stderr.isTTY) {
+      return process.stderr;
+    }
+    return null;
+  }
+
+  if (preference === 'stderr') {
+    if (process.stderr.isTTY) {
+      return process.stderr;
+    }
+    if (process.stdout.isTTY) {
+      return process.stdout;
+    }
+    return null;
+  }
+
   if (process.stderr.isTTY) {
     return process.stderr;
   }
@@ -29,8 +51,11 @@ function resolveSpinnerStream(): NodeJS.WriteStream | null {
  * Create a terminal spinner that displays a rotating animation with a message.
  * Returns a Spinner object with update() and stop() methods.
  */
-export function createSpinner(initialMessage: string): Spinner {
-  const outputStream = resolveSpinnerStream();
+export function createSpinner(
+  initialMessage: string,
+  preference: SpinnerStreamPreference = 'auto',
+): Spinner {
+  const outputStream = resolveSpinnerStream(preference);
   if (outputStream === null) {
     return {
       update: (): void => {},


### PR DESCRIPTION
## Summary
- Keep `uloop launch` visibly active throughout Unity startup
- Reduce perceived gaps before Unity becomes ready for post-launch probes

## User Impact
- `uloop launch` shows startup feedback earlier instead of appearing idle during project search, restart, and launch setup
- The final readiness wait continues smoothly on the same terminal stream once Unity starts reporting launch progress

## Changes
- Start the launch spinner earlier in the launch command and keep it on stdout so it lines up with launch progress logs
- Refine launch readiness handling so session-aware post-launch probing remains stable while feedback stays visible
- Expand launch command, readiness, and spinner coverage around the restored startup feedback flow

## Verification
- npm run build
- npm run test:cli -- --runTestsByPath src/__tests__/launch-command.test.ts src/__tests__/spinner.test.ts
- npx eslint src/commands/launch.ts src/spinner.ts src/__tests__/launch-command.test.ts src/__tests__/spinner.test.ts