### PR TITLE
chore: Prepare beta release automation for v3

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,23 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git ref to publish from (tag, branch, or SHA). Defaults to default branch.'
+        description: "Git ref to publish from (tag, branch, or SHA). Defaults to default branch."
         required: false
-        default: ''
+        default: ""
       dry-run:
-        description: 'Dry run (skip actual publish)'
+        description: "Dry run (skip actual publish)"
         type: boolean
         default: false
 
 permissions:
   contents: read
-  id-token: write  # Required for npm OIDC trusted publishing
+  id-token: write # Required for npm OIDC trusted publishing
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # For workflow_dispatch, only allow from main branch
-    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    # For workflow_dispatch, only allow release-managed branches
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -30,8 +30,8 @@ jobs:
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: 📋 Check version
         id: version
@@ -43,6 +43,17 @@ jobs:
           fi
           echo "version=${CLI_VERSION}" >> "$GITHUB_OUTPUT"
           echo "📋 CLI version: ${CLI_VERSION}"
+          case "${CLI_VERSION}" in
+            *-*)
+              NPM_TAG=${CLI_VERSION#*-}
+              NPM_TAG=${NPM_TAG%%.*}
+              ;;
+            *)
+              NPM_TAG=latest
+              ;;
+          esac
+          echo "npm_tag=${NPM_TAG}" >> "$GITHUB_OUTPUT"
+          echo "📋 npm dist-tag: ${NPM_TAG}"
 
           PUBLISHED=$(npm view uloop-cli versions --json 2>/dev/null || echo '[]')
           if echo "$PUBLISHED" | jq -e ". | index(\"${CLI_VERSION}\")" > /dev/null 2>&1; then
@@ -65,6 +76,8 @@ jobs:
         run: |
           cd Packages/src/Cli~
           npm pack --dry-run --json > /tmp/pack.json
+          jq -e '.[0].files[] | select(.path=="dist/dispatcher.bundle.cjs")' /tmp/pack.json > /dev/null
+          echo "✅ dist/dispatcher.bundle.cjs found in package"
           jq -e '.[0].files[] | select(.path=="dist/cli.bundle.cjs")' /tmp/pack.json > /dev/null
           echo "✅ dist/cli.bundle.cjs found in package"
 
@@ -72,11 +85,11 @@ jobs:
         if: steps.version.outputs.already_published == 'false' && inputs.dry-run != true
         run: |
           cd Packages/src/Cli~
-          npm publish --access public --provenance
-          echo "✅ CLI v${{ steps.version.outputs.version }} published to npm with provenance"
+          npm publish --tag "${{ steps.version.outputs.npm_tag }}" --access public --provenance
+          echo "✅ CLI v${{ steps.version.outputs.version }} published to npm with ${{ steps.version.outputs.npm_tag }} tag and provenance"
 
       - name: 🧪 Dry run - skip publish
         if: inputs.dry-run == true
         run: |
           echo "🧪 Dry run mode - skipping actual publish"
-          echo "Would publish uloop-cli@${{ steps.version.outputs.version }}"
+          echo "Would publish uloop-cli@${{ steps.version.outputs.version }} with ${{ steps.version.outputs.npm_tag }} tag"

--- a/.github/workflows/npm-version-check.yml
+++ b/.github/workflows/npm-version-check.yml
@@ -3,7 +3,7 @@ name: npm version check
 on:
   schedule:
     # Run daily at 09:00 UTC (18:00 JST)
-    - cron: '0 9 * * *'
+    - cron: "0 9 * * *"
   workflow_dispatch:
 
 permissions:
@@ -29,10 +29,22 @@ jobs:
             exit 0
           fi
 
+          case "${GIT_VERSION}" in
+            *-*)
+              NPM_TAG="${GIT_VERSION#*-}"
+              NPM_TAG="${NPM_TAG%%.*}"
+              NPM_PACKAGE_SPEC="uloop-cli@${NPM_TAG}"
+              ;;
+            *)
+              NPM_TAG="latest"
+              NPM_PACKAGE_SPEC="uloop-cli"
+              ;;
+          esac
+
           # Retry up to 3 times to avoid false positives from transient network errors
           NPM_VERSION=""
           for i in 1 2 3; do
-            if NPM_VERSION=$(npm view uloop-cli version 2>/dev/null); then
+            if NPM_VERSION=$(npm view "${NPM_PACKAGE_SPEC}" version 2>/dev/null); then
               break
             fi
             echo "⚠️ npm view attempt ${i} failed, retrying in 10s..."
@@ -46,8 +58,9 @@ jobs:
 
           echo "git_version=${GIT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "npm_version=${NPM_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=${NPM_TAG}" >> "$GITHUB_OUTPUT"
           echo "📋 Git tag: v${GIT_VERSION}"
-          echo "📋 npm: ${NPM_VERSION}"
+          echo "📋 npm (${NPM_TAG}): ${NPM_VERSION}"
 
           if [ "${GIT_VERSION}" = "${NPM_VERSION}" ]; then
             echo "✅ Versions match"
@@ -77,17 +90,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_VERSION: ${{ steps.compare.outputs.git_version }}
           NPM_VERSION: ${{ steps.compare.outputs.npm_version }}
+          NPM_TAG: ${{ steps.compare.outputs.npm_tag }}
         run: |
           gh label create "npm-publish-failed" --color "d73a4a" --description "npm publish failed for a release" --force
           gh issue create \
-            --title "npm publish failed: v${GIT_VERSION} not on npm" \
+            --title "npm publish failed: v${GIT_VERSION} not on npm ${NPM_TAG}" \
             --label "npm-publish-failed" \
             --body "## npm version mismatch detected
 
           | Source | Version |
           |--------|---------|
           | Git tag | v${GIT_VERSION} |
-          | npm | ${NPM_VERSION} |
+          | npm (${NPM_TAG}) | ${NPM_VERSION} |
 
           ### How to fix
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,13 +3,14 @@ name: release-please
 on:
   push:
     branches:
-      - main
+      - v3-beta
   # Enable manual execution via "Run workflow" button in browser
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Target branch name (uses current ref if not specified)'
+        description: "Target beta branch name"
         required: false
+        default: "v3-beta"
 
 permissions:
   contents: write
@@ -21,11 +22,29 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
+      target_branch: ${{ steps.target.outputs.branch }}
+      target_sha: ${{ steps.target.outputs.sha }}
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0      # Required for tag fetching
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
+          fetch-depth: 0 # Required for tag fetching
+
+      - name: 🎯 Resolve target branch
+        id: target
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+        run: |
+          TARGET_BRANCH="${INPUT_BRANCH:-v3-beta}"
+          if [ "${TARGET_BRANCH}" != "v3-beta" ]; then
+            echo "This prerelease workflow only supports v3-beta." >&2
+            exit 1
+          fi
+
+          TARGET_SHA="$(git rev-parse HEAD)"
+          echo "branch=${TARGET_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
 
       # ── Debug: Show repository structure ─────────────────────────
       - name: 🕵️ Show file tree
@@ -38,7 +57,6 @@ jobs:
       - name: 🧪 Sanity check
         run: |
           test -f Packages/src/package.json && echo "✅ Unity package.json OK"
-          test -f Packages/src/TypeScriptServer~/package.json && echo "✅ TypeScript Server package.json OK"
           test -f Packages/src/Cli~/package.json && echo "✅ CLI package.json OK"
 
       # ── Execute release-please ───────────────────────────
@@ -48,43 +66,52 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: ${{ steps.target.outputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # ── Rebuild bundles when Release PR is created/updated ──
-      # GITHUB_TOKEN-created PRs do not trigger pull_request events,
-      # so build-and-test.yml cannot handle this — must rebuild here.
-      - name: 🔧 Setup Node.js for bundle rebuild
-        if: ${{ steps.release.outputs.pr != '' }}
+      - name: 🔧 Setup Node.js
+        if: steps.release.outputs.prs_created == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: "Packages/src/Cli~/package-lock.json"
 
-      - name: 📦 Rebuild server bundle for Release PR
-        if: ${{ steps.release.outputs.pr != '' }}
+      - name: 📦 Rebuild CLI bundle in release PR
+        if: steps.release.outputs.prs_created == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_JSON: ${{ steps.release.outputs.pr }}
+          RELEASE_PLEASE_PR: ${{ steps.release.outputs.pr || '' }}
+          RELEASE_PLEASE_PRS: ${{ steps.release.outputs.prs || '' }}
         run: |
-          PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')
-          echo "🔄 Release PR #${PR_NUMBER} detected, rebuilding server bundle..."
+          PR_DATA="${RELEASE_PLEASE_PRS:-${RELEASE_PLEASE_PR:-}}"
+          RELEASE_BRANCH=$(
+            printf '%s' "${PR_DATA}" \
+              | jq -r 'if type == "array" then .[0] else . end | .headBranchName // .headRefName // .head.ref // empty'
+          )
 
-          gh pr checkout "${PR_NUMBER}"
-
-          cd Packages/src/TypeScriptServer~
-          npm ci --ignore-scripts=false
-          ULOOPMCP_PRODUCTION=true NODE_ENV=production npm run build:production
-          cd "$GITHUB_WORKSPACE"
-
-          git add Packages/src/TypeScriptServer~/dist/server.bundle.js Packages/src/TypeScriptServer~/dist/server.bundle.js.map
-          if git diff --cached --quiet; then
-            echo "✅ No changes to bundle, skipping commit"
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git commit -m "chore: rebuild server bundle for release"
-            git push
-            echo "✅ Server bundle rebuilt and pushed to PR"
+          if [ -z "${RELEASE_BRANCH}" ]; then
+            echo "Release Please did not report a release PR branch." >&2
+            exit 1
           fi
+
+          git fetch origin "${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+          git checkout -B "${RELEASE_BRANCH}" "origin/${RELEASE_BRANCH}"
+
+          cd Packages/src/Cli~
+          npm ci
+          npm run build
+          cd ../../..
+
+          if git diff --quiet -- Packages/src/Cli~/dist/cli.bundle.cjs; then
+            echo "Project-local CLI bundle is already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Packages/src/Cli~/dist/cli.bundle.cjs
+          git commit -m "chore: rebuild project CLI bundle"
+          git push origin "HEAD:${RELEASE_BRANCH}"
 
   # ── Dispatch npm-publish when release is created ────────────
   # Keep npm-publish.yml as the single trusted publisher entrypoint.
@@ -101,12 +128,14 @@ jobs:
       - name: 🚀 Dispatch npm-publish workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: ${{ needs.release.outputs.target_branch }}
+          TARGET_SHA: ${{ needs.release.outputs.target_sha }}
         run: |
           STARTED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           gh workflow run npm-publish.yml \
-            --ref main \
-            -f ref="${GITHUB_SHA}" \
+            --ref "${TARGET_BRANCH}" \
+            -f ref="${TARGET_SHA}" \
             -f dry-run=false \
             --repo "${GITHUB_REPOSITORY}"
 
@@ -117,7 +146,7 @@ jobs:
               gh run list \
                 --workflow npm-publish.yml \
                 --event workflow_dispatch \
-                --commit "${GITHUB_SHA}" \
+                --branch "${TARGET_BRANCH}" \
                 --repo "${GITHUB_REPOSITORY}" \
                 --limit 10 \
                 --json databaseId,createdAt \

--- a/.github/workflows/update-launch-unity.yml
+++ b/.github/workflows/update-launch-unity.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Target version of launch-unity (empty = latest from npm)'
+        description: "Target version of launch-unity (empty = latest from npm)"
         required: false
-        default: ''
+        default: ""
 
 permissions:
   contents: write
@@ -24,7 +24,7 @@ jobs:
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: 🔍 Resolve versions
         id: version
@@ -49,28 +49,23 @@ jobs:
 
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-          # Get current versions from both package.json files
           CLI_VERSION=$(node -p "require('./Packages/src/Cli~/package.json').dependencies['launch-unity']")
-          SERVER_VERSION=$(node -p "require('./Packages/src/TypeScriptServer~/package.json').dependencies['launch-unity']")
           echo "cli_version=$CLI_VERSION" >> "$GITHUB_OUTPUT"
-          echo "server_version=$SERVER_VERSION" >> "$GITHUB_OUTPUT"
 
-          echo "📋 Current: Cli~=$CLI_VERSION, Server~=$SERVER_VERSION → Target: $NEW_VERSION"
+          echo "📋 Current: Cli~=$CLI_VERSION → Target: $NEW_VERSION"
 
       - name: ✅ Check if update is needed
         id: check
         env:
           NEW: ${{ steps.version.outputs.new_version }}
           CLI: ${{ steps.version.outputs.cli_version }}
-          SERVER: ${{ steps.version.outputs.server_version }}
         run: |
-          # Skip if both are already up to date
-          if [ "$NEW" = "$CLI" ] && [ "$NEW" = "$SERVER" ]; then
+          if [ "$NEW" = "$CLI" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Both packages already at $NEW — skipping."
+            echo "Cli~ already at $NEW — skipping."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "Update needed: Cli~=$CLI, Server~=$SERVER → $NEW"
+            echo "Update needed: Cli~=$CLI → $NEW"
           fi
 
       - name: 📦 Update Cli~ dependency
@@ -80,12 +75,10 @@ jobs:
           TARGET_VERSION: ${{ steps.version.outputs.new_version }}
         run: npm install "launch-unity@${TARGET_VERSION}" --save-exact
 
-      - name: 📦 Update TypeScriptServer~ dependency
+      - name: 🧱 Rebuild project CLI bundle
         if: steps.check.outputs.skip == 'false'
-        working-directory: Packages/src/TypeScriptServer~
-        env:
-          TARGET_VERSION: ${{ steps.version.outputs.new_version }}
-        run: npm install "launch-unity@${TARGET_VERSION}" --save-exact
+        working-directory: Packages/src/Cli~
+        run: npm run build
 
       - name: 📝 Fetch CHANGELOG diff
         if: steps.check.outputs.skip == 'false'
@@ -118,7 +111,6 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.version.outputs.new_version }}
           CLI_VERSION: ${{ steps.version.outputs.cli_version }}
-          SERVER_VERSION: ${{ steps.version.outputs.server_version }}
         run: |
           {
             echo "Automated update triggered by launch-unity release."
@@ -126,7 +118,6 @@ jobs:
             echo "## Changes"
             echo "- Update \`launch-unity\` to \`${NEW_VERSION}\`"
             echo "- Cli~ was at \`${CLI_VERSION}\`"
-            echo "- TypeScriptServer~ was at \`${SERVER_VERSION}\`"
             echo ""
             echo "## CHANGELOG (launch-unity ${CLI_VERSION} → ${NEW_VERSION})"
             echo ""


### PR DESCRIPTION
## Summary
- Splits the beta release workflow changes out of the dispatcher runtime PR.
- Keeps Release Please and npm publish behavior reviewable as a separate release-policy change.

## User Impact
- The dispatcher runtime PR can be reviewed without release automation policy mixed in.
- v3 beta release behavior can be checked independently before merging.

## Changes
- Routes Release Please and npm publish flows for the v3 beta branch.
- Compares prerelease npm versions against the matching dist-tag.
- Rebuilds the project CLI bundle in release/dependency update flows where needed.

## Verification
- `git diff --check feature/hatayama/v3-dispatcher-runtime...feature/hatayama/v3-beta-release-automation`
- `npm run lint` (0 errors, existing security warnings)
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR extracts beta release workflow changes from the dispatcher runtime PR, keeping release automation policy changes separate and reviewable independently. The changes route Release Please and npm publish flows for the v3 beta branch, with logic to compare prerelease npm versions against matching dist-tags and rebuild the CLI bundle in release/dependency update flows.

## Workflow Changes

### npm-publish.yml
- Computes an `npm_tag` output during the version-check step by parsing CLI semver
- Prerelease versions (containing `-`) extract the substring after `-` up to the first dot; non-prerelease versions use `latest`
- Extends job triggering for `workflow_dispatch` to allow publishing from `refs/heads/v3-beta` in addition to `main`
- Adds stricter package-content assertion ensuring `dist/dispatcher.bundle.cjs` is present
- Updates `npm publish` command to publish with the computed dist-tag via `--tag` flag
- Both publish and dry-run log messages now include the selected tag
- **Lines changed:** +24/-11

### npm-version-check.yml
- Determines npm tag/package spec from git tag
- If `GIT_VERSION` contains a hyphenated segment, extracts an npm tag component and constructs `uloop-cli@${NPM_TAG}`; otherwise targets unscoped `uloop-cli` with `latest` default
- The `npm view` version check uses computed package spec instead of always querying `uloop-cli`
- Step outputs and downstream issue creation now include `npm_tag`
- Logged output and GitHub issue title/body reflect the specific npm tag/version being compared (e.g., `npm (${NPM_TAG})`)
- **Lines changed:** +19/-5

### release-please.yml
- Targets `v3-beta` branch exclusively for both push events and release-please configuration
- Introduces target-resolution step that validates `v3-beta` and exports both `target_branch` and `target_sha`
- Propagates resolved values into release-please action and downstream `npm-publish` dispatch
- Switches dispatch/ref selection from `main` + `GITHUB_SHA` to resolved target
- Bundle-rebuild job logic rewritten:
  - No longer builds the TypeScript Server bundle
  - Rebuilds only CLI bundle when release-please indicates PRs were created
  - Determines relevant release PR branch from either `release.outputs.pr` or `release.outputs.prs`
  - Checks out that branch, runs CLI build, conditionally commits `cli.bundle.cjs`, and pushes back
- **Lines changed:** +65/-36

### update-launch-unity.yml
- Resolves and compares only the `launch-unity` dependency version used by `Packages/src/Cli~`
- Removes all Server~/TypeScriptServer~ version detection, output wiring, skip-condition branching, and PR body reporting
- Stops installing `launch-unity` into `Packages/src/TypeScriptServer~`
- Runs `npm run build` in `Packages/src/Cli~` as the follow-up step
- Minor formatting: switches several YAML string literals from single quotes to double quotes
- **Lines changed:** +10/-19

## Impact

- Enables v3 beta release behavior to be checked and reviewed independently before merging
- Allows the dispatcher runtime PR to be reviewed without release automation policy mixed in
- Focuses CLI bundle rebuild logic specifically on beta release scenarios
- Establishes clear npm tagging strategy for prerelease vs. stable releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->