### PR TITLE
fix: Beta releases no longer get blocked by stale release PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Test release automation shell helpers
         run: |
           scripts/test-resolve-native-cli-release-target.sh
+          scripts/test-mark-release-pr-tagged.sh
+          scripts/test-sync-published-release-pr-labels.sh
           scripts/test-sync-release-please-go-cli-dist.sh
           scripts/test-notify-release-workflow-failure.sh
           scripts/test-install-release-filter.sh

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -22,6 +22,8 @@ on:
 
 permissions:
   contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   publish:
@@ -224,6 +226,16 @@ jobs:
               gh release edit "${RELEASE_TAG}" --draft=false
               ;;
           esac
+
+      - name: Mark release PR as tagged
+        if: github.event_name == 'push' && (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          TARGET_SHA: ${{ steps.release.outputs.sha }}
+          TARGET_BRANCH: ${{ github.ref_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: scripts/mark-release-pr-tagged.sh
 
       - name: Dry run summary
         if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run == 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,6 +58,13 @@ jobs:
         run: |
           test -f Packages/src/package.json && echo "✅ Unity package.json OK"
 
+      - name: 🏷️ Sync published release PR labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: ${{ steps.target.outputs.branch }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: scripts/sync-published-release-pr-labels.sh
+
       # ── Execute release-please ───────────────────────────
       - name: 🚀 Run release‑please
         id: release

--- a/scripts/mark-release-pr-tagged.sh
+++ b/scripts/mark-release-pr-tagged.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+: "${TARGET_SHA:?TARGET_SHA is required}"
+: "${TARGET_BRANCH:?TARGET_BRANCH is required}"
+
+REPO_FULL_NAME=${GITHUB_REPOSITORY:-hatayama/unity-cli-loop}
+PENDING_LABEL="autorelease: pending"
+TAGGED_LABEL="autorelease: tagged"
+
+RELEASE_JSON=$(gh release view "$RELEASE_TAG" \
+  --repo "$REPO_FULL_NAME" \
+  --json isDraft,targetCommitish)
+RELEASE_IS_DRAFT=$(printf '%s\n' "$RELEASE_JSON" | jq -r '.isDraft')
+RELEASE_TARGET_SHA=$(printf '%s\n' "$RELEASE_JSON" | jq -r '.targetCommitish')
+
+if [ "$RELEASE_IS_DRAFT" != "false" ]; then
+  echo "Release $RELEASE_TAG is still draft; leaving release PR labels unchanged."
+  exit 0
+fi
+
+if [ "$RELEASE_TARGET_SHA" != "$TARGET_SHA" ]; then
+  echo "Release $RELEASE_TAG points at $RELEASE_TARGET_SHA, expected $TARGET_SHA." >&2
+  exit 1
+fi
+
+PENDING_RELEASE_PRS=$(gh pr list \
+  --repo "$REPO_FULL_NAME" \
+  --state merged \
+  --base "$TARGET_BRANCH" \
+  --label "$PENDING_LABEL" \
+  --json number,title,mergeCommit)
+MATCHING_RELEASE_PRS=$(printf '%s\n' "$PENDING_RELEASE_PRS" \
+  | jq --arg target_sha "$TARGET_SHA" '[.[] | select(.mergeCommit.oid == $target_sha)]')
+MATCHING_RELEASE_PR_COUNT=$(printf '%s\n' "$MATCHING_RELEASE_PRS" | jq 'length')
+
+case "$MATCHING_RELEASE_PR_COUNT" in
+  0)
+    echo "No pending release PR found for $RELEASE_TAG at $TARGET_SHA."
+    exit 0
+    ;;
+  1)
+    ;;
+  *)
+    echo "Expected one pending release PR for $RELEASE_TAG at $TARGET_SHA, found $MATCHING_RELEASE_PR_COUNT." >&2
+    exit 1
+    ;;
+esac
+
+RELEASE_PR_NUMBER=$(printf '%s\n' "$MATCHING_RELEASE_PRS" | jq -r '.[0].number')
+gh pr edit "$RELEASE_PR_NUMBER" \
+  --repo "$REPO_FULL_NAME" \
+  --remove-label "$PENDING_LABEL" \
+  --add-label "$TAGGED_LABEL"
+
+echo "Marked release PR #$RELEASE_PR_NUMBER as tagged for $RELEASE_TAG."

--- a/scripts/sync-published-release-pr-labels.sh
+++ b/scripts/sync-published-release-pr-labels.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -eu
+
+: "${TARGET_BRANCH:?TARGET_BRANCH is required}"
+
+REPO_FULL_NAME=${GITHUB_REPOSITORY:-hatayama/unity-cli-loop}
+PENDING_LABEL="autorelease: pending"
+TAGGED_LABEL="autorelease: tagged"
+
+release_version_from_title() {
+  title=$1
+
+  printf '%s\n' "$title" | jq -R -r '
+    try capture("^chore(\\([^)]*\\))?: release (?<version>[0-9][A-Za-z0-9._-]*)$").version catch ""
+  '
+}
+
+release_is_published_at_sha() {
+  release_tag=$1
+  expected_sha=$2
+  release_error_file=$(mktemp)
+
+  if ! release_json=$(gh release view "$release_tag" \
+    --repo "$REPO_FULL_NAME" \
+    --json isDraft,targetCommitish 2>"$release_error_file"); then
+    release_error=$(cat "$release_error_file")
+    rm -f "$release_error_file"
+    case "$release_error" in
+      *"release not found"*|*"HTTP 404"*|*"Not Found"*)
+        return 1
+        ;;
+    esac
+
+    printf '%s\n' "$release_error" >&2
+    return 2
+  fi
+
+  rm -f "$release_error_file"
+  release_is_draft=$(printf '%s\n' "$release_json" | jq -r '.isDraft')
+  release_target_sha=$(printf '%s\n' "$release_json" | jq -r '.targetCommitish')
+
+  [ "$release_is_draft" = "false" ] && [ "$release_target_sha" = "$expected_sha" ]
+}
+
+PENDING_RELEASE_PRS=$(gh pr list \
+  --repo "$REPO_FULL_NAME" \
+  --state merged \
+  --base "$TARGET_BRANCH" \
+  --label "$PENDING_LABEL" \
+  --json number,title,mergeCommit)
+
+PENDING_RELEASE_PR_COUNT=$(printf '%s\n' "$PENDING_RELEASE_PRS" | jq 'length')
+if [ "$PENDING_RELEASE_PR_COUNT" -eq 0 ]; then
+  echo "No pending merged release PR labels found for $TARGET_BRANCH."
+  exit 0
+fi
+
+printf '%s\n' "$PENDING_RELEASE_PRS" | jq -c '.[]' | while IFS= read -r release_pr_json; do
+  release_pr_number=$(printf '%s\n' "$release_pr_json" | jq -r '.number')
+  release_pr_title=$(printf '%s\n' "$release_pr_json" | jq -r '.title')
+  release_pr_sha=$(printf '%s\n' "$release_pr_json" | jq -r '.mergeCommit.oid')
+  release_version=$(release_version_from_title "$release_pr_title")
+
+  if [ -z "$release_version" ]; then
+    echo "Skipping pending PR #$release_pr_number because the title is not a release-please release title: $release_pr_title"
+    continue
+  fi
+
+  release_tag="v$release_version"
+  if release_is_published_at_sha "$release_tag" "$release_pr_sha"; then
+    gh pr edit "$release_pr_number" \
+      --repo "$REPO_FULL_NAME" \
+      --remove-label "$PENDING_LABEL" \
+      --add-label "$TAGGED_LABEL"
+    echo "Marked release PR #$release_pr_number as tagged for $release_tag."
+    continue
+  fi
+
+  echo "Pending release PR #$release_pr_number does not have a matching published release yet: $release_tag"
+done

--- a/scripts/sync-published-release-pr-labels.sh
+++ b/scripts/sync-published-release-pr-labels.sh
@@ -67,14 +67,25 @@ printf '%s\n' "$PENDING_RELEASE_PRS" | jq -c '.[]' | while IFS= read -r release_
   fi
 
   release_tag="v$release_version"
-  if release_is_published_at_sha "$release_tag" "$release_pr_sha"; then
-    gh pr edit "$release_pr_number" \
-      --repo "$REPO_FULL_NAME" \
-      --remove-label "$PENDING_LABEL" \
-      --add-label "$TAGGED_LABEL"
-    echo "Marked release PR #$release_pr_number as tagged for $release_tag."
-    continue
-  fi
+  set +e
+  release_is_published_at_sha "$release_tag" "$release_pr_sha"
+  release_status=$?
+  set -e
 
-  echo "Pending release PR #$release_pr_number does not have a matching published release yet: $release_tag"
+  case "$release_status" in
+    0)
+      gh pr edit "$release_pr_number" \
+        --repo "$REPO_FULL_NAME" \
+        --remove-label "$PENDING_LABEL" \
+        --add-label "$TAGGED_LABEL"
+      echo "Marked release PR #$release_pr_number as tagged for $release_tag."
+      ;;
+    1)
+      echo "Pending release PR #$release_pr_number does not have a matching published release yet: $release_tag"
+      continue
+      ;;
+    *)
+      exit "$release_status"
+      ;;
+  esac
 done

--- a/scripts/test-mark-release-pr-tagged.sh
+++ b/scripts/test-mark-release-pr-tagged.sh
@@ -55,6 +55,19 @@ assert_contains() {
   fi
 }
 
+assert_file_equals() {
+  file=$1
+  expected=$2
+  actual=$(cat "$file")
+
+  if [ "$actual" != "$expected" ]; then
+    echo "Expected $file to equal: $expected" >&2
+    echo "Actual content:" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
 assert_not_contains() {
   file=$1
   unexpected=$2
@@ -101,7 +114,7 @@ test_marks_matching_release_pr() {
     '{"isDraft":false,"targetCommitish":"abc123"}' \
     '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]'
 
-  assert_contains "$TMP_DIR/marks-pr/status.txt" "0"
+  assert_file_equals "$TMP_DIR/marks-pr/status.txt" "0"
   assert_contains "$TMP_DIR/marks-pr/gh.log" "pr edit 1082 --repo hatayama/unity-cli-loop --remove-label autorelease: pending --add-label autorelease: tagged"
   assert_contains "$TMP_DIR/marks-pr/output.txt" "Marked release PR #1082 as tagged for v3.0.0-beta.3."
 }
@@ -112,7 +125,7 @@ test_skips_draft_release() {
     '{"isDraft":true,"targetCommitish":"abc123"}' \
     '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]'
 
-  assert_contains "$TMP_DIR/draft-release/status.txt" "0"
+  assert_file_equals "$TMP_DIR/draft-release/status.txt" "0"
   assert_contains "$TMP_DIR/draft-release/output.txt" "Release v3.0.0-beta.3 is still draft; leaving release PR labels unchanged."
   assert_not_contains "$TMP_DIR/draft-release/gh.log" "pr edit"
 }
@@ -123,7 +136,7 @@ test_fails_on_release_target_mismatch() {
     '{"isDraft":false,"targetCommitish":"different"}' \
     '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]'
 
-  assert_contains "$TMP_DIR/target-mismatch/status.txt" "1"
+  assert_file_equals "$TMP_DIR/target-mismatch/status.txt" "1"
   assert_contains "$TMP_DIR/target-mismatch/stderr.txt" "Release v3.0.0-beta.3 points at different, expected abc123."
   assert_not_contains "$TMP_DIR/target-mismatch/gh.log" "pr edit"
 }
@@ -134,7 +147,7 @@ test_skips_when_pending_release_pr_is_missing() {
     '{"isDraft":false,"targetCommitish":"abc123"}' \
     '[]'
 
-  assert_contains "$TMP_DIR/missing-pr/status.txt" "0"
+  assert_file_equals "$TMP_DIR/missing-pr/status.txt" "0"
   assert_contains "$TMP_DIR/missing-pr/output.txt" "No pending release PR found for v3.0.0-beta.3 at abc123."
   assert_not_contains "$TMP_DIR/missing-pr/gh.log" "pr edit"
 }

--- a/scripts/test-mark-release-pr-tagged.sh
+++ b/scripts/test-mark-release-pr-tagged.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/mark-release-pr-tagged.sh"
+TMP_DIR=$(mktemp -d)
+ORIGINAL_PATH=$PATH
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT HUP TERM
+
+write_mock_gh() {
+  work_dir=$1
+  mock_bin="$work_dir/bin"
+  mkdir -p "$mock_bin"
+
+  cat > "$mock_bin/gh" <<'MOCK_GH'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$GH_LOG"
+
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  printf '%s\n' "$GH_RELEASE_JSON"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '%s\n' "$GH_PR_LIST_JSON"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+  exit 0
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 1
+MOCK_GH
+
+  chmod +x "$mock_bin/gh"
+}
+
+assert_contains() {
+  file=$1
+  expected=$2
+
+  if ! grep -F "$expected" "$file" >/dev/null; then
+    echo "Expected $file to contain: $expected" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  file=$1
+  unexpected=$2
+
+  if grep -F "$unexpected" "$file" >/dev/null; then
+    echo "Expected $file not to contain: $unexpected" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+run_case() {
+  name=$1
+  release_json=$2
+  pr_list_json=$3
+
+  work_dir="$TMP_DIR/$name"
+  mkdir -p "$work_dir"
+  write_mock_gh "$work_dir"
+  touch "$work_dir/gh.log"
+
+  (
+    cd "$work_dir"
+    set +e
+    PATH="$work_dir/bin:$ORIGINAL_PATH" \
+      GH_LOG="$work_dir/gh.log" \
+      GH_RELEASE_JSON="$release_json" \
+      GH_PR_LIST_JSON="$pr_list_json" \
+      RELEASE_TAG=v3.0.0-beta.3 \
+      TARGET_SHA=abc123 \
+      TARGET_BRANCH=v3-beta \
+      GITHUB_REPOSITORY=hatayama/unity-cli-loop \
+      "$SCRIPT" > output.txt 2> stderr.txt
+    status=$?
+    set -e
+
+    printf '%s\n' "$status" > status.txt
+  )
+}
+
+# Verifies a published release moves the matching release PR from pending to tagged.
+test_marks_matching_release_pr() {
+  run_case marks-pr \
+    '{"isDraft":false,"targetCommitish":"abc123"}' \
+    '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]'
+
+  assert_contains "$TMP_DIR/marks-pr/status.txt" "0"
+  assert_contains "$TMP_DIR/marks-pr/gh.log" "pr edit 1082 --repo hatayama/unity-cli-loop --remove-label autorelease: pending --add-label autorelease: tagged"
+  assert_contains "$TMP_DIR/marks-pr/output.txt" "Marked release PR #1082 as tagged for v3.0.0-beta.3."
+}
+
+# Verifies draft releases do not update release PR labels.
+test_skips_draft_release() {
+  run_case draft-release \
+    '{"isDraft":true,"targetCommitish":"abc123"}' \
+    '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]'
+
+  assert_contains "$TMP_DIR/draft-release/status.txt" "0"
+  assert_contains "$TMP_DIR/draft-release/output.txt" "Release v3.0.0-beta.3 is still draft; leaving release PR labels unchanged."
+  assert_not_contains "$TMP_DIR/draft-release/gh.log" "pr edit"
+}
+
+# Verifies release target mismatches fail before editing labels.
+test_fails_on_release_target_mismatch() {
+  run_case target-mismatch \
+    '{"isDraft":false,"targetCommitish":"different"}' \
+    '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]'
+
+  assert_contains "$TMP_DIR/target-mismatch/status.txt" "1"
+  assert_contains "$TMP_DIR/target-mismatch/stderr.txt" "Release v3.0.0-beta.3 points at different, expected abc123."
+  assert_not_contains "$TMP_DIR/target-mismatch/gh.log" "pr edit"
+}
+
+# Verifies missing pending PRs are treated as already settled.
+test_skips_when_pending_release_pr_is_missing() {
+  run_case missing-pr \
+    '{"isDraft":false,"targetCommitish":"abc123"}' \
+    '[]'
+
+  assert_contains "$TMP_DIR/missing-pr/status.txt" "0"
+  assert_contains "$TMP_DIR/missing-pr/output.txt" "No pending release PR found for v3.0.0-beta.3 at abc123."
+  assert_not_contains "$TMP_DIR/missing-pr/gh.log" "pr edit"
+}
+
+test_marks_matching_release_pr
+test_skips_draft_release
+test_fails_on_release_target_mismatch
+test_skips_when_pending_release_pr_is_missing

--- a/scripts/test-sync-published-release-pr-labels.sh
+++ b/scripts/test-sync-published-release-pr-labels.sh
@@ -1,0 +1,148 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/sync-published-release-pr-labels.sh"
+TMP_DIR=$(mktemp -d)
+ORIGINAL_PATH=$PATH
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT HUP TERM
+
+write_mock_gh() {
+  work_dir=$1
+  mock_bin="$work_dir/bin"
+  mkdir -p "$mock_bin"
+
+  cat > "$mock_bin/gh" <<'MOCK_GH'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$GH_LOG"
+
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '%s\n' "$GH_PR_LIST_JSON"
+  exit 0
+fi
+
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  release_tag=$3
+  release_json=$(printf '%s\n' "$GH_RELEASES_JSON" | jq -c --arg tag "$release_tag" '.[$tag] // empty')
+  if [ -z "$release_json" ]; then
+    echo "release not found: $release_tag" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$release_json"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+  exit 0
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 1
+MOCK_GH
+
+  chmod +x "$mock_bin/gh"
+}
+
+assert_contains() {
+  file=$1
+  expected=$2
+
+  if ! grep -F "$expected" "$file" >/dev/null; then
+    echo "Expected $file to contain: $expected" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  file=$1
+  unexpected=$2
+
+  if grep -F "$unexpected" "$file" >/dev/null; then
+    echo "Expected $file not to contain: $unexpected" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+run_case() {
+  name=$1
+  pr_list_json=$2
+  releases_json=$3
+
+  work_dir="$TMP_DIR/$name"
+  mkdir -p "$work_dir"
+  write_mock_gh "$work_dir"
+  touch "$work_dir/gh.log"
+
+  (
+    cd "$work_dir"
+    set +e
+    PATH="$work_dir/bin:$ORIGINAL_PATH" \
+      GH_LOG="$work_dir/gh.log" \
+      GH_PR_LIST_JSON="$pr_list_json" \
+      GH_RELEASES_JSON="$releases_json" \
+      TARGET_BRANCH=v3-beta \
+      GITHUB_REPOSITORY=hatayama/unity-cli-loop \
+      "$SCRIPT" > output.txt 2> stderr.txt
+    status=$?
+    set -e
+
+    printf '%s\n' "$status" > status.txt
+  )
+}
+
+# Verifies stale pending labels are repaired when the published release matches the merge commit.
+test_marks_stale_pending_release_pr() {
+  run_case marks-stale \
+    '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]' \
+    '{"v3.0.0-beta.3":{"isDraft":false,"targetCommitish":"abc123"}}'
+
+  assert_contains "$TMP_DIR/marks-stale/status.txt" "0"
+  assert_contains "$TMP_DIR/marks-stale/gh.log" "pr edit 1082 --repo hatayama/unity-cli-loop --remove-label autorelease: pending --add-label autorelease: tagged"
+  assert_contains "$TMP_DIR/marks-stale/output.txt" "Marked release PR #1082 as tagged for v3.0.0-beta.3."
+}
+
+# Verifies draft releases remain pending so release completion is not hidden.
+test_keeps_draft_release_pending() {
+  run_case draft-release \
+    '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]' \
+    '{"v3.0.0-beta.3":{"isDraft":true,"targetCommitish":"abc123"}}'
+
+  assert_contains "$TMP_DIR/draft-release/status.txt" "0"
+  assert_contains "$TMP_DIR/draft-release/output.txt" "Pending release PR #1082 does not have a matching published release yet: v3.0.0-beta.3"
+  assert_not_contains "$TMP_DIR/draft-release/gh.log" "pr edit"
+}
+
+# Verifies release target mismatches remain pending.
+test_keeps_mismatched_release_pending() {
+  run_case target-mismatch \
+    '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]' \
+    '{"v3.0.0-beta.3":{"isDraft":false,"targetCommitish":"different"}}'
+
+  assert_contains "$TMP_DIR/target-mismatch/status.txt" "0"
+  assert_contains "$TMP_DIR/target-mismatch/output.txt" "Pending release PR #1082 does not have a matching published release yet: v3.0.0-beta.3"
+  assert_not_contains "$TMP_DIR/target-mismatch/gh.log" "pr edit"
+}
+
+# Verifies there is no edit when no merged pending release PR exists.
+test_exits_when_no_pending_release_pr_exists() {
+  run_case no-pending '[]' '{}'
+
+  assert_contains "$TMP_DIR/no-pending/status.txt" "0"
+  assert_contains "$TMP_DIR/no-pending/output.txt" "No pending merged release PR labels found for v3-beta."
+  assert_not_contains "$TMP_DIR/no-pending/gh.log" "pr edit"
+}
+
+test_marks_stale_pending_release_pr
+test_keeps_draft_release_pending
+test_keeps_mismatched_release_pending
+test_exits_when_no_pending_release_pr_exists

--- a/scripts/test-sync-published-release-pr-labels.sh
+++ b/scripts/test-sync-published-release-pr-labels.sh
@@ -67,6 +67,19 @@ assert_contains() {
   fi
 }
 
+assert_file_equals() {
+  file=$1
+  expected=$2
+  actual=$(cat "$file")
+
+  if [ "$actual" != "$expected" ]; then
+    echo "Expected $file to equal: $expected" >&2
+    echo "Actual content:" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
 assert_not_contains() {
   file=$1
   unexpected=$2
@@ -113,7 +126,7 @@ test_marks_stale_pending_release_pr() {
     '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]' \
     '{"v3.0.0-beta.3":{"isDraft":false,"targetCommitish":"abc123"}}'
 
-  assert_contains "$TMP_DIR/marks-stale/status.txt" "0"
+  assert_file_equals "$TMP_DIR/marks-stale/status.txt" "0"
   assert_contains "$TMP_DIR/marks-stale/gh.log" "pr edit 1082 --repo hatayama/unity-cli-loop --remove-label autorelease: pending --add-label autorelease: tagged"
   assert_contains "$TMP_DIR/marks-stale/output.txt" "Marked release PR #1082 as tagged for v3.0.0-beta.3."
 }
@@ -124,7 +137,7 @@ test_keeps_draft_release_pending() {
     '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]' \
     '{"v3.0.0-beta.3":{"isDraft":true,"targetCommitish":"abc123"}}'
 
-  assert_contains "$TMP_DIR/draft-release/status.txt" "0"
+  assert_file_equals "$TMP_DIR/draft-release/status.txt" "0"
   assert_contains "$TMP_DIR/draft-release/output.txt" "Pending release PR #1082 does not have a matching published release yet: v3.0.0-beta.3"
   assert_not_contains "$TMP_DIR/draft-release/gh.log" "pr edit"
 }
@@ -135,7 +148,7 @@ test_keeps_mismatched_release_pending() {
     '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]' \
     '{"v3.0.0-beta.3":{"isDraft":false,"targetCommitish":"different"}}'
 
-  assert_contains "$TMP_DIR/target-mismatch/status.txt" "0"
+  assert_file_equals "$TMP_DIR/target-mismatch/status.txt" "0"
   assert_contains "$TMP_DIR/target-mismatch/output.txt" "Pending release PR #1082 does not have a matching published release yet: v3.0.0-beta.3"
   assert_not_contains "$TMP_DIR/target-mismatch/gh.log" "pr edit"
 }
@@ -144,7 +157,7 @@ test_keeps_mismatched_release_pending() {
 test_exits_when_no_pending_release_pr_exists() {
   run_case no-pending '[]' '{}'
 
-  assert_contains "$TMP_DIR/no-pending/status.txt" "0"
+  assert_file_equals "$TMP_DIR/no-pending/status.txt" "0"
   assert_contains "$TMP_DIR/no-pending/output.txt" "No pending merged release PR labels found for v3-beta."
   assert_not_contains "$TMP_DIR/no-pending/gh.log" "pr edit"
 }
@@ -156,7 +169,7 @@ test_fails_when_release_lookup_fails_unexpectedly() {
     '{}' \
     'GraphQL: Resource not accessible by integration'
 
-  assert_contains "$TMP_DIR/release-api-failure/status.txt" "2"
+  assert_file_equals "$TMP_DIR/release-api-failure/status.txt" "2"
   assert_contains "$TMP_DIR/release-api-failure/stderr.txt" "GraphQL: Resource not accessible by integration"
   assert_not_contains "$TMP_DIR/release-api-failure/gh.log" "pr edit"
 }

--- a/scripts/test-sync-published-release-pr-labels.sh
+++ b/scripts/test-sync-published-release-pr-labels.sh
@@ -29,6 +29,11 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
 fi
 
 if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  if [ -n "$GH_RELEASE_VIEW_ERROR" ]; then
+    printf '%s\n' "$GH_RELEASE_VIEW_ERROR" >&2
+    exit 1
+  fi
+
   release_tag=$3
   release_json=$(printf '%s\n' "$GH_RELEASES_JSON" | jq -c --arg tag "$release_tag" '.[$tag] // empty')
   if [ -z "$release_json" ]; then
@@ -77,6 +82,7 @@ run_case() {
   name=$1
   pr_list_json=$2
   releases_json=$3
+  release_view_error=${4:-}
 
   work_dir="$TMP_DIR/$name"
   mkdir -p "$work_dir"
@@ -90,6 +96,7 @@ run_case() {
       GH_LOG="$work_dir/gh.log" \
       GH_PR_LIST_JSON="$pr_list_json" \
       GH_RELEASES_JSON="$releases_json" \
+      GH_RELEASE_VIEW_ERROR="$release_view_error" \
       TARGET_BRANCH=v3-beta \
       GITHUB_REPOSITORY=hatayama/unity-cli-loop \
       "$SCRIPT" > output.txt 2> stderr.txt
@@ -142,7 +149,20 @@ test_exits_when_no_pending_release_pr_exists() {
   assert_not_contains "$TMP_DIR/no-pending/gh.log" "pr edit"
 }
 
+# Verifies release API failures stop the sync instead of hiding stale labels.
+test_fails_when_release_lookup_fails_unexpectedly() {
+  run_case release-api-failure \
+    '[{"number":1082,"title":"chore(v3-beta): release 3.0.0-beta.3","mergeCommit":{"oid":"abc123"}}]' \
+    '{}' \
+    'GraphQL: Resource not accessible by integration'
+
+  assert_contains "$TMP_DIR/release-api-failure/status.txt" "2"
+  assert_contains "$TMP_DIR/release-api-failure/stderr.txt" "GraphQL: Resource not accessible by integration"
+  assert_not_contains "$TMP_DIR/release-api-failure/gh.log" "pr edit"
+}
+
 test_marks_stale_pending_release_pr
 test_keeps_draft_release_pending
 test_keeps_mismatched_release_pending
 test_exits_when_no_pending_release_pr_exists
+test_fails_when_release_lookup_fails_unexpectedly


### PR DESCRIPTION
## Summary
- Beta release automation now repairs stale release PR labels before running release-please.
- Native CLI publishing marks the matching release PR as tagged after a release is published.

## User Impact
- Previously, a beta release could publish successfully but leave its release PR marked as pending, causing the next release-please run to abort without opening a new release PR.
- After this change, the workflow repairs that stale state automatically and continues preparing the next beta release PR.

## Changes
- Added a publish-time step that moves the matching release PR from `autorelease: pending` to `autorelease: tagged`.
- Added a release-please preflight that repairs already-published release PRs that still have the pending label.
- Added shell tests for both label repair paths and wired them into the release automation helper test suite.

## Verification
- `scripts/test-resolve-native-cli-release-target.sh`
- `scripts/test-mark-release-pr-tagged.sh`
- `scripts/test-sync-published-release-pr-labels.sh`
- `scripts/test-sync-release-please-go-cli-dist.sh`
- `scripts/test-notify-release-workflow-failure.sh`
- `scripts/test-install-release-filter.sh`