### PR TITLE
fix: Unity no longer imports stale empty folders

### DIFF
--- a/Assets/Editor/CustomCommandSamples/RecordInput.meta
+++ b/Assets/Editor/CustomCommandSamples/RecordInput.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 718854cec742b410da4d8325793c1cd9
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Editor/CustomCommandSamples/Recordings.meta
+++ b/Assets/Editor/CustomCommandSamples/Recordings.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: ec41080fe5da34370a6809e6869184e2
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Editor/CustomCommandSamples/ReplayInput.meta
+++ b/Assets/Editor/CustomCommandSamples/ReplayInput.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 5f7cf0f133fca4c55aad5dc59edf63d1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 6e2002c5944cd48e49404fe598840b74
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/RecordInput.meta
+++ b/Assets/Scripts/RecordInput.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 1488002abacdb4ecdbc53a734070bb52
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/ReplayInput.meta
+++ b/Assets/Scripts/ReplayInput.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 11e4b9d65ac754f99afcfc6c50deb938
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/SimulateMouse.meta
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouse.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3c67385424dd04b3e9b63c8718961608
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Packages/src/Runtime/SimulateMouse.meta
+++ b/Packages/src/Runtime/SimulateMouse.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 28ecd26082de04c979c9d649d58c07ac
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Unity no longer carries stale empty folder assets in the project.
- Removed tracked folder metadata that pointed at folders with no contents.

## User Impact
- Unity project imports stay cleaner because stale empty folders and their metadata are no longer present.
- Developers should see fewer stale folder artifacts when refreshing or compiling the project.

## Changes
- Removed tracked .meta files for empty Unity folders under Assets and Packages/src.
- Removed the now-empty Assets/Scripts folder metadata after its child folders were deleted.

## Verification
- `uloop compile --project-path /Users/a12115/ghq/hatayama/unity-cli-loop2` (Success=true, ErrorCount=0, WarningCount=0)
- Confirmed there are no remaining empty directories with matching tracked .meta files outside ignored generated directories.