### PR TITLE
fix: CLI uninstall no longer reinstalls immediately

### DIFF
--- a/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
+++ b/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
@@ -131,6 +131,59 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(detector.ForceRefreshCount, Is.EqualTo(2));
         }
 
+        [Test]
+        public async Task EnsureGlobalCliCurrentAsync_AfterManualUninstall_SkipsInstallForCurrentSession()
+        {
+            // Verifies that startup auto install does not immediately undo a successful manual uninstall.
+            FakeNativeCliInstaller nativeCliInstaller = new();
+            FakeCliInstallationDetector detector = new(new string[] { null });
+            CliSetupApplicationService service = new(detector, nativeCliInstaller);
+
+            CliInstallResult uninstallResult = await service.UninstallGlobalCliAsync(
+                RuntimePlatform.OSXEditor,
+                CancellationToken.None);
+            CliInstallResult ensureResult = await service.EnsureGlobalCliCurrentAsync(
+                RuntimePlatform.OSXEditor,
+                CancellationToken.None);
+
+            Assert.That(uninstallResult.Success, Is.True);
+            Assert.That(ensureResult.Success, Is.True);
+            Assert.That(nativeCliInstaller.UninstallCount, Is.EqualTo(1));
+            Assert.That(nativeCliInstaller.InstallCount, Is.EqualTo(0));
+            Assert.That(detector.ForceRefreshCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task EnsureGlobalCliCurrentAsync_AfterFailedManualUninstall_StillInstallsMinimumRelease()
+        {
+            // Verifies that failed manual uninstall attempts do not disable startup recovery.
+            FakeNativeCliInstaller nativeCliInstaller = new()
+            {
+                UninstallResult = new CliInstallResult(false, "uninstall failed")
+            };
+            FakeCliInstallationDetector detector = new(
+                new string[]
+                {
+                    "3.0.0-beta.5",
+                    "3.0.0-beta.5",
+                    CliConstants.MINIMUM_REQUIRED_CLI_VERSION
+                });
+            CliSetupApplicationService service = new(detector, nativeCliInstaller);
+
+            CliInstallResult uninstallResult = await service.UninstallGlobalCliAsync(
+                RuntimePlatform.OSXEditor,
+                CancellationToken.None);
+            CliInstallResult ensureResult = await service.EnsureGlobalCliCurrentAsync(
+                RuntimePlatform.OSXEditor,
+                CancellationToken.None);
+
+            Assert.That(uninstallResult.Success, Is.False);
+            Assert.That(ensureResult.Success, Is.True);
+            Assert.That(nativeCliInstaller.UninstallCount, Is.EqualTo(1));
+            Assert.That(nativeCliInstaller.InstallCount, Is.EqualTo(1));
+            Assert.That(detector.ForceRefreshCount, Is.EqualTo(2));
+        }
+
         private sealed class FakeCliInstallationDetector : ICliInstallationDetector
         {
             private readonly string[] _versions;
@@ -170,6 +223,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             public string InstalledVersion { get; private set; }
             public int InstallCount { get; private set; }
+            public int UninstallCount { get; private set; }
+            public CliInstallResult UninstallResult { get; set; } = new(true, "");
 
             public bool IsPackageOwnedCurrentUserInstallPath(string cliExecutablePath, RuntimePlatform platform)
             {
@@ -188,7 +243,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             public Task<CliInstallResult> UninstallGlobalCliAsync(RuntimePlatform platform, CancellationToken ct)
             {
-                return Task.FromResult(new CliInstallResult(true, ""));
+                UninstallCount++;
+                return Task.FromResult(UninstallResult);
             }
 
             public NativeCliInstallCommand GetGlobalCliInstallCommand(

--- a/Packages/src/Editor/Application/CliSetupApplicationService.cs
+++ b/Packages/src/Editor/Application/CliSetupApplicationService.cs
@@ -61,6 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
     {
         private readonly ICliInstallationDetector _cliInstallationDetector;
         private readonly INativeCliInstaller _nativeCliInstaller;
+        private bool _isAutoInstallSuppressedForCurrentSession;
 
         public CliSetupApplicationService(
             ICliInstallationDetector cliInstallationDetector,
@@ -163,6 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
         {
             ct.ThrowIfCancellationRequested();
 
+            _isAutoInstallSuppressedForCurrentSession = false;
             CliInstallResult result = await _nativeCliInstaller.InstallGlobalCliAsync(
                 platform,
                 GetMinimumRequiredCliReleaseTag(),
@@ -174,6 +176,13 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public async Task<CliInstallResult> EnsureGlobalCliCurrentAsync(RuntimePlatform platform, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
+
+            if (_isAutoInstallSuppressedForCurrentSession)
+            {
+                return new CliInstallResult(
+                    true,
+                    "Manual uninstall disabled automatic CLI install for this editor session.");
+            }
 
             await _cliInstallationDetector.ForceRefreshCliVersionAsync(ct);
             string cliVersion = _cliInstallationDetector.GetCachedCliVersion();
@@ -206,6 +215,11 @@ namespace io.github.hatayama.UnityCliLoop.Application
             ct.ThrowIfCancellationRequested();
 
             CliInstallResult result = await _nativeCliInstaller.UninstallGlobalCliAsync(platform, ct);
+            if (result.Success)
+            {
+                _isAutoInstallSuppressedForCurrentSession = true;
+            }
+
             _cliInstallationDetector.InvalidateCache();
             return result;
         }


### PR DESCRIPTION
## Summary
- Uninstalling the package-owned CLI from Settings now leaves it removed for the current editor session.
- Manual reinstall still works normally when the user clicks Install CLI again.

## User Impact
- Before this change, the CLI could appear to remain installed after pressing Uninstall CLI because startup auto install could put it back.
- After this change, a successful uninstall is respected until the user explicitly installs the CLI again or starts a new editor session.

## Changes
- Suppress automatic CLI install for the current editor session after a successful manual uninstall.
- Clear that suppression when the user starts a manual CLI install.
- Add focused EditMode coverage for successful and failed uninstall flows.

## Verification
- `uloop run-tests --project-path /Users/a12115/ghq/hatayama/unity-cli-loop-v3-uninstall-fix --test-mode EditMode --filter-type regex --filter-value "io\\.github\\.hatayama\\.UnityCliLoop\\.Tests\\.Editor\\.CliSetupApplicationServiceTests\\.(EnsureGlobalCliCurrentAsync_AfterManualUninstall_SkipsInstallForCurrentSession|EnsureGlobalCliCurrentAsync_AfterFailedManualUninstall_StillInstallsMinimumRelease)$"`
- `uloop run-tests --project-path /Users/a12115/ghq/hatayama/unity-cli-loop-v3-uninstall-fix --test-mode EditMode --filter-type regex --filter-value "io\\.github\\.hatayama\\.UnityCliLoop\\.Tests\\.Editor\\.CliSetupApplicationServiceTests\\..*"`
- `uloop compile --project-path /Users/a12115/ghq/hatayama/unity-cli-loop-v3-uninstall-fix --force-recompile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a bug where manually uninstalling the CLI from Settings would result in the CLI being immediately reinstalled by the automatic startup installer. Now, a successful uninstall is respected for the duration of the editor session, and suppression is cleared when the user explicitly reinstalls the CLI.

## Changes Made

### CliSetupApplicationService.cs
Implemented session-based suppression of automatic CLI installation:
- Added `_isAutoInstallSuppressedForCurrentSession` flag to track suppression state per service instance
- Modified `EnsureGlobalCliCurrentAsync` to check suppression flag first; if active, returns a successful `CliInstallResult` with a message indicating automatic installation is disabled for the current session
- Modified `UninstallGlobalCliAsync` to set the suppression flag to `true` after successful uninstall
- Modified `InstallGlobalCliAsync` to reset the suppression flag to `false`, allowing manual installation to clear the suppression

No changes to public API signatures.

### CliSetupApplicationServiceTests.cs
Added two new NUnit test cases to verify correct behavior after manual uninstall:
- `EnsureGlobalCliCurrentAsync_AfterManualUninstall_SkipsInstallForCurrentSession()`: Verifies that after a successful uninstall, the startup routine skips automatic CLI installation for the current session
- `EnsureGlobalCliCurrentAsync_AfterFailedManualUninstall_StillInstallsMinimumRelease()`: Verifies that when uninstall fails, the startup routine still attempts to install/restore the minimum CLI version

Enhanced `FakeNativeCliInstaller` test helper:
- Added `UninstallCount` property to track uninstall invocations
- Added configurable `UninstallResult` property to allow test control over uninstall success/failure
- Updated `UninstallGlobalCliAsync` to increment the counter and return the configured result

## User Impact

- Manual uninstall of the CLI is now respected for the current editor session
- Users no longer experience unwanted CLI reinstallation immediately after uninstalling
- Manual reinstall still works normally when the user clicks "Install CLI"
- Suppression is cleared when manual installation is initiated
- Closing and reopening the editor will revert to the default behavior (automatic CLI installation on startup if not present)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1113)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->