### PR TITLE
fix: Skill improvements for selected Hierarchy inspection

### DIFF
--- a/.agents/skills/uloop-find-game-objects/SKILL.md
+++ b/.agents/skills/uloop-find-game-objects/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: uloop-find-game-objects
-description: "Find GameObjects in the active scene by various criteria. Use when you need to: (1) Search for objects by name, regex, or path, (2) Find objects with specific components, tags, or layers, (3) Get currently selected GameObjects in Unity Editor. Returns matching GameObjects with hierarchy paths and components (or writes to a file when multiple GameObjects are selected)."
+description: "Inspect Unity GameObjects by search criteria or the current Hierarchy selection. Use when you need to: (1) Get details for GameObject(s) the user selected in the Unity Hierarchy with `--search-mode Selected`, (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
 ---
 
 # uloop find-game-objects
 
-Find GameObjects with search criteria or get currently selected objects.
+Find GameObjects with search criteria or get details for currently selected Hierarchy objects.
 
 ## Usage
 

--- a/.agents/skills/uloop-get-hierarchy/SKILL.md
+++ b/.agents/skills/uloop-get-hierarchy/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: uloop-get-hierarchy
-description: "Get Unity scene hierarchy as a structured tree. Use when you need to: (1) Inspect scene structure and parent-child relationships, (2) Explore GameObjects and their components, (3) Get hierarchy from a specific root path or selected objects. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
+description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use when you need to: (1) Inspect the child tree under GameObject(s) the user selected in the Unity Hierarchy with `--use-selection`, (2) Inspect scene structure and parent-child relationships, (3) Explore GameObjects and their components. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
 ---
 
 # uloop get-hierarchy
 
-Get Unity Hierarchy structure.
+Get Unity Hierarchy structure from the whole scene, a root path, or selected Hierarchy objects.
 
 ## Usage
 

--- a/.claude/skills/uloop-find-game-objects/SKILL.md
+++ b/.claude/skills/uloop-find-game-objects/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: uloop-find-game-objects
-description: "Find GameObjects in the active scene by various criteria. Use when you need to: (1) Search for objects by name, regex, or path, (2) Find objects with specific components, tags, or layers, (3) Get currently selected GameObjects in Unity Editor. Returns matching GameObjects with hierarchy paths and components (or writes to a file when multiple GameObjects are selected)."
+description: "Inspect Unity GameObjects by search criteria or the current Hierarchy selection. Use when you need to: (1) Get details for GameObject(s) the user selected in the Unity Hierarchy with `--search-mode Selected`, (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
 ---
 
 # uloop find-game-objects
 
-Find GameObjects with search criteria or get currently selected objects.
+Find GameObjects with search criteria or get details for currently selected Hierarchy objects.
 
 ## Usage
 

--- a/.claude/skills/uloop-get-hierarchy/SKILL.md
+++ b/.claude/skills/uloop-get-hierarchy/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: uloop-get-hierarchy
-description: "Get Unity scene hierarchy as a structured tree. Use when you need to: (1) Inspect scene structure and parent-child relationships, (2) Explore GameObjects and their components, (3) Get hierarchy from a specific root path or selected objects. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
+description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use when you need to: (1) Inspect the child tree under GameObject(s) the user selected in the Unity Hierarchy with `--use-selection`, (2) Inspect scene structure and parent-child relationships, (3) Explore GameObjects and their components. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
 ---
 
 # uloop get-hierarchy
 
-Get Unity Hierarchy structure.
+Get Unity Hierarchy structure from the whole scene, a root path, or selected Hierarchy objects.
 
 ## Usage
 

--- a/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsSchema.cs
@@ -6,7 +6,7 @@ namespace io.github.hatayama.uLoopMCP
     {
         // Search criteria
         public string NamePattern { get; set; } = "";
-        [Description("Search mode (Exact(0), Path(1), Regex(2), Contains(3), Selected(4))")]
+        [Description("Search mode. Use Selected(4) to inspect the GameObject(s) currently selected in the Unity Hierarchy. Other modes are Exact(0), Path(1), Regex(2), Contains(3).")]
         public SearchMode SearchMode { get; set; } = SearchMode.Exact;
         public string[] RequiredComponents { get; set; } = new string[0];
         public string Tag { get; set; } = "";

--- a/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsTool.cs
@@ -17,7 +17,7 @@ namespace io.github.hatayama.uLoopMCP
     /// - FindGameObjectsSchema: Search parameters
     /// - FindGameObjectsResponse: Type-safe response structure
     /// </summary>
-    [McpTool(Description = "Find multiple GameObjects with advanced search criteria (component type, tag, layer, etc.)")]
+    [McpTool(Description = "Find GameObjects by search criteria or inspect GameObject(s) currently selected in the Unity Hierarchy using SearchMode.Selected.")]
     public class FindGameObjectsTool : AbstractUnityTool<FindGameObjectsSchema, FindGameObjectsResponse>
     {
         public override string ToolName => "find-game-objects";

--- a/Packages/src/Editor/Api/McpTools/FindGameObjects/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/FindGameObjects/Skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: uloop-find-game-objects
-description: "Find GameObjects in the active scene by various criteria. Use when you need to: (1) Search for objects by name, regex, or path, (2) Find objects with specific components, tags, or layers, (3) Get currently selected GameObjects in Unity Editor. Returns matching GameObjects with hierarchy paths and components (or writes to a file when multiple GameObjects are selected)."
+description: "Inspect Unity GameObjects by search criteria or the current Hierarchy selection. Use when you need to: (1) Get details for GameObject(s) the user selected in the Unity Hierarchy with `--search-mode Selected`, (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
 ---
 
 # uloop find-game-objects
 
-Find GameObjects with search criteria or get currently selected objects.
+Find GameObjects with search criteria or get details for currently selected Hierarchy objects.
 
 ## Usage
 

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/GetHierarchySchema.cs
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/GetHierarchySchema.cs
@@ -26,7 +26,7 @@ namespace io.github.hatayama.uLoopMCP
         [Description("Use LUT for components (auto|true|false)")]
         public string UseComponentsLut { get; set; } = "auto";
 
-        [Description("Whether to use currently selected GameObject(s) as root(s) for hierarchy traversal. When true, RootPath is ignored.")]
+        [Description("Whether to use GameObject(s) currently selected in the Unity Hierarchy as root(s) for hierarchy traversal. When true, RootPath is ignored.")]
         public bool UseSelection { get; set; } = false;
     }
 }

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/GetHierarchyTool.cs
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/GetHierarchyTool.cs
@@ -21,7 +21,7 @@ namespace io.github.hatayama.uLoopMCP
     /// - GetHierarchySchema: Type-safe parameter schema
     /// - GetHierarchyResponse: Type-safe response structure
     /// </summary>
-    [McpTool(Description = "Get Unity Hierarchy structure in AI-friendly format")]
+    [McpTool(Description = "Get Unity Hierarchy structure for the whole scene, a root path, or GameObject(s) currently selected in the Unity Hierarchy using UseSelection.")]
     public class GetHierarchyTool : AbstractUnityTool<GetHierarchySchema, GetHierarchyResponse>
     {
         public override string ToolName => "get-hierarchy";

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: uloop-get-hierarchy
-description: "Get Unity scene hierarchy as a structured tree. Use when you need to: (1) Inspect scene structure and parent-child relationships, (2) Explore GameObjects and their components, (3) Get hierarchy from a specific root path or selected objects. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
+description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use when you need to: (1) Inspect the child tree under GameObject(s) the user selected in the Unity Hierarchy with `--use-selection`, (2) Inspect scene structure and parent-child relationships, (3) Explore GameObjects and their components. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
 ---
 
 # uloop get-hierarchy
 
-Get Unity Hierarchy structure.
+Get Unity Hierarchy structure from the whole scene, a root path, or selected Hierarchy objects.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Make selection-based Unity inspection workflows discoverable from skill descriptions and tool metadata.
- Clarify that agents can inspect GameObjects selected in the Unity Hierarchy via find-game-objects and get-hierarchy.

## User Impact
- Before this change, an agent could miss that the tools support the currently selected Hierarchy object because that workflow was not prominent in the descriptions it reads.
- After this change, agents are more likely to choose the right command when a user asks about the selected GameObject or the tree under it.

## Changes
- Updated source skill descriptions for selection-based inspection workflows.
- Synchronized generated Claude and .agents skill copies through the normal skills install path.
- Updated Unity tool and parameter metadata so selection support is visible outside the skill files too.

## Verification
- uloop compile