### PR TITLE
chore: Obsolete TypeScript CLI leftovers no longer appear in package rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,10 +113,6 @@ Packages/src/TypeScriptServer~/dist/*
 !Packages/src/TypeScriptServer~/dist/server.bundle.js
 !Packages/src/TypeScriptServer~/dist/server.bundle.js.map
 
-# CLI dispatcher is published to npm; project CLI bundle is included in the Unity package
-Packages/src/Cli~/dist/*
-!Packages/src/Cli~/dist/cli.bundle.cjs
-
 # Native Go CLI release artifacts are included in the Unity package
 Packages/src/GoCli~/dist/*
 !Packages/src/GoCli~/dist/darwin-arm64/


### PR DESCRIPTION
## Summary
- The package ignore rules no longer suggest that the old TypeScript CLI bundle is still part of the Unity package surface.
- The v3 branch now points contributors toward the native Go CLI package only.

## User Impact
- Before this cleanup, local Packages/src/Cli~ leftovers could look like an active package area because .gitignore still contained old exceptions for it.
- After this cleanup, the repository metadata matches the v3 Go CLI layout and reduces confusion when scanning package contents.

## Changes
- Removed stale .gitignore rules for Packages/src/Cli~/dist.
- Verified that Packages/src/Cli~ has no tracked files and current repository references target Packages/src/GoCli~.

## Verification
- git diff --check HEAD~1..HEAD
- git ls-files "Packages/src/Cli~" returned 0 tracked files
- repository search found no active Packages/src/Cli~ references outside the removed ignore rules