### PR TITLE
fix: Test runs avoid unsaved editor-change prompts

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -7,7 +7,7 @@ description: "Execute Unity Test Runner and get detailed results. Use when you n
 
 Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
-Before executing tests, `uloop run-tests` checks for unsaved loaded Scene changes and unsaved current Prefab Stage changes. If any are found, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner. Save or discard those editor changes, then rerun the command.
+Before executing tests, `uloop run-tests` checks for unsaved loaded Scene changes and unsaved current Prefab Stage changes. If any are found, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner. Save or discard those editor changes, then rerun the command. Use `--save-before-run true` only when the user explicitly asks to save editor changes before continuing.
 
 ## Usage
 
@@ -22,6 +22,7 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
+| `--save-before-run` | boolean | `false` | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
 
 ## Global Options
 
@@ -37,6 +38,9 @@ uloop run-tests
 
 # Run PlayMode tests
 uloop run-tests --test-mode PlayMode
+
+# Save explicitly approved editor changes before running tests
+uloop run-tests --save-before-run true
 
 # Run specific test
 uloop run-tests --filter-type exact --filter-value "MyTest.TestMethod"

--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -7,6 +7,8 @@ description: "Execute Unity Test Runner and get detailed results. Use when you n
 
 Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
+Before executing tests, `uloop run-tests` checks for unsaved loaded Scene changes and unsaved current Prefab Stage changes. If any are found, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner. Save or discard those editor changes, then rerun the command.
+
 ## Usage
 
 ```bash

--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -7,8 +7,6 @@ description: "Execute Unity Test Runner and get detailed results. Use when you n
 
 Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
-Before executing tests, `uloop run-tests` checks for unsaved loaded Scene changes and unsaved current Prefab Stage changes. If any are found, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner. Save or discard those editor changes, then rerun the command. Use `--save-before-run true` only when the user explicitly asks to save editor changes before continuing.
-
 ## Usage
 
 ```bash
@@ -22,7 +20,6 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--save-before-run` | boolean | `false` | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
 
 ## Global Options
 
@@ -38,9 +35,6 @@ uloop run-tests
 
 # Run PlayMode tests
 uloop run-tests --test-mode PlayMode
-
-# Save explicitly approved editor changes before running tests
-uloop run-tests --save-before-run true
 
 # Run specific test
 uloop run-tests --filter-type exact --filter-value "MyTest.TestMethod"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@ The C# namespace is `io.github.hatayama.uLoopMCP` for historical reasons, but th
 
 Comments in the code, commit messages, PR titles, and PR descriptions must all be written in English.
 
+## Generated Skill Files
+
+Do not directly edit skill files under the project-root `.agents/` or `.claude/` directories.
+These files are generated copies. Update the source skill definitions instead, then regenerate the copies through the normal workflow.
+
 ## Unity Freeze Prevention
 
 Do not add or keep Unity EditMode tests that can freeze the Editor.

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -61,6 +61,7 @@ namespace io.github.hatayama.uLoopMCP
             // Assert - Schema should have default values
             Assert.That(schema.FilterType, Is.EqualTo(TestFilterType.all));
             Assert.That(schema.FilterValue ?? string.Empty, Is.EqualTo(string.Empty));
+            Assert.That(schema.SaveBeforeRun, Is.False);
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -11,14 +11,17 @@ namespace io.github.hatayama.uLoopMCP
         public async Task ExecuteAsync_WithInvalidExecutionState_ShouldFailFastWithoutRunningTests()
         {
             StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(
+                ValidationResult.Failure("EditMode tests cannot run during play mode"));
             RunTestsUseCase useCase = new(
                 new TestFilterCreationService(),
                 executionService,
-                new StubTestExecutionStateValidationService(ValidationResult.Failure("EditMode tests cannot run during play mode"))
+                validationService
             );
             RunTestsSchema parameters = new()
             {
-                TestMode = TestMode.EditMode
+                TestMode = TestMode.EditMode,
+                SaveBeforeRun = true
             };
 
             RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
@@ -31,19 +34,23 @@ namespace io.github.hatayama.uLoopMCP
             Assert.That(response.FailedCount, Is.EqualTo(0));
             Assert.That(response.SkippedCount, Is.EqualTo(0));
             Assert.That(executionService.WasCalled, Is.False);
+            Assert.That(validationService.SaveBeforeRun, Is.True);
         }
 
         private sealed class StubTestExecutionStateValidationService : TestExecutionStateValidationService
         {
             private readonly ValidationResult _result;
 
+            public bool SaveBeforeRun { get; private set; }
+
             public StubTestExecutionStateValidationService(ValidationResult result)
             {
                 _result = result;
             }
 
-            public override ValidationResult Validate(TestMode testMode)
+            public override ValidationResult Validate(TestMode testMode, bool saveBeforeRun)
             {
+                SaveBeforeRun = saveBeforeRun;
                 return _result;
             }
         }

--- a/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
+++ b/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
@@ -77,29 +77,56 @@ namespace io.github.hatayama.uLoopMCP
             Assert.That(result.ErrorMessage, Is.EqualTo("Tests cannot run while the editor is updating"));
         }
 
+        [Test]
+        public void Validate_WhenEditorHasUnsavedChanges_ShouldReturnFailure()
+        {
+            string[] unsavedEditorChanges =
+            {
+                "Scene: Assets/Scenes/Minecraft.unity",
+                "Prefab Stage: Assets/Scenes/GameCanvas.prefab"
+            };
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
+                isPlaying: false,
+                unsavedEditorChanges: unsavedEditorChanges);
+
+            ValidationResult result = service.Validate(TestMode.PlayMode);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("Tests cannot run while the editor has unsaved scene or prefab changes"));
+            Assert.That(result.ErrorMessage, Does.Contain("Scene: Assets/Scenes/Minecraft.unity"));
+            Assert.That(result.ErrorMessage, Does.Contain("Prefab Stage: Assets/Scenes/GameCanvas.prefab"));
+        }
+
         private sealed class StubTestExecutionStateValidationService : TestExecutionStateValidationService
         {
             private readonly bool _isPlaying;
             private readonly bool _isCompiling;
             private readonly bool _isDomainReloadInProgress;
             private readonly bool _isUpdating;
+            private readonly string[] _unsavedEditorChanges;
 
             public StubTestExecutionStateValidationService(
                 bool isPlaying,
                 bool isCompiling = false,
                 bool isDomainReloadInProgress = false,
-                bool isUpdating = false)
+                bool isUpdating = false,
+                string[] unsavedEditorChanges = null)
             {
                 _isPlaying = isPlaying;
                 _isCompiling = isCompiling;
                 _isDomainReloadInProgress = isDomainReloadInProgress;
                 _isUpdating = isUpdating;
+                _unsavedEditorChanges = unsavedEditorChanges ?? new string[0];
             }
 
             protected override bool IsPlaying => _isPlaying;
             protected override bool IsCompiling => _isCompiling;
             protected override bool IsDomainReloadInProgress => _isDomainReloadInProgress;
             protected override bool IsUpdating => _isUpdating;
+            protected override string[] DetectUnsavedEditorChanges()
+            {
+                return _unsavedEditorChanges;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
+++ b/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
@@ -10,7 +10,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(true);
 
-            ValidationResult result = service.Validate(TestMode.EditMode);
+            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode"));
@@ -21,7 +21,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(false);
 
-            ValidationResult result = service.Validate(TestMode.EditMode);
+            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(result.ErrorMessage, Is.Null);
@@ -32,7 +32,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(true);
 
-            ValidationResult result = service.Validate(TestMode.PlayMode);
+            ValidationResult result = service.Validate(TestMode.PlayMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(result.ErrorMessage, Is.Null);
@@ -45,7 +45,7 @@ namespace io.github.hatayama.uLoopMCP
                 isPlaying: false,
                 isCompiling: true);
 
-            ValidationResult result = service.Validate(TestMode.EditMode);
+            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("Tests cannot run while compilation is in progress"));
@@ -58,7 +58,7 @@ namespace io.github.hatayama.uLoopMCP
                 isPlaying: false,
                 isDomainReloadInProgress: true);
 
-            ValidationResult result = service.Validate(TestMode.EditMode);
+            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("Tests cannot run while domain reload is in progress"));
@@ -71,14 +71,14 @@ namespace io.github.hatayama.uLoopMCP
                 isPlaying: false,
                 isUpdating: true);
 
-            ValidationResult result = service.Validate(TestMode.EditMode);
+            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("Tests cannot run while the editor is updating"));
         }
 
         [Test]
-        public void Validate_WhenEditorHasUnsavedChanges_ShouldReturnFailure()
+        public void Validate_WhenEditorHasUnsavedChangesAndSaveBeforeRunIsFalse_ShouldReturnFailure()
         {
             string[] unsavedEditorChanges =
             {
@@ -89,12 +89,51 @@ namespace io.github.hatayama.uLoopMCP
                 isPlaying: false,
                 unsavedEditorChanges: unsavedEditorChanges);
 
-            ValidationResult result = service.Validate(TestMode.PlayMode);
+            ValidationResult result = service.Validate(TestMode.PlayMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Does.Contain("Tests cannot run while the editor has unsaved scene or prefab changes"));
             Assert.That(result.ErrorMessage, Does.Contain("Scene: Assets/Scenes/Minecraft.unity"));
             Assert.That(result.ErrorMessage, Does.Contain("Prefab Stage: Assets/Scenes/GameCanvas.prefab"));
+        }
+
+        [Test]
+        public void Validate_WhenEditorHasUnsavedChangesAndSaveBeforeRunIsTrue_ShouldSaveAndReturnSuccess()
+        {
+            string[] unsavedEditorChanges =
+            {
+                "Scene: Assets/Scenes/Minecraft.unity"
+            };
+            StubTestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
+                isPlaying: false,
+                unsavedEditorChanges: unsavedEditorChanges,
+                saveResult: ValidationResult.Success(),
+                clearUnsavedChangesAfterSave: true);
+
+            ValidationResult result = service.Validate(TestMode.PlayMode, saveBeforeRun: true);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(result.ErrorMessage, Is.Null);
+            Assert.That(service.SaveWasCalled, Is.True);
+        }
+
+        [Test]
+        public void Validate_WhenSaveBeforeRunFails_ShouldReturnFailure()
+        {
+            string[] unsavedEditorChanges =
+            {
+                "Prefab Stage: Assets/Scenes/Crosshair.prefab"
+            };
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
+                isPlaying: false,
+                unsavedEditorChanges: unsavedEditorChanges,
+                saveResult: ValidationResult.Failure("Tests cannot save unsaved scene or prefab changes before running tests. Unsaved changes that failed to save: Prefab Stage: Assets/Scenes/Crosshair.prefab"));
+
+            ValidationResult result = service.Validate(TestMode.PlayMode, saveBeforeRun: true);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("Tests cannot save unsaved scene or prefab changes before running tests"));
+            Assert.That(result.ErrorMessage, Does.Contain("Prefab Stage: Assets/Scenes/Crosshair.prefab"));
         }
 
         private sealed class StubTestExecutionStateValidationService : TestExecutionStateValidationService
@@ -103,20 +142,28 @@ namespace io.github.hatayama.uLoopMCP
             private readonly bool _isCompiling;
             private readonly bool _isDomainReloadInProgress;
             private readonly bool _isUpdating;
-            private readonly string[] _unsavedEditorChanges;
+            private readonly ValidationResult _saveResult;
+            private readonly bool _clearUnsavedChangesAfterSave;
+            private string[] _unsavedEditorChanges;
+
+            public bool SaveWasCalled { get; private set; }
 
             public StubTestExecutionStateValidationService(
                 bool isPlaying,
                 bool isCompiling = false,
                 bool isDomainReloadInProgress = false,
                 bool isUpdating = false,
-                string[] unsavedEditorChanges = null)
+                string[] unsavedEditorChanges = null,
+                ValidationResult saveResult = null,
+                bool clearUnsavedChangesAfterSave = false)
             {
                 _isPlaying = isPlaying;
                 _isCompiling = isCompiling;
                 _isDomainReloadInProgress = isDomainReloadInProgress;
                 _isUpdating = isUpdating;
                 _unsavedEditorChanges = unsavedEditorChanges ?? new string[0];
+                _saveResult = saveResult ?? ValidationResult.Success();
+                _clearUnsavedChangesAfterSave = clearUnsavedChangesAfterSave;
             }
 
             protected override bool IsPlaying => _isPlaying;
@@ -126,6 +173,17 @@ namespace io.github.hatayama.uLoopMCP
             protected override string[] DetectUnsavedEditorChanges()
             {
                 return _unsavedEditorChanges;
+            }
+
+            protected override ValidationResult SaveUnsavedEditorChanges()
+            {
+                SaveWasCalled = true;
+                if (_clearUnsavedChangesAfterSave)
+                {
+                    _unsavedEditorChanges = new string[0];
+                }
+
+                return _saveResult;
             }
         }
     }

--- a/Packages/src/Cli~/README.md
+++ b/Packages/src/Cli~/README.md
@@ -150,11 +150,13 @@ Execute Unity Test Runner.
 | `--test-mode` | enum | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | enum | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | | Filter value (used when filter-type is not `all`) |
+| `--save-before-run` | boolean | `false` | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
 
 ```bash
 uloop run-tests
 uloop run-tests --test-mode EditMode --filter-type regex --filter-value "MyTests"
 uloop run-tests --filter-type assembly --filter-value "MyApp.Tests.Editor"
+uloop run-tests --save-before-run true
 ```
 
 **Output:**

--- a/Packages/src/Cli~/README_ja.md
+++ b/Packages/src/Cli~/README_ja.md
@@ -150,11 +150,13 @@ Unity Test Runner を実行します。
 | `--test-mode` | enum | `EditMode` | テストモード: `EditMode`, `PlayMode` |
 | `--filter-type` | enum | `all` | フィルタタイプ: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | | フィルタ値（filter-type が `all` 以外の場合に使用） |
+| `--save-before-run` | boolean | `false` | 未保存のロード済み Scene 変更と現在の Prefab Stage 変更を保存してからテストを実行 |
 
 ```bash
 uloop run-tests
 uloop run-tests --test-mode EditMode --filter-type regex --filter-value "MyTests"
 uloop run-tests --filter-type assembly --filter-value "MyApp.Tests.Editor"
+uloop run-tests --save-before-run true
 ```
 
 **Output:**

--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -34,6 +34,21 @@ jest.mock('../tool-settings-loader.js', () => ({
   isToolEnabled: jest.fn(),
 }));
 
+const mockBeginUnityRestartAttempt = jest.fn<void, [string]>();
+
+jest.mock('../launch-restart-guard.js', () => ({
+  beginUnityRestartAttempt: (projectPath: string): void =>
+    mockBeginUnityRestartAttempt(projectPath),
+}));
+
+const mockFindUnityProjectRoot = jest.fn<string | null, []>();
+const mockIsUnityProject = jest.fn<boolean, [string]>();
+
+jest.mock('../project-root.js', () => ({
+  findUnityProjectRoot: (): string | null => mockFindUnityProjectRoot(),
+  isUnityProject: (projectPath: string): boolean => mockIsUnityProject(projectPath),
+}));
+
 import { Command } from 'commander';
 import { orchestrateLaunch } from 'launch-unity';
 import {
@@ -62,6 +77,11 @@ describe('launch command', () => {
     });
     mockSpinnerUpdate.mockReset();
     mockSpinnerStop.mockReset();
+    mockBeginUnityRestartAttempt.mockReset();
+    mockFindUnityProjectRoot.mockReset();
+    mockFindUnityProjectRoot.mockReturnValue('/project');
+    mockIsUnityProject.mockReset();
+    mockIsUnityProject.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -191,5 +211,72 @@ describe('launch command', () => {
     expect(waitForLaunchReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(waitForDynamicCodeReadyAfterLaunchMock).not.toHaveBeenCalled();
     expect(prewarmDynamicCodeAfterLaunchMock).not.toHaveBeenCalled();
+  });
+
+  it('records a restart guard before restart orchestration touches Unity', async () => {
+    const observedCalls: string[] = [];
+    mockBeginUnityRestartAttempt.mockImplementation((projectPath: string): void => {
+      observedCalls.push(`guard:${projectPath}`);
+    });
+    orchestrateLaunchMock.mockImplementation(() => {
+      observedCalls.push('orchestrate');
+      return Promise.resolve({
+        action: 'focused',
+        projectPath: '/project',
+        pid: 4321,
+      });
+    });
+
+    const program = new Command();
+    registerLaunchCommand(program);
+
+    await program.parseAsync(['node', 'uloop', 'launch', '/project', '--restart']);
+
+    expect(observedCalls).toEqual(['guard:/project', 'orchestrate']);
+    expect(mockBeginUnityRestartAttempt).toHaveBeenCalledWith('/project');
+    expect(orchestrateLaunchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectPath: '/project',
+        restart: true,
+      }),
+    );
+  });
+
+  it('stops before restart orchestration when the restart guard blocks', async () => {
+    mockBeginUnityRestartAttempt.mockImplementation((): void => {
+      throw new Error('restart blocked');
+    });
+
+    const program = new Command();
+    registerLaunchCommand(program);
+
+    await expect(
+      program.parseAsync(['node', 'uloop', 'launch', '/project', '--restart']),
+    ).rejects.toThrow('restart blocked');
+
+    expect(orchestrateLaunchMock).not.toHaveBeenCalled();
+    expect(mockCreateSpinner).not.toHaveBeenCalled();
+  });
+
+  it('skips the restart guard for invalid explicit project paths', async () => {
+    mockIsUnityProject.mockReturnValue(false);
+    orchestrateLaunchMock.mockResolvedValue({
+      action: 'focused',
+      projectPath: '/not-a-project',
+      pid: 4321,
+    });
+
+    const program = new Command();
+    registerLaunchCommand(program);
+
+    await program.parseAsync(['node', 'uloop', 'launch', '/not-a-project', '--restart']);
+
+    expect(mockBeginUnityRestartAttempt).not.toHaveBeenCalled();
+    expect(orchestrateLaunchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectPath: '/not-a-project',
+        restart: true,
+      }),
+    );
   });
 });

--- a/Packages/src/Cli~/src/__tests__/launch-restart-guard.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-restart-guard.test.ts
@@ -94,6 +94,27 @@ describe('launch restart guard', () => {
     });
   });
 
+  it('allows a Unity restart attempt when the guard record is future dated', () => {
+    const guardPath: string = getUnityRestartGuardFilePath(projectPath);
+    files.set(
+      guardPath,
+      `${JSON.stringify({
+        projectPath,
+        startedAt: now + 1,
+        pid: 1357,
+      })}\n`,
+    );
+
+    beginUnityRestartAttempt(projectPath, dependencies);
+
+    const record: GuardRecord = readWrittenRecord(guardPath);
+    expect(record).toEqual({
+      projectPath,
+      startedAt: 1000000,
+      pid: 2468,
+    });
+  });
+
   function readExistingFile(path: string): string {
     const content: string | undefined = files.get(path);
     if (content === undefined) {

--- a/Packages/src/Cli~/src/__tests__/launch-restart-guard.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-restart-guard.test.ts
@@ -1,0 +1,77 @@
+import type { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+import {
+  beginUnityRestartAttempt,
+  getUnityRestartGuardFilePath,
+  UNITY_RESTART_GUARD_COOLDOWN_MS,
+  UnityRestartCooldownError,
+  type UnityRestartGuardDependencies,
+} from '../launch-restart-guard.js';
+
+interface GuardRecord {
+  projectPath?: string;
+  startedAt?: number;
+  pid?: number;
+}
+
+describe('launch restart guard', () => {
+  let projectPath: string;
+  let now: number;
+  let files: Map<string, string>;
+  let dependencies: UnityRestartGuardDependencies;
+
+  beforeEach(() => {
+    projectPath = '/UnityProject';
+    now = 1000000;
+    files = new Map<string, string>();
+    dependencies = {
+      existsSyncFn: ((path: string): boolean => files.has(path)) as typeof existsSync,
+      mkdirSyncFn: (): undefined => undefined,
+      readFileSyncFn: ((path: string): string => files.get(path) ?? '') as typeof readFileSync,
+      writeFileSyncFn: ((path: string, content: string): void => {
+        files.set(path, content);
+      }) as typeof writeFileSync,
+      nowFn: (): number => now,
+      pid: 2468,
+    };
+  });
+
+  it('writes a restart guard record before relaunching Unity', () => {
+    beginUnityRestartAttempt(projectPath, dependencies);
+
+    const guardPath: string = getUnityRestartGuardFilePath(projectPath);
+    const record: GuardRecord = readWrittenRecord(guardPath);
+
+    expect(record).toEqual({
+      projectPath,
+      startedAt: 1000000,
+      pid: 2468,
+    });
+  });
+
+  it('blocks repeated Unity restart attempts during the cooldown window', () => {
+    beginUnityRestartAttempt(projectPath, dependencies);
+    now += 1000;
+
+    expect(() => beginUnityRestartAttempt(projectPath, dependencies)).toThrow(
+      UnityRestartCooldownError,
+    );
+  });
+
+  it('allows a Unity restart attempt after the cooldown window', () => {
+    beginUnityRestartAttempt(projectPath, dependencies);
+    now += UNITY_RESTART_GUARD_COOLDOWN_MS;
+
+    beginUnityRestartAttempt(projectPath, dependencies);
+
+    const guardPath: string = getUnityRestartGuardFilePath(projectPath);
+    const record: GuardRecord = readWrittenRecord(guardPath);
+    expect(record.startedAt).toBe(1000000 + UNITY_RESTART_GUARD_COOLDOWN_MS);
+  });
+
+  function readWrittenRecord(guardPath: string): GuardRecord {
+    const content: string | undefined = files.get(guardPath);
+    expect(content).toBeDefined();
+    return JSON.parse(content ?? '{}') as GuardRecord;
+  }
+});

--- a/Packages/src/Cli~/src/__tests__/launch-restart-guard.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-restart-guard.test.ts
@@ -1,4 +1,4 @@
-import type { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import type { readFileSync, writeFileSync } from 'node:fs';
 
 import {
   beginUnityRestartAttempt,
@@ -25,9 +25,8 @@ describe('launch restart guard', () => {
     now = 1000000;
     files = new Map<string, string>();
     dependencies = {
-      existsSyncFn: ((path: string): boolean => files.has(path)) as typeof existsSync,
       mkdirSyncFn: (): undefined => undefined,
-      readFileSyncFn: ((path: string): string => files.get(path) ?? '') as typeof readFileSync,
+      readFileSyncFn: ((path: string): string => readExistingFile(path)) as typeof readFileSync,
       writeFileSyncFn: ((path: string, content: string): void => {
         files.set(path, content);
       }) as typeof writeFileSync,
@@ -68,6 +67,41 @@ describe('launch restart guard', () => {
     const record: GuardRecord = readWrittenRecord(guardPath);
     expect(record.startedAt).toBe(1000000 + UNITY_RESTART_GUARD_COOLDOWN_MS);
   });
+
+  it('allows a Unity restart attempt when the guard file disappears before read', () => {
+    dependencies.readFileSyncFn = ((): string => {
+      throw new Error('missing guard file');
+    }) as unknown as typeof readFileSync;
+
+    beginUnityRestartAttempt(projectPath, dependencies);
+
+    const guardPath: string = getUnityRestartGuardFilePath(projectPath);
+    const record: GuardRecord = readWrittenRecord(guardPath);
+    expect(record.startedAt).toBe(1000000);
+  });
+
+  it('allows a Unity restart attempt when the guard file is corrupt', () => {
+    const guardPath: string = getUnityRestartGuardFilePath(projectPath);
+    files.set(guardPath, '{');
+
+    beginUnityRestartAttempt(projectPath, dependencies);
+
+    const record: GuardRecord = readWrittenRecord(guardPath);
+    expect(record).toEqual({
+      projectPath,
+      startedAt: 1000000,
+      pid: 2468,
+    });
+  });
+
+  function readExistingFile(path: string): string {
+    const content: string | undefined = files.get(path);
+    if (content === undefined) {
+      throw new Error(`Missing file: ${path}`);
+    }
+
+    return content;
+  }
 
   function readWrittenRecord(guardPath: string): GuardRecord {
     const content: string | undefined = files.get(guardPath);

--- a/Packages/src/Cli~/src/commands/launch.ts
+++ b/Packages/src/Cli~/src/commands/launch.ts
@@ -15,7 +15,9 @@ import {
   waitForDynamicCodeReadyAfterLaunch,
   waitForLaunchReadyAfterLaunch,
 } from '../launch-readiness.js';
+import { beginUnityRestartAttempt } from '../launch-restart-guard.js';
 import { type ResolvedUnityConnection } from '../port-resolver.js';
+import { findUnityProjectRoot, isUnityProject } from '../project-root.js';
 import { createSpinner } from '../spinner.js';
 import { isToolEnabled } from '../tool-settings-loader.js';
 
@@ -67,10 +69,19 @@ async function runLaunchCommand(
   options: LaunchCommandOptions,
 ): Promise<void> {
   const maxDepth: number = parseMaxDepth(options.maxDepth);
+  const resolvedProjectPath: string | undefined = projectPath ? resolve(projectPath) : undefined;
+  if (options.restart === true) {
+    const restartGuardProjectPath: string | null =
+      resolveRestartGuardProjectPath(resolvedProjectPath);
+    if (restartGuardProjectPath !== null) {
+      beginUnityRestartAttempt(restartGuardProjectPath);
+    }
+  }
+
   const spinner = createSpinner('Waiting for Unity to finish starting...', 'stdout');
   try {
     const launchResult: OrchestrateResult = await orchestrateLaunch({
-      projectPath: projectPath ? resolve(projectPath) : undefined,
+      projectPath: resolvedProjectPath,
       searchRoot: process.cwd(),
       searchMaxDepth: maxDepth,
       platform: options.platform,
@@ -102,4 +113,16 @@ async function runLaunchCommand(
   } finally {
     spinner.stop();
   }
+}
+
+function resolveRestartGuardProjectPath(resolvedProjectPath: string | undefined): string | null {
+  if (resolvedProjectPath === undefined) {
+    return findUnityProjectRoot(process.cwd());
+  }
+
+  if (!isUnityProject(resolvedProjectPath)) {
+    return null;
+  }
+
+  return resolvedProjectPath;
 }

--- a/Packages/src/Cli~/src/default-tools.json
+++ b/Packages/src/Cli~/src/default-tools.json
@@ -89,6 +89,11 @@
           "FilterValue": {
             "type": "string",
             "description": "Filter value"
+          },
+          "SaveBeforeRun": {
+            "type": "boolean",
+            "description": "Save unsaved loaded Scene changes and current Prefab Stage changes before running tests",
+            "default": false
           }
         }
       }

--- a/Packages/src/Cli~/src/launch-restart-guard.ts
+++ b/Packages/src/Cli~/src/launch-restart-guard.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export const UNITY_RESTART_GUARD_COOLDOWN_MS = 120000;
+const UNITY_RESTART_GUARD_DIR = '.uloop';
+const UNITY_RESTART_GUARD_FILE = 'launch-restart-guard.json';
+
+interface UnityRestartGuardRecord {
+  projectPath: string;
+  startedAt: number;
+  pid: number;
+}
+
+export interface UnityRestartGuardDependencies {
+  existsSyncFn: typeof existsSync;
+  mkdirSyncFn: typeof mkdirSync;
+  readFileSyncFn: typeof readFileSync;
+  writeFileSyncFn: typeof writeFileSync;
+  nowFn: () => number;
+  pid: number;
+}
+
+const defaultDependencies: UnityRestartGuardDependencies = {
+  existsSyncFn: existsSync,
+  mkdirSyncFn: mkdirSync,
+  readFileSyncFn: readFileSync,
+  writeFileSyncFn: writeFileSync,
+  nowFn: () => Date.now(),
+  pid: process.pid,
+};
+
+export class UnityRestartCooldownError extends Error {
+  public constructor(projectPath: string, remainingMilliseconds: number) {
+    const remainingSeconds = Math.ceil(remainingMilliseconds / 1000);
+    super(
+      `Refusing to restart Unity for ${projectPath} because a restart was requested recently. ` +
+        `Wait ${remainingSeconds}s before retrying, or launch without --restart.`,
+    );
+    this.name = 'UnityRestartCooldownError';
+  }
+}
+
+export function getUnityRestartGuardFilePath(projectPath: string): string {
+  assert(projectPath.length > 0, 'projectPath must not be empty');
+  return join(projectPath, UNITY_RESTART_GUARD_DIR, UNITY_RESTART_GUARD_FILE);
+}
+
+export function beginUnityRestartAttempt(
+  projectPath: string,
+  dependencies: UnityRestartGuardDependencies = defaultDependencies,
+): void {
+  assert(projectPath.length > 0, 'projectPath must not be empty');
+  assertUnityRestartAllowed(projectPath, dependencies);
+
+  const guardPath = getUnityRestartGuardFilePath(projectPath);
+  dependencies.mkdirSyncFn(dirname(guardPath), { recursive: true });
+  const record: UnityRestartGuardRecord = {
+    projectPath,
+    startedAt: dependencies.nowFn(),
+    pid: dependencies.pid,
+  };
+  dependencies.writeFileSyncFn(guardPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+}
+
+export function assertUnityRestartAllowed(
+  projectPath: string,
+  dependencies: UnityRestartGuardDependencies = defaultDependencies,
+): void {
+  assert(projectPath.length > 0, 'projectPath must not be empty');
+
+  const guardPath = getUnityRestartGuardFilePath(projectPath);
+  if (!dependencies.existsSyncFn(guardPath)) {
+    return;
+  }
+
+  const record = readGuardRecord(guardPath, dependencies);
+  const elapsedMilliseconds = dependencies.nowFn() - record.startedAt;
+  if (elapsedMilliseconds >= UNITY_RESTART_GUARD_COOLDOWN_MS) {
+    return;
+  }
+
+  throw new UnityRestartCooldownError(
+    projectPath,
+    UNITY_RESTART_GUARD_COOLDOWN_MS - elapsedMilliseconds,
+  );
+}
+
+function readGuardRecord(
+  guardPath: string,
+  dependencies: UnityRestartGuardDependencies,
+): UnityRestartGuardRecord {
+  const content = dependencies.readFileSyncFn(guardPath, 'utf8');
+  const parsed = JSON.parse(content) as Partial<UnityRestartGuardRecord>;
+  assert(typeof parsed.projectPath === 'string', 'restart guard projectPath must be a string');
+  assert(typeof parsed.startedAt === 'number', 'restart guard startedAt must be a number');
+  assert(typeof parsed.pid === 'number', 'restart guard pid must be a number');
+  return {
+    projectPath: parsed.projectPath,
+    startedAt: parsed.startedAt,
+    pid: parsed.pid,
+  };
+}

--- a/Packages/src/Cli~/src/launch-restart-guard.ts
+++ b/Packages/src/Cli~/src/launch-restart-guard.ts
@@ -63,7 +63,7 @@ export function beginUnityRestartAttempt(
   dependencies.writeFileSyncFn(guardPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
 }
 
-export function assertUnityRestartAllowed(
+function assertUnityRestartAllowed(
   projectPath: string,
   dependencies: UnityRestartGuardDependencies = defaultDependencies,
 ): void {

--- a/Packages/src/Cli~/src/launch-restart-guard.ts
+++ b/Packages/src/Cli~/src/launch-restart-guard.ts
@@ -73,7 +73,7 @@ function assertUnityRestartAllowed(
     return;
   }
   const elapsedMilliseconds = dependencies.nowFn() - record.startedAt;
-  if (elapsedMilliseconds >= UNITY_RESTART_GUARD_COOLDOWN_MS) {
+  if (elapsedMilliseconds < 0 || elapsedMilliseconds >= UNITY_RESTART_GUARD_COOLDOWN_MS) {
     return;
   }
 

--- a/Packages/src/Cli~/src/launch-restart-guard.ts
+++ b/Packages/src/Cli~/src/launch-restart-guard.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 export const UNITY_RESTART_GUARD_COOLDOWN_MS = 120000;
@@ -13,7 +13,6 @@ interface UnityRestartGuardRecord {
 }
 
 export interface UnityRestartGuardDependencies {
-  existsSyncFn: typeof existsSync;
   mkdirSyncFn: typeof mkdirSync;
   readFileSyncFn: typeof readFileSync;
   writeFileSyncFn: typeof writeFileSync;
@@ -22,7 +21,6 @@ export interface UnityRestartGuardDependencies {
 }
 
 const defaultDependencies: UnityRestartGuardDependencies = {
-  existsSyncFn: existsSync,
   mkdirSyncFn: mkdirSync,
   readFileSyncFn: readFileSync,
   writeFileSyncFn: writeFileSync,
@@ -70,11 +68,10 @@ function assertUnityRestartAllowed(
   assert(projectPath.length > 0, 'projectPath must not be empty');
 
   const guardPath = getUnityRestartGuardFilePath(projectPath);
-  if (!dependencies.existsSyncFn(guardPath)) {
+  const record = readGuardRecordOrNull(guardPath, dependencies);
+  if (record === null) {
     return;
   }
-
-  const record = readGuardRecord(guardPath, dependencies);
   const elapsedMilliseconds = dependencies.nowFn() - record.startedAt;
   if (elapsedMilliseconds >= UNITY_RESTART_GUARD_COOLDOWN_MS) {
     return;
@@ -86,18 +83,22 @@ function assertUnityRestartAllowed(
   );
 }
 
-function readGuardRecord(
+function readGuardRecordOrNull(
   guardPath: string,
   dependencies: UnityRestartGuardDependencies,
-): UnityRestartGuardRecord {
-  const content = dependencies.readFileSyncFn(guardPath, 'utf8');
-  const parsed = JSON.parse(content) as Partial<UnityRestartGuardRecord>;
-  assert(typeof parsed.projectPath === 'string', 'restart guard projectPath must be a string');
-  assert(typeof parsed.startedAt === 'number', 'restart guard startedAt must be a number');
-  assert(typeof parsed.pid === 'number', 'restart guard pid must be a number');
-  return {
-    projectPath: parsed.projectPath,
-    startedAt: parsed.startedAt,
-    pid: parsed.pid,
-  };
+): UnityRestartGuardRecord | null {
+  try {
+    const content = dependencies.readFileSyncFn(guardPath, 'utf8');
+    const parsed = JSON.parse(content) as Partial<UnityRestartGuardRecord>;
+    assert(typeof parsed.projectPath === 'string', 'restart guard projectPath must be a string');
+    assert(typeof parsed.startedAt === 'number', 'restart guard startedAt must be a number');
+    assert(typeof parsed.pid === 'number', 'restart guard pid must be a number');
+    return {
+      projectPath: parsed.projectPath,
+      startedAt: parsed.startedAt,
+      pid: parsed.pid,
+    };
+  } catch {
+    return null;
+  }
 }

--- a/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
@@ -41,5 +41,8 @@ namespace io.github.hatayama.uLoopMCP
         [Description("Filter value (specify when filterType is not all)\n• exact: Individual test method name (e.g.: io.github.hatayama.uLoopMCP.ConsoleLogRetrieverTests.GetAllLogs_WithMaskAllOff_StillReturnsAllLogs)\n• regex: Class name or namespace (e.g.: io.github.hatayama.uLoopMCP.ConsoleLogRetrieverTests, io.github.hatayama.uLoopMCP)\n• assembly: Assembly name (e.g.: uLoopMCP.Tests.Editor)")]
         public string FilterValue { get; set; } = "";
 
+        [Description("Save unsaved loaded Scene changes and current Prefab Stage changes before running tests")]
+        public bool SaveBeforeRun { get; set; } = false;
+
     }
 } 

--- a/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
@@ -7,7 +7,7 @@ description: "Execute Unity Test Runner and get detailed results. Use when you n
 
 Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
-Before executing tests, `uloop run-tests` checks for unsaved loaded Scene changes and unsaved current Prefab Stage changes. If any are found, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner. Save or discard those editor changes, then rerun the command.
+Before executing tests, `uloop run-tests` checks for unsaved loaded Scene changes and unsaved current Prefab Stage changes. If any are found, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner. Save or discard those editor changes, then rerun the command. Use `--save-before-run true` only when the user explicitly asks to save editor changes before continuing.
 
 ## Usage
 
@@ -22,6 +22,7 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
+| `--save-before-run` | boolean | `false` | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
 
 ## Global Options
 
@@ -37,6 +38,9 @@ uloop run-tests
 
 # Run PlayMode tests
 uloop run-tests --test-mode PlayMode
+
+# Save explicitly approved editor changes before running tests
+uloop run-tests --save-before-run true
 
 # Run specific test
 uloop run-tests --filter-type exact --filter-value "MyTest.TestMethod"

--- a/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
@@ -7,6 +7,8 @@ description: "Execute Unity Test Runner and get detailed results. Use when you n
 
 Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
+Before executing tests, `uloop run-tests` checks for unsaved loaded Scene changes and unsaved current Prefab Stage changes. If any are found, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner. Save or discard those editor changes, then rerun the command.
+
 ## Usage
 
 ```bash

--- a/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
@@ -47,7 +47,7 @@ namespace io.github.hatayama.uLoopMCP
         /// <returns>Test execution result</returns>
         public override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken cancellationToken)
         {
-            ValidationResult validation = _validationService.Validate(parameters.TestMode);
+            ValidationResult validation = _validationService.Validate(parameters.TestMode, parameters.SaveBeforeRun);
             if (!validation.IsValid)
             {
                 return CreateFailureResponse(validation.ErrorMessage);

--- a/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs
@@ -1,14 +1,25 @@
+using System.Collections.Generic;
 using UnityEditor;
+using UnityEditor.SceneManagement;
 using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace io.github.hatayama.uLoopMCP
 {
     public class TestExecutionStateValidationService
     {
+        private const string UnsavedEditorChangesFailureMessage =
+            "Tests cannot run while the editor has unsaved scene or prefab changes. Save or discard these changes before running tests.";
+
         protected virtual bool IsPlaying => EditorApplication.isPlaying;
         protected virtual bool IsCompiling => EditorApplication.isCompiling;
         protected virtual bool IsDomainReloadInProgress => DomainReloadDetectionService.IsDomainReloadInProgress();
         protected virtual bool IsUpdating => EditorApplication.isUpdating;
+        protected virtual string[] DetectUnsavedEditorChanges()
+        {
+            return DetectCurrentUnsavedEditorChanges();
+        }
 
         public virtual ValidationResult Validate(TestMode testMode)
         {
@@ -27,12 +38,91 @@ namespace io.github.hatayama.uLoopMCP
                 return ValidationResult.Failure("Tests cannot run while the editor is updating");
             }
 
+            string[] unsavedEditorChanges = DetectUnsavedEditorChanges();
+            Debug.Assert(unsavedEditorChanges != null, "Unsaved editor change detection must return an array");
+            if (unsavedEditorChanges.Length > 0)
+            {
+                return ValidationResult.Failure(CreateUnsavedEditorChangesFailureMessage(unsavedEditorChanges));
+            }
+
             if (testMode == TestMode.EditMode && IsPlaying)
             {
                 return ValidationResult.Failure("EditMode tests cannot run during play mode");
             }
 
             return ValidationResult.Success();
+        }
+
+        private static string[] DetectCurrentUnsavedEditorChanges()
+        {
+            List<string> unsavedEditorChanges = new List<string>();
+            AddDirtyLoadedScenes(unsavedEditorChanges);
+            AddDirtyPrefabStage(unsavedEditorChanges);
+            return unsavedEditorChanges.ToArray();
+        }
+
+        private static void AddDirtyLoadedScenes(List<string> unsavedEditorChanges)
+        {
+            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
+
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
+                {
+                    continue;
+                }
+
+                unsavedEditorChanges.Add("Scene: " + GetSceneDisplayPath(scene));
+            }
+        }
+
+        private static void AddDirtyPrefabStage(List<string> unsavedEditorChanges)
+        {
+            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
+
+            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
+            {
+                return;
+            }
+
+            unsavedEditorChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
+        }
+
+        private static string GetSceneDisplayPath(Scene scene)
+        {
+            if (!string.IsNullOrEmpty(scene.path))
+            {
+                return scene.path;
+            }
+
+            if (!string.IsNullOrEmpty(scene.name))
+            {
+                return scene.name;
+            }
+
+            return "Untitled scene";
+        }
+
+        private static string GetPrefabStageDisplayPath(PrefabStage prefabStage)
+        {
+            Debug.Assert(prefabStage != null, "prefabStage must not be null");
+
+            if (!string.IsNullOrEmpty(prefabStage.assetPath))
+            {
+                return prefabStage.assetPath;
+            }
+
+            return GetSceneDisplayPath(prefabStage.scene);
+        }
+
+        private static string CreateUnsavedEditorChangesFailureMessage(string[] unsavedEditorChanges)
+        {
+            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
+            Debug.Assert(unsavedEditorChanges.Length > 0, "unsavedEditorChanges must not be empty");
+
+            return UnsavedEditorChangesFailureMessage + " Unsaved changes: " + string.Join(", ", unsavedEditorChanges);
         }
     }
 }

--- a/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs
@@ -11,6 +11,8 @@ namespace io.github.hatayama.uLoopMCP
     {
         private const string UnsavedEditorChangesFailureMessage =
             "Tests cannot run while the editor has unsaved scene or prefab changes. Save or discard these changes before running tests.";
+        private const string UnsavedEditorChangesSaveFailureMessage =
+            "Tests cannot save unsaved scene or prefab changes before running tests.";
 
         protected virtual bool IsPlaying => EditorApplication.isPlaying;
         protected virtual bool IsCompiling => EditorApplication.isCompiling;
@@ -20,8 +22,12 @@ namespace io.github.hatayama.uLoopMCP
         {
             return DetectCurrentUnsavedEditorChanges();
         }
+        protected virtual ValidationResult SaveUnsavedEditorChanges()
+        {
+            return SaveCurrentUnsavedEditorChanges();
+        }
 
-        public virtual ValidationResult Validate(TestMode testMode)
+        public virtual ValidationResult Validate(TestMode testMode, bool saveBeforeRun)
         {
             if (IsCompiling)
             {
@@ -38,16 +44,25 @@ namespace io.github.hatayama.uLoopMCP
                 return ValidationResult.Failure("Tests cannot run while the editor is updating");
             }
 
+            if (testMode == TestMode.EditMode && IsPlaying)
+            {
+                return ValidationResult.Failure("EditMode tests cannot run during play mode");
+            }
+
+            if (saveBeforeRun)
+            {
+                ValidationResult saveResult = SaveUnsavedEditorChanges();
+                if (!saveResult.IsValid)
+                {
+                    return saveResult;
+                }
+            }
+
             string[] unsavedEditorChanges = DetectUnsavedEditorChanges();
             Debug.Assert(unsavedEditorChanges != null, "Unsaved editor change detection must return an array");
             if (unsavedEditorChanges.Length > 0)
             {
                 return ValidationResult.Failure(CreateUnsavedEditorChangesFailureMessage(unsavedEditorChanges));
-            }
-
-            if (testMode == TestMode.EditMode && IsPlaying)
-            {
-                return ValidationResult.Failure("EditMode tests cannot run during play mode");
             }
 
             return ValidationResult.Success();
@@ -59,6 +74,19 @@ namespace io.github.hatayama.uLoopMCP
             AddDirtyLoadedScenes(unsavedEditorChanges);
             AddDirtyPrefabStage(unsavedEditorChanges);
             return unsavedEditorChanges.ToArray();
+        }
+
+        private static ValidationResult SaveCurrentUnsavedEditorChanges()
+        {
+            List<string> failedChanges = new List<string>();
+            SaveDirtyLoadedScenes(failedChanges);
+            SaveDirtyPrefabStage(failedChanges);
+            if (failedChanges.Count > 0)
+            {
+                return ValidationResult.Failure(CreateUnsavedEditorChangesSaveFailureMessage(failedChanges.ToArray()));
+            }
+
+            return ValidationResult.Success();
         }
 
         private static void AddDirtyLoadedScenes(List<string> unsavedEditorChanges)
@@ -77,6 +105,25 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
+        private static void SaveDirtyLoadedScenes(List<string> failedChanges)
+        {
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(scene.path) || !EditorSceneManager.SaveScene(scene))
+                {
+                    failedChanges.Add("Scene: " + GetSceneDisplayPath(scene));
+                }
+            }
+        }
+
         private static void AddDirtyPrefabStage(List<string> unsavedEditorChanges)
         {
             Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
@@ -88,6 +135,41 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             unsavedEditorChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
+        }
+
+        private static void SaveDirtyPrefabStage(List<string> failedChanges)
+        {
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+
+            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
+            {
+                return;
+            }
+
+            if (!SavePrefabStage(prefabStage))
+            {
+                failedChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
+            }
+        }
+
+        private static bool SavePrefabStage(PrefabStage prefabStage)
+        {
+            Debug.Assert(prefabStage != null, "prefabStage must not be null");
+
+            if (string.IsNullOrEmpty(prefabStage.assetPath))
+            {
+                return false;
+            }
+
+            bool success;
+            PrefabUtility.SaveAsPrefabAsset(prefabStage.prefabContentsRoot, prefabStage.assetPath, out success);
+            if (success)
+            {
+                prefabStage.ClearDirtiness();
+            }
+
+            return success;
         }
 
         private static string GetSceneDisplayPath(Scene scene)
@@ -123,6 +205,14 @@ namespace io.github.hatayama.uLoopMCP
             Debug.Assert(unsavedEditorChanges.Length > 0, "unsavedEditorChanges must not be empty");
 
             return UnsavedEditorChangesFailureMessage + " Unsaved changes: " + string.Join(", ", unsavedEditorChanges);
+        }
+
+        private static string CreateUnsavedEditorChangesSaveFailureMessage(string[] failedChanges)
+        {
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+            Debug.Assert(failedChanges.Length > 0, "failedChanges must not be empty");
+
+            return UnsavedEditorChangesSaveFailureMessage + " Unsaved changes that failed to save: " + string.Join(", ", failedChanges);
         }
     }
 }

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -328,10 +328,12 @@ This allows you to retrieve logs while keeping the context small.
 Executes Unity Test Runner and retrieves test results. You can set conditions with FilterType and FilterValue.
 - FilterType: all (all tests), exact (individual test method name), regex (class name or namespace), assembly (assembly name)
 - FilterValue: Value according to filter type (class name, namespace, etc.)
+- SaveBeforeRun: Saves unsaved loaded Scene changes and current Prefab Stage changes before running tests when explicitly enabled
 Test results can be output as xml. The output path is returned so AI can read it.
 This is also a strategy to avoid consuming context.
 ```text
 → run-tests (FilterType: exact, FilterValue: "PlayerControllerTests.TestJump")
+→ run-tests (SaveBeforeRun: true)
 → Check failed tests, fix implementation to pass tests
 ```
 > [!WARNING]

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -326,10 +326,12 @@ LogTypeや検索対象の文字列で絞り込む事ができます。また、s
 Unity Test Runnerを実行し、テスト結果を取得します。FilterTypeとFilterValueで条件を設定できます。
 - FilterType: all（全テスト）、exact（個別テストメソッド名）、regex（クラス名や名前空間）、assembly（アセンブリ名）
 - FilterValue: フィルタータイプに応じた値（クラス名、名前空間など）
+- SaveBeforeRun: 明示的に有効化した場合、未保存のロード済みScene変更と現在のPrefab Stage変更を保存してからテストを実行
 テスト結果をxmlで出力する事が可能です。出力pathを返すので、それをAIに読み取ってもらう事ができます。
 これもコンテキストを圧迫しないための工夫です。
 ```text
 → run-tests (FilterType: exact, FilterValue: "PlayerControllerTests.TestJump")
+→ run-tests (SaveBeforeRun: true)
 → 失敗したテストを確認、実装を修正してテストをパス
 ```
 > [!WARNING]

--- a/Packages/src/TOOL_REFERENCE.md
+++ b/Packages/src/TOOL_REFERENCE.md
@@ -67,6 +67,7 @@ All tools automatically include the following property:
     - `assembly`: Assembly name (e.g.: uLoopMCP.Tests.Editor)
   - `TestMode` (enum): Test mode - "EditMode"(0), "PlayMode"(1) (default: "EditMode")
     - **PlayMode Warning**: During PlayMode test execution, domain reload is temporarily disabled
+  - `SaveBeforeRun` (boolean): Save unsaved loaded Scene changes and current Prefab Stage changes before running tests (default: false)
 - **Response**:
   - `Success` (boolean): Whether test execution was successful
   - `Message` (string): Test execution message

--- a/Packages/src/TOOL_REFERENCE_ja.md
+++ b/Packages/src/TOOL_REFERENCE_ja.md
@@ -67,6 +67,7 @@
     - `assembly`: アセンブリ名（例：uLoopMCP.Tests.Editor）
   - `TestMode` (enum): テストモード - "EditMode"(0), "PlayMode"(1)（デフォルト: "EditMode"）
     - **PlayMode注意**: PlayModeテスト実行時は、一時的にdomain reloadが無効化されます
+  - `SaveBeforeRun` (boolean): 未保存のロード済みScene変更と現在のPrefab Stage変更を保存してからテストを実行（デフォルト: false）
 - **レスポンス**:
   - `Success` (boolean): テスト実行が成功したかどうか
   - `Message` (string): テスト実行メッセージ

--- a/README.md
+++ b/README.md
@@ -328,10 +328,12 @@ This allows you to retrieve logs while keeping the context small.
 Executes Unity Test Runner and retrieves test results. You can set conditions with FilterType and FilterValue.
 - FilterType: all (all tests), exact (individual test method name), regex (class name or namespace), assembly (assembly name)
 - FilterValue: Value according to filter type (class name, namespace, etc.)
+- SaveBeforeRun: Saves unsaved loaded Scene changes and current Prefab Stage changes before running tests when explicitly enabled
 Test results can be output as xml. The output path is returned so AI can read it.
 This is also a strategy to avoid consuming context.
 ```text
 → run-tests (FilterType: exact, FilterValue: "PlayerControllerTests.TestJump")
+→ run-tests (SaveBeforeRun: true)
 → Check failed tests, fix implementation to pass tests
 ```
 > [!WARNING]

--- a/README_ja.md
+++ b/README_ja.md
@@ -326,10 +326,12 @@ LogTypeや検索対象の文字列で絞り込む事ができます。また、s
 Unity Test Runnerを実行し、テスト結果を取得します。FilterTypeとFilterValueで条件を設定できます。
 - FilterType: all（全テスト）、exact（個別テストメソッド名）、regex（クラス名や名前空間）、assembly（アセンブリ名）
 - FilterValue: フィルタータイプに応じた値（クラス名、名前空間など）
+- SaveBeforeRun: 明示的に有効化した場合、未保存のロード済みScene変更と現在のPrefab Stage変更を保存してからテストを実行
 テスト結果をxmlで出力する事が可能です。出力pathを返すので、それをAIに読み取ってもらう事ができます。
 これもコンテキストを圧迫しないための工夫です。
 ```text
 → run-tests (FilterType: exact, FilterValue: "PlayerControllerTests.TestJump")
+→ run-tests (SaveBeforeRun: true)
 → 失敗したテストを確認、実装を修正してテストをパス
 ```
 > [!WARNING]


### PR DESCRIPTION
## Summary
- Test runs now stop before Unity opens a save dialog when loaded scenes or the current prefab stage have unsaved changes.
- When explicitly approved, test runs can save those editor changes first and continue.
- Repeated Unity restart requests are now blocked briefly to avoid relaunch loops.

## User Impact
- Before this change, entering test mode with dirty scenes or prefabs could trigger a Unity save dialog and leave automation stuck.
- After this change, the CLI either reports the unsaved items without starting tests, or saves loaded scenes and the current prefab stage when --save-before-run true is provided.
- If Unity was recently restarted, another --restart request fails before touching the editor, reducing the chance of repeated launch loops.

## Changes
- Added unsaved loaded-scene and prefab-stage validation before test execution.
- Added an explicit SaveBeforeRun option and CLI metadata/docs for --save-before-run.
- Added a short restart cooldown guard around uloop launch --restart.

## Verification
- uloop compile
- uloop run-tests --filter-type regex --filter-value "RunTestsUseCaseTests|RunTestsToolTests|TestExecutionStateValidationServiceTests" --save-before-run true
- npm run test:cli -- --runTestsByPath src/__tests__/launch-restart-guard.test.ts src/__tests__/launch-command.test.ts
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Test Execution State Validation and Restart Guard

## Overview

This PR introduces three key improvements to test automation reliability:

1. **Unsaved Editor State Validation** – Tests are blocked from running if loaded scenes or the current Prefab Stage contain unsaved changes
2. **Optional Automatic Saving** – A new `SaveBeforeRun` option allows explicit approval to save editor state and proceed with tests
3. **Restart Cooldown Guard** – Prevents rapid Unity relaunch loops by enforcing a 120-second cooldown between consecutive `--restart` attempts

## Architecture

### Validation Flow

```mermaid
classDiagram
    class RunTestsUseCase {
        +ExecuteAsync(parameters)
    }
    
    class TestExecutionStateValidationService {
        +Validate(testMode, saveBeforeRun)
        -DetectUnsavedEditorChanges()
        -SaveUnsavedEditorChanges()
    }
    
    class ValidationResult {
        +Success: bool
        +Message: string
    }
    
    RunTestsUseCase --> TestExecutionStateValidationService : calls
    TestExecutionStateValidationService --> ValidationResult : returns
```

The validation service now:
- Checks for dirty loaded scenes and dirty prefab stages after other pre-checks (compile, domain reload, etc.)
- If `saveBeforeRun` is true, attempts to save changes before validation
- Reports failure with unsaved item paths if changes remain
- Returns success only when editor state is clean or has been successfully saved

### Restart Guard Flow

```mermaid
classDiagram
    class LaunchCommand {
        +execute()
    }
    
    class UnityRestartGuard {
        +beginUnityRestartAttempt(projectPath)
        -validateCooldown()
        -writeGuardRecord()
    }
    
    class UnityRestartCooldownError {
        +projectPath: string
        +remainingMilliseconds: number
    }
    
    LaunchCommand --> UnityRestartGuard : calls when --restart
    UnityRestartGuard --> UnityRestartCooldownError : throws on cooldown
```

The restart guard:
- Creates a project-local guard record at `.uloop/launch-restart-guard.json`
- Tracks the previous restart attempt timestamp and process ID
- Enforces 120-second cooldown between attempts
- Handles missing or corrupt guard files gracefully (treats as absent)

## Key Changes

### Schema & Configuration
- **RunTestsSchema.cs** – Added `SaveBeforeRun` boolean property (default: false)
- **default-tools.json** – Registered `SaveBeforeRun` as CLI tool input parameter

### Validation Service
- **TestExecutionStateValidationService.cs** – Extended `Validate()` signature to accept `saveBeforeRun` parameter; added detection and saving logic for dirty scenes/prefabs

### Use Cases & Commands
- **RunTestsUseCase.cs** – Passes `SaveBeforeRun` from parameters to validation service
- **launch.ts** – Integrates restart guard call before orchestrating launch; resolves project path once for reuse

### Restart Guard
- **launch-restart-guard.ts** (new) – Exports cooldown constant, guard error class, and `beginUnityRestartAttempt()` function with injectable dependencies for filesystem and time

### Documentation
- **CLI README (EN/JA)** – Documents new `--save-before-run` flag with examples
- **SKILL.md** – Specifies validation behavior and new option in skill metadata
- **TOOL_REFERENCE (EN/JA)** – Documents `SaveBeforeRun` parameter in tool reference
- **Package READMEs (EN/JA)** – Shows `SaveBeforeRun` usage in code examples
- **AGENTS.md** – Clarifies that generated `.agents/.claude/` files are outputs, not sources

### Tests
- **RunTestsToolTests.cs** – Verifies default `SaveBeforeRun` is false
- **RunTestsUseCaseTests.cs** – Tests that use case propagates `SaveBeforeRun` into validation
- **TestExecutionStateValidationServiceTests.cs** – Comprehensive coverage: unsaved detection, save success, save failure scenarios
- **launch-command.test.ts** – Tests restart guard integration in launch command
- **launch-restart-guard.test.ts** (new) – Tests cooldown enforcement, error handling, and guard file resilience

## Behavior Changes

**Before:** Entering test mode with dirty scenes/prefabs could trigger a Unity save dialog and block automation.

**After:**
- By default, the CLI detects unsaved changes and reports them without starting tests
- With `--save-before-run true`, the CLI saves the editor state first and proceeds with tests
- Consecutive `--restart` commands within 120 seconds fail with a cooldown error

<!-- end of auto-generated comment: release notes by coderabbit.ai -->