### PR TITLE
fix: Beta releases no longer create npm publish alerts

### DIFF
--- a/.github/workflows/npm-version-check.yml
+++ b/.github/workflows/npm-version-check.yml
@@ -22,9 +22,11 @@ jobs:
       - name: 🔍 Compare git tag vs npm version
         id: compare
         run: |
-          GIT_VERSION=$(git tag --list 'v*' --sort=-version:refname | head -1 | sed 's/^v//')
+          # Why: v3 beta releases ship as native GitHub Release assets, while npm only tracks
+          # stable TypeScript-era releases that still use the uloop-cli package.
+          GIT_VERSION=$(git tag --list 'v*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 | sed 's/^v//')
           if [ -z "${GIT_VERSION}" ]; then
-            echo "⚠️ No git tags found matching 'v*', skipping check"
+            echo "⚠️ No stable git tags found matching 'vX.Y.Z', skipping check"
             echo "mismatch=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- The scheduled npm version check now ignores v3 beta release tags.
- npm publish alerts remain limited to stable releases that are still delivered through npm.

## User Impact
- v3 beta GitHub Release tags should no longer create misleading npm publish failure issues.
- Stable npm releases are still monitored for real mismatches.

## Changes
- Filter the tag lookup to stable `vX.Y.Z` tags before comparing against the npm `uloop-cli` version.
- Update the no-tag message to clarify that the workflow is looking for stable release tags.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/npm-version-check.yml"); puts "yaml ok"'
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/npm-version-check.yml
- git diff --check
- git tag --list 'v*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 | sed 's/^v//'
- npm view uloop-cli version
- Local comparison result: `git_version=2.1.0`, `npm_version=2.1.0`, `mismatch=false`