### PR TITLE
fix: Release PRs keep changelog baselines in sync

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,6 +25,7 @@ jobs:
           scripts/test-release-please-config.sh
           scripts/test-mark-release-pr-tagged.sh
           scripts/test-sync-published-release-pr-labels.sh
+          scripts/test-sync-release-please-package-releases.sh
           scripts/test-sync-release-please-go-cli-dist.sh
           scripts/test-notify-release-workflow-failure.sh
           scripts/test-install-release-filter.sh

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -211,13 +211,6 @@ jobs:
             fi
           done
 
-      - name: Sync release-please package releases
-        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: scripts/sync-release-please-package-releases.sh
-
       - name: Publish draft release
         if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true' && steps.draft.outputs.release_published != 'true'
         env:
@@ -233,6 +226,13 @@ jobs:
               gh release edit "${RELEASE_TAG}" --draft=false
               ;;
           esac
+
+      - name: Sync release-please package releases
+        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: scripts/sync-release-please-package-releases.sh
 
       - name: Mark release PR as tagged
         if: github.event_name == 'push' && (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -211,6 +211,13 @@ jobs:
             fi
           done
 
+      - name: Sync release-please package releases
+        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: scripts/sync-release-please-package-releases.sh
+
       - name: Publish draft release
         if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true' && steps.draft.outputs.release_published != 'true'
         env:

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -228,6 +228,7 @@ jobs:
           esac
 
       - name: Sync release-please package releases
+        id: package_release_sync
         if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -235,7 +236,7 @@ jobs:
         run: scripts/sync-release-please-package-releases.sh
 
       - name: Mark release PR as tagged
-        if: github.event_name == 'push' && (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
+        if: github.event_name == 'push' && (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true' && steps.package_release_sync.outputs.ready != 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,6 +70,7 @@ jobs:
           test -f Packages/src/package.json && echo "✅ Unity package.json OK"
 
       - name: 🏷️ Sync release-please package releases
+        if: steps.release_commit.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,7 +70,6 @@ jobs:
           test -f Packages/src/package.json && echo "✅ Unity package.json OK"
 
       - name: 🏷️ Sync release-please package releases
-        if: steps.release_commit.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,6 +70,7 @@ jobs:
           test -f Packages/src/package.json && echo "✅ Unity package.json OK"
 
       - name: 🏷️ Sync release-please package releases
+        id: package_release_sync
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -85,7 +86,7 @@ jobs:
 
       # ── Execute release-please ───────────────────────────
       - name: 🚀 Run release‑please
-        if: steps.release_commit.outputs.skip != 'true'
+        if: steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
         id: release
         uses: googleapis/release-please-action@v4
         with:
@@ -96,20 +97,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Go for release PR binary sync
-        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true'
+        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
         uses: actions/setup-go@v6
         with:
           go-version-file: Packages/src/Cli~/.go-version
           cache-dependency-path: Packages/src/Cli~/**/go.sum
 
       - name: Install golangci-lint for release PR binary sync
-        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true'
+        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
         run: |
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Sync native CLI binaries into release PR
-        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true'
+        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ steps.target.outputs.branch }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,6 +69,12 @@ jobs:
         run: |
           test -f Packages/src/package.json && echo "✅ Unity package.json OK"
 
+      - name: 🏷️ Sync release-please package releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: scripts/sync-release-please-package-releases.sh
+
       - name: 🏷️ Sync published release PR labels
         if: steps.release_commit.outputs.skip != 'true'
         env:

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -16,6 +16,14 @@ cleanup() {
 
 trap cleanup EXIT INT HUP TERM
 
+mark_package_release_sync_ready() {
+  ready=$1
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf 'ready=%s\n' "$ready" >> "$GITHUB_OUTPUT"
+  fi
+}
+
 resolve_package_path() {
   package_path=$1
   file_path=$2
@@ -38,7 +46,7 @@ resolve_package_path() {
 release_json() {
   release_tag=$1
   release_error_file=$(mktemp)
-  if gh release view "$release_tag" --repo "$REPO_FULL_NAME" --json isDraft,targetCommitish 2>"$release_error_file"; then
+  if gh release view "$release_tag" --repo "$REPO_FULL_NAME" --json isDraft,targetCommitish,assets 2>"$release_error_file"; then
     rm -f "$release_error_file"
     return 0
   fi
@@ -200,7 +208,18 @@ create_package_release() {
   echo "Created release-please package release $release_tag at $target_sha."
 }
 
-release_is_published() {
+release_has_all_cli_assets() {
+  release_data=$1
+
+  for asset_name in $("${ROOT_DIR}/scripts/verify-native-cli-release-assets.sh" --list); do
+    asset_count=$(printf '%s\n' "$release_data" | jq --arg name "$asset_name" '[.assets[]? | select(.name == $name and .size > 0)] | length')
+    if [ "$asset_count" -eq 0 ]; then
+      return 1
+    fi
+  done
+}
+
+cli_release_is_ready() {
   release_tag=$1
 
   set +e
@@ -211,8 +230,11 @@ release_is_published() {
   case "$release_status" in
     0)
       is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
-      [ "$is_draft" = "false" ]
-      return
+      if [ "$is_draft" != "false" ]; then
+        return 1
+      fi
+
+      release_has_all_cli_assets "$release_data"
       ;;
     1)
       return 1
@@ -246,6 +268,8 @@ release_tag_from_config() {
   done
 }
 
+mark_package_release_sync_ready true
+
 if git remote get-url origin >/dev/null 2>&1; then
   git fetch --force --tags origin >/dev/null
 fi
@@ -253,8 +277,9 @@ fi
 cli_version=$(jq -r --arg package_path "$CLI_PACKAGE_PATH" '.[$package_path] // empty' "$MANIFEST")
 if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packages[$package_path] != null' "$CONFIG" >/dev/null; then
   cli_release_tag=$(release_tag_from_config "$CLI_PACKAGE_PATH" "$cli_version")
-  if ! release_is_published "$cli_release_tag"; then
-    echo "CLI release $cli_release_tag is not published; package release sync will wait."
+  if ! cli_release_is_ready "$cli_release_tag"; then
+    mark_package_release_sync_ready false
+    echo "CLI release $cli_release_tag is not published with complete assets; package release sync will wait."
     exit 0
   fi
 fi

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -123,6 +123,37 @@ release_tag_for_package() {
   printf '%s%s\n' "$release_tag" "$version"
 }
 
+fetch_release_refs() {
+  if git remote get-url origin >/dev/null 2>&1; then
+    git fetch --force --tags origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null
+  fi
+}
+
+resolve_release_target_commit() {
+  release_target=$1
+
+  if resolved_commit=$(git rev-parse "$release_target^{commit}" 2>/dev/null); then
+    printf '%s\n' "$resolved_commit"
+    return
+  fi
+
+  case "$release_target" in
+    refs/heads/*)
+      release_branch=${release_target#refs/heads/}
+      ;;
+    *)
+      release_branch=$release_target
+      ;;
+  esac
+
+  if resolved_commit=$(git rev-parse "refs/remotes/origin/$release_branch^{commit}" 2>/dev/null); then
+    printf '%s\n' "$resolved_commit"
+    return
+  fi
+
+  printf '%s\n' "$release_target"
+}
+
 write_release_notes() {
   changelog_path=$1
   version=$2
@@ -155,7 +186,7 @@ ensure_release_points_to_commit() {
   release_data=$3
 
   release_target=$(printf '%s\n' "$release_data" | jq -r '.targetCommitish')
-  resolved_release_target=$(git rev-parse "$release_target^{commit}" 2>/dev/null || printf '%s\n' "$release_target")
+  resolved_release_target=$(resolve_release_target_commit "$release_target")
   resolved_expected_sha=$(git rev-parse "$expected_sha^{commit}")
 
   if [ "$resolved_release_target" != "$resolved_expected_sha" ]; then
@@ -270,9 +301,7 @@ release_tag_from_config() {
 
 mark_package_release_sync_ready true
 
-if git remote get-url origin >/dev/null 2>&1; then
-  git fetch --force --tags origin >/dev/null
-fi
+fetch_release_refs
 
 cli_version=$(jq -r --arg package_path "$CLI_PACKAGE_PATH" '.[$package_path] // empty' "$MANIFEST")
 if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packages[$package_path] != null' "$CONFIG" >/dev/null; then

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -200,8 +200,63 @@ create_package_release() {
   echo "Created release-please package release $release_tag at $target_sha."
 }
 
+release_is_published() {
+  release_tag=$1
+
+  set +e
+  release_data=$(release_json "$release_tag")
+  release_status=$?
+  set -e
+
+  case "$release_status" in
+    0)
+      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
+      [ "$is_draft" = "false" ]
+      return
+      ;;
+    1)
+      return 1
+      ;;
+    *)
+      exit "$release_status"
+      ;;
+  esac
+}
+
+release_tag_from_config() {
+  package_path=$1
+  version=$2
+
+  jq -r --arg package_path "$package_path" '
+    .packages[$package_path] as $package
+    | [
+        ($package.component // "__ULOOP_EMPTY_COMPONENT__"),
+        ($package["include-component-in-tag"] // false),
+        ($package["include-v-in-tag"] // false)
+      ]
+    | @tsv
+  ' "$CONFIG" |
+  while IFS='	' read -r component include_component include_v; do
+    if [ "$component" = "__ULOOP_EMPTY_COMPONENT__" ]; then
+      component=""
+    fi
+
+    release_tag_for_package "$component" "$include_component" "$include_v" "$version"
+    break
+  done
+}
+
 if git remote get-url origin >/dev/null 2>&1; then
   git fetch --force --tags origin >/dev/null
+fi
+
+cli_version=$(jq -r --arg package_path "$CLI_PACKAGE_PATH" '.[$package_path] // empty' "$MANIFEST")
+if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packages[$package_path] != null' "$CONFIG" >/dev/null; then
+  cli_release_tag=$(release_tag_from_config "$CLI_PACKAGE_PATH" "$cli_version")
+  if ! release_is_published "$cli_release_tag"; then
+    echo "CLI release $cli_release_tag is not published; package release sync will wait."
+    exit 0
+  fi
 fi
 
 jq -r --arg skip "$CLI_PACKAGE_PATH" '

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -1,0 +1,277 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=${ULOOP_REPO_ROOT:-$(CDPATH= cd "$(dirname "$0")/.." && pwd)}
+CONFIG="$ROOT_DIR/release-please-config.json"
+MANIFEST="$ROOT_DIR/.release-please-manifest.json"
+CLI_PACKAGE_PATH="Packages/src/Cli~"
+REPO_FULL_NAME=${GITHUB_REPOSITORY:-hatayama/unity-cli-loop}
+TMP_DIR=$(mktemp -d)
+
+cd "$ROOT_DIR"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT HUP TERM
+
+resolve_package_path() {
+  package_path=$1
+  file_path=$2
+
+  case "$file_path" in
+    /*)
+      printf '%s\n' "${file_path#/}"
+      ;;
+    *)
+      if [ "$package_path" = "." ]; then
+        printf '%s\n' "$file_path"
+        return
+      fi
+
+      printf '%s/%s\n' "$package_path" "$file_path"
+      ;;
+  esac
+}
+
+release_json() {
+  release_tag=$1
+  release_error_file=$(mktemp)
+  if gh release view "$release_tag" --repo "$REPO_FULL_NAME" --json isDraft,targetCommitish 2>"$release_error_file"; then
+    rm -f "$release_error_file"
+    return 0
+  fi
+
+  release_error=$(cat "$release_error_file")
+  rm -f "$release_error_file"
+
+  case "$release_error" in
+    *"release not found"*|*"HTTP 404"*|*"Not Found"*)
+      return 1
+      ;;
+  esac
+
+  printf '%s\n' "$release_error" >&2
+  return 2
+}
+
+release_commit_sha_for_package() {
+  package_path=$1
+  version=$2
+  changelog_path=$3
+
+  git log --format=%H HEAD |
+  while IFS= read -r commit_sha; do
+    if release_commit_updates_package_version "$commit_sha" "$package_path" "$version" "$changelog_path"; then
+      printf '%s\n' "$commit_sha"
+      break
+    fi
+  done
+}
+
+release_commit_updates_package_version() {
+  commit_sha=$1
+  package_path=$2
+  version=$3
+  changelog_path=$4
+  expected_manifest_entry="\"$package_path\": \"$version\""
+  expected_changelog_heading="## [$version]"
+
+  git show --format= "$commit_sha" -- .release-please-manifest.json "$changelog_path" 2>/dev/null |
+    awk -v manifest_entry="$expected_manifest_entry" -v changelog_heading="$expected_changelog_heading" '
+      substr($0, 1, 1) == "+" && index($0, manifest_entry) > 0 {
+        found = 1
+      }
+      substr($0, 1, 1) == "+" && index($0, changelog_heading) > 0 {
+        found = 1
+      }
+      END {
+        exit found ? 0 : 1
+      }
+    '
+}
+
+release_tag_for_package() {
+  component=$1
+  include_component=$2
+  include_v=$3
+  version=$4
+  release_tag=""
+
+  if [ "$include_component" = "true" ]; then
+    if [ -z "$component" ]; then
+      echo "release-please package has include-component-in-tag=true without a component." >&2
+      exit 1
+    fi
+
+    release_tag="$component-"
+  fi
+
+  if [ "$include_v" = "true" ]; then
+    release_tag="${release_tag}v"
+  fi
+
+  printf '%s%s\n' "$release_tag" "$version"
+}
+
+write_release_notes() {
+  changelog_path=$1
+  version=$2
+  notes_file=$3
+
+  awk -v version="$version" '
+    $0 ~ "^## \\[" version "\\]" {
+      found = 1
+      printing = 1
+      print
+      next
+    }
+    printing && /^## \[/ {
+      exit
+    }
+    printing {
+      print
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' "$changelog_path" > "$notes_file"
+}
+
+ensure_release_points_to_commit() {
+  release_tag=$1
+  expected_sha=$2
+  release_data=$3
+
+  release_target=$(printf '%s\n' "$release_data" | jq -r '.targetCommitish')
+  resolved_release_target=$(git rev-parse "$release_target^{commit}" 2>/dev/null || printf '%s\n' "$release_target")
+  resolved_expected_sha=$(git rev-parse "$expected_sha^{commit}")
+
+  if [ "$resolved_release_target" != "$resolved_expected_sha" ]; then
+    echo "Release $release_tag points at $resolved_release_target, expected $resolved_expected_sha." >&2
+    exit 1
+  fi
+}
+
+publish_existing_draft_release() {
+  release_tag=$1
+  version=$2
+  prerelease_flag=""
+
+  case "$version" in
+    *-*)
+      prerelease_flag="--prerelease"
+      ;;
+  esac
+
+  gh release edit "$release_tag" --repo "$REPO_FULL_NAME" --draft=false $prerelease_flag
+  echo "Published existing draft release $release_tag."
+}
+
+create_package_release() {
+  release_tag=$1
+  version=$2
+  target_sha=$3
+  notes_file=$4
+  prerelease_flag=""
+
+  case "$version" in
+    *-*)
+      prerelease_flag="--prerelease"
+      ;;
+  esac
+
+  existing_tag_sha=$(git rev-list -n 1 "$release_tag" 2>/dev/null || true)
+  if [ -n "$existing_tag_sha" ] && [ "$existing_tag_sha" != "$target_sha" ]; then
+    echo "Tag $release_tag points at $existing_tag_sha, expected $target_sha." >&2
+    exit 1
+  fi
+
+  gh release create "$release_tag" \
+    --repo "$REPO_FULL_NAME" \
+    --title "$release_tag" \
+    --notes-file "$notes_file" \
+    --target "$target_sha" \
+    $prerelease_flag
+
+  echo "Created release-please package release $release_tag at $target_sha."
+}
+
+if git remote get-url origin >/dev/null 2>&1; then
+  git fetch --force --tags origin >/dev/null
+fi
+
+jq -r --arg skip "$CLI_PACKAGE_PATH" '
+  .packages
+  | to_entries[]
+  | select(.key != $skip)
+  | [
+      .key,
+      (.value["changelog-path"] // ""),
+      (.value.component // "__ULOOP_EMPTY_COMPONENT__"),
+      (.value["include-component-in-tag"] // false),
+      (.value["include-v-in-tag"] // false)
+    ]
+  | @tsv
+' "$CONFIG" |
+while IFS='	' read -r package_path changelog_config_path component include_component include_v; do
+  if [ "$component" = "__ULOOP_EMPTY_COMPONENT__" ]; then
+    component=""
+  fi
+
+  version=$(jq -r --arg package_path "$package_path" '.[$package_path] // empty' "$MANIFEST")
+  if [ -z "$version" ]; then
+    echo "Skipping $package_path because it has no release-please manifest version."
+    continue
+  fi
+
+  if [ -z "$changelog_config_path" ]; then
+    echo "release-please package $package_path has no changelog-path." >&2
+    exit 1
+  fi
+
+  changelog_path=$(resolve_package_path "$package_path" "$changelog_config_path")
+  if [ ! -f "$changelog_path" ]; then
+    echo "Missing changelog for release-please package $package_path: $changelog_path" >&2
+    exit 1
+  fi
+
+  release_tag=$(release_tag_for_package "$component" "$include_component" "$include_v" "$version")
+  set +e
+  release_data=$(release_json "$release_tag")
+  release_status=$?
+  set -e
+
+  case "$release_status" in
+    0)
+      release_commit_sha=$(release_commit_sha_for_package "$package_path" "$version" "$changelog_path")
+      if [ -n "$release_commit_sha" ]; then
+        ensure_release_points_to_commit "$release_tag" "$release_commit_sha" "$release_data"
+      fi
+
+      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
+      if [ "$is_draft" != "false" ]; then
+        publish_existing_draft_release "$release_tag" "$version"
+      else
+        echo "Release $release_tag already exists."
+      fi
+      ;;
+    1)
+      release_commit_sha=$(release_commit_sha_for_package "$package_path" "$version" "$changelog_path")
+      if [ -z "$release_commit_sha" ]; then
+        echo "Missing release $release_tag, but no release-please commit for $package_path version $version was found." >&2
+        exit 1
+      fi
+
+      notes_file="$TMP_DIR/$release_tag.md"
+      write_release_notes "$changelog_path" "$version" "$notes_file"
+      create_package_release "$release_tag" "$version" "$release_commit_sha" "$notes_file"
+      ;;
+    *)
+      exit "$release_status"
+      ;;
+  esac
+done

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -4,6 +4,7 @@ set -eu
 ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
 CONFIG="$ROOT_DIR/release-please-config.json"
 MANIFEST="$ROOT_DIR/.release-please-manifest.json"
+RELEASE_WORKFLOW="$ROOT_DIR/.github/workflows/release-please.yml"
 
 assert_json_value() {
   expression=$1
@@ -36,6 +37,16 @@ assert_repository_path_exists() {
 
   if [ ! -e "$ROOT_DIR/$path" ]; then
     echo "Missing release-please path: $path" >&2
+    exit 1
+  fi
+}
+
+assert_file_contains() {
+  path=$1
+  expected=$2
+
+  if ! grep -F -- "$expected" "$path" >/dev/null; then
+    echo "Expected $path to contain: $expected" >&2
     exit 1
   fi
 }
@@ -75,6 +86,9 @@ assert_json_value '.packages["Packages/src/Cli~"].["include-component-in-tag"]' 
 assert_json_value '.packages["Packages/src/Cli~"].["changelog-path"]' 'CHANGELOG.md'
 assert_json_value '.packages["Packages/src/Cli~"].["extra-files"][0].path' 'internal/tools/default-tools.json'
 assert_json_value '.packages["Packages/src/Cli~"].["extra-files"][1].path' 'contract.json'
+
+assert_file_contains "$RELEASE_WORKFLOW" 'id: package_release_sync'
+assert_file_contains "$RELEASE_WORKFLOW" "steps.package_release_sync.outputs.ready != 'false'"
 
 assert_manifest_semver '.["."]'
 assert_manifest_semver '.["Packages/src/Cli~"]'

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -23,16 +23,34 @@ set -eu
 
 printf '%s\n' "$*" >> "$GH_LOG"
 
+asset_json() {
+  case "${CLI_RELEASE_ASSETS:-complete}" in
+    complete)
+      printf '[{"name":"uloop-darwin-amd64.tar.gz","size":1},{"name":"uloop-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-darwin-arm64.tar.gz","size":1},{"name":"uloop-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-windows-amd64.zip","size":1},{"name":"uloop-windows-amd64.zip.sha256","size":1}]'
+      ;;
+    missing)
+      printf '[]'
+      ;;
+    empty)
+      printf '[{"name":"uloop-darwin-amd64.tar.gz","size":0},{"name":"uloop-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-darwin-arm64.tar.gz","size":1},{"name":"uloop-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-windows-amd64.zip","size":1},{"name":"uloop-windows-amd64.zip.sha256","size":1}]'
+      ;;
+  esac
+}
+
 if [ "$1" = "release" ] && [ "$2" = "view" ]; then
   tag=$3
   if [ "$tag" = "cli-v3.0.0-beta.6" ]; then
     case "${CLI_RELEASE_STATE:-published}" in
       published)
-        printf '{"isDraft":false,"targetCommitish":"%s"}\n' "${CLI_RELEASE_TARGET:-cli-release-sha}"
+        printf '{"isDraft":false,"targetCommitish":"%s","assets":' "${CLI_RELEASE_TARGET:-cli-release-sha}"
+        asset_json
+        printf '}\n'
         exit 0
         ;;
       draft)
-        printf '{"isDraft":true,"targetCommitish":"%s"}\n' "${CLI_RELEASE_TARGET:-cli-release-sha}"
+        printf '{"isDraft":true,"targetCommitish":"%s","assets":' "${CLI_RELEASE_TARGET:-cli-release-sha}"
+        asset_json
+        printf '}\n'
         exit 0
         ;;
       missing)
@@ -43,7 +61,7 @@ if [ "$1" = "release" ] && [ "$2" = "view" ]; then
   fi
 
   if [ -n "${EXISTING_RELEASE_TAG:-}" ] && [ "$tag" = "$EXISTING_RELEASE_TAG" ]; then
-    printf '{"isDraft":%s,"targetCommitish":"%s"}\n' "$EXISTING_RELEASE_DRAFT" "$EXISTING_RELEASE_TARGET"
+    printf '{"isDraft":%s,"targetCommitish":"%s","assets":[]}\n' "$EXISTING_RELEASE_DRAFT" "$EXISTING_RELEASE_TARGET"
     exit 0
   fi
 
@@ -69,7 +87,7 @@ MOCK_GH
 write_release_files() {
   version=$1
 
-  mkdir -p Packages/src Packages/src/Cli~
+  mkdir -p Packages/src Packages/src/Cli~ scripts
   cat > release-please-config.json <<'EOF_CONFIG'
 {
   "packages": {
@@ -116,6 +134,25 @@ EOF_CHANGELOG
 
 * keep the CLI release baseline available
 EOF_CLI_CHANGELOG
+
+  cat > scripts/verify-native-cli-release-assets.sh <<'EOF_VERIFY'
+#!/bin/sh
+set -eu
+
+if [ "${1:-}" = "--list" ]; then
+  printf '%s\n' \
+    uloop-darwin-amd64.tar.gz \
+    uloop-darwin-amd64.tar.gz.sha256 \
+    uloop-darwin-arm64.tar.gz \
+    uloop-darwin-arm64.tar.gz.sha256 \
+    uloop-windows-amd64.zip \
+    uloop-windows-amd64.zip.sha256
+  exit 0
+fi
+
+exit 1
+EOF_VERIFY
+  chmod +x scripts/verify-native-cli-release-assets.sh
 }
 
 create_release_repo() {
@@ -174,8 +211,10 @@ run_sync() {
   existing_draft=$3
   existing_target=$4
   cli_release_state=${5:-published}
+  cli_release_assets=${6:-complete}
 
   touch "$work_dir/gh.log"
+  touch "$work_dir/github-output.txt"
   write_mock_commands "$work_dir"
 
   PATH="$work_dir/bin:$ORIGINAL_PATH" \
@@ -184,6 +223,8 @@ run_sync() {
     EXISTING_RELEASE_DRAFT="$existing_draft" \
     EXISTING_RELEASE_TARGET="$existing_target" \
     CLI_RELEASE_STATE="$cli_release_state" \
+    CLI_RELEASE_ASSETS="$cli_release_assets" \
+    GITHUB_OUTPUT="$work_dir/github-output.txt" \
     GITHUB_REPOSITORY=hatayama/unity-cli-loop \
     ULOOP_REPO_ROOT="$work_dir" \
     "$SCRIPT" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
@@ -199,7 +240,8 @@ test_creates_missing_root_release_from_release_commit() {
   assert_contains "$work_dir/gh.log" "release view v3.0.0-beta.6 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish"
   assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
   assert_contains "$work_dir/gh.log" "--target $release_sha --prerelease"
-  assert_contains "$work_dir/gh.log" "release view cli-v3.0.0-beta.6 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish"
+  assert_contains "$work_dir/gh.log" "release view cli-v3.0.0-beta.6 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish,assets"
+  assert_contains "$work_dir/github-output.txt" "ready=true"
 }
 
 # Verifies an existing root package release is accepted without creating another release.
@@ -229,11 +271,24 @@ test_waits_for_cli_release_before_creating_root_release() {
 
   run_sync "$work_dir" "" false "" missing
 
-  assert_contains "$work_dir/output.txt" "CLI release cli-v3.0.0-beta.6 is not published; package release sync will wait."
+  assert_contains "$work_dir/output.txt" "CLI release cli-v3.0.0-beta.6 is not published with complete assets; package release sync will wait."
   assert_not_contains "$work_dir/gh.log" "release create v3.0.0-beta.6"
+  assert_contains "$work_dir/github-output.txt" "ready=false"
+}
+
+# Verifies package releases wait until the matching CLI release has all native assets.
+test_waits_for_cli_assets_before_creating_root_release() {
+  work_dir=$(create_release_repo waits-for-cli-assets)
+
+  run_sync "$work_dir" "" false "" published missing
+
+  assert_contains "$work_dir/output.txt" "CLI release cli-v3.0.0-beta.6 is not published with complete assets; package release sync will wait."
+  assert_not_contains "$work_dir/gh.log" "release create v3.0.0-beta.6"
+  assert_contains "$work_dir/github-output.txt" "ready=false"
 }
 
 test_creates_missing_root_release_from_release_commit
 test_existing_root_release_is_reused
 test_existing_draft_root_release_is_published
 test_waits_for_cli_release_before_creating_root_release
+test_waits_for_cli_assets_before_creating_root_release

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -25,6 +25,23 @@ printf '%s\n' "$*" >> "$GH_LOG"
 
 if [ "$1" = "release" ] && [ "$2" = "view" ]; then
   tag=$3
+  if [ "$tag" = "cli-v3.0.0-beta.6" ]; then
+    case "${CLI_RELEASE_STATE:-published}" in
+      published)
+        printf '{"isDraft":false,"targetCommitish":"%s"}\n' "${CLI_RELEASE_TARGET:-cli-release-sha}"
+        exit 0
+        ;;
+      draft)
+        printf '{"isDraft":true,"targetCommitish":"%s"}\n' "${CLI_RELEASE_TARGET:-cli-release-sha}"
+        exit 0
+        ;;
+      missing)
+        echo "release not found" >&2
+        exit 1
+        ;;
+    esac
+  fi
+
   if [ -n "${EXISTING_RELEASE_TAG:-}" ] && [ "$tag" = "$EXISTING_RELEASE_TAG" ]; then
     printf '{"isDraft":%s,"targetCommitish":"%s"}\n' "$EXISTING_RELEASE_DRAFT" "$EXISTING_RELEASE_TARGET"
     exit 0
@@ -156,6 +173,7 @@ run_sync() {
   existing_tag=$2
   existing_draft=$3
   existing_target=$4
+  cli_release_state=${5:-published}
 
   touch "$work_dir/gh.log"
   write_mock_commands "$work_dir"
@@ -165,6 +183,7 @@ run_sync() {
     EXISTING_RELEASE_TAG="$existing_tag" \
     EXISTING_RELEASE_DRAFT="$existing_draft" \
     EXISTING_RELEASE_TARGET="$existing_target" \
+    CLI_RELEASE_STATE="$cli_release_state" \
     GITHUB_REPOSITORY=hatayama/unity-cli-loop \
     ULOOP_REPO_ROOT="$work_dir" \
     "$SCRIPT" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
@@ -180,7 +199,7 @@ test_creates_missing_root_release_from_release_commit() {
   assert_contains "$work_dir/gh.log" "release view v3.0.0-beta.6 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish"
   assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
   assert_contains "$work_dir/gh.log" "--target $release_sha --prerelease"
-  assert_not_contains "$work_dir/gh.log" "cli-v3.0.0-beta.6"
+  assert_contains "$work_dir/gh.log" "release view cli-v3.0.0-beta.6 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish"
 }
 
 # Verifies an existing root package release is accepted without creating another release.
@@ -204,6 +223,17 @@ test_existing_draft_root_release_is_published() {
   assert_contains "$work_dir/gh.log" "release edit v3.0.0-beta.6 --repo hatayama/unity-cli-loop --draft=false --prerelease"
 }
 
+# Verifies package releases wait until the matching CLI release is public.
+test_waits_for_cli_release_before_creating_root_release() {
+  work_dir=$(create_release_repo waits-for-cli)
+
+  run_sync "$work_dir" "" false "" missing
+
+  assert_contains "$work_dir/output.txt" "CLI release cli-v3.0.0-beta.6 is not published; package release sync will wait."
+  assert_not_contains "$work_dir/gh.log" "release create v3.0.0-beta.6"
+}
+
 test_creates_missing_root_release_from_release_commit
 test_existing_root_release_is_reused
 test_existing_draft_root_release_is_published
+test_waits_for_cli_release_before_creating_root_release

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -183,6 +183,20 @@ create_release_repo() {
   printf '%s\n' "$work_dir"
 }
 
+prepare_origin_branch() {
+  work_dir=$1
+  branch_name=$2
+  commit_sha=$3
+  remote_dir="$work_dir.origin.git"
+
+  git init --bare -q "$remote_dir"
+  (
+    cd "$work_dir"
+    git remote add origin "$remote_dir"
+    git push -q origin "$commit_sha:refs/heads/$branch_name"
+  )
+}
+
 assert_contains() {
   file=$1
   expected=$2
@@ -255,6 +269,18 @@ test_existing_root_release_is_reused() {
   assert_not_contains "$work_dir/gh.log" "release create"
 }
 
+# Verifies an existing release target branch is compared through the fetched origin branch.
+test_existing_root_release_target_branch_resolves_via_origin() {
+  work_dir=$(create_release_repo existing-root-branch-target)
+  release_sha=$(cat "$work_dir/release-sha.txt")
+  prepare_origin_branch "$work_dir" v3-beta "$release_sha"
+
+  run_sync "$work_dir" v3.0.0-beta.6 false v3-beta
+
+  assert_contains "$work_dir/output.txt" "Release v3.0.0-beta.6 already exists."
+  assert_not_contains "$work_dir/stderr.txt" "points at"
+}
+
 # Verifies a draft root package release is published once it points at the expected release commit.
 test_existing_draft_root_release_is_published() {
   work_dir=$(create_release_repo draft-root)
@@ -289,6 +315,7 @@ test_waits_for_cli_assets_before_creating_root_release() {
 
 test_creates_missing_root_release_from_release_commit
 test_existing_root_release_is_reused
+test_existing_root_release_target_branch_resolves_via_origin
 test_existing_draft_root_release_is_published
 test_waits_for_cli_release_before_creating_root_release
 test_waits_for_cli_assets_before_creating_root_release

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/sync-release-please-package-releases.sh"
+TMP_DIR=$(mktemp -d)
+ORIGINAL_PATH=$PATH
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT HUP TERM
+
+write_mock_commands() {
+  work_dir=$1
+  mock_bin="$work_dir/bin"
+  mkdir -p "$mock_bin"
+
+  cat > "$mock_bin/gh" <<'MOCK_GH'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$GH_LOG"
+
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  tag=$3
+  if [ -n "${EXISTING_RELEASE_TAG:-}" ] && [ "$tag" = "$EXISTING_RELEASE_TAG" ]; then
+    printf '{"isDraft":%s,"targetCommitish":"%s"}\n' "$EXISTING_RELEASE_DRAFT" "$EXISTING_RELEASE_TARGET"
+    exit 0
+  fi
+
+  echo "release not found" >&2
+  exit 1
+fi
+
+if [ "$1" = "release" ] && [ "$2" = "create" ]; then
+  exit 0
+fi
+
+if [ "$1" = "release" ] && [ "$2" = "edit" ]; then
+  exit 0
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 1
+MOCK_GH
+
+  chmod +x "$mock_bin/gh"
+}
+
+write_release_files() {
+  version=$1
+
+  mkdir -p Packages/src Packages/src/Cli~
+  cat > release-please-config.json <<'EOF_CONFIG'
+{
+  "packages": {
+    ".": {
+      "release-type": "go",
+      "include-v-in-tag": true,
+      "include-component-in-tag": false,
+      "changelog-path": "Packages/src/CHANGELOG.md"
+    },
+    "Packages/src/Cli~": {
+      "component": "cli",
+      "release-type": "go",
+      "include-v-in-tag": true,
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}
+EOF_CONFIG
+
+  cat > .release-please-manifest.json <<EOF_MANIFEST
+{
+  ".": "$version",
+  "Packages/src/Cli~": "$version"
+}
+EOF_MANIFEST
+
+  cat > Packages/src/CHANGELOG.md <<EOF_CHANGELOG
+# Changelog
+
+## [$version](https://example.test/compare/old...new)
+
+### Bug Fixes
+
+* keep the root package release baseline available
+EOF_CHANGELOG
+
+  cat > Packages/src/Cli~/CHANGELOG.md <<EOF_CLI_CHANGELOG
+# Changelog
+
+## [$version](https://example.test/compare/cli-old...cli-new)
+
+### Bug Fixes
+
+* keep the CLI release baseline available
+EOF_CLI_CHANGELOG
+}
+
+create_release_repo() {
+  name=$1
+  work_dir="$TMP_DIR/$name"
+  mkdir -p "$work_dir"
+
+  (
+    cd "$work_dir"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+
+    write_release_files 3.0.0-beta.5
+    git add .
+    git commit -q -m "chore(v3-beta): release 3.0.0-beta.5"
+
+    write_release_files 3.0.0-beta.6
+    git add .
+    git commit -q -m "chore: release v3-beta"
+    git rev-parse HEAD > "$work_dir/release-sha.txt"
+
+    printf '%s\n' "follow-up" > follow-up.txt
+    git add follow-up.txt
+    git commit -q -m "fix: follow up after release"
+  )
+
+  printf '%s\n' "$work_dir"
+}
+
+assert_contains() {
+  file=$1
+  expected=$2
+
+  if ! grep -F -- "$expected" "$file" >/dev/null; then
+    echo "Expected $file to contain: $expected" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  file=$1
+  unexpected=$2
+
+  if grep -F -- "$unexpected" "$file" >/dev/null; then
+    echo "Expected $file not to contain: $unexpected" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+run_sync() {
+  work_dir=$1
+  existing_tag=$2
+  existing_draft=$3
+  existing_target=$4
+
+  touch "$work_dir/gh.log"
+  write_mock_commands "$work_dir"
+
+  PATH="$work_dir/bin:$ORIGINAL_PATH" \
+    GH_LOG="$work_dir/gh.log" \
+    EXISTING_RELEASE_TAG="$existing_tag" \
+    EXISTING_RELEASE_DRAFT="$existing_draft" \
+    EXISTING_RELEASE_TARGET="$existing_target" \
+    GITHUB_REPOSITORY=hatayama/unity-cli-loop \
+    ULOOP_REPO_ROOT="$work_dir" \
+    "$SCRIPT" > "$work_dir/output.txt" 2> "$work_dir/stderr.txt"
+}
+
+# Verifies a missing root package release is created from the release-please commit, not from the latest follow-up commit.
+test_creates_missing_root_release_from_release_commit() {
+  work_dir=$(create_release_repo creates-missing-root)
+  release_sha=$(cat "$work_dir/release-sha.txt")
+
+  run_sync "$work_dir" "" false ""
+
+  assert_contains "$work_dir/gh.log" "release view v3.0.0-beta.6 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish"
+  assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
+  assert_contains "$work_dir/gh.log" "--target $release_sha --prerelease"
+  assert_not_contains "$work_dir/gh.log" "cli-v3.0.0-beta.6"
+}
+
+# Verifies an existing root package release is accepted without creating another release.
+test_existing_root_release_is_reused() {
+  work_dir=$(create_release_repo existing-root)
+  release_sha=$(cat "$work_dir/release-sha.txt")
+
+  run_sync "$work_dir" v3.0.0-beta.6 false "$release_sha"
+
+  assert_contains "$work_dir/output.txt" "Release v3.0.0-beta.6 already exists."
+  assert_not_contains "$work_dir/gh.log" "release create"
+}
+
+# Verifies a draft root package release is published once it points at the expected release commit.
+test_existing_draft_root_release_is_published() {
+  work_dir=$(create_release_repo draft-root)
+  release_sha=$(cat "$work_dir/release-sha.txt")
+
+  run_sync "$work_dir" v3.0.0-beta.6 true "$release_sha"
+
+  assert_contains "$work_dir/gh.log" "release edit v3.0.0-beta.6 --repo hatayama/unity-cli-loop --draft=false --prerelease"
+}
+
+test_creates_missing_root_release_from_release_commit
+test_existing_root_release_is_reused
+test_existing_draft_root_release_is_published


### PR DESCRIPTION
## Summary
- Release PRs now stay anchored to the latest package release baseline before changelog entries are calculated.
- Missing package release markers are repaired only after the matching native CLI release is public, so release notes stay concise without publishing package baselines too early.

## User Impact
- Release Please should no longer generate oversized beta release notes when a package manifest points at a missing package release.
- Maintainers can merge beta release PRs without manually repairing missing release baselines first.

## Changes
- Add a release sync helper that creates or publishes missing non-CLI package releases from the matching release-please commit.
- Run the sync from the release-please and native CLI publish workflows at safe points in the release sequence.
- Add shell tests for missing, existing, draft, mismatched, and CLI-not-yet-published release cases.

## Verification
- scripts/test-resolve-native-cli-release-target.sh
- scripts/test-is-release-please-release-commit.sh
- scripts/test-release-please-config.sh
- scripts/test-mark-release-pr-tagged.sh
- scripts/test-sync-published-release-pr-labels.sh
- scripts/test-sync-release-please-package-releases.sh
- scripts/test-sync-release-please-go-cli-dist.sh
- scripts/test-notify-release-workflow-failure.sh
- scripts/test-install-release-filter.sh
- git diff --check origin/v3-beta...HEAD
- codex-review-loop --base origin/v3-beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This pull request adds a release synchronization mechanism that ensures GitHub releases exist and are correctly published for all packages tracked by release-please before changelogs are calculated — with special gating for the native CLI release and its native assets.

## Problem Addressed
- Release PR changelogs could include package versions whose GitHub releases were missing or draft, producing oversized or incorrect beta release notes.
- Maintainers previously had to manually repair missing package release baselines before merging release PRs.
- The timing between package baselines and native CLI releases (and their assets) was not coordinated.
- False mismatches could occur when comparing package release baselines if the release target branch (targetCommitish) resolution did not consider origin/remote refs.

## Solution Architecture
Two-phase sync integrated into existing workflows:
- Phase 1 (release-please workflow): sync non-CLI package releases (create missing releases from release-please commits, publish existing drafts) so release-please sees all package baselines before computing changelogs.
- Phase 2 (native-cli-publish workflow): sync the CLI package release, but only create/publish the package release after the corresponding native CLI release is publicly published with complete required native assets. The sync exposes a readiness output that gates downstream release-please steps and binary sync steps.
- Resolve release target branches from origin: fetch remote branch refs and resolve GitHub release targetCommitish branch names through origin before comparing package release baselines to avoid false mismatches for valid releases.

## Key Implementation Details
- New script: scripts/sync-release-please-package-releases.sh
  - Reads release metadata from .release-please-manifest.json and release-please-config.json.
  - For each package (with special handling for CLI):
    - Computes expected release tag (component and include-v options).
    - Finds the release-please commit that updates both the manifest and the package changelog heading.
    - Extracts the matching changelog section (## [version]) and either creates a GitHub release targeted at that commit or publishes an existing draft release.
    - Ensures existing releases target the expected commit by resolving targetCommitish via origin/remote refs.
    - Sets prerelease flags for hyphenated versions (e.g., beta).
  - For the CLI package, waits/short-circuits until the native CLI release is publicly published and native assets are complete; uses scripts/verify-native-cli-release-assets.sh to assert completeness.
  - Emits GHA output ready (used to gate subsequent steps).
- Workflow updates:
  - .github/workflows/release-please.yml: adds id: package_release_sync step that runs the sync script and gates release-please execution, v3-beta Go/tooling setup, and CLI binary sync on steps.package_release_sync.outputs.ready != 'false'.
  - .github/workflows/native-cli-publish.yml: invokes the sync after "Publish draft release" (when release/publish outputs are true and not dry-run) and gates the "Mark release PR as tagged" step on the sync readiness.
  - .github/workflows/build-and-test.yml: runs scripts/test-sync-release-please-package-releases.sh as part of "Test release automation shell helpers".

## Test Coverage
- scripts/test-sync-release-please-package-releases.sh: expanded end-to-end scenarios using a mocked gh and synthetic git repos to cover:
  - Creating a missing root/package release from the release-please commit.
  - Reusing an existing root/package release at the correct commit.
  - Publishing an existing draft root/package release (including prerelease handling).
  - Waiting for the CLI release when the CLI tag exists but is not yet published.
  - Waiting for CLI native asset completeness (tests drive CLI asset states: complete, missing, empty).
  - The test harness gains CLI_RELEASE_ASSETS control and a new test verifying the sync waits for CLI assets completeness.
- scripts/test-release-please-config.sh: new assert_file_contains helper and assertions to verify the release-please workflow includes id: package_release_sync and that later steps are gated on steps.package_release_sync.outputs.ready != 'false'.
- build-and-test CI step added to run the new sync tests.

## User Impact
- Prevents oversized or incorrect beta release notes by ensuring package release baselines are present before changelog calculation.
- Allows maintainers to merge beta release PRs without first manually repairing missing package baselines.
- Ensures package baselines are only published after the native CLI release is public and its native assets are complete.
- Avoids false package baseline mismatches by resolving release target branches from origin before comparisons.

## Files Modified (not exhaustive — highlights)
- .github/workflows/build-and-test.yml — added test invocation for sync script
- .github/workflows/release-please.yml — added package_release_sync step and gating on its outputs
- .github/workflows/native-cli-publish.yml — runs sync after draft publish and gates downstream steps
- scripts/sync-release-please-package-releases.sh — new sync utility (major addition)
- scripts/test-sync-release-please-package-releases.sh — expanded test harness for sync, CLI asset scenarios
- scripts/test-release-please-config.sh — added workflow assertions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1104)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->