### PR TITLE
fix: Release PRs only open after main updates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,14 +3,14 @@ name: release-please
 on:
   push:
     branches:
-      - v3-beta
+      - main
   # Enable manual execution via "Run workflow" button in browser
   workflow_dispatch:
     inputs:
       branch:
-        description: "Target beta branch name"
+        description: "Target branch name"
         required: false
-        default: "v3-beta"
+        default: "main"
 
 permissions:
   contents: write
@@ -36,9 +36,9 @@ jobs:
         env:
           INPUT_BRANCH: ${{ github.event.inputs.branch }}
         run: |
-          TARGET_BRANCH="${INPUT_BRANCH:-v3-beta}"
-          if [ "${TARGET_BRANCH}" != "v3-beta" ]; then
-            echo "This prerelease workflow only supports v3-beta." >&2
+          TARGET_BRANCH="${INPUT_BRANCH:-main}"
+          if [ "${TARGET_BRANCH}" != "main" ]; then
+            echo "This release workflow only supports main." >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Prevent release-please from opening release PRs after v3-beta branch updates.
- Keep the release workflow scoped to main pushes and main manual dispatches.

## User Impact
- Merging feature work into v3-beta no longer creates or updates release PRs unexpectedly.
- Release Please runs only when main is updated, matching the expected release flow.

## Changes
- Restored the release-please workflow trigger from v3-beta to main.
- Restored the manual dispatch default and guard to main.

## Verification
- git diff --check -- .github/workflows/release-please.yml
- Reviewed the final branch diff against origin/v3-beta.