### PR TITLE
fix: uloop launch docs now explain Unity startup waiting

### DIFF
--- a/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
+++ b/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
@@ -7,6 +7,9 @@ description: "Launch Unity project with matching Editor version via uloop CLI. U
 
 Launch Unity Editor with the correct version for a project.
 
+`uloop launch` is not fire-and-forget. When Unity needs to start or restart, the command waits
+until Unity is actually ready for CLI operations before it exits.
+
 ## Usage
 
 ```bash
@@ -48,4 +51,4 @@ uloop launch -a
 - Prints detected Unity version
 - Prints project path
 - If Unity is already running, focuses the existing window
-- If launching, opens Unity in background
+- If launching, waits until Unity finishes startup and the CLI can connect to the project


### PR DESCRIPTION
## Summary
- Clarifies that `uloop launch` waits for Unity to become ready instead of returning immediately after requesting a launch.
- Updates the launch skill output description so agents understand when the command is safe to follow with CLI operations.

## User Impact
- Before this change, the skill could read like `uloop launch` only started Unity in the background.
- After this change, users and agents can tell that the command waits until Unity finishes startup and the CLI can connect to the project.

## Changes
- Added an explicit note that `uloop launch` is not fire-and-forget.
- Replaced the output description about opening Unity in the background with readiness-focused wording.

## Verification
- Not run; documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Documentation update clarifying the behavior of the `uloop launch` command by explicitly stating that it blocks until Unity startup completes and is ready for CLI interaction, rather than behaving as fire-and-forget.

## Changes
- **File Modified**: `Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md`
- **Type**: Documentation-only
- **Lines Changed**: +4/-1

The documentation now clarifies that `uloop launch` waits for Unity to become ready for CLI interaction. The output description has been updated from indicating the command "opens Unity in background" to explicitly stating that the command blocks until startup completes and the CLI can connect to the project.

## User Impact
Removes ambiguity about command behavior. Prior wording could be misinterpreted as starting Unity in the background only. Users and agents will now understand that the command is not fire-and-forget and that they can follow it directly with CLI operations after it returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->