### PR TITLE
fix: Dynamic code execution stays fast with system .NET 6 installed

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
+{
+    [TestFixture]
+    public class SharedRoslynCompilerWorkerHostTests
+    {
+        [Test]
+        public void ConfigureWorkerDotnetRuntimeEnvironment_WhenCalled_ShouldDisableMultilevelLookup()
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.EnvironmentVariables[SharedRoslynCompilerWorkerHost.DotnetMultilevelLookupEnvironmentVariableName] = "1";
+
+            SharedRoslynCompilerWorkerHost.ConfigureWorkerDotnetRuntimeEnvironment(startInfo);
+
+            Assert.That(
+                startInfo.EnvironmentVariables[SharedRoslynCompilerWorkerHost.DotnetMultilevelLookupEnvironmentVariableName],
+                Is.EqualTo(SharedRoslynCompilerWorkerHost.DotnetMultilevelLookupDisabledValue));
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8b49813482e2c4488d3be1f909b241e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Compilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/Compilation/SharedRoslynCompilerWorkerHost.cs
@@ -549,6 +549,7 @@ namespace io.github.hatayama.uLoopMCP
                 RedirectStandardError = true,
                 CreateNoWindow = true
             };
+            ConfigureWorkerDotnetRuntimeEnvironment(startInfo);
 
             using Process process = ProcessStartHelper.TryStart(startInfo);
             if (process == null)

--- a/Packages/src/Editor/Compilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/Compilation/SharedRoslynCompilerWorkerHost.cs
@@ -21,6 +21,8 @@ namespace io.github.hatayama.uLoopMCP
         private const string RoslynWorkerCompileResponseFileName = "RoslynCompilerWorker.rsp";
         private const int SharedCompilerWorkerResponseTimeoutMilliseconds = 30000;
         private const int WorkerAssemblyBuildTimeoutMilliseconds = 30000;
+        internal const string DotnetMultilevelLookupEnvironmentVariableName = "DOTNET_MULTILEVEL_LOOKUP";
+        internal const string DotnetMultilevelLookupDisabledValue = "0";
 
         private static readonly object SharedCompilerWorkerLock = new();
         private static Action<string> s_deleteWorkerDirectory = path => Directory.Delete(path, true);
@@ -486,7 +488,7 @@ namespace io.github.hatayama.uLoopMCP
             ExternalCompilerPaths externalCompilerPaths,
             WorkerPaths workerPaths)
         {
-            return new ProcessStartInfo
+            ProcessStartInfo startInfo = new ProcessStartInfo
             {
                 FileName = externalCompilerPaths.DotnetHostPath,
                 Arguments = "exec"
@@ -500,6 +502,19 @@ namespace io.github.hatayama.uLoopMCP
                 RedirectStandardError = false,
                 CreateNoWindow = true
             };
+
+            ConfigureWorkerDotnetRuntimeEnvironment(startInfo);
+            return startInfo;
+        }
+
+        internal static void ConfigureWorkerDotnetRuntimeEnvironment(ProcessStartInfo startInfo)
+        {
+            Debug.Assert(startInfo != null, "startInfo must not be null");
+
+            // Why: global probing can select a system .NET 6 runtime while Unity 6000.4 worker
+            // references come from the bundled .NET 8 runtime, which breaks assembly binding.
+            startInfo.EnvironmentVariables[DotnetMultilevelLookupEnvironmentVariableName] =
+                DotnetMultilevelLookupDisabledValue;
         }
 
         private static WorkerAssemblyBuildResult CompileWorkerAssembly(


### PR DESCRIPTION
## Summary
- Prevent the shared Roslyn worker from probing system-wide .NET runtimes when Unity launches it.
- Keep the worker runtime aligned with the Unity bundled runtime so .NET 8 references are not executed on system .NET 6.
- Add an EditMode regression test for the worker runtime environment setting.

## Reproduction
- Confirmed on `main` with Unity `6000.4.3f1` and system `Microsoft.NETCore.App 6.0.36` installed.
- The shared worker logs `execute-dynamic-code shared Roslyn worker failed to operate correctly` and falls back to one-shot compiler execution.

## Verification
- `uloop compile --force-recompile false --wait-for-domain-reload true` completed with 0 errors and 0 warnings.
- `SharedRoslynCompilerWorkerHostTests.ConfigureWorkerDotnetRuntimeEnvironment_WhenCalled_ShouldDisableMultilevelLookup` passed.
- On this PR branch with Unity `6000.4.3f1` and system `.NET 6.0.36`, `execute-dynamic-code` returned `6000.4.3f1` successfully.
- `uloop get-logs --search-text "shared Roslyn worker" --max-count 50 --include-stack-trace true` returned `TotalCount: 0`.
- `uloop get-logs --log-type Error --max-count 50 --include-stack-trace false` returned `TotalCount: 0`.

Fixes #985