### PR TITLE
fix: Setup now requires the single-binary CLI before running tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@ Comments in the code, commit messages, PR titles, and PR descriptions must all b
 
 Every test method must have a short comment that states what behavior the test verifies.
 
+## Commit-Time Version Checks
+
+Before committing a C# package version bump, check whether `CliConstants.MINIMUM_REQUIRED_CLI_VERSION` must also change.
+If the package release depends on behavior from a newer native CLI contract, update the minimum required CLI version and add or update focused tests.
+If the minimum CLI version stays unchanged, make sure that decision is intentional before committing.
+
 ## Generated Skill Files
 
 Do not directly edit skill files under the project-root `.agents/` or `.claude/` directories.

--- a/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
+++ b/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
@@ -31,6 +31,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void GetMinimumRequiredCliVersion_RequiresSingleBinaryCliRelease()
+        {
+            // Verifies this package release rejects CLIs older than the single-binary release.
+            CliSetupApplicationService service = new(
+                new FakeCliInstallationDetector(new string[] { null }),
+                new FakeNativeCliInstaller());
+
+            Assert.That(service.GetMinimumRequiredCliVersion(), Is.EqualTo("3.0.0-beta.7"));
+        }
+
+        [Test]
         public void GetGlobalCliInstallCommand_UsesMinimumRequiredCliReleaseTag()
         {
             // Verifies that fallback manual commands point at the independent CLI release stream.

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -6,7 +6,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     public static class CliConstants
     {
         public const string EXECUTABLE_NAME = "uloop";
-        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.6";
+        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.7";
         public const string VERSION_FLAG = "--version";
         public const string RAW_CONTENT_BASE_URL = "https://raw.githubusercontent.com/hatayama/unity-cli-loop";
         public const string STABLE_INSTALLER_SOURCE_REF = "main";


### PR DESCRIPTION
## Summary
- Setup and the JSON-RPC compatibility gate now require the first single-binary native CLI release before tools run.
- Project instructions now require commit-time checks when C# package version bumps may need a matching CLI minimum bump.

## User Impact
- Users with older beta CLI versions get an explicit update path to the single uloop binary before the Unity package accepts tool requests.
- Future package releases are less likely to ship with a stale minimum CLI requirement.

## Changes
- Bumped the package minimum required native CLI version to 3.0.0-beta.7.
- Added a focused EditMode test that locks this release requirement in place.
- Documented the package-version and minimum-CLI-version check in AGENTS.md.

## Verification
- /tmp/uloop-beta7 compile --wait-for-domain-reload --project-path /Users/a12115/ghq/hatayama/unity-cli-loop
- /tmp/uloop-beta7 run-tests --test-mode EditMode --filter-type exact --filter-value io.github.hatayama.UnityCliLoop.Tests.Editor.CliSetupApplicationServiceTests.GetMinimumRequiredCliVersion_RequiresSingleBinaryCliRelease --project-path /Users/a12115/ghq/hatayama/unity-cli-loop
- /tmp/uloop-beta7 run-tests --test-mode EditMode --filter-type regex --filter-value io\\.github\\.hatayama\\.UnityCliLoop\\.Tests\\.Editor\\.(CliSetupApplicationServiceTests|JsonRpcProcessorCliVersionGateTests)\\..* --project-path /Users/a12115/ghq/hatayama/unity-cli-loop
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## fix: Setup now requires the single-binary CLI before running tools

### Overview
This PR enforces a minimum native CLI version of `3.0.0-beta.7` (the first single-binary `uloop` release) before setup and tool operations proceed. The change includes a version constant update, test coverage, and guidance documentation for future package releases.

### Key Changes

**CliConstants.cs**
- Updated `MINIMUM_REQUIRED_CLI_VERSION` from `"3.0.0-beta.6"` to `"3.0.0-beta.7"`

**CliSetupApplicationServiceTests.cs**
- Added test `GetMinimumRequiredCliVersion_RequiresSingleBinaryCliRelease()` to verify the setup service reports the correct minimum required CLI version
- Test assertions ensure the service returns exactly `"3.0.0-beta.7"`

**AGENTS.md**
- Added "Commit-Time Version Checks" section with guidance for future maintainers
- Documents the requirement to review `CliConstants.MINIMUM_REQUIRED_CLI_VERSION` whenever C# package versions are bumped
- Specifies that test updates are necessary when releases depend on newer native CLI contracts
- Emphasizes intentionality in minimum version decisions

### Impact
- Users running older beta CLI versions will encounter explicit upgrade requirements before package operations are allowed
- Establishes a commit-time check process to prevent future releases from shipping with stale CLI version requirements
- Reduces version mismatch issues between the C# package and native CLI components

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->