### PR TITLE
fix: Setup and Settings now clean up grouped skill folders and avoid rerunning skill checks after CLI updates

### DIFF
--- a/Assets/Tests/Editor/CliInstallRefreshPolicyTests.cs
+++ b/Assets/Tests/Editor/CliInstallRefreshPolicyTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP.Tests.Editor
+{
+    public class CliInstallRefreshPolicyTests
+    {
+        [Test]
+        public void ShouldRefreshSkillsAfterCliInstall_WhenCliWasNotInstalled_ReturnsTrue()
+        {
+            bool shouldRefresh = CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(
+                wasCliInstalledBeforeInstall: false);
+
+            Assert.That(shouldRefresh, Is.True);
+        }
+
+        [Test]
+        public void ShouldRefreshSkillsAfterCliInstall_WhenCliWasAlreadyInstalled_ReturnsFalse()
+        {
+            bool shouldRefresh = CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(
+                wasCliInstalledBeforeInstall: true);
+
+            Assert.That(shouldRefresh, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/CliInstallRefreshPolicyTests.cs.meta
+++ b/Assets/Tests/Editor/CliInstallRefreshPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6027ebea3bc57481c83f357138507b3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -208,6 +208,48 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_RemovesUnexpectedManagedSkillDirectories()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-fake-skill",
+                "FakeTool",
+                "reference.md",
+                "reference");
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
+            string managedSkillsRoot = Path.Combine(
+                skillsRoot,
+                SkillInstallLayout.ManagedSkillsDirName);
+            Directory.CreateDirectory(skillsRoot);
+            WriteSkillFile(Path.Combine(managedSkillsRoot, "uloop-fake-skill"));
+            WriteSkillFile(Path.Combine(managedSkillsRoot, "uloop-stale-skill"));
+
+            ToolSkillSynchronizer.SkillTargetInfo target = new(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true);
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
+                    temporaryRoot,
+                    new[] { target },
+                    groupSkillsUnderUnityCliLoop: false);
+
+            string installedSkillDir = Path.Combine(
+                skillsRoot,
+                "uloop-fake-skill");
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(File.Exists(Path.Combine(installedSkillDir, SkillInstallLayout.SkillFileName)), Is.True);
+            Assert.That(Directory.Exists(managedSkillsRoot), Is.False);
+        }
+
+        [Test]
         public void DetectTargets_DoesNotIncludeTargetsWithOnlyParentDirectory()
         {
             // Arrange

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -250,6 +250,43 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public async Task InstallSkillFilesAtProjectRoot_WhenManagedSkillsParentOnlyHasExcludedFiles_RemovesParentDirectory()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-fake-skill",
+                "FakeTool",
+                "reference.md",
+                "reference");
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
+            string managedSkillsRoot = Path.Combine(
+                skillsRoot,
+                SkillInstallLayout.ManagedSkillsDirName);
+            Directory.CreateDirectory(skillsRoot);
+            WriteSkillFile(Path.Combine(managedSkillsRoot, "uloop-fake-skill"));
+            File.WriteAllText(Path.Combine(managedSkillsRoot, ".DS_Store"), "ignored");
+
+            ToolSkillSynchronizer.SkillTargetInfo target = new(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true);
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
+                    temporaryRoot,
+                    new[] { target },
+                    groupSkillsUnderUnityCliLoop: false);
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(Directory.Exists(managedSkillsRoot), Is.False);
+        }
+
+        [Test]
         public void DetectTargets_DoesNotIncludeTargetsWithOnlyParentDirectory()
         {
             // Arrange

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -165,6 +165,49 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_RemovesEmptyManagedSkillsParentDirectory()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-fake-skill",
+                "FakeTool",
+                "reference.md",
+                "reference");
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
+            string managedSkillsRoot = Path.Combine(
+                skillsRoot,
+                SkillInstallLayout.ManagedSkillsDirName);
+            Directory.CreateDirectory(skillsRoot);
+            WriteSkillFile(Path.Combine(
+                managedSkillsRoot,
+                "uloop-fake-skill"));
+
+            ToolSkillSynchronizer.SkillTargetInfo target = new(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true);
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
+                    temporaryRoot,
+                    new[] { target },
+                    groupSkillsUnderUnityCliLoop: false);
+
+            string installedSkillDir = Path.Combine(
+                skillsRoot,
+                "uloop-fake-skill");
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(File.Exists(Path.Combine(installedSkillDir, SkillInstallLayout.SkillFileName)), Is.True);
+            Assert.That(Directory.Exists(managedSkillsRoot), Is.False);
+        }
+
+        [Test]
         public void DetectTargets_DoesNotIncludeTargetsWithOnlyParentDirectory()
         {
             // Arrange

--- a/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
@@ -741,12 +741,42 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
+            DeleteExcludedFilesAtRoot(managedSkillsRoot);
+            DeleteEmptyDirectoriesAtRoot(managedSkillsRoot);
             if (Directory.EnumerateFileSystemEntries(managedSkillsRoot).Any())
             {
                 return;
             }
 
             Directory.Delete(managedSkillsRoot);
+        }
+
+        private static void DeleteExcludedFilesAtRoot(string directoryPath)
+        {
+            foreach (string filePath in Directory.EnumerateFiles(directoryPath))
+            {
+                string fileName = Path.GetFileName(filePath);
+                if (!IsExcludedSkillFile(fileName))
+                {
+                    continue;
+                }
+
+                File.Delete(filePath);
+            }
+        }
+
+        private static void DeleteEmptyDirectoriesAtRoot(string directoryPath)
+        {
+            foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
+            {
+                DeleteEmptyDirectories(childDirectoryPath);
+                if (Directory.EnumerateFileSystemEntries(childDirectoryPath).Any())
+                {
+                    continue;
+                }
+
+                Directory.Delete(childDirectoryPath);
+            }
         }
     }
 }

--- a/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
@@ -476,6 +476,17 @@ namespace io.github.hatayama.uLoopMCP
                 targetRoot,
                 enabledSkills.Select(skill => skill.Name),
                 groupSkillsUnderUnityCliLoop);
+
+            if (!groupSkillsUnderUnityCliLoop)
+            {
+                DeleteUnexpectedInstalledSkillDirectories(
+                    targetRoot,
+                    enabledSkills.Select(skill => skill.Name),
+                    groupSkillsUnderUnityCliLoop: true);
+                DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
+                    targetRoot,
+                    groupSkillsUnderUnityCliLoop: true);
+            }
         }
 
         private static bool IsSkillDisabled(

--- a/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
@@ -712,6 +712,30 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             Directory.Delete(installedSkillDirectory, true);
+            DeleteEmptyManagedSkillsParentDirectoryIfNeeded(targetRoot, groupSkillsUnderUnityCliLoop);
+        }
+
+        private static void DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
+            string targetRoot,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            if (!groupSkillsUnderUnityCliLoop)
+            {
+                return;
+            }
+
+            string managedSkillsRoot = SkillInstallLayout.GetManagedSkillsRoot(targetRoot);
+            if (!Directory.Exists(managedSkillsRoot))
+            {
+                return;
+            }
+
+            if (Directory.EnumerateFileSystemEntries(managedSkillsRoot).Any())
+            {
+                return;
+            }
+
+            Directory.Delete(managedSkillsRoot);
         }
     }
 }

--- a/Packages/src/Editor/UI/CliInstallRefreshPolicy.cs
+++ b/Packages/src/Editor/UI/CliInstallRefreshPolicy.cs
@@ -1,0 +1,10 @@
+namespace io.github.hatayama.uLoopMCP
+{
+    internal static class CliInstallRefreshPolicy
+    {
+        internal static bool ShouldRefreshSkillsAfterCliInstall(bool wasCliInstalledBeforeInstall)
+        {
+            return !wasCliInstalledBeforeInstall;
+        }
+    }
+}

--- a/Packages/src/Editor/UI/CliInstallRefreshPolicy.cs.meta
+++ b/Packages/src/Editor/UI/CliInstallRefreshPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e244a03db91a449e0b0b0aed8f1a7abd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -682,6 +682,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private async void HandleInstallCli()
         {
+            bool wasCliInstalledBeforeInstall = CliInstallationDetector.IsCliInstalled();
             string npmPath = NodeEnvironmentResolver.FindNpmPath();
             if (string.IsNullOrEmpty(npmPath))
             {
@@ -742,7 +743,9 @@ namespace io.github.hatayama.uLoopMCP
             finally
             {
                 _isInstallingCli = false;
-                RefreshAllSections(refreshSkillInstallState: true);
+                RefreshAllSections(
+                    refreshSkillInstallState:
+                    CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(wasCliInstalledBeforeInstall));
             }
         }
 

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -371,7 +371,7 @@ namespace io.github.hatayama.uLoopMCP
         private void ScheduleInitialRefresh()
         {
             _initialRefreshScheduledItem?.Pause();
-            _initialRefreshScheduledItem = rootVisualElement.schedule.Execute(RefreshUI).StartingIn(0);
+            _initialRefreshScheduledItem = rootVisualElement.schedule.Execute(() => RefreshUI()).StartingIn(0);
         }
 
         private void RefreshSkillsSection()
@@ -386,10 +386,29 @@ namespace io.github.hatayama.uLoopMCP
             ScheduleResizeToContent();
         }
 
-        private async void RefreshUI()
+        private async void RefreshUI(bool refreshSkillsSection = true)
         {
             CancelSkillInstallStateRefresh();
-            ApplyInitialCheckingState();
+            RefreshAutoShowToggle();
+            ViewDataBinder.SetVisible(_nodejsWarning, false);
+            ViewDataBinder.SetVisible(_nodejsOk, false);
+            ViewDataBinder.ToggleClass(_cliStatusIcon, "setup-status-icon--success", false);
+            ViewDataBinder.ToggleClass(_cliStatusIcon, "setup-status-icon--pending", true);
+            _cliStatusLabel.text = "Checking...";
+            _installCliButton.SetEnabled(false);
+            _installCliButton.text = "Checking...";
+            if (refreshSkillsSection)
+            {
+                ViewDataBinder.SetVisible(_groupSkillsRow, false);
+                _groupSkillsToggle.SetEnabled(false);
+                UpdateSkillsStatusLabel("Checking installed skills...");
+                _installSkillsButton.SetEnabled(false);
+                _installSkillsButton.text = "Checking...";
+                ViewDataBinder.SetVisible(_skillsTargetRow, _shouldUseFirstInstallSkillsUi);
+                ViewDataBinder.SetVisible(_skillsTargetList, !_shouldUseFirstInstallSkillsUi);
+                _skillsTargetList.Clear();
+            }
+
             await Task.Yield();
 
             RuntimePlatform platform = Application.platform;
@@ -419,6 +438,12 @@ namespace io.github.hatayama.uLoopMCP
             bool cliVersionMatched = IsCliVersionMatched(cliVersion);
 
             UpdateCliStep(cliInstalled, cliVersion, cliVersionMatched);
+
+            if (!refreshSkillsSection)
+            {
+                ScheduleResizeToContent();
+                return;
+            }
 
             string projectRoot = UnityMcpPathResolver.GetProjectRoot();
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
@@ -773,6 +798,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private async void HandleInstallCli()
         {
+            bool wasCliInstalledBeforeInstall = CliInstallationDetector.IsCliInstalled();
             string npmPath = NodeEnvironmentResolver.FindNpmPath();
             if (string.IsNullOrEmpty(npmPath))
             {
@@ -818,7 +844,8 @@ namespace io.github.hatayama.uLoopMCP
             finally
             {
                 _isInstallingCli = false;
-                RefreshUI();
+                RefreshUI(CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(
+                    wasCliInstalledBeforeInstall));
             }
         }
 


### PR DESCRIPTION
## Summary
- Setup and Settings now remove the empty grouped parent folder after migrating skills to the flat layout.
- Updating an existing uloop CLI installation no longer restarts the skills status check in Settings or the Setup Wizard.

## User Impact
- Before this change, migrating from grouped skill folders to the flat layout could leave an empty `skills/unity-cli-loop` parent folder behind.
- Before this change, clicking `Update CLI` could make the skills section go back to `Checking...` even though the user had not asked to refresh skill installation state.
- After this change, grouped-to-flat migrations fully clean up the old container folder, and CLI updates leave the current skills status alone.

## Changes
- Remove the empty managed skills parent directory when the last grouped skill folder is deleted during flat-layout installs.
- Add a regression test that covers grouped-to-flat migration cleanup.
- Add a small refresh policy so first-time CLI installs can still refresh skills, while CLI updates skip the extra skill-state refresh in both Settings and the Setup Wizard.
- Add tests for the CLI install refresh policy and keep the existing Setup Wizard tests green.

## Verification
- `uloop compile`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "ToolSkillSynchronizerTests"`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "CliInstallRefreshPolicyTests|SetupWizardWindowTests"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes two issues with the uloop CLI and skill management:
1. **Grouped-to-flat migration cleanup**: Empty parent directories are now properly removed after migrating grouped skills to the flat layout
2. **CLI update refresh behavior**: The skills status check no longer restarts unexpectedly when updating an existing CLI installation

## Changes

### Core Logic Changes

**Skill Directory Cleanup** (`ToolSkillSynchronizer.cs`)
- Added `DeleteEmptyManagedSkillsParentDirectoryIfNeeded()` helper method
- When deleting a skill directory with grouped layout enabled, the managed skills parent directory (`SkillsDirName/ManagedSkillsDirName`) is removed if empty
- Prevents orphaned legacy container folders (e.g., `skills/unity-cli-loop`)

**CLI Install Refresh Policy** (`CliInstallRefreshPolicy.cs`)
- New internal static class with single method: `ShouldRefreshSkillsAfterCliInstall(bool wasCliInstalledBeforeInstall)`
- Returns `true` for first-time installs (when CLI was not previously installed)
- Returns `false` for updates to existing installations
- Policy prevents unnecessary skill state refreshes during CLI updates

### Integration Points

**McpEditorWindow.cs**
- Snapshots CLI installation state before starting installation via `CliInstallationDetector.IsCliInstalled()`
- Uses `CliInstallRefreshPolicy` to conditionally refresh skill state in the post-install handler
- Maintains existing control flow and `_isInstallingCli` toggling

**SetupWizardWindow.cs**
- Modified `RefreshUI()` to accept optional `refreshSkillsSection` parameter (default: `true`)
- Enhanced initialization to use lambda wrapper for scheduled refresh: `Execute(() => RefreshUI())`
- After CLI update step completes, calls `RefreshUI(false)` to skip skills refresh and only resize the window
- Calls `RefreshUI(refreshSkillInstallState)` using the policy result after CLI installation completes
- Explicit UI reset includes Node.js status elements and conditional skills section updates

### Test Coverage

**CliInstallRefreshPolicyTests.cs** (New)
- Test: `ShouldRefreshSkillsAfterCliInstall_WhenCliWasNotInstalled_ReturnsTrue()` - Verifies first-time install returns `true`
- Test: `ShouldRefreshSkillsAfterCliInstall_WhenCliWasAlreadyInstalled_ReturnsFalse()` - Verifies CLI update returns `false`

**ToolSkillSynchronizerTests.cs** (New test added)
- Test: `InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_RemovesEmptyManagedSkillsParentDirectory()`
  - Verifies empty managed skills parent directory is deleted during grouped-to-flat migration
  - Confirms skill files are properly installed in flat layout
  - Regression test for cleanup logic

## Architecture

```
CliInstallRefreshPolicy
├── ShouldRefreshSkillsAfterCliInstall(wasCliInstalledBeforeInstall: bool)
│   └── Returns bool: refresh only if first-time install

McpEditorWindow
├── HandleInstallCli()
│   ├── Snapshot: wasCliInstalledBeforeInstall
│   └── Use CliInstallRefreshPolicy for refresh decision

SetupWizardWindow
├── RefreshUI(refreshSkillsSection = true)
│   ├── Reset Node.js status UI
│   └── Conditionally reset skills section UI
└── HandleInstallCli()
    └── Use CliInstallRefreshPolicy for RefreshUI parameter

ToolSkillSynchronizer
├── DeleteSkillDirectoryIfExists()
│   └── Call DeleteEmptyManagedSkillsParentDirectoryIfNeeded()
└── DeleteEmptyManagedSkillsParentDirectoryIfNeeded()
    └── Remove empty managed skills parent if grouping enabled
```

## User Impact

**Before**: 
- Grouped-to-flat migrations left empty legacy folders behind
- Clicking "Update CLI" reset the skills section to "Checking..." unexpectedly

**After**:
- Grouped-to-flat migrations fully clean up legacy container folders
- CLI updates preserve the skills section state and avoid restarting status checks
- First-time CLI installations still perform full skills refresh as expected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->