### PR TITLE
fix: Settings opens faster and tool toggles stay scoped

### DIFF
--- a/Assets/Tests/Editor/McpEditorWindowRefreshPolicyTests.cs
+++ b/Assets/Tests/Editor/McpEditorWindowRefreshPolicyTests.cs
@@ -25,5 +25,34 @@ namespace io.github.hatayama.uLoopMCP
 
             Assert.That(shouldRefresh, Is.False);
         }
+
+        [Test]
+        public void ShouldRunExpensiveChecks_WhenInitialPaint_ReturnsFalse()
+        {
+            bool shouldRun = McpEditorWindowRefreshPolicy.ShouldRunExpensiveChecks(
+                McpEditorWindowRefreshMode.InitialPaint);
+
+            Assert.That(shouldRun, Is.False);
+        }
+
+        [Test]
+        public void ShouldRefreshSkillInstallState_WhenInitialPaintEvenIfRequested_ReturnsFalse()
+        {
+            bool shouldRefresh = McpEditorWindowRefreshPolicy.ShouldRefreshSkillInstallState(
+                McpEditorWindowRefreshMode.InitialPaint,
+                refreshRequested: true);
+
+            Assert.That(shouldRefresh, Is.False);
+        }
+
+        [Test]
+        public void ShouldRefreshSkillInstallState_WhenFullRefreshRequested_ReturnsTrue()
+        {
+            bool shouldRefresh = McpEditorWindowRefreshPolicy.ShouldRefreshSkillInstallState(
+                McpEditorWindowRefreshMode.Full,
+                refreshRequested: true);
+
+            Assert.That(shouldRefresh, Is.True);
+        }
     }
 }

--- a/Assets/Tests/Editor/McpEditorWindowRefreshPolicyTests.cs
+++ b/Assets/Tests/Editor/McpEditorWindowRefreshPolicyTests.cs
@@ -54,5 +54,54 @@ namespace io.github.hatayama.uLoopMCP
 
             Assert.That(shouldRefresh, Is.True);
         }
+
+        [Test]
+        public void ShouldKeepToolSettingsCatalogDirty_WhenOpenRegistryUnavailable_ReturnsTrue()
+        {
+            ToolSettingsSectionData toolSettingsData = CreateToolSettingsData(
+                showToolSettings: true,
+                isRegistryAvailable: false);
+
+            bool shouldKeepDirty = McpEditorWindowRefreshPolicy.ShouldKeepToolSettingsCatalogDirty(toolSettingsData);
+
+            Assert.That(shouldKeepDirty, Is.True);
+        }
+
+        [Test]
+        public void ShouldKeepToolSettingsCatalogDirty_WhenOpenRegistryAvailable_ReturnsFalse()
+        {
+            ToolSettingsSectionData toolSettingsData = CreateToolSettingsData(
+                showToolSettings: true,
+                isRegistryAvailable: true);
+
+            bool shouldKeepDirty = McpEditorWindowRefreshPolicy.ShouldKeepToolSettingsCatalogDirty(toolSettingsData);
+
+            Assert.That(shouldKeepDirty, Is.False);
+        }
+
+        [Test]
+        public void ShouldKeepToolSettingsCatalogDirty_WhenClosedRegistryUnavailable_ReturnsFalse()
+        {
+            ToolSettingsSectionData toolSettingsData = CreateToolSettingsData(
+                showToolSettings: false,
+                isRegistryAvailable: false);
+
+            bool shouldKeepDirty = McpEditorWindowRefreshPolicy.ShouldKeepToolSettingsCatalogDirty(toolSettingsData);
+
+            Assert.That(shouldKeepDirty, Is.False);
+        }
+
+        private static ToolSettingsSectionData CreateToolSettingsData(
+            bool showToolSettings,
+            bool isRegistryAvailable)
+        {
+            return new ToolSettingsSectionData(
+                showToolSettings,
+                allowThirdPartyTools: false,
+                DynamicCodeSecurityLevel.Restricted,
+                System.Array.Empty<ToolToggleItem>(),
+                System.Array.Empty<ToolToggleItem>(),
+                isRegistryAvailable);
+        }
     }
 }

--- a/Assets/Tests/Editor/McpEditorWindowRefreshPolicyTests.cs
+++ b/Assets/Tests/Editor/McpEditorWindowRefreshPolicyTests.cs
@@ -91,6 +91,57 @@ namespace io.github.hatayama.uLoopMCP
             Assert.That(shouldKeepDirty, Is.False);
         }
 
+        [Test]
+        public void ShouldStartToolSettingsRegistryWarmup_WhenNotScheduledAndBelowMaxAttempts_ReturnsTrue()
+        {
+            bool shouldStart = McpEditorWindowRefreshPolicy.ShouldStartToolSettingsRegistryWarmup(
+                isAlreadyScheduled: false,
+                attemptCount: 4,
+                maxAttempts: 5);
+
+            Assert.That(shouldStart, Is.True);
+        }
+
+        [Test]
+        public void ShouldStartToolSettingsRegistryWarmup_WhenAlreadyScheduled_ReturnsFalse()
+        {
+            bool shouldStart = McpEditorWindowRefreshPolicy.ShouldStartToolSettingsRegistryWarmup(
+                isAlreadyScheduled: true,
+                attemptCount: 0,
+                maxAttempts: 5);
+
+            Assert.That(shouldStart, Is.False);
+        }
+
+        [Test]
+        public void ShouldStartToolSettingsRegistryWarmup_WhenMaxAttemptsReached_ReturnsFalse()
+        {
+            bool shouldStart = McpEditorWindowRefreshPolicy.ShouldStartToolSettingsRegistryWarmup(
+                isAlreadyScheduled: false,
+                attemptCount: 5,
+                maxAttempts: 5);
+
+            Assert.That(shouldStart, Is.False);
+        }
+
+        [TestCase(0, 0.05)]
+        [TestCase(1, 0.1)]
+        [TestCase(2, 0.2)]
+        [TestCase(3, 0.4)]
+        [TestCase(4, 0.8)]
+        [TestCase(5, 0.8)]
+        public void CalculateToolSettingsRegistryWarmupDelaySeconds_UsesExponentialBackoffWithCap(
+            int attemptCount,
+            double expectedDelaySeconds)
+        {
+            double delaySeconds = McpEditorWindowRefreshPolicy.CalculateToolSettingsRegistryWarmupDelaySeconds(
+                initialDelaySeconds: 0.05,
+                maxDelaySeconds: 0.8,
+                attemptCount);
+
+            Assert.That(delaySeconds, Is.EqualTo(expectedDelaySeconds).Within(0.0001));
+        }
+
         private static ToolSettingsSectionData CreateToolSettingsData(
             bool showToolSettings,
             bool isRegistryAvailable)

--- a/Assets/Tests/Editor/ToolSettingsSectionTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsSectionTests.cs
@@ -7,6 +7,8 @@ namespace io.github.hatayama.uLoopMCP
     [TestFixture]
     public class ToolSettingsSectionTests
     {
+        private const int ToolListRowHeight = 24;
+
         [Test]
         public void Update_ClosedWithoutToolListData_DoesNotCreateToolRows()
         {
@@ -66,6 +68,7 @@ namespace io.github.hatayama.uLoopMCP
             Assert.AreEqual(5, items.Count);
             Assert.AreEqual(DisplayStyle.Flex, listView.style.display.value);
             Assert.AreEqual(DisplayStyle.None, statusLabel.style.display.value);
+            Assert.AreEqual((5 * ToolListRowHeight) + 2, listView.style.height.value.value);
         }
 
         [Test]

--- a/Assets/Tests/Editor/ToolSettingsSectionTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsSectionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using NUnit.Framework;
 using UnityEngine.UIElements;
 
@@ -7,87 +8,113 @@ namespace io.github.hatayama.uLoopMCP
     public class ToolSettingsSectionTests
     {
         [Test]
-        public void Update_SameLayout_DoesNotReplaceToggleElements()
-        {
-            VisualElement root = CreateRootElement();
-            ToolSettingsSection section = new ToolSettingsSection(root);
-            ToolSettingsSectionData data = CreateData(compileEnabled: true, includeGetLogs: false);
-            VisualElement container = root.Q<VisualElement>("tool-list-container");
-
-            section.Update(data);
-            Toggle beforeToggle = FindToggleByToolName(container, "compile");
-
-            section.Update(data);
-            Toggle afterToggle = FindToggleByToolName(container, "compile");
-
-            Assert.IsNotNull(beforeToggle);
-            Assert.AreSame(beforeToggle, afterToggle);
-        }
-
-        [Test]
-        public void Update_SameLayout_UpdatesToggleStateWithoutRebuild()
-        {
-            VisualElement root = CreateRootElement();
-            ToolSettingsSection section = new ToolSettingsSection(root);
-            ToolSettingsSectionData enabledData = CreateData(compileEnabled: true, includeGetLogs: false);
-            ToolSettingsSectionData disabledData = CreateData(compileEnabled: false, includeGetLogs: false);
-            VisualElement container = root.Q<VisualElement>("tool-list-container");
-
-            section.Update(enabledData);
-            Toggle beforeToggle = FindToggleByToolName(container, "compile");
-            Assert.IsNotNull(beforeToggle);
-            Assert.IsTrue(beforeToggle.value);
-
-            section.Update(disabledData);
-            Toggle afterToggle = FindToggleByToolName(container, "compile");
-
-            Assert.AreSame(beforeToggle, afterToggle);
-            Assert.IsFalse(afterToggle.value);
-        }
-
-        [Test]
-        public void Update_LayoutChanged_RebuildsToggleElements()
-        {
-            VisualElement root = CreateRootElement();
-            ToolSettingsSection section = new ToolSettingsSection(root);
-            ToolSettingsSectionData initialData = CreateData(compileEnabled: true, includeGetLogs: false);
-            ToolSettingsSectionData changedLayoutData = CreateData(compileEnabled: true, includeGetLogs: true);
-            VisualElement container = root.Q<VisualElement>("tool-list-container");
-
-            section.Update(initialData);
-            Toggle beforeToggle = FindToggleByToolName(container, "compile");
-
-            section.Update(changedLayoutData);
-            Toggle afterToggle = FindToggleByToolName(container, "compile");
-            Toggle getLogsToggle = FindToggleByToolName(container, "get-logs");
-
-            Assert.IsNotNull(beforeToggle);
-            Assert.IsNotNull(afterToggle);
-            Assert.AreNotSame(beforeToggle, afterToggle);
-            Assert.IsNotNull(getLogsToggle);
-        }
-
-        [Test]
-        public void Update_ThirdPartyToolsDisabled_GraysOutThirdPartyGroupOnly()
+        public void Update_ClosedWithoutToolListData_DoesNotCreateToolRows()
         {
             VisualElement root = CreateRootElement();
             ToolSettingsSection section = new ToolSettingsSection(root);
             ToolSettingsSectionData data = CreateData(
                 compileEnabled: true,
-                includeGetLogs: false,
-                allowThirdPartyTools: false,
-                includeThirdPartyTool: true);
-            VisualElement container = root.Q<VisualElement>("tool-list-container");
+                includeGetLogs: true,
+                showToolSettings: false,
+                hasToolListData: false);
 
             section.Update(data);
 
-            VisualElement builtInGroup = FindGroupByHeader(container, "Built-in Tools");
-            VisualElement thirdPartyGroup = FindGroupByHeader(container, "Third Party Tools");
+            IList items = GetToolListItems(root);
+            ListView listView = GetToolListView(root);
+            Assert.AreEqual(0, items.Count);
+            Assert.AreEqual(DisplayStyle.None, listView.style.display.value);
+        }
 
-            Assert.IsNotNull(builtInGroup);
-            Assert.IsNotNull(thirdPartyGroup);
-            Assert.IsTrue(builtInGroup.enabledSelf);
-            Assert.IsFalse(thirdPartyGroup.enabledSelf);
+        [Test]
+        public void Update_OpenWithoutToolListData_ShowsLoadingWithoutToolRows()
+        {
+            VisualElement root = CreateRootElement();
+            ToolSettingsSection section = new ToolSettingsSection(root);
+            ToolSettingsSectionData data = CreateData(
+                compileEnabled: true,
+                includeGetLogs: true,
+                showToolSettings: true,
+                hasToolListData: false);
+
+            section.Update(data);
+
+            IList items = GetToolListItems(root);
+            Label statusLabel = root.Q<Label>("tool-list-status-label");
+            ListView listView = GetToolListView(root);
+            Assert.AreEqual(0, items.Count);
+            Assert.AreEqual("Loading tools...", statusLabel.text);
+            Assert.AreEqual(DisplayStyle.Flex, statusLabel.style.display.value);
+            Assert.AreEqual(DisplayStyle.None, listView.style.display.value);
+        }
+
+        [Test]
+        public void Update_LoadedData_PopulatesVirtualizedRows()
+        {
+            VisualElement root = CreateRootElement();
+            ToolSettingsSection section = new ToolSettingsSection(root);
+            ToolSettingsSectionData data = CreateData(
+                compileEnabled: true,
+                includeGetLogs: true,
+                includeThirdPartyTool: true);
+
+            section.Update(data);
+
+            IList items = GetToolListItems(root);
+            ListView listView = GetToolListView(root);
+            Label statusLabel = root.Q<Label>("tool-list-status-label");
+            Assert.AreEqual(5, items.Count);
+            Assert.AreEqual(DisplayStyle.Flex, listView.style.display.value);
+            Assert.AreEqual(DisplayStyle.None, statusLabel.style.display.value);
+        }
+
+        [Test]
+        public void Update_HeaderOnlyRefreshAfterLoad_PreservesLoadedRows()
+        {
+            VisualElement root = CreateRootElement();
+            ToolSettingsSection section = new ToolSettingsSection(root);
+            ToolSettingsSectionData loadedData = CreateData(
+                compileEnabled: true,
+                includeGetLogs: false,
+                includeThirdPartyTool: true);
+            ToolSettingsSectionData headerOnlyData = CreateData(
+                compileEnabled: false,
+                includeGetLogs: false,
+                allowThirdPartyTools: false,
+                includeThirdPartyTool: true,
+                hasToolListData: false);
+
+            section.Update(loadedData);
+            section.Update(headerOnlyData);
+
+            IList items = GetToolListItems(root);
+            ListView listView = GetToolListView(root);
+            Assert.AreEqual(4, items.Count);
+            Assert.AreEqual(DisplayStyle.Flex, listView.style.display.value);
+        }
+
+        [Test]
+        public void Update_ClosedAfterLoad_ReleasesLoadedRows()
+        {
+            VisualElement root = CreateRootElement();
+            ToolSettingsSection section = new ToolSettingsSection(root);
+            ToolSettingsSectionData loadedData = CreateData(
+                compileEnabled: true,
+                includeGetLogs: false,
+                includeThirdPartyTool: true);
+            ToolSettingsSectionData closedData = CreateData(
+                compileEnabled: true,
+                includeGetLogs: false,
+                showToolSettings: false,
+                hasToolListData: false);
+
+            section.Update(loadedData);
+            section.Update(closedData);
+
+            IList items = GetToolListItems(root);
+            ListView listView = GetToolListView(root);
+            Assert.AreEqual(0, items.Count);
+            Assert.AreEqual(DisplayStyle.None, listView.style.display.value);
         }
 
         [Test]
@@ -167,12 +194,17 @@ namespace io.github.hatayama.uLoopMCP
             {
                 name = "security-level-description"
             };
+            VisualElement toolSettingsInfoContainer = new VisualElement
+            {
+                name = "tool-settings-info-container"
+            };
 
             foldout.Add(allowThirdPartyToggle);
             foldout.Add(allowThirdPartyLabel);
             foldout.Add(securityLevelRestrictedButton);
             foldout.Add(securityLevelFullAccessButton);
             foldout.Add(securityLevelDescription);
+            foldout.Add(toolSettingsInfoContainer);
             foldout.Add(container);
             root.Add(foldout);
             root.Add(cliReferenceLink);
@@ -182,8 +214,10 @@ namespace io.github.hatayama.uLoopMCP
         private static ToolSettingsSectionData CreateData(
             bool compileEnabled,
             bool includeGetLogs,
+            bool showToolSettings = true,
             bool allowThirdPartyTools = true,
             bool includeThirdPartyTool = false,
+            bool hasToolListData = true,
             DynamicCodeSecurityLevel dynamicCodeSecurityLevel = DynamicCodeSecurityLevel.Restricted)
         {
             ToolToggleItem compile = new ToolToggleItem(
@@ -202,77 +236,43 @@ namespace io.github.hatayama.uLoopMCP
                 }
                 : System.Array.Empty<ToolToggleItem>();
 
-            if (!includeGetLogs)
+            ToolToggleItem[] builtInTools;
+            if (includeGetLogs)
             {
-                return new ToolSettingsSectionData(
-                    showToolSettings: true,
-                    allowThirdPartyTools: allowThirdPartyTools,
-                    dynamicCodeSecurityLevel: dynamicCodeSecurityLevel,
-                    builtInTools: new[] { compile },
-                    thirdPartyTools: thirdPartyTools,
-                    isRegistryAvailable: true);
+                ToolToggleItem getLogs = new ToolToggleItem(
+                    toolName: "get-logs",
+                    description: "Read Unity logs",
+                    isEnabled: true,
+                    isThirdParty: false);
+                builtInTools = new[] { compile, getLogs };
             }
-
-            ToolToggleItem getLogs = new ToolToggleItem(
-                toolName: "get-logs",
-                description: "Read Unity logs",
-                isEnabled: true,
-                isThirdParty: false);
+            else
+            {
+                builtInTools = new[] { compile };
+            }
 
             return new ToolSettingsSectionData(
-                showToolSettings: true,
+                showToolSettings: showToolSettings,
                 allowThirdPartyTools: allowThirdPartyTools,
                 dynamicCodeSecurityLevel: dynamicCodeSecurityLevel,
-                builtInTools: new[] { compile, getLogs },
+                builtInTools: builtInTools,
                 thirdPartyTools: thirdPartyTools,
-                isRegistryAvailable: true);
+                isRegistryAvailable: true,
+                hasToolListData: hasToolListData);
         }
 
-        private static VisualElement FindGroupByHeader(VisualElement container, string headerText)
+        private static IList GetToolListItems(VisualElement root)
         {
-            for (int i = 0; i < container.childCount; i++)
-            {
-                VisualElement group = container[i];
-                if (!group.ClassListContains("mcp-tool-group") || group.childCount == 0)
-                {
-                    continue;
-                }
-
-                if (group[0] is Label header && header.text == headerText)
-                {
-                    return group;
-                }
-            }
-
-            return null;
+            ListView listView = GetToolListView(root);
+            Assert.IsNotNull(listView.itemsSource);
+            return listView.itemsSource;
         }
 
-        private static Toggle FindToggleByToolName(VisualElement container, string toolName)
+        private static ListView GetToolListView(VisualElement root)
         {
-            for (int i = 0; i < container.childCount; i++)
-            {
-                VisualElement group = container[i];
-                for (int j = 0; j < group.childCount; j++)
-                {
-                    VisualElement row = group[j];
-                    bool isToggleRow = row.ClassListContains("mcp-tool-toggle-row");
-                    if (!isToggleRow || row.childCount < 2)
-                    {
-                        continue;
-                    }
-
-                    Toggle toggle = row[0] as Toggle;
-                    Label label = row[1] as Label;
-                    bool isTargetRow = label != null && label.text == toolName;
-
-                    if (isTargetRow)
-                    {
-                        return toggle;
-                    }
-                }
-            }
-
-            return null;
+            ListView listView = root.Q<ListView>("tool-list-view");
+            Assert.IsNotNull(listView);
+            return listView;
         }
     }
 }

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -407,6 +407,52 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public async Task InstallSkillFilesForToolAtProjectRoot_WhenFlatLayoutRequested_PreservesDisabledAndDeprecatedGroupedSkills()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-enabled-skill",
+                "EnabledTool",
+                "reference.md",
+                "enabled-reference");
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-disabled-skill",
+                "DisabledTool",
+                "reference.md",
+                "disabled-reference");
+            ToolSettings.SaveSettings(new ToolSettingsData
+            {
+                disabledTools = new[] { "disabled-skill" }
+            });
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
+            string managedSkillsRoot = Path.Combine(skillsRoot, SkillInstallLayout.ManagedSkillsDirName);
+            string flatDisabledSkillDir = Path.Combine(skillsRoot, "uloop-disabled-skill");
+            string flatDeprecatedSkillDir = Path.Combine(skillsRoot, "uloop-capture-window");
+            string groupedDisabledSkillDir = Path.Combine(managedSkillsRoot, "uloop-disabled-skill");
+            string groupedDeprecatedSkillDir = Path.Combine(managedSkillsRoot, "uloop-capture-window");
+            WriteSkillFile(flatDisabledSkillDir, "---\nname: uloop-disabled-skill\n---\n");
+            WriteSkillFile(flatDeprecatedSkillDir, "---\nname: uloop-capture-window\n---\n");
+            WriteSkillFile(groupedDisabledSkillDir, "---\nname: uloop-disabled-skill\n---\n");
+            WriteSkillFile(groupedDeprecatedSkillDir, "---\nname: uloop-capture-window\n---\n");
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesForToolAtProjectRoot(
+                    temporaryRoot,
+                    "enabled-skill",
+                    groupSkillsUnderUnityCliLoop: false);
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(Directory.Exists(flatDisabledSkillDir), Is.False);
+            Assert.That(Directory.Exists(flatDeprecatedSkillDir), Is.False);
+            Assert.That(Directory.Exists(groupedDisabledSkillDir), Is.True);
+            Assert.That(Directory.Exists(groupedDeprecatedSkillDir), Is.True);
+        }
+
+        [Test]
         public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_PreservesThirdPartyManagedSkillDirectories()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -296,6 +296,46 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public async Task InstallSkillFilesForToolAtProjectRoot_DoesNotUpdateUnrelatedSkills()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-enabled-skill",
+                "EnabledTool",
+                "reference.md",
+                "enabled-reference");
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-unrelated-skill",
+                "UnrelatedTool",
+                "reference.md",
+                "new-unrelated-reference");
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
+            Directory.CreateDirectory(skillsRoot);
+            string unrelatedSkillDir = Path.Combine(skillsRoot, "uloop-unrelated-skill");
+            WriteSkillFile(unrelatedSkillDir, "---\nname: uloop-unrelated-skill\n---\n");
+            File.WriteAllText(Path.Combine(unrelatedSkillDir, "reference.md"), "old-unrelated-reference");
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesForToolAtProjectRoot(
+                    temporaryRoot,
+                    "enabled-skill",
+                    groupSkillsUnderUnityCliLoop: false);
+
+            string enabledSkillDir = Path.Combine(skillsRoot, "uloop-enabled-skill");
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(result.AttemptedTargets, Is.EqualTo(1));
+            Assert.That(File.ReadAllText(Path.Combine(enabledSkillDir, "reference.md")), Is.EqualTo("enabled-reference"));
+            Assert.That(
+                File.ReadAllText(Path.Combine(unrelatedSkillDir, "reference.md")),
+                Is.EqualTo("old-unrelated-reference"));
+        }
+
+        [Test]
         public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_PreservesThirdPartyManagedSkillDirectories()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -8,14 +8,22 @@ namespace io.github.hatayama.uLoopMCP
     [TestFixture]
     public class ToolSkillSynchronizerTests
     {
+        private static readonly string ToolSettingsFilePath =
+            Path.Combine(McpConstants.ULOOP_DIR, McpConstants.ULOOP_TOOL_SETTINGS_FILE_NAME);
+
         private string _projectRoot;
         private string[] _nonExistentDirsBefore;
         private string[] _temporaryRoots;
+        private bool _toolSettingsFileExisted;
+        private string _toolSettingsFileContent;
 
         [SetUp]
         public void SetUp()
         {
             _projectRoot = UnityMcpPathResolver.GetProjectRoot();
+            _toolSettingsFileExisted = File.Exists(ToolSettingsFilePath);
+            _toolSettingsFileContent = _toolSettingsFileExisted ? File.ReadAllText(ToolSettingsFilePath) : null;
+            ToolSettings.InvalidateCache();
 
             _nonExistentDirsBefore = ToolSkillSynchronizer.SkillTargetDirs
                 .Where(dir => !Directory.Exists(Path.Combine(_projectRoot, dir)))
@@ -53,6 +61,9 @@ namespace io.github.hatayama.uLoopMCP
                     Directory.Delete(temporaryRoot, true);
                 }
             }
+
+            RestoreToolSettingsFile();
+            ToolSettings.InvalidateCache();
         }
 
         [Test]
@@ -333,6 +344,66 @@ namespace io.github.hatayama.uLoopMCP
             Assert.That(
                 File.ReadAllText(Path.Combine(unrelatedSkillDir, "reference.md")),
                 Is.EqualTo("old-unrelated-reference"));
+        }
+
+        [Test]
+        public async Task InstallSkillFilesForToolAtProjectRoot_RemovesDisabledAndDeprecatedSkillsWithoutUpdatingUnrelatedSkills()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-enabled-skill",
+                "EnabledTool",
+                "reference.md",
+                "enabled-reference");
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-disabled-skill",
+                "DisabledTool",
+                "reference.md",
+                "disabled-reference");
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-unrelated-skill",
+                "UnrelatedTool",
+                "reference.md",
+                "new-unrelated-reference");
+            ToolSettings.SaveSettings(new ToolSettingsData
+            {
+                disabledTools = new[] { "disabled-skill" }
+            });
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
+            Directory.CreateDirectory(skillsRoot);
+            string disabledSkillDir = Path.Combine(skillsRoot, "uloop-disabled-skill");
+            string deprecatedSkillDir = Path.Combine(skillsRoot, "uloop-capture-window");
+            string unrelatedSkillDir = Path.Combine(skillsRoot, "uloop-unrelated-skill");
+            string thirdPartySkillDir = Path.Combine(skillsRoot, "acme-third-party");
+            WriteSkillFile(disabledSkillDir, "---\nname: uloop-disabled-skill\n---\n");
+            WriteSkillFile(deprecatedSkillDir, "---\nname: uloop-capture-window\n---\n");
+            WriteSkillFile(unrelatedSkillDir, "---\nname: uloop-unrelated-skill\n---\n");
+            File.WriteAllText(Path.Combine(unrelatedSkillDir, "reference.md"), "old-unrelated-reference");
+            WriteSkillFile(
+                thirdPartySkillDir,
+                "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesForToolAtProjectRoot(
+                    temporaryRoot,
+                    "enabled-skill",
+                    groupSkillsUnderUnityCliLoop: false);
+
+            string enabledSkillDir = Path.Combine(skillsRoot, "uloop-enabled-skill");
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(File.ReadAllText(Path.Combine(enabledSkillDir, "reference.md")), Is.EqualTo("enabled-reference"));
+            Assert.That(Directory.Exists(disabledSkillDir), Is.False);
+            Assert.That(Directory.Exists(deprecatedSkillDir), Is.False);
+            Assert.That(
+                File.ReadAllText(Path.Combine(unrelatedSkillDir, "reference.md")),
+                Is.EqualTo("old-unrelated-reference"));
+            Assert.That(Directory.Exists(thirdPartySkillDir), Is.True);
         }
 
         [Test]
@@ -1121,6 +1192,20 @@ namespace io.github.hatayama.uLoopMCP
         {
             Directory.CreateDirectory(skillDir);
             File.WriteAllText(Path.Combine(skillDir, SkillInstallLayout.SkillFileName), content);
+        }
+
+        private void RestoreToolSettingsFile()
+        {
+            if (_toolSettingsFileExisted)
+            {
+                File.WriteAllText(ToolSettingsFilePath, _toolSettingsFileContent);
+                return;
+            }
+
+            if (File.Exists(ToolSettingsFilePath))
+            {
+                File.Delete(ToolSettingsFilePath);
+            }
         }
 
         private static void CreateFakeSourceSkill(

--- a/Packages/src/Editor/Api/McpTools/Core/CustomToolManager.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/CustomToolManager.cs
@@ -81,6 +81,11 @@ namespace io.github.hatayama.uLoopMCP
             return SharedRegistry;
         }
 
+        internal static UnityToolRegistry TryGetRegistry()
+        {
+            return _sharedRegistry;
+        }
+
         internal static void WarmupRegistry()
         {
             _ = SharedRegistry;

--- a/Packages/src/Editor/Api/McpTools/Core/CustomToolManager.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/CustomToolManager.cs
@@ -11,6 +11,8 @@ namespace io.github.hatayama.uLoopMCP
     {
         private static UnityToolRegistry _sharedRegistry;
 
+        internal static event Action OnToolsChanged;
+
         /// <summary>
         /// Get shared registry (lazy initialization)
         /// </summary>
@@ -106,6 +108,7 @@ namespace io.github.hatayama.uLoopMCP
         public static void NotifyToolChanges()
         {
             UnityToolRegistry.TriggerToolsChangedNotification();
+            OnToolsChanged?.Invoke();
         }
     }
 }

--- a/Packages/src/Editor/Api/McpTools/Core/UnityToolRegistry.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/UnityToolRegistry.cs
@@ -304,6 +304,24 @@ namespace io.github.hatayama.uLoopMCP
             }).ToArray();
         }
 
+        public ToolSettingsCatalogItem[] GetToolSettingsCatalog()
+        {
+            return _tools.Values.Select(tool =>
+            {
+                Type toolType = tool.GetType();
+                McpToolAttribute attribute = toolType.GetCustomAttribute<McpToolAttribute>();
+                string description = attribute?.Description ?? "";
+                bool displayDevelopmentOnly = attribute?.DisplayDevelopmentOnly ?? false;
+                bool isThirdParty = IsThirdPartyAssembly(toolType.Assembly.GetName().Name);
+
+                return new ToolSettingsCatalogItem(
+                    tool.ToolName,
+                    description,
+                    displayDevelopmentOnly,
+                    isThirdParty);
+            }).ToArray();
+        }
+
         /// <summary>
         /// Check if a tool belongs to a third-party assembly.
         /// </summary>
@@ -314,6 +332,11 @@ namespace io.github.hatayama.uLoopMCP
                 return true;
             }
             string assemblyName = tool.GetType().Assembly.GetName().Name;
+            return IsThirdPartyAssembly(assemblyName);
+        }
+
+        private static bool IsThirdPartyAssembly(string assemblyName)
+        {
             return assemblyName != "uLoopMCP.Editor";
         }
 
@@ -372,6 +395,29 @@ namespace io.github.hatayama.uLoopMCP
             Description = description;
             ParameterSchema = parameterSchema;
             DisplayDevelopmentOnly = displayDevelopmentOnly;
+        }
+    }
+
+    /// <summary>
+    /// Lightweight registry metadata used by Tool Settings UI without generating parameter schemas.
+    /// </summary>
+    public class ToolSettingsCatalogItem
+    {
+        public readonly string Name;
+        public readonly string Description;
+        public readonly bool DisplayDevelopmentOnly;
+        public readonly bool IsThirdParty;
+
+        public ToolSettingsCatalogItem(
+            string name,
+            string description,
+            bool displayDevelopmentOnly,
+            bool isThirdParty)
+        {
+            Name = name;
+            Description = description;
+            DisplayDevelopmentOnly = displayDevelopmentOnly;
+            IsThirdParty = isThirdParty;
         }
     }
 }

--- a/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
@@ -383,6 +383,21 @@ namespace io.github.hatayama.uLoopMCP
             return await InstallSkillFiles(targets, groupSkillsUnderUnityCliLoop);
         }
 
+        public static async Task<SkillInstallResult> InstallSkillFilesForTool(
+            string toolName,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
+
+            string projectRoot = UnityMcpPathResolver.GetProjectRoot();
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            return await InstallSkillFilesForToolAtProjectRoot(
+                projectRoot,
+                toolName,
+                groupSkillsUnderUnityCliLoop);
+        }
+
         public static async Task<SkillInstallResult> InstallSkillFiles(List<SkillTargetInfo> targets)
         {
             return await InstallSkillFiles(targets, groupSkillsUnderUnityCliLoop: false);
@@ -427,6 +442,40 @@ namespace io.github.hatayama.uLoopMCP
                         target,
                         disabledSkills,
                         enabledSkills,
+                        groupSkillsUnderUnityCliLoop);
+                    succeeded++;
+                }
+
+                return new SkillInstallResult(targetArray.Length, succeeded);
+            });
+        }
+
+        internal static async Task<SkillInstallResult> InstallSkillFilesForToolAtProjectRoot(
+            string projectRoot,
+            string toolName,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
+
+            SkillTargetInfo[] targetArray = DetectTargetsWithSkillsDirectory(projectRoot).ToArray();
+            return await Task.Run(() =>
+            {
+                List<SkillInstallLayout.SkillSourceInfo> toolSkills = SkillInstallLayout.GetSkillSourceInfos(projectRoot)
+                    .Where(skill => IsSkillForTool(skill, toolName))
+                    .ToList();
+                if (toolSkills.Count == 0)
+                {
+                    return new SkillInstallResult(0, 0);
+                }
+
+                int succeeded = 0;
+                foreach (SkillTargetInfo target in targetArray)
+                {
+                    InstallSpecificSkillsForTarget(
+                        projectRoot,
+                        target,
+                        toolSkills,
                         groupSkillsUnderUnityCliLoop);
                     succeeded++;
                 }
@@ -497,6 +546,39 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
+        private static void InstallSpecificSkillsForTarget(
+            string projectRoot,
+            SkillTargetInfo target,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> skills,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            string targetRoot = Path.Combine(projectRoot, target.DirName);
+            string skillsRoot = SkillInstallLayout.GetSkillsRoot(targetRoot);
+            Directory.CreateDirectory(skillsRoot);
+
+            if (groupSkillsUnderUnityCliLoop)
+            {
+                Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
+            }
+
+            foreach (SkillInstallLayout.SkillSourceInfo skill in skills)
+            {
+                string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
+                    targetRoot,
+                    skill.Name,
+                    groupSkillsUnderUnityCliLoop);
+                SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop);
+            }
+
+            if (!groupSkillsUnderUnityCliLoop)
+            {
+                DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
+                    targetRoot,
+                    groupSkillsUnderUnityCliLoop: true);
+            }
+        }
+
         private static bool IsSkillDisabled(
             SkillInstallLayout.SkillSourceInfo skill,
             IReadOnlyCollection<string> disabledTools)
@@ -506,18 +588,60 @@ namespace io.github.hatayama.uLoopMCP
                 return false;
             }
 
-            string toolName = skill.ToolName;
-            if (string.IsNullOrEmpty(toolName) && skill.Name.StartsWith(CliConstants.SKILL_DIR_PREFIX, StringComparison.Ordinal))
-            {
-                toolName = skill.Name.Substring(CliConstants.SKILL_DIR_PREFIX.Length);
-            }
-
+            string toolName = GetToolNameForSkill(skill);
             if (string.IsNullOrEmpty(toolName))
             {
                 return false;
             }
 
             return disabledTools.Contains(toolName);
+        }
+
+        private static bool IsSkillForTool(
+            SkillInstallLayout.SkillSourceInfo skill,
+            string toolName)
+        {
+            string skillToolName = GetToolNameForSkill(skill);
+            return string.Equals(skillToolName, toolName, StringComparison.Ordinal);
+        }
+
+        private static string GetToolNameForSkill(SkillInstallLayout.SkillSourceInfo skill)
+        {
+            string toolName = skill.ToolName;
+            if (string.IsNullOrEmpty(toolName) && skill.Name.StartsWith(CliConstants.SKILL_DIR_PREFIX, StringComparison.Ordinal))
+            {
+                toolName = skill.Name.Substring(CliConstants.SKILL_DIR_PREFIX.Length);
+            }
+
+            return toolName;
+        }
+
+        private static List<SkillTargetInfo> DetectTargetsWithSkillsDirectory(string projectRoot)
+        {
+            List<SkillTargetInfo> targets = new();
+            foreach (SkillTargetDefinition target in SkillTargets)
+            {
+                string targetRoot = Path.Combine(projectRoot, target.DirName);
+                if (!Directory.Exists(targetRoot))
+                {
+                    continue;
+                }
+
+                bool hasSkillsDirectory = SkillInstallLayout.HasOptedInSkillsDirectory(targetRoot);
+                if (!hasSkillsDirectory)
+                {
+                    continue;
+                }
+
+                targets.Add(new SkillTargetInfo(
+                    target.DisplayName,
+                    target.DirName,
+                    target.Flag,
+                    hasSkillsDirectory,
+                    hasExistingSkills: false));
+            }
+
+            return targets;
         }
 
         private static void DeleteUnexpectedInstalledSkillDirectories(

--- a/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
@@ -511,8 +511,8 @@ namespace io.github.hatayama.uLoopMCP
                 Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
             }
 
-            DeleteDeprecatedSkillDirectories(targetRoot);
-            DeleteDisabledSkillDirectories(targetRoot, disabledSkills);
+            DeleteDeprecatedSkillDirectoriesFromAllLayouts(targetRoot);
+            DeleteDisabledSkillDirectoriesFromAllLayouts(targetRoot, disabledSkills);
 
             foreach (SkillInstallLayout.SkillSourceInfo skill in enabledSkills)
             {
@@ -559,8 +559,8 @@ namespace io.github.hatayama.uLoopMCP
                 Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
             }
 
-            DeleteDeprecatedSkillDirectories(targetRoot);
-            DeleteDisabledSkillDirectories(targetRoot, disabledSkills);
+            DeleteDeprecatedSkillDirectoriesForLayout(targetRoot, groupSkillsUnderUnityCliLoop);
+            DeleteDisabledSkillDirectoriesForLayout(targetRoot, disabledSkills, groupSkillsUnderUnityCliLoop);
 
             foreach (SkillInstallLayout.SkillSourceInfo skill in skills)
             {
@@ -706,7 +706,7 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
-        private static void DeleteDeprecatedSkillDirectories(string targetRoot)
+        private static void DeleteDeprecatedSkillDirectoriesFromAllLayouts(string targetRoot)
         {
             foreach (string deprecatedSkillName in DeprecatedSkillNames)
             {
@@ -715,7 +715,7 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
-        private static void DeleteDisabledSkillDirectories(
+        private static void DeleteDisabledSkillDirectoriesFromAllLayouts(
             string targetRoot,
             IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills)
         {
@@ -723,6 +723,27 @@ namespace io.github.hatayama.uLoopMCP
             {
                 DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: true);
                 DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: false);
+            }
+        }
+
+        private static void DeleteDeprecatedSkillDirectoriesForLayout(
+            string targetRoot,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            foreach (string deprecatedSkillName in DeprecatedSkillNames)
+            {
+                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop);
+            }
+        }
+
+        private static void DeleteDisabledSkillDirectoriesForLayout(
+            string targetRoot,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            foreach (SkillInstallLayout.SkillSourceInfo skill in disabledSkills)
+            {
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop);
             }
         }
 

--- a/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
@@ -461,7 +461,12 @@ namespace io.github.hatayama.uLoopMCP
             SkillTargetInfo[] targetArray = DetectTargetsWithSkillsDirectory(projectRoot).ToArray();
             return await Task.Run(() =>
             {
-                List<SkillInstallLayout.SkillSourceInfo> toolSkills = SkillInstallLayout.GetSkillSourceInfos(projectRoot)
+                string[] disabledTools = ToolSettings.GetDisabledTools();
+                List<SkillInstallLayout.SkillSourceInfo> allSkills = SkillInstallLayout.GetSkillSourceInfos(projectRoot);
+                List<SkillInstallLayout.SkillSourceInfo> disabledSkills = allSkills
+                    .Where(skill => IsSkillDisabled(skill, disabledTools))
+                    .ToList();
+                List<SkillInstallLayout.SkillSourceInfo> toolSkills = allSkills
                     .Where(skill => IsSkillForTool(skill, toolName))
                     .ToList();
                 if (toolSkills.Count == 0)
@@ -475,6 +480,7 @@ namespace io.github.hatayama.uLoopMCP
                     InstallSpecificSkillsForTarget(
                         projectRoot,
                         target,
+                        disabledSkills,
                         toolSkills,
                         groupSkillsUnderUnityCliLoop);
                     succeeded++;
@@ -505,17 +511,8 @@ namespace io.github.hatayama.uLoopMCP
                 Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
             }
 
-            foreach (string deprecatedSkillName in DeprecatedSkillNames)
-            {
-                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: true);
-                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: false);
-            }
-
-            foreach (SkillInstallLayout.SkillSourceInfo skill in disabledSkills)
-            {
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: true);
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: false);
-            }
+            DeleteDeprecatedSkillDirectories(targetRoot);
+            DeleteDisabledSkillDirectories(targetRoot, disabledSkills);
 
             foreach (SkillInstallLayout.SkillSourceInfo skill in enabledSkills)
             {
@@ -549,6 +546,7 @@ namespace io.github.hatayama.uLoopMCP
         private static void InstallSpecificSkillsForTarget(
             string projectRoot,
             SkillTargetInfo target,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
             IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> skills,
             bool groupSkillsUnderUnityCliLoop)
         {
@@ -560,6 +558,9 @@ namespace io.github.hatayama.uLoopMCP
             {
                 Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
             }
+
+            DeleteDeprecatedSkillDirectories(targetRoot);
+            DeleteDisabledSkillDirectories(targetRoot, disabledSkills);
 
             foreach (SkillInstallLayout.SkillSourceInfo skill in skills)
             {
@@ -702,6 +703,26 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     RollbackSkillDirectory(skillDirectory, backupFiles, skillDirectoryExisted);
                 }
+            }
+        }
+
+        private static void DeleteDeprecatedSkillDirectories(string targetRoot)
+        {
+            foreach (string deprecatedSkillName in DeprecatedSkillNames)
+            {
+                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: true);
+                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: false);
+            }
+        }
+
+        private static void DeleteDisabledSkillDirectories(
+            string targetRoot,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills)
+        {
+            foreach (SkillInstallLayout.SkillSourceInfo skill in disabledSkills)
+            {
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: true);
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: false);
             }
         }
 

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -22,6 +22,8 @@ namespace io.github.hatayama.uLoopMCP
         private bool _isInstallingCli;
         private bool _isInstallingSkills;
         private bool _isRefreshingVersion;
+        private bool _isToolSettingsCatalogDirty = true;
+        private bool _isToolSettingsRefreshScheduled;
         private SkillInstallState _selectedTargetInstallState = SkillInstallState.Missing;
         private CancellationTokenSource _skillInstallStateRefreshCts;
 
@@ -41,6 +43,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             CancelSkillInstallStateRefresh();
             _view?.Dispose();
+            _view = null;
         }
 
         private void CreateGUI()
@@ -170,6 +173,7 @@ namespace io.github.hatayama.uLoopMCP
             CleanupEventHandler();
             SaveSessionState();
             _view?.Dispose();
+            _view = null;
         }
 
         private void CleanupEventHandler()
@@ -217,8 +221,8 @@ namespace io.github.hatayama.uLoopMCP
             EditorConfigData configData = CreateEditorConfigData();
             _view.UpdateEditorConfig(configData);
 
-            ToolSettingsSectionData toolSettingsData = CreateToolSettingsData();
-            _view.UpdateToolSettings(toolSettingsData);
+            RefreshToolSettingsHeader();
+            ScheduleToolSettingsCatalogRefreshIfNeeded();
         }
 
         private async void RefreshCliVersionInBackground()
@@ -330,6 +334,59 @@ namespace io.github.hatayama.uLoopMCP
                 _model.UI.ShowRepositoryRootToggle);
         }
 
+        public void InvalidateToolSettingsCatalog()
+        {
+            _isToolSettingsCatalogDirty = true;
+        }
+
+        private void RefreshToolSettingsHeader()
+        {
+            ToolSettingsSectionData toolSettingsData = CreateToolSettingsHeaderData();
+            _view.UpdateToolSettings(toolSettingsData);
+        }
+
+        private void RefreshToolSettingsCatalog()
+        {
+            ToolSettingsSectionData toolSettingsData = CreateToolSettingsData();
+            _view.UpdateToolSettings(toolSettingsData);
+            _isToolSettingsCatalogDirty = false;
+        }
+
+        private void ScheduleToolSettingsCatalogRefreshIfNeeded()
+        {
+            if (!_model.UI.ShowToolSettings || !_isToolSettingsCatalogDirty || _isToolSettingsRefreshScheduled)
+            {
+                return;
+            }
+
+            _isToolSettingsRefreshScheduled = true;
+            EditorApplication.delayCall += RefreshToolSettingsCatalogIfNeeded;
+        }
+
+        private void RefreshToolSettingsCatalogIfNeeded()
+        {
+            _isToolSettingsRefreshScheduled = false;
+
+            if (_view == null || !_model.UI.ShowToolSettings)
+            {
+                return;
+            }
+
+            RefreshToolSettingsCatalog();
+        }
+
+        private ToolSettingsSectionData CreateToolSettingsHeaderData()
+        {
+            return new ToolSettingsSectionData(
+                _model.UI.ShowToolSettings,
+                ULoopSettings.GetAllowThirdPartyTools(),
+                ULoopSettings.GetDynamicCodeSecurityLevel(),
+                System.Array.Empty<ToolToggleItem>(),
+                System.Array.Empty<ToolToggleItem>(),
+                true,
+                false);
+        }
+
         private ToolSettingsSectionData CreateToolSettingsData()
         {
             UnityToolRegistry registry = CustomToolManager.GetRegistry();
@@ -341,24 +398,24 @@ namespace io.github.hatayama.uLoopMCP
                     ULoopSettings.GetDynamicCodeSecurityLevel(),
                     System.Array.Empty<ToolToggleItem>(),
                     System.Array.Empty<ToolToggleItem>(),
-                    false);
+                    false,
+                    true);
             }
 
-            ToolInfo[] allTools = registry.GetAllRegisteredToolInfos();
+            ToolSettingsCatalogItem[] allTools = registry.GetToolSettingsCatalog();
 
             System.Collections.Generic.List<ToolToggleItem> builtIn = new();
             System.Collections.Generic.List<ToolToggleItem> thirdParty = new();
 
-            foreach (ToolInfo tool in allTools)
+            foreach (ToolSettingsCatalogItem tool in allTools)
             {
-                // Internal tools are always enabled and hidden from UI
                 if (tool.DisplayDevelopmentOnly)
                 {
                     continue;
                 }
 
                 bool isEnabled = ToolSettings.IsToolEnabled(tool.Name);
-                bool isThirdPartyTool = registry.IsThirdPartyTool(tool.Name);
+                bool isThirdPartyTool = tool.IsThirdParty;
 
                 ToolToggleItem item = new ToolToggleItem(tool.Name, tool.Description, isEnabled, isThirdPartyTool);
                 if (isThirdPartyTool)
@@ -381,12 +438,22 @@ namespace io.github.hatayama.uLoopMCP
                 ULoopSettings.GetDynamicCodeSecurityLevel(),
                 builtIn.ToArray(),
                 thirdParty.ToArray(),
+                true,
                 true);
         }
 
         private void UpdateShowToolSettings(bool show)
         {
             _model.UpdateShowToolSettings(show);
+            RefreshToolSettingsHeader();
+
+            if (!show)
+            {
+                _isToolSettingsCatalogDirty = true;
+                return;
+            }
+
+            ScheduleToolSettingsCatalogRefreshIfNeeded();
         }
 
         private void HandleToolToggled(string toolName, bool enabled)
@@ -516,7 +583,7 @@ namespace io.github.hatayama.uLoopMCP
         private void UpdateAllowThirdPartyTools(bool allow)
         {
             _model.UpdateAllowThirdPartyTools(allow);
-            RefreshAllSections();
+            RefreshToolSettingsHeader();
         }
 
         private void UpdateAddRepositoryRoot(bool addRepositoryRoot)

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -12,7 +12,9 @@ namespace io.github.hatayama.uLoopMCP
     {
         private const bool ForceFlatSkillInstall = true;
         private const double DeferredInitialRefreshDelaySeconds = 0.05;
-        private const double ToolSettingsRegistryWarmupDelaySeconds = 0.05;
+        private const double ToolSettingsRegistryWarmupInitialDelaySeconds = 0.05;
+        private const double ToolSettingsRegistryWarmupMaxDelaySeconds = 0.8;
+        private const int ToolSettingsRegistryWarmupMaxAttempts = 5;
 
         private McpConfigServiceFactory _configServiceFactory;
         private McpEditorWindowUI _view;
@@ -30,6 +32,7 @@ namespace io.github.hatayama.uLoopMCP
         private double _deferredInitialRefreshDueTime;
         private bool _isToolSettingsRegistryWarmupScheduled;
         private double _toolSettingsRegistryWarmupDueTime;
+        private int _toolSettingsRegistryWarmupAttemptCount;
         private SkillInstallState _selectedTargetInstallState = SkillInstallState.Missing;
         private CancellationTokenSource _skillInstallStateRefreshCts;
 
@@ -49,6 +52,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             CancelDeferredInitialRefresh();
             CancelToolSettingsRegistryWarmup();
+            ResetToolSettingsRegistryWarmupAttemptCount();
             CancelSkillInstallStateRefresh();
             _view?.Dispose();
             _view = null;
@@ -171,6 +175,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             CancelDeferredInitialRefresh();
             CancelToolSettingsRegistryWarmup();
+            ResetToolSettingsRegistryWarmupAttemptCount();
             CancelSkillInstallStateRefresh();
             CleanupEventHandler();
             SaveSessionState();
@@ -432,12 +437,18 @@ namespace io.github.hatayama.uLoopMCP
 
             if (McpEditorWindowRefreshPolicy.ShouldKeepToolSettingsCatalogDirty(toolSettingsData))
             {
-                _isToolSettingsCatalogDirty = true;
-                ScheduleToolSettingsRegistryWarmup();
+                if (ScheduleToolSettingsRegistryWarmup())
+                {
+                    _isToolSettingsCatalogDirty = true;
+                    return;
+                }
+
+                _isToolSettingsCatalogDirty = false;
                 return;
             }
 
             CancelToolSettingsRegistryWarmup();
+            ResetToolSettingsRegistryWarmupAttemptCount();
             _isToolSettingsCatalogDirty = false;
         }
 
@@ -532,22 +543,33 @@ namespace io.github.hatayama.uLoopMCP
             {
                 _isToolSettingsCatalogDirty = true;
                 CancelToolSettingsRegistryWarmup();
+                ResetToolSettingsRegistryWarmupAttemptCount();
                 return;
             }
 
             RefreshToolSettingsCatalogIfNeeded();
         }
 
-        private void ScheduleToolSettingsRegistryWarmup()
+        private bool ScheduleToolSettingsRegistryWarmup()
         {
-            if (_isToolSettingsRegistryWarmupScheduled)
+            if (McpEditorWindowRefreshPolicy.ShouldStartToolSettingsRegistryWarmup(
+                    _isToolSettingsRegistryWarmupScheduled,
+                    _toolSettingsRegistryWarmupAttemptCount,
+                    ToolSettingsRegistryWarmupMaxAttempts))
             {
-                return;
+                double delaySeconds = McpEditorWindowRefreshPolicy.CalculateToolSettingsRegistryWarmupDelaySeconds(
+                    ToolSettingsRegistryWarmupInitialDelaySeconds,
+                    ToolSettingsRegistryWarmupMaxDelaySeconds,
+                    _toolSettingsRegistryWarmupAttemptCount);
+
+                _isToolSettingsRegistryWarmupScheduled = true;
+                _toolSettingsRegistryWarmupDueTime = EditorApplication.timeSinceStartup + delaySeconds;
+                _toolSettingsRegistryWarmupAttemptCount++;
+                EditorApplication.update += RunToolSettingsRegistryWarmupWhenDue;
+                return true;
             }
 
-            _isToolSettingsRegistryWarmupScheduled = true;
-            _toolSettingsRegistryWarmupDueTime = EditorApplication.timeSinceStartup + ToolSettingsRegistryWarmupDelaySeconds;
-            EditorApplication.update += RunToolSettingsRegistryWarmupWhenDue;
+            return _isToolSettingsRegistryWarmupScheduled;
         }
 
         private void RunToolSettingsRegistryWarmupWhenDue()
@@ -561,6 +583,7 @@ namespace io.github.hatayama.uLoopMCP
 
             if (_view == null || !_model.UI.ShowToolSettings)
             {
+                ResetToolSettingsRegistryWarmupAttemptCount();
                 return;
             }
 
@@ -578,6 +601,11 @@ namespace io.github.hatayama.uLoopMCP
 
             EditorApplication.update -= RunToolSettingsRegistryWarmupWhenDue;
             _isToolSettingsRegistryWarmupScheduled = false;
+        }
+
+        private void ResetToolSettingsRegistryWarmupAttemptCount()
+        {
+            _toolSettingsRegistryWarmupAttemptCount = 0;
         }
 
         private void HandleToolToggled(string toolName, bool enabled)

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -11,6 +11,7 @@ namespace io.github.hatayama.uLoopMCP
     public class McpEditorWindow : EditorWindow
     {
         private const bool ForceFlatSkillInstall = true;
+        private const double DeferredInitialRefreshDelaySeconds = 0.05;
 
         private McpConfigServiceFactory _configServiceFactory;
         private McpEditorWindowUI _view;
@@ -23,6 +24,9 @@ namespace io.github.hatayama.uLoopMCP
         private bool _isInstallingSkills;
         private bool _isRefreshingVersion;
         private bool _isToolSettingsCatalogDirty = true;
+        private bool _isDeferredInitialRefreshScheduled;
+        private bool _hasCompletedDeferredInitialRefresh;
+        private double _deferredInitialRefreshDueTime;
         private SkillInstallState _selectedTargetInstallState = SkillInstallState.Missing;
         private CancellationTokenSource _skillInstallStateRefreshCts;
 
@@ -40,6 +44,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private void OnDestroy()
         {
+            CancelDeferredInitialRefresh();
             CancelSkillInstallStateRefresh();
             _view?.Dispose();
             _view = null;
@@ -48,7 +53,8 @@ namespace io.github.hatayama.uLoopMCP
         private void CreateGUI()
         {
             InitializeView();
-            RefreshAllSections(refreshSkillInstallState: true);
+            RefreshAllSections(refreshMode: McpEditorWindowRefreshMode.InitialPaint);
+            ScheduleDeferredInitialRefresh();
         }
 
         private void InitializeAll()
@@ -118,16 +124,7 @@ namespace io.github.hatayama.uLoopMCP
         private void LoadSavedSettings()
         {
             _model.LoadFromSettings();
-            ApplyFlatSkillInstallPreference();
-
-            bool gitRootDiffers = UnityMcpPathResolver.GitRootDiffersFromProjectRoot();
-            _model.UpdateSupportsRepositoryRootToggle(gitRootDiffers);
-            _model.UpdateShowRepositoryRootToggle(gitRootDiffers);
-
-            if (!gitRootDiffers && _model.UI.AddRepositoryRoot)
-            {
-                _model.UpdateAddRepositoryRoot(false);
-            }
+            _installSkillsFlat = ForceFlatSkillInstall;
         }
 
         private void RestoreSessionState()
@@ -168,6 +165,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private void OnDisable()
         {
+            CancelDeferredInitialRefresh();
             CancelSkillInstallStateRefresh();
             CleanupEventHandler();
             SaveSessionState();
@@ -185,43 +183,105 @@ namespace io.github.hatayama.uLoopMCP
             _model.SaveToSessionState();
         }
 
-        private void OnFocus()
+        private void ScheduleDeferredInitialRefresh()
         {
-            RefreshAllSections();
+            if (_isDeferredInitialRefreshScheduled)
+            {
+                return;
+            }
+
+            _isDeferredInitialRefreshScheduled = true;
+            _deferredInitialRefreshDueTime = EditorApplication.timeSinceStartup + DeferredInitialRefreshDelaySeconds;
+            EditorApplication.update += RunDeferredInitialRefreshWhenDue;
         }
 
-        public void RefreshAllSections(bool refreshSkillInstallState = false)
+        private void RunDeferredInitialRefreshWhenDue()
+        {
+            if (EditorApplication.timeSinceStartup < _deferredInitialRefreshDueTime)
+            {
+                return;
+            }
+
+            CancelDeferredInitialRefresh();
+            if (_view == null)
+            {
+                return;
+            }
+
+            _hasCompletedDeferredInitialRefresh = true;
+            _selectedTargetInstallState = SkillInstallState.Checking;
+            RefreshRepositoryRootSupport();
+            RefreshAllSections(
+                refreshSkillInstallState: false,
+                refreshMode: McpEditorWindowRefreshMode.Full);
+            RefreshSelectedTargetInstallStateInBackground();
+        }
+
+        private void CancelDeferredInitialRefresh()
+        {
+            if (!_isDeferredInitialRefreshScheduled)
+            {
+                return;
+            }
+
+            EditorApplication.update -= RunDeferredInitialRefreshWhenDue;
+            _isDeferredInitialRefreshScheduled = false;
+        }
+
+        private void OnFocus()
+        {
+            if (!_hasCompletedDeferredInitialRefresh)
+            {
+                RefreshAllSections(refreshMode: McpEditorWindowRefreshMode.InitialPaint);
+            }
+
+            ScheduleDeferredInitialRefresh();
+        }
+
+        internal void RefreshAllSections(
+            bool refreshSkillInstallState = false,
+            McpEditorWindowRefreshMode refreshMode = McpEditorWindowRefreshMode.Full)
         {
             if (_view == null)
             {
                 return;
             }
 
+            bool runExpensiveChecks = McpEditorWindowRefreshPolicy.ShouldRunExpensiveChecks(refreshMode);
+
             ConnectionModeData modeData = new ConnectionModeData(_model.UI.ConnectionMode);
             _view.UpdateConnectionMode(modeData);
             _view.UpdateConfigurationFoldout(_model.UI.ShowConfiguration);
             _view.UpdateSectionVisibility(_model.UI.ConnectionMode);
 
-            if (refreshSkillInstallState)
+            if (McpEditorWindowRefreshPolicy.ShouldRefreshSkillInstallState(refreshMode, refreshSkillInstallState))
             {
                 RefreshSelectedTargetInstallStateFast();
             }
 
-            RefreshCliVersionInBackground();
-            if (refreshSkillInstallState)
+            if (runExpensiveChecks)
             {
-                RefreshSelectedTargetInstallStateInBackground();
+                RefreshCliVersionInBackground();
+                if (refreshSkillInstallState)
+                {
+                    RefreshSelectedTargetInstallStateInBackground();
+                }
             }
-            RefreshCliSetupSection();
+            RefreshCliSetupSection(runExpensiveChecks);
 
             ConnectedToolsData toolsData = CreateConnectedToolsData();
             _view.UpdateConnectedTools(toolsData);
 
-            EditorConfigData configData = CreateEditorConfigData();
+            EditorConfigData configData = runExpensiveChecks
+                ? CreateEditorConfigData()
+                : CreateEditorConfigPlaceholderData();
             _view.UpdateEditorConfig(configData);
 
             RefreshToolSettingsHeader();
-            RefreshToolSettingsCatalogIfNeeded();
+            if (runExpensiveChecks)
+            {
+                RefreshToolSettingsCatalogIfNeeded();
+            }
         }
 
         private async void RefreshCliVersionInBackground()
@@ -331,6 +391,22 @@ namespace io.github.hatayama.uLoopMCP
                 _model.UI.AddRepositoryRoot,
                 _model.UI.SupportsRepositoryRootToggle,
                 _model.UI.ShowRepositoryRootToggle);
+        }
+
+        private EditorConfigData CreateEditorConfigPlaceholderData()
+        {
+            return new EditorConfigData(
+                _model.UI.SelectedEditorType,
+                McpServerController.IsServerRunning,
+                McpServerController.ServerPort,
+                isConfigured: false,
+                hasPortMismatch: false,
+                configurationError: null,
+                isUpdateNeeded: true,
+                addRepositoryRoot: _model.UI.AddRepositoryRoot,
+                supportsRepositoryRootToggle: _model.UI.SupportsRepositoryRootToggle,
+                showRepositoryRootToggle: _model.UI.ShowRepositoryRootToggle,
+                isChecking: true);
         }
 
         public void InvalidateToolSettingsCatalog()
@@ -596,22 +672,24 @@ namespace io.github.hatayama.uLoopMCP
             RefreshCliSetupSection();
         }
 
-        private void RefreshCliSetupSection()
+        private void RefreshCliSetupSection(bool includeSkillDirectoryChecks = true)
         {
             if (_view == null)
             {
                 return;
             }
 
-            CliSetupData cliData = CreateCliSetupData();
+            CliSetupData cliData = CreateCliSetupData(includeSkillDirectoryChecks);
             _view.UpdateCliSetup(cliData);
         }
 
-        private CliSetupData CreateCliSetupData()
+        private CliSetupData CreateCliSetupData(bool includeSkillDirectoryChecks = true)
         {
             string cliVersion = CliInstallationDetector.GetCachedCliVersion();
             bool isCliInstalled = cliVersion != null;
-            bool isChecking = !CliInstallationDetector.IsCheckCompleted() || _isRefreshingVersion;
+            bool isChecking = !CliInstallationDetector.IsCheckCompleted()
+                || _isRefreshingVersion
+                || !includeSkillDirectoryChecks;
             string packageVersion = McpConstants.PackageInfo.version;
             bool needsUpdate = false;
             bool needsDowngrade = false;
@@ -623,24 +701,9 @@ namespace io.github.hatayama.uLoopMCP
                 needsDowngrade = cliVer > pkgVer;
             }
             bool groupSkillsUnderUnityCliLoop = !_installSkillsFlat;
-            bool isClaudeInstalled = CliInstallationDetector.AreSkillsInstalled(
-                ".claude",
-                groupSkillsUnderUnityCliLoop);
-            bool isAgentsInstalled = CliInstallationDetector.AreSkillsInstalled(
-                ".agents",
-                groupSkillsUnderUnityCliLoop);
-            bool isCursorInstalled = CliInstallationDetector.AreSkillsInstalled(
-                ".cursor",
-                groupSkillsUnderUnityCliLoop);
-            bool isGeminiInstalled = CliInstallationDetector.AreSkillsInstalled(
-                ".gemini",
-                groupSkillsUnderUnityCliLoop);
-            bool isCodexInstalled = CliInstallationDetector.AreSkillsInstalled(
-                ".codex",
-                groupSkillsUnderUnityCliLoop);
-            bool isAntigravityInstalled = CliInstallationDetector.AreSkillsInstalled(
-                ".agent",
-                groupSkillsUnderUnityCliLoop);
+            SkillInstallState selectedTargetInstallState = includeSkillDirectoryChecks
+                ? _selectedTargetInstallState
+                : SkillInstallState.Checking;
 
             return new CliSetupData(
                 isCliInstalled,
@@ -650,13 +713,13 @@ namespace io.github.hatayama.uLoopMCP
                 needsDowngrade,
                 _isInstallingCli,
                 isChecking,
-                isClaudeInstalled,
-                isAgentsInstalled,
-                isCursorInstalled,
-                isGeminiInstalled,
-                isCodexInstalled,
-                isAntigravityInstalled,
-                _selectedTargetInstallState,
+                isClaudeSkillsInstalled: false,
+                isAgentsSkillsInstalled: false,
+                isCursorSkillsInstalled: false,
+                isGeminiSkillsInstalled: false,
+                isCodexSkillsInstalled: false,
+                isAntigravitySkillsInstalled: false,
+                selectedTargetInstallState,
                 _skillsTarget,
                 groupSkillsUnderUnityCliLoop,
                 _isInstallingSkills);
@@ -852,6 +915,20 @@ namespace io.github.hatayama.uLoopMCP
             ApplyFlatSkillInstallPreference();
             RefreshSelectedTargetInstallStateFast();
             RefreshSelectedTargetInstallStateInBackground();
+        }
+
+        private void RefreshRepositoryRootSupport()
+        {
+            ApplyFlatSkillInstallPreference();
+
+            bool gitRootDiffers = UnityMcpPathResolver.GitRootDiffersFromProjectRoot();
+            _model.UpdateSupportsRepositoryRootToggle(gitRootDiffers);
+            _model.UpdateShowRepositoryRootToggle(gitRootDiffers);
+
+            if (!gitRootDiffers && _model.UI.AddRepositoryRoot)
+            {
+                _model.UpdateAddRepositoryRoot(false);
+            }
         }
 
         private void ApplyFlatSkillInstallPreference()

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -542,7 +542,7 @@ namespace io.github.hatayama.uLoopMCP
             }
             else
             {
-                await ToolSkillSynchronizer.InstallSkillFiles(!_installSkillsFlat);
+                await ToolSkillSynchronizer.InstallSkillFilesForTool(toolName, !_installSkillsFlat);
 
                 if (!ToolSkillSynchronizer.IsSkillInstalled(toolName))
                 {

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.uLoopMCP
     {
         private const bool ForceFlatSkillInstall = true;
         private const double DeferredInitialRefreshDelaySeconds = 0.05;
+        private const double ToolSettingsRegistryWarmupDelaySeconds = 0.05;
 
         private McpConfigServiceFactory _configServiceFactory;
         private McpEditorWindowUI _view;
@@ -27,6 +28,8 @@ namespace io.github.hatayama.uLoopMCP
         private bool _isDeferredInitialRefreshScheduled;
         private bool _hasCompletedDeferredInitialRefresh;
         private double _deferredInitialRefreshDueTime;
+        private bool _isToolSettingsRegistryWarmupScheduled;
+        private double _toolSettingsRegistryWarmupDueTime;
         private SkillInstallState _selectedTargetInstallState = SkillInstallState.Missing;
         private CancellationTokenSource _skillInstallStateRefreshCts;
 
@@ -45,6 +48,7 @@ namespace io.github.hatayama.uLoopMCP
         private void OnDestroy()
         {
             CancelDeferredInitialRefresh();
+            CancelToolSettingsRegistryWarmup();
             CancelSkillInstallStateRefresh();
             _view?.Dispose();
             _view = null;
@@ -166,6 +170,7 @@ namespace io.github.hatayama.uLoopMCP
         private void OnDisable()
         {
             CancelDeferredInitialRefresh();
+            CancelToolSettingsRegistryWarmup();
             CancelSkillInstallStateRefresh();
             CleanupEventHandler();
             SaveSessionState();
@@ -424,6 +429,15 @@ namespace io.github.hatayama.uLoopMCP
         {
             ToolSettingsSectionData toolSettingsData = CreateToolSettingsData();
             _view.UpdateToolSettings(toolSettingsData);
+
+            if (McpEditorWindowRefreshPolicy.ShouldKeepToolSettingsCatalogDirty(toolSettingsData))
+            {
+                _isToolSettingsCatalogDirty = true;
+                ScheduleToolSettingsRegistryWarmup();
+                return;
+            }
+
+            CancelToolSettingsRegistryWarmup();
             _isToolSettingsCatalogDirty = false;
         }
 
@@ -517,10 +531,53 @@ namespace io.github.hatayama.uLoopMCP
             if (!show)
             {
                 _isToolSettingsCatalogDirty = true;
+                CancelToolSettingsRegistryWarmup();
                 return;
             }
 
             RefreshToolSettingsCatalogIfNeeded();
+        }
+
+        private void ScheduleToolSettingsRegistryWarmup()
+        {
+            if (_isToolSettingsRegistryWarmupScheduled)
+            {
+                return;
+            }
+
+            _isToolSettingsRegistryWarmupScheduled = true;
+            _toolSettingsRegistryWarmupDueTime = EditorApplication.timeSinceStartup + ToolSettingsRegistryWarmupDelaySeconds;
+            EditorApplication.update += RunToolSettingsRegistryWarmupWhenDue;
+        }
+
+        private void RunToolSettingsRegistryWarmupWhenDue()
+        {
+            if (EditorApplication.timeSinceStartup < _toolSettingsRegistryWarmupDueTime)
+            {
+                return;
+            }
+
+            CancelToolSettingsRegistryWarmup();
+
+            if (_view == null || !_model.UI.ShowToolSettings)
+            {
+                return;
+            }
+
+            CustomToolManager.WarmupRegistry();
+            InvalidateToolSettingsCatalog();
+            RefreshToolSettingsCatalogIfNeeded();
+        }
+
+        private void CancelToolSettingsRegistryWarmup()
+        {
+            if (!_isToolSettingsRegistryWarmupScheduled)
+            {
+                return;
+            }
+
+            EditorApplication.update -= RunToolSettingsRegistryWarmupWhenDue;
+            _isToolSettingsRegistryWarmupScheduled = false;
         }
 
         private void HandleToolToggled(string toolName, bool enabled)

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -23,7 +23,6 @@ namespace io.github.hatayama.uLoopMCP
         private bool _isInstallingSkills;
         private bool _isRefreshingVersion;
         private bool _isToolSettingsCatalogDirty = true;
-        private bool _isToolSettingsRefreshScheduled;
         private SkillInstallState _selectedTargetInstallState = SkillInstallState.Missing;
         private CancellationTokenSource _skillInstallStateRefreshCts;
 
@@ -222,7 +221,7 @@ namespace io.github.hatayama.uLoopMCP
             _view.UpdateEditorConfig(configData);
 
             RefreshToolSettingsHeader();
-            ScheduleToolSettingsCatalogRefreshIfNeeded();
+            RefreshToolSettingsCatalogIfNeeded();
         }
 
         private async void RefreshCliVersionInBackground()
@@ -352,22 +351,14 @@ namespace io.github.hatayama.uLoopMCP
             _isToolSettingsCatalogDirty = false;
         }
 
-        private void ScheduleToolSettingsCatalogRefreshIfNeeded()
+        private void RefreshToolSettingsCatalogIfNeeded()
         {
-            if (!_model.UI.ShowToolSettings || !_isToolSettingsCatalogDirty || _isToolSettingsRefreshScheduled)
+            if (!_model.UI.ShowToolSettings || !_isToolSettingsCatalogDirty)
             {
                 return;
             }
 
-            _isToolSettingsRefreshScheduled = true;
-            EditorApplication.delayCall += RefreshToolSettingsCatalogIfNeeded;
-        }
-
-        private void RefreshToolSettingsCatalogIfNeeded()
-        {
-            _isToolSettingsRefreshScheduled = false;
-
-            if (_view == null || !_model.UI.ShowToolSettings)
+            if (_view == null)
             {
                 return;
             }
@@ -389,7 +380,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private ToolSettingsSectionData CreateToolSettingsData()
         {
-            UnityToolRegistry registry = CustomToolManager.GetRegistry();
+            UnityToolRegistry registry = CustomToolManager.TryGetRegistry();
             if (registry == null)
             {
                 return new ToolSettingsSectionData(
@@ -453,7 +444,7 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            ScheduleToolSettingsCatalogRefreshIfNeeded();
+            RefreshToolSettingsCatalogIfNeeded();
         }
 
         private void HandleToolToggled(string toolName, bool enabled)

--- a/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
@@ -194,6 +194,13 @@ namespace io.github.hatayama.uLoopMCP
         {
             return refreshRequested && ShouldRunExpensiveChecks(refreshMode);
         }
+
+        public static bool ShouldKeepToolSettingsCatalogDirty(ToolSettingsSectionData toolSettingsData)
+        {
+            Debug.Assert(toolSettingsData != null, "toolSettingsData must not be null");
+
+            return toolSettingsData.ShowToolSettings && !toolSettingsData.IsRegistryAvailable;
+        }
     }
 
     internal enum McpEditorWindowRefreshMode

--- a/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
@@ -97,6 +97,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private void OnServerStateChanged()
         {
+            _window.InvalidateToolSettingsCatalog();
             _model.RequestRepaint();
         }
 

--- a/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
@@ -182,5 +182,23 @@ namespace io.github.hatayama.uLoopMCP
 
             return runtimeState.NeedsRepaint;
         }
+
+        public static bool ShouldRunExpensiveChecks(McpEditorWindowRefreshMode refreshMode)
+        {
+            return refreshMode == McpEditorWindowRefreshMode.Full;
+        }
+
+        public static bool ShouldRefreshSkillInstallState(
+            McpEditorWindowRefreshMode refreshMode,
+            bool refreshRequested)
+        {
+            return refreshRequested && ShouldRunExpensiveChecks(refreshMode);
+        }
+    }
+
+    internal enum McpEditorWindowRefreshMode
+    {
+        InitialPaint,
+        Full
     }
 }

--- a/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
@@ -201,6 +201,35 @@ namespace io.github.hatayama.uLoopMCP
 
             return toolSettingsData.ShowToolSettings && !toolSettingsData.IsRegistryAvailable;
         }
+
+        public static bool ShouldStartToolSettingsRegistryWarmup(
+            bool isAlreadyScheduled,
+            int attemptCount,
+            int maxAttempts)
+        {
+            Debug.Assert(attemptCount >= 0, "attemptCount must not be negative");
+            Debug.Assert(maxAttempts > 0, "maxAttempts must be positive");
+
+            return !isAlreadyScheduled && attemptCount < maxAttempts;
+        }
+
+        public static double CalculateToolSettingsRegistryWarmupDelaySeconds(
+            double initialDelaySeconds,
+            double maxDelaySeconds,
+            int attemptCount)
+        {
+            Debug.Assert(initialDelaySeconds > 0.0, "initialDelaySeconds must be positive");
+            Debug.Assert(maxDelaySeconds >= initialDelaySeconds, "maxDelaySeconds must not be smaller than initialDelaySeconds");
+            Debug.Assert(attemptCount >= 0, "attemptCount must not be negative");
+
+            double delaySeconds = initialDelaySeconds;
+            for (int i = 0; i < attemptCount; i++)
+            {
+                delaySeconds *= 2.0;
+            }
+
+            return System.Math.Min(delaySeconds, maxDelaySeconds);
+        }
     }
 
     internal enum McpEditorWindowRefreshMode

--- a/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
@@ -70,6 +70,7 @@ namespace io.github.hatayama.uLoopMCP
             McpBridgeServer.OnServerStarted += OnServerStateChanged;
             McpBridgeServer.OnServerStopping += OnServerStateChanged;
             ConnectedToolsMonitoringService.OnConnectedToolsChanged += OnConnectedToolsChanged;
+            CustomToolManager.OnToolsChanged += OnToolsChanged;
 
             McpBridgeServer currentServer = McpServerController.CurrentServer;
             if (currentServer != null)
@@ -84,6 +85,7 @@ namespace io.github.hatayama.uLoopMCP
             McpBridgeServer.OnServerStarted -= OnServerStateChanged;
             McpBridgeServer.OnServerStopping -= OnServerStateChanged;
             ConnectedToolsMonitoringService.OnConnectedToolsChanged -= OnConnectedToolsChanged;
+            CustomToolManager.OnToolsChanged -= OnToolsChanged;
 
             McpBridgeServer currentServer = McpServerController.CurrentServer;
             if (currentServer != null)
@@ -100,6 +102,12 @@ namespace io.github.hatayama.uLoopMCP
 
         private void OnConnectedToolsChanged()
         {
+            _model.RequestRepaint();
+        }
+
+        private void OnToolsChanged()
+        {
+            _window.InvalidateToolSettingsCatalog();
             _model.RequestRepaint();
         }
 

--- a/Packages/src/Editor/UI/McpEditorWindowViewData.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowViewData.cs
@@ -122,6 +122,7 @@ namespace io.github.hatayama.uLoopMCP
         public readonly ToolToggleItem[] BuiltInTools;
         public readonly ToolToggleItem[] ThirdPartyTools;
         public readonly bool IsRegistryAvailable;
+        public readonly bool HasToolListData;
 
         public ToolSettingsSectionData(
             bool showToolSettings,
@@ -129,7 +130,8 @@ namespace io.github.hatayama.uLoopMCP
             DynamicCodeSecurityLevel dynamicCodeSecurityLevel,
             ToolToggleItem[] builtInTools,
             ToolToggleItem[] thirdPartyTools,
-            bool isRegistryAvailable)
+            bool isRegistryAvailable,
+            bool hasToolListData = true)
         {
             ShowToolSettings = showToolSettings;
             AllowThirdPartyTools = allowThirdPartyTools;
@@ -137,6 +139,7 @@ namespace io.github.hatayama.uLoopMCP
             BuiltInTools = builtInTools;
             ThirdPartyTools = thirdPartyTools;
             IsRegistryAvailable = isRegistryAvailable;
+            HasToolListData = hasToolListData;
         }
     }
 

--- a/Packages/src/Editor/UI/McpEditorWindowViewData.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowViewData.cs
@@ -72,8 +72,9 @@ namespace io.github.hatayama.uLoopMCP
         public readonly bool AddRepositoryRoot;
         public readonly bool SupportsRepositoryRootToggle;
         public readonly bool ShowRepositoryRootToggle;
+        public readonly bool IsChecking;
 
-        public EditorConfigData(McpEditorType selectedEditor, bool isServerRunning, int currentPort, bool isConfigured = false, bool hasPortMismatch = false, string configurationError = null, bool isUpdateNeeded = true, bool addRepositoryRoot = false, bool supportsRepositoryRootToggle = false, bool showRepositoryRootToggle = false)
+        public EditorConfigData(McpEditorType selectedEditor, bool isServerRunning, int currentPort, bool isConfigured = false, bool hasPortMismatch = false, string configurationError = null, bool isUpdateNeeded = true, bool addRepositoryRoot = false, bool supportsRepositoryRootToggle = false, bool showRepositoryRootToggle = false, bool isChecking = false)
         {
             SelectedEditor = selectedEditor;
             IsServerRunning = isServerRunning;
@@ -85,6 +86,7 @@ namespace io.github.hatayama.uLoopMCP
             AddRepositoryRoot = addRepositoryRoot;
             SupportsRepositoryRootToggle = supportsRepositoryRootToggle;
             ShowRepositoryRootToggle = showRepositoryRootToggle;
+            IsChecking = isChecking;
         }
     }
 

--- a/Packages/src/Editor/UI/UIToolkit/Components/EditorConfigSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/EditorConfigSection.cs
@@ -124,7 +124,12 @@ namespace io.github.hatayama.uLoopMCP
             string buttonText;
             bool buttonEnabled = true;
 
-            if (data.IsConfigured)
+            if (data.IsChecking)
+            {
+                buttonText = $"Checking {editorName} Settings...";
+                buttonEnabled = false;
+            }
+            else if (data.IsConfigured)
             {
                 if (data.IsUpdateNeeded)
                 {

--- a/Packages/src/Editor/UI/UIToolkit/Components/ToolSettingsSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/ToolSettingsSection.cs
@@ -7,12 +7,14 @@ using UnityEngine.UIElements;
 namespace io.github.hatayama.uLoopMCP
 {
     /// <summary>
-    /// UI section for per-tool enable/disable toggles.
-    /// Groups tools into Built-in and Third Party categories.
-    /// Uses differential updates to avoid full rebuild on each toggle change.
+    /// UI section for tool permissions and a virtualized per-tool enable list.
+    /// The expensive list is allowed to stay unloaded while the foldout is collapsed.
     /// </summary>
     public class ToolSettingsSection
     {
+        private const int ToolListRowHeight = 24;
+        private const int MaxVisibleToolRows = 14;
+
         private readonly Foldout _foldout;
         private readonly Toggle _allowThirdPartyToggle;
         private readonly Label _allowThirdPartyLabel;
@@ -21,10 +23,14 @@ namespace io.github.hatayama.uLoopMCP
         private readonly Label _securityLevelDescription;
         private readonly VisualElement _toolSettingsInfoContainer;
         private readonly VisualElement _toolListContainer;
+        private readonly Label _toolListStatusLabel;
+        private readonly ListView _toolListView;
+        private readonly List<ToolListRowData> _toolListRows = new();
         private readonly Dictionary<string, Toggle> _togglesByToolName = new();
-        private VisualElement _thirdPartyGroupContainer;
+        private bool _allowThirdPartyTools = true;
         private bool _isRegistryAvailable;
         private bool _isUnavailableStateShown;
+        private bool _isLoadingStateShown;
         private string _layoutSignature = string.Empty;
 
         public event Action<bool> OnFoldoutChanged;
@@ -42,6 +48,13 @@ namespace io.github.hatayama.uLoopMCP
             _securityLevelDescription = root.Q<Label>("security-level-description");
             _toolSettingsInfoContainer = root.Q<VisualElement>("tool-settings-info-container");
             _toolListContainer = root.Q<VisualElement>("tool-list-container");
+            Debug.Assert(_toolListContainer != null, "tool-list-container must not be null");
+
+            _toolListStatusLabel = CreateToolListStatusLabel();
+            _toolListView = CreateToolListView();
+            _toolListContainer.Add(_toolListStatusLabel);
+            _toolListContainer.Add(_toolListView);
+            ClearToolList();
 
             Label cliReferenceLink = root.Q<Label>("cli-reference-link");
             if (cliReferenceLink != null)
@@ -76,10 +89,24 @@ namespace io.github.hatayama.uLoopMCP
 
         public void Update(ToolSettingsSectionData data)
         {
+            _allowThirdPartyTools = data.AllowThirdPartyTools;
+
             ViewDataBinder.UpdateFoldout(_foldout, data.ShowToolSettings);
             ViewDataBinder.UpdateToggle(_allowThirdPartyToggle, data.AllowThirdPartyTools);
             UpdateSecurityLevelSelection(data.DynamicCodeSecurityLevel);
             UpdateSecurityLevelDescription(data.DynamicCodeSecurityLevel);
+
+            if (!data.ShowToolSettings)
+            {
+                ClearToolList();
+                return;
+            }
+
+            if (!data.HasToolListData)
+            {
+                UpdateDeferredState();
+                return;
+            }
 
             if (!data.IsRegistryAvailable)
             {
@@ -90,38 +117,108 @@ namespace io.github.hatayama.uLoopMCP
             UpdateToolList(data);
         }
 
-        /// <summary>
-        /// Update a single toggle value without rebuilding the entire list.
-        /// </summary>
         public void UpdateSingleToggle(string toolName, bool enabled)
         {
+            for (int i = 0; i < _toolListRows.Count; i++)
+            {
+                ToolListRowData row = _toolListRows[i];
+                if (row.IsHeader || row.ToolName != toolName)
+                {
+                    continue;
+                }
+
+                row.IsEnabled = enabled;
+                break;
+            }
+
             if (_togglesByToolName.TryGetValue(toolName, out Toggle toggle))
             {
                 toggle.SetValueWithoutNotify(enabled);
             }
+
+            RefreshToolListView();
+        }
+
+        private void UpdateDeferredState()
+        {
+            if (_toolListRows.Count > 0 || _isUnavailableStateShown)
+            {
+                UpdateThirdPartyGroupState(_allowThirdPartyTools);
+                return;
+            }
+
+            UpdateLoadingState();
+        }
+
+        private void UpdateLoadingState()
+        {
+            _toolListRows.Clear();
+            _togglesByToolName.Clear();
+            _layoutSignature = string.Empty;
+
+            SetToolListStatus("Loading tools...");
+            ViewDataBinder.SetVisible(_toolListView, false);
+            SetToolSettingsInfoVisible(false);
+
+            _isRegistryAvailable = false;
+            _isUnavailableStateShown = false;
+            _isLoadingStateShown = true;
         }
 
         private void UpdateUnavailableState()
         {
-            if (_isRegistryAvailable || !_isUnavailableStateShown)
-            {
-                RebuildUnavailable();
-            }
+            _toolListRows.Clear();
+            _togglesByToolName.Clear();
+            _layoutSignature = string.Empty;
 
-            if (_toolSettingsInfoContainer != null)
-            {
-                ViewDataBinder.SetVisible(_toolSettingsInfoContainer, false);
-            }
+            SetToolListStatus("Tool registry not yet initialized. Start the server first.");
+            ViewDataBinder.SetVisible(_toolListView, false);
+            SetToolSettingsInfoVisible(false);
 
             _isRegistryAvailable = false;
             _isUnavailableStateShown = true;
+            _isLoadingStateShown = false;
+        }
+
+        private void ClearToolList()
+        {
+            _toolListRows.Clear();
+            _togglesByToolName.Clear();
             _layoutSignature = string.Empty;
+
+            ViewDataBinder.SetVisible(_toolListStatusLabel, false);
+            ViewDataBinder.SetVisible(_toolListView, false);
+            SetToolSettingsInfoVisible(false);
+            RefreshToolListView();
+
+            _isRegistryAvailable = false;
+            _isUnavailableStateShown = false;
+            _isLoadingStateShown = false;
+        }
+
+        private void SetToolListStatus(string text)
+        {
+            _toolListStatusLabel.text = text;
+            ViewDataBinder.SetVisible(_toolListStatusLabel, true);
+        }
+
+        private void SetToolSettingsInfoVisible(bool visible)
+        {
+            if (_toolSettingsInfoContainer == null)
+            {
+                return;
+            }
+
+            ViewDataBinder.SetVisible(_toolSettingsInfoContainer, visible);
         }
 
         private void UpdateToolList(ToolSettingsSectionData data)
         {
             string layoutSignature = CreateLayoutSignature(data);
-            bool shouldRebuild = !_isRegistryAvailable || _layoutSignature != layoutSignature;
+            bool shouldRebuild = !_isRegistryAvailable
+                || _isUnavailableStateShown
+                || _isLoadingStateShown
+                || _layoutSignature != layoutSignature;
 
             if (shouldRebuild)
             {
@@ -134,20 +231,14 @@ namespace io.github.hatayama.uLoopMCP
                 UpdateToggleStates(data.ThirdPartyTools);
             }
 
+            ViewDataBinder.SetVisible(_toolListStatusLabel, false);
+            ViewDataBinder.SetVisible(_toolListView, true);
+            SetToolSettingsInfoVisible(true);
             UpdateThirdPartyGroupState(data.AllowThirdPartyTools);
 
             _isRegistryAvailable = true;
             _isUnavailableStateShown = false;
-        }
-
-        private void RebuildUnavailable()
-        {
-            _toolListContainer.Clear();
-            _togglesByToolName.Clear();
-            _thirdPartyGroupContainer = null;
-            Label unavailableLabel = new Label("Tool registry not yet initialized. Start the server first.");
-            unavailableLabel.AddToClassList("mcp-tool-registry-unavailable");
-            _toolListContainer.Add(unavailableLabel);
+            _isLoadingStateShown = false;
         }
 
         private void UpdateSecurityLevelDescription(DynamicCodeSecurityLevel currentLevel)
@@ -188,43 +279,32 @@ namespace io.github.hatayama.uLoopMCP
 
         private void Rebuild(ToolSettingsSectionData data)
         {
-            _toolListContainer.Clear();
+            _toolListRows.Clear();
             _togglesByToolName.Clear();
-            _thirdPartyGroupContainer = null;
 
             if (data.BuiltInTools.Length > 0)
             {
-                VisualElement builtInGroup = CreateGroupContainer();
-                AddGroupHeader(builtInGroup, "Built-in Tools");
-                AddToolSettingsInfo(builtInGroup);
-                foreach (ToolToggleItem item in data.BuiltInTools)
-                {
-                    AddToolToggle(builtInGroup, item);
-                }
-                _toolListContainer.Add(builtInGroup);
+                _toolListRows.Add(ToolListRowData.CreateHeader("Built-in Tools", false));
+                AddToolRows(data.BuiltInTools);
             }
 
             if (data.ThirdPartyTools.Length > 0)
             {
-                _thirdPartyGroupContainer = CreateGroupContainer();
-                AddGroupHeader(_thirdPartyGroupContainer, "Third Party Tools");
-                foreach (ToolToggleItem item in data.ThirdPartyTools)
-                {
-                    AddToolToggle(_thirdPartyGroupContainer, item);
-                }
-                _toolListContainer.Add(_thirdPartyGroupContainer);
+                _toolListRows.Add(ToolListRowData.CreateHeader("Third Party Tools", true));
+                AddToolRows(data.ThirdPartyTools);
             }
+
+            UpdateToolListHeight();
+            RefreshToolListView();
         }
 
-        private void AddToolSettingsInfo(VisualElement container)
+        private void AddToolRows(IReadOnlyList<ToolToggleItem> items)
         {
-            if (_toolSettingsInfoContainer == null)
+            for (int i = 0; i < items.Count; i++)
             {
-                return;
+                ToolToggleItem item = items[i];
+                _toolListRows.Add(ToolListRowData.CreateTool(item));
             }
-
-            ViewDataBinder.SetVisible(_toolSettingsInfoContainer, true);
-            container.Add(_toolSettingsInfoContainer);
         }
 
         private void UpdateToggleStates(IReadOnlyList<ToolToggleItem> items)
@@ -232,7 +312,22 @@ namespace io.github.hatayama.uLoopMCP
             for (int i = 0; i < items.Count; i++)
             {
                 ToolToggleItem item = items[i];
-                UpdateSingleToggle(item.ToolName, item.IsEnabled);
+                UpdateToggleState(item.ToolName, item.IsEnabled);
+            }
+        }
+
+        private void UpdateToggleState(string toolName, bool isEnabled)
+        {
+            for (int i = 0; i < _toolListRows.Count; i++)
+            {
+                ToolListRowData row = _toolListRows[i];
+                if (row.IsHeader || row.ToolName != toolName)
+                {
+                    continue;
+                }
+
+                row.IsEnabled = isEnabled;
+                return;
             }
         }
 
@@ -261,62 +356,207 @@ namespace io.github.hatayama.uLoopMCP
 
         private void UpdateThirdPartyGroupState(bool allowThirdPartyTools)
         {
-            if (_thirdPartyGroupContainer == null)
-            {
-                return;
-            }
-
-            ViewDataBinder.SetEnabled(_thirdPartyGroupContainer, allowThirdPartyTools);
-            ViewDataBinder.ToggleClass(_thirdPartyGroupContainer, "mcp-tool-group--disabled", !allowThirdPartyTools);
+            _allowThirdPartyTools = allowThirdPartyTools;
+            RefreshToolListView();
         }
 
-        private static VisualElement CreateGroupContainer()
+        private static Label CreateToolListStatusLabel()
         {
-            VisualElement container = new VisualElement();
-            container.AddToClassList("mcp-tool-group");
-            return container;
+            Label label = new Label();
+            label.name = "tool-list-status-label";
+            label.AddToClassList("mcp-tool-registry-unavailable");
+            return label;
         }
 
-        private static void AddGroupHeader(VisualElement container, string text)
+        private ListView CreateToolListView()
         {
-            Label header = new Label(text);
-            header.AddToClassList("mcp-tool-group-header");
-            container.Add(header);
+            ListView listView = new ListView();
+            listView.name = "tool-list-view";
+            listView.AddToClassList("mcp-tool-list-view");
+            listView.fixedItemHeight = ToolListRowHeight;
+            listView.virtualizationMethod = CollectionVirtualizationMethod.FixedHeight;
+            listView.selectionType = SelectionType.None;
+            listView.itemsSource = _toolListRows;
+            listView.makeItem = CreateToolListRowElement;
+            listView.bindItem = BindToolListRowElement;
+            listView.unbindItem = UnbindToolListRowElement;
+            return listView;
         }
 
-        private void AddToolToggle(VisualElement container, ToolToggleItem item)
+        private static VisualElement CreateToolListRowElement()
         {
             VisualElement row = new VisualElement();
             row.AddToClassList("mcp-tool-toggle-row");
+            row.AddToClassList("mcp-tool-list-row");
 
             Toggle toggle = new Toggle();
+            toggle.name = "tool-list-row-toggle";
             toggle.AddToClassList("mcp-tool-toggle-row__toggle");
-            toggle.SetValueWithoutNotify(item.IsEnabled);
-
-            string toolName = item.ToolName;
             toggle.RegisterValueChangedCallback(evt =>
             {
-                // Foldout uses an internal Toggle that listens for ChangeEvent<bool>.
-                // Without StopPropagation, this event bubbles up and collapses the Foldout.
                 evt.StopPropagation();
-                OnToolToggled?.Invoke(toolName, evt.newValue);
+
+                if (row.userData is not ToolListRowData item || item.IsHeader)
+                {
+                    return;
+                }
+
+                item.Owner?.OnToolToggled?.Invoke(item.ToolName, evt.newValue);
             });
 
-            Label label = new Label(item.ToolName);
+            Label label = new Label();
+            label.name = "tool-list-row-label";
             label.AddToClassList("mcp-tool-toggle-row__label");
-            label.tooltip = item.Description;
             label.RegisterCallback<ClickEvent>(evt =>
             {
                 evt.StopPropagation();
-                bool newValue = !toggle.value;
-                toggle.SetValueWithoutNotify(newValue);
-                OnToolToggled?.Invoke(toolName, newValue);
+
+                if (row.userData is not ToolListRowData item || item.IsHeader || !item.CanToggle)
+                {
+                    return;
+                }
+
+                Toggle rowToggle = row.Q<Toggle>("tool-list-row-toggle");
+                bool newValue = !rowToggle.value;
+                rowToggle.SetValueWithoutNotify(newValue);
+                item.Owner?.OnToolToggled?.Invoke(item.ToolName, newValue);
             });
 
             row.Add(toggle);
             row.Add(label);
-            container.Add(row);
-            _togglesByToolName[toolName] = toggle;
+            return row;
+        }
+
+        private void BindToolListRowElement(VisualElement row, int index)
+        {
+            Debug.Assert(index >= 0 && index < _toolListRows.Count, "tool list index must be valid");
+
+            ToolListRowData item = _toolListRows[index];
+            item.Owner = this;
+            item.CanToggle = !item.IsThirdParty || _allowThirdPartyTools;
+            row.userData = item;
+
+            Toggle toggle = row.Q<Toggle>("tool-list-row-toggle");
+            Label label = row.Q<Label>("tool-list-row-label");
+            Debug.Assert(toggle != null, "tool-list-row-toggle must not be null");
+            Debug.Assert(label != null, "tool-list-row-label must not be null");
+
+            ResetRowClasses(row, label);
+
+            if (item.IsHeader)
+            {
+                BindHeaderRow(row, toggle, label, item);
+                return;
+            }
+
+            BindToolRow(row, toggle, label, item);
+        }
+
+        private void BindHeaderRow(VisualElement row, Toggle toggle, Label label, ToolListRowData item)
+        {
+            ViewDataBinder.SetVisible(toggle, false);
+            label.text = item.Label;
+            label.tooltip = string.Empty;
+            row.SetEnabled(true);
+            row.AddToClassList("mcp-tool-list-row--header");
+            label.AddToClassList("mcp-tool-group-header");
+            ViewDataBinder.ToggleClass(row, "mcp-tool-list-row--disabled", item.IsThirdParty && !_allowThirdPartyTools);
+        }
+
+        private void BindToolRow(VisualElement row, Toggle toggle, Label label, ToolListRowData item)
+        {
+            ViewDataBinder.SetVisible(toggle, true);
+            toggle.SetValueWithoutNotify(item.IsEnabled);
+            label.text = item.ToolName;
+            label.tooltip = item.Description;
+
+            row.SetEnabled(item.CanToggle);
+            ViewDataBinder.ToggleClass(row, "mcp-tool-list-row--disabled", !item.CanToggle);
+            _togglesByToolName[item.ToolName] = toggle;
+        }
+
+        private static void ResetRowClasses(VisualElement row, Label label)
+        {
+            row.RemoveFromClassList("mcp-tool-list-row--header");
+            row.RemoveFromClassList("mcp-tool-list-row--disabled");
+            label.RemoveFromClassList("mcp-tool-group-header");
+        }
+
+        private void UnbindToolListRowElement(VisualElement row, int index)
+        {
+            if (row.userData is ToolListRowData item && !item.IsHeader)
+            {
+                _togglesByToolName.Remove(item.ToolName);
+            }
+
+            row.userData = null;
+        }
+
+        private void RefreshToolListView()
+        {
+            _togglesByToolName.Clear();
+            _toolListView.RefreshItems();
+        }
+
+        private void UpdateToolListHeight()
+        {
+            int visibleRows = Math.Min(_toolListRows.Count, MaxVisibleToolRows);
+            if (visibleRows <= 0)
+            {
+                visibleRows = 1;
+            }
+
+            _toolListView.style.height = (visibleRows * ToolListRowHeight) + 2;
+        }
+
+        private sealed class ToolListRowData
+        {
+            public readonly bool IsHeader;
+            public readonly string ToolName;
+            public readonly string Label;
+            public readonly string Description;
+            public readonly bool IsThirdParty;
+            public bool IsEnabled;
+            public bool CanToggle = true;
+            public ToolSettingsSection Owner;
+
+            private ToolListRowData(
+                bool isHeader,
+                string toolName,
+                string label,
+                string description,
+                bool isEnabled,
+                bool isThirdParty)
+            {
+                IsHeader = isHeader;
+                ToolName = toolName;
+                Label = label;
+                Description = description;
+                IsEnabled = isEnabled;
+                IsThirdParty = isThirdParty;
+            }
+
+            public static ToolListRowData CreateHeader(string label, bool isThirdParty)
+            {
+                return new ToolListRowData(
+                    true,
+                    string.Empty,
+                    label,
+                    string.Empty,
+                    true,
+                    isThirdParty);
+            }
+
+            public static ToolListRowData CreateTool(ToolToggleItem item)
+            {
+                return new ToolListRowData(
+                    false,
+                    item.ToolName,
+                    item.ToolName,
+                    item.Description,
+                    item.IsEnabled,
+                    item.IsThirdParty);
+            }
         }
     }
 }

--- a/Packages/src/Editor/UI/UIToolkit/Components/ToolSettingsSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/ToolSettingsSection.cs
@@ -13,7 +13,7 @@ namespace io.github.hatayama.uLoopMCP
     public class ToolSettingsSection
     {
         private const int ToolListRowHeight = 24;
-        private const int MaxVisibleToolRows = 14;
+        private const int InlineToolRowLimit = 40;
 
         private readonly Foldout _foldout;
         private readonly Toggle _allowThirdPartyToggle;
@@ -500,7 +500,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private void UpdateToolListHeight()
         {
-            int visibleRows = Math.Min(_toolListRows.Count, MaxVisibleToolRows);
+            int visibleRows = Math.Min(_toolListRows.Count, InlineToolRowLimit);
             if (visibleRows <= 0)
             {
                 visibleRows = 1;

--- a/Packages/src/Editor/UI/UIToolkit/McpEditorWindow.uss
+++ b/Packages/src/Editor/UI/UIToolkit/McpEditorWindow.uss
@@ -523,6 +523,31 @@
     flex-grow: 1;
 }
 
+.mcp-tool-list-container {
+    padding-left: 0;
+}
+
+.mcp-tool-list-view {
+    margin-top: 4px;
+    margin-left: 0;
+    margin-right: 0;
+    border-width: 0;
+    background-color: transparent;
+}
+
+.mcp-tool-list-row {
+    min-height: 24px;
+}
+
+.mcp-tool-list-row--header {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+.mcp-tool-list-row--disabled {
+    opacity: 0.45;
+}
+
 .mcp-tool-registry-unavailable {
     color: #888888;
     -unity-font-style: italic;


### PR DESCRIPTION
## Summary
- Settings now paints quickly before slower CLI, skill, and tool-list checks run.
- Keeping Settings open no longer keeps rebuilding the tool list unnecessarily.
- Re-enabling one tool now updates only that tool’s skill files instead of touching unrelated skills.

## User Impact
- Previously, opening Settings could show a black window for 1-2 seconds and trigger the macOS spinning cursor while filesystem-heavy checks ran before the first paint.
- Tool Settings could stay expensive while open, especially with larger custom tool sets.
- Turning a tool off and back on could rewrite unrelated installed skills, creating surprising file changes outside the selected tool.

## Changes
- Render lightweight initial Settings data first, then defer slower CLI, repository, editor configuration, skill-state, and tool catalog refreshes.
- Keep the tool list virtualized and avoid warming the registry just to show Settings.
- Add a scoped skill install path for tool toggles so only the re-enabled tool is synchronized.
- Add tests for initial-refresh policy, tool-list rendering behavior, and scoped skill synchronization.

## Verification
- uloop compile --force-recompile false --wait-for-domain-reload true
- uloop run-tests --test-mode EditMode --filter-type regex --filter-value "McpEditorWindowRefreshPolicyTests|ToolSettingsSectionTests|CliSetupSectionTests"
- uloop run-tests --test-mode EditMode --filter-type regex --filter-value "ToolSkillSynchronizerTests"
- uloop compile --project-path <EXTERNAL_PROJECT_ROOT> --force-recompile false --wait-for-domain-reload true
- Opened Settings in an external Unity project via uloop execute-dynamic-code and confirmed the window opens immediately, then the tool list appears after deferred loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves Settings performance and correctness by deferring heavy work, virtualizing the tool list, scoping skill syncs to individual tools, and adding guarded warmup retries.

Key changes
- Deferred initial refresh: CreateGUI performs a lightweight InitialPaint pass and schedules a one-shot deferred Full refresh. Expensive filesystem/environment checks (CLI, repo, editor-config, skill-state, catalog refresh) are deferred so the window paints immediately.
- Refresh policy: Adds McpEditorWindowRefreshMode (InitialPaint, Full) and McpEditorWindowRefreshPolicy helpers:
  - ShouldRunExpensiveChecks(refreshMode) — expensive checks only in Full
  - ShouldRefreshSkillInstallState(refreshMode, refreshRequested) — skill install-state refresh only when allowed
  - ShouldKeepToolSettingsCatalogDirty(toolSettingsData) — retain dirty catalog when tool-settings shown but registry unavailable
  - ShouldStartToolSettingsRegistryWarmup(...) and CalculateToolSettingsRegistryWarmupDelaySeconds(...) — warmup scheduling with capped exponential backoff
- Registry and catalog behavior:
  - CustomToolManager exposes OnToolsChanged; McpEditorWindow listens and invalidates the tool settings catalog.
  - TryGetRegistry() avoids lazy registry creation during initial paint; GetToolSettingsCatalog() returns lightweight ToolSettingsCatalogItem[] (name, description, dev-only flag, third-party indicator) to avoid schema generation.
  - InvalidateToolSettingsCatalog() plus a bounded retry/warmup: leave catalog dirty when registry unavailable and retry a short deferred warmup (with capped exponential backoff and max attempts) to refresh the catalog.
  - Prevents continuous tool-list rebuilds while Settings remains open; header refreshes are separated from catalog loading.
- UI & virtualization:
  - Replaces per-tool VisualElements with a virtualized ListView backed by ToolListRowData; shows loading/status label when tool-list data absent; updates toggles by mutating in-memory row state and refreshing ListView rather than rebuilding elements.
  - Per-row third-party styling and interactivity applied during binding; toggle event routing via userData and a _togglesByToolName map.
  - View-data flags: EditorConfigData.IsChecking and ToolSettingsSectionData.HasToolListData added for deferred-checking/loading states.
- Scoped skill installation & cleanup:
  - Adds public InstallSkillFilesForTool(toolName, groupSkillsUnderUnityCliLoop) in ToolSkillSynchronizer to install/sync only skills matching the specified tool.
  - Shared GetToolNameForSkill derivation (including CLI-prefixed fallback); IsSkillDisabled returns false when no tool name derived.
  - Scoped cleanup removes disabled/deprecated managed skills only for the requested layout; full installer retains broad cleanup behavior.
  - Targeted sync early-returns when no matching skills and avoids rewriting unrelated enabled skills while still removing disabled/deprecated managed skills for the scoped layout.
- Event wiring and lifecycle:
  - McpEditorWindowEventHandler subscribes to CustomToolManager.OnToolsChanged and invalidates the catalog on server-state changes; scheduled callbacks are cancelled on disable/destroy; OnFocus continues lightweight refreshes until deferred pass completes.
- Tests:
  - McpEditorWindowRefreshPolicyTests: verifies InitialPaint skips expensive checks and gates skill refresh; warmup scheduling and capped exponential-backoff delay behavior.
  - ToolSettingsSectionTests: covers ListView lifecycle (hidden/no-data, loading state, populated items and computed list height, subsequent refresh/close behavior).
  - ToolSkillSynchronizerTests: ensures InstallSkillFilesForTool updates only targeted tool skills, removes disabled/deprecated managed skills as expected, preserves unrelated/third-party legacy directories, and verifies layout-scoped cleanup (flat vs grouped). Tests snapshot and restore tool-settings to avoid cross-test interference.

User impact
- Eliminates ~1–2s black/blocked initial paint and macOS spinning cursor caused by upfront filesystem checks; Settings opens immediately with deferred tool-list loading.
- Reduces expensive idle refreshes for Tool Settings with large custom tool sets; catalog refresh uses lifecycle events and bounded retries instead of repeated warmups.
- Re-enabling a tool synchronizes only that tool’s skill files and no longer rewrites unrelated enabled skills; disabled/deprecated managed skills are cleaned up according to the scoped layout.
- Includes automated tests and manual verification steps to validate deferred loading, list virtualization, scoped synchronization, and capped warmup retries.

Commit note
- Adds capped exponential backoff for deferred registry warmup so Settings stops retrying indefinitely when the registry is unavailable, keeping the window quiet in stuck initialization states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
