### PR TITLE
fix: allow installation without Unity Test Framework

### DIFF
--- a/Assets/Tests/Editor/CliVersionComparisonTests.cs
+++ b/Assets/Tests/Editor/CliVersionComparisonTests.cs
@@ -1,0 +1,52 @@
+using System;
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP.Tests.Editor
+{
+    public class CliVersionComparisonTests
+    {
+        [TestCase("2.1.0", "2.1.0", 0)]
+        [TestCase("v2.1.0", "2.1.0", 0)]
+        [TestCase("2.1.0", "3.0.0-beta.0", -1)]
+        [TestCase("3.0.0-beta.0", "2.1.0", 1)]
+        [TestCase("3.0.0-beta.0", "3.0.0", -1)]
+        [TestCase("3.0.0-beta.1", "3.0.0-beta.0", 1)]
+        [TestCase("3.0.0-alpha.10", "3.0.0-alpha.2", 1)]
+        public void TryCompare_WhenVersionUsesSemVer_ReturnsExpectedOrder(
+            string leftVersion,
+            string rightVersion,
+            int expectedSign)
+        {
+            bool parsed = CliVersionComparison.TryCompare(leftVersion, rightVersion, out int comparison);
+
+            Assert.That(parsed, Is.True);
+            Assert.That(Math.Sign(comparison), Is.EqualTo(expectedSign));
+        }
+
+        [TestCase("invalid", "2.1.0")]
+        [TestCase("2.1.0", "invalid")]
+        [TestCase("2.1", "2.1.0")]
+        public void TryCompare_WhenVersionCannotParse_ReturnsFalse(string leftVersion, string rightVersion)
+        {
+            bool parsed = CliVersionComparison.TryCompare(leftVersion, rightVersion, out int comparison);
+
+            Assert.That(parsed, Is.False);
+            Assert.That(comparison, Is.EqualTo(0));
+        }
+
+        [TestCase("2.1.0", "2.1.0", true)]
+        [TestCase("v2.1.0", "2.1.0", true)]
+        [TestCase("3.0.0-beta.0", "3.0.0-beta.0", true)]
+        [TestCase("3.0.0-beta.0", "3.0.0", false)]
+        [TestCase("invalid", "2.1.0", false)]
+        public void IsSameVersion_ReturnsExpectedValue(
+            string leftVersion,
+            string rightVersion,
+            bool expected)
+        {
+            bool isSame = CliVersionComparison.IsSameVersion(leftVersion, rightVersion);
+
+            Assert.That(isSame, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Assets/Tests/Editor/CliVersionComparisonTests.cs
+++ b/Assets/Tests/Editor/CliVersionComparisonTests.cs
@@ -26,6 +26,9 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         [TestCase("invalid", "2.1.0")]
         [TestCase("2.1.0", "invalid")]
         [TestCase("2.1", "2.1.0")]
+        [TestCase("3.0.0-alpha..1", "3.0.0")]
+        [TestCase("3.0.0-alpha_1", "3.0.0")]
+        [TestCase("3.0.0-01", "3.0.0")]
         public void TryCompare_WhenVersionCannotParse_ReturnsFalse(string leftVersion, string rightVersion)
         {
             bool parsed = CliVersionComparison.TryCompare(leftVersion, rightVersion, out int comparison);

--- a/Assets/Tests/Editor/CliVersionComparisonTests.cs.meta
+++ b/Assets/Tests/Editor/CliVersionComparisonTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1700d3b6f57b9249bf16aa599f14fc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -37,11 +37,13 @@ namespace io.github.hatayama.uLoopMCP
             // Arrange - Test the Schema object directly
             RunTestsSchema schema = new RunTestsSchema
             {
+                TestMode = RunTestMode.PlayMode,
                 FilterType = TestFilterType.regex,
                 FilterValue = "TestClass"
             };
 
             // Assert - Schema properties should match what we set
+            Assert.That(schema.TestMode, Is.EqualTo(RunTestMode.PlayMode));
             Assert.That(schema.FilterType, Is.EqualTo(TestFilterType.regex));
             Assert.That(schema.FilterValue, Is.EqualTo("TestClass"));
         }
@@ -59,6 +61,7 @@ namespace io.github.hatayama.uLoopMCP
             RunTestsSchema schema = new RunTestsSchema();
 
             // Assert - Schema should have default values
+            Assert.That(schema.TestMode, Is.EqualTo(RunTestMode.EditMode));
             Assert.That(schema.FilterType, Is.EqualTo(TestFilterType.all));
             Assert.That(schema.FilterValue ?? string.Empty, Is.EqualTo(string.Empty));
             Assert.That(schema.SaveBeforeRun, Is.False);
@@ -98,6 +101,20 @@ namespace io.github.hatayama.uLoopMCP
             {
                 filterService.CreateFilter((TestFilterType)999, "value");
             });
+        }
+
+        [Test]
+        public void CreateTestFrameworkUnavailable_ShouldReturnUnsupportedResponse()
+        {
+            RunTestsResponse response = RunTestsResponse.CreateTestFrameworkUnavailable();
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Does.Contain("com.unity.test-framework"));
+            Assert.That(response.CompletedAt, Is.Not.Empty);
+            Assert.That(response.TestCount, Is.EqualTo(0));
+            Assert.That(response.PassedCount, Is.EqualTo(0));
+            Assert.That(response.FailedCount, Is.EqualTo(0));
+            Assert.That(response.SkippedCount, Is.EqualTo(0));
         }
     }
 } 

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -126,6 +126,7 @@ namespace io.github.hatayama.uLoopMCP
             Assert.That(response.PassedCount, Is.EqualTo(0));
             Assert.That(response.FailedCount, Is.EqualTo(0));
             Assert.That(response.SkippedCount, Is.EqualTo(0));
+            Assert.That(response.XmlPath, Is.Null);
         }
     }
 } 

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -67,6 +67,17 @@ namespace io.github.hatayama.uLoopMCP
             Assert.That(schema.SaveBeforeRun, Is.False);
         }
 
+        [Test]
+        public void RunTestMode_NumericValues_ShouldMatchUnityTestRunnerApi()
+        {
+            Assert.That(
+                (int)RunTestMode.EditMode,
+                Is.EqualTo((int)UnityEditor.TestTools.TestRunner.Api.TestMode.EditMode));
+            Assert.That(
+                (int)RunTestMode.PlayMode,
+                Is.EqualTo((int)UnityEditor.TestTools.TestRunner.Api.TestMode.PlayMode));
+        }
+
         /// <summary>
         /// Test for filter creation via service.
         /// </summary>

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -1,7 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using UnityEditor.TestTools.TestRunner.Api;
 
 namespace io.github.hatayama.uLoopMCP
 {
@@ -20,7 +19,7 @@ namespace io.github.hatayama.uLoopMCP
             );
             RunTestsSchema parameters = new()
             {
-                TestMode = TestMode.EditMode,
+                TestMode = RunTestMode.EditMode,
                 SaveBeforeRun = true
             };
 
@@ -48,7 +47,7 @@ namespace io.github.hatayama.uLoopMCP
                 _result = result;
             }
 
-            public override ValidationResult Validate(TestMode testMode, bool saveBeforeRun)
+            public override ValidationResult Validate(RunTestMode testMode, bool saveBeforeRun)
             {
                 SaveBeforeRun = saveBeforeRun;
                 return _result;

--- a/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
+++ b/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using UnityEditor.TestTools.TestRunner.Api;
 
 namespace io.github.hatayama.uLoopMCP
 {
@@ -10,7 +9,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(true);
 
-            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(RunTestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode"));
@@ -21,7 +20,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(false);
 
-            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(RunTestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(result.ErrorMessage, Is.Null);
@@ -32,7 +31,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(true);
 
-            ValidationResult result = service.Validate(TestMode.PlayMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(RunTestMode.PlayMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(result.ErrorMessage, Is.Null);
@@ -45,7 +44,7 @@ namespace io.github.hatayama.uLoopMCP
                 isPlaying: false,
                 isCompiling: true);
 
-            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(RunTestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("Tests cannot run while compilation is in progress"));
@@ -58,7 +57,7 @@ namespace io.github.hatayama.uLoopMCP
                 isPlaying: false,
                 isDomainReloadInProgress: true);
 
-            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(RunTestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("Tests cannot run while domain reload is in progress"));
@@ -71,7 +70,7 @@ namespace io.github.hatayama.uLoopMCP
                 isPlaying: false,
                 isUpdating: true);
 
-            ValidationResult result = service.Validate(TestMode.EditMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(RunTestMode.EditMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo("Tests cannot run while the editor is updating"));
@@ -89,7 +88,7 @@ namespace io.github.hatayama.uLoopMCP
                 isPlaying: false,
                 unsavedEditorChanges: unsavedEditorChanges);
 
-            ValidationResult result = service.Validate(TestMode.PlayMode, saveBeforeRun: false);
+            ValidationResult result = service.Validate(RunTestMode.PlayMode, saveBeforeRun: false);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Does.Contain("Tests cannot run while the editor has unsaved scene or prefab changes"));
@@ -110,7 +109,7 @@ namespace io.github.hatayama.uLoopMCP
                 saveResult: ValidationResult.Success(),
                 clearUnsavedChangesAfterSave: true);
 
-            ValidationResult result = service.Validate(TestMode.PlayMode, saveBeforeRun: true);
+            ValidationResult result = service.Validate(RunTestMode.PlayMode, saveBeforeRun: true);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(result.ErrorMessage, Is.Null);
@@ -129,7 +128,7 @@ namespace io.github.hatayama.uLoopMCP
                 unsavedEditorChanges: unsavedEditorChanges,
                 saveResult: ValidationResult.Failure("Tests cannot save unsaved scene or prefab changes before running tests. Unsaved changes that failed to save: Prefab Stage: Assets/Scenes/Crosshair.prefab"));
 
-            ValidationResult result = service.Validate(TestMode.PlayMode, saveBeforeRun: true);
+            ValidationResult result = service.Validate(RunTestMode.PlayMode, saveBeforeRun: true);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Does.Contain("Tests cannot save unsaved scene or prefab changes before running tests"));

--- a/Assets/Tests/Editor/ToolExecutionAvailabilityTests.cs
+++ b/Assets/Tests/Editor/ToolExecutionAvailabilityTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP.Tests.Editor
+{
+    public class ToolExecutionAvailabilityTests
+    {
+        [Test]
+        public void ShouldReportDependencyUnavailableBeforeDisabled_WhenRunTestsDependencyIsMissing_ReturnsTrue()
+        {
+            bool shouldReportDependency = ToolExecutionAvailability
+                .ShouldReportDependencyUnavailableBeforeDisabled(
+                    McpConstants.TOOL_NAME_RUN_TESTS,
+                    isTestFrameworkAvailable: false);
+
+            Assert.That(shouldReportDependency, Is.True);
+        }
+
+        [Test]
+        public void ShouldReportDependencyUnavailableBeforeDisabled_WhenRunTestsDependencyExists_ReturnsFalse()
+        {
+            bool shouldReportDependency = ToolExecutionAvailability
+                .ShouldReportDependencyUnavailableBeforeDisabled(
+                    McpConstants.TOOL_NAME_RUN_TESTS,
+                    isTestFrameworkAvailable: true);
+
+            Assert.That(shouldReportDependency, Is.False);
+        }
+
+        [Test]
+        public void ShouldReportDependencyUnavailableBeforeDisabled_WhenOtherToolIsDisabled_ReturnsFalse()
+        {
+            bool shouldReportDependency = ToolExecutionAvailability
+                .ShouldReportDependencyUnavailableBeforeDisabled(
+                    "compile",
+                    isTestFrameworkAvailable: false);
+
+            Assert.That(shouldReportDependency, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/ToolExecutionAvailabilityTests.cs
+++ b/Assets/Tests/Editor/ToolExecutionAvailabilityTests.cs
@@ -36,5 +36,53 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
 
             Assert.That(shouldReportDependency, Is.False);
         }
+
+        [Test]
+        public void ShouldExposeInRegisteredTools_WhenRunTestsDisabledAndDependencyIsMissing_ReturnsTrue()
+        {
+            bool shouldExpose = ToolExecutionAvailability
+                .ShouldExposeInRegisteredTools(
+                    McpConstants.TOOL_NAME_RUN_TESTS,
+                    isToolEnabled: false,
+                    isTestFrameworkAvailable: false);
+
+            Assert.That(shouldExpose, Is.True);
+        }
+
+        [Test]
+        public void ShouldExposeInRegisteredTools_WhenRunTestsDisabledAndDependencyExists_ReturnsFalse()
+        {
+            bool shouldExpose = ToolExecutionAvailability
+                .ShouldExposeInRegisteredTools(
+                    McpConstants.TOOL_NAME_RUN_TESTS,
+                    isToolEnabled: false,
+                    isTestFrameworkAvailable: true);
+
+            Assert.That(shouldExpose, Is.False);
+        }
+
+        [Test]
+        public void ShouldExposeInRegisteredTools_WhenOtherToolIsEnabled_ReturnsTrue()
+        {
+            bool shouldExpose = ToolExecutionAvailability
+                .ShouldExposeInRegisteredTools(
+                    "compile",
+                    isToolEnabled: true,
+                    isTestFrameworkAvailable: false);
+
+            Assert.That(shouldExpose, Is.True);
+        }
+
+        [Test]
+        public void ShouldExposeInRegisteredTools_WhenOtherToolIsDisabled_ReturnsFalse()
+        {
+            bool shouldExpose = ToolExecutionAvailability
+                .ShouldExposeInRegisteredTools(
+                    "compile",
+                    isToolEnabled: false,
+                    isTestFrameworkAvailable: false);
+
+            Assert.That(shouldExpose, Is.False);
+        }
     }
 }

--- a/Assets/Tests/Editor/ToolExecutionAvailabilityTests.cs.meta
+++ b/Assets/Tests/Editor/ToolExecutionAvailabilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 384bce2373b377340bc6718f4c7f19e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -404,6 +405,38 @@ namespace io.github.hatayama.uLoopMCP
                 File.ReadAllText(Path.Combine(unrelatedSkillDir, "reference.md")),
                 Is.EqualTo("old-unrelated-reference"));
             Assert.That(Directory.Exists(thirdPartySkillDir), Is.True);
+        }
+
+        [Test]
+        public void IsSkillDisabledByToolSettings_WhenRunTestsDependencyIsMissing_ReturnsFalse()
+        {
+            SkillInstallLayout.SkillSourceInfo skill = new(
+                "uloop-run-tests",
+                string.Empty,
+                new Dictionary<string, byte[]>());
+
+            bool isDisabled = ToolSkillSynchronizer.IsSkillDisabledByToolSettings(
+                skill,
+                new[] { McpConstants.TOOL_NAME_RUN_TESTS },
+                isTestFrameworkAvailable: false);
+
+            Assert.That(isDisabled, Is.False);
+        }
+
+        [Test]
+        public void IsSkillDisabledByToolSettings_WhenRunTestsDependencyExists_ReturnsTrue()
+        {
+            SkillInstallLayout.SkillSourceInfo skill = new(
+                "uloop-run-tests",
+                string.Empty,
+                new Dictionary<string, byte[]>());
+
+            bool isDisabled = ToolSkillSynchronizer.IsSkillDisabledByToolSettings(
+                skill,
+                new[] { McpConstants.TOOL_NAME_RUN_TESTS },
+                isTestFrameworkAvailable: true);
+
+            Assert.That(isDisabled, Is.True);
         }
 
         [Test]

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -234,7 +234,6 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.unity.test-framework": "1.1.33",
         "com.unity.ugui": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.2.1"
       }

--- a/Packages/src/Cli~/src/__tests__/package-metadata.test.ts
+++ b/Packages/src/Cli~/src/__tests__/package-metadata.test.ts
@@ -7,11 +7,42 @@ type PackageManifest = {
   readonly bin?: Record<string, string>;
 };
 
+type UnityPackageManifest = {
+  readonly dependencies?: Record<string, string>;
+};
+
+type AssemblyVersionDefine = {
+  readonly name?: string;
+  readonly expression?: string;
+  readonly define?: string;
+};
+
+type AssemblyDefinition = {
+  readonly versionDefines?: readonly AssemblyVersionDefine[];
+};
+
+const TEST_FRAMEWORK_PACKAGE_NAME = 'com.unity.test-framework';
+const TEST_FRAMEWORK_DEFINE = 'ULOOPMCP_HAS_TEST_FRAMEWORK';
+
 function loadPackageManifest(): PackageManifest {
   const packageJsonPath = join(__dirname, '..', '..', 'package.json');
   // eslint-disable-next-line security/detect-non-literal-fs-filename
   const packageJsonText = readFileSync(packageJsonPath, 'utf8');
   return JSON.parse(packageJsonText) as PackageManifest;
+}
+
+function loadUnityPackageManifest(): UnityPackageManifest {
+  const packageJsonPath = join(__dirname, '..', '..', '..', 'package.json');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const packageJsonText = readFileSync(packageJsonPath, 'utf8');
+  return JSON.parse(packageJsonText) as UnityPackageManifest;
+}
+
+function loadEditorAssemblyDefinition(): AssemblyDefinition {
+  const asmdefPath = join(__dirname, '..', '..', '..', 'Editor', 'uLoopMCP.Editor.asmdef');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const asmdefText = readFileSync(asmdefPath, 'utf8');
+  return JSON.parse(asmdefText) as AssemblyDefinition;
 }
 
 describe('package metadata', () => {
@@ -24,5 +55,24 @@ describe('package metadata', () => {
     for (const [, binTarget] of binEntries) {
       expect(binTarget).not.toMatch(/^(?:\.{1,2}[\\/]|[\\/])/);
     }
+  });
+
+  it('does not force Unity Test Framework into consuming projects', () => {
+    const packageManifest = loadUnityPackageManifest();
+
+    expect(Object.keys(packageManifest.dependencies ?? {})).not.toContain(
+      TEST_FRAMEWORK_PACKAGE_NAME,
+    );
+  });
+
+  it('defines a compile symbol when Unity Test Framework is installed', () => {
+    const assemblyDefinition = loadEditorAssemblyDefinition();
+
+    expect(assemblyDefinition.versionDefines ?? []).toContainEqual(
+      expect.objectContaining({
+        name: TEST_FRAMEWORK_PACKAGE_NAME,
+        define: TEST_FRAMEWORK_DEFINE,
+      }),
+    );
   });
 });

--- a/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
+++ b/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
@@ -14,6 +14,7 @@ import {
   getInstallDir,
   getManagedSkillsDir,
   getProjectSkillSearchRoots,
+  installAllSkills,
   migrateLegacyManagedSkills,
   parseFrontmatter,
   removeDeprecatedSkillDirs,
@@ -318,6 +319,39 @@ describe('skill install layout', () => {
     expect(
       skills.find((skill) => skill.name === 'uloop-replay-tool' && skill.source === 'project'),
     ).toBeDefined();
+  });
+
+  it('should install run-tests skill when test framework package is missing', () => {
+    const projectRoot = createUnityProjectRoot();
+    const runTestsSkillDir = join(
+      projectRoot,
+      'Packages',
+      'src',
+      'Editor',
+      'Api',
+      'McpTools',
+      'RunTests',
+      'Skill',
+    );
+    mkdirSync(runTestsSkillDir, { recursive: true });
+    writeFileSync(
+      join(runTestsSkillDir, 'SKILL.md'),
+      ['---', 'name: uloop-run-tests', '---', '', '# Run Tests', ''].join('\n'),
+      'utf-8',
+    );
+    mkdirSync(join(projectRoot, '.uloop'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, '.uloop', 'settings.tools.json'),
+      JSON.stringify({ disabledTools: ['run-tests'] }),
+      'utf-8',
+    );
+    process.chdir(projectRoot);
+
+    installAllSkills(getTargetConfig('claude'), false, true);
+
+    expect(
+      existsSync(join(projectRoot, '.claude', 'skills', 'unity-cli-loop', 'uloop-run-tests')),
+    ).toBe(true);
   });
 
   it('should ignore sibling implementation files beside a direct SKILL.md in the tool folder', () => {

--- a/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
+++ b/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
@@ -125,6 +125,25 @@ describe('tool-settings-loader', () => {
     it('should return true when no settings file exists', () => {
       expect(isToolEnabled('compile')).toBe(true);
     });
+
+    it('should keep run-tests callable when test framework package is missing', () => {
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ disabledTools: ['run-tests'] }),
+      );
+
+      expect(isToolEnabled('run-tests')).toBe(true);
+    });
+
+    it('should disable run-tests when test framework package is installed', () => {
+      writePackageManifest(testDir, { 'com.unity.test-framework': '1.3.9' });
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ disabledTools: ['run-tests'] }),
+      );
+
+      expect(isToolEnabled('run-tests')).toBe(false);
+    });
   });
 
   // ── filterEnabledTools ─────────────────────────────────────────
@@ -146,6 +165,11 @@ describe('tool-settings-loader', () => {
         description: 'Clear',
         inputSchema: { type: 'object', properties: {} },
       },
+      {
+        name: 'run-tests',
+        description: 'Run tests',
+        inputSchema: { type: 'object', properties: {} },
+      },
     ];
 
     it('should filter out disabled tools', () => {
@@ -156,8 +180,9 @@ describe('tool-settings-loader', () => {
 
       const result: ToolDefinition[] = filterEnabledTools(mockTools);
 
-      expect(result).toHaveLength(1);
+      expect(result).toHaveLength(2);
       expect(result[0].name).toBe('get-logs');
+      expect(result[1].name).toBe('run-tests');
     });
 
     it('should return all tools when none are disabled', () => {
@@ -168,13 +193,36 @@ describe('tool-settings-loader', () => {
 
       const result: ToolDefinition[] = filterEnabledTools(mockTools);
 
-      expect(result).toHaveLength(3);
+      expect(result).toHaveLength(4);
     });
 
     it('should return all tools when settings file does not exist', () => {
       const result: ToolDefinition[] = filterEnabledTools(mockTools);
 
-      expect(result).toHaveLength(3);
+      expect(result).toHaveLength(4);
+    });
+
+    it('should keep run-tests when test framework package is missing', () => {
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ disabledTools: ['run-tests'] }),
+      );
+
+      const result: ToolDefinition[] = filterEnabledTools(mockTools);
+
+      expect(result.map((tool) => tool.name)).toContain('run-tests');
+    });
+
+    it('should filter run-tests when test framework package is installed', () => {
+      writePackageManifest(testDir, { 'com.unity.test-framework': '1.3.9' });
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ disabledTools: ['run-tests'] }),
+      );
+
+      const result: ToolDefinition[] = filterEnabledTools(mockTools);
+
+      expect(result.map((tool) => tool.name)).not.toContain('run-tests');
     });
   });
 
@@ -258,3 +306,8 @@ describe('tool-settings-loader', () => {
     });
   });
 });
+
+function writePackageManifest(projectRoot: string, dependencies: Record<string, string>): void {
+  mkdirSync(join(projectRoot, 'Packages'), { recursive: true });
+  writeFileSync(join(projectRoot, 'Packages', 'manifest.json'), JSON.stringify({ dependencies }));
+}

--- a/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
+++ b/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
@@ -154,6 +154,17 @@ describe('tool-settings-loader', () => {
 
       expect(isToolEnabled('run-tests')).toBe(false);
     });
+
+    it('should use packages-lock when manifest cannot be read', () => {
+      mkdirSync(join(testDir, 'Packages', 'manifest.json'), { recursive: true });
+      writePackagesLock(testDir, { 'com.unity.test-framework': { version: '1.3.9' } });
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ disabledTools: ['run-tests'] }),
+      );
+
+      expect(isToolEnabled('run-tests')).toBe(false);
+    });
   });
 
   // ── filterEnabledTools ─────────────────────────────────────────

--- a/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
+++ b/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
@@ -144,6 +144,16 @@ describe('tool-settings-loader', () => {
 
       expect(isToolEnabled('run-tests')).toBe(false);
     });
+
+    it('should disable run-tests when test framework package is resolved', () => {
+      writePackagesLock(testDir, { 'com.unity.test-framework': { version: '1.3.9' } });
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ disabledTools: ['run-tests'] }),
+      );
+
+      expect(isToolEnabled('run-tests')).toBe(false);
+    });
   });
 
   // ── filterEnabledTools ─────────────────────────────────────────
@@ -215,6 +225,18 @@ describe('tool-settings-loader', () => {
 
     it('should filter run-tests when test framework package is installed', () => {
       writePackageManifest(testDir, { 'com.unity.test-framework': '1.3.9' });
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ disabledTools: ['run-tests'] }),
+      );
+
+      const result: ToolDefinition[] = filterEnabledTools(mockTools);
+
+      expect(result.map((tool) => tool.name)).not.toContain('run-tests');
+    });
+
+    it('should filter run-tests when test framework package is resolved', () => {
+      writePackagesLock(testDir, { 'com.unity.test-framework': { version: '1.3.9' } });
       writeFileSync(
         join(testDir, '.uloop', 'settings.tools.json'),
         JSON.stringify({ disabledTools: ['run-tests'] }),
@@ -310,4 +332,12 @@ describe('tool-settings-loader', () => {
 function writePackageManifest(projectRoot: string, dependencies: Record<string, string>): void {
   mkdirSync(join(projectRoot, 'Packages'), { recursive: true });
   writeFileSync(join(projectRoot, 'Packages', 'manifest.json'), JSON.stringify({ dependencies }));
+}
+
+function writePackagesLock(projectRoot: string, dependencies: Record<string, unknown>): void {
+  mkdirSync(join(projectRoot, 'Packages'), { recursive: true });
+  writeFileSync(
+    join(projectRoot, 'Packages', 'packages-lock.json'),
+    JSON.stringify({ dependencies }),
+  );
 }

--- a/Packages/src/Cli~/src/skills/skills-manager.ts
+++ b/Packages/src/Cli~/src/skills/skills-manager.ts
@@ -24,7 +24,7 @@ import { homedir } from 'os';
 import { TargetConfig } from './target-config.js';
 import { findUnityProjectRoot, getUnityProjectStatus } from '../project-root.js';
 import { DEPRECATED_SKILLS } from './deprecated-skills.js';
-import { loadDisabledTools } from '../tool-settings-loader.js';
+import { isToolEnabled, loadDisabledTools } from '../tool-settings-loader.js';
 
 type SkillStatus = 'installed' | 'not_installed' | 'outdated';
 
@@ -815,7 +815,7 @@ function isSkillDisabledByToolSettings(skill: SkillDefinition, disabledTools: st
   if (toolName === null) {
     return false;
   }
-  return disabledTools.includes(toolName);
+  return disabledTools.includes(toolName) && !isToolEnabled(toolName);
 }
 
 interface UninstallResult {

--- a/Packages/src/Cli~/src/tool-settings-loader.ts
+++ b/Packages/src/Cli~/src/tool-settings-loader.ts
@@ -15,6 +15,7 @@ const ULOOP_DIR = '.uloop';
 const TOOL_SETTINGS_FILE = 'settings.tools.json';
 const PACKAGES_DIR = 'Packages';
 const MANIFEST_FILE = 'manifest.json';
+const PACKAGES_LOCK_FILE = 'packages-lock.json';
 const RUN_TESTS_TOOL_NAME = 'run-tests';
 const UNITY_TEST_FRAMEWORK_DEPENDENCY_PATTERN = /"com\.unity\.test-framework"\s*:/;
 
@@ -114,10 +115,18 @@ function shouldBypassDisabledSettingForDependencyError(
 
 function isUnityTestFrameworkInstalled(projectRoot: string): boolean {
   const manifestPath: string = join(projectRoot, PACKAGES_DIR, MANIFEST_FILE);
-  if (!existsSync(manifestPath)) {
+  const packagesLockPath: string = join(projectRoot, PACKAGES_DIR, PACKAGES_LOCK_FILE);
+
+  return (
+    fileContainsUnityTestFramework(manifestPath) || fileContainsUnityTestFramework(packagesLockPath)
+  );
+}
+
+function fileContainsUnityTestFramework(filePath: string): boolean {
+  if (!existsSync(filePath)) {
     return false;
   }
 
-  const content: string = readFileSync(manifestPath, 'utf-8');
+  const content: string = readFileSync(filePath, 'utf-8');
   return UNITY_TEST_FRAMEWORK_DEPENDENCY_PATTERN.test(content);
 }

--- a/Packages/src/Cli~/src/tool-settings-loader.ts
+++ b/Packages/src/Cli~/src/tool-settings-loader.ts
@@ -6,25 +6,73 @@
 // File paths are constructed from Unity project root, not from untrusted user input
 /* eslint-disable security/detect-non-literal-fs-filename */
 
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { findUnityProjectRoot } from './project-root.js';
 import type { ToolDefinition } from './tool-cache.js';
 
 const ULOOP_DIR = '.uloop';
 const TOOL_SETTINGS_FILE = 'settings.tools.json';
+const PACKAGES_DIR = 'Packages';
+const MANIFEST_FILE = 'manifest.json';
+const RUN_TESTS_TOOL_NAME = 'run-tests';
+const UNITY_TEST_FRAMEWORK_DEPENDENCY_PATTERN = /"com\.unity\.test-framework"\s*:/;
 
 interface ToolSettingsData {
   disabledTools: string[];
 }
 
 export function loadDisabledTools(projectPath?: string): string[] {
-  const projectRoot: string | null =
-    projectPath !== undefined ? resolve(projectPath) : findUnityProjectRoot();
+  const projectRoot: string | null = resolveProjectRoot(projectPath);
   if (projectRoot === null) {
     return [];
   }
 
+  return loadDisabledToolsFromProjectRoot(projectRoot);
+}
+
+export function isToolEnabled(toolName: string, projectPath?: string): boolean {
+  const projectRoot: string | null = resolveProjectRoot(projectPath);
+  if (projectRoot === null) {
+    return true;
+  }
+
+  const disabledTools: string[] = loadDisabledToolsFromProjectRoot(projectRoot);
+  if (!disabledTools.includes(toolName)) {
+    return true;
+  }
+
+  return shouldBypassDisabledSettingForDependencyError(toolName, projectRoot);
+}
+
+export function filterEnabledTools(
+  tools: ToolDefinition[],
+  projectPath?: string,
+): ToolDefinition[] {
+  const projectRoot: string | null = resolveProjectRoot(projectPath);
+  if (projectRoot === null) {
+    return tools;
+  }
+
+  const disabledTools: string[] = loadDisabledToolsFromProjectRoot(projectRoot);
+  if (disabledTools.length === 0) {
+    return tools;
+  }
+
+  return tools.filter((tool) => {
+    if (!disabledTools.includes(tool.name)) {
+      return true;
+    }
+
+    return shouldBypassDisabledSettingForDependencyError(tool.name, projectRoot);
+  });
+}
+
+function resolveProjectRoot(projectPath?: string): string | null {
+  return projectPath !== undefined ? resolve(projectPath) : findUnityProjectRoot();
+}
+
+function loadDisabledToolsFromProjectRoot(projectRoot: string): string[] {
   const settingsPath: string = join(projectRoot, ULOOP_DIR, TOOL_SETTINGS_FILE);
 
   let content: string;
@@ -57,18 +105,19 @@ export function loadDisabledTools(projectPath?: string): string[] {
   return data.disabledTools;
 }
 
-export function isToolEnabled(toolName: string, projectPath?: string): boolean {
-  const disabledTools: string[] = loadDisabledTools(projectPath);
-  return !disabledTools.includes(toolName);
+function shouldBypassDisabledSettingForDependencyError(
+  toolName: string,
+  projectRoot: string,
+): boolean {
+  return toolName === RUN_TESTS_TOOL_NAME && !isUnityTestFrameworkInstalled(projectRoot);
 }
 
-export function filterEnabledTools(
-  tools: ToolDefinition[],
-  projectPath?: string,
-): ToolDefinition[] {
-  const disabledTools: string[] = loadDisabledTools(projectPath);
-  if (disabledTools.length === 0) {
-    return tools;
+function isUnityTestFrameworkInstalled(projectRoot: string): boolean {
+  const manifestPath: string = join(projectRoot, PACKAGES_DIR, MANIFEST_FILE);
+  if (!existsSync(manifestPath)) {
+    return false;
   }
-  return tools.filter((tool) => !disabledTools.includes(tool.name));
+
+  const content: string = readFileSync(manifestPath, 'utf-8');
+  return UNITY_TEST_FRAMEWORK_DEPENDENCY_PATTERN.test(content);
 }

--- a/Packages/src/Cli~/src/tool-settings-loader.ts
+++ b/Packages/src/Cli~/src/tool-settings-loader.ts
@@ -127,6 +127,19 @@ function fileContainsUnityTestFramework(filePath: string): boolean {
     return false;
   }
 
-  const content: string = readFileSync(filePath, 'utf-8');
+  const content: string | null = tryReadTextFile(filePath);
+  if (content === null) {
+    return false;
+  }
+
   return UNITY_TEST_FRAMEWORK_DEPENDENCY_PATTERN.test(content);
+}
+
+function tryReadTextFile(filePath: string): string | null {
+  try {
+    return readFileSync(filePath, 'utf-8');
+  } catch {
+    // Files can disappear or become unreadable between existsSync and readFileSync.
+    return null;
+  }
 }

--- a/Packages/src/Editor/Api/McpTools/Core/ToolExecutionAvailability.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/ToolExecutionAvailability.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    internal static class ToolExecutionAvailability
+    {
+        internal static bool ShouldReportDependencyUnavailableBeforeDisabled(string toolName)
+        {
+            return ShouldReportDependencyUnavailableBeforeDisabled(
+                toolName,
+                isTestFrameworkAvailable: IsTestFrameworkAvailable);
+        }
+
+        internal static bool ShouldReportDependencyUnavailableBeforeDisabled(
+            string toolName,
+            bool isTestFrameworkAvailable)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
+
+            return toolName == McpConstants.TOOL_NAME_RUN_TESTS && !isTestFrameworkAvailable;
+        }
+
+        private static bool IsTestFrameworkAvailable
+        {
+            get
+            {
+#if ULOOPMCP_HAS_TEST_FRAMEWORK
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Api/McpTools/Core/ToolExecutionAvailability.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/ToolExecutionAvailability.cs
@@ -20,6 +20,25 @@ namespace io.github.hatayama.uLoopMCP
             return toolName == McpConstants.TOOL_NAME_RUN_TESTS && !isTestFrameworkAvailable;
         }
 
+        internal static bool ShouldExposeInRegisteredTools(string toolName)
+        {
+            return ShouldExposeInRegisteredTools(
+                toolName,
+                isToolEnabled: ToolSettings.IsToolEnabled(toolName),
+                isTestFrameworkAvailable: IsTestFrameworkAvailable);
+        }
+
+        internal static bool ShouldExposeInRegisteredTools(
+            string toolName,
+            bool isToolEnabled,
+            bool isTestFrameworkAvailable)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
+
+            return isToolEnabled ||
+                ShouldReportDependencyUnavailableBeforeDisabled(toolName, isTestFrameworkAvailable);
+        }
+
         private static bool IsTestFrameworkAvailable
         {
             get

--- a/Packages/src/Editor/Api/McpTools/Core/ToolExecutionAvailability.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/ToolExecutionAvailability.cs
@@ -39,7 +39,7 @@ namespace io.github.hatayama.uLoopMCP
                 ShouldReportDependencyUnavailableBeforeDisabled(toolName, isTestFrameworkAvailable);
         }
 
-        private static bool IsTestFrameworkAvailable
+        internal static bool IsTestFrameworkAvailable
         {
             get
             {

--- a/Packages/src/Editor/Api/McpTools/Core/ToolExecutionAvailability.cs.meta
+++ b/Packages/src/Editor/Api/McpTools/Core/ToolExecutionAvailability.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12a3cd3bb7213f14ab18fa845fe17f13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Api/McpTools/Core/UnityToolRegistry.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/UnityToolRegistry.cs
@@ -213,7 +213,8 @@ namespace io.github.hatayama.uLoopMCP
                 throw new ArgumentException($"Unknown tool: {toolName}");
             }
 
-            if (!ToolSettings.IsToolEnabled(toolName))
+            if (!ToolSettings.IsToolEnabled(toolName)
+                && !ToolExecutionAvailability.ShouldReportDependencyUnavailableBeforeDisabled(toolName))
             {
                 throw new ToolDisabledException(toolName);
             }

--- a/Packages/src/Editor/Api/McpTools/Core/UnityToolRegistry.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/UnityToolRegistry.cs
@@ -264,7 +264,7 @@ namespace io.github.hatayama.uLoopMCP
         public ToolInfo[] GetRegisteredTools()
         {
             return _tools.Values
-                .Where(tool => ToolSettings.IsToolEnabled(tool.ToolName))
+                .Where(tool => ToolExecutionAvailability.ShouldExposeInRegisteredTools(tool.ToolName))
                 .Select(tool =>
             {
                 // Check if tool has McpTool attribute with DisplayDevelopmentOnly

--- a/Packages/src/Editor/Api/McpTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/Api/McpTools/RunTests/RunTestsResponse.cs
@@ -8,6 +8,9 @@ namespace io.github.hatayama.uLoopMCP
     /// </summary>
     public class RunTestsResponse : BaseToolResponse
     {
+        public const string TestFrameworkUnavailableMessage =
+            "run-tests requires the Unity Test Framework package (com.unity.test-framework). Install it via Package Manager to use test execution.";
+
         /// <summary>
         /// Whether test execution was successful
         /// </summary>
@@ -73,5 +76,19 @@ namespace io.github.hatayama.uLoopMCP
             CompletedAt = string.Empty;
             XmlPath = string.Empty;
         }
+
+        public static RunTestsResponse CreateTestFrameworkUnavailable()
+        {
+            return new RunTestsResponse(
+                success: false,
+                message: TestFrameworkUnavailableMessage,
+                completedAt: DateTime.UtcNow.ToString("o"),
+                testCount: 0,
+                passedCount: 0,
+                failedCount: 0,
+                skippedCount: 0,
+                xmlPath: null
+            );
+        }
     }
-} 
+}

--- a/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
@@ -1,8 +1,14 @@
 using System.ComponentModel;
-using UnityEditor.TestTools.TestRunner.Api;
 
 namespace io.github.hatayama.uLoopMCP
 {
+    // Mirrors Unity Test Runner mode names without making the command schema depend on Test Framework types.
+    public enum RunTestMode
+    {
+        EditMode = 0,
+        PlayMode = 1
+    }
+
     /// <summary>
     /// Supported test filter types
     /// </summary>
@@ -24,7 +30,7 @@ namespace io.github.hatayama.uLoopMCP
         /// Test mode - EditMode(0), PlayMode(1)
         /// </summary>
         [Description("Test mode - EditMode(0), PlayMode(1)")]
-        public TestMode TestMode { get; set; } = TestMode.EditMode;
+        public RunTestMode TestMode { get; set; } = RunTestMode.EditMode;
 
         /// <summary>
         /// Type of test filter - all(0), exact(1), regex(2), assembly(3)

--- a/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
@@ -5,8 +5,8 @@ namespace io.github.hatayama.uLoopMCP
     // Mirrors Unity Test Runner mode names without making the command schema depend on Test Framework types.
     public enum RunTestMode
     {
-        EditMode = 0,
-        PlayMode = 1
+        EditMode = 1,
+        PlayMode = 2
     }
 
     /// <summary>
@@ -27,9 +27,9 @@ namespace io.github.hatayama.uLoopMCP
     public class RunTestsSchema : BaseToolSchema
     {
         /// <summary>
-        /// Test mode - EditMode(0), PlayMode(1)
+        /// Test mode - EditMode(1), PlayMode(2)
         /// </summary>
-        [Description("Test mode - EditMode(0), PlayMode(1)")]
+        [Description("Test mode - EditMode(1), PlayMode(2)")]
         public RunTestMode TestMode { get; set; } = RunTestMode.EditMode;
 
         /// <summary>

--- a/Packages/src/Editor/Api/McpTools/RunTests/RunTestsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/RunTests/RunTestsTool.cs
@@ -22,13 +22,13 @@ namespace io.github.hatayama.uLoopMCP
     )]
     public class RunTestsTool : AbstractUnityTool<RunTestsSchema, RunTestsResponse>
     {
-        public override string ToolName => "run-tests";
+        public override string ToolName => McpConstants.TOOL_NAME_RUN_TESTS;
 
-        protected override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken cancellationToken)
+        protected override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken ct)
         {
             // Create and execute RunTestsUseCase instance
             RunTestsUseCase useCase = new();
-            return await useCase.ExecuteAsync(parameters, cancellationToken);
+            return await useCase.ExecuteAsync(parameters, ct);
         }
 
     }

--- a/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
@@ -61,7 +61,7 @@ Returns JSON with:
 - `PassedCount` (number): Passed tests
 - `FailedCount` (number): Failed tests
 - `SkippedCount` (number): Skipped tests
-- `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
+- `XmlPath` (string | null): Path to NUnit XML result file. `null` when no XML was saved; populated only when tests failed and the XML file exists on disk.
 
 ### XML Result File
 

--- a/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
@@ -5,7 +5,9 @@ description: "Execute Unity Test Runner and get detailed results. Use when you n
 
 # uloop run-tests
 
-Execute Unity Test Runner. When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
+Execute Unity Test Runner. This command requires the Unity Test Framework package (`com.unity.test-framework`). If that package is not installed, the command returns `Success: false` with an unsupported message and does not affect the other Unity CLI Loop tools.
+
+When tests fail, NUnit XML results with error messages and stack traces are automatically saved. Read the XML file at `XmlPath` for detailed failure diagnosis.
 
 Before executing tests, `uloop run-tests` checks for unsaved loaded Scene changes and unsaved current Prefab Stage changes. If any are found, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner. Save or discard those editor changes, then rerun the command. Use `--save-before-run true` only when the user explicitly asks to save editor changes before continuing.
 

--- a/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/Tools/RunTestsUseCase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using System.Threading;
-using UnityEditor.TestTools.TestRunner.Api;
 using UnityEngine;
 
 namespace io.github.hatayama.uLoopMCP
@@ -45,8 +44,12 @@ namespace io.github.hatayama.uLoopMCP
         /// <param name="parameters">Test execution parameters</param>
         /// <param name="cancellationToken">Cancellation control token</param>
         /// <returns>Test execution result</returns>
-        public override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken cancellationToken)
+        public override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken ct)
         {
+#if !ULOOPMCP_HAS_TEST_FRAMEWORK
+            ct.ThrowIfCancellationRequested();
+            return await Task.FromResult(RunTestsResponse.CreateTestFrameworkUnavailable());
+#else
             ValidationResult validation = _validationService.Validate(parameters.TestMode, parameters.SaveBeforeRun);
             if (!validation.IsValid)
             {
@@ -61,12 +64,12 @@ namespace io.github.hatayama.uLoopMCP
             }
             
             // 2. Test execution
-            cancellationToken.ThrowIfCancellationRequested();
+            ct.ThrowIfCancellationRequested();
             SerializableTestResult result;
             
             try
             {
-                if (parameters.TestMode == TestMode.PlayMode)
+                if (parameters.TestMode == RunTestMode.PlayMode)
                 {
                     // TODO: Add cancellationToken parameter when TestExecutionService supports it
                     result = await _executionService.ExecutePlayModeTestAsync(filter);
@@ -107,6 +110,7 @@ namespace io.github.hatayama.uLoopMCP
                 skippedCount: result.skippedCount,
                 xmlPath: result.xmlPath
             );
+#endif
         }
 
         private static RunTestsResponse CreateFailureResponse(string message)

--- a/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Config/ToolSkillSynchronizer.cs
@@ -429,7 +429,10 @@ namespace io.github.hatayama.uLoopMCP
                 string[] disabledTools = ToolSettings.GetDisabledTools();
                 List<SkillInstallLayout.SkillSourceInfo> allSkills = SkillInstallLayout.GetSkillSourceInfos(projectRoot);
                 List<SkillInstallLayout.SkillSourceInfo> disabledSkills = allSkills
-                    .Where(skill => IsSkillDisabled(skill, disabledTools))
+                    .Where(skill => IsSkillDisabledByToolSettings(
+                        skill,
+                        disabledTools,
+                        ToolExecutionAvailability.IsTestFrameworkAvailable))
                     .ToList();
                 List<SkillInstallLayout.SkillSourceInfo> enabledSkills = allSkills
                     .Except(disabledSkills)
@@ -465,7 +468,10 @@ namespace io.github.hatayama.uLoopMCP
                 string[] disabledTools = ToolSettings.GetDisabledTools();
                 List<SkillInstallLayout.SkillSourceInfo> allSkills = SkillInstallLayout.GetSkillSourceInfos(projectRoot);
                 List<SkillInstallLayout.SkillSourceInfo> disabledSkills = allSkills
-                    .Where(skill => IsSkillDisabled(skill, disabledTools))
+                    .Where(skill => IsSkillDisabledByToolSettings(
+                        skill,
+                        disabledTools,
+                        ToolExecutionAvailability.IsTestFrameworkAvailable))
                     .ToList();
                 List<SkillInstallLayout.SkillSourceInfo> toolSkills = allSkills
                     .Where(skill => IsSkillForTool(skill, toolName))
@@ -581,9 +587,10 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
-        private static bool IsSkillDisabled(
+        internal static bool IsSkillDisabledByToolSettings(
             SkillInstallLayout.SkillSourceInfo skill,
-            IReadOnlyCollection<string> disabledTools)
+            IReadOnlyCollection<string> disabledTools,
+            bool isTestFrameworkAvailable)
         {
             if (disabledTools.Count == 0)
             {
@@ -596,7 +603,10 @@ namespace io.github.hatayama.uLoopMCP
                 return false;
             }
 
-            return disabledTools.Contains(toolName);
+            return disabledTools.Contains(toolName)
+                && !ToolExecutionAvailability.ShouldReportDependencyUnavailableBeforeDisabled(
+                    toolName,
+                    isTestFrameworkAvailable);
         }
 
         private static bool IsSkillForTool(

--- a/Packages/src/Editor/Core/ApplicationServices/TestExecutionService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/TestExecutionService.cs
@@ -10,6 +10,7 @@ namespace io.github.hatayama.uLoopMCP
     /// </summary>
     public class TestExecutionService
     {
+#if ULOOPMCP_HAS_TEST_FRAMEWORK
         /// <summary>
         /// Execute tests in PlayMode
         /// </summary>
@@ -29,5 +30,16 @@ namespace io.github.hatayama.uLoopMCP
         {
             return await PlayModeTestExecuter.ExecuteEditModeTest(filter);
         }
+#else
+        public virtual Task<SerializableTestResult> ExecutePlayModeTestAsync(TestExecutionFilter filter)
+        {
+            return Task.FromResult(SerializableTestResult.CreateTestFrameworkUnavailable());
+        }
+
+        public virtual Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter)
+        {
+            return Task.FromResult(SerializableTestResult.CreateTestFrameworkUnavailable());
+        }
+#endif
     }
 }

--- a/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/TestExecutionStateValidationService.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.SceneManagement;
-using UnityEditor.TestTools.TestRunner.Api;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -27,7 +26,7 @@ namespace io.github.hatayama.uLoopMCP
             return SaveCurrentUnsavedEditorChanges();
         }
 
-        public virtual ValidationResult Validate(TestMode testMode, bool saveBeforeRun)
+        public virtual ValidationResult Validate(RunTestMode testMode, bool saveBeforeRun)
         {
             if (IsCompiling)
             {
@@ -44,7 +43,7 @@ namespace io.github.hatayama.uLoopMCP
                 return ValidationResult.Failure("Tests cannot run while the editor is updating");
             }
 
-            if (testMode == TestMode.EditMode && IsPlaying)
+            if (testMode == RunTestMode.EditMode && IsPlaying)
             {
                 return ValidationResult.Failure("EditMode tests cannot run during play mode");
             }

--- a/Packages/src/Editor/Core/CoreTools/TestRunner/NUnitXmlResultExporter.cs
+++ b/Packages/src/Editor/Core/CoreTools/TestRunner/NUnitXmlResultExporter.cs
@@ -1,3 +1,4 @@
+#if ULOOPMCP_HAS_TEST_FRAMEWORK
 using System;
 using System.IO;
 using System.Text;
@@ -267,3 +268,4 @@ namespace io.github.hatayama.uLoopMCP
         }
     }
 }
+#endif

--- a/Packages/src/Editor/Core/CoreTools/TestRunner/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/Core/CoreTools/TestRunner/PlayModeTestExecuter.cs
@@ -1,3 +1,4 @@
+#if ULOOPMCP_HAS_TEST_FRAMEWORK
 using System;
 using System.Threading.Tasks;
 using UnityEditor.TestTools.TestRunner.Api;
@@ -141,3 +142,4 @@ namespace io.github.hatayama.uLoopMCP
         }
     }
 }
+#endif

--- a/Packages/src/Editor/Core/CoreTools/TestRunner/SerializableTestResult.cs
+++ b/Packages/src/Editor/Core/CoreTools/TestRunner/SerializableTestResult.cs
@@ -1,5 +1,7 @@
 using System;
+#if ULOOPMCP_HAS_TEST_FRAMEWORK
 using UnityEditor.TestTools.TestRunner.Api;
+#endif
 using UnityEngine;
 
 namespace io.github.hatayama.uLoopMCP
@@ -18,7 +20,23 @@ namespace io.github.hatayama.uLoopMCP
         [SerializeField] public int failedCount;
         [SerializeField] public int skippedCount;
         [SerializeField] public string xmlPath;
+
+        public static SerializableTestResult CreateTestFrameworkUnavailable()
+        {
+            return new SerializableTestResult
+            {
+                success = false,
+                message = RunTestsResponse.TestFrameworkUnavailableMessage,
+                completedAt = DateTime.UtcNow.ToString("o"),
+                testCount = 0,
+                passedCount = 0,
+                failedCount = 0,
+                skippedCount = 0,
+                xmlPath = null
+            };
+        }
         
+#if ULOOPMCP_HAS_TEST_FRAMEWORK
         /// <summary>
         /// Convert from ITestResultAdaptor to SerializableTestResult
         /// </summary>
@@ -133,5 +151,6 @@ namespace io.github.hatayama.uLoopMCP
                 }
             }
         }
+#endif
     }
 }

--- a/Packages/src/Editor/UI/CliVersionComparison.cs
+++ b/Packages/src/Editor/UI/CliVersionComparison.cs
@@ -57,7 +57,7 @@ namespace io.github.hatayama.uLoopMCP
                 normalized = normalized.Substring(0, preReleaseIndex);
             }
 
-            if (preReleaseIndex >= 0 && string.IsNullOrEmpty(preRelease))
+            if (preReleaseIndex >= 0 && !IsValidPreRelease(preRelease))
             {
                 return false;
             }
@@ -96,6 +96,50 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             return int.TryParse(component, NumberStyles.None, CultureInfo.InvariantCulture, out value);
+        }
+
+        private static bool IsValidPreRelease(string preRelease)
+        {
+            if (string.IsNullOrEmpty(preRelease))
+            {
+                return false;
+            }
+
+            string[] identifiers = preRelease.Split('.');
+            foreach (string identifier in identifiers)
+            {
+                if (!IsValidPreReleaseIdentifier(identifier))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsValidPreReleaseIdentifier(string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                return false;
+            }
+
+            bool numericOnly = true;
+            foreach (char character in identifier)
+            {
+                bool isDigit = character >= '0' && character <= '9';
+                bool isUpper = character >= 'A' && character <= 'Z';
+                bool isLower = character >= 'a' && character <= 'z';
+                bool isHyphen = character == '-';
+                if (!isDigit && !isUpper && !isLower && !isHyphen)
+                {
+                    return false;
+                }
+
+                numericOnly = numericOnly && isDigit;
+            }
+
+            return !numericOnly || identifier.Length == 1 || identifier[0] != '0';
         }
 
         private static int Compare(CliSemanticVersion left, CliSemanticVersion right)

--- a/Packages/src/Editor/UI/CliVersionComparison.cs
+++ b/Packages/src/Editor/UI/CliVersionComparison.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Globalization;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    internal static class CliVersionComparison
+    {
+        internal static bool TryCompare(string leftVersionText, string rightVersionText, out int comparison)
+        {
+            comparison = 0;
+
+            if (!TryParse(leftVersionText, out CliSemanticVersion leftVersion))
+            {
+                return false;
+            }
+
+            if (!TryParse(rightVersionText, out CliSemanticVersion rightVersion))
+            {
+                return false;
+            }
+
+            comparison = Compare(leftVersion, rightVersion);
+            return true;
+        }
+
+        internal static bool IsSameVersion(string leftVersionText, string rightVersionText)
+        {
+            if (!TryCompare(leftVersionText, rightVersionText, out int comparison))
+            {
+                return false;
+            }
+
+            return comparison == 0;
+        }
+
+        private static bool TryParse(string versionText, out CliSemanticVersion version)
+        {
+            version = default;
+
+            if (string.IsNullOrWhiteSpace(versionText))
+            {
+                return false;
+            }
+
+            string normalized = versionText.Trim().TrimStart('v', 'V');
+            int buildMetadataIndex = normalized.IndexOf('+');
+            if (buildMetadataIndex >= 0)
+            {
+                normalized = normalized.Substring(0, buildMetadataIndex);
+            }
+
+            string preRelease = string.Empty;
+            int preReleaseIndex = normalized.IndexOf('-');
+            if (preReleaseIndex >= 0)
+            {
+                preRelease = normalized.Substring(preReleaseIndex + 1);
+                normalized = normalized.Substring(0, preReleaseIndex);
+            }
+
+            if (preReleaseIndex >= 0 && string.IsNullOrEmpty(preRelease))
+            {
+                return false;
+            }
+
+            string[] components = normalized.Split('.');
+            if (components.Length != 3)
+            {
+                return false;
+            }
+
+            if (!TryParseComponent(components[0], out int major))
+            {
+                return false;
+            }
+
+            if (!TryParseComponent(components[1], out int minor))
+            {
+                return false;
+            }
+
+            if (!TryParseComponent(components[2], out int patch))
+            {
+                return false;
+            }
+
+            version = new CliSemanticVersion(major, minor, patch, preRelease);
+            return true;
+        }
+
+        private static bool TryParseComponent(string component, out int value)
+        {
+            value = 0;
+            if (string.IsNullOrEmpty(component))
+            {
+                return false;
+            }
+
+            return int.TryParse(component, NumberStyles.None, CultureInfo.InvariantCulture, out value);
+        }
+
+        private static int Compare(CliSemanticVersion left, CliSemanticVersion right)
+        {
+            int majorComparison = left.Major.CompareTo(right.Major);
+            if (majorComparison != 0)
+            {
+                return majorComparison;
+            }
+
+            int minorComparison = left.Minor.CompareTo(right.Minor);
+            if (minorComparison != 0)
+            {
+                return minorComparison;
+            }
+
+            int patchComparison = left.Patch.CompareTo(right.Patch);
+            if (patchComparison != 0)
+            {
+                return patchComparison;
+            }
+
+            return ComparePreRelease(left, right);
+        }
+
+        private static int ComparePreRelease(CliSemanticVersion left, CliSemanticVersion right)
+        {
+            if (!left.HasPreRelease && !right.HasPreRelease)
+            {
+                return 0;
+            }
+
+            if (!left.HasPreRelease)
+            {
+                return 1;
+            }
+
+            if (!right.HasPreRelease)
+            {
+                return -1;
+            }
+
+            string[] leftIdentifiers = left.PreRelease.Split('.');
+            string[] rightIdentifiers = right.PreRelease.Split('.');
+            int maxLength = Math.Max(leftIdentifiers.Length, rightIdentifiers.Length);
+
+            for (int i = 0; i < maxLength; i++)
+            {
+                if (i >= leftIdentifiers.Length)
+                {
+                    return -1;
+                }
+
+                if (i >= rightIdentifiers.Length)
+                {
+                    return 1;
+                }
+
+                int identifierComparison = ComparePreReleaseIdentifier(leftIdentifiers[i], rightIdentifiers[i]);
+                if (identifierComparison != 0)
+                {
+                    return identifierComparison;
+                }
+            }
+
+            return 0;
+        }
+
+        private static int ComparePreReleaseIdentifier(string left, string right)
+        {
+            bool leftIsNumeric = int.TryParse(left, NumberStyles.None, CultureInfo.InvariantCulture, out int leftNumber);
+            bool rightIsNumeric = int.TryParse(right, NumberStyles.None, CultureInfo.InvariantCulture, out int rightNumber);
+
+            if (leftIsNumeric && rightIsNumeric)
+            {
+                return leftNumber.CompareTo(rightNumber);
+            }
+
+            if (leftIsNumeric)
+            {
+                return -1;
+            }
+
+            if (rightIsNumeric)
+            {
+                return 1;
+            }
+
+            return string.Compare(left, right, StringComparison.Ordinal);
+        }
+
+        private readonly struct CliSemanticVersion
+        {
+            internal readonly int Major;
+            internal readonly int Minor;
+            internal readonly int Patch;
+            internal readonly string PreRelease;
+
+            internal CliSemanticVersion(int major, int minor, int patch, string preRelease)
+            {
+                Major = major;
+                Minor = minor;
+                Patch = patch;
+                PreRelease = preRelease;
+            }
+
+            internal bool HasPreRelease => !string.IsNullOrEmpty(PreRelease);
+        }
+    }
+}

--- a/Packages/src/Editor/UI/CliVersionComparison.cs.meta
+++ b/Packages/src/Editor/UI/CliVersionComparison.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 984ecd7223ecf2e41b1f37a7662ef824
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -780,10 +780,12 @@ namespace io.github.hatayama.uLoopMCP
             bool needsDowngrade = false;
             if (isCliInstalled)
             {
-                System.Version cliVer = new System.Version(cliVersion);
-                System.Version pkgVer = new System.Version(packageVersion);
-                needsUpdate = cliVer < pkgVer;
-                needsDowngrade = cliVer > pkgVer;
+                bool comparisonAvailable = CliVersionComparison.TryCompare(
+                    cliVersion,
+                    packageVersion,
+                    out int cliVersionComparison);
+                needsUpdate = comparisonAvailable && cliVersionComparison < 0;
+                needsDowngrade = comparisonAvailable && cliVersionComparison > 0;
             }
             bool groupSkillsUnderUnityCliLoop = !_installSkillsFlat;
             SkillInstallState selectedTargetInstallState = includeSkillDirectoryChecks

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -597,13 +597,7 @@ namespace io.github.hatayama.uLoopMCP
         }
         private static bool IsCliVersionMatched(string cliVersion)
         {
-            if (string.IsNullOrEmpty(cliVersion)) return false;
-
-            string normalized = cliVersion.Trim().TrimStart('v', 'V');
-            if (!System.Version.TryParse(normalized, out System.Version installed)) return false;
-            if (!System.Version.TryParse(McpConstants.PackageInfo.version, out System.Version required)) return false;
-
-            return installed.CompareTo(required) == 0;
+            return CliVersionComparison.IsSameVersion(cliVersion, McpConstants.PackageInfo.version);
         }
 
         private void UpdateSkillsStep(

--- a/Packages/src/Editor/uLoopMCP.Editor.asmdef
+++ b/Packages/src/Editor/uLoopMCP.Editor.asmdef
@@ -22,6 +22,11 @@
             "name": "com.unity.inputsystem",
             "expression": "",
             "define": "ULOOPMCP_HAS_INPUT_SYSTEM"
+        },
+        {
+            "name": "com.unity.test-framework",
+            "expression": "",
+            "define": "ULOOPMCP_HAS_TEST_FRAMEWORK"
         }
     ],
     "noEngineReferences": false

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -76,6 +76,7 @@ Scope(s): io.github.hatayama.uloopmcp
 
 > [!NOTE]
 > `com.unity.inputsystem` is now an optional dependency. Install it only if you want Input System features such as `simulate-keyboard`, `simulate-mouse-input`, `record-input`, `replay-input`, and the Recordings window.
+> `com.unity.test-framework` is also optional. Install it only if you want the `run-tests` tool to execute Unity Test Runner.
 
 # Quickstart
 
@@ -325,7 +326,7 @@ This allows you to retrieve logs while keeping the context small.
 ```
 
 ### 3. run-tests - Execute TestRunner (PlayMode, EditMode supported)
-Executes Unity Test Runner and retrieves test results. You can set conditions with FilterType and FilterValue.
+Executes Unity Test Runner and retrieves test results. This tool requires the Unity Test Framework package. If the package is not installed, `run-tests` returns an unsupported message while the rest of Unity CLI Loop keeps working. You can set conditions with FilterType and FilterValue.
 - FilterType: all (all tests), exact (individual test method name), regex (class name or namespace), assembly (assembly name)
 - FilterValue: Value according to filter type (class name, namespace, etc.)
 - SaveBeforeRun: Saves unsaved loaded Scene changes and current Prefab Stage changes before running tests when explicitly enabled

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -77,6 +77,7 @@ Scope(s): io.github.hatayama.uloopmcp
 
 > [!NOTE]
 > `com.unity.inputsystem` は optional dependency になりました。`simulate-keyboard`、`simulate-mouse-input`、`record-input`、`replay-input`、Recordings ウィンドウを使いたい場合だけ追加してください。
+> `com.unity.test-framework` も optional dependency です。`run-tests` で Unity Test Runner を実行したい場合だけ追加してください。
 
 # クイックスタート
 
@@ -324,7 +325,7 @@ LogTypeや検索対象の文字列で絞り込む事ができます。また、s
 ```
 
 ### 3. run-tests - TestRunnerの実行 (PlayMode, EditMode対応)
-Unity Test Runnerを実行し、テスト結果を取得します。FilterTypeとFilterValueで条件を設定できます。
+Unity Test Runnerを実行し、テスト結果を取得します。このツールは Unity Test Framework パッケージが必要です。未導入の場合、`run-tests` は unsupported メッセージを返し、それ以外の Unity CLI Loop 機能は動作し続けます。FilterTypeとFilterValueで条件を設定できます。
 - FilterType: all（全テスト）、exact（個別テストメソッド名）、regex（クラス名や名前空間）、assembly（アセンブリ名）
 - FilterValue: フィルタータイプに応じた値（クラス名、名前空間など）
 - SaveBeforeRun: 明示的に有効化した場合、未保存のロード済みScene変更と現在のPrefab Stage変更を保存してからテストを実行

--- a/Packages/src/TypeScriptServer~/package-lock.json
+++ b/Packages/src/TypeScriptServer~/package-lock.json
@@ -4620,12 +4620,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5078,9 +5078,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5214,9 +5214,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/Packages/src/TypeScriptServer~/package.json
+++ b/Packages/src/TypeScriptServer~/package.json
@@ -92,7 +92,7 @@
   },
   "overrides": {
     "@hono/node-server": "1.19.13",
-    "hono": "4.12.14",
+    "hono": "4.12.18",
     "minimatch": "10.2.4"
   }
 }

--- a/Packages/src/package.json
+++ b/Packages/src/package.json
@@ -12,7 +12,6 @@
     "url": "https://github.com/hatayama/uLoopMCP"
   },
   "dependencies": {
-    "com.unity.test-framework": "1.1.33",
     "com.unity.ugui": "1.0.0",
     "com.unity.nuget.newtonsoft-json": "3.2.1"
   },

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Scope(s): io.github.hatayama.uloopmcp
 
 > [!NOTE]
 > `com.unity.inputsystem` is now an optional dependency. Install it only if you want Input System features such as `simulate-keyboard`, `simulate-mouse-input`, `record-input`, `replay-input`, and the Recordings window.
+> `com.unity.test-framework` is also optional. Install it only if you want the `run-tests` tool to execute Unity Test Runner.
 
 # Quickstart
 
@@ -325,7 +326,7 @@ This allows you to retrieve logs while keeping the context small.
 ```
 
 ### 3. run-tests - Execute TestRunner (PlayMode, EditMode supported)
-Executes Unity Test Runner and retrieves test results. You can set conditions with FilterType and FilterValue.
+Executes Unity Test Runner and retrieves test results. This tool requires the Unity Test Framework package. If the package is not installed, `run-tests` returns an unsupported message while the rest of Unity CLI Loop keeps working. You can set conditions with FilterType and FilterValue.
 - FilterType: all (all tests), exact (individual test method name), regex (class name or namespace), assembly (assembly name)
 - FilterValue: Value according to filter type (class name, namespace, etc.)
 - SaveBeforeRun: Saves unsaved loaded Scene changes and current Prefab Stage changes before running tests when explicitly enabled

--- a/README_ja.md
+++ b/README_ja.md
@@ -77,6 +77,7 @@ Scope(s): io.github.hatayama.uloopmcp
 
 > [!NOTE]
 > `com.unity.inputsystem` は optional dependency になりました。`simulate-keyboard`、`simulate-mouse-input`、`record-input`、`replay-input`、Recordings ウィンドウを使いたい場合だけ追加してください。
+> `com.unity.test-framework` も optional dependency です。`run-tests` で Unity Test Runner を実行したい場合だけ追加してください。
 
 # クイックスタート
 
@@ -324,7 +325,7 @@ LogTypeや検索対象の文字列で絞り込む事ができます。また、s
 ```
 
 ### 3. run-tests - TestRunnerの実行 (PlayMode, EditMode対応)
-Unity Test Runnerを実行し、テスト結果を取得します。FilterTypeとFilterValueで条件を設定できます。
+Unity Test Runnerを実行し、テスト結果を取得します。このツールは Unity Test Framework パッケージが必要です。未導入の場合、`run-tests` は unsupported メッセージを返し、それ以外の Unity CLI Loop 機能は動作し続けます。FilterTypeとFilterValueで条件を設定できます。
 - FilterType: all（全テスト）、exact（個別テストメソッド名）、regex（クラス名や名前空間）、assembly（アセンブリ名）
 - FilterValue: フィルタータイプに応じた値（クラス名、名前空間など）
 - SaveBeforeRun: 明示的に有効化した場合、未保存のロード済みScene変更と現在のPrefab Stage変更を保存してからテストを実行


### PR DESCRIPTION
## Summary
- Unity projects can install uLoop without adding Unity Test Framework to their package dependencies.
- run-tests remains discoverable and returns a clear missing-dependency response when Test Framework is unavailable.
- The PR supply-chain audit now passes with refreshed TypeScript server dependency resolution.

## User Impact
- Before, projects without Unity Test Framework could fail to compile the package or see confusing run-tests behavior such as disabled-tool or command-not-found responses.
- After, the package installs without forcing Test Framework. Users can still invoke run-tests and get an actionable message explaining that Test Framework is required for test execution.
- Setup and settings version checks no longer choke on prerelease-style CLI versions.

## Changes
- Removed com.unity.test-framework from the distributable package dependency list and gated Test Runner integration behind ULOOPMCP_HAS_TEST_FRAMEWORK.
- Added fallback responses and availability checks so missing dependency errors are reported before disabled-tool handling.
- Kept run-tests in CLI tool metadata for projects without Test Framework.
- Added SemVer-aware CLI version comparison for editor setup/settings UI paths.
- Updated TypeScript server lockfile resolution for hono, express-rate-limit, and ip-address audit findings.
- Updated README, package README copies, skill guidance, and focused tests.

## Verification
- GitHub Actions for PR #1062: build-typescript-server, test-unity-package, README Sync Check, Security Code Scan, Unity Compile Check all passed.
- npx jest src/__tests__/package-metadata.test.ts --testTimeout=60000 --runInBand
- npm run lint
- npm run build
- node Packages/src/Cli~/dist/cli.bundle.cjs compile --project-path /Users/a12115/ghq/hatayama/unity-cli-loop2 --force-recompile false --wait-for-domain-reload true
- targeted EditMode run-tests checks for unavailable response, RunTestsUseCase validation, and TestExecutionStateValidationService behavior
- cd Packages/src/TypeScriptServer~ && npm ci --ignore-scripts=false
- cd Packages/src/TypeScriptServer~ && ULOOPMCP_PRODUCTION=true NODE_ENV=production npm run build:production
- cd Packages/src/TypeScriptServer~ && npx tsc --noEmit
- cd Packages/src/TypeScriptServer~ && npx knip
- cd Packages/src/TypeScriptServer~ && npm run security:check
- cd Packages/src/TypeScriptServer~ && npm audit --audit-level=moderate
- cd Packages/src/TypeScriptServer~ && npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --allowed-schemes "https:" "git+https:"
- sh scripts/sync-readmes.sh --check
- git diff --check
- Codex review loop against origin/main: 0 valid findings

Closes #1061

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR makes the Unity Test Framework (`com.unity.test-framework`) an optional dependency for the uLoop MCP package, allowing projects to install and use uLoop without requiring the Test Framework. The `run-tests` tool remains discoverable in the CLI metadata but returns a clear unsupported response when the Test Framework is unavailable, while all other uLoop tools continue to function normally.

## Key Changes

### Package Dependencies
- Removed `com.unity.test-framework` (v1.1.33) from `package.json` and `packages-lock.json`
- Pinned `hono` dependency to version 4.12.18 in TypeScript server `package.json` (audit fix)

### Conditional Compilation & Test Framework Gating
Introduced `ULOOPMCP_HAS_TEST_FRAMEWORK` preprocessor symbol to gate Test Framework integration:

- **RunTestsUseCase.cs**: Wrapped execution flow—when `ULOOPMCP_HAS_TEST_FRAMEWORK` is undefined, returns `RunTestsResponse` indicating unavailable framework; otherwise proceeds with validation and test execution
- **TestExecutionService.cs**: Both `ExecutePlayModeTestAsync` and `ExecuteEditModeTestAsync` conditionally compile; when unavailable, return early with `SerializableTestResult.CreateTestFrameworkUnavailable()`
- **PlayModeTestExecuter.cs** & **NUnitXmlResultExporter.cs**: Entire implementations wrapped in conditional compilation guards
- **SerializableTestResult.cs**: Test-result conversion logic and `ITestResultAdaptor` dependencies gated; added `CreateTestFrameworkUnavailable()` factory method

### Schema & Type Changes
- Introduced local `RunTestMode` enum in `RunTestsSchema.cs` (values: `EditMode = 1`, `PlayMode = 2`) to remove dependency on Unity's `TestMode` type
- Updated `TestExecutionStateValidationService.Validate()` signature from `TestMode` to `RunTestMode`
- Updated all test files and use cases to use `RunTestMode` instead of `TestMode`
- Removed import of `UnityEditor.TestTools.TestRunner.Api` from validation service

### Fallback Responses
- Added `RunTestsResponse.TestFrameworkUnavailableMessage` constant and `CreateTestFrameworkUnavailable()` factory method with `Success == false`, framework-unavailable message, zeroed test counts, and current UTC timestamp
- Added `SerializableTestResult.CreateTestFrameworkUnavailable()` for consistent internal serialization

### Tool Availability & Registration Logic
- Introduced `ToolExecutionAvailability` class with `ShouldReportDependencyUnavailableBeforeDisabled()` and `ShouldExposeInRegisteredTools()` methods that check test framework availability
- Updated `UnityToolRegistry.ExecuteToolAsync` to throw `ToolDisabledException` only when a tool is disabled AND not subject to dependency-unavailable bypass
- Updated `UnityToolRegistry.GetRegisteredTools()` to use `ToolExecutionAvailability.ShouldExposeInRegisteredTools()` for determining tool visibility
- `run-tests` now remains discoverable/exposed when disabled if the test framework is unavailable, so users receive a dependency-unavailable response instead of command-not-found

### CLI Version Comparison (SemVer-Aware)
- Added `CliVersionComparison` utility class supporting semantic versioning with pre-release parsing
  - `TryCompare(leftVersion, rightVersion, out comparison)`: Parses versions with optional `v` prefix, removes `+` build metadata, handles `-` pre-release tags, and compares using semantic rules
  - `IsSameVersion(leftVersion, rightVersion)`: Equality check delegating to comparison logic
- Updated `McpEditorWindow.CreateCliSetupData` to use `CliVersionComparison.TryCompare` instead of `System.Version` parsing
- Updated `SetupWizardWindow.IsCliVersionMatched` to use `CliVersionComparison.IsSameVersion`

### Tool Settings & Skill Installation
- **tool-settings-loader.ts**: 
  - Refactored to resolve Unity project root via `resolveProjectRoot(...)` helper
  - Added `shouldBypassDisabledSettingForDependencyError()` to conditionally treat `run-tests` as enabled when the test framework is not installed
  - `isToolEnabled()` and `filterEnabledTools()` now apply framework-availability bypass for `run-tests`
  
- **ToolSkillSynchronizer.cs**: 
  - Added `IsSkillDisabledByToolSettings()` predicate incorporating test framework availability
  - Modified skill installation to gate disablement on `ShouldReportDependencyUnavailableBeforeDisabled()` when framework is unavailable
  
- **skills-manager.ts**: Updated to differentiate tool-disabling—presence in `disabledTools` only triggers removal if `isToolEnabled()` also returns `false`

### Documentation
- **README.md & README_ja.md**: Added explicit note that `com.unity.test-framework` is optional and only required for `run-tests`; documented that `run-tests` returns an unsupported message when the package is missing
- **Packages/src/README.md & README_ja.md**: Updated dependency notes and tool descriptions with same framework-optional messaging
- **SKILL.md**: Updated to state `run-tests` requires the Unity Test Framework and returns `Success: false` with unsupported message when absent

## Test Coverage
- **RunTestsToolTests.cs**: Added assertions on `RunTestsSchema.TestMode` default value and numeric enum mapping; added `CreateTestFrameworkUnavailable_ShouldReturnUnsupportedResponse` test
- **RunTestsUseCaseTests.cs**: Updated stub validation service to use `RunTestMode` parameter
- **TestExecutionStateValidationServiceTests.cs**: Updated all test cases to pass `RunTestMode` values
- **CliVersionComparisonTests.cs** (new): Tests SemVer parsing, optional `v` prefix, pre-release handling, and invalid version detection
- **ToolExecutionAvailabilityTests.cs** (new): Tests dependency unavailability and tool exposure behavior for `run-tests` with and without framework
- **ToolSkillSynchronizerTests.cs**: Added tests for skill disablement based on test framework availability
- **tool-settings-loader.test.ts**: Added test cases for `run-tests` enabling/disabling based on framework package presence in manifests
- **skills-manager.test.ts**: Added integration test for skill installation when test framework is absent
- **package-metadata.test.ts**: Verifies `com.unity.test-framework` is not in distributable package dependencies and `versionDefines` entry exists in editor asmdef

## Impact
- Projects without Unity Test Framework can now successfully install and use uLoop MCP
- The `run-tests` command remains discoverable but returns a clear unsupported/dependency-missing response when the framework is absent
- All other uLoop tools remain functional regardless of Test Framework installation status
- CLI version comparisons now properly handle pre-release versions (e.g., `1.0.0-beta`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->