### PR TITLE
chore: v2 CLI rollback steps are easier to follow

### DIFF
--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -72,6 +72,8 @@ Scope(s): io.github.hatayama.uloopmcp
 
 Select Window > Unity CLI Loop > Settings. A dedicated window will open. If the **CLI** button is not highlighted in blue, press **Install CLI**.
 
+To return to the v2 line, press **Uninstall CLI** in Settings, downgrade the U-LOOP package to a v2 version such as `2.1.1`, then press **Install CLI** again from Settings.
+
 <details>
 <summary>CLI-only terminal install</summary>
 
@@ -92,6 +94,24 @@ On Windows, set `ULOOP_REMOVE_LEGACY=1` to remove package-owned legacy `uloop` l
 ```powershell
 $env:ULOOP_REMOVE_LEGACY = "1"
 irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.ps1 | iex
+```
+
+If the Unity UI path is not available or your terminal still resolves `uloop` to the v3 CLI, remove that command first, then install the v2 version you want:
+
+```bash
+rm -f "$HOME/.local/bin/uloop"
+npm install -g uloop-cli@2.1.1
+which uloop
+uloop --version
+```
+
+On Windows PowerShell:
+
+```powershell
+Remove-Item "$env:LOCALAPPDATA\Programs\uloop\bin\uloop.exe" -Force -ErrorAction SilentlyContinue
+npm install -g uloop-cli@2.1.1
+Get-Command uloop
+uloop --version
 ```
 
 </details>
@@ -634,7 +654,7 @@ scripts/build-go-cli.sh
 
 ### Unity CLI Loop Files
 
-`UserSettings/UnityCliLoopSettings.json` stores per-user editor session state and should always remain local-only.
+`UserSettings/UnityMcpSettings.json` stores per-user editor session state and should always remain local-only. The file name is a historical compatibility name.
 
 The `.uloop/` directory at the project root stores CLI cache, tool registry, and runtime outputs. Most of its contents are local-only, but some files can optionally be git-tracked for team sharing.
 

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -73,6 +73,8 @@ Scope(s): io.github.hatayama.uloopmcp
 
 Window > Unity CLI Loop > Settingsを選択します。専用ウィンドウが開くので、**CLI** ボタンが青くなっていなければ **Install CLI** を押してください。
 
+v2系に戻したい場合は、Settings で **Uninstall CLI** を押し、Unity Package Manager か `manifest.json` で U-LOOP package を `2.1.1` などのv2系のバージョンへ下げてから、もう一度 Settings で **Install CLI** を押してください。
+
 <details>
 <summary>CLIだけをterminalからinstallする場合はこちら</summary>
 
@@ -93,6 +95,24 @@ Windows では `ULOOP_REMOVE_LEGACY=1` を設定すると、package-owned な古
 ```powershell
 $env:ULOOP_REMOVE_LEGACY = "1"
 irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.ps1 | iex
+```
+
+Unity UIから戻せない場合や、ターミナルの `uloop` がまだv3系のCLIを指している場合は、先にその `uloop` コマンドを削除してから、戻したいv2系のバージョンをインストールしてください。
+
+```bash
+rm -f "$HOME/.local/bin/uloop"
+npm install -g uloop-cli@2.1.1
+which uloop
+uloop --version
+```
+
+Windows PowerShell の場合:
+
+```powershell
+Remove-Item "$env:LOCALAPPDATA\Programs\uloop\bin\uloop.exe" -Force -ErrorAction SilentlyContinue
+npm install -g uloop-cli@2.1.1
+Get-Command uloop
+uloop --version
 ```
 
 </details>
@@ -619,7 +639,7 @@ description: "ツールの説明と使用タイミング"
 
 ### Unity CLI Loop 関連ファイル
 
-`UserSettings/UnityCliLoopSettings.json` はユーザー個別のエディタセッション状態を保持するため、常にローカル専用です。
+`UserSettings/UnityMcpSettings.json` はユーザー個別のエディタセッション状態を保持するため、常にローカル専用です。このファイル名は旧名称由来の互換名です。
 
 プロジェクトルートの `.uloop/` ディレクトリには、CLIキャッシュ、ツールレジストリ、ランタイム出力が格納されます。大半はローカル専用ですが、一部のファイルはチーム共有のためにオプションでgit管理できます。
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Scope(s): io.github.hatayama.uloopmcp
 
 Select Window > Unity CLI Loop > Settings. A dedicated window will open. If the **CLI** button is not highlighted in blue, press **Install CLI**.
 
+To return to the v2 line, press **Uninstall CLI** in Settings, downgrade the U-LOOP package to a v2 version such as `2.1.1`, then press **Install CLI** again from Settings.
+
 <details>
 <summary>CLI-only terminal install</summary>
 
@@ -92,6 +94,24 @@ On Windows, set `ULOOP_REMOVE_LEGACY=1` to remove package-owned legacy `uloop` l
 ```powershell
 $env:ULOOP_REMOVE_LEGACY = "1"
 irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.ps1 | iex
+```
+
+If the Unity UI path is not available or your terminal still resolves `uloop` to the v3 CLI, remove that command first, then install the v2 version you want:
+
+```bash
+rm -f "$HOME/.local/bin/uloop"
+npm install -g uloop-cli@2.1.1
+which uloop
+uloop --version
+```
+
+On Windows PowerShell:
+
+```powershell
+Remove-Item "$env:LOCALAPPDATA\Programs\uloop\bin\uloop.exe" -Force -ErrorAction SilentlyContinue
+npm install -g uloop-cli@2.1.1
+Get-Command uloop
+uloop --version
 ```
 
 </details>

--- a/README_ja.md
+++ b/README_ja.md
@@ -73,6 +73,8 @@ Scope(s): io.github.hatayama.uloopmcp
 
 Window > Unity CLI Loop > Settingsを選択します。専用ウィンドウが開くので、**CLI** ボタンが青くなっていなければ **Install CLI** を押してください。
 
+v2系に戻したい場合は、Settings で **Uninstall CLI** を押し、Unity Package Manager か `manifest.json` で U-LOOP package を `2.1.1` などのv2系のバージョンへ下げてから、もう一度 Settings で **Install CLI** を押してください。
+
 <details>
 <summary>CLIだけをterminalからinstallする場合はこちら</summary>
 
@@ -93,6 +95,24 @@ Windows では `ULOOP_REMOVE_LEGACY=1` を設定すると、package-owned な古
 ```powershell
 $env:ULOOP_REMOVE_LEGACY = "1"
 irm https://raw.githubusercontent.com/hatayama/unity-cli-loop/main/scripts/install.ps1 | iex
+```
+
+Unity UIから戻せない場合や、ターミナルの `uloop` がまだv3系のCLIを指している場合は、先にその `uloop` コマンドを削除してから、戻したいv2系のバージョンをインストールしてください。
+
+```bash
+rm -f "$HOME/.local/bin/uloop"
+npm install -g uloop-cli@2.1.1
+which uloop
+uloop --version
+```
+
+Windows PowerShell の場合:
+
+```powershell
+Remove-Item "$env:LOCALAPPDATA\Programs\uloop\bin\uloop.exe" -Force -ErrorAction SilentlyContinue
+npm install -g uloop-cli@2.1.1
+Get-Command uloop
+uloop --version
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- Document the UI-first path for returning to the v2 CLI line from Settings.
- Add terminal fallback commands for users whose `uloop` command still resolves to the v3 CLI.

## User Impact
- Users who decide to go back to the latest v2 release can follow the downgrade flow without learning internal CLI implementation terms.
- The English and Japanese README copies now describe the same rollback path.

## Changes
- Added v2 rollback guidance to the Quickstart CLI install section.
- Added macOS/Linux and Windows terminal fallback commands using `uloop-cli@2.1.1`.
- Synced the package README copies from the root README files.

## Verification
- `scripts/sync-readmes.sh --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request updates documentation across the root and package READMEs to provide clearer guidance for users who need to downgrade from the v3 CLI back to v2. The changes are replicated in both English and Japanese versions to ensure consistency.

## Changes

**Documentation Updates (English & Japanese versions synchronized):**

- **README.md / README_ja.md** (+20 lines): Enhanced the Quickstart/installation instructions with a new "Return to v2 CLI" section that guides users through the UI-based downgrade path via Settings, including steps to uninstall the CLI, downgrade the U-LOOP package to v2, and reinstall.

- **README.md / README_ja.md**: Extended the CLI-only terminal install section with fallback commands for users whose `uloop` command still resolves to the v3 CLI, including:
  - POSIX shell: Remove existing `~/.local/bin/uloop` and reinstall `uloop-cli@2.1.1`
  - Windows PowerShell: Remove v3 launcher and reinstall `uloop-cli@2.1.1`

- **Packages/src/README.md / Packages/src/README_ja.md** (+21 lines): Mirrored the same rollback guidance to package-level documentation and updated the settings configuration filename reference from `UserSettings/UnityCliLoopSettings.json` to `UserSettings/UnityMcpSettings.json`, noting it as a historical compatibility filename.

## Verification

- All documentation changes are UI-first with terminal-based fallback instructions
- English and Japanese versions now document the same rollback path consistently
- Changes are documentation-only with no impact to exported or public code entities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->