### PR TITLE
fix(build): exclude Editor-only assemblies from player builds

### DIFF
--- a/Packages/src/Plugins/CodeAnalysis/System.Collections.Immutable.dll.meta
+++ b/Packages/src/Plugins/CodeAnalysis/System.Collections.Immutable.dll.meta
@@ -12,14 +12,14 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      Any: 
+      Any:
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:

--- a/Packages/src/Plugins/CodeAnalysis/System.Reflection.Metadata.dll.meta
+++ b/Packages/src/Plugins/CodeAnalysis/System.Reflection.Metadata.dll.meta
@@ -12,14 +12,14 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      Any: 
+      Any:
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:

--- a/Packages/src/Plugins/CodeAnalysis/System.Runtime.CompilerServices.Unsafe.dll.meta
+++ b/Packages/src/Plugins/CodeAnalysis/System.Runtime.CompilerServices.Unsafe.dll.meta
@@ -12,14 +12,14 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      Any: 
+      Any:
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:

--- a/Packages/src/Runtime/uLoopMCP.Runtime.asmdef
+++ b/Packages/src/Runtime/uLoopMCP.Runtime.asmdef
@@ -2,7 +2,9 @@
     "name": "uLoopMCP.Runtime",
     "rootNamespace": "",
     "references": [],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
## Summary
- Restrict `uLoopMCP.Runtime.asmdef` to the Editor platform — the input-visualization overlays inside it are only driven by Editor-side simulate/record/replay tools, but the asmdef had no `includePlatforms`, so the assembly shipped to every player build.
- Flip the `Any` / `Editor` enable flags on the three `Plugins/CodeAnalysis/*.dll.meta` files. The DLLs (`System.Collections.Immutable`, `System.Reflection.Metadata`, `System.Runtime.CompilerServices.Unsafe`) are only referenced from `Editor/MetadataValidation` and `Editor/Compilation`, but the meta files declared `Any: enabled: 1` with `Editor: enabled: 0`, which inverted the intent and shipped them to every non-Editor target.

## Why
A consumer project that adds uLoopMCP for AI-driven development can get ~758 KB of unused Roslyn / runtime assemblies bundled into shipped player builds, depending on the build configuration. Beyond the byte count, the current setup is structurally incorrect: the package's stated intent (Editor-side tooling) does not match what gets shipped to players.

## Verification
Built an empty Unity 6 (6000.2.6f2) project with this package both before and after the fix on two backends:

### A. Standalone Windows 64 / Mono2x / Managed Stripping = Disabled

| Stage | Build size | uloop-origin DLLs in `*_Data/Managed/` |
|---|---|---|
| Before | 96.26 MB | 4 (`uLoopMCP.Runtime.dll`, `System.Collections.Immutable.dll`, `System.Reflection.Metadata.dll`, `System.Runtime.CompilerServices.Unsafe.dll`) |
| After  | 95.52 MB | 0 |

Identity of removed DLLs confirmed by byte-for-byte size match against `Packages/src/Plugins/CodeAnalysis/*.dll`. The remaining `System.Runtime.CompilerServices.Unsafe.dll` (18,024 bytes) in the build is from `com.unity.collections`, unrelated to this package.

### B. Android / IL2CPP / ARM64 / Managed Stripping = Minimal (defaults)

| Stage | APK size | uloop-origin DLLs in IL2CPP input `Managed/` | uloop / Immutable / Reflection.Metadata matches across the 325 generated `il2cppOutput/*.cpp` files |
|---|---|---|---|
| Before | 32,742,254 B (32.74 MB) | 0 | 0 |
| After  | 32,741,417 B (32.74 MB) | 0 | 0 |

On IL2CPP builds the visible APK delta is ~837 bytes (essentially noise). The reason is that `UnityLinker` (active whenever Managed Stripping is anything but `Disabled`, which is the default for IL2CPP) already removes assemblies that have no incoming references from `Assembly-CSharp`. The four DLLs in question never reach IL2CPP either way, so the fix mostly serves as a correctness improvement here — but the BackUp / il2cppOutput folders confirm no uloop traces survive, so there is no regression.

### Where the fix actually pays off

- Mono backends on all platforms (Standalone / Android Mono / etc.), especially when **Managed Stripping is Disabled** — the original ~758 KB savings applies directly.
- IL2CPP projects that have explicitly set Managed Stripping to `Disabled` — same savings as Mono.
- Every configuration benefits from the structural fix: the package's declared platform compatibility now matches its actual usage, so future regressions where a Player-side assembly accidentally references the Editor-only Runtime DLL become impossible at the asmdef level.

## Test plan
- [ ] Open a Unity project with this package installed; confirm Editor-side menus (`uloop` CLI / MCP server / dynamic-code execution / record / replay / simulate-keyboard / simulate-mouse) still work.
- [ ] Build a standalone player and inspect `*_Data/Managed/`: the four DLLs above must not be present.