### PR TITLE
chore: CLI guidance now matches native v3 releases

### DIFF
--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -4,116 +4,89 @@ paths: Packages/src/Cli~/**
 
 # uloop CLI
 
-A CLI tool for communicating with Unity Editor. Completely independent from the MCP server (TypeScriptServer~).
+The uloop CLI is the native Go command surface for communicating with Unity Editor. It is independent from the MCP server (`TypeScriptServer~`) and is not published to npm.
 
 ## Architecture
 
-- **Zero dependency on TypeScriptServer~**
-- Communicates with Unity directly via TCP connection in `direct-unity-client.ts`
-- Interacts directly with Unity TCP server without going through MCP server
+- `Dispatcher~` contains the global/user-facing `uloop-dispatcher` entrypoint.
+- `Core~` contains the project-local `uloop-core` implementation that resolves Unity connections and dispatches tool calls.
+- `Shared~` contains common domain, project, framing, and version helpers used by both binaries.
+- `layout-contract.json`, `Core~/contract.json`, and `Dispatcher~/contract.json` define the versioned CLI layout contract.
 
 ## Directory Structure
 
 ```text
-src/
-├── cli.ts                 # Entry point (commander.js)
-├── version.ts             # Version management (auto-updated by release-please)
-├── execute-tool.ts        # Tool execution logic
-├── direct-unity-client.ts # Direct Unity TCP communication
-├── simple-framer.ts       # TCP framing
-├── port-resolver.ts       # Port detection
-├── tool-cache.ts          # Tool cache (.uloop/tools.json)
-├── arg-parser.ts          # Argument parsing
-├── default-tools.json     # Default tool definitions
-├── skills/                # Claude Code skills feature
-│   ├── skills-command.ts
-│   ├── skills-manager.ts  # Collects bundled + project skills
-│   ├── bundled-skills.ts  # Auto-generated from SKILL.md files
-│   └── skill-definitions/
-│       └── cli-only/      # CLI-only internal skills
-└── __tests__/
-    └── cli-e2e.test.ts    # E2E tests
+Cli~/
+├── Core~/
+│   ├── cmd/uloop-core/        # Core binary entrypoint
+│   ├── internal/application/  # Use cases
+│   ├── internal/ports/        # Boundary interfaces
+│   ├── internal/adapters/     # Unity transport and platform adapters
+│   └── internal/presentation/ # CLI commands, tools, skills, and output
+├── Dispatcher~/
+│   ├── cmd/uloop-dispatcher/  # Dispatcher binary entrypoint
+│   └── internal/dispatcher/   # Project-local core resolution and dispatch
+├── Shared~/                  # Shared domain and adapter packages
+└── layout-contract.json
 ```
 
-## Global Options
+## Build and Validation
 
-All commands that communicate with Unity support these global options:
-
-| Option | Description |
-|--------|-------------|
-| `--project-path <path>` | Specify Unity project path to auto-resolve port |
-
-### --project-path
-
-Resolves the target Unity instance by reading `UserSettings/UnityMcpSettings.json` from the specified project directory. Path resolution follows the same rules as `cd` — absolute paths (starting with `/`) are used as-is, relative paths are resolved from the current working directory.
+Use the repository scripts instead of npm commands:
 
 ```bash
-# Absolute path
-uloop compile --project-path /Users/foo/moorestech_server
-
-# Relative path (resolved from cwd)
-uloop compile --project-path ./moorestech_server
-uloop compile --project-path ../other/project
+scripts/check-go-cli.sh
 ```
 
-## Build
+This runs the Go CLI source checks and validates checked-in dist artifacts.
+
+Release asset packaging is handled by:
 
 ```bash
-npm run build    # Generates dist/cli.bundle.cjs
-npm run lint     # Run ESLint
+scripts/package-go-cli.sh
+scripts/verify-native-cli-release-assets.sh
 ```
 
-## E2E Tests
+## Native CLI Releases
 
-E2E tests communicate with actual Unity Editor, so the following prerequisites are required:
+The v3 CLI is released through GitHub Release assets built by `native-cli-publish.yml`.
 
-1. Unity Editor must be running
-2. uLoopMCP package must be installed
-3. CLI must be built (`npm run build`)
+Do not add npm publish or npm version-check workflows for the v3 CLI. TypeScript CLI publishing is obsolete on the v3 beta line.
 
-```bash
-npm run test:cli # Run E2E tests (Unity must be running)
-```
+Expected release assets:
 
-### Domain Reload and Connection Drops
-
-**Important**: After `compile` command execution, Unity triggers a Domain Reload which forcibly disconnects the C# TCP server. This causes a few seconds of unavailability where Unity connections will fail. This behavior is unavoidable.
-
-When writing E2E tests:
-- Use `runCliWithRetry()` instead of `runCli()` for commands that run after `compile`
-- Place `compile --force-recompile` tests at the end of the test suite to minimize impact on other tests
-- Be aware that any test immediately following a compile-related test may experience connection instability
-
-## npm Publishing
-
-This directory is published to npm as the `uloop-cli` package.
-Version is synchronized with `Packages/src/package.json` (managed by release-please).
+- `install.sh`
+- `install.ps1`
+- `uloop-darwin-amd64.tar.gz`
+- `uloop-darwin-arm64.tar.gz`
+- `uloop-windows-amd64.zip`
+- matching `.sha256` files for each binary archive
 
 ## Skills System
 
 Skills are collected from two sources:
 
-1. **Bundled skills** (build-time): Auto-generated from `SKILL.md` files in:
-   - `Editor/Api/McpTools/<ToolFolder>/SKILL.md`
-   - `skill-definitions/cli-only/<SkillFolder>/SKILL.md`
-
-2. **Project skills** (runtime): Scanned from Unity project's `Editor/` folders:
+1. CLI-only bundled skills under `Core~/internal/presentation/cli/skill-definitions/cli-only/`
+2. Project skills scanned from Unity project's `Editor/` folders:
    - `Assets/**/Editor/`
    - `Packages/**/Editor/`
    - `Library/PackageCache/**/Editor/`
 
-Run `npx tsx scripts/generate-bundled-skills.ts` to regenerate `bundled-skills.ts`.
-
-Skills with `internal: true` in frontmatter are excluded from bundled skills.
+Skills with `internal: true` in frontmatter are excluded from the user-facing bundled skills list.
 
 Currently internal skills:
+
 - `uloop-get-project-info`
 - `uloop-get-version`
 
 When updating README documentation about bundled skills count, remember to exclude internal skills from the count.
 
-## Notes
+## Domain Reload and Connection Drops
 
-- `version.ts` is a separate file from TypeScriptServer~ (not a copy)
-- Build artifact `dist/cli.bundle.cjs` is excluded via `.gitignore`
-- `node_modules/` is also excluded via `.gitignore`
+After `compile` command execution, Unity triggers a Domain Reload that disconnects the Unity-side server for a few seconds. This behavior is unavoidable.
+
+When writing CLI tests:
+
+- Prefer pure Go tests for command, contract, and dispatch behavior.
+- Use retry-aware helpers for commands that run after `compile`.
+- Place compile-related E2E checks at the end of a suite when Unity Editor state is involved.

--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -51,7 +51,7 @@ scripts/verify-native-cli-release-assets.sh
 
 The v3 CLI is released through GitHub Release assets built by `native-cli-publish.yml`.
 
-Do not add npm publish or npm version-check workflows for the v3 CLI. TypeScript CLI publishing is obsolete on the v3 beta line.
+Do not add npm publish or npm version-check workflows for the v3 CLI. The v3 CLI is distributed through native GitHub Release assets, not npm.
 
 Expected release assets:
 

--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -4,7 +4,7 @@ paths: Packages/src/Cli~/**
 
 # uloop CLI
 
-The uloop CLI is the native Go command surface for communicating with Unity Editor. It is independent from the MCP server (`TypeScriptServer~`).
+The uloop CLI is the native Go command surface for communicating with Unity Editor.
 
 ## Architecture
 
@@ -32,7 +32,7 @@ Cli~/
 
 ## Build and Validation
 
-Use the repository scripts instead of npm commands:
+Use the repository scripts:
 
 ```bash
 scripts/check-go-cli.sh

--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -4,7 +4,7 @@ paths: Packages/src/Cli~/**
 
 # uloop CLI
 
-The uloop CLI is the native Go command surface for communicating with Unity Editor. It is independent from the MCP server (`TypeScriptServer~`) and is not published to npm.
+The uloop CLI is the native Go command surface for communicating with Unity Editor. It is independent from the MCP server (`TypeScriptServer~`).
 
 ## Architecture
 
@@ -51,7 +51,7 @@ scripts/verify-native-cli-release-assets.sh
 
 The v3 CLI is released through GitHub Release assets built by `native-cli-publish.yml`.
 
-Do not add npm publish or npm version-check workflows for the v3 CLI. The v3 CLI is distributed through native GitHub Release assets, not npm.
+Do not add npm publish or npm version-check workflows for the v3 CLI.
 
 Expected release assets:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,10 @@
 ## Architecture Overview
 
 This project provides a **CLI tool (`uloop`)** that communicates with Unity Editor via TCP.
-AI agents interact with Unity through `uloop` CLI commands (e.g., `uloop get-logs`, `uloop compile`).
+AI agents interact with Unity through `uloop` CLI commands (e.g., `uloop get-logs`, `uloop compile`), NOT through MCP protocol directly.
+The MCP server (TypeScriptServer~) exists as a separate component but is not the primary interface for AI agents.
 
-When writing or updating current v3 CLI guidance, describe the current CLI architecture and release flow directly. Do not add contrastive context about implementation names, publishing models, or adjacent subsystems unless the user explicitly asks for that context.
+The C# namespace is `io.github.hatayama.uLoopMCP` for historical reasons, but this is a CLI-based tool, not an MCP tool.
 
 Comments in the code, commit messages, PR titles, and PR descriptions must all be written in English.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,9 @@
 ## Architecture Overview
 
 This project provides a **CLI tool (`uloop`)** that communicates with Unity Editor via TCP.
-AI agents interact with Unity through `uloop` CLI commands (e.g., `uloop get-logs`, `uloop compile`), NOT through MCP protocol directly.
-The MCP server (TypeScriptServer~) exists as a separate component but is not the primary interface for AI agents.
+AI agents interact with Unity through `uloop` CLI commands (e.g., `uloop get-logs`, `uloop compile`).
 
-The C# namespace is `io.github.hatayama.uLoopMCP` for historical reasons, but this is a CLI-based tool, not an MCP tool.
+When writing or updating current v3 CLI guidance, describe the current CLI architecture and release flow directly. Do not add contrastive context about implementation names, publishing models, or adjacent subsystems unless the user explicitly asks for that context.
 
 Comments in the code, commit messages, PR titles, and PR descriptions must all be written in English.
 


### PR DESCRIPTION
## Summary
- CLI guidance now describes the current v3 CLI architecture and release flow directly.
- The CLI rules now stay focused on the current command surface, validation scripts, and release assets.

## User Impact
- Contributors working on v3 beta CLI changes get guidance that stays focused on the current workflow.
- The rules avoid pulling unrelated component or publishing context into current CLI guidance.

## Changes
- Simplify the CLI rule introduction to describe only the current command surface.
- Document the current Go CLI layout around Dispatcher, Core, and Shared.
- Document the repository scripts and expected release assets used by the current native release flow.

## Verification
- git diff --check
- searched .claude/rules/cli.md for disallowed contrastive wording
- confirmed AGENTS.md is no longer part of the PR diff