### PR TITLE
fix: Setup now keeps third-party skills when switching folder layouts

### DIFF
--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -253,12 +253,13 @@ namespace io.github.hatayama.uLoopMCP
         public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_InstallsProjectLocalCustomSkills()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
-            CreateFakeProjectLocalSkill(
+            string projectLocalToolDir = CreateFakeProjectLocalSkill(
                 temporaryRoot,
                 "uloop-get-unitask-tracker",
-                "GetUniTaskTracker",
-                "reference.md",
-                "reference");
+                "GetUniTaskTracker");
+            File.WriteAllText(
+                Path.Combine(projectLocalToolDir, "GetUniTaskTrackerTool.cs"),
+                "internal sealed class GetUniTaskTrackerTool {}");
 
             string targetRoot = Path.Combine(temporaryRoot, ".claude");
             string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
@@ -290,7 +291,7 @@ namespace io.github.hatayama.uLoopMCP
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(File.Exists(Path.Combine(installedSkillDir, SkillInstallLayout.SkillFileName)), Is.True);
-            Assert.That(File.ReadAllText(Path.Combine(installedSkillDir, "reference.md")), Is.EqualTo("reference"));
+            Assert.That(File.Exists(Path.Combine(installedSkillDir, "GetUniTaskTrackerTool.cs")), Is.False);
             Assert.That(Directory.Exists(groupedSkillDir), Is.False);
         }
 
@@ -1110,12 +1111,10 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
-        private static void CreateFakeProjectLocalSkill(
+        private static string CreateFakeProjectLocalSkill(
             string projectRoot,
             string skillName,
-            string toolDirectoryName,
-            string additionalFileRelativePath,
-            string additionalFileContent)
+            string toolDirectoryName)
         {
             string skillDir = Path.Combine(
                 projectRoot,
@@ -1128,7 +1127,7 @@ namespace io.github.hatayama.uLoopMCP
             File.WriteAllText(
                 Path.Combine(skillDir, SkillInstallLayout.SkillFileName),
                 $"---\nname: {skillName}\n---\n");
-            File.WriteAllText(Path.Combine(skillDir, additionalFileRelativePath), additionalFileContent);
+            return skillDir;
         }
 
         private static void WriteManifestDependencies(string projectRoot, string dependenciesContent)

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -208,7 +208,7 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
-        public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_RemovesUnexpectedManagedSkillDirectories()
+        public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_RemovesDeprecatedManagedSkillDirectories()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
             CreateFakeSourceSkill(
@@ -225,7 +225,7 @@ namespace io.github.hatayama.uLoopMCP
                 SkillInstallLayout.ManagedSkillsDirName);
             Directory.CreateDirectory(skillsRoot);
             WriteSkillFile(Path.Combine(managedSkillsRoot, "uloop-fake-skill"));
-            WriteSkillFile(Path.Combine(managedSkillsRoot, "uloop-stale-skill"));
+            WriteSkillFile(Path.Combine(managedSkillsRoot, "uloop-capture-window"));
 
             ToolSkillSynchronizer.SkillTargetInfo target = new(
                 "Claude Code",
@@ -247,6 +247,98 @@ namespace io.github.hatayama.uLoopMCP
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(File.Exists(Path.Combine(installedSkillDir, SkillInstallLayout.SkillFileName)), Is.True);
             Assert.That(Directory.Exists(managedSkillsRoot), Is.False);
+        }
+
+        [Test]
+        public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_InstallsProjectLocalCustomSkills()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeProjectLocalSkill(
+                temporaryRoot,
+                "uloop-get-unitask-tracker",
+                "GetUniTaskTracker",
+                "reference.md",
+                "reference");
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
+            string managedSkillsRoot = Path.Combine(
+                skillsRoot,
+                SkillInstallLayout.ManagedSkillsDirName);
+            Directory.CreateDirectory(skillsRoot);
+            WriteSkillFile(Path.Combine(managedSkillsRoot, "uloop-get-unitask-tracker"));
+
+            ToolSkillSynchronizer.SkillTargetInfo target = new(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true);
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
+                    temporaryRoot,
+                    new[] { target },
+                    groupSkillsUnderUnityCliLoop: false);
+
+            string installedSkillDir = Path.Combine(
+                skillsRoot,
+                "uloop-get-unitask-tracker");
+            string groupedSkillDir = Path.Combine(
+                managedSkillsRoot,
+                "uloop-get-unitask-tracker");
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(File.Exists(Path.Combine(installedSkillDir, SkillInstallLayout.SkillFileName)), Is.True);
+            Assert.That(File.ReadAllText(Path.Combine(installedSkillDir, "reference.md")), Is.EqualTo("reference"));
+            Assert.That(Directory.Exists(groupedSkillDir), Is.False);
+        }
+
+        [Test]
+        public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_PreservesThirdPartyManagedSkillDirectories()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-fake-skill",
+                "FakeTool",
+                "reference.md",
+                "reference");
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
+            string managedSkillsRoot = Path.Combine(
+                skillsRoot,
+                SkillInstallLayout.ManagedSkillsDirName);
+            Directory.CreateDirectory(skillsRoot);
+            WriteSkillFile(Path.Combine(managedSkillsRoot, "uloop-fake-skill"));
+            WriteSkillFile(
+                Path.Combine(managedSkillsRoot, "acme-third-party"),
+                "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
+
+            ToolSkillSynchronizer.SkillTargetInfo target = new(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true);
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
+                    temporaryRoot,
+                    new[] { target },
+                    groupSkillsUnderUnityCliLoop: false);
+
+            string installedSkillDir = Path.Combine(
+                skillsRoot,
+                "uloop-fake-skill");
+            string thirdPartySkillDir = Path.Combine(
+                managedSkillsRoot,
+                "acme-third-party");
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(File.Exists(Path.Combine(installedSkillDir, SkillInstallLayout.SkillFileName)), Is.True);
+            Assert.That(Directory.Exists(thirdPartySkillDir), Is.True);
         }
 
         [Test]
@@ -400,6 +492,7 @@ namespace io.github.hatayama.uLoopMCP
         public void DetectTargets_WhenManagedSkillsDirectoryContainsSkills_ReportsInstalled()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
             foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(temporaryRoot, dir);
@@ -472,6 +565,7 @@ namespace io.github.hatayama.uLoopMCP
         public void DetectTargets_WhenFlatLayoutRequested_IgnoresGroupedInstalledSkills()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
             foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(temporaryRoot, dir);
@@ -519,6 +613,36 @@ namespace io.github.hatayama.uLoopMCP
             {
                 Assert.IsTrue(target.HasExistingSkills,
                     $"Target '{target.DirName}' should treat legacy third-party skills as installed");
+            }
+        }
+
+        [Test]
+        public void DetectTargets_WhenOnlyGroupedThirdPartySkillsExist_DoesNotReportInstalled()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            {
+                string targetRoot = Path.Combine(temporaryRoot, dir);
+                WriteSkillFile(
+                    Path.Combine(
+                        targetRoot,
+                        SkillInstallLayout.SkillsDirName,
+                        SkillInstallLayout.ManagedSkillsDirName,
+                        "acme-third-party"),
+                    "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
+            }
+
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+                    temporaryRoot,
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: true)
+                .ToArray();
+
+            Assert.AreEqual(ToolSkillSynchronizer.SkillTargetDirs.Length, detectedTargets.Length);
+            foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
+            {
+                Assert.IsFalse(target.HasExistingSkills,
+                    $"Target '{target.DirName}' should ignore grouped third-party skills outside uLoop management");
             }
         }
 
@@ -592,6 +716,7 @@ namespace io.github.hatayama.uLoopMCP
         public void AreSkillsInstalled_ReturnsTrueForManagedLegacyAndNamespacedSkillsOnly()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
 
             string manualTargetRoot = Path.Combine(temporaryRoot, ".claude");
             WriteSkillFile(
@@ -621,6 +746,7 @@ namespace io.github.hatayama.uLoopMCP
         public void AreSkillsInstalled_WhenLayoutSpecified_MatchesOnlySelectedLayout()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
 
             string flatTargetRoot = Path.Combine(temporaryRoot, ".claude");
             WriteSkillFile(Path.Combine(flatTargetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
@@ -804,7 +930,7 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
-        public void DetectTargets_WhenUnexpectedManagedSkillDirectoryExists_ReportsOutdated()
+        public void DetectTargets_WhenDeprecatedManagedSkillDirectoryExists_DoesNotReportOutdated()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
             CreateFakeSourceSkill(
@@ -823,12 +949,12 @@ namespace io.github.hatayama.uLoopMCP
             WriteSkillFile(installedSkillDir, "---\nname: uloop-public-skill\n---\n");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
 
-            string staleSkillDir = Path.Combine(
+            string deprecatedSkillDir = Path.Combine(
                 targetRoot,
                 SkillInstallLayout.SkillsDirName,
                 SkillInstallLayout.ManagedSkillsDirName,
-                "uloop-stale-skill");
-            WriteSkillFile(staleSkillDir, "---\nname: uloop-stale-skill\n---\n");
+                "uloop-capture-window");
+            WriteSkillFile(deprecatedSkillDir, "---\nname: uloop-capture-window\n---\n");
 
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
@@ -837,11 +963,11 @@ namespace io.github.hatayama.uLoopMCP
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
-            Assert.That(detectedTargets[0].InstallState, Is.EqualTo(SkillInstallState.Outdated));
+            Assert.That(detectedTargets[0].InstallState, Is.EqualTo(SkillInstallState.Installed));
         }
 
         [Test]
-        public async Task InstallSkillFilesAtProjectRoot_WhenUnexpectedManagedSkillDirectoryExists_RemovesIt()
+        public async Task InstallSkillFilesAtProjectRoot_WhenDeprecatedManagedSkillDirectoryExists_RemovesIt()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
             CreateFakeSourceSkill(
@@ -854,12 +980,12 @@ namespace io.github.hatayama.uLoopMCP
             string targetRoot = Path.Combine(temporaryRoot, ".claude");
             Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName));
 
-            string staleSkillDir = Path.Combine(
+            string deprecatedSkillDir = Path.Combine(
                 targetRoot,
                 SkillInstallLayout.SkillsDirName,
                 SkillInstallLayout.ManagedSkillsDirName,
-                "uloop-stale-skill");
-            WriteSkillFile(staleSkillDir, "---\nname: uloop-stale-skill\n---\n");
+                "uloop-capture-window");
+            WriteSkillFile(deprecatedSkillDir, "---\nname: uloop-capture-window\n---\n");
 
             ToolSkillSynchronizer.SkillTargetInfo target = new(
                 "Claude Code",
@@ -882,7 +1008,7 @@ namespace io.github.hatayama.uLoopMCP
                 "uloop-public-skill");
 
             Assert.That(result.IsSuccessful, Is.True);
-            Assert.That(Directory.Exists(staleSkillDir), Is.False);
+            Assert.That(Directory.Exists(deprecatedSkillDir), Is.False);
             Assert.That(File.Exists(Path.Combine(installedSkillDir, SkillInstallLayout.SkillFileName)), Is.True);
             Assert.That(File.ReadAllText(Path.Combine(installedSkillDir, "reference.md")), Is.EqualTo("reference"));
         }
@@ -982,6 +1108,27 @@ namespace io.github.hatayama.uLoopMCP
             {
                 File.WriteAllText(Path.Combine(skillDir, sourceMetaFileRelativePath), "meta");
             }
+        }
+
+        private static void CreateFakeProjectLocalSkill(
+            string projectRoot,
+            string skillName,
+            string toolDirectoryName,
+            string additionalFileRelativePath,
+            string additionalFileContent)
+        {
+            string skillDir = Path.Combine(
+                projectRoot,
+                "Assets",
+                "Vision",
+                "Editor",
+                "McpExtensions",
+                toolDirectoryName);
+            Directory.CreateDirectory(skillDir);
+            File.WriteAllText(
+                Path.Combine(skillDir, SkillInstallLayout.SkillFileName),
+                $"---\nname: {skillName}\n---\n");
+            File.WriteAllText(Path.Combine(skillDir, additionalFileRelativePath), additionalFileContent);
         }
 
         private static void WriteManifestDependencies(string projectRoot, string dependenciesContent)

--- a/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
+++ b/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
@@ -9,6 +9,7 @@ import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 
 import {
+  getAllSkillStatuses,
   getPreferredSkillDir,
   getInstallDir,
   getManagedSkillsDir,
@@ -173,8 +174,10 @@ name: minimal-skill
 
 describe('skill install layout', () => {
   const temporaryRoots: string[] = [];
+  const originalCwd = process.cwd();
 
   afterEach(() => {
+    process.chdir(originalCwd);
     while (temporaryRoots.length > 0) {
       const temporaryRoot = temporaryRoots.pop();
       if (temporaryRoot) {
@@ -195,6 +198,18 @@ describe('skill install layout', () => {
   function writeSkill(skillDir: string, content: string = '---\nname: test-skill\n---\n'): void {
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(join(skillDir, 'SKILL.md'), content, 'utf-8');
+  }
+
+  function createUnityProjectRoot(): string {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'uloop-skill-project-'));
+    temporaryRoots.push(projectRoot);
+
+    mkdirSync(join(projectRoot, 'Assets'), { recursive: true });
+    mkdirSync(join(projectRoot, 'ProjectSettings'), { recursive: true });
+    mkdirSync(join(projectRoot, 'UserSettings'), { recursive: true });
+    writeFileSync(join(projectRoot, 'UserSettings', 'UnityMcpSettings.json'), '{}', 'utf-8');
+
+    return projectRoot;
   }
 
   it('should resolve managed skills under the unity-cli-loop namespace', () => {
@@ -276,6 +291,68 @@ describe('skill install layout', () => {
     expect(searchRoots).not.toContain(
       join(projectRoot, 'Library', 'PackageCache', 'com.example.unused@1.0.0'),
     );
+  });
+
+  it('should discover project skills from a direct SKILL.md in the tool folder', () => {
+    const projectRoot = createUnityProjectRoot();
+    const toolDir = join(projectRoot, 'Assets', 'Vision', 'Editor', 'McpExtensions', 'ReplayTool');
+    mkdirSync(toolDir, { recursive: true });
+    writeFileSync(
+      join(toolDir, 'SKILL.md'),
+      [
+        '---',
+        'name: uloop-replay-tool',
+        'description: Replay tool',
+        '---',
+        '',
+        '# Replay Tool',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    process.chdir(projectRoot);
+
+    const skills = getAllSkillStatuses(getTargetConfig('claude'), false, true);
+
+    expect(
+      skills.find((skill) => skill.name === 'uloop-replay-tool' && skill.source === 'project'),
+    ).toBeDefined();
+  });
+
+  it('should ignore sibling implementation files beside a direct SKILL.md in the tool folder', () => {
+    const projectRoot = createUnityProjectRoot();
+    const toolDir = join(projectRoot, 'Assets', 'Vision', 'Editor', 'McpExtensions', 'CaptureTool');
+    mkdirSync(toolDir, { recursive: true });
+    const skillContent = [
+      '---',
+      'name: uloop-capture-tool',
+      'description: Capture tool',
+      '---',
+      '',
+      '# Capture Tool',
+      '',
+    ].join('\n');
+    writeFileSync(join(toolDir, 'SKILL.md'), skillContent, 'utf-8');
+    writeFileSync(
+      join(toolDir, 'CaptureTool.cs'),
+      'internal sealed class CaptureTool { }',
+      'utf-8',
+    );
+
+    process.chdir(projectRoot);
+
+    const skillsRoot = getInstallDir(getTargetConfig('claude'), false);
+    syncInstalledSkillDirectory(
+      join(skillsRoot, 'uloop-capture-tool'),
+      'SKILL.md',
+      skillContent,
+      undefined,
+    );
+
+    const result = getAllSkillStatuses(getTargetConfig('claude'), false, true);
+
+    expect(result.find((skill) => skill.name === 'uloop-capture-tool')?.status).toBe('installed');
   });
 
   it('should migrate only managed legacy skills into the unity-cli-loop namespace', () => {

--- a/Packages/src/Cli~/src/skills/skills-manager.ts
+++ b/Packages/src/Cli~/src/skills/skills-manager.ts
@@ -349,38 +349,39 @@ export function parseFrontmatter(content: string): Record<string, string | boole
   return Object.fromEntries(frontmatterMap);
 }
 
-const warnedLegacyPaths = new Set<string>();
+interface SkillSourcePath {
+  skillDirectory: string;
+  skillMdPath: string;
+  includeSiblingFiles: boolean;
+}
 
-function warnLegacySkillStructure(toolPath: string, legacySkillMdPath: string): void {
-  if (warnedLegacyPaths.has(legacySkillMdPath)) {
-    return;
+function resolveSkillSourcePath(toolPath: string): SkillSourcePath | null {
+  const nestedSkillDirectory = join(toolPath, SkillsPathConstants.SKILL_DIR);
+  const nestedSkillMdPath = join(nestedSkillDirectory, SkillsPathConstants.SKILL_FILE);
+  if (existsSync(nestedSkillMdPath)) {
+    return {
+      skillDirectory: nestedSkillDirectory,
+      skillMdPath: nestedSkillMdPath,
+      includeSiblingFiles: true,
+    };
   }
-  warnedLegacyPaths.add(legacySkillMdPath);
 
-  /* eslint-disable no-console -- CLI user-facing warning output */
-  console.error('\x1b[33m' + '='.repeat(70) + '\x1b[0m');
-  console.error('\x1b[33mWarning: Legacy skill structure detected\x1b[0m');
-  console.error(`  Path: ${legacySkillMdPath}`);
-  console.error('');
-  console.error('  The skill structure has changed. Please migrate to the new format:');
-  console.error('    1. Create a "Skill" folder in the tool directory');
-  console.error('    2. Move SKILL.md and any additional files/folders into Skill/');
-  console.error('');
-  console.error('  Expected structure:');
-  console.error('    ToolName/');
-  console.error('      └── Skill/');
-  console.error('            ├── SKILL.md');
-  console.error('            └── (any additional files or directories)');
-  console.error('\x1b[33m' + '='.repeat(70) + '\x1b[0m');
-  console.error('');
-  /* eslint-enable no-console */
+  const directSkillMdPath = join(toolPath, SkillsPathConstants.SKILL_FILE);
+  if (existsSync(directSkillMdPath)) {
+    return {
+      skillDirectory: toolPath,
+      skillMdPath: directSkillMdPath,
+      includeSiblingFiles: false,
+    };
+  }
+
+  return null;
 }
 
 function scanEditorFolderForSkills(
   editorPath: string,
   skills: SkillDefinition[],
   sourceType: SkillDefinition['sourceType'],
-  warnLegacy: boolean = true,
 ): void {
   if (!existsSync(editorPath)) {
     return;
@@ -396,15 +397,10 @@ function scanEditorFolderForSkills(
     const fullPath = join(editorPath, entry.name);
 
     if (entry.isDirectory()) {
-      const skillDir = join(fullPath, SkillsPathConstants.SKILL_DIR);
-      const skillMdPath = join(skillDir, SkillsPathConstants.SKILL_FILE);
-
-      const legacySkillMdPath = join(fullPath, SkillsPathConstants.SKILL_FILE);
-      if (warnLegacy && !existsSync(skillMdPath) && existsSync(legacySkillMdPath)) {
-        warnLegacySkillStructure(fullPath, legacySkillMdPath);
-      }
-
-      if (existsSync(skillMdPath)) {
+      const skillSource: SkillSourcePath | null = resolveSkillSourcePath(fullPath);
+      if (skillSource !== null) {
+        const skillDir = skillSource.skillDirectory;
+        const skillMdPath = skillSource.skillMdPath;
         const content = readFileSync(skillMdPath, 'utf-8');
         const frontmatter = parseFrontmatter(content);
 
@@ -419,7 +415,9 @@ function scanEditorFolderForSkills(
 
         const toolName =
           typeof frontmatter.toolName === 'string' ? frontmatter.toolName : undefined;
-        const additionalFiles = collectSkillFolderFiles(skillDir);
+        const additionalFiles = skillSource.includeSiblingFiles
+          ? collectSkillFolderFiles(skillDir)
+          : undefined;
 
         skills.push({
           name,
@@ -432,7 +430,7 @@ function scanEditorFolderForSkills(
         });
       }
 
-      scanEditorFolderForSkills(fullPath, skills, sourceType, warnLegacy);
+      scanEditorFolderForSkills(fullPath, skills, sourceType);
     }
   }
 }
@@ -898,7 +896,7 @@ function collectCliOnlySkills(): SkillDefinition[] {
     return [];
   }
   const skills: SkillDefinition[] = [];
-  scanEditorFolderForSkills(cliOnlyRoot, skills, 'cli-only', false);
+  scanEditorFolderForSkills(cliOnlyRoot, skills, 'cli-only');
   return skills;
 }
 

--- a/Packages/src/Editor/CLI/CliInstallationDetector.cs
+++ b/Packages/src/Editor/CLI/CliInstallationDetector.cs
@@ -73,7 +73,7 @@ namespace io.github.hatayama.uLoopMCP
             UnityEngine.Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
 
             string targetRoot = Path.Combine(projectRoot, targetDir);
-            return SkillInstallLayout.HasInstalledSkills(targetRoot);
+            return SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot);
         }
 
         internal static bool AreSkillsInstalled(
@@ -85,7 +85,7 @@ namespace io.github.hatayama.uLoopMCP
             UnityEngine.Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
 
             string targetRoot = Path.Combine(projectRoot, targetDir);
-            return SkillInstallLayout.HasInstalledSkills(targetRoot, groupSkillsUnderUnityCliLoop);
+            return SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
         }
 
         public static async Task ForceRefreshCliVersionAsync(CancellationToken ct)

--- a/Packages/src/Editor/Config/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Config/SkillInstallLayout.cs
@@ -283,7 +283,7 @@ namespace io.github.hatayama.uLoopMCP
             Dictionary<string, byte[]> sourceFiles,
             string installedSkillDirectory)
         {
-            Dictionary<string, byte[]> installedFiles = CollectSkillFiles(installedSkillDirectory);
+            Dictionary<string, byte[]> installedFiles = CollectInstalledSkillFiles(installedSkillDirectory);
             if (sourceFiles.Count != installedFiles.Count)
             {
                 return true;
@@ -305,7 +305,7 @@ namespace io.github.hatayama.uLoopMCP
             return false;
         }
 
-        private static Dictionary<string, byte[]> CollectSkillFiles(string skillDirectory)
+        private static Dictionary<string, byte[]> CollectInstalledSkillFiles(string skillDirectory)
         {
             Dictionary<string, byte[]> files = new(StringComparer.Ordinal);
             foreach (string filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories))
@@ -321,6 +321,24 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             return files;
+        }
+
+        private static Dictionary<string, byte[]> CollectSourceSkillFiles(
+            string skillDirectory,
+            string skillFilePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(skillDirectory), "skillDirectory must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(skillFilePath), "skillFilePath must not be null or empty");
+
+            if (string.Equals(Path.GetFileName(skillDirectory), "Skill", StringComparison.Ordinal))
+            {
+                return CollectInstalledSkillFiles(skillDirectory);
+            }
+
+            return new Dictionary<string, byte[]>(StringComparer.Ordinal)
+            {
+                [SkillFileName] = File.ReadAllBytes(skillFilePath)
+            };
         }
 
         private static Dictionary<string, SkillSourceDefinition> GetSkillSources(string projectRoot)
@@ -363,7 +381,7 @@ namespace io.github.hatayama.uLoopMCP
                         skillName,
                         ParseToolNameFromFrontmatter(skillContent),
                         skillDirectory,
-                        CollectSkillFiles(skillDirectory));
+                        CollectSourceSkillFiles(skillDirectory, skillFilePath));
                 }
             }
 

--- a/Packages/src/Editor/Config/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Config/SkillInstallLayout.cs
@@ -90,15 +90,46 @@ namespace io.github.hatayama.uLoopMCP
 
         internal static bool HasInstalledSkills(string targetRoot)
         {
-            return EnumerateInstalledSkillDirectories(targetRoot).Any();
+            string projectRoot = UnityMcpPathResolver.GetProjectRoot();
+            return HasInstalledSkills(projectRoot, targetRoot);
         }
 
         internal static bool HasInstalledSkills(string targetRoot, bool groupSkillsUnderUnityCliLoop)
         {
-            IEnumerable<string> skillDirs = groupSkillsUnderUnityCliLoop
-                ? EnumerateManagedSkillDirectories(targetRoot)
-                : EnumerateLegacyManagedSkillDirectories(targetRoot);
-            return skillDirs.Any();
+            string projectRoot = UnityMcpPathResolver.GetProjectRoot();
+            return HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
+        }
+
+        internal static bool HasInstalledSkills(string projectRoot, string targetRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(targetRoot), "targetRoot must not be null or empty");
+
+            return HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop: false)
+                || HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop: true);
+        }
+
+        internal static bool HasInstalledSkills(
+            string projectRoot,
+            string targetRoot,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(targetRoot), "targetRoot must not be null or empty");
+
+            if (!groupSkillsUnderUnityCliLoop && EnumerateLegacyManagedSkillDirectories(targetRoot).Any())
+            {
+                return true;
+            }
+
+            Dictionary<string, SkillSourceDefinition> expectedSkills = GetSkillSources(projectRoot);
+            if (expectedSkills.Count == 0)
+            {
+                return false;
+            }
+
+            return expectedSkills.Keys.Any(skillName =>
+                Directory.Exists(GetInstalledSkillDirectoryPath(targetRoot, skillName, groupSkillsUnderUnityCliLoop)));
         }
 
         internal static SkillInstallState GetInstalledState(
@@ -107,7 +138,7 @@ namespace io.github.hatayama.uLoopMCP
             bool groupSkillsUnderUnityCliLoop)
         {
             Dictionary<string, SkillSourceDefinition> expectedSkills = GetSkillSources(projectRoot);
-            bool hasLayoutSkills = HasInstalledSkills(targetRoot, groupSkillsUnderUnityCliLoop);
+            bool hasLayoutSkills = HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
             if (expectedSkills.Count == 0)
             {
                 return hasLayoutSkills ? SkillInstallState.Installed : SkillInstallState.Missing;
@@ -133,14 +164,6 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     return SkillInstallState.Outdated;
                 }
-            }
-
-            if (HasUnexpectedInstalledSkillDirectories(
-                targetRoot,
-                expectedSkills.Keys,
-                groupSkillsUnderUnityCliLoop))
-            {
-                return SkillInstallState.Outdated;
             }
 
             if (!hasInstalledExpectedSkill)
@@ -256,33 +279,6 @@ namespace io.github.hatayama.uLoopMCP
             return Path.Combine(skillsRoot, skillName);
         }
 
-        private static bool HasUnexpectedInstalledSkillDirectories(
-            string targetRoot,
-            IEnumerable<string> expectedSkillNames,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            HashSet<string> expectedSkillNameSet = new(expectedSkillNames, StringComparer.Ordinal);
-            IEnumerable<string> installedSkillDirectories = groupSkillsUnderUnityCliLoop
-                ? EnumerateManagedSkillDirectories(targetRoot)
-                : EnumerateLegacyManagedSkillDirectories(targetRoot);
-
-            foreach (string installedSkillDirectory in installedSkillDirectories)
-            {
-                string installedSkillName = Path.GetFileName(installedSkillDirectory);
-                if (string.IsNullOrEmpty(installedSkillName))
-                {
-                    continue;
-                }
-
-                if (!expectedSkillNameSet.Contains(installedSkillName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         private static bool IsSkillDirectoryOutdated(
             Dictionary<string, byte[]> sourceFiles,
             string installedSkillDirectory)
@@ -344,7 +340,7 @@ namespace io.github.hatayama.uLoopMCP
                 foreach (string skillFilePath in skillFilePaths)
                 {
                     string skillDirectory = Path.GetDirectoryName(skillFilePath);
-                    if (skillDirectory == null || Path.GetFileName(skillDirectory) != "Skill")
+                    if (skillDirectory == null)
                     {
                         continue;
                     }

--- a/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
@@ -271,7 +271,8 @@ namespace io.github.hatayama.uLoopMCP
                     continue;
                 }
 
-                bool hasULoopSkills = hasSkillsDirectory && SkillInstallLayout.HasInstalledSkills(targetRoot);
+                bool hasULoopSkills = hasSkillsDirectory
+                    && SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot);
                 targets.Add(new SkillTargetInfo(
                     target.DisplayName,
                     target.DirName,
@@ -332,7 +333,7 @@ namespace io.github.hatayama.uLoopMCP
                     || installState == SkillInstallState.Checking
                     || installState == SkillInstallState.Outdated;
                 bool hasDifferentLayoutSkills = hasSkillsDirectory
-                    && SkillInstallLayout.HasInstalledSkills(targetRoot, !groupSkillsUnderUnityCliLoop);
+                    && SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, !groupSkillsUnderUnityCliLoop);
                 targets.Add(new SkillTargetInfo(
                     target.DisplayName,
                     target.DirName,
@@ -360,7 +361,7 @@ namespace io.github.hatayama.uLoopMCP
 
             if (!includeFreshnessCheck)
             {
-                return SkillInstallLayout.HasInstalledSkills(targetRoot, groupSkillsUnderUnityCliLoop)
+                return SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop)
                     ? SkillInstallState.Checking
                     : SkillInstallState.Missing;
             }
@@ -443,6 +444,11 @@ namespace io.github.hatayama.uLoopMCP
         {
             string targetRoot = Path.Combine(projectRoot, target.DirName);
             string skillsRoot = SkillInstallLayout.GetSkillsRoot(targetRoot);
+            HashSet<string> managedSkillNames = new(
+                enabledSkills.Select(skill => skill.Name),
+                StringComparer.Ordinal);
+            managedSkillNames.UnionWith(disabledSkills.Select(skill => skill.Name));
+            managedSkillNames.UnionWith(DeprecatedSkillNames);
             Directory.CreateDirectory(skillsRoot);
 
             if (groupSkillsUnderUnityCliLoop)
@@ -475,6 +481,7 @@ namespace io.github.hatayama.uLoopMCP
             DeleteUnexpectedInstalledSkillDirectories(
                 targetRoot,
                 enabledSkills.Select(skill => skill.Name),
+                managedSkillNames,
                 groupSkillsUnderUnityCliLoop);
 
             if (!groupSkillsUnderUnityCliLoop)
@@ -482,6 +489,7 @@ namespace io.github.hatayama.uLoopMCP
                 DeleteUnexpectedInstalledSkillDirectories(
                     targetRoot,
                     enabledSkills.Select(skill => skill.Name),
+                    managedSkillNames,
                     groupSkillsUnderUnityCliLoop: true);
                 DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
                     targetRoot,
@@ -515,14 +523,21 @@ namespace io.github.hatayama.uLoopMCP
         private static void DeleteUnexpectedInstalledSkillDirectories(
             string targetRoot,
             IEnumerable<string> expectedSkillNames,
+            IEnumerable<string> removableSkillNames,
             bool groupSkillsUnderUnityCliLoop)
         {
             HashSet<string> expectedSkillNameSet = new(expectedSkillNames, StringComparer.Ordinal);
+            HashSet<string> removableSkillNameSet = new(removableSkillNames, StringComparer.Ordinal);
             foreach (string installedSkillName in SkillInstallLayout.EnumerateInstalledSkillDirectoryNamesForLayout(
                          targetRoot,
                          groupSkillsUnderUnityCliLoop))
             {
                 if (expectedSkillNameSet.Contains(installedSkillName))
+                {
+                    continue;
+                }
+
+                if (!removableSkillNameSet.Contains(installedSkillName))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Setup now preserves third-party skills when migrating from grouped folders to the flat skills layout.
- Only uLoop-managed grouped skills are cleaned up during the migration.

## User Impact
- Before this change, switching older grouped skill folders to the flat layout could delete third-party skills stored under the grouped skills folder.
- After this change, Setup still cleans up stale uLoop-managed folders, but it leaves third-party skills in place.

## Changes
- Limit grouped-layout cleanup to uLoop-managed skill directories.
- Add regression tests for preserving grouped third-party skills and for not treating them as installed uLoop skills.

## Verification
- Ran uloop compile for the updated worktree.
- Ran the targeted regression tests for grouped third-party skill preservation.
- Ran the full ToolSkillSynchronizerTests EditMode suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes an issue where third-party skills under the grouped skill layout (e.g. skills/unity-cli-loop/) could be removed when migrating from the grouped (nested) layout to the flat skills layout. The migration and cleanup now only remove uLoop-managed skill directories; third-party directories are preserved.

## Root cause
Installed-skill detection and grouped-layout cleanup treated any directory under the grouped managed-skills root as uLoop-managed, and cleanup logic deleted unexpected directories during layout migration.

## Changes Made

- General strategy
  - Restrict cleanup of grouped-layout directories to only uLoop-managed (removable) skill directories, and update installed-skill detection to rely on expected skill sources rather than a blind enumeration of subdirectories.
  - Add regression tests verifying third-party grouped skills are preserved and are not counted as installed uLoop skills.

- Packages/src/Editor/Config/SkillInstallLayout.cs
  - Refactored HasInstalledSkills overloads to route through new overloads that accept projectRoot.
  - Changed installed-skill detection to check for expected installed directories derived from GetSkillSources(projectRoot) (using CollectSourceSkillFiles) and Directory.Exists for each expected skill path.
  - Removed the “unexpected installed directories → Outdated” path: HasUnexpectedInstalledSkillDirectories was deleted and GetInstalledState no longer returns Outdated for unexpected directories.
  - Reworked source/installed file collection helpers: introduced CollectSourceSkillFiles and renamed CollectInstalledSkillFiles; updated GetSkillSources to build precise expected file-sets and to correctly handle nested Skill/ vs direct SKILL.md layouts.

- Packages/src/Editor/Config/ToolSkillSynchronizer.cs
  - Updated calls to SkillInstallLayout.HasInstalledSkills to pass projectRoot and targetRoot.
  - InstallSkillsForTarget now computes a managedSkillNames (enabled, disabled, deprecated) set and passes it into directory cleanup to restrict deletions to removable (uLoop-managed/deprecated) names.
  - DeleteUnexpectedInstalledSkillDirectories now accepts removableSkillNames and skips deletions unless a directory is in that set.

- Packages/src/Editor/CLI/CliInstallationDetector.cs
  - Updated AreSkillsInstalled calls to pass projectRoot into SkillInstallLayout.HasInstalledSkills.

- Packages/src/Cli~/src/skills/skills-manager.ts
  - Replaced legacy-warning logic with resolveSkillSourcePath to detect nested vs direct SKILL.md formats and to control inclusion of sibling/additional files accordingly.
  - scanEditorFolderForSkills no longer emits legacy warnings per-scan; sibling/additional files are only included for nested Skill/ layout.

- Packages/src/Cli~/src/__tests__/skills-manager.test.ts
  - Added tests for discovering SKILL.md placed directly under tool folder paths and for marking skills as installed when a sibling implementation file exists.
  - Added helpers to create temporary Unity-like project roots and ensure test cwd restoration.

- Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
  - Updated existing tests to reflect removal of “stale” vs “deprecated” naming, adjust expectations, and remove reporting of deprecated as outdated.
  - Added regression tests:
    - Preserving third-party managed directories when migrating to flat layout (ensures acme-third-party remains while uloop-managed skill is installed).
    - DetectTargets_WhenOnlyGroupedThirdPartySkillsExist_DoesNotReportInstalled (grouped third-party directories do not cause targets to be reported as having existing uLoop skills).
  - Added helper to create a project-local skill and other coverage adjustments.

## Verification
- Ran uloop compile for the updated worktree.
- Ran targeted regression tests for grouped third-party skill preservation.
- Ran the full ToolSkillSynchronizerTests EditMode suite.

## Impact
- Switching older grouped skill folders to the flat layout no longer deletes third-party skills stored under the grouped managed-skills root.
- Setup still cleans up stale uLoop-managed folders (including deprecated names) but no longer removes third-party directories.
- Installed/Outdated detection is more precise and based on expected skill sources rather than enumerating arbitrary subdirectories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->