### PR TITLE
fix: Release PRs no longer include old changelog entries after publishing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Test release automation shell helpers
         run: |
           scripts/test-resolve-native-cli-release-target.sh
+          scripts/test-is-release-please-release-commit.sh
           scripts/test-mark-release-pr-tagged.sh
           scripts/test-sync-published-release-pr-labels.sh
           scripts/test-sync-release-please-go-cli-dist.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,6 +46,17 @@ jobs:
           echo "branch=${TARGET_BRANCH}" >> "$GITHUB_OUTPUT"
           echo "sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
 
+      - name: 🧭 Detect release commit
+        id: release_commit
+        run: |
+          COMMIT_SUBJECT="$(git log -1 --format=%s)"
+          if scripts/is-release-please-release-commit.sh "${COMMIT_SUBJECT}"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Release commit detected; release-please will wait for the next non-release commit."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # ── Debug: Show repository structure ─────────────────────────
       - name: 🕵️ Show file tree
         run: |
@@ -59,6 +70,7 @@ jobs:
           test -f Packages/src/package.json && echo "✅ Unity package.json OK"
 
       - name: 🏷️ Sync published release PR labels
+        if: steps.release_commit.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ steps.target.outputs.branch }}
@@ -67,6 +79,7 @@ jobs:
 
       # ── Execute release-please ───────────────────────────
       - name: 🚀 Run release‑please
+        if: steps.release_commit.outputs.skip != 'true'
         id: release
         uses: googleapis/release-please-action@v4
         with:
@@ -77,20 +90,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Go for release PR binary sync
-        if: steps.target.outputs.branch == 'v3-beta'
+        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true'
         uses: actions/setup-go@v6
         with:
           go-version-file: Packages/src/Cli~/.go-version
           cache-dependency-path: Packages/src/Cli~/**/go.sum
 
       - name: Install golangci-lint for release PR binary sync
-        if: steps.target.outputs.branch == 'v3-beta'
+        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true'
         run: |
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Sync native CLI binaries into release PR
-        if: steps.target.outputs.branch == 'v3-beta'
+        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ steps.target.outputs.branch }}

--- a/scripts/is-release-please-release-commit.sh
+++ b/scripts/is-release-please-release-commit.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+COMMIT_SUBJECT=${1:?commit subject is required}
+
+case "$COMMIT_SUBJECT" in
+  "chore: release "*|chore\(*\):\ release\ *)
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac

--- a/scripts/test-is-release-please-release-commit.sh
+++ b/scripts/test-is-release-please-release-commit.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/is-release-please-release-commit.sh"
+
+assert_release_commit() {
+  subject=$1
+
+  if ! "$SCRIPT" "$subject"; then
+    echo "Expected release commit subject: $subject" >&2
+    exit 1
+  fi
+}
+
+assert_not_release_commit() {
+  subject=$1
+
+  if "$SCRIPT" "$subject"; then
+    echo "Expected non-release commit subject: $subject" >&2
+    exit 1
+  fi
+}
+
+# Verifies the scoped release-please commit title used by beta release PRs is detected.
+test_detects_scoped_release_commit() {
+  assert_release_commit "chore(v3-beta): release 3.0.0-beta.4"
+}
+
+# Verifies unscoped release-please commit titles are detected for the main branch.
+test_detects_unscoped_release_commit() {
+  assert_release_commit "chore: release 1.2.3"
+}
+
+# Verifies ordinary feature commits continue to run release-please.
+test_rejects_feature_commit() {
+  assert_not_release_commit "fix: Setup now upgrades to the native CLI cleanly"
+}
+
+# Verifies release-related maintenance commits are not treated as release PR merges.
+test_rejects_non_release_chore() {
+  assert_not_release_commit "chore(v3-beta): update release notes"
+}
+
+test_detects_scoped_release_commit
+test_detects_unscoped_release_commit
+test_rejects_feature_commit
+test_rejects_non_release_chore


### PR DESCRIPTION
## Summary
- Prevent release-please from opening a new release PR from a release commit before the native publisher has finished creating the GitHub release.
- Keep generated release PRs scoped to the actual changes since the latest published release.

## User Impact
- A merged release PR no longer immediately creates a follow-up release PR with historical changelog entries.
- Maintainers can close the oversized beta.5 release PR and continue from the next real change.

## Changes
- Detect release-please release commit subjects before running the release workflow body.
- Skip release-please and release PR binary sync when the push is only a release commit.
- Add a shell helper test so scoped beta release commits and normal commits are handled separately.

## Verification
- scripts/test-resolve-native-cli-release-target.sh
- scripts/test-is-release-please-release-commit.sh
- scripts/test-mark-release-pr-tagged.sh
- scripts/test-sync-published-release-pr-labels.sh
- scripts/test-sync-release-please-go-cli-dist.sh
- scripts/test-notify-release-workflow-failure.sh
- scripts/test-install-release-filter.sh