### PR TITLE
fix: Native releases now stop mismatched beta and stable publishes

### DIFF
--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -57,6 +57,7 @@ jobs:
         id: release
         env:
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF_NAME: ${{ github.ref_name }}
           BEFORE_SHA: ${{ github.event.before }}
           INPUT_RELEASE_TAG: ${{ inputs.release-tag }}
           INPUT_DRY_RUN: ${{ inputs.dry-run }}
@@ -86,18 +87,46 @@ jobs:
               ;;
           esac
 
+          IS_PRERELEASE="false"
+          case "${VERSION}" in
+            *-*)
+              IS_PRERELEASE="true"
+              ;;
+          esac
+
           SHOULD_PUBLISH="true"
           if [ "${EVENT_NAME}" = "push" ]; then
-            case "${BEFORE_SHA}" in
-              ""|0000000000000000000000000000000000000000)
-                echo "Cannot compare release manifest from push before SHA: ${BEFORE_SHA}" >&2
-                exit 1
+            case "${EVENT_REF_NAME}" in
+              main)
+                if [ "${IS_PRERELEASE}" = "true" ]; then
+                  echo "Refusing to publish prerelease version ${VERSION} from main." >&2
+                  exit 1
+                fi
+                ;;
+              v3-beta)
+                if [ "${IS_PRERELEASE}" != "true" ]; then
+                  echo "Refusing to publish stable version ${VERSION} from v3-beta." >&2
+                  exit 1
+                fi
+                ;;
+              *)
+                echo "Skipping native CLI publish for unsupported branch ${EVENT_REF_NAME}."
+                SHOULD_PUBLISH="false"
                 ;;
             esac
 
-            PREVIOUS_VERSION=$(git show "${BEFORE_SHA}:.release-please-manifest.json" | jq -r '.["Packages/src"]')
-            if [ "${PREVIOUS_VERSION}" = "${VERSION}" ]; then
-              SHOULD_PUBLISH="false"
+            if [ "${SHOULD_PUBLISH}" = "true" ]; then
+              case "${BEFORE_SHA}" in
+                ""|0000000000000000000000000000000000000000)
+                  echo "Cannot compare release manifest from push before SHA: ${BEFORE_SHA}" >&2
+                  exit 1
+                  ;;
+              esac
+
+              PREVIOUS_VERSION=$(git show "${BEFORE_SHA}:.release-please-manifest.json" | jq -r '.["Packages/src"]')
+              if [ "${PREVIOUS_VERSION}" = "${VERSION}" ]; then
+                SHOULD_PUBLISH="false"
+              fi
             fi
           fi
 


### PR DESCRIPTION
## Summary
- Native release automation now keeps beta and stable publishes on the correct branch.
- Release assets still publish automatically from both v3-beta and main when the version type matches the branch.

## User Impact
- Beta releases can continue publishing from v3-beta without accidentally becoming stable releases.
- Stable releases can publish from main, while beta versions on main fail fast before tags or assets are created.

## Changes
- Check the manifest version type during push-triggered native publishes.
- Allow prerelease versions only from v3-beta and stable versions only from main.
- Leave workflow_dispatch available for manual recovery and rerun scenarios.

## Verification
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts path }' .github/workflows/native-cli-publish.yml .github/workflows/release-please.yml
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/native-cli-publish.yml .github/workflows/release-please.yml
- Local branch/version gate checks: main + beta fails, main + stable passes, v3-beta + beta passes, v3-beta + stable fails