### PR TITLE
chore: v3-beta merges now prepare beta releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches:
       - main
+      - v3-beta
   # Enable manual execution via "Run workflow" button in browser
   workflow_dispatch:
     inputs:
       branch:
-        description: "Target branch name"
+        description: "Target branch name (uses current ref if not specified)"
         required: false
-        default: "main"
 
 permissions:
   contents: write
@@ -36,11 +36,15 @@ jobs:
         env:
           INPUT_BRANCH: ${{ github.event.inputs.branch }}
         run: |
-          TARGET_BRANCH="${INPUT_BRANCH:-main}"
-          if [ "${TARGET_BRANCH}" != "main" ]; then
-            echo "This release workflow only supports main." >&2
-            exit 1
-          fi
+          TARGET_BRANCH="${INPUT_BRANCH:-${GITHUB_REF_NAME}}"
+          case "${TARGET_BRANCH}" in
+            main|v3-beta)
+              ;;
+            *)
+              echo "This release workflow only supports main and v3-beta." >&2
+              exit 1
+              ;;
+          esac
 
           TARGET_SHA="$(git rev-parse HEAD)"
           echo "branch=${TARGET_BRANCH}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Merges into v3-beta can now run release-please for beta prerelease preparation.
- The workflow still rejects unsupported target branches, so release automation stays limited to main and v3-beta.

## User Impact
- Before this change, updates merged into v3-beta did not start the beta release preparation flow.
- After this change, v3-beta updates can produce a beta release PR such as chore(v3-beta): release 3.0.0-beta.1.

## Changes
- Add v3-beta to the release-please push trigger.
- Resolve the release target from the manual branch input or the pushed ref name.
- Allow only main and v3-beta as release targets.

## Verification
- git diff --check
- jq empty release-please-config.json .release-please-manifest.json
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml")'
- npx release-please release-pr --repo-url hatayama/unity-cli-loop --target-branch v3-beta --config-file release-please-config.json --manifest-file .release-please-manifest.json --dry-run --token <gh-token>
- Local shell check for main, v3-beta, manual branch input, and unsupported branch resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This pull request extends the release automation workflow to support beta releases on the `v3-beta` branch in addition to the existing `main` branch. Previously, the release-please workflow only triggered on `main` pushes and rejected any other target branches. The changes enable automated beta release candidate generation for the v3-beta development stream.

## Changes
The release-please workflow (`.github/workflows/release-please.yml`) has been modified with the following key changes:

1. **Expanded push trigger** (lines 4-7)
   - Added `v3-beta` to the list of branches that automatically trigger the workflow
   - Workflow now runs on both `main` and `v3-beta` branch pushes

2. **Improved manual execution** (lines 11-13)
   - Removed the hardcoded default value of `"main"` from the `branch` workflow input
   - Updated description to clarify that the workflow uses the current ref name when no branch is explicitly provided
   - Maintains `required: false` to allow implicit fallback behavior

3. **Enhanced branch resolution** (lines 34-51)
   - Added a new "Resolve target branch" step that:
     - Derives the target branch from either the manual `github.event.inputs.branch` parameter or the current `GITHUB_REF_NAME`
     - Validates the resolved branch against an allowlist using a `case` statement for `main` and `v3-beta` only
     - Returns an error with message: "This release workflow only supports main and v3-beta." for unsupported branches
   - Captures both the resolved branch name and commit SHA as step outputs
   - Ensures the release-please action uses the validated target branch (line 72)

## Impact
- **Beta release automation**: Merges to `v3-beta` now trigger release-please to create beta release PRs (e.g., `chore(v3-beta): release 3.0.0-beta.1`)
- **Backward compatible**: The manual workflow dispatch now intelligently falls back to the current branch when no branch input is provided, instead of defaulting to `main`
- **Improved safety**: Branch validation prevents accidental releases on unsupported branches and provides clear error messaging
- **Publishing workflow integration**: The dispatch-publish job continues to work with both branches, using the resolved target branch for consistency

## Code Review Effort
Medium - The changes are straightforward but involve workflow logic coordination across multiple steps and represent a meaningful expansion of release automation scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->