### PR TITLE
fix: Unity 6.5 projects compile and keep fast code execution available

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExternalCompilerPathResolverTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExternalCompilerPathResolverTests.cs
@@ -88,6 +88,19 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         }
 
         [Test]
+        public void ResolveScriptingRootPath_WhenResourcesScriptingDotNetSdkLayoutExists_ShouldReturnResourcesScriptingPath()
+        {
+            string contentsPath = CreateDirectory("Contents");
+            string expectedScriptingRootPath = CreateDirectory(Path.Combine("Contents", "Resources", "Scripting"));
+            CreateDirectory(Path.Combine("Contents", "Resources", "Scripting", "NetCoreRuntime"));
+            CreateDirectory(Path.Combine("Contents", "Resources", "Scripting", "DotNetSdk", "sdk", "8.0.318", "Roslyn", "bincore"));
+
+            string resolvedScriptingRootPath = ExternalCompilerPathResolver.ResolveScriptingRootPath(contentsPath);
+
+            Assert.That(resolvedScriptingRootPath, Is.EqualTo(expectedScriptingRootPath));
+        }
+
+        [Test]
         public void ResolveScriptingRootPath_WhenBothLayoutsExist_ShouldPreferResourcesScriptingLayout()
         {
             string contentsPath = CreateDirectory("Contents");
@@ -113,6 +126,30 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
             string resolvedScriptingRootPath = ExternalCompilerPathResolver.ResolveScriptingRootPath(contentsPath);
 
             Assert.That(resolvedScriptingRootPath, Is.EqualTo(expectedScriptingRootPath));
+        }
+
+        [Test]
+        public void ResolveCompilerDirectoryPath_WhenLegacyLayoutExists_ShouldReturnDotNetSdkRoslynPath()
+        {
+            string scriptingRootPath = CreateDirectory("Scripting");
+            string expectedCompilerDirectoryPath = CreateDirectory(Path.Combine("Scripting", "DotNetSdkRoslyn"));
+
+            string resolvedCompilerDirectoryPath = ExternalCompilerPathResolver.ResolveCompilerDirectoryPath(scriptingRootPath);
+
+            Assert.That(resolvedCompilerDirectoryPath, Is.EqualTo(expectedCompilerDirectoryPath));
+        }
+
+        [Test]
+        public void ResolveCompilerDirectoryPath_WhenDotNetSdkLayoutHasMultipleSdkVersions_ShouldChooseHighestSdkRoslynBincorePath()
+        {
+            string scriptingRootPath = CreateDirectory("Scripting");
+            CreateDirectory(Path.Combine("Scripting", "DotNetSdk", "sdk", "8.0.100", "Roslyn", "bincore"));
+            string expectedCompilerDirectoryPath = CreateDirectory(Path.Combine("Scripting", "DotNetSdk", "sdk", "8.0.318", "Roslyn", "bincore"));
+            CreateDirectory(Path.Combine("Scripting", "DotNetSdk", "sdk", "current", "Roslyn", "bincore"));
+
+            string resolvedCompilerDirectoryPath = ExternalCompilerPathResolver.ResolveCompilerDirectoryPath(scriptingRootPath);
+
+            Assert.That(resolvedCompilerDirectoryPath, Is.EqualTo(expectedCompilerDirectoryPath));
         }
 
         private string CreateDirectory(string relativePath)

--- a/Assets/Tests/Editor/FindGameObjectsToolTests.cs
+++ b/Assets/Tests/Editor/FindGameObjectsToolTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -652,11 +653,13 @@ namespace io.github.hatayama.uLoopMCP
                 Assert.That(probeAnchor, Is.Not.Null, "MeshRenderer should have Probe Anchor property");
                 Assert.That(probeAnchor.type, Is.EqualTo("ObjectReference"));
 
-                // Value should be a structured object with name, type, instanceId
+                string expectedEntityId = GetExpectedObjectId(anchorTarget.transform);
+
+                // Value should be a structured object with name, type, entityId
                 JObject valueObj = JObject.FromObject(probeAnchor.value);
                 Assert.That(valueObj["name"].ToString(), Is.EqualTo("AnchorTarget"));
                 Assert.That(valueObj["type"].ToString(), Is.EqualTo("Transform"));
-                Assert.That(valueObj["instanceId"].Value<int>(), Is.EqualTo(anchorTarget.transform.GetInstanceID()));
+                Assert.That(valueObj["entityId"].ToString(), Is.EqualTo(expectedEntityId));
             }
             finally
             {
@@ -695,7 +698,20 @@ namespace io.github.hatayama.uLoopMCP
             JObject valueObj = JObject.FromObject(probeAnchor.value);
             Assert.That(valueObj["name"].ToString(), Is.EqualTo("None"));
             Assert.That(valueObj["type"].ToString(), Is.EqualTo("None"));
-            Assert.That(valueObj["instanceId"].Value<int>(), Is.EqualTo(0));
+            Assert.That(valueObj["entityId"].ToString(), Is.EqualTo("0"));
+        }
+
+        private static string GetExpectedObjectId(Object obj)
+        {
+            UnityEngine.Debug.Assert(obj != null, "Unity Object must exist before reading its identifier.");
+
+#if UNITY_6000_4_OR_NEWER
+            ulong entityId = UnityEngine.EntityId.ToULong(obj.GetEntityId());
+            return entityId.ToString(CultureInfo.InvariantCulture);
+#else
+            int instanceId = obj.GetInstanceID();
+            return instanceId.ToString(CultureInfo.InvariantCulture);
+#endif
         }
 
         [Test]

--- a/Assets/Tests/Editor/HierarchySerializerTests.cs
+++ b/Assets/Tests/Editor/HierarchySerializerTests.cs
@@ -19,8 +19,8 @@ namespace io.github.hatayama.uLoopMCP
             // Arrange
             List<HierarchyNode> nodes = new()
             {
-                new(1, "Root", null, 0, true, new[] { "Transform" }, "SceneA"),
-                new(2, "Child", 1, 1, true, new[] { "Transform", "MeshRenderer" }, "SceneA")
+                new("1", "Root", null, 0, true, new[] { "Transform" }, "SceneA"),
+                new("2", "Child", "1", 1, true, new[] { "Transform", "MeshRenderer" }, "SceneA")
             };
             
             HierarchyContext context = new HierarchyContext("editor", "TestScene", 0, 0);
@@ -72,10 +72,10 @@ namespace io.github.hatayama.uLoopMCP
             // Arrange
             List<HierarchyNode> nodes = new()
             {
-                new(1, "Root", null, 0, true, new string[0]),
-                new(2, "Level1", 1, 1, true, new string[0]),
-                new(3, "Level2", 2, 2, true, new string[0]),
-                new(4, "Level3", 3, 3, true, new string[0])
+                new("1", "Root", null, 0, true, new string[0]),
+                new("2", "Level1", "1", 1, true, new string[0]),
+                new("3", "Level2", "2", 2, true, new string[0]),
+                new("4", "Level3", "3", 3, true, new string[0])
             };
             
             HierarchyContext context = new HierarchyContext("editor", "DeepScene", 0, 0);

--- a/Packages/src/Editor/Compilation/ExternalCompilerPathResolver.cs
+++ b/Packages/src/Editor/Compilation/ExternalCompilerPathResolver.cs
@@ -8,6 +8,20 @@ namespace io.github.hatayama.uLoopMCP
 {
     internal static class ExternalCompilerPathResolver
     {
+        private const string NetCoreRuntimeDirectoryName = "NetCoreRuntime";
+        private const string DotNetSdkRoslynDirectoryName = "DotNetSdkRoslyn";
+        private const string DotNetSdkDirectoryName = "DotNetSdk";
+        private const string DotNetSdkSdkDirectoryName = "sdk";
+        private const string RoslynDirectoryName = "Roslyn";
+        private const string CompilerBincoreDirectoryName = "bincore";
+        private const string CompilerDllFileName = "csc.dll";
+        private const string CompilerRuntimeConfigFileName = "csc.runtimeconfig.json";
+        private const string CompilerDepsFileName = "csc.deps.json";
+        private const string CodeAnalysisDllFileName = "Microsoft.CodeAnalysis.dll";
+        private const string CodeAnalysisCSharpDllFileName = "Microsoft.CodeAnalysis.CSharp.dll";
+        private const string NetCoreRuntimeSharedDirectoryName = "shared";
+        private const string NetCoreRuntimeSharedFrameworkName = "Microsoft.NETCore.App";
+
         public static ExternalCompilerPaths Resolve()
         {
             string editorPath = EditorApplication.applicationPath;
@@ -26,23 +40,34 @@ namespace io.github.hatayama.uLoopMCP
             string dotnetHostFileName = UnityEngine.Application.platform == UnityEngine.RuntimePlatform.WindowsEditor
                 ? "dotnet.exe"
                 : "dotnet";
+            string effectiveScriptingRootPath = scriptingRootPath ?? contentsPath;
+            string compilerDirectoryPath = ResolveCompilerDirectoryPath(effectiveScriptingRootPath);
 
             List<string> missingComponents = new List<string>();
             if (string.IsNullOrEmpty(scriptingRootPath))
             {
-                missingComponents.Add(Path.Combine(contentsPath, "NetCoreRuntime"));
-                missingComponents.Add(Path.Combine(contentsPath, "DotNetSdkRoslyn"));
-                missingComponents.Add(Path.Combine(contentsPath, "Resources", "Scripting", "NetCoreRuntime"));
-                missingComponents.Add(Path.Combine(contentsPath, "Resources", "Scripting", "DotNetSdkRoslyn"));
+                missingComponents.Add(Path.Combine(contentsPath, NetCoreRuntimeDirectoryName));
+                missingComponents.Add(Path.Combine(contentsPath, DotNetSdkRoslynDirectoryName));
+                missingComponents.Add(Path.Combine(contentsPath, DotNetSdkDirectoryName, DotNetSdkSdkDirectoryName, "*", RoslynDirectoryName, CompilerBincoreDirectoryName));
+                missingComponents.Add(Path.Combine(contentsPath, "Resources", "Scripting", NetCoreRuntimeDirectoryName));
+                missingComponents.Add(Path.Combine(contentsPath, "Resources", "Scripting", DotNetSdkRoslynDirectoryName));
+                missingComponents.Add(Path.Combine(contentsPath, "Resources", "Scripting", DotNetSdkDirectoryName, DotNetSdkSdkDirectoryName, "*", RoslynDirectoryName, CompilerBincoreDirectoryName));
             }
 
-            string dotnetHostPath = Path.Combine(scriptingRootPath ?? contentsPath, "NetCoreRuntime", dotnetHostFileName);
-            string compilerDllPath = Path.Combine(scriptingRootPath ?? contentsPath, "DotNetSdkRoslyn", "csc.dll");
-            string compilerRuntimeConfigPath = Path.Combine(scriptingRootPath ?? contentsPath, "DotNetSdkRoslyn", "csc.runtimeconfig.json");
-            string compilerDepsFilePath = Path.Combine(scriptingRootPath ?? contentsPath, "DotNetSdkRoslyn", "csc.deps.json");
-            string codeAnalysisDllPath = Path.Combine(scriptingRootPath ?? contentsPath, "DotNetSdkRoslyn", "Microsoft.CodeAnalysis.dll");
-            string codeAnalysisCSharpDllPath = Path.Combine(scriptingRootPath ?? contentsPath, "DotNetSdkRoslyn", "Microsoft.CodeAnalysis.CSharp.dll");
-            string netCoreRuntimeSharedRootPath = Path.Combine(scriptingRootPath ?? contentsPath, "NetCoreRuntime", "shared", "Microsoft.NETCore.App");
+            if (string.IsNullOrEmpty(compilerDirectoryPath))
+            {
+                compilerDirectoryPath = Path.Combine(effectiveScriptingRootPath, DotNetSdkRoslynDirectoryName);
+                missingComponents.Add(compilerDirectoryPath);
+                missingComponents.Add(Path.Combine(effectiveScriptingRootPath, DotNetSdkDirectoryName, DotNetSdkSdkDirectoryName, "*", RoslynDirectoryName, CompilerBincoreDirectoryName));
+            }
+
+            string dotnetHostPath = Path.Combine(effectiveScriptingRootPath, NetCoreRuntimeDirectoryName, dotnetHostFileName);
+            string compilerDllPath = Path.Combine(compilerDirectoryPath, CompilerDllFileName);
+            string compilerRuntimeConfigPath = Path.Combine(compilerDirectoryPath, CompilerRuntimeConfigFileName);
+            string compilerDepsFilePath = Path.Combine(compilerDirectoryPath, CompilerDepsFileName);
+            string codeAnalysisDllPath = Path.Combine(compilerDirectoryPath, CodeAnalysisDllFileName);
+            string codeAnalysisCSharpDllPath = Path.Combine(compilerDirectoryPath, CodeAnalysisCSharpDllFileName);
+            string netCoreRuntimeSharedRootPath = Path.Combine(effectiveScriptingRootPath, NetCoreRuntimeDirectoryName, NetCoreRuntimeSharedDirectoryName, NetCoreRuntimeSharedFrameworkName);
             string netCoreRuntimeSharedDirectoryPath = ResolveNetCoreRuntimeSharedDirectoryPath(netCoreRuntimeSharedRootPath);
 
             if (!File.Exists(dotnetHostPath))
@@ -122,6 +147,22 @@ namespace io.github.hatayama.uLoopMCP
             return ResolveScriptingRootPathByScan(contentsPath);
         }
 
+        internal static string ResolveCompilerDirectoryPath(string scriptingRootPath)
+        {
+            if (string.IsNullOrEmpty(scriptingRootPath))
+            {
+                return null;
+            }
+
+            string legacyCompilerDirectoryPath = Path.Combine(scriptingRootPath, DotNetSdkRoslynDirectoryName);
+            if (Directory.Exists(legacyCompilerDirectoryPath))
+            {
+                return legacyCompilerDirectoryPath;
+            }
+
+            return ResolveDotNetSdkCompilerDirectoryPath(scriptingRootPath);
+        }
+
         internal static string ResolveNetCoreRuntimeSharedDirectoryPath(string netCoreRuntimeSharedRootPath)
         {
             if (!Directory.Exists(netCoreRuntimeSharedRootPath))
@@ -159,8 +200,58 @@ namespace io.github.hatayama.uLoopMCP
 
         private static bool ContainsExternalCompilerLayout(string rootPath)
         {
-            return Directory.Exists(Path.Combine(rootPath, "NetCoreRuntime"))
-                && Directory.Exists(Path.Combine(rootPath, "DotNetSdkRoslyn"));
+            return Directory.Exists(Path.Combine(rootPath, NetCoreRuntimeDirectoryName))
+                && !string.IsNullOrEmpty(ResolveCompilerDirectoryPath(rootPath));
+        }
+
+        private static string ResolveDotNetSdkCompilerDirectoryPath(string scriptingRootPath)
+        {
+            string sdkRootPath = Path.Combine(scriptingRootPath, DotNetSdkDirectoryName, DotNetSdkSdkDirectoryName);
+            if (!Directory.Exists(sdkRootPath))
+            {
+                return null;
+            }
+
+            List<string> sdkDirectoryPaths = Directory.GetDirectories(sdkRootPath).ToList();
+            sdkDirectoryPaths.Sort(CompareSdkDirectoryPathsDescending);
+
+            foreach (string sdkDirectoryPath in sdkDirectoryPaths)
+            {
+                string compilerDirectoryPath = Path.Combine(sdkDirectoryPath, RoslynDirectoryName, CompilerBincoreDirectoryName);
+                if (Directory.Exists(compilerDirectoryPath))
+                {
+                    return compilerDirectoryPath;
+                }
+            }
+
+            return null;
+        }
+
+        private static int CompareSdkDirectoryPathsDescending(string leftPath, string rightPath)
+        {
+            string leftVersionText = Path.GetFileName(leftPath);
+            string rightVersionText = Path.GetFileName(rightPath);
+            bool leftIsVersion = Version.TryParse(leftVersionText, out Version leftVersion);
+            bool rightIsVersion = Version.TryParse(rightVersionText, out Version rightVersion);
+
+            if (leftIsVersion && rightIsVersion)
+            {
+                int versionComparison = rightVersion.CompareTo(leftVersion);
+                if (versionComparison != 0)
+                {
+                    return versionComparison;
+                }
+            }
+            else if (leftIsVersion)
+            {
+                return -1;
+            }
+            else if (rightIsVersion)
+            {
+                return 1;
+            }
+
+            return string.Compare(rightVersionText, leftVersionText, StringComparison.Ordinal);
         }
 
         private static string ResolveScriptingRootPathByScan(string contentsPath)

--- a/Packages/src/Editor/Core/CoreTools/GameObjectFinder/ComponentPropertySerializer.cs
+++ b/Packages/src/Editor/Core/CoreTools/GameObjectFinder/ComponentPropertySerializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using UnityEngine;
 using UnityEditor;
@@ -85,20 +86,62 @@ namespace io.github.hatayama.uLoopMCP
                 case SerializedPropertyType.LayerMask:
                     return property.intValue;
                 case SerializedPropertyType.ObjectReference:
-                    UnityEngine.Object obj = property.objectReferenceValue;
-                    if (obj == null)
-                    {
-                        // objectReferenceInstanceIDValue != 0 means a broken (Missing) reference
-                        if (property.objectReferenceInstanceIDValue != 0)
-                        {
-                            return new { name = "Missing", type = "Missing", instanceId = property.objectReferenceInstanceIDValue };
-                        }
-                        return new { name = "None", type = "None", instanceId = 0 };
-                    }
-                    return new { name = obj.name, type = obj.GetType().Name, instanceId = obj.GetInstanceID() };
+                    return GetObjectReferenceValue(property);
                 default:
                     return null; // Unsupported property types
             }
+        }
+
+        private object GetObjectReferenceValue(SerializedProperty property)
+        {
+            UnityEngine.Debug.Assert(property != null, "SerializedProperty must exist before reading object references.");
+            UnityEngine.Debug.Assert(property.propertyType == SerializedPropertyType.ObjectReference, "Object reference serialization requires an ObjectReference property.");
+
+            UnityEngine.Object obj = property.objectReferenceValue;
+            if (obj == null)
+            {
+                if (HasStoredObjectReferenceId(property))
+                {
+                    return new { name = "Missing", type = "Missing", entityId = GetStoredObjectReferenceId(property) };
+                }
+
+                return new { name = "None", type = "None", entityId = "0" };
+            }
+
+            return new { name = obj.name, type = obj.GetType().Name, entityId = GetObjectId(obj) };
+        }
+
+        private static bool HasStoredObjectReferenceId(SerializedProperty property)
+        {
+#if UNITY_6000_4_OR_NEWER
+            return property.objectReferenceEntityIdValue != UnityEngine.EntityId.None;
+#else
+            return property.objectReferenceInstanceIDValue != 0;
+#endif
+        }
+
+        private static string GetStoredObjectReferenceId(SerializedProperty property)
+        {
+#if UNITY_6000_4_OR_NEWER
+            ulong entityId = UnityEngine.EntityId.ToULong(property.objectReferenceEntityIdValue);
+            return entityId.ToString(CultureInfo.InvariantCulture);
+#else
+            int instanceId = property.objectReferenceInstanceIDValue;
+            return instanceId.ToString(CultureInfo.InvariantCulture);
+#endif
+        }
+
+        private static string GetObjectId(UnityEngine.Object obj)
+        {
+            UnityEngine.Debug.Assert(obj != null, "Unity Object must exist before reading its identifier.");
+
+#if UNITY_6000_4_OR_NEWER
+            ulong entityId = UnityEngine.EntityId.ToULong(obj.GetEntityId());
+            return entityId.ToString(CultureInfo.InvariantCulture);
+#else
+            int instanceId = obj.GetInstanceID();
+            return instanceId.ToString(CultureInfo.InvariantCulture);
+#endif
         }
         
         

--- a/Packages/src/Editor/Core/CoreTools/HierarchyAnalyzer/HierarchyNode.cs
+++ b/Packages/src/Editor/Core/CoreTools/HierarchyAnalyzer/HierarchyNode.cs
@@ -10,9 +10,9 @@ namespace io.github.hatayama.uLoopMCP
     public class HierarchyNode
     {
         /// <summary>
-        /// Unity's GetInstanceID() value - unique within session
+        /// Session-unique Unity object identifier
         /// </summary>
-        public readonly int id;
+        public readonly string id;
         
         /// <summary>
         /// GameObject name
@@ -20,9 +20,9 @@ namespace io.github.hatayama.uLoopMCP
         public readonly string name;
         
         /// <summary>
-        /// Parent node's instance ID (null for root objects)
+        /// Parent node's session-unique Unity object identifier (null for root objects)
         /// </summary>
-        public readonly int? parent;
+        public readonly string parent;
         
         /// <summary>
         /// Depth level in hierarchy (0 for root)
@@ -52,9 +52,9 @@ namespace io.github.hatayama.uLoopMCP
         /// <summary>
         /// Constructor for HierarchyNode
         /// </summary>
-        public HierarchyNode(int id, string name, int? parent, int depth, bool isActive, string[] components, string sceneName = "", int? siblingIndex = null, string tag = null, int? layer = null)
+        public HierarchyNode(string id, string name, string parent, int depth, bool isActive, string[] components, string sceneName = "", int? siblingIndex = null, string tag = null, int? layer = null)
         {
-            this.id = id;
+            this.id = id ?? string.Empty;
             this.name = name ?? string.Empty;
             this.parent = parent;
             this.depth = depth;

--- a/Packages/src/Editor/Core/CoreTools/HierarchyAnalyzer/HierarchySerializer.cs
+++ b/Packages/src/Editor/Core/CoreTools/HierarchyAnalyzer/HierarchySerializer.cs
@@ -35,7 +35,7 @@ namespace io.github.hatayama.uLoopMCP
             );
 
             // Group by scene
-            var groups = nodes
+            List<SceneHierarchyGroup> groups = nodes
                 .GroupBy(n => n.sceneName)
                 .Select(g => BuildGroupForScene(g.Key ?? string.Empty, g.ToList(), options))
                 .ToList();
@@ -46,7 +46,7 @@ namespace io.github.hatayama.uLoopMCP
         private SceneHierarchyGroup BuildGroupForScene(string sceneName, List<HierarchyNode> sceneNodes, HierarchySerializationOptions options)
         {
             // Build nested structure per scene
-            Dictionary<int, HierarchyNodeNested> nodeDict = new Dictionary<int, HierarchyNodeNested>();
+            Dictionary<string, HierarchyNodeNested> nodeDict = new Dictionary<string, HierarchyNodeNested>();
 
             foreach (HierarchyNode flat in sceneNodes)
             {
@@ -70,7 +70,7 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     roots.Add(nested);
                 }
-                else if (nodeDict.TryGetValue(flat.parent.Value, out var parentNested))
+                else if (nodeDict.TryGetValue(flat.parent, out HierarchyNodeNested parentNested))
                 {
                     parentNested.children.Add(nested);
                 }
@@ -121,7 +121,7 @@ namespace io.github.hatayama.uLoopMCP
             return unique * 2 < all.Count; // more than 50% duplicates
         }
 
-        private static List<string> BuildComponentsLutAndApply(List<HierarchyNode> sceneNodes, Dictionary<int, HierarchyNodeNested> nodeDict)
+        private static List<string> BuildComponentsLutAndApply(List<HierarchyNode> sceneNodes, Dictionary<string, HierarchyNodeNested> nodeDict)
         {
             Dictionary<string, int> lutIndex = new Dictionary<string, int>();
             List<string> lut = new List<string>();

--- a/Packages/src/Editor/Core/CoreTools/HierarchyAnalyzer/HierarchyService.cs
+++ b/Packages/src/Editor/Core/CoreTools/HierarchyAnalyzer/HierarchyService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -334,7 +335,7 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
-        private void TraverseHierarchy(GameObject obj, int? parentId, int depth, HierarchyOptions options, List<HierarchyNode> nodes)
+        private void TraverseHierarchy(GameObject obj, string parentId, int depth, HierarchyOptions options, List<HierarchyNode> nodes)
         {
             // Check depth limit
             if (options.MaxDepth >= 0 && depth > options.MaxDepth)
@@ -352,8 +353,9 @@ namespace io.github.hatayama.uLoopMCP
             }
             
             // Create node
+            string currentId = GetObjectId(obj);
             HierarchyNode node = new HierarchyNode(
-                id: obj.GetInstanceID(),
+                id: currentId,
                 name: obj.name,
                 parent: parentId,
                 depth: depth,
@@ -368,7 +370,6 @@ namespace io.github.hatayama.uLoopMCP
             nodes.Add(node);
             
             // Traverse children
-            int currentId = obj.GetInstanceID();
             foreach (Transform child in obj.transform)
             {
                 if (!options.IncludeInactive && !child.gameObject.activeInHierarchy)
@@ -376,6 +377,19 @@ namespace io.github.hatayama.uLoopMCP
                     
                 TraverseHierarchy(child.gameObject, currentId, depth + 1, options, nodes);
             }
+        }
+
+        private static string GetObjectId(UnityEngine.Object obj)
+        {
+            UnityEngine.Debug.Assert(obj != null, "Unity Object must exist before reading its identifier.");
+
+#if UNITY_6000_4_OR_NEWER
+            ulong entityId = UnityEngine.EntityId.ToULong(obj.GetEntityId());
+            return entityId.ToString(CultureInfo.InvariantCulture);
+#else
+            int instanceId = obj.GetInstanceID();
+            return instanceId.ToString(CultureInfo.InvariantCulture);
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- Unity 6.5 projects can compile without being blocked by obsolete Unity object identifier APIs.
- Dynamic code execution can keep using the fast Roslyn path with the Unity 6000.5 Editor layout.

## User Impact
- Before this change, Unity 6.5 reports obsolete API usage as compile errors in object reference and hierarchy serialization paths.
- Unity 6000.5 beta also moved the bundled Roslyn compiler, causing execute-dynamic-code to fall back to the slower AssemblyBuilder path.
- After this change, the package supports the newer Unity object identifier APIs and finds the new compiler location while preserving older Unity support.

## Changes
- Use EntityId-based object identifiers on Unity 6000.4 or newer, with the previous InstanceID path kept for older Editors.
- Serialize hierarchy and object reference identifiers as strings so both old and new Unity identifier formats fit the same API response shape.
- Resolve Roslyn from both the legacy DotNetSdkRoslyn layout and the newer DotNetSdk/sdk/*/Roslyn/bincore layout.
- Added targeted EditMode coverage for the Unity 6000.5 compiler layout and updated identifier serialization tests.

## Verification
- Direct Unity 6000.5 C# compile for uLoopMCP.Editor: passed with pre-existing warnings.
- Direct Unity 6000.5 C# compile for uLoopMCP.Tests.Editor: passed.
- Local embedded CLI compile on Unity 6000.5.0b7: Success true, ErrorCount 0.
- ExternalCompilerPathResolverTests: 10 passed.
- execute-dynamic-code returned Application.unityVersion as 6000.5.0b7 without dynamic_code_fast_path_unavailable or AssemblyBuilder fallback logs.
- codex-review-loop against origin/main: 0 valid findings after reviewer withdrew a dirty-working-tree-only manifest finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Support for Unity 6.5 and Fast Code Execution

### Problem Statement
Unity 6.5 projects could not compile due to obsolete Unity object identifier APIs being treated as compile errors. Additionally, the Unity 6000.5 beta relocating the bundled Roslyn compiler caused the dynamic code execution path to fall back to the slower AssemblyBuilder approach instead of using the faster Roslyn-based execution.

### Solution Overview
This PR modernizes the package to support both legacy and contemporary Unity identifier formats while maintaining backward compatibility. The solution uses conditional compilation to switch between `EntityId` (Unity 6000.4+) and `InstanceID` (older versions), serializes all identifiers as strings for API consistency, and implements Roslyn compiler resolution logic that supports both the legacy and new Unity SDK layouts.

### Technical Changes

#### Object Identifier Migration
- **HierarchyNode**: Changed `id` and `parent` fields from `int`/`int?` to `string` types, normalizing `null` to `string.Empty` for root nodes
- **ComponentPropertySerializer**: Introduced `GetObjectReferenceValue` helper that:
  - Returns `EntityId` (formatted as string) on Unity 6000.4+
  - Falls back to `InstanceID` on older versions
  - Formats all identifiers using `CultureInfo.InvariantCulture`
- **HierarchyService**: Updated `GetObjectId` helper to return string-formatted object identifiers conditionally based on Unity version

#### Identifier Serialization
- All object references now serialize as strings to maintain consistent API response shape across identifier formats
- "Missing/None" references use `entityId = "0"` format
- **HierarchySerializer**: Updated internal `Dictionary<string, HierarchyNodeNested>` to work with string-based identifiers throughout parent-child attachment logic

#### Roslyn Compiler Resolution
- **ExternalCompilerPathResolver**: Enhanced `Resolve()` method to:
  - Compute `effectiveScriptingRootPath` and derive dedicated `compilerDirectoryPath` 
  - Support legacy `DotNetSdkRoslyn` layout
  - Support newer `DotNetSdk/sdk/*/Roslyn/bincore` layout with automatic SDK version ordering
  - Implement `ResolveDotNetSdkCompilerDirectoryPath` to select the highest SDK version using semantic versioning
  - Include deterministic string-based fallback for version comparison
  - Expand missing component detection to both legacy and new layouts
- Updated layout detection to verify presence of both `NetCoreRuntime` and a resolvable compiler directory

### Test Coverage
- **ExternalCompilerPathResolverTests**: Added 3 new test cases:
  - `ResolveScriptingRootPath_WhenResourcesScriptingDotNetSdkLayoutExists_ShouldReturnResourcesScriptingPath()`
  - `ResolveCompilerDirectoryPath_WhenLegacyLayoutExists_ShouldReturnDotNetSdkRoslynPath()`
  - `ResolveCompilerDirectoryPath_WhenDotNetSdkLayoutHasMultipleSdkVersions_ShouldChooseHighestSdkRoslynBincorePath()`
- **FindGameObjectsToolTests**: Updated to validate `entityId` representation with conditional compilation for version-specific assertions
- **HierarchySerializerTests**: Refactored test fixtures to use string-based identifiers

### Verification Results
- Direct Unity 6000.5 C# compiles for uLoopMCP.Editor and uLoopMCP.Tests.Editor: ✓ Passed (with pre-existing warnings)
- Local embedded CLI compile on Unity 6000.5.0b7: Success, ErrorCount 0
- ExternalCompilerPathResolverTests: 10 passed
- execute-dynamic-code returned `Application.unityVersion 6000.5.0b7` without fallback logs
- Fast code execution path confirmed available (no AssemblyBuilder fallback)
- Code review analysis: 0 valid findings (1 withdrawn)

### Backward Compatibility
The changes maintain full backward compatibility with older Unity versions through:
- Conditional compilation directives (`UNITY_6000_4_OR_NEWER`)
- Fallback paths for legacy compiler layouts
- Version-agnostic string-based identifier serialization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1119)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->