### PR TITLE
fix: Beta release recovery no longer blocks the next release PR

### DIFF
--- a/scripts/resolve-native-cli-release-target.sh
+++ b/scripts/resolve-native-cli-release-target.sh
@@ -196,8 +196,9 @@ release_commit_sha_for_version() {
           return 0
         }
 
+        scope_end = index(subject, ")")
         marker_index = index(subject, scoped_marker)
-        if (marker_index == 0) {
+        if (scope_end == 0 || marker_index != scope_end) {
           return 0
         }
 

--- a/scripts/resolve-native-cli-release-target.sh
+++ b/scripts/resolve-native-cli-release-target.sh
@@ -173,6 +173,24 @@ dispatcher_release_inputs_changed() {
     || core_required_dispatcher_version_changed "$base_ref" "$head_ref"
 }
 
+release_commit_sha_for_version() {
+  version=$1
+  build_sha=$2
+
+  git log --format='%H	%s' "$build_sha" \
+    | awk -F '	' -v version="$version" '
+      {
+        marker = "release " version
+        marker_index = index($2, marker)
+        next_character = substr($2, marker_index + length(marker), 1)
+      }
+      marker_index > 0 && (next_character == "" || next_character == " ") {
+        print $1
+        exit
+      }
+    '
+}
+
 VERSION=$(jq -r '.["Packages/src"]' .release-please-manifest.json)
 if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
   echo "Could not resolve Packages/src version from .release-please-manifest.json." >&2
@@ -228,6 +246,12 @@ if [ "$EVENT_NAME" = "push" ]; then
 fi
 
 TARGET_SHA=$(git rev-parse HEAD)
+BUILD_SHA=$TARGET_SHA
+RELEASE_TARGET_SHA=$(release_commit_sha_for_version "$VERSION" "$BUILD_SHA")
+if [ -z "$RELEASE_TARGET_SHA" ]; then
+  RELEASE_TARGET_SHA=$BUILD_SHA
+fi
+
 if [ "$CAN_EVALUATE_DISPATCHER_RELEASE" != "true" ]; then
   SHOULD_PUBLISH=false
   SHOULD_RELEASE=false
@@ -263,9 +287,11 @@ printf 'publish=%s\n' "$SHOULD_PUBLISH"
 printf 'release=%s\n' "$SHOULD_RELEASE"
 printf 'tag=%s\n' "$RELEASE_TAG"
 printf 'version=%s\n' "$VERSION"
-printf 'sha=%s\n' "$TARGET_SHA"
+printf 'sha=%s\n' "$RELEASE_TARGET_SHA"
+printf 'build_sha=%s\n' "$BUILD_SHA"
 printf 'dry_run=%s\n' "$DRY_RUN"
 
 echo "Publish: $SHOULD_PUBLISH" >&2
 echo "Release tag: $RELEASE_TAG" >&2
-echo "Target SHA: $TARGET_SHA" >&2
+echo "Target SHA: $RELEASE_TARGET_SHA" >&2
+echo "Build SHA: $BUILD_SHA" >&2

--- a/scripts/resolve-native-cli-release-target.sh
+++ b/scripts/resolve-native-cli-release-target.sh
@@ -179,12 +179,33 @@ release_commit_sha_for_version() {
 
   git log --format='%H	%s' "$build_sha" \
     | awk -F '	' -v version="$version" '
-      {
-        marker = "release " version
-        marker_index = index($2, marker)
-        next_character = substr($2, marker_index + length(marker), 1)
+      function version_boundary_matches(subject, prefix) {
+        next_character = substr(subject, length(prefix) + 1, 1)
+        return next_character == "" || next_character == " "
       }
-      marker_index > 0 && (next_character == "" || next_character == " ") {
+
+      function is_release_please_subject(subject) {
+        plain_prefix = "chore: release " version
+        scoped_marker = "): release " version
+
+        if (index(subject, plain_prefix) == 1) {
+          return version_boundary_matches(subject, plain_prefix)
+        }
+
+        if (index(subject, "chore(") != 1) {
+          return 0
+        }
+
+        marker_index = index(subject, scoped_marker)
+        if (marker_index == 0) {
+          return 0
+        }
+
+        scoped_prefix = substr(subject, 1, marker_index + length(scoped_marker) - 1)
+        return version_boundary_matches(subject, scoped_prefix)
+      }
+
+      is_release_please_subject($2) {
         print $1
         exit
       }

--- a/scripts/test-resolve-native-cli-release-target.sh
+++ b/scripts/test-resolve-native-cli-release-target.sh
@@ -28,7 +28,13 @@ case "$1" in
     exit 0
     ;;
   rev-parse)
-    printf '%s\n' target-sha
+    printf '%s\n' "${BUILD_SHA_VALUE:-target-sha}"
+    ;;
+  log)
+    printf '%s\t%s\n' "${BUILD_SHA_VALUE:-target-sha}" "$BUILD_COMMIT_SUBJECT"
+    if [ -n "${RELEASE_COMMIT_SHA:-}" ] && [ "$RELEASE_COMMIT_SHA" != "${BUILD_SHA_VALUE:-target-sha}" ]; then
+      printf '%s\t%s\n' "$RELEASE_COMMIT_SHA" "$RELEASE_COMMIT_SUBJECT"
+    fi
     ;;
   show)
     case "$2" in
@@ -176,6 +182,17 @@ run_success_case() {
   core_required_changed=${11}
   expected_publish=${12}
   expected_release=${13}
+  expected_sha=${14:-target-sha}
+  build_sha_value=${15:-target-sha}
+  release_commit_sha=${16:-target-sha}
+  release_commit_subject=${17:-}
+  build_commit_subject=${18:-}
+  if [ -z "$release_commit_subject" ]; then
+    release_commit_subject="chore(v3-beta): release $current_version"
+  fi
+  if [ -z "$build_commit_subject" ]; then
+    build_commit_subject=$release_commit_subject
+  fi
 
   work_dir="$TMP_DIR/$name"
   mock_bin="$work_dir/bin"
@@ -189,6 +206,10 @@ run_success_case() {
       CURRENT_VERSION="$current_version" \
       CURRENT_RELEASE_STATE="$current_release_state" \
       CURRENT_RELEASE_HAS_ASSETS="$current_release_has_assets" \
+      BUILD_SHA_VALUE="$build_sha_value" \
+      BUILD_COMMIT_SUBJECT="$build_commit_subject" \
+      RELEASE_COMMIT_SHA="$release_commit_sha" \
+      RELEASE_COMMIT_SUBJECT="$release_commit_subject" \
       PREVIOUS_RELEASE_TAG="$previous_release_tag" \
       PREVIOUS_RELEASE_HAS_ASSETS="$previous_release_has_assets" \
       DISPATCHER_CHANGED="$dispatcher_changed" \
@@ -205,7 +226,8 @@ run_success_case() {
     assert_contains output.txt "release=$expected_release"
     assert_contains output.txt "tag=v$current_version"
     assert_contains output.txt "version=$current_version"
-    assert_contains output.txt "sha=target-sha"
+    assert_contains output.txt "sha=$expected_sha"
+    assert_contains output.txt "build_sha=$build_sha_value"
     assert_contains output.txt "dry_run=false"
   )
 }
@@ -231,6 +253,10 @@ run_failure_case() {
       CURRENT_VERSION="$current_version" \
       CURRENT_RELEASE_STATE="$current_release_state" \
       CURRENT_RELEASE_HAS_ASSETS=false \
+      BUILD_SHA_VALUE=target-sha \
+      BUILD_COMMIT_SUBJECT="chore(v3-beta): release $current_version" \
+      RELEASE_COMMIT_SHA=target-sha \
+      RELEASE_COMMIT_SUBJECT="chore(v3-beta): release $current_version" \
       PREVIOUS_RELEASE_TAG=v3.0.0-beta.1 \
       PREVIOUS_RELEASE_HAS_ASSETS=true \
       DISPATCHER_CHANGED=false \
@@ -289,6 +315,16 @@ test_missing_previous_dispatcher_release_publishes() {
   run_success_case bootstrap 3.0.0-beta.0 push v3-beta missing false "" false false false false true true
 }
 
+# Verifies a recovered release still tags the original release PR merge commit.
+test_recovery_targets_release_commit() {
+  run_success_case recovery-target 3.0.0-beta.2 push v3-beta missing false v3.0.0-beta.1 true true false false true true release-sha build-sha release-sha "chore(v3-beta): release 3.0.0-beta.2" "fix: follow-up change"
+}
+
+# Verifies version matching does not confuse beta.2 with beta.20.
+test_recovery_target_uses_exact_version_boundary() {
+  run_success_case recovery-boundary 3.0.0-beta.2 push v3-beta missing false v3.0.0-beta.1 true true false false true true release-sha build-sha release-sha "chore(v3-beta): release 3.0.0-beta.2" "chore(v3-beta): release 3.0.0-beta.20"
+}
+
 # Verifies main refuses prerelease versions.
 test_main_prerelease_fails() {
   run_failure_case main-prerelease 3.0.0-beta.2 push main "Refusing to publish prerelease version 3.0.0-beta.2 from main."
@@ -311,6 +347,8 @@ test_published_current_release_can_receive_dispatcher_assets
 test_dispatcher_contract_change_publishes
 test_core_required_dispatcher_change_publishes
 test_missing_previous_dispatcher_release_publishes
+test_recovery_targets_release_commit
+test_recovery_target_uses_exact_version_boundary
 test_main_prerelease_fails
 test_v3_beta_stable_fails
 test_release_lookup_error_fails

--- a/scripts/test-resolve-native-cli-release-target.sh
+++ b/scripts/test-resolve-native-cli-release-target.sh
@@ -320,6 +320,11 @@ test_recovery_targets_release_commit() {
   run_success_case recovery-target 3.0.0-beta.2 push v3-beta missing false v3.0.0-beta.1 true true false false true true release-sha build-sha release-sha "chore(v3-beta): release 3.0.0-beta.2" "fix: follow-up change"
 }
 
+# Verifies recovery ignores follow-up commits that only mention the release version.
+test_recovery_ignores_non_release_subject_mentions() {
+  run_success_case recovery-non-release-subject 3.0.0-beta.2 push v3-beta missing false v3.0.0-beta.1 true true false false true true release-sha build-sha release-sha "chore(v3-beta): release 3.0.0-beta.2" "fix: keep release 3.0.0-beta.2 on the release commit"
+}
+
 # Verifies version matching does not confuse beta.2 with beta.20.
 test_recovery_target_uses_exact_version_boundary() {
   run_success_case recovery-boundary 3.0.0-beta.2 push v3-beta missing false v3.0.0-beta.1 true true false false true true release-sha build-sha release-sha "chore(v3-beta): release 3.0.0-beta.2" "chore(v3-beta): release 3.0.0-beta.20"
@@ -348,6 +353,7 @@ test_dispatcher_contract_change_publishes
 test_core_required_dispatcher_change_publishes
 test_missing_previous_dispatcher_release_publishes
 test_recovery_targets_release_commit
+test_recovery_ignores_non_release_subject_mentions
 test_recovery_target_uses_exact_version_boundary
 test_main_prerelease_fails
 test_v3_beta_stable_fails

--- a/scripts/test-resolve-native-cli-release-target.sh
+++ b/scripts/test-resolve-native-cli-release-target.sh
@@ -325,6 +325,11 @@ test_recovery_ignores_non_release_subject_mentions() {
   run_success_case recovery-non-release-subject 3.0.0-beta.2 push v3-beta missing false v3.0.0-beta.1 true true false false true true release-sha build-sha release-sha "chore(v3-beta): release 3.0.0-beta.2" "fix: keep release 3.0.0-beta.2 on the release commit"
 }
 
+# Verifies recovery ignores non-release subjects with a later release marker.
+test_recovery_requires_release_marker_after_scope() {
+  run_success_case recovery-scoped-marker 3.0.0-beta.2 push v3-beta missing false v3.0.0-beta.1 true true false false true true release-sha build-sha release-sha "chore(v3-beta): release 3.0.0-beta.2" "chore(v3-beta) follow-up): release 3.0.0-beta.2"
+}
+
 # Verifies version matching does not confuse beta.2 with beta.20.
 test_recovery_target_uses_exact_version_boundary() {
   run_success_case recovery-boundary 3.0.0-beta.2 push v3-beta missing false v3.0.0-beta.1 true true false false true true release-sha build-sha release-sha "chore(v3-beta): release 3.0.0-beta.2" "chore(v3-beta): release 3.0.0-beta.20"
@@ -354,6 +359,7 @@ test_core_required_dispatcher_change_publishes
 test_missing_previous_dispatcher_release_publishes
 test_recovery_targets_release_commit
 test_recovery_ignores_non_release_subject_mentions
+test_recovery_requires_release_marker_after_scope
 test_recovery_target_uses_exact_version_boundary
 test_main_prerelease_fails
 test_v3_beta_stable_fails


### PR DESCRIPTION
## Summary
- Beta release recovery now keeps the GitHub Release tag on the release commit even when Dispatcher assets are rebuilt from a newer v3-beta commit.
- This prevents release-please from treating a recovered release as untagged and blocking the next beta release PR.

## User Impact
- Before this change, a manual recovery publish could leave the beta release tag pointing at a follow-up commit, so the next release-please run could stop instead of opening the next beta release PR.
- After this change, recovered beta releases keep the expected tag target while still allowing Dispatcher assets to be built from the latest branch state.

## Changes
- Resolve the release tag target from the matching release commit for the current package version.
- Keep the build SHA available separately from the release tag SHA.
- Add shell coverage for recovered releases and exact beta version matching.

## Verification
- scripts/test-resolve-native-cli-release-target.sh
- scripts/test-install-release-filter.sh
- scripts/test-sync-release-please-go-cli-dist.sh
- scripts/test-notify-release-workflow-failure.sh
- git diff --check
- GOTOOLCHAIN=go1.26.3 scripts/check-go-cli.sh
- EVENT_NAME=push EVENT_REF_NAME=v3-beta scripts/resolve-native-cli-release-target.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes an issue in the beta release workflow where a manual recovery publish could cause `release-please` to halt and block the next beta release PR. The fix introduces logic to preserve the GitHub Release tag on the original release commit, while allowing Dispatcher assets to be rebuilt from a newer v3-beta commit.

## Problem
Previously, when recovering a beta release, the release tag could end up pointing to a follow-up commit rather than the original release commit. This caused `release-please` to treat the recovered release as untagged and prevented it from opening the next beta release PR.

## Solution
The fix implements a separation between the **release target SHA** (where the tag should point) and the **build SHA** (the commit from which assets are built):

- **`scripts/resolve-native-cli-release-target.sh`**: Added a new `release_commit_sha_for_version(version, build_sha)` helper function that scans the commit history from the build SHA to find a commit matching the pattern `release <version>`. This commit becomes the release target, ensuring the tag points to the correct original release commit even when assets are rebuilt from a newer state.
  - Exports both `sha` (release target SHA) and `build_sha` (the SHA used for building)
  - Falls back to `BUILD_SHA` if no matching release commit is found
  - Updates logging to clearly distinguish "Target SHA" and "Build SHA"

- **`scripts/test-resolve-native-cli-release-target.sh`**: Expanded test coverage with:
  - Configurable SHA values and commit subjects via environment variables
  - Updated mocked `git rev-parse` and `git log` to support flexible test scenarios
  - Two new recovery-focused tests:
    1. Verification that recovered releases preserve tagging behavior tied to the original release merge commit
    2. Verification that recovery uses exact beta version matching (e.g., distinguishing `beta.2` from `beta.20`)

## Changes
- `scripts/resolve-native-cli-release-target.sh`: +28 lines, -2 lines
- `scripts/test-resolve-native-cli-release-target.sh`: +40 lines, -2 lines

## Impact
- Recovered beta releases now maintain the expected tag target while Dispatcher assets can be built from the latest branch state
- Release workflow continuity is preserved, allowing subsequent release PRs to be created without blocking
- Added shell test coverage to prevent regression of this issue

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1083)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->