### PR TITLE
fix: AI selects the right tool for selected GameObject inspection

### DIFF
--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: uloop-execute-dynamic-code
-description: "Execute C# code dynamically in Unity Editor. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) Execute Unity Editor menu commands through EditorApplication.ExecuteMenuItem, (5) PlayMode automation (click buttons, invoke methods, tweak runtime state), (6) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (7) PlayMode inspection (scene info, reflection, physics state, raycast checks). NOT for file I/O or script authoring."
+description: "Execute C# code dynamically in Unity Editor. Use find-game-objects first for basic selected GameObject discovery or property inspection. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) Execute Unity Editor menu commands through EditorApplication.ExecuteMenuItem, (5) PlayMode automation (click buttons, invoke methods, tweak runtime state), (6) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (7) PlayMode inspection that requires custom Unity API code beyond existing tools. NOT for file I/O or script authoring."
 context: fork
 ---
 
 # Task
 
 Execute the following request using `uloop execute-dynamic-code`: $ARGUMENTS
+
+For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
 ## Workflow
 

--- a/.agents/skills/uloop-find-game-objects/SKILL.md
+++ b/.agents/skills/uloop-find-game-objects/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: uloop-find-game-objects
-description: "Inspect Unity GameObjects by search criteria or the current Hierarchy selection. Use when you need to: (1) Get details for GameObject(s) the user selected in the Unity Hierarchy with `--search-mode Selected`, (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
+description: "Use first when the user asks about the currently selected GameObject in the Unity Hierarchy. Inspect selected object details with `--search-mode Selected` before using `execute-dynamic-code`. Use when you need to: (1) Get details and component properties for selected GameObject(s), (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Use get-hierarchy when the child tree under the selection is needed. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
 ---
 
 # uloop find-game-objects
 
 Find GameObjects with search criteria or get details for currently selected Hierarchy objects.
+
+Use this before `execute-dynamic-code` when identifying or inspecting selected GameObjects. Use `get-hierarchy` instead when you need the child tree, parent-child structure, or descendants under the selection.
 
 ## Usage
 

--- a/.agents/skills/uloop-get-hierarchy/SKILL.md
+++ b/.agents/skills/uloop-get-hierarchy/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: uloop-get-hierarchy
-description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use when you need to: (1) Inspect the child tree under GameObject(s) the user selected in the Unity Hierarchy with `--use-selection`, (2) Inspect scene structure and parent-child relationships, (3) Explore GameObjects and their components. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
+description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use this when you need the child tree, parent-child structure, or descendants under selected GameObject(s) with `--use-selection`. Use find-game-objects for selected object details and component properties. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
 ---
 
 # uloop get-hierarchy
 
 Get Unity Hierarchy structure from the whole scene, a root path, or selected Hierarchy objects.
+
+Use this for hierarchy structure, especially descendants under the current selection. Use `find-game-objects --search-mode Selected` when you need selected object details or component properties.
 
 ## Usage
 

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: uloop-execute-dynamic-code
-description: "Execute C# code dynamically in Unity Editor. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) Execute Unity Editor menu commands through EditorApplication.ExecuteMenuItem, (5) PlayMode automation (click buttons, invoke methods, tweak runtime state), (6) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (7) PlayMode inspection (scene info, reflection, physics state, raycast checks). NOT for file I/O or script authoring."
+description: "Execute C# code dynamically in Unity Editor. Use find-game-objects first for basic selected GameObject discovery or property inspection. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) Execute Unity Editor menu commands through EditorApplication.ExecuteMenuItem, (5) PlayMode automation (click buttons, invoke methods, tweak runtime state), (6) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (7) PlayMode inspection that requires custom Unity API code beyond existing tools. NOT for file I/O or script authoring."
 context: fork
 ---
 
 # Task
 
 Execute the following request using `uloop execute-dynamic-code`: $ARGUMENTS
+
+For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
 ## Workflow
 

--- a/.claude/skills/uloop-find-game-objects/SKILL.md
+++ b/.claude/skills/uloop-find-game-objects/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: uloop-find-game-objects
-description: "Inspect Unity GameObjects by search criteria or the current Hierarchy selection. Use when you need to: (1) Get details for GameObject(s) the user selected in the Unity Hierarchy with `--search-mode Selected`, (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
+description: "Use first when the user asks about the currently selected GameObject in the Unity Hierarchy. Inspect selected object details with `--search-mode Selected` before using `execute-dynamic-code`. Use when you need to: (1) Get details and component properties for selected GameObject(s), (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Use get-hierarchy when the child tree under the selection is needed. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
 ---
 
 # uloop find-game-objects
 
 Find GameObjects with search criteria or get details for currently selected Hierarchy objects.
+
+Use this before `execute-dynamic-code` when identifying or inspecting selected GameObjects. Use `get-hierarchy` instead when you need the child tree, parent-child structure, or descendants under the selection.
 
 ## Usage
 

--- a/.claude/skills/uloop-get-hierarchy/SKILL.md
+++ b/.claude/skills/uloop-get-hierarchy/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: uloop-get-hierarchy
-description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use when you need to: (1) Inspect the child tree under GameObject(s) the user selected in the Unity Hierarchy with `--use-selection`, (2) Inspect scene structure and parent-child relationships, (3) Explore GameObjects and their components. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
+description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use this when you need the child tree, parent-child structure, or descendants under selected GameObject(s) with `--use-selection`. Use find-game-objects for selected object details and component properties. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
 ---
 
 # uloop get-hierarchy
 
 Get Unity Hierarchy structure from the whole scene, a root path, or selected Hierarchy objects.
+
+Use this for hierarchy structure, especially descendants under the current selection. Use `find-game-objects --search-mode Selected` when you need selected object details or component properties.
 
 ## Usage
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeTool.cs
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeTool.cs
@@ -9,6 +9,8 @@ namespace io.github.hatayama.uLoopMCP
     /// </summary>
     [McpTool(Description = @"Execute C# code dynamically in Unity Editor for editor automation.
 
+Use find-game-objects first for basic selected GameObject discovery or property inspection. Use this after built-in inspection tools are not enough or when you need to modify Unity state.
+
 Direct statements only (no classes/namespaces/methods); return is optional (auto 'return null;' if omitted).
 
 You may include using directives at the top; they are hoisted above the wrapper.

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: uloop-execute-dynamic-code
-description: "Execute C# code dynamically in Unity Editor. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) Execute Unity Editor menu commands through EditorApplication.ExecuteMenuItem, (5) PlayMode automation (click buttons, invoke methods, tweak runtime state), (6) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (7) PlayMode inspection (scene info, reflection, physics state, raycast checks). NOT for file I/O or script authoring."
+description: "Execute C# code dynamically in Unity Editor. Use find-game-objects first for basic selected GameObject discovery or property inspection. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) Execute Unity Editor menu commands through EditorApplication.ExecuteMenuItem, (5) PlayMode automation (click buttons, invoke methods, tweak runtime state), (6) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (7) PlayMode inspection that requires custom Unity API code beyond existing tools. NOT for file I/O or script authoring."
 context: fork
 ---
 
 # Task
 
 Execute the following request using `uloop execute-dynamic-code`: $ARGUMENTS
+
+For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
 ## Workflow
 

--- a/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsTool.cs
@@ -17,7 +17,7 @@ namespace io.github.hatayama.uLoopMCP
     /// - FindGameObjectsSchema: Search parameters
     /// - FindGameObjectsResponse: Type-safe response structure
     /// </summary>
-    [McpTool(Description = "Find GameObjects by search criteria or inspect GameObject(s) currently selected in the Unity Hierarchy using SearchMode.Selected.")]
+    [McpTool(Description = "Use first when the user asks about the currently selected GameObject in the Unity Hierarchy. Inspect selected object details and component properties with SearchMode.Selected before using execute-dynamic-code. Also search by name, path, regex, tag, layer, or required components. Use get-hierarchy when the child tree under the selection is needed.")]
     public class FindGameObjectsTool : AbstractUnityTool<FindGameObjectsSchema, FindGameObjectsResponse>
     {
         public override string ToolName => "find-game-objects";

--- a/Packages/src/Editor/Api/McpTools/FindGameObjects/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/FindGameObjects/Skill/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: uloop-find-game-objects
-description: "Inspect Unity GameObjects by search criteria or the current Hierarchy selection. Use when you need to: (1) Get details for GameObject(s) the user selected in the Unity Hierarchy with `--search-mode Selected`, (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
+description: "Use first when the user asks about the currently selected GameObject in the Unity Hierarchy. Inspect selected object details with `--search-mode Selected` before using `execute-dynamic-code`. Use when you need to: (1) Get details and component properties for selected GameObject(s), (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Use get-hierarchy when the child tree under the selection is needed. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
 ---
 
 # uloop find-game-objects
 
 Find GameObjects with search criteria or get details for currently selected Hierarchy objects.
+
+Use this before `execute-dynamic-code` when identifying or inspecting selected GameObjects. Use `get-hierarchy` instead when you need the child tree, parent-child structure, or descendants under the selection.
 
 ## Usage
 

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/GetHierarchyTool.cs
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/GetHierarchyTool.cs
@@ -21,7 +21,7 @@ namespace io.github.hatayama.uLoopMCP
     /// - GetHierarchySchema: Type-safe parameter schema
     /// - GetHierarchyResponse: Type-safe response structure
     /// </summary>
-    [McpTool(Description = "Get Unity Hierarchy structure for the whole scene, a root path, or GameObject(s) currently selected in the Unity Hierarchy using UseSelection.")]
+    [McpTool(Description = "Get Unity Hierarchy structure for the whole scene, a root path, or selected GameObject descendants using UseSelection. Use this when the child tree, parent-child structure, or descendants under the selection are needed. Use find-game-objects for selected object details and component properties.")]
     public class GetHierarchyTool : AbstractUnityTool<GetHierarchySchema, GetHierarchyResponse>
     {
         public override string ToolName => "get-hierarchy";

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: uloop-get-hierarchy
-description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use when you need to: (1) Inspect the child tree under GameObject(s) the user selected in the Unity Hierarchy with `--use-selection`, (2) Inspect scene structure and parent-child relationships, (3) Explore GameObjects and their components. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
+description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use this when you need the child tree, parent-child structure, or descendants under selected GameObject(s) with `--use-selection`. Use find-game-objects for selected object details and component properties. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
 ---
 
 # uloop get-hierarchy
 
 Get Unity Hierarchy structure from the whole scene, a root path, or selected Hierarchy objects.
+
+Use this for hierarchy structure, especially descendants under the current selection. Use `find-game-objects --search-mode Selected` when you need selected object details or component properties.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Make selected GameObject inspection easier for agents to route to the dedicated inspection tool.
- Clarify when hierarchy-tree inspection and dynamic code execution should be used instead.

## User Impact
- Before this change, agents could treat selected GameObject inspection as a generic Unity API task and jump straight to dynamic code in larger projects with many skills.
- After this change, both the installed skill descriptions and MCP tool descriptions point agents to the narrower inspection tool first, while keeping hierarchy traversal and dynamic code for their intended cases.

## Changes
- Put selected GameObject inspection first in the find-game-objects skill and MCP tool descriptions.
- Clarified the boundary between selected object details, selected descendants, and custom Unity API code.
- Added matching guidance to get-hierarchy and execute-dynamic-code descriptions.

## Verification
- git diff --check
- uloop compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# AI Tool Routing Clarification for Selected GameObject Inspection

## Overview
This PR improves how AI agents select the appropriate tool for different GameObject inspection tasks by clarifying the intended use cases and boundaries between three related tools: `find-game-objects`, `get-hierarchy`, and `execute-dynamic-code`.

## Changes Made

All changes are documentation and tool metadata updates with no functional code modifications.

### Tool Description Updates

**FindGameObjectsTool** (`Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsTool.cs`)
- Updated `McpTool.Description` attribute to emphasize this tool should be used first when inspecting the currently selected GameObject
- Added explicit instruction to use `--search-mode Selected` for selected object details and component properties
- Clarified supported search criteria (name, path, regex, tag, layer, components)
- Directed agents to use `get-hierarchy` when child tree/descendant information is needed

**ExecuteDynamicCodeTool** (`Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/ExecuteDynamicCodeTool.cs`)
- Added guidance to use `find-game-objects` first for basic selected GameObject discovery or property inspection
- Clarified this tool should only be used when built-in inspection tools are insufficient or when Unity state modifications are needed

**GetHierarchyTool** (`Packages/src/Editor/Api/McpTools/GetHierarchy/GetHierarchyTool.cs`)
- Updated `McpTool.Description` to focus on hierarchy structure and descendants under selection
- Added explicit direction to use `find-game-objects` for selected object details and component properties

### Skill Documentation Updates

**FindGameObjects SKILL.md** (`Packages/src/Editor/Api/McpTools/FindGameObjects/Skill/SKILL.md`)
- Updated frontmatter description to prioritize selected GameObject inspection
- Added usage guidance paragraph clarifying workflow and when to use alternative tools

**ExecuteDynamicCode SKILL.md** (`Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md`)
- Updated frontmatter description with guidance to use `find-game-objects` first
- Added dedicated workflow paragraph reiterating the recommended tool selection logic

**GetHierarchy SKILL.md** (`Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md`)
- Updated frontmatter description to emphasize descendants and hierarchy structure
- Added guidance paragraph with concrete example of using `find-game-objects --search-mode Selected` for selection details

## Impact

- **For agents**: Clear routing information ensures selected GameObject inspection requests are directed to the appropriate tool first, reducing unnecessary complexity in large projects
- **For users**: Clearer tool descriptions make it easier to understand which tool to use for specific tasks
- **Boundary clarification**: Explicit documentation distinguishes between:
  - Selected object details and properties (`find-game-objects`)
  - Hierarchy structure and descendant information (`get-hierarchy`)
  - Custom Unity API code and state modifications (`execute-dynamic-code`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->