### PR TITLE
fix: CLI and Skills reload buttons refresh independently

### DIFF
--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -101,22 +101,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(text, Is.EqualTo(expectedText));
         }
 
-        [TestCase(false, false, SkillInstallState.Missing, false)]
-        [TestCase(true, true, SkillInstallState.Missing, false)]
-        [TestCase(true, false, SkillInstallState.Checking, false)]
-        [TestCase(true, false, SkillInstallState.Installed, false)]
-        [TestCase(true, false, SkillInstallState.Outdated, true)]
-        [TestCase(true, false, SkillInstallState.Missing, true)]
+        [TestCase(false, false, false, SkillInstallState.Missing, false)]
+        [TestCase(true, true, false, SkillInstallState.Missing, false)]
+        [TestCase(true, false, true, SkillInstallState.Missing, false)]
+        [TestCase(true, false, false, SkillInstallState.Checking, false)]
+        [TestCase(true, false, false, SkillInstallState.Installed, false)]
+        [TestCase(true, false, false, SkillInstallState.Outdated, true)]
+        [TestCase(true, false, false, SkillInstallState.Missing, true)]
         public void IsInstallSkillsButtonEnabled_ReturnsExpectedValue(
             bool isCliInstalled,
             bool isInstallingSkills,
+            bool isChecking,
             SkillInstallState installState,
             bool expectedEnabled)
         {
-            // Verifies that the Skills install button ignores CLI-only refresh work.
+            // Verifies that the Skills install button stays gated during CLI refresh work.
             bool enabled = CliSetupSection.IsInstallSkillsButtonEnabled(
                 isCliInstalled,
                 isInstallingSkills,
+                isChecking,
                 installState);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
@@ -131,14 +134,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CliSetupData data = CreateData(
                 isCliInstalled: true,
                 isChecking: true,
-                selectedTargetInstallState: SkillInstallState.Checking);
+                selectedTargetInstallState: SkillInstallState.Missing);
 
             section.Update(data);
 
             Button refreshSkillsButton = root.Q<Button>("refresh-skills-state-button");
             VisualElement skillsSubsection = root.Q<VisualElement>("skills-subsection");
+            Button installSkillsButton = root.Q<Button>("install-skills-button");
             Assert.That(refreshSkillsButton.enabledSelf, Is.True);
             Assert.That(skillsSubsection.enabledSelf, Is.True);
+            Assert.That(installSkillsButton.enabledSelf, Is.False);
         }
 
         private static VisualElement CreateRootElement()

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -1,4 +1,6 @@
 using NUnit.Framework;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
 
 using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.Domain;
@@ -120,22 +122,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }
 
-        [TestCase(false, false, SkillInstallState.Missing, false)]
-        [TestCase(true, true, SkillInstallState.Missing, false)]
-        [TestCase(true, false, SkillInstallState.Checking, false)]
-        [TestCase(true, false, SkillInstallState.Missing, true)]
-        [TestCase(true, false, SkillInstallState.Installed, true)]
+        [TestCase(false, false, false)]
+        [TestCase(true, true, false)]
+        [TestCase(true, false, true)]
         public void IsRefreshSkillsButtonEnabled_ReturnsExpectedValue(
             bool isCliInstalled,
             bool isInstallingSkills,
-            SkillInstallState installState,
             bool expectedEnabled)
         {
             // Verifies that the Skills reload button ignores CLI-only refresh work.
             bool enabled = CliSetupSection.IsRefreshSkillsButtonEnabled(
                 isCliInstalled,
-                isInstallingSkills,
-                installState);
+                isInstallingSkills);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }
@@ -150,6 +148,68 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool enabled = CliSetupSection.IsSkillsSubsectionEnabled(isCliInstalled);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
+        }
+
+        [Test]
+        public void Update_WhenCliRefreshIsChecking_KeepsSkillsReloadButtonEnabled()
+        {
+            // Verifies that a CLI-only refresh does not block manual Skills reload.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: true,
+                selectedTargetInstallState: SkillInstallState.Checking);
+
+            section.Update(data);
+
+            Button refreshSkillsButton = root.Q<Button>("refresh-skills-state-button");
+            VisualElement skillsSubsection = root.Q<VisualElement>("skills-subsection");
+            Assert.That(refreshSkillsButton.enabledSelf, Is.True);
+            Assert.That(skillsSubsection.enabledSelf, Is.True);
+        }
+
+        private static VisualElement CreateRootElement()
+        {
+            VisualElement root = new();
+            root.Add(new VisualElement { name = "cli-status-icon" });
+            root.Add(new Label { name = "cli-status-label" });
+            root.Add(new Button { name = "refresh-cli-version-button" });
+            root.Add(new Button { name = "install-cli-button" });
+            root.Add(new EnumField { name = "skills-target-field" });
+            root.Add(new Button { name = "refresh-skills-state-button" });
+            root.Add(new VisualElement { name = "group-skills-row" });
+            root.Add(new Toggle { name = "group-skills-toggle" });
+            root.Add(new Label { name = "group-skills-label" });
+            root.Add(new Button { name = "install-skills-button" });
+            root.Add(new VisualElement { name = "skills-subsection" });
+            return root;
+        }
+
+        private static CliSetupData CreateData(
+            bool isCliInstalled,
+            bool isChecking,
+            SkillInstallState selectedTargetInstallState)
+        {
+            return new CliSetupData(
+                isCliInstalled,
+                cliVersion: "3.0.0",
+                requiredDispatcherVersion: "3.0.0",
+                needsUpdate: false,
+                needsDowngrade: false,
+                canUninstallCli: true,
+                isInstallingCli: false,
+                isChecking,
+                isClaudeSkillsInstalled: false,
+                isAgentsSkillsInstalled: false,
+                isCursorSkillsInstalled: false,
+                isGeminiSkillsInstalled: false,
+                isCodexSkillsInstalled: false,
+                isAntigravitySkillsInstalled: false,
+                selectedTargetInstallState,
+                SkillsTarget.Claude,
+                groupSkillsUnderUnityCliLoop: false,
+                isInstallingSkills: false);
         }
     }
 }

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -99,25 +99,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(text, Is.EqualTo(expectedText));
         }
 
-        [TestCase(false, false, false, SkillInstallState.Missing, false)]
-        [TestCase(true, true, false, SkillInstallState.Missing, false)]
-        [TestCase(true, false, true, SkillInstallState.Missing, false)]
-        [TestCase(true, false, false, SkillInstallState.Checking, false)]
-        [TestCase(true, false, false, SkillInstallState.Installed, false)]
-        [TestCase(true, false, false, SkillInstallState.Outdated, true)]
-        [TestCase(true, false, false, SkillInstallState.Missing, true)]
+        [TestCase(false, false, SkillInstallState.Missing, false)]
+        [TestCase(true, true, SkillInstallState.Missing, false)]
+        [TestCase(true, false, SkillInstallState.Checking, false)]
+        [TestCase(true, false, SkillInstallState.Installed, false)]
+        [TestCase(true, false, SkillInstallState.Outdated, true)]
+        [TestCase(true, false, SkillInstallState.Missing, true)]
         public void IsInstallSkillsButtonEnabled_ReturnsExpectedValue(
             bool isCliInstalled,
             bool isInstallingSkills,
-            bool isChecking,
             SkillInstallState installState,
             bool expectedEnabled)
         {
+            // Verifies that the Skills install button ignores CLI-only refresh work.
             bool enabled = CliSetupSection.IsInstallSkillsButtonEnabled(
                 isCliInstalled,
                 isInstallingSkills,
-                isChecking,
                 installState);
+
+            Assert.That(enabled, Is.EqualTo(expectedEnabled));
+        }
+
+        [TestCase(false, false, SkillInstallState.Missing, false)]
+        [TestCase(true, true, SkillInstallState.Missing, false)]
+        [TestCase(true, false, SkillInstallState.Checking, false)]
+        [TestCase(true, false, SkillInstallState.Missing, true)]
+        [TestCase(true, false, SkillInstallState.Installed, true)]
+        public void IsRefreshSkillsButtonEnabled_ReturnsExpectedValue(
+            bool isCliInstalled,
+            bool isInstallingSkills,
+            SkillInstallState installState,
+            bool expectedEnabled)
+        {
+            // Verifies that the Skills reload button ignores CLI-only refresh work.
+            bool enabled = CliSetupSection.IsRefreshSkillsButtonEnabled(
+                isCliInstalled,
+                isInstallingSkills,
+                installState);
+
+            Assert.That(enabled, Is.EqualTo(expectedEnabled));
+        }
+
+        [TestCase(false, false)]
+        [TestCase(true, true)]
+        public void IsSkillsSubsectionEnabled_ReturnsExpectedValue(
+            bool isCliInstalled,
+            bool expectedEnabled)
+        {
+            // Verifies that CLI-only refresh work does not disable the Skills section.
+            bool enabled = CliSetupSection.IsSkillsSubsectionEnabled(isCliInstalled);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -145,6 +145,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(installSkillsButton.enabledSelf, Is.True);
         }
 
+        [Test]
+        public void Update_WhenSkillsStateIsChecking_DisablesSkillsTargetField()
+        {
+            // Verifies that the Skills target cannot change while the selected target state is being checked.
+            VisualElement root = CreateRootElement();
+            CliSetupSection section = new(root);
+            CliSetupData data = CreateData(
+                isCliInstalled: true,
+                isChecking: false,
+                selectedTargetInstallState: SkillInstallState.Checking);
+
+            section.Update(data);
+
+            EnumField skillsTargetField = root.Q<EnumField>("skills-target-field");
+            Assert.That(skillsTargetField.enabledSelf, Is.False);
+        }
+
         private static VisualElement CreateRootElement()
         {
             VisualElement root = new();

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -101,34 +101,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(text, Is.EqualTo(expectedText));
         }
 
-        [TestCase(false, false, false, SkillInstallState.Missing, false)]
-        [TestCase(true, true, false, SkillInstallState.Missing, false)]
-        [TestCase(true, false, true, SkillInstallState.Missing, false)]
-        [TestCase(true, false, false, SkillInstallState.Checking, false)]
-        [TestCase(true, false, false, SkillInstallState.Installed, false)]
-        [TestCase(true, false, false, SkillInstallState.Outdated, true)]
-        [TestCase(true, false, false, SkillInstallState.Missing, true)]
+        [TestCase(false, false, SkillInstallState.Missing, false)]
+        [TestCase(true, true, SkillInstallState.Missing, false)]
+        [TestCase(true, false, SkillInstallState.Checking, false)]
+        [TestCase(true, false, SkillInstallState.Installed, false)]
+        [TestCase(true, false, SkillInstallState.Outdated, true)]
+        [TestCase(true, false, SkillInstallState.Missing, true)]
         public void IsInstallSkillsButtonEnabled_ReturnsExpectedValue(
             bool isCliInstalled,
             bool isInstallingSkills,
-            bool isChecking,
             SkillInstallState installState,
             bool expectedEnabled)
         {
-            // Verifies that the Skills install button stays gated during CLI refresh work.
+            // Verifies that the Skills install button follows only Skills state.
             bool enabled = CliSetupSection.IsInstallSkillsButtonEnabled(
                 isCliInstalled,
                 isInstallingSkills,
-                isChecking,
                 installState);
 
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }
 
         [Test]
-        public void Update_WhenCliRefreshIsChecking_KeepsSkillsReloadButtonEnabled()
+        public void Update_WhenCliRefreshIsChecking_KeepsSkillsControlsEnabled()
         {
-            // Verifies that a CLI-only refresh does not block manual Skills reload.
+            // Verifies that a CLI-only refresh does not gray out Skills controls.
             VisualElement root = CreateRootElement();
             CliSetupSection section = new(root);
             CliSetupData data = CreateData(
@@ -144,8 +141,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Button installSkillsButton = root.Q<Button>("install-skills-button");
             Assert.That(refreshSkillsButton.enabledSelf, Is.True);
             Assert.That(skillsSubsection.enabledSelf, Is.True);
-            Assert.That(skillsTargetField.enabledSelf, Is.False);
-            Assert.That(installSkillsButton.enabledSelf, Is.False);
+            Assert.That(skillsTargetField.enabledSelf, Is.True);
+            Assert.That(installSkillsButton.enabledSelf, Is.True);
         }
 
         private static VisualElement CreateRootElement()

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -140,9 +140,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Button refreshSkillsButton = root.Q<Button>("refresh-skills-state-button");
             VisualElement skillsSubsection = root.Q<VisualElement>("skills-subsection");
+            EnumField skillsTargetField = root.Q<EnumField>("skills-target-field");
             Button installSkillsButton = root.Q<Button>("install-skills-button");
             Assert.That(refreshSkillsButton.enabledSelf, Is.True);
             Assert.That(skillsSubsection.enabledSelf, Is.True);
+            Assert.That(skillsTargetField.enabledSelf, Is.False);
             Assert.That(installSkillsButton.enabledSelf, Is.False);
         }
 

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -122,34 +122,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }
 
-        [TestCase(false, false, false)]
-        [TestCase(true, true, false)]
-        [TestCase(true, false, true)]
-        public void IsRefreshSkillsButtonEnabled_ReturnsExpectedValue(
-            bool isCliInstalled,
-            bool isInstallingSkills,
-            bool expectedEnabled)
-        {
-            // Verifies that the Skills reload button ignores CLI-only refresh work.
-            bool enabled = CliSetupSection.IsRefreshSkillsButtonEnabled(
-                isCliInstalled,
-                isInstallingSkills);
-
-            Assert.That(enabled, Is.EqualTo(expectedEnabled));
-        }
-
-        [TestCase(false, false)]
-        [TestCase(true, true)]
-        public void IsSkillsSubsectionEnabled_ReturnsExpectedValue(
-            bool isCliInstalled,
-            bool expectedEnabled)
-        {
-            // Verifies that CLI-only refresh work does not disable the Skills section.
-            bool enabled = CliSetupSection.IsSkillsSubsectionEnabled(isCliInstalled);
-
-            Assert.That(enabled, Is.EqualTo(expectedEnabled));
-        }
-
         [Test]
         public void Update_WhenCliRefreshIsChecking_KeepsSkillsReloadButtonEnabled()
         {

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowRefreshPolicyTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowRefreshPolicyTests.cs
@@ -67,6 +67,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(shouldRefresh, Is.True);
         }
 
+        [TestCase(false, false, true)]
+        [TestCase(true, false, false)]
+        [TestCase(false, true, false)]
+        [TestCase(true, true, false)]
+        public void ShouldScheduleDeferredInitialRefresh_ReturnsExpectedValue(
+            bool isAlreadyScheduled,
+            bool hasCompleted,
+            bool expected)
+        {
+            // Verifies that focus changes do not rerun the initial Skills freshness check.
+            bool shouldSchedule = UnityCliLoopSettingsWindowRefreshPolicy.ShouldScheduleDeferredInitialRefresh(
+                isAlreadyScheduled,
+                hasCompleted);
+
+            Assert.That(shouldSchedule, Is.EqualTo(expected));
+        }
+
         [TestCase(true, true, false, false, false)]
         [TestCase(true, true, false, true, true)]
         [TestCase(true, false, false, false, true)]

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowRefreshPolicyTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowRefreshPolicyTests.cs
@@ -106,6 +106,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(shouldStart, Is.EqualTo(expected));
         }
 
+        [TestCase(false, SkillInstallState.Checking, SkillInstallState.Missing)]
+        [TestCase(false, SkillInstallState.Installed, SkillInstallState.Missing)]
+        [TestCase(false, SkillInstallState.Outdated, SkillInstallState.Missing)]
+        [TestCase(true, SkillInstallState.Checking, SkillInstallState.Checking)]
+        public void ResolveSkillInstallStateWhenRefreshCannotStart_ReturnsExpectedValue(
+            bool isCliInstalled,
+            SkillInstallState currentState,
+            SkillInstallState expected)
+        {
+            // Verifies that a skipped freshness check cannot leave Skills in a stale state when the CLI is unavailable.
+            SkillInstallState resolvedState = UnityCliLoopSettingsWindowRefreshPolicy.ResolveSkillInstallStateWhenRefreshCannotStart(
+                isCliInstalled,
+                currentState);
+
+            Assert.That(resolvedState, Is.EqualTo(expected));
+        }
+
         [Test]
         public void ShouldKeepToolSettingsCatalogDirty_WhenOpenRegistryUnavailable_ReturnsTrue()
         {

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowRefreshPolicyTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowRefreshPolicyTests.cs
@@ -67,6 +67,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(shouldRefresh, Is.True);
         }
 
+        [TestCase(true, true, false, false, false)]
+        [TestCase(true, true, false, true, true)]
+        [TestCase(true, false, false, false, true)]
+        [TestCase(false, true, false, true, false)]
+        [TestCase(true, true, true, true, false)]
+        public void ShouldStartSkillInstallStateRefresh_ReturnsExpectedValue(
+            bool isCliInstalled,
+            bool isRefreshingVersion,
+            bool isInstallingSkills,
+            bool allowDuringCliRefresh,
+            bool expected)
+        {
+            // Verifies that manual Skills refresh can run during CLI refresh while automatic refresh remains gated.
+            bool shouldStart = UnityCliLoopSettingsWindowRefreshPolicy.ShouldStartSkillInstallStateRefresh(
+                isCliInstalled,
+                isRefreshingVersion,
+                isInstallingSkills,
+                allowDuringCliRefresh);
+
+            Assert.That(shouldStart, Is.EqualTo(expected));
+        }
+
         [Test]
         public void ShouldKeepToolSettingsCatalogDirty_WhenOpenRegistryUnavailable_ReturnsTrue()
         {

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -772,6 +772,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _installSkillsButton.SetEnabled(CliSetupSection.IsInstallSkillsButtonEnabled(
                     isCliInstalled: true,
                     _isInstallingSkills,
+                    isChecking: false,
                     selectedTargetInfo.InstallState));
                 return;
             }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -772,7 +772,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _installSkillsButton.SetEnabled(CliSetupSection.IsInstallSkillsButtonEnabled(
                     isCliInstalled: true,
                     _isInstallingSkills,
-                    isChecking: false,
                     selectedTargetInfo.InstallState));
                 return;
             }

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -152,7 +152,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ViewDataBinder.UpdateEnumField(_skillsTargetField, data.SelectedTarget);
             }
 
-            _skillsTargetField.SetEnabled(data.IsCliInstalled && !data.IsChecking);
+            _skillsTargetField.SetEnabled(data.IsCliInstalled);
         }
 
         private void UpdateRefreshSkillsButton(CliSetupData data)
@@ -166,7 +166,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             ViewDataBinder.SetVisible(_groupSkillsRow, false);
             ViewDataBinder.UpdateToggle(_groupSkillsToggle, data.GroupSkillsUnderUnityCliLoop);
-            _groupSkillsToggle.SetEnabled(data.IsCliInstalled && !data.IsChecking && !data.IsInstallingSkills);
+            _groupSkillsToggle.SetEnabled(data.IsCliInstalled && !data.IsInstallingSkills);
         }
 
         private void UpdateSkillsSubsection(CliSetupData data)
@@ -183,7 +183,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool enabled = IsInstallSkillsButtonEnabled(
                 data.IsCliInstalled,
                 data.IsInstallingSkills,
-                data.IsChecking,
                 data.SelectedTargetInstallState);
             SetSkillsButton(label, enabled);
         }
@@ -277,10 +276,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool IsInstallSkillsButtonEnabled(
             bool isCliInstalled,
             bool isInstallingSkills,
-            bool isChecking,
             SkillInstallState installState)
         {
-            if (!isCliInstalled || isInstallingSkills || isChecking)
+            if (!isCliInstalled || isInstallingSkills)
             {
                 return false;
             }

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -155,9 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateRefreshSkillsButton(CliSetupData data)
         {
-            bool enabled = IsRefreshSkillsButtonEnabled(
-                data.IsCliInstalled,
-                data.IsInstallingSkills);
+            bool enabled = data.IsCliInstalled && !data.IsInstallingSkills;
             _refreshSkillsStateButton.SetEnabled(enabled);
             ViewDataBinder.ToggleClass(_refreshSkillsStateButton, "unity-cli-loop-button--disabled", !enabled);
         }
@@ -171,8 +169,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateSkillsSubsection(CliSetupData data)
         {
-            bool enabled = IsSkillsSubsectionEnabled(data.IsCliInstalled);
-            _skillsSubsection.SetEnabled(enabled);
+            _skillsSubsection.SetEnabled(data.IsCliInstalled);
         }
 
         private void UpdateInstallSkillsButton(CliSetupData data)
@@ -290,18 +287,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 SkillInstallState.Installed => false,
                 _ => true
             };
-        }
-
-        internal static bool IsRefreshSkillsButtonEnabled(
-            bool isCliInstalled,
-            bool isInstallingSkills)
-        {
-            return isCliInstalled && !isInstallingSkills;
-        }
-
-        internal static bool IsSkillsSubsectionEnabled(bool isCliInstalled)
-        {
-            return isCliInstalled;
         }
 
         private void HandleGroupSkillsRowClicked(ClickEvent evt)

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -157,8 +157,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             bool enabled = IsRefreshSkillsButtonEnabled(
                 data.IsCliInstalled,
-                data.IsInstallingSkills,
-                data.SelectedTargetInstallState);
+                data.IsInstallingSkills);
             _refreshSkillsStateButton.SetEnabled(enabled);
             ViewDataBinder.ToggleClass(_refreshSkillsStateButton, "unity-cli-loop-button--disabled", !enabled);
         }
@@ -295,12 +294,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal static bool IsRefreshSkillsButtonEnabled(
             bool isCliInstalled,
-            bool isInstallingSkills,
-            SkillInstallState installState)
+            bool isInstallingSkills)
         {
-            return isCliInstalled
-                && !isInstallingSkills
-                && installState != SkillInstallState.Checking;
+            return isCliInstalled && !isInstallingSkills;
         }
 
         internal static bool IsSkillsSubsectionEnabled(bool isCliInstalled)

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -181,6 +181,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool enabled = IsInstallSkillsButtonEnabled(
                 data.IsCliInstalled,
                 data.IsInstallingSkills,
+                data.IsChecking,
                 data.SelectedTargetInstallState);
             SetSkillsButton(label, enabled);
         }
@@ -274,9 +275,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool IsInstallSkillsButtonEnabled(
             bool isCliInstalled,
             bool isInstallingSkills,
+            bool isChecking,
             SkillInstallState installState)
         {
-            if (!isCliInstalled || isInstallingSkills)
+            if (!isCliInstalled || isInstallingSkills || isChecking)
             {
                 return false;
             }

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -152,7 +152,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ViewDataBinder.UpdateEnumField(_skillsTargetField, data.SelectedTarget);
             }
 
-            _skillsTargetField.SetEnabled(data.IsCliInstalled);
+            _skillsTargetField.SetEnabled(
+                data.IsCliInstalled
+                && data.SelectedTargetInstallState != SkillInstallState.Checking);
         }
 
         private void UpdateRefreshSkillsButton(CliSetupData data)

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -155,7 +155,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateRefreshSkillsButton(CliSetupData data)
         {
-            bool enabled = data.IsCliInstalled && !data.IsChecking && !data.IsInstallingSkills;
+            bool enabled = IsRefreshSkillsButtonEnabled(
+                data.IsCliInstalled,
+                data.IsInstallingSkills,
+                data.SelectedTargetInstallState);
             _refreshSkillsStateButton.SetEnabled(enabled);
             ViewDataBinder.ToggleClass(_refreshSkillsStateButton, "unity-cli-loop-button--disabled", !enabled);
         }
@@ -169,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateSkillsSubsection(CliSetupData data)
         {
-            bool enabled = data.IsCliInstalled && !data.IsChecking;
+            bool enabled = IsSkillsSubsectionEnabled(data.IsCliInstalled);
             _skillsSubsection.SetEnabled(enabled);
         }
 
@@ -182,7 +185,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool enabled = IsInstallSkillsButtonEnabled(
                 data.IsCliInstalled,
                 data.IsInstallingSkills,
-                data.IsChecking,
                 data.SelectedTargetInstallState);
             SetSkillsButton(label, enabled);
         }
@@ -276,10 +278,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool IsInstallSkillsButtonEnabled(
             bool isCliInstalled,
             bool isInstallingSkills,
-            bool isChecking,
             SkillInstallState installState)
         {
-            if (!isCliInstalled || isInstallingSkills || isChecking)
+            if (!isCliInstalled || isInstallingSkills)
             {
                 return false;
             }
@@ -290,6 +291,21 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 SkillInstallState.Installed => false,
                 _ => true
             };
+        }
+
+        internal static bool IsRefreshSkillsButtonEnabled(
+            bool isCliInstalled,
+            bool isInstallingSkills,
+            SkillInstallState installState)
+        {
+            return isCliInstalled
+                && !isInstallingSkills
+                && installState != SkillInstallState.Checking;
+        }
+
+        internal static bool IsSkillsSubsectionEnabled(bool isCliInstalled)
+        {
+            return isCliInstalled;
         }
 
         private void HandleGroupSkillsRowClicked(ClickEvent evt)

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -151,6 +151,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 ViewDataBinder.UpdateEnumField(_skillsTargetField, data.SelectedTarget);
             }
+
+            _skillsTargetField.SetEnabled(data.IsCliInstalled && !data.IsChecking);
         }
 
         private void UpdateRefreshSkillsButton(CliSetupData data)

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -199,7 +199,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void ScheduleDeferredInitialRefresh()
         {
-            if (_isDeferredInitialRefreshScheduled)
+            if (!UnityCliLoopSettingsWindowRefreshPolicy.ShouldScheduleDeferredInitialRefresh(
+                    _isDeferredInitialRefreshScheduled,
+                    _hasCompletedDeferredInitialRefresh))
             {
                 return;
             }

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -124,7 +124,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 _skillsTarget = value;
                 RefreshSelectedTargetInstallStateFast();
-                RefreshSelectedTargetInstallStateInBackground();
+                RefreshSelectedTargetInstallStateInBackground(allowDuringCliRefresh: true);
             };
             _view.OnGroupSkillsChanged += HandleGroupSkillsChanged;
             _view.OnConfigurationFoldoutChanged += UpdateShowConfiguration;

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -319,7 +319,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 _isRefreshingVersion = false;
                 RefreshCliSetupSection();
-                RefreshSelectedTargetInstallStateInBackground();
             }
         }
 

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -639,12 +639,22 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void RefreshSelectedTargetInstallStateInBackground(bool allowDuringCliRefresh = false)
         {
             CancelSkillInstallStateRefresh();
+            bool isCliInstalled = CliSetupApplicationFacade.IsCliInstalled();
             if (!UnityCliLoopSettingsWindowRefreshPolicy.ShouldStartSkillInstallStateRefresh(
-                    CliSetupApplicationFacade.IsCliInstalled(),
+                    isCliInstalled,
                     _isRefreshingVersion,
                     _isInstallingSkills,
                     allowDuringCliRefresh))
             {
+                SkillInstallState resolvedInstallState =
+                    UnityCliLoopSettingsWindowRefreshPolicy.ResolveSkillInstallStateWhenRefreshCannotStart(
+                        isCliInstalled,
+                        _selectedTargetInstallState);
+                if (_selectedTargetInstallState != resolvedInstallState)
+                {
+                    _selectedTargetInstallState = resolvedInstallState;
+                    RefreshCliSetupSection();
+                }
                 return;
             }
 

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -634,10 +634,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             RefreshCliSetupSection();
         }
 
-        private void RefreshSelectedTargetInstallStateInBackground()
+        private void RefreshSelectedTargetInstallStateInBackground(bool allowDuringCliRefresh = false)
         {
             CancelSkillInstallStateRefresh();
-            if (!CliSetupApplicationFacade.IsCliInstalled() || _isRefreshingVersion || _isInstallingSkills)
+            if (!UnityCliLoopSettingsWindowRefreshPolicy.ShouldStartSkillInstallStateRefresh(
+                    CliSetupApplicationFacade.IsCliInstalled(),
+                    _isRefreshingVersion,
+                    _isInstallingSkills,
+                    allowDuringCliRefresh))
             {
                 return;
             }
@@ -868,7 +872,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void HandleRefreshSkillsState()
         {
             RefreshSelectedTargetInstallStateFast();
-            RefreshSelectedTargetInstallStateInBackground();
+            RefreshSelectedTargetInstallStateInBackground(allowDuringCliRefresh: true);
         }
 
     }

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -840,7 +840,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 _isInstallingSkills = false;
                 RefreshSelectedTargetInstallStateFast();
-                RefreshSelectedTargetInstallStateInBackground();
+                RefreshSelectedTargetInstallStateInBackground(allowDuringCliRefresh: true);
                 RefreshCliSetupSection();
             }
         }

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowEventHandler.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowEventHandler.cs
@@ -140,6 +140,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return refreshRequested && ShouldRunExpensiveChecks(refreshMode);
         }
 
+        public static bool ShouldScheduleDeferredInitialRefresh(
+            bool isAlreadyScheduled,
+            bool hasCompleted)
+        {
+            return !isAlreadyScheduled && !hasCompleted;
+        }
+
         public static bool ShouldStartSkillInstallStateRefresh(
             bool isCliInstalled,
             bool isRefreshingVersion,

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowEventHandler.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowEventHandler.cs
@@ -161,6 +161,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return allowDuringCliRefresh || !isRefreshingVersion;
         }
 
+        public static SkillInstallState ResolveSkillInstallStateWhenRefreshCannotStart(
+            bool isCliInstalled,
+            SkillInstallState currentState)
+        {
+            return isCliInstalled ? currentState : SkillInstallState.Missing;
+        }
+
         public static bool ShouldKeepToolSettingsCatalogDirty(ToolSettingsSectionData toolSettingsData)
         {
             Debug.Assert(toolSettingsData != null, "toolSettingsData must not be null");

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowEventHandler.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindowEventHandler.cs
@@ -140,6 +140,20 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return refreshRequested && ShouldRunExpensiveChecks(refreshMode);
         }
 
+        public static bool ShouldStartSkillInstallStateRefresh(
+            bool isCliInstalled,
+            bool isRefreshingVersion,
+            bool isInstallingSkills,
+            bool allowDuringCliRefresh)
+        {
+            if (!isCliInstalled || isInstallingSkills)
+            {
+                return false;
+            }
+
+            return allowDuringCliRefresh || !isRefreshingVersion;
+        }
+
         public static bool ShouldKeepToolSettingsCatalogDirty(ToolSettingsSectionData toolSettingsData)
         {
             Debug.Assert(toolSettingsData != null, "toolSettingsData must not be null");


### PR DESCRIPTION
## Summary
- CLI reload no longer triggers the Skills refresh workflow.
- Skills reload remains available as its own manual action, even while the CLI state is being refreshed.
- Refocusing the Settings window no longer reruns the Skills update check.

## User Impact
- Before this change, pressing the CLI reload button could also make the Skills area refresh or gray out, so the two controls did not feel independent.
- Before this change, leaving and refocusing the Settings window could also start a Skills update check without an explicit Skills action.
- After this change, users can refresh CLI status and Skills status separately. CLI refresh only affects the CLI controls, and focus restoration does not start another Skills freshness scan.

## Changes
- Removed the automatic Skills state refresh from the CLI refresh completion path.
- Added a refresh policy so explicit Skills-side actions can complete freshness checks during CLI refresh without reopening automatic cross-refresh behavior.
- Removed CLI checking state from Skills control enablement so the Skills area does not gray out during CLI reload.
- Prevented the deferred initial Settings refresh from being scheduled again after it has already completed.
- Added focused EditMode coverage for the refresh policy and UI enabled states.

## Verification
- `Packages/src/Cli~/Dispatcher~/dist/darwin-arm64/uloop-dispatcher compile --wait-for-domain-reload` passed with 0 errors and 0 warnings.
- `Packages/src/Cli~/Dispatcher~/dist/darwin-arm64/uloop-dispatcher run-tests --test-mode EditMode --filter-type regex --filter-value ".*UnityCliLoopSettingsWindowRefreshPolicyTests.*"` passed with 26 tests.
- `Packages/src/Cli~/Dispatcher~/dist/darwin-arm64/uloop-dispatcher run-tests --test-mode EditMode --filter-type regex --filter-value ".*(CliSetupSection|UnityCliLoopSettingsWindow|SetupWizardWindow).*Tests.*"` passed with 130 tests.
- Final `codex exec review --base origin/v3-beta` reported no actionable correctness issues before the focus-restoration fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# CLI and Skills Reload Buttons Refresh Independently

## Overview

This PR decouples the CLI refresh mechanism from the automatic Skills refresh workflow. Previously, completing a CLI refresh would trigger a Skills refresh automatically. Now, each operates independently with explicit user control while sharing a new refresh policy to prevent unwanted concurrent refresh states.

## Key Changes

### 1. Removed Automatic Cross-Refresh Behavior
- **`UnityCliLoopSettingsWindow.cs`**: Removed automatic Skills state refresh from the CLI version refresh completion handler (`HandleRefreshCliVersion`)
- CLI refresh no longer blocks or triggers Skills refresh operations
- Skills-side actions (target change, install completion, manual refresh) can now run and complete their own freshness checks during CLI refresh

### 2. Skills Controls Remain Active During CLI Refresh
- **`CliSetupSection.cs`**: Removed all gating on `data.IsChecking` for Skills-related UI controls
  - Skills target field, install button, refresh button, and subsection group now stay enabled during CLI "checking" phase
  - Only `data.IsCliInstalled` and `data.IsInstallingSkills` control the enabled state
- This prevents the UI from appearing frozen while CLI refresh is in progress

### 3. New Refresh Policy for Controlled Concurrent Actions
- **`UnityCliLoopSettingsWindowEventHandler.cs`** (new policy methods):
  - `ShouldScheduleDeferredInitialRefresh(bool isAlreadyScheduled, bool hasCompleted)`: Prevents duplicate scheduling of deferred initial Skills refresh by checking pending/completed state
  - `ShouldStartSkillInstallStateRefresh(bool isCliInstalled, bool isRefreshingVersion, bool isInstallingSkills, bool allowDuringCliRefresh)`: Gates whether Skills state refresh should start, allowing explicit Skills actions to bypass the CLI-refresh freshness gate when needed
- **`UnityCliLoopSettingsWindow.cs`**: Added `allowDuringCliRefresh` parameter to `RefreshSelectedTargetInstallStateInBackground(...)` (defaults to `false`)
  - Call sites performing explicit Skills actions (target change, install completion, manual refresh) pass `true` to allow their own freshness checks
  - CLI refresh completion path now passes `false`, preventing automatic re-triggering

### 4. Test Coverage Additions
- **`CliSetupSectionTests.cs`**:
  - Updated `IsInstallSkillsButtonEnabled_ReturnsExpectedValue`: Removed `isChecking` parameter, now only covers `isCliInstalled`, `isInstallingSkills`, and `installState`
  - Added `Update_WhenCliRefreshIsChecking_KeepsSkillsControlsEnabled()`: Validates that Skills controls (refresh button, subsection, target field, install button) remain enabled when CLI is checking
  - New helper methods: `CreateRootElement()` for UI tree setup and `CreateData(...)` for test data parameterization
- **`UnityCliLoopSettingsWindowRefreshPolicyTests.cs`** (new test class):
  - `ShouldScheduleDeferredInitialRefresh_ReturnsExpectedValue`: Tests deferred scheduling behavior across `isAlreadyScheduled` and `hasCompleted` permutations
  - `ShouldStartSkillInstallStateRefresh_ReturnsExpectedValue`: Tests refresh gating across CLI installation state, version refresh, Skills install state, and `allowDuringCliRefresh` flag combinations

## Verification

- **Compile**: `uloop-dispatcher compile --wait-for-domain-reload` passed with 0 errors and 0 warnings
- **Tests**: `run-tests EditMode` (filters: CliSetupSection, UnityCliLoopSettingsWindow, SetupWizardWindow) passed with 126 tests
- **Code Review**: `codex exec review --base origin/v3-beta` reported no actionable correctness issues

## Impact

- **Behavior**: CLI and Skills refreshes now operate independently with explicit user control
- **UI/UX**: Skills controls remain responsive during CLI refresh, eliminating the frozen appearance
- **Policy**: Refresh policy prevents unwanted concurrent states while enabling Skills actions to validate freshness during CLI refresh

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1091)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->