### PR TITLE
fix: Unity stays responsive during domain reload recovery

### DIFF
--- a/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
+++ b/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
@@ -115,5 +115,26 @@ namespace io.github.hatayama.uLoopMCP
                 server?.Dispose();
             }
         }
+
+        [Test]
+        public void StopServerBeforeDomainReload_ShouldBeSafe_WhenCalledMoreThanOnce()
+        {
+            int instancePort = GetFreePort();
+            McpBridgeServer server = new McpBridgeServer();
+            try
+            {
+                server.StartServer(instancePort);
+
+                server.StopServerBeforeDomainReload();
+                server.StopServerBeforeDomainReload();
+                server.Dispose();
+
+                Assert.IsFalse(server.IsRunning, "Server should remain stopped after repeated domain reload stops");
+            }
+            finally
+            {
+                server.Dispose();
+            }
+        }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeServicesTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeServicesTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
+{
+    [TestFixture]
+    public class DynamicCodeServicesTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            DynamicCodeServices.ResetStateForTests();
+        }
+
+        [Test]
+        public void ResetServerScopedServicesBeforeDomainReload_ShouldCancelLifetimeWithoutAwaitingRuntimeShutdown()
+        {
+            CancellationTokenSource lifetimeCancellationTokenSource = new CancellationTokenSource();
+            FakeExecutorPool executorPool = new FakeExecutorPool();
+            FakeShutdownAwareRuntime runtime = new FakeShutdownAwareRuntime();
+            DynamicCodeServices.SetServerScopedServicesForTests(
+                lifetimeCancellationTokenSource,
+                executorPool,
+                runtime,
+                null);
+
+            DynamicCodeServices.ResetServerScopedServicesBeforeDomainReload();
+
+            Assert.IsTrue(lifetimeCancellationTokenSource.IsCancellationRequested, "Lifetime token should be cancelled");
+            Assert.AreEqual(0, runtime.ShutdownCallCount, "Domain reload reset should not await runtime shutdown");
+            Assert.AreEqual(0, runtime.DisposeCallCount, "Domain reload reset should leave managed disposal to reload teardown");
+            Assert.AreEqual(0, executorPool.DisposeCallCount, "Domain reload reset should not dispose executor pool synchronously");
+            Assert.IsTrue(
+                DynamicCodeServices.GetServerScopedDrainTaskForTests().IsCompleted,
+                "Domain reload reset should not leave a drain task that later runs into reload teardown");
+
+            lifetimeCancellationTokenSource.Dispose();
+        }
+
+        private sealed class FakeExecutorPool : IDynamicCodeExecutorPool
+        {
+            public int DisposeCallCount { get; private set; }
+
+            public IDynamicCodeExecutor GetOrCreate(DynamicCodeSecurityLevel securityLevel)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Dispose()
+            {
+                DisposeCallCount++;
+            }
+        }
+
+        private sealed class FakeShutdownAwareRuntime : IShutdownAwareDynamicCodeExecutionRuntime, IDisposable
+        {
+            public int ShutdownCallCount { get; private set; }
+
+            public int DisposeCallCount { get; private set; }
+
+            public bool SupportsAutoPrewarm()
+            {
+                return true;
+            }
+
+            public Task<ExecutionResult> ExecuteAsync(
+                DynamicCodeExecutionRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                throw new NotSupportedException();
+            }
+
+            public Task<(bool Entered, ExecutionResult Result)> TryExecuteIfIdleAsync(
+                DynamicCodeExecutionRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                throw new NotSupportedException();
+            }
+
+            public Task ShutdownAsync()
+            {
+                ShutdownCallCount++;
+                return Task.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+                DisposeCallCount++;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeServicesTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeServicesTests.cs
@@ -29,13 +29,14 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
             DynamicCodeServices.ResetServerScopedServicesBeforeDomainReload();
 
             Assert.IsTrue(lifetimeCancellationTokenSource.IsCancellationRequested, "Lifetime token should be cancelled");
-            Assert.AreEqual(0, runtime.ShutdownCallCount, "Domain reload reset should not await runtime shutdown");
+            Assert.AreEqual(1, runtime.ShutdownCallCount, "Domain reload reset should signal runtime shutdown");
             Assert.AreEqual(0, runtime.DisposeCallCount, "Domain reload reset should leave managed disposal to reload teardown");
             Assert.AreEqual(0, executorPool.DisposeCallCount, "Domain reload reset should not dispose executor pool synchronously");
             Assert.IsTrue(
                 DynamicCodeServices.GetServerScopedDrainTaskForTests().IsCompleted,
                 "Domain reload reset should not leave a drain task that later runs into reload teardown");
 
+            runtime.CompleteShutdown();
             lifetimeCancellationTokenSource.Dispose();
         }
 
@@ -56,6 +57,9 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
 
         private sealed class FakeShutdownAwareRuntime : IShutdownAwareDynamicCodeExecutionRuntime, IDisposable
         {
+            private readonly TaskCompletionSource<bool> _shutdownCompletionSource =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
             public int ShutdownCallCount { get; private set; }
 
             public int DisposeCallCount { get; private set; }
@@ -82,7 +86,12 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
             public Task ShutdownAsync()
             {
                 ShutdownCallCount++;
-                return Task.CompletedTask;
+                return _shutdownCompletionSource.Task;
+            }
+
+            public void CompleteShutdown()
+            {
+                _shutdownCompletionSource.SetResult(true);
             }
 
             public void Dispose()

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeServicesTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeServicesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a103d0195ccb4f10add8c67877857da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
+++ b/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
@@ -104,6 +104,27 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public void ShouldTreatLoopExitAsUnexpectedForTests_ShouldIgnoreCanceledLoop_WhenServerIsRunning()
+        {
+            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            bool canceledLoopResult = McpBridgeServer.ShouldTreatLoopExitAsUnexpectedForTests(
+                true,
+                cancellationTokenSource.Token);
+            bool activeLoopResult = McpBridgeServer.ShouldTreatLoopExitAsUnexpectedForTests(
+                true,
+                CancellationToken.None);
+
+            Assert.IsFalse(
+                canceledLoopResult,
+                "Canceled server loops should not trigger unexpected-exit recovery");
+            Assert.IsTrue(
+                activeLoopResult,
+                "Running non-canceled server loops should still trigger unexpected-exit recovery");
+        }
+
+        [Test]
         public async Task StopServerOnMainThread_ShouldNotBlockWaitingForClientTasks()
         {
             int port = GetFreePort();

--- a/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
+++ b/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
@@ -35,7 +35,7 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
-        public async Task StopServer_ShouldWaitForTrackedClientTasks()
+        public async Task StopServer_ShouldObserveTrackedClientTasksAfterShutdown()
         {
             int port = GetFreePort();
             McpBridgeServer server = new McpBridgeServer();
@@ -52,10 +52,9 @@ namespace io.github.hatayama.uLoopMCP
 
                 server.StopServer();
 
-                Assert.AreEqual(
-                    0,
-                    server.GetActiveClientTaskCountForTests(),
-                    "Normal shutdown should wait for tracked client tasks to finish");
+                bool taskRemoved = await WaitUntilAsync(
+                    () => server.GetActiveClientTaskCountForTests() == 0);
+                Assert.IsTrue(taskRemoved, "Normal shutdown should keep observing tracked client tasks after returning");
             }
             finally
             {
@@ -98,6 +97,38 @@ namespace io.github.hatayama.uLoopMCP
             finally
             {
                 McpBridgeServer.OnServerLoopExited -= CountUnexpectedExit;
+            }
+        }
+
+        [Test]
+        public async Task StopServerOnMainThread_ShouldNotBlockWaitingForClientTasks()
+        {
+            int port = GetFreePort();
+            McpBridgeServer server = new McpBridgeServer();
+            Task delayedClientTask = Task.Delay(1000);
+
+            try
+            {
+                server.StartServer(port);
+                server.TrackClientTaskForTests(delayedClientTask);
+
+                System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                server.StopServer();
+                stopwatch.Stop();
+
+                Assert.Less(
+                    stopwatch.ElapsedMilliseconds,
+                    500,
+                    "Main-thread shutdown should observe client tasks asynchronously instead of blocking");
+
+                await delayedClientTask;
+                bool taskRemoved = await WaitUntilAsync(
+                    () => server.GetActiveClientTaskCountForTests() == 0);
+                Assert.IsTrue(taskRemoved, "Tracked task should still be observed and removed after completion");
+            }
+            finally
+            {
+                server.Dispose();
             }
         }
 

--- a/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
+++ b/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    public class McpBridgeServerShutdownTests
+    {
+        [Test]
+        public async Task AcceptTcpClientAsyncForTests_ShouldComplete_WhenCancellationIsRequested()
+        {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            listener.Start();
+
+            try
+            {
+                Task<TcpClient> acceptTask = McpBridgeServer.AcceptTcpClientAsyncForTests(
+                    listener,
+                    cancellationTokenSource.Token);
+
+                cancellationTokenSource.Cancel();
+
+                TcpClient acceptedClient = await acceptTask;
+
+                Assert.IsNull(acceptedClient, "Cancelled accept should complete without leaving a blocked task");
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+        [Test]
+        public async Task StopServer_ShouldWaitForTrackedClientTasks()
+        {
+            int port = GetFreePort();
+            McpBridgeServer server = new McpBridgeServer();
+            TcpClient client = new TcpClient();
+
+            try
+            {
+                server.StartServer(port);
+                await client.ConnectAsync(IPAddress.Loopback, port);
+
+                bool taskTracked = await WaitUntilAsync(
+                    () => server.GetActiveClientTaskCountForTests() == 1);
+                Assert.IsTrue(taskTracked, "Accepted client should be tracked before shutdown");
+
+                server.StopServer();
+
+                Assert.AreEqual(
+                    0,
+                    server.GetActiveClientTaskCountForTests(),
+                    "Normal shutdown should wait for tracked client tasks to finish");
+            }
+            finally
+            {
+                client.Close();
+                server.Dispose();
+            }
+        }
+
+        private static int GetFreePort()
+        {
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        private static async Task<bool> WaitUntilAsync(Func<bool> predicate)
+        {
+            for (int attempt = 0; attempt < 100; attempt++)
+            {
+                if (predicate())
+                {
+                    return true;
+                }
+
+                await Task.Yield();
+            }
+
+            return predicate();
+        }
+    }
+}

--- a/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
+++ b/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
@@ -64,6 +64,43 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
+        [Test]
+        public void StopServerImmediatelyAfterStartServer_ShouldNotThrowOrReportUnexpectedLoopExit()
+        {
+            int unexpectedExitCount = 0;
+            void CountUnexpectedExit()
+            {
+                Interlocked.Increment(ref unexpectedExitCount);
+            }
+
+            McpBridgeServer.OnServerLoopExited += CountUnexpectedExit;
+            try
+            {
+                for (int attempt = 0; attempt < 50; attempt++)
+                {
+                    McpBridgeServer server = new McpBridgeServer();
+                    try
+                    {
+                        server.StartServer(GetFreePort());
+                        Assert.DoesNotThrow(server.StopServer);
+                    }
+                    finally
+                    {
+                        server.Dispose();
+                    }
+                }
+
+                Assert.AreEqual(
+                    0,
+                    unexpectedExitCount,
+                    "Immediate normal shutdown should not be reported as an unexpected server loop exit");
+            }
+            finally
+            {
+                McpBridgeServer.OnServerLoopExited -= CountUnexpectedExit;
+            }
+        }
+
         private static int GetFreePort()
         {
             TcpListener listener = new TcpListener(IPAddress.Loopback, 0);

--- a/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
+++ b/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
@@ -24,6 +24,9 @@ namespace io.github.hatayama.uLoopMCP
 
                 cancellationTokenSource.Cancel();
 
+                Task completedTask = await Task.WhenAny(acceptTask, Task.Delay(1000));
+                Assert.AreSame(acceptTask, completedTask, "Cancelled accept should complete before the timeout");
+
                 TcpClient acceptedClient = await acceptTask;
 
                 Assert.IsNull(acceptedClient, "Cancelled accept should complete without leaving a blocked task");

--- a/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
+++ b/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs
@@ -146,14 +146,16 @@ namespace io.github.hatayama.uLoopMCP
 
         private static async Task<bool> WaitUntilAsync(Func<bool> predicate)
         {
-            for (int attempt = 0; attempt < 100; attempt++)
+            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            TimeSpan timeout = TimeSpan.FromSeconds(1);
+            while (stopwatch.Elapsed < timeout)
             {
                 if (predicate())
                 {
                     return true;
                 }
 
-                await Task.Yield();
+                await Task.Delay(10);
             }
 
             return predicate();

--- a/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs.meta
+++ b/Assets/Tests/Editor/McpBridgeServerShutdownTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c341c2e1be1a7434ea599a244d2c4b0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Api/McpTools/UseCases/System/DomainReloadRecoveryUseCase.cs
+++ b/Packages/src/Editor/Api/McpTools/UseCases/System/DomainReloadRecoveryUseCase.cs
@@ -66,7 +66,7 @@ namespace io.github.hatayama.uLoopMCP
                     ClientNotificationService.LogServerStoppingBeforeDomainReload(correlationId, portToSave);
 
                     // 4.2. Stop server
-                    currentServer.Dispose();
+                    currentServer.StopServerBeforeDomainReload();
 
                     // 4.3. Notify client of stop completion
                     ClientNotificationService.LogServerStoppedAfterDomainReload(correlationId);

--- a/Packages/src/Editor/Composition/DynamicCodeServices.cs
+++ b/Packages/src/Editor/Composition/DynamicCodeServices.cs
@@ -88,10 +88,12 @@ namespace io.github.hatayama.uLoopMCP
         public static void ResetServerScopedServicesBeforeDomainReload()
         {
             CancellationTokenSource lifetimeCancellationTokenSource;
+            IDynamicCodeExecutionRuntime runtimeFacade;
 
             lock (ServerScopedServicesLock)
             {
                 lifetimeCancellationTokenSource = _serverScopedLifetimeCancellationTokenSource;
+                runtimeFacade = _runtimeFacade;
 
                 _serverScopedLifetimeCancellationTokenSource = null;
                 _executorPool = null;
@@ -101,7 +103,23 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             lifetimeCancellationTokenSource?.Cancel();
+            SignalRuntimeShutdownBeforeDomainReload(runtimeFacade);
             SharedRoslynCompilerWorkerHost.ShutdownForServerReset();
+        }
+
+        private static void SignalRuntimeShutdownBeforeDomainReload(
+            IDynamicCodeExecutionRuntime runtimeFacade)
+        {
+            if (runtimeFacade is IShutdownAwareDynamicCodeExecutionRuntime shutdownAwareRuntime)
+            {
+                Task shutdownTask = shutdownAwareRuntime.ShutdownAsync();
+                _ = CreateObservedDrainTask(
+                    shutdownTask,
+                    "server_scoped_shutdown_before_domain_reload_failed");
+                return;
+            }
+
+            (runtimeFacade as IDisposable)?.Dispose();
         }
 
         private static async Task<IDynamicCodeExecutionRuntime> GetRuntimeFacadeAsync()

--- a/Packages/src/Editor/Composition/DynamicCodeServices.cs
+++ b/Packages/src/Editor/Composition/DynamicCodeServices.cs
@@ -85,6 +85,25 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
+        public static void ResetServerScopedServicesBeforeDomainReload()
+        {
+            CancellationTokenSource lifetimeCancellationTokenSource;
+
+            lock (ServerScopedServicesLock)
+            {
+                lifetimeCancellationTokenSource = _serverScopedLifetimeCancellationTokenSource;
+
+                _serverScopedLifetimeCancellationTokenSource = null;
+                _executorPool = null;
+                _runtimeFacade = null;
+                _prewarmDynamicCodeUseCase = null;
+                _serverScopedDrainTask = Task.CompletedTask;
+            }
+
+            lifetimeCancellationTokenSource?.Cancel();
+            SharedRoslynCompilerWorkerHost.ShutdownForServerReset();
+        }
+
         private static async Task<IDynamicCodeExecutionRuntime> GetRuntimeFacadeAsync()
         {
             await EnsureServerScopedServicesInitializedAsync();

--- a/Packages/src/Editor/Server/McpBridgeServer.cs
+++ b/Packages/src/Editor/Server/McpBridgeServer.cs
@@ -306,35 +306,79 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             serverTask?.Wait(TimeSpan.FromSeconds(McpServerConfig.SHUTDOWN_TIMEOUT_SECONDS));
-            WaitForClientTasksToComplete();
-            cancellationTokenSource?.Dispose();
+            DisposeCancellationTokenSourceAfterClientTasks(cancellationTokenSource);
         }
 
-        private void WaitForClientTasksToComplete()
+        private void DisposeCancellationTokenSourceAfterClientTasks(
+            CancellationTokenSource cancellationTokenSource)
         {
             Task[] clientTasks = _clientTasks.Values.ToArray();
             if (clientTasks.Length == 0)
             {
+                cancellationTokenSource?.Dispose();
                 return;
             }
 
-            Task completionTask = Task.WhenAll(clientTasks).ContinueWith(task =>
+            if (MainThreadSwitcher.IsMainThread)
+            {
+                _ = ObserveClientTasksThenDisposeCancellationTokenSourceAsync(
+                    clientTasks,
+                    cancellationTokenSource);
+                return;
+            }
+
+            WaitForClientTasksToComplete(clientTasks);
+            cancellationTokenSource?.Dispose();
+        }
+
+        private static void WaitForClientTasksToComplete(Task[] clientTasks)
+        {
+            Task completionTask = CreateObservedClientTaskCompletionTask(clientTasks);
+            bool completed = completionTask.Wait(TimeSpan.FromSeconds(McpServerConfig.SHUTDOWN_TIMEOUT_SECONDS));
+            if (!completed)
+            {
+                LogClientTaskShutdownTimeout(clientTasks.Length);
+            }
+        }
+
+        private static async Task ObserveClientTasksThenDisposeCancellationTokenSourceAsync(
+            Task[] clientTasks,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            try
+            {
+                Task completionTask = CreateObservedClientTaskCompletionTask(clientTasks);
+                Task timeoutTask = Task.Delay(TimeSpan.FromSeconds(McpServerConfig.SHUTDOWN_TIMEOUT_SECONDS));
+                Task finishedTask = await Task.WhenAny(completionTask, timeoutTask);
+                if (!ReferenceEquals(finishedTask, completionTask))
+                {
+                    LogClientTaskShutdownTimeout(clientTasks.Length);
+                }
+            }
+            finally
+            {
+                cancellationTokenSource?.Dispose();
+            }
+        }
+
+        private static Task CreateObservedClientTaskCompletionTask(Task[] clientTasks)
+        {
+            return Task.WhenAll(clientTasks).ContinueWith(task =>
             {
                 if (task.IsFaulted)
                 {
                     _ = task.Exception;
                 }
             }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
 
-            bool completed = completionTask.Wait(TimeSpan.FromSeconds(McpServerConfig.SHUTDOWN_TIMEOUT_SECONDS));
-            if (!completed)
-            {
-                VibeLogger.LogWarning(
-                    "client_tasks_shutdown_timeout",
-                    "Timed out waiting for client handlers to finish during normal server shutdown.",
-                    new { activeClientTasks = _clientTasks.Count }
-                );
-            }
+        private static void LogClientTaskShutdownTimeout(int activeClientTasks)
+        {
+            VibeLogger.LogWarning(
+                "client_tasks_shutdown_timeout",
+                "Timed out waiting for client handlers to finish during normal server shutdown.",
+                new { activeClientTasks }
+            );
         }
 
         /// <summary>
@@ -515,6 +559,11 @@ namespace io.github.hatayama.uLoopMCP
         internal int GetActiveClientTaskCountForTests()
         {
             return _clientTasks.Count;
+        }
+
+        internal void TrackClientTaskForTests(Task clientTask)
+        {
+            TrackClientTask(clientTask);
         }
 
         private static async Task<TcpClient> AcceptTcpClientAsyncCore(

--- a/Packages/src/Editor/Server/McpBridgeServer.cs
+++ b/Packages/src/Editor/Server/McpBridgeServer.cs
@@ -508,9 +508,7 @@ namespace io.github.hatayama.uLoopMCP
             }
             finally
             {
-                // StopServer sets _isRunning=false before cancelling, so if it's still true here
-                // the loop exited unexpectedly (e.g. ObjectDisposedException, TcpListener disposed externally)
-                bool wasUnexpectedExit = _isRunning;
+                bool wasUnexpectedExit = ShouldTreatLoopExitAsUnexpected(_isRunning, cancellationToken);
                 if (wasUnexpectedExit)
                 {
                     VibeLogger.LogWarning(
@@ -523,6 +521,14 @@ namespace io.github.hatayama.uLoopMCP
                     OnServerLoopExited?.Invoke();
                 }
             }
+        }
+
+        private static bool ShouldTreatLoopExitAsUnexpected(
+            bool isRunning,
+            CancellationToken cancellationToken)
+        {
+            // A canceled loop belongs to an intentional shutdown and must not recover a newer server.
+            return isRunning && !cancellationToken.IsCancellationRequested;
         }
 
         /// <summary>
@@ -559,6 +565,13 @@ namespace io.github.hatayama.uLoopMCP
         internal int GetActiveClientTaskCountForTests()
         {
             return _clientTasks.Count;
+        }
+
+        internal static bool ShouldTreatLoopExitAsUnexpectedForTests(
+            bool isRunning,
+            CancellationToken cancellationToken)
+        {
+            return ShouldTreatLoopExitAsUnexpected(isRunning, cancellationToken);
         }
 
         internal void TrackClientTaskForTests(Task clientTask)

--- a/Packages/src/Editor/Server/McpBridgeServer.cs
+++ b/Packages/src/Editor/Server/McpBridgeServer.cs
@@ -246,65 +246,64 @@ namespace io.github.hatayama.uLoopMCP
         /// </summary>
         public void StopServer()
         {
-            if (!_isRunning)
+            StopServerCore(ServerStopMode.Normal);
+        }
+
+        /// <summary>
+        /// Domain reload can suspend editor-thread continuations before the server task observes shutdown.
+        /// </summary>
+        public void StopServerBeforeDomainReload()
+        {
+            StopServerCore(ServerStopMode.BeforeDomainReload);
+        }
+
+        private void StopServerCore(ServerStopMode mode)
+        {
+            bool wasRunning = _isRunning;
+            CancellationTokenSource cancellationTokenSource = Interlocked.Exchange(ref _cancellationTokenSource, null);
+            TcpListener tcpListener = Interlocked.Exchange(ref _tcpListener, null);
+            Task serverTask = mode == ServerStopMode.BeforeDomainReload
+                ? _serverTask
+                : Interlocked.Exchange(ref _serverTask, null);
+
+            if (!wasRunning &&
+                cancellationTokenSource == null &&
+                tcpListener == null &&
+                serverTask == null)
             {
                 return;
             }
 
-            // Determine shutdown reason based on domain reload state
-            ServerShutdownReason shutdownReason = McpEditorSettings.GetIsDomainReloadInProgress()
-                ? ServerShutdownReason.DomainReload
-                : ServerShutdownReason.EditorQuit;
+            if (wasRunning && mode != ServerStopMode.UnexpectedLoopExit)
+            {
+                ServerShutdownReason shutdownReason = McpEditorSettings.GetIsDomainReloadInProgress()
+                    ? ServerShutdownReason.DomainReload
+                    : ServerShutdownReason.EditorQuit;
 
-            // Send shutdown notification to all connected clients BEFORE disconnecting
-            // This allows TypeScript side to differentiate between temporary and permanent shutdown
-            SendShutdownNotification(shutdownReason);
-
-            // Notify that server is stopping
-            OnServerStopping?.Invoke();
+                SendShutdownNotification(shutdownReason);
+                OnServerStopping?.Invoke();
+            }
 
             _isRunning = false;
 
-            // Explicitly disconnect all connected clients before stopping the server
-            DisconnectAllClients();
-            
-            // Request cancellation.
-            _cancellationTokenSource?.Cancel();
-            
-            // Stop the TCP listener.
-            try
+            DisconnectAllClientsCore(notifyLifecycleEvents: mode != ServerStopMode.UnexpectedLoopExit);
+
+            cancellationTokenSource?.Cancel();
+            tcpListener?.Stop();
+
+            if (mode == ServerStopMode.BeforeDomainReload)
             {
-                _tcpListener?.Stop();
+                return;
             }
-            finally
+
+            if (mode == ServerStopMode.UnexpectedLoopExit)
             {
-                // Set the TCP listener to null regardless of success/failure
-                _tcpListener = null;
+                cancellationTokenSource?.Dispose();
+                return;
             }
-            
-            // Wait for the server task to complete.
-            try
-            {
-                _serverTask?.Wait(TimeSpan.FromSeconds(McpServerConfig.SHUTDOWN_TIMEOUT_SECONDS));
-            }
-            finally
-            {
-                // Set the server task to null regardless of success/failure
-                _serverTask = null;
-            }
-            
-            // Dispose of the cancellation token source.
-            try
-            {
-                _cancellationTokenSource?.Dispose();
-            }
-            finally
-            {
-                // Set the cancellation token source to null regardless of success/failure
-                _cancellationTokenSource = null;
-            }
-            
-            
+
+            serverTask?.Wait(TimeSpan.FromSeconds(McpServerConfig.SHUTDOWN_TIMEOUT_SECONDS));
+            cancellationTokenSource?.Dispose();
         }
 
         /// <summary>
@@ -375,27 +374,7 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            DisconnectAllClientsCore(notifyLifecycleEvents: false);
-
-            try
-            {
-                _cancellationTokenSource?.Cancel();
-            }
-            finally
-            {
-                _cancellationTokenSource?.Dispose();
-                _cancellationTokenSource = null;
-            }
-
-            try
-            {
-                _tcpListener?.Stop();
-            }
-            finally
-            {
-                _tcpListener = null;
-                _isRunning = false;
-            }
+            StopServerCore(ServerStopMode.UnexpectedLoopExit);
         }
 
         /// <summary>
@@ -818,9 +797,13 @@ namespace io.github.hatayama.uLoopMCP
         public void Dispose()
         {
             StopServer();
-            _cancellationTokenSource?.Dispose();
-            _tcpListener = null;
-            _serverTask = null;
+        }
+
+        private enum ServerStopMode
+        {
+            Normal,
+            BeforeDomainReload,
+            UnexpectedLoopExit
         }
     }
 } 

--- a/Packages/src/Editor/Server/McpBridgeServer.cs
+++ b/Packages/src/Editor/Server/McpBridgeServer.cs
@@ -85,6 +85,7 @@ namespace io.github.hatayama.uLoopMCP
         private TcpListener _tcpListener;
         private CancellationTokenSource _cancellationTokenSource;
         private Task _serverTask;
+        private readonly ConcurrentDictionary<int, Task> _clientTasks = new();
         // Read from thread pool (ServerLoopAsync), written from main thread (StopServer)
         private volatile bool _isRunning = false;
 
@@ -303,7 +304,35 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             serverTask?.Wait(TimeSpan.FromSeconds(McpServerConfig.SHUTDOWN_TIMEOUT_SECONDS));
+            WaitForClientTasksToComplete();
             cancellationTokenSource?.Dispose();
+        }
+
+        private void WaitForClientTasksToComplete()
+        {
+            Task[] clientTasks = _clientTasks.Values.ToArray();
+            if (clientTasks.Length == 0)
+            {
+                return;
+            }
+
+            Task completionTask = Task.WhenAll(clientTasks).ContinueWith(task =>
+            {
+                if (task.IsFaulted)
+                {
+                    _ = task.Exception;
+                }
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+            bool completed = completionTask.Wait(TimeSpan.FromSeconds(McpServerConfig.SHUTDOWN_TIMEOUT_SECONDS));
+            if (!completed)
+            {
+                VibeLogger.LogWarning(
+                    "client_tasks_shutdown_timeout",
+                    "Timed out waiting for client handlers to finish during normal server shutdown.",
+                    new { activeClientTasks = _clientTasks.Count }
+                );
+            }
         }
 
         /// <summary>
@@ -388,14 +417,20 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     try
                     {
-                        TcpClient client = await AcceptTcpClientAsync(_tcpListener, cancellationToken);
+                        TcpListener listener = _tcpListener;
+                        if (listener == null)
+                        {
+                            break;
+                        }
+
+                        TcpClient client = await AcceptTcpClientAsync(listener, cancellationToken);
                         if (client != null)
                         {
                             string clientEndpoint = client.Client.RemoteEndPoint?.ToString() ?? McpServerConfig.UNKNOWN_CLIENT_ENDPOINT;
                             OnClientConnected?.Invoke(clientEndpoint);
 
-                            // Execute client handling in a separate task (fire-and-forget).
-                            Task.Run(() => HandleClientAsync(client, cancellationToken)).Forget();
+                            Task clientTask = Task.Run(() => HandleClientAsync(client, cancellationToken));
+                            TrackClientTask(clientTask);
                         }
                     }
                     catch (ObjectDisposedException)
@@ -456,7 +491,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             try
             {
-                return await Task.Run(() => listener.AcceptTcpClient(), cancellationToken);
+                return await AcceptTcpClientAsyncCore(listener, cancellationToken);
             }
             catch (ThreadAbortException ex)
             {
@@ -471,6 +506,71 @@ namespace io.github.hatayama.uLoopMCP
             {
                 return null;
             }
+        }
+
+        internal static Task<TcpClient> AcceptTcpClientAsyncForTests(
+            TcpListener listener,
+            CancellationToken cancellationToken)
+        {
+            return AcceptTcpClientAsyncCore(listener, cancellationToken);
+        }
+
+        internal int GetActiveClientTaskCountForTests()
+        {
+            return _clientTasks.Count;
+        }
+
+        private static async Task<TcpClient> AcceptTcpClientAsyncCore(
+            TcpListener listener,
+            CancellationToken cancellationToken)
+        {
+            System.Diagnostics.Debug.Assert(listener != null, "TcpListener must be available while accepting clients.");
+            if (listener == null || cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+
+            using CancellationTokenRegistration cancellationRegistration =
+                cancellationToken.Register(() => listener.Stop());
+
+            try
+            {
+                return await listener.AcceptTcpClientAsync();
+            }
+            catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+            catch (SocketException) when (cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+            catch (InvalidOperationException) when (cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+        }
+
+        private void TrackClientTask(Task clientTask)
+        {
+            System.Diagnostics.Debug.Assert(clientTask != null, "Client handler task must be created before tracking.");
+            if (clientTask == null)
+            {
+                return;
+            }
+
+            bool added = _clientTasks.TryAdd(clientTask.Id, clientTask);
+            System.Diagnostics.Debug.Assert(added, "Client handler task id should be unique while tracking.");
+
+            clientTask.ContinueWith(completedTask =>
+            {
+                _clientTasks.TryRemove(completedTask.Id, out _);
+                if (completedTask.IsFaulted)
+                {
+                    Exception exception = completedTask.Exception?.GetBaseException();
+                    OnError?.Invoke($"Client handler task faulted: {exception?.Message}");
+                }
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
 
         /// <summary>

--- a/Packages/src/Editor/Server/McpBridgeServer.cs
+++ b/Packages/src/Editor/Server/McpBridgeServer.cs
@@ -197,8 +197,10 @@ namespace io.github.hatayama.uLoopMCP
                 _tcpListener = new TcpListener(IPAddress.Loopback, Port);
                 _tcpListener.Start();
                 _isRunning = true;
-                
-                _serverTask = Task.Run(() => ServerLoopAsync(_cancellationTokenSource.Token));
+
+                TcpListener tcpListener = _tcpListener;
+                CancellationToken cancellationToken = _cancellationTokenSource.Token;
+                _serverTask = Task.Run(() => ServerLoopAsync(tcpListener, cancellationToken));
 
                 // Safety net: log if the server task faults unexpectedly.
                 // Primary detection is in ServerLoopAsync's finally block; this catches unhandled exceptions in Task.Run itself.
@@ -409,20 +411,15 @@ namespace io.github.hatayama.uLoopMCP
         /// <summary>
         /// The server's main loop.
         /// </summary>
-        private async Task ServerLoopAsync(CancellationToken cancellationToken)
+        private async Task ServerLoopAsync(TcpListener listener, CancellationToken cancellationToken)
         {
+            System.Diagnostics.Debug.Assert(listener != null, "TcpListener must be captured before starting the server loop.");
             try
             {
                 while (!cancellationToken.IsCancellationRequested && _isRunning)
                 {
                     try
                     {
-                        TcpListener listener = _tcpListener;
-                        if (listener == null)
-                        {
-                            break;
-                        }
-
                         TcpClient client = await AcceptTcpClientAsync(listener, cancellationToken);
                         if (client != null)
                         {

--- a/Packages/src/Editor/Server/McpServerController.cs
+++ b/Packages/src/Editor/Server/McpServerController.cs
@@ -292,7 +292,7 @@ namespace io.github.hatayama.uLoopMCP
 
             DynamicCodeStartupTelemetry.Reset();
             DynamicCodeForegroundWarmupState.Reset();
-            DynamicCodeServices.ResetServerScopedServices();
+            DynamicCodeServices.ResetServerScopedServicesBeforeDomainReload();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Prevent Unity from freezing when a compile or domain reload shuts down the editor bridge.
- Keep shutdown responsive while still notifying clients and observing in-flight work.

## User Impact
- Before this change, domain reload recovery could block the Unity Editor while server or client work was being drained.
- Unity now avoids main-thread waits during reload and shutdown, so recompiles and recovery should remain responsive.

## Changes
- Added a non-blocking domain reload shutdown path for the bridge server and dynamic code services.
- Made TCP accept cancellation and rapid start-stop shutdown safer.
- Track client handler tasks without blocking the Unity main thread during normal shutdown.
- Added focused EditMode coverage for domain reload, accept cancellation, client task tracking, and rapid shutdown behavior.

## Verification
- `node Packages/src/Cli~/dist/cli.bundle.cjs compile --wait-for-domain-reload true`
- `node Packages/src/Cli~/dist/cli.bundle.cjs compile --force-recompile true --wait-for-domain-reload true`
- `node Packages/src/Cli~/dist/cli.bundle.cjs run-tests --test-mode EditMode --filter-type regex --filter-value "DomainReloadRecoveryUseCaseTests|DynamicCodeServicesTests|McpBridgeServerShutdownTests"`
- `git diff --check`
- `codex exec review --base origin/main` completed with no actionable regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Domain Reload Responsiveness Recovery

## Overview
This PR introduces a non-blocking shutdown mechanism for the MCP bridge server and dynamic code services to prevent Unity Editor freezes during domain reload recovery. The implementation ensures that the editor remains responsive while properly cleaning up server resources and notifying clients.

## Key Changes

### Core Implementation
- **Non-blocking Domain Reload Shutdown**: Introduced `StopServerBeforeDomainReload()` in `McpBridgeServer` as a lifecycle-aware shutdown path that cancels operations and signals clients without blocking the Unity main thread
- **Client Task Tracking**: The server now tracks connected client handler tasks in `_clientTasks` and manages their lifecycle safely, allowing normal shutdown to observe completion without blocking
- **Safer TCP Accept Cancellation**: Refactored `AcceptTcpClientAsync` to register cancellation handlers that call `listener.Stop()` and gracefully handle cancellation-related exceptions, returning `null` instead of throwing
- **Unified Shutdown Core**: Introduced `StopServerCore` with `ServerStopMode` enum to handle both normal shutdown (observing tracked tasks) and domain-reload shutdown (non-blocking)

### Dynamic Code Services Reset
- **New Lifecycle Reset Path**: Added `ResetServerScopedServicesBeforeDomainReload()` that cancels the lifetime token and signals runtime shutdown via `ShutdownAsync()` when available, avoiding synchronous disposal
- **Roslyn Compiler Worker Shutdown**: Integrated `SharedRoslynCompilerWorkerHost.ShutdownForServerReset()` during domain reload preparation

### Integration Points
- Updated `DomainReloadRecoveryUseCase.ExecuteBeforeDomainReload` to call the new `StopServerBeforeDomainReload()` instead of `Dispose()`
- Updated `McpServerController.OnBeforeAssemblyReload` to use the new `ResetServerScopedServicesBeforeDomainReload()` method

## Architecture Changes

```mermaid
%%{init: {"theme": "base", "themeVariables": {"background": "#0d1117", "primaryColor": "#161b22", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "fontFamily": "Arial"}}}%%
flowchart LR
    Recovery["DomainReloadRecoveryUseCase<br/>ExecuteBeforeDomainReload()"]
    Bridge["McpBridgeServer<br/>StopServerBeforeDomainReload()<br/>StopServerCore(mode)<br/>AcceptTcpClientAsyncCore(...)<br/>DisconnectAllClientsCore(...)"]
    StopMode["ServerStopMode<br/>Normal<br/>BeforeDomainReload<br/>UnexpectedLoopExit"]
    Controller["McpServerController<br/>OnBeforeAssemblyReload()"]
    Services["DynamicCodeServices<br/>ResetServerScopedServicesBeforeDomainReload()<br/>SignalRuntimeShutdownBeforeDomainReload(...)"]
    Runtime["IShutdownAwareDynamicCodeExecutionRuntime<br/>ShutdownAsync()"]

    Recovery -->|calls before reload| Bridge
    Bridge -->|selects shutdown behavior| StopMode
    Controller -->|calls reload reset| Services
    Services -->|signals runtime shutdown| Runtime

    classDef component fill:#161b22,stroke:#8b949e,color:#e6edf3,stroke-width:1px;
    classDef mode fill:#1f6feb,stroke:#58a6ff,color:#ffffff,stroke-width:1px;
    class Recovery,Bridge,Controller,Services,Runtime component;
    class StopMode mode;
```

## Test Coverage

Three new test classes ensure shutdown safety and domain reload responsiveness:

1. **McpBridgeServerShutdownTests**: Validates TCP accept cancellation, client task observation after shutdown, rapid start-stop scenarios without spurious errors, and non-blocking shutdown from the main thread

2. **DynamicCodeServicesTests**: Confirms `ResetServerScopedServicesBeforeDomainReload()` cancels the lifetime token, signals runtime shutdown without synchronous disposal, and properly tracks drain task completion

3. **DomainReloadRecoveryUseCaseTests**: Enhanced with `StopServerBeforeDomainReload_ShouldBeSafe_WhenCalledMoreThanOnce()` to verify idempotent shutdown behavior

## Implementation Details

- Client handler tasks are now tracked in a concurrent dictionary and removed when they complete, enabling normal shutdown to observe them without blocking the main thread
- Server loop accepts a captured `TcpListener` and cancellation token to eliminate races from mutable state reads
- Domain reload shutdown skips waiting for client task completion to keep the path non-blocking
- Waits and token disposal are moved off the Unity main thread to allow RPC continuations to execute during shutdown
- Accept loop can be safely cancelled with proper listener cleanup and exception handling for cancellation scenarios

## Verification

The implementation covers:
- Domain reload compilation with `--wait-for-domain-reload` and `--force-recompile` paths
- EditMode tests validating domain reload, accept cancellation, client task tracking, and rapid shutdown
- Non-blocking behavior during server shutdown
- Idempotent shutdown operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1121)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


