### PR TITLE
feat: Help older custom tools migrate to V3 automatically

### DIFF
--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -852,6 +852,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void MigrationWizardStartup_WhenLoaded_SchedulesTargetCheckInsteadOfPreviewingSynchronously()
+        {
+            // Tests that migration target detection does not block the synchronous Editor startup hook.
+            string migrationWizardSource = ReadProductionSource(
+                "Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs");
+
+            Assert.That(migrationWizardSource, Does.Contain("EditorApplication.delayCall += TryShowOnMigrationTargets;"));
+            Assert.That(migrationWizardSource, Does.Not.Contain("\n            TryShowOnMigrationTargets();"));
+        }
+
+        [Test]
         public void ProjectAsmdefs_WhenLoaded_DoNotReferenceRemovedSharedAssemblyGuid()
         {
             // Tests that removed module asmdefs do not leave stale GUID references in dependent asmdefs.

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -52,22 +52,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _editorSettingsRepository.InvalidateCache();
         }
 
-        [TestCase("", "1.7.3", false, true)]
-        [TestCase("1.7.2", "1.7.3", false, true)]
-        [TestCase("1.7.4", "1.7.3", false, true)]
-        [TestCase("1.7.3", "1.7.3", false, false)]
-        [TestCase("", "1.7.3", true, false)]
-        [TestCase("1.7.2", "1.7.3", true, false)]
+        [TestCase("", "1.7.3", false, false, true)]
+        [TestCase("1.7.2", "1.7.3", false, false, true)]
+        [TestCase("1.7.4", "1.7.3", false, false, true)]
+        [TestCase("1.7.3", "1.7.3", false, false, false)]
+        [TestCase("", "1.7.3", true, false, false)]
+        [TestCase("1.7.2", "1.7.3", true, false, false)]
+        [TestCase("1.7.2", "1.7.3", true, true, true)]
+        [TestCase("1.7.3", "1.7.3", true, true, false)]
         public void ShouldAutoShowForVersion_ReturnsExpectedValue(
             string lastSeenVersion,
             string currentVersion,
             bool suppressAutoShow,
+            bool hasThirdPartyToolMigrationTargets,
             bool expected)
         {
             bool shouldAutoShow =
-                SetupWizardWindow.ShouldAutoShowForVersion(currentVersion, lastSeenVersion, suppressAutoShow);
+                SetupWizardWindow.ShouldAutoShowForVersion(
+                    currentVersion,
+                    lastSeenVersion,
+                    suppressAutoShow,
+                    hasThirdPartyToolMigrationTargets);
 
             Assert.That(shouldAutoShow, Is.EqualTo(expected));
+        }
+
+        [TestCase(1, "1 file needs V3 custom tool migration.")]
+        [TestCase(3, "3 files need V3 custom tool migration.")]
+        public void GetThirdPartyToolMigrationStatusText_WhenTargetsExist_ReturnsFileCount(
+            int fileCount,
+            string expectedText)
+        {
+            // Verifies that the setup wizard summarizes detected V2 custom tool files.
+            string text = SetupWizardWindow.GetThirdPartyToolMigrationStatusText(fileCount);
+
+            Assert.That(text, Is.EqualTo(expectedText));
+        }
+
+        [TestCase(false, "Migrate")]
+        [TestCase(true, "Migrating...")]
+        public void GetThirdPartyToolMigrationButtonText_ReturnsExpectedLabel(
+            bool isMigrating,
+            string expectedLabel)
+        {
+            // Verifies that the migration action communicates its current state.
+            string label = SetupWizardWindow.GetThirdPartyToolMigrationButtonText(isMigrating);
+
+            Assert.That(label, Is.EqualTo(expectedLabel));
         }
 
         [Test]

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -77,6 +77,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(shouldAutoShow, Is.EqualTo(expected));
         }
 
+        [TestCase("1.7.2", "1.7.3", true, true)]
+        [TestCase("1.7.3", "1.7.3", true, false)]
+        [TestCase("1.7.2", "1.7.3", false, false)]
+        public void ShouldCheckThirdPartyToolMigrationTargets_ReturnsExpectedValue(
+            string lastSeenVersion,
+            string currentVersion,
+            bool suppressAutoShow,
+            bool expected)
+        {
+            bool shouldCheck =
+                SetupWizardWindow.ShouldCheckThirdPartyToolMigrationTargets(
+                    currentVersion,
+                    lastSeenVersion,
+                    suppressAutoShow);
+
+            Assert.That(shouldCheck, Is.EqualTo(expected));
+        }
+
         [TestCase(1, "1 file needs V3 custom tool migration.")]
         [TestCase(3, "3 files need V3 custom tool migration.")]
         public void GetThirdPartyToolMigrationStatusText_WhenTargetsExist_ReturnsFileCount(

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -52,103 +52,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _editorSettingsRepository.InvalidateCache();
         }
 
-        [TestCase("", "1.7.3", false, false, true)]
-        [TestCase("1.7.2", "1.7.3", false, false, true)]
-        [TestCase("1.7.4", "1.7.3", false, false, true)]
-        [TestCase("1.7.3", "1.7.3", false, false, false)]
-        [TestCase("", "1.7.3", true, false, false)]
-        [TestCase("1.7.2", "1.7.3", true, false, false)]
-        [TestCase("1.7.2", "1.7.3", true, true, true)]
-        [TestCase("1.7.3", "1.7.3", true, true, false)]
+        [TestCase("", "1.7.3", false, true)]
+        [TestCase("1.7.2", "1.7.3", false, true)]
+        [TestCase("1.7.4", "1.7.3", false, true)]
+        [TestCase("1.7.3", "1.7.3", false, false)]
+        [TestCase("", "1.7.3", true, false)]
+        [TestCase("1.7.2", "1.7.3", true, false)]
         public void ShouldAutoShowForVersion_ReturnsExpectedValue(
             string lastSeenVersion,
             string currentVersion,
             bool suppressAutoShow,
-            bool hasThirdPartyToolMigrationTargets,
             bool expected)
         {
             bool shouldAutoShow =
                 SetupWizardWindow.ShouldAutoShowForVersion(
                     currentVersion,
                     lastSeenVersion,
-                    suppressAutoShow,
-                    hasThirdPartyToolMigrationTargets);
+                    suppressAutoShow);
 
             Assert.That(shouldAutoShow, Is.EqualTo(expected));
-        }
-
-        [TestCase("1.7.2", "1.7.3", true)]
-        [TestCase("1.7.3", "1.7.3", false)]
-        public void ShouldCheckThirdPartyToolMigrationTargets_ReturnsExpectedValue(
-            string lastSeenVersion,
-            string currentVersion,
-            bool expected)
-        {
-            bool shouldCheck =
-                SetupWizardWindow.ShouldCheckThirdPartyToolMigrationTargets(
-                    currentVersion,
-                    lastSeenVersion);
-
-            Assert.That(shouldCheck, Is.EqualTo(expected));
-        }
-
-        [TestCase(true, true)]
-        [TestCase(false, false)]
-        public void ShouldRefreshThirdPartyToolMigrationOnOpen_ReturnsStartupDetectionResult(
-            bool hasThirdPartyToolMigrationTargets,
-            bool expected)
-        {
-            // Verifies that manual setup wizard opens do not start the project-wide migration preview.
-            bool shouldRefresh =
-                SetupWizardWindow.ShouldRefreshThirdPartyToolMigrationOnOpen(
-                    hasThirdPartyToolMigrationTargets);
-
-            Assert.That(shouldRefresh, Is.EqualTo(expected));
-        }
-
-        [TestCase(
-            1,
-            "1 file needs V3 custom tool migration.\n" +
-            "The Unity Console is showing errors because this file still uses the old custom tool API.\n\n" +
-            "Click Migrate to update it automatically. The errors should disappear after migration.")]
-        [TestCase(
-            3,
-            "3 files need V3 custom tool migration.\n" +
-            "The Unity Console is showing errors because these files still use the old custom tool API.\n\n" +
-            "Click Migrate to update them automatically. The errors should disappear after migration.")]
-        public void GetThirdPartyToolMigrationStatusText_WhenTargetsExist_ReturnsFileCount(
-            int fileCount,
-            string expectedText)
-        {
-            // Verifies that the setup wizard summarizes detected V2 custom tool files.
-            string text = SetupWizardWindow.GetThirdPartyToolMigrationStatusText(fileCount);
-
-            Assert.That(text, Is.EqualTo(expectedText));
-        }
-
-        [Test]
-        public void GetThirdPartyToolMigrationProgressText_WhenProgressExists_ReturnsCheckCount()
-        {
-            // Verifies that the setup wizard reports scan progress while migration targets are unknown.
-            ThirdPartyToolMigrationProgress progress = new(3, 12);
-
-            string text = SetupWizardWindow.GetThirdPartyToolMigrationProgressText(progress);
-
-            Assert.That(
-                text,
-                Is.EqualTo("Scanning project for V3 custom tool migration...\n3/12 checks complete."));
-        }
-
-        [TestCase(false, "Migrate")]
-        [TestCase(true, "Migrating...")]
-        public void GetThirdPartyToolMigrationButtonText_ReturnsExpectedLabel(
-            bool isMigrating,
-            string expectedLabel)
-        {
-            // Verifies that the migration action communicates its current state.
-            string label = SetupWizardWindow.GetThirdPartyToolMigrationButtonText(isMigrating);
-
-            Assert.That(label, Is.EqualTo(expectedLabel));
         }
 
         [Test]
@@ -322,7 +244,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "Unity CLI Loop Setup",
                     position,
                     "1.9.0",
-                    true,
                     true);
 
                 SerializedObject serializedWindow = new(window);
@@ -330,8 +251,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     serializedWindow.FindProperty("_lastSeenSetupWizardVersionBeforeOpen");
                 SerializedProperty recordVersionProperty =
                     serializedWindow.FindProperty("_shouldRecordLastSeenVersionAfterCreateGui");
-                SerializedProperty refreshMigrationProperty =
-                    serializedWindow.FindProperty("_shouldRefreshThirdPartyToolMigrationAfterCreateGui");
 
                 Assert.That(window.titleContent.text, Is.EqualTo("Unity CLI Loop Setup"));
                 Assert.That(window.position, Is.EqualTo(position));
@@ -339,8 +258,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Assert.That(lastSeenVersionProperty.stringValue, Is.EqualTo("1.9.0"));
                 Assert.That(recordVersionProperty, Is.Not.Null);
                 Assert.That(recordVersionProperty.boolValue, Is.True);
-                Assert.That(refreshMigrationProperty, Is.Not.Null);
-                Assert.That(refreshMigrationProperty.boolValue, Is.True);
             }
             finally
             {

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -77,22 +77,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(shouldAutoShow, Is.EqualTo(expected));
         }
 
-        [TestCase("1.7.2", "1.7.3", true, true)]
-        [TestCase("1.7.3", "1.7.3", true, false)]
-        [TestCase("1.7.2", "1.7.3", false, false)]
+        [TestCase("1.7.2", "1.7.3", true)]
+        [TestCase("1.7.3", "1.7.3", false)]
         public void ShouldCheckThirdPartyToolMigrationTargets_ReturnsExpectedValue(
             string lastSeenVersion,
             string currentVersion,
-            bool suppressAutoShow,
             bool expected)
         {
             bool shouldCheck =
                 SetupWizardWindow.ShouldCheckThirdPartyToolMigrationTargets(
                     currentVersion,
-                    lastSeenVersion,
-                    suppressAutoShow);
+                    lastSeenVersion);
 
             Assert.That(shouldCheck, Is.EqualTo(expected));
+        }
+
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public void ShouldRefreshThirdPartyToolMigrationOnOpen_ReturnsStartupDetectionResult(
+            bool hasThirdPartyToolMigrationTargets,
+            bool expected)
+        {
+            // Verifies that manual setup wizard opens do not start the project-wide migration preview.
+            bool shouldRefresh =
+                SetupWizardWindow.ShouldRefreshThirdPartyToolMigrationOnOpen(
+                    hasThirdPartyToolMigrationTargets);
+
+            Assert.That(shouldRefresh, Is.EqualTo(expected));
         }
 
         [TestCase(
@@ -311,6 +322,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "Unity CLI Loop Setup",
                     position,
                     "1.9.0",
+                    true,
                     true);
 
                 SerializedObject serializedWindow = new(window);
@@ -318,6 +330,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     serializedWindow.FindProperty("_lastSeenSetupWizardVersionBeforeOpen");
                 SerializedProperty recordVersionProperty =
                     serializedWindow.FindProperty("_shouldRecordLastSeenVersionAfterCreateGui");
+                SerializedProperty refreshMigrationProperty =
+                    serializedWindow.FindProperty("_shouldRefreshThirdPartyToolMigrationAfterCreateGui");
 
                 Assert.That(window.titleContent.text, Is.EqualTo("Unity CLI Loop Setup"));
                 Assert.That(window.position, Is.EqualTo(position));
@@ -325,6 +339,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Assert.That(lastSeenVersionProperty.stringValue, Is.EqualTo("1.9.0"));
                 Assert.That(recordVersionProperty, Is.Not.Null);
                 Assert.That(recordVersionProperty.boolValue, Is.True);
+                Assert.That(refreshMigrationProperty, Is.Not.Null);
+                Assert.That(refreshMigrationProperty.boolValue, Is.True);
             }
             finally
             {

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -98,12 +98,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(
             1,
             "1 file needs V3 custom tool migration.\n" +
-            "The Unity Console is showing errors because this file still uses the old custom tool API.\n" +
+            "The Unity Console is showing errors because this file still uses the old custom tool API.\n\n" +
             "Click Migrate to update it automatically. The errors should disappear after migration.")]
         [TestCase(
             3,
             "3 files need V3 custom tool migration.\n" +
-            "The Unity Console is showing errors because these files still use the old custom tool API.\n" +
+            "The Unity Console is showing errors because these files still use the old custom tool API.\n\n" +
             "Click Migrate to update them automatically. The errors should disappear after migration.")]
         public void GetThirdPartyToolMigrationStatusText_WhenTargetsExist_ReturnsFileCount(
             int fileCount,
@@ -113,6 +113,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string text = SetupWizardWindow.GetThirdPartyToolMigrationStatusText(fileCount);
 
             Assert.That(text, Is.EqualTo(expectedText));
+        }
+
+        [Test]
+        public void GetThirdPartyToolMigrationProgressText_WhenProgressExists_ReturnsCheckCount()
+        {
+            // Verifies that the setup wizard reports scan progress while migration targets are unknown.
+            ThirdPartyToolMigrationProgress progress = new(3, 12);
+
+            string text = SetupWizardWindow.GetThirdPartyToolMigrationProgressText(progress);
+
+            Assert.That(
+                text,
+                Is.EqualTo("Scanning project for V3 custom tool migration...\n3/12 checks complete."));
         }
 
         [TestCase(false, "Migrate")]

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -95,8 +95,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(shouldCheck, Is.EqualTo(expected));
         }
 
-        [TestCase(1, "1 file needs V3 custom tool migration.")]
-        [TestCase(3, "3 files need V3 custom tool migration.")]
+        [TestCase(
+            1,
+            "1 file needs V3 custom tool migration.\n" +
+            "The Unity Console is showing errors because this file still uses the old custom tool API.\n" +
+            "Click Migrate to update it automatically. The errors should disappear after migration.")]
+        [TestCase(
+            3,
+            "3 files need V3 custom tool migration.\n" +
+            "The Unity Console is showing errors because these files still use the old custom tool API.\n" +
+            "Click Migrate to update them automatically. The errors should disappear after migration.")]
         public void GetThirdPartyToolMigrationStatusText_WhenTargetsExist_ReturnsFileCount(
             int fileCount,
             string expectedText)

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -208,6 +208,50 @@ public static class CurrentManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenCurrentManualRegistrationExistsWithLegacyAsmdefGuid_AddsContractReferences()
+        {
+            // Verifies that partially migrated GUID refs are expanded to the assemblies current registrar APIs expose.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string registrationPath = Path.Combine(toolDirectory, "CurrentManualToolRegistration.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string registrationSource = @"using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+public static class CurrentManualToolRegistration
+{
+    public static void Register(IUnityCliLoopTool tool)
+    {
+        UnityCliLoopToolRegistrar.RegisterCustomTool(tool);
+    }
+}";
+                File.WriteAllText(registrationPath, registrationSource);
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(registrationPath), Is.EqualTo(registrationSource));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenDomainMetadataExistsWithoutManualRegistration_AddsDomainReference()
         {
             // Verifies that ToolInfo-only metadata helpers migrate their asmdef dependency.
@@ -510,6 +554,43 @@ public sealed class HelloResponse : BaseToolResponse
                 Assert.That(File.ReadAllText(toolAttributePath), Does.Contain(
                     "io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopTool"));
                 Assert.That(File.ReadAllText(toolAttributePath), Does.Contain("Old.IUnityCliLoopTool"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyAlias_RewritesSplitAliasQualifiedContractTypes()
+        {
+            // Verifies that alias-qualified legacy contract types migrate in sibling files.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string responseFactoryPath = Path.Combine(toolDirectory, "ResponseFactory.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(globalUsingPath, "global using Old = io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(
+                    responseFactoryPath,
+                    "public static class ResponseFactory { public static Old.BaseToolResponse Create() => null; }");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(3));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain("io.github.hatayama.UnityCliLoop.ToolContracts"));
+                Assert.That(File.ReadAllText(responseFactoryPath), Does.Contain("Old.UnityCliLoopToolResponse Create"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
             }
             finally

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -1166,6 +1166,40 @@ public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
         }
 
         [Test]
+        public void PreviewMigration_WhenUnrelatedCustomToolManagerExists_KeepsAsmdef()
+        {
+            // Verifies that project-owned type names do not trigger migration dependencies by themselves.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string sourcePath = Path.Combine(toolDirectory, "CustomToolManager.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string source = "public sealed class CustomToolManager {}";
+                string asmdefSource = @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": []
+}";
+                File.WriteAllText(sourcePath, source);
+                File.WriteAllText(asmdefPath, asmdefSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = service.PreviewMigration(projectRoot);
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(preview.HasTargets, Is.False);
+                Assert.That(result.FileCount, Is.EqualTo(0));
+                Assert.That(File.ReadAllText(sourcePath), Is.EqualTo(source));
+                Assert.That(File.ReadAllText(asmdefPath), Is.EqualTo(asmdefSource));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenUserSidecarFilesExist_PreservesSidecarFiles()
         {
             // Verifies that project-wide source rewrites do not treat user sidecars as migration scratch files.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 using NUnit.Framework;
 
@@ -1380,6 +1383,118 @@ public sealed class PackageToolResponse : BaseToolResponse
             }
         }
 
+        [Test]
+        public void PreviewMigration_WhenCacheIsInvalidated_RefreshesChangedProject()
+        {
+            // Verifies that repeated setup wizard previews can reuse scans and refresh after invalidation.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview firstPreview = service.PreviewMigration(projectRoot);
+                File.WriteAllText(toolPath, "public sealed class HelloTool {}");
+                ThirdPartyToolMigrationPreview cachedPreview = service.PreviewMigration(projectRoot);
+                service.InvalidatePreviewCache();
+                ThirdPartyToolMigrationPreview refreshedPreview = service.PreviewMigration(projectRoot);
+
+                Assert.That(firstPreview.HasTargets, Is.True);
+                Assert.That(cachedPreview.FileCount, Is.EqualTo(firstPreview.FileCount));
+                Assert.That(refreshedPreview.HasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task PreviewMigrationAsync_WhenProjectContainsManyFiles_ReportsIncrementalProgress()
+        {
+            // Verifies that setup wizard previews report progress before the full scan finishes.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                for (int i = 0; i < 48; i++)
+                {
+                    File.WriteAllText(
+                        Path.Combine(toolDirectory, $"Plain{i}.cs"),
+                        $"public sealed class Plain{i} {{}}");
+                }
+
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                List<ThirdPartyToolMigrationProgress> reports = new();
+                RecordingMigrationProgress progress = new(reports);
+                ThirdPartyToolMigrationFileService service = new();
+
+                ThirdPartyToolMigrationPreview preview =
+                    await service.PreviewMigrationAsync(projectRoot, progress, CancellationToken.None);
+
+                Assert.That(preview.HasTargets, Is.True);
+                Assert.That(reports.Count, Is.GreaterThan(1));
+                Assert.That(
+                    reports.Any(report =>
+                        report.TotalItemCount > 0 &&
+                        report.ProcessedItemCount > 0 &&
+                        report.ProcessedItemCount < report.TotalItemCount),
+                    Is.True);
+                ThirdPartyToolMigrationProgress lastReport = reports[reports.Count - 1];
+                Assert.That(lastReport.ProcessedItemCount, Is.EqualTo(lastReport.TotalItemCount));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
         private static string CreateProjectRoot()
         {
             string projectRoot = Path.Combine(
@@ -1391,6 +1506,23 @@ public sealed class PackageToolResponse : BaseToolResponse
             Directory.CreateDirectory(Path.Combine(projectRoot, "ProjectSettings"));
             Directory.CreateDirectory(Path.Combine(projectRoot, "Assets"));
             return projectRoot;
+        }
+
+        private sealed class RecordingMigrationProgress : IProgress<ThirdPartyToolMigrationProgress>
+        {
+            private readonly List<ThirdPartyToolMigrationProgress> _reports;
+
+            public RecordingMigrationProgress(List<ThirdPartyToolMigrationProgress> reports)
+            {
+                Assert.That(reports, Is.Not.Null);
+
+                _reports = reports;
+            }
+
+            public void Report(ThirdPartyToolMigrationProgress value)
+            {
+                _reports.Add(value);
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -1004,6 +1004,55 @@ public sealed class HelloResponse : BaseToolResponse
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyToolInfoAlias_RewritesSplitAliasConstructors()
+        {
+            // Verifies that global type aliases provide constructor migration context to sibling files.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string metadataPath = Path.Combine(toolDirectory, "ToolMetadataProvider.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(
+                    globalUsingPath,
+                    "global using LegacyToolInfo = io.github.hatayama.uLoopMCP.ToolInfo;");
+                File.WriteAllText(
+                    metadataPath,
+                    @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+public static class ToolMetadataProvider
+{
+    public static LegacyToolInfo Create(ToolParameterSchema schema)
+    {
+        return new LegacyToolInfo(""hello"", ""description"", schema);
+    }
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(3));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain(
+                    "global using LegacyToolInfo = io.github.hatayama.UnityCliLoop.Domain.ToolInfo;"));
+                Assert.That(File.ReadAllText(metadataPath), Does.Contain(
+                    "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema)"));
+                Assert.That(File.ReadAllText(metadataPath), Does.Not.Contain("\"description\", schema"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenLegacyToolExistsUnderAsmref_RewritesReferencedAsmdef()
         {
             // Verifies that asmref folders mark the referenced asmdef as the migrated assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -295,6 +295,49 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenCurrentDomainMetadataExistsWithLegacyAsmdefGuid_AddsDomainReference()
+        {
+            // Verifies that partially migrated metadata helpers receive the asmdef refs they already require.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string metadataPath = Path.Combine(toolDirectory, "ToolMetadataProvider.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string metadataSource = @"using io.github.hatayama.UnityCliLoop.Domain;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo[] GetTools()
+    {
+        return new ToolInfo[0];
+    }
+}";
+                File.WriteAllText(metadataPath, metadataSource);
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(metadataPath), Is.EqualTo(metadataSource));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesSplitContractFiles()
         {
             // Verifies that schema files relying on global legacy usings migrate with their assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -1485,6 +1485,56 @@ public sealed class HelloResponse : UnityCliLoopToolResponse
         }
 
         [Test]
+        public async Task HasMigrationTargetsAsync_WhenUnrelatedAsmdefJsonIsMalformed_StillDetectsAsmdefRepair()
+        {
+            // Verifies that unrelated malformed asmdefs do not block startup detection for repairable tools.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string unrelatedDirectory = Path.Combine(projectRoot, "Assets", "Unrelated");
+                Directory.CreateDirectory(unrelatedDirectory);
+                File.WriteAllText(Path.Combine(unrelatedDirectory, "Broken.asmdef"), "{");
+
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "CurrentHelloTool.cs"),
+                    @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+}");
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "VendorTools.Editor.asmdef"),
+                    @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
+
+                Assert.That(hasTargets, Is.True);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public async Task HasMigrationTargetsAsync_WhenCurrentApplicationGuidReferenceExists_ReturnsFalse()
         {
             // Verifies that current V3 Application references do not trigger the startup migration prompt.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -694,6 +694,30 @@ public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
         }
 
         [Test]
+        public void PreviewMigration_WhenLegacyToolExistsOutsideAssets_IgnoresFile()
+        {
+            // Verifies that repository tooling outside Unity source roots is not migrated.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolsDirectory = Path.Combine(projectRoot, "tools");
+                Directory.CreateDirectory(toolsDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolsDirectory, "LegacyToolFixture.cs"),
+                    "using io.github.hatayama.uLoopMCP; [McpTool] public sealed class LegacyToolFixture {}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = service.PreviewMigration(projectRoot);
+
+                Assert.That(preview.HasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenLegacyToolExistsUnderAssetsPackagesDirectory_RewritesAssetsFiles()
         {
             // Verifies that only Unity's project-root Packages directory is excluded from migration scans.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -1053,6 +1053,44 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyToolInfoAlias_KeepsUnrelatedBareTypes()
+        {
+            // Verifies that ToolInfo type aliases do not grant full legacy namespace context to sibling files.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string unrelatedPath = Path.Combine(toolDirectory, "UnrelatedMetadata.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string unrelatedSource = "public sealed class UnrelatedMetadata { public BaseToolSchema Schema; }";
+                File.WriteAllText(
+                    globalUsingPath,
+                    "global using LegacyToolInfo = io.github.hatayama.uLoopMCP.ToolInfo;");
+                File.WriteAllText(unrelatedPath, unrelatedSource);
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain(
+                    "global using LegacyToolInfo = io.github.hatayama.UnityCliLoop.Domain.ToolInfo;"));
+                Assert.That(File.ReadAllText(unrelatedPath), Is.EqualTo(unrelatedSource));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenLegacyToolExistsUnderAsmref_RewritesReferencedAsmdef()
         {
             // Verifies that asmref folders mark the referenced asmdef as the migrated assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -142,6 +142,49 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsingAndSplitManualRegistration_AddsApplicationReference()
+        {
+            // Verifies that manual registration files relying on assembly-level legacy detection get required refs.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string registrationPath = Path.Combine(toolDirectory, "ManualToolRegistration.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(registrationPath, @"public static class ManualToolRegistration
+{
+    public static void Register(IUnityTool tool)
+    {
+        CustomToolManager.RegisterCustomTool(tool);
+    }
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(3));
+                Assert.That(File.ReadAllText(registrationPath), Does.Contain(
+                    "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.RegisterCustomTool"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void PreviewMigration_WhenLegacyToolExistsUnderExcludedDirectory_IgnoresFile()
         {
             // Verifies that generated Unity folders are not scanned for third-party tools.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies project-wide V3 third-party tool migration file behavior.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationFileServiceTests
+    {
+        [Test]
+        public void ApplyMigration_WhenLegacyToolAssemblyExists_RewritesSourceAndAsmdef()
+        {
+            // Verifies that project-wide migration rewrites both custom tool source and its asmdef reference.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = service.PreviewMigration(projectRoot);
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(preview.FileCount, Is.EqualTo(2));
+                Assert.That(preview.FilePaths.Contains(toolPath), Is.True);
+                Assert.That(preview.FilePaths.Contains(asmdefPath), Is.True);
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(toolPath), Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void PreviewMigration_WhenLegacyToolExistsUnderExcludedDirectory_IgnoresFile()
+        {
+            // Verifies that generated Unity folders are not scanned for third-party tools.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string generatedDirectory = Path.Combine(projectRoot, "Library");
+                Directory.CreateDirectory(generatedDirectory);
+                File.WriteAllText(
+                    Path.Combine(generatedDirectory, "GeneratedTool.cs"),
+                    "using io.github.hatayama.uLoopMCP; [McpTool] public sealed class GeneratedTool {}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = service.PreviewMigration(projectRoot);
+
+                Assert.That(preview.HasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        private static string CreateProjectRoot()
+        {
+            string projectRoot = Path.Combine(
+                Path.GetTempPath(),
+                "UnityCliLoopTests",
+                "ThirdPartyToolMigration",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(projectRoot);
+            Directory.CreateDirectory(Path.Combine(projectRoot, "ProjectSettings"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "Assets"));
+            return projectRoot;
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -98,6 +98,7 @@ public static class ManualToolRegistration
                     "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.RegisterCustomTool"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -1384,6 +1384,133 @@ public sealed class PackageToolResponse : BaseToolResponse
         }
 
         [Test]
+        public async Task HasMigrationTargetsAsync_WhenLegacyToolExistsUnderAssets_ReturnsTrue()
+        {
+            // Verifies that startup detection can find V2 custom tools without building a migration preview.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "HelloTool.cs"),
+                    "using io.github.hatayama.uLoopMCP; [McpTool] public sealed class HelloTool {}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
+
+                Assert.That(hasTargets, Is.True);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task HasMigrationTargetsAsync_WhenLegacyAsmdefNameExistsUnderAssets_ReturnsTrue()
+        {
+            // Verifies that startup detection catches old assembly names without relying on source files.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "VendorTools.Editor.asmdef"),
+                    @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""uLoopMCP.Editor""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
+
+                Assert.That(hasTargets, Is.True);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task HasMigrationTargetsAsync_WhenCurrentApplicationGuidReferenceExists_ReturnsFalse()
+        {
+            // Verifies that current V3 Application references do not trigger the startup migration prompt.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "CurrentManualToolRegistration.cs"),
+                    @"using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+public static class CurrentManualToolRegistration
+{
+    public static void Register(IUnityCliLoopTool tool)
+    {
+        UnityCliLoopToolRegistrar.RegisterCustomTool(tool);
+    }
+}");
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "VendorTools.Editor.asmdef"),
+                    @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d"",
+        ""GUID:fc3fd32eddbee40e39c2d76dc184957b""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
+
+                Assert.That(hasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task HasMigrationTargetsAsync_WhenLegacyToolExistsUnderPackagesDirectory_ReturnsFalse()
+        {
+            // Verifies that startup detection keeps Package Manager contents outside migration scope.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string packageDirectory = Path.Combine(
+                    projectRoot,
+                    "Packages",
+                    "com.example.legacy-tool",
+                    "Editor");
+                Directory.CreateDirectory(packageDirectory);
+                File.WriteAllText(
+                    Path.Combine(packageDirectory, "PackageTool.cs"),
+                    "using io.github.hatayama.uLoopMCP; [McpTool] public sealed class PackageTool {}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
+
+                Assert.That(hasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void PreviewMigration_WhenCacheIsInvalidated_RefreshesChangedProject()
         {
             // Verifies that repeated setup wizard previews can reuse scans and refresh after invalidation.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -257,6 +257,42 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesSplitReturnContractTypes()
+        {
+            // Verifies that helper return types relying on global legacy usings migrate with their assembly.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string responseFactoryPath = Path.Combine(toolDirectory, "ResponseFactory.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(
+                    responseFactoryPath,
+                    "public static class ResponseFactory { public static BaseToolResponse Create() => null; }");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(3));
+                Assert.That(File.ReadAllText(responseFactoryPath), Does.Contain("UnityCliLoopToolResponse Create"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenLegacyToolExistsUnderAsmref_RewritesReferencedAsmdef()
         {
             // Verifies that asmref folders mark the referenced asmdef as the migrated assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -570,6 +570,54 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenUnrelatedAsmdefJsonIsMalformedAndNoAsmrefs_AppliesAsmdefRepair()
+        {
+            // Verifies that unrelated malformed asmdefs do not block applying repairable asmdef changes.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string unrelatedDirectory = Path.Combine(projectRoot, "Assets", "Unrelated");
+                Directory.CreateDirectory(unrelatedDirectory);
+                File.WriteAllText(Path.Combine(unrelatedDirectory, "Broken.asmdef"), "{");
+
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "CurrentHelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesSplitContractFiles()
         {
             // Verifies that schema files relying on global legacy usings migrate with their assembly.
@@ -1535,6 +1583,48 @@ public sealed class HelloResponse : UnityCliLoopToolResponse
         }
 
         [Test]
+        public async Task HasMigrationTargetsAsync_WhenAssemblyUsesCurrentDomainGlobalUsingAndSplitMetadata_ReturnsTrue()
+        {
+            // Verifies that startup detection treats current Domain global usings as assembly-scoped.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "GlobalUsings.cs"),
+                    "global using io.github.hatayama.UnityCliLoop.Domain;");
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "ToolMetadataProvider.cs"),
+                    @"public static class ToolMetadataProvider
+{
+    public static ToolInfo[] GetTools()
+    {
+        return new ToolInfo[0];
+    }
+}");
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "VendorTools.Editor.asmdef"),
+                    @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
+
+                Assert.That(hasTargets, Is.True);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public async Task HasMigrationTargetsAsync_WhenCurrentApplicationGuidReferenceExists_ReturnsFalse()
         {
             // Verifies that current V3 Application references do not trigger the startup migration prompt.
@@ -1698,6 +1788,59 @@ public sealed class HelloResponse : BaseToolResponse
 
                 Assert.That(firstPreview.HasTargets, Is.True);
                 Assert.That(refreshedPreview.HasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task PreviewMigrationAsync_WhenUnrelatedAsmdefJsonIsMalformedAndNoAsmrefs_PreviewsAsmdefRepair()
+        {
+            // Verifies that unrelated malformed asmdefs do not block previewing repairable asmdef changes.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string unrelatedDirectory = Path.Combine(projectRoot, "Assets", "Unrelated");
+                Directory.CreateDirectory(unrelatedDirectory);
+                File.WriteAllText(Path.Combine(unrelatedDirectory, "Broken.asmdef"), "{");
+
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "CurrentHelloTool.cs"),
+                    @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+}");
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "VendorTools.Editor.asmdef"),
+                    @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                Progress<ThirdPartyToolMigrationProgress> progress = new();
+
+                ThirdPartyToolMigrationPreview preview =
+                    await service.PreviewMigrationAsync(projectRoot, progress, CancellationToken.None);
+
+                Assert.That(preview.HasTargets, Is.True);
+                Assert.That(preview.FileCount, Is.EqualTo(1));
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -18,6 +18,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     public sealed class ThirdPartyToolMigrationFileServiceTests
     {
         [Test]
+        public void ThirdPartyToolMigrationPreview_WhenInputFilePathsMutate_KeepsSnapshot()
+        {
+            // Verifies that preview file paths cannot be changed by mutating the constructor input array.
+            string[] filePaths =
+            {
+                "Assets/VendorTools/HelloTool.cs"
+            };
+            ThirdPartyToolMigrationPreview preview = new(1, 1, filePaths);
+
+            filePaths[0] = "Assets/Changed.cs";
+            preview.FilePaths[0] = "Assets/ChangedAgain.cs";
+
+            Assert.That(preview.FilePaths, Is.EqualTo(new[] { "Assets/VendorTools/HelloTool.cs" }));
+        }
+
+        [Test]
+        public void ThirdPartyToolMigrationResult_WhenInputFilePathsMutate_KeepsSnapshot()
+        {
+            // Verifies that result file paths cannot be changed by mutating the constructor input array.
+            string[] filePaths =
+            {
+                "Assets/VendorTools/HelloTool.cs"
+            };
+            ThirdPartyToolMigrationResult result = new(1, 1, filePaths);
+
+            filePaths[0] = "Assets/Changed.cs";
+            result.FilePaths[0] = "Assets/ChangedAgain.cs";
+
+            Assert.That(result.FilePaths, Is.EqualTo(new[] { "Assets/VendorTools/HelloTool.cs" }));
+        }
+
+        [Test]
         public void ApplyMigration_WhenLegacyToolAssemblyExists_RewritesSourceAndAsmdef()
         {
             // Verifies that project-wide migration rewrites both custom tool source and its asmdef reference.
@@ -622,6 +654,108 @@ public static class ToolMetadataProvider
                 string unrelatedDirectory = Path.Combine(projectRoot, "Assets", "Unrelated");
                 Directory.CreateDirectory(unrelatedDirectory);
                 File.WriteAllText(Path.Combine(unrelatedDirectory, "Broken.asmdef"), "{");
+
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "CurrentHelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenUnrelatedAsmdefJsonIsMalformedAndAsmrefExists_AppliesAsmdefRepair()
+        {
+            // Verifies that malformed asmdefs do not block asmref-aware migration scans.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string unrelatedDirectory = Path.Combine(projectRoot, "Assets", "Unrelated");
+                Directory.CreateDirectory(unrelatedDirectory);
+                File.WriteAllText(Path.Combine(unrelatedDirectory, "Broken.asmdef"), "{");
+
+                string asmrefDirectory = Path.Combine(projectRoot, "Assets", "VendorToolParts");
+                Directory.CreateDirectory(asmrefDirectory);
+                File.WriteAllText(Path.Combine(asmrefDirectory, "VendorTools.Editor.asmref"), @"{
+    ""reference"": ""VendorTools.Editor""
+}");
+
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "CurrentHelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenUnrelatedAsmrefJsonIsMalformed_AppliesAsmdefRepair()
+        {
+            // Verifies that malformed asmrefs do not block migration scans for valid assemblies.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string unrelatedDirectory = Path.Combine(projectRoot, "Assets", "Unrelated");
+                Directory.CreateDirectory(unrelatedDirectory);
+                File.WriteAllText(Path.Combine(unrelatedDirectory, "Broken.asmref"), "{");
 
                 string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
                 Directory.CreateDirectory(toolDirectory);
@@ -1977,6 +2111,59 @@ public sealed class HelloResponse : BaseToolResponse
                 string unrelatedDirectory = Path.Combine(projectRoot, "Assets", "Unrelated");
                 Directory.CreateDirectory(unrelatedDirectory);
                 File.WriteAllText(Path.Combine(unrelatedDirectory, "Broken.asmdef"), "{");
+
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "CurrentHelloTool.cs"),
+                    @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+}");
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "VendorTools.Editor.asmdef"),
+                    @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                Progress<ThirdPartyToolMigrationProgress> progress = new();
+
+                ThirdPartyToolMigrationPreview preview =
+                    await service.PreviewMigrationAsync(projectRoot, progress, CancellationToken.None);
+
+                Assert.That(preview.HasTargets, Is.True);
+                Assert.That(preview.FileCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task PreviewMigrationAsync_WhenUnrelatedAsmrefJsonIsMalformed_PreviewsAsmdefRepair()
+        {
+            // Verifies that malformed asmrefs do not block async preview scans for repairable assemblies.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string unrelatedDirectory = Path.Combine(projectRoot, "Assets", "Unrelated");
+                Directory.CreateDirectory(unrelatedDirectory);
+                File.WriteAllText(Path.Combine(unrelatedDirectory, "Broken.asmref"), "{");
 
                 string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
                 Directory.CreateDirectory(toolDirectory);

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -379,6 +379,45 @@ public sealed class HelloResponse : BaseToolResponse
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyAlias_RewritesSplitAliasQualifiedFiles()
+        {
+            // Verifies that global namespace aliases provide legacy context to sibling files.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string toolAttributePath = Path.Combine(toolDirectory, "HelloTool.Attribute.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(globalUsingPath, "global using Old = io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(
+                    toolAttributePath,
+                    "[Old.McpTool]\npublic sealed partial class HelloTool\n{\n    private Old.IUnityTool tool;\n}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(3));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain("io.github.hatayama.UnityCliLoop.ToolContracts"));
+                Assert.That(File.ReadAllText(toolAttributePath), Does.Contain(
+                    "io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopTool"));
+                Assert.That(File.ReadAllText(toolAttributePath), Does.Contain("Old.IUnityCliLoopTool"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenLegacyToolExistsUnderAsmref_RewritesReferencedAsmdef()
         {
             // Verifies that asmref folders mark the referenced asmdef as the migrated assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -185,6 +185,86 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_KeepsUnrelatedFiles()
+        {
+            // Verifies that assembly-level migration does not rename unrelated project types.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string unrelatedPath = Path.Combine(toolDirectory, "BaseToolSchema.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string unrelatedSource = "public sealed class BaseToolSchema {}";
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(unrelatedPath, unrelatedSource);
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain("io.github.hatayama.UnityCliLoop.ToolContracts"));
+                Assert.That(File.ReadAllText(unrelatedPath), Is.EqualTo(unrelatedSource));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenLegacyToolExistsUnderAsmref_RewritesReferencedAsmdef()
+        {
+            // Verifies that asmref folders mark the referenced asmdef as the migrated assembly.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string asmdefDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                string asmrefDirectory = Path.Combine(projectRoot, "Assets", "VendorToolParts");
+                Directory.CreateDirectory(asmdefDirectory);
+                Directory.CreateDirectory(asmrefDirectory);
+                string toolPath = Path.Combine(asmrefDirectory, "HelloTool.cs");
+                string asmrefPath = Path.Combine(asmrefDirectory, "VendorTools.Editor.asmref");
+                string asmdefPath = Path.Combine(asmdefDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}");
+                File.WriteAllText(asmrefPath, @"{
+    ""reference"": ""VendorTools.Editor""
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(toolPath), Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenNoAsmdefAssemblyUsesGlobalLegacyUsing_RewritesSplitContractFiles()
         {
             // Verifies that predefined assemblies get the same assembly-level migration as asmdef assemblies.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -107,6 +107,49 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenDomainMetadataExistsWithoutManualRegistration_AddsDomainReference()
+        {
+            // Verifies that ToolInfo-only metadata helpers migrate their asmdef dependency.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string metadataPath = Path.Combine(toolDirectory, "ToolMetadataProvider.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(metadataPath, @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo[] GetTools()
+    {
+        return new ToolInfo[0];
+    }
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(metadataPath), Does.Contain(
+                    "io.github.hatayama.UnityCliLoop.Domain.ToolInfo[]"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesSplitContractFiles()
         {
             // Verifies that schema files relying on global legacy usings migrate with their assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -299,6 +299,50 @@ public sealed class HelloResponse : UnityCliLoopToolResponse
         }
 
         [Test]
+        public void ApplyMigration_WhenCurrentRegistrarExistsWithToolContractsAsmdefReference_AddsApplicationReferences()
+        {
+            // Verifies that already-replaced asmdef refs still receive missing current assembly dependencies.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string registrationPath = Path.Combine(toolDirectory, "CurrentManualToolRegistration.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string registrationSource = @"using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+public static class CurrentManualToolRegistration
+{
+    public static void Register(IUnityCliLoopTool tool)
+    {
+        UnityCliLoopToolRegistrar.RegisterCustomTool(tool);
+    }
+}";
+                File.WriteAllText(registrationPath, registrationSource);
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:fc3fd32eddbee40e39c2d76dc184957b""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(registrationPath), Is.EqualTo(registrationSource));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenDomainMetadataExistsWithoutManualRegistration_AddsDomainReference()
         {
             // Verifies that ToolInfo-only metadata helpers migrate their asmdef dependency.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -1560,6 +1560,56 @@ public sealed class HelloResponse : BaseToolResponse
         }
 
         [Test]
+        public async Task PreviewMigrationAsync_WhenProjectChangesAfterCachedPreview_RefreshesCurrentProject()
+        {
+            // Verifies that migration wizard Refresh reads the current files instead of reusing a stale preview.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                Progress<ThirdPartyToolMigrationProgress> progress = new();
+                ThirdPartyToolMigrationPreview firstPreview =
+                    await service.PreviewMigrationAsync(projectRoot, progress, CancellationToken.None);
+                File.WriteAllText(toolPath, "public sealed class HelloTool {}");
+
+                ThirdPartyToolMigrationPreview refreshedPreview =
+                    await service.PreviewMigrationAsync(projectRoot, progress, CancellationToken.None);
+
+                Assert.That(firstPreview.HasTargets, Is.True);
+                Assert.That(refreshedPreview.HasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void PreviewMigration_WhenCurrentApplicationGuidReferenceExists_KeepsAsmdef()
         {
             // Verifies that V3 Application references are not reported as legacy asmdef migration.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -252,6 +252,53 @@ public static class CurrentManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenCurrentToolContractsExistsWithLegacyAsmdefGuid_RewritesToToolContractsReference()
+        {
+            // Verifies that partially migrated tool implementations receive the ToolContracts asmdef reference.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "CurrentHelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string toolSource = @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+}";
+                File.WriteAllText(toolPath, toolSource);
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(toolPath), Is.EqualTo(toolSource));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenDomainMetadataExistsWithoutManualRegistration_AddsDomainReference()
         {
             // Verifies that ToolInfo-only metadata helpers migrate their asmdef dependency.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -142,6 +142,33 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenNoAsmdefAssemblyUsesGlobalLegacyUsing_RewritesSplitContractFiles()
+        {
+            // Verifies that predefined assemblies get the same assembly-level migration as asmdef assemblies.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "Editor", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string schemaPath = Path.Combine(toolDirectory, "HelloSchema.cs");
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(schemaPath, "public sealed class HelloSchema : BaseToolSchema {}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain("io.github.hatayama.UnityCliLoop.ToolContracts"));
+                Assert.That(File.ReadAllText(schemaPath), Does.Contain("UnityCliLoopToolSchema"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsingAndSplitManualRegistration_AddsApplicationReference()
         {
             // Verifies that manual registration files relying on assembly-level legacy detection get required refs.
@@ -177,6 +204,41 @@ public static class ManualToolRegistration
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenUserSidecarFilesExist_PreservesSidecarFiles()
+        {
+            // Verifies that project-wide source rewrites do not treat user sidecars as migration scratch files.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                string tempSidecarPath = toolPath + ".tmp";
+                string backupSidecarPath = toolPath + ".bak";
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}");
+                File.WriteAllText(tempSidecarPath, "user temp sidecar");
+                File.WriteAllText(backupSidecarPath, "user backup sidecar");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(toolPath), Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+                Assert.That(File.ReadAllText(tempSidecarPath), Is.EqualTo("user temp sidecar"));
+                Assert.That(File.ReadAllText(backupSidecarPath), Is.EqualTo("user backup sidecar"));
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -107,6 +107,64 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenCurrentManualRegistrationExists_PreservesApplicationReference()
+        {
+            // Verifies that mixed assemblies keep current registrar dependencies while legacy tools migrate.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                string registrationPath = Path.Combine(toolDirectory, "CurrentManualToolRegistration.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+                File.WriteAllText(registrationPath, @"using io.github.hatayama.UnityCliLoop.Application;
+
+public static class CurrentManualToolRegistration
+{
+    public static void Register(object tool)
+    {
+        UnityCliLoopToolRegistrar.RegisterCustomTool(tool);
+    }
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(toolPath), Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+                Assert.That(File.ReadAllText(registrationPath), Does.Contain("UnityCliLoopToolRegistrar"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenDomainMetadataExistsWithoutManualRegistration_AddsDomainReference()
         {
             // Verifies that ToolInfo-only metadata helpers migrate their asmdef dependency.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -165,6 +165,49 @@ public static class CurrentManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenCurrentManualRegistrationExistsWithLegacyAsmdefName_AddsApplicationReference()
+        {
+            // Verifies that partially migrated registrar code receives the asmdef refs it already requires.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string registrationPath = Path.Combine(toolDirectory, "CurrentManualToolRegistration.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string registrationSource = @"using io.github.hatayama.UnityCliLoop.Application;
+
+public static class CurrentManualToolRegistration
+{
+    public static void Register(object tool)
+    {
+        UnityCliLoopToolRegistrar.RegisterCustomTool(tool);
+    }
+}";
+                File.WriteAllText(registrationPath, registrationSource);
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""uLoopMCP.Editor""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(registrationPath), Is.EqualTo(registrationSource));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenDomainMetadataExistsWithoutManualRegistration_AddsDomainReference()
         {
             // Verifies that ToolInfo-only metadata helpers migrate their asmdef dependency.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -169,6 +169,36 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenNoAsmdefEditorAssemblyUsesGlobalLegacyUsing_KeepsRuntimeFiles()
+        {
+            // Verifies that predefined editor migration does not rewrite the separate runtime assembly.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string editorDirectory = Path.Combine(projectRoot, "Assets", "Editor", "VendorTools");
+                string runtimeDirectory = Path.Combine(projectRoot, "Assets", "Scripts");
+                Directory.CreateDirectory(editorDirectory);
+                Directory.CreateDirectory(runtimeDirectory);
+                string globalUsingPath = Path.Combine(editorDirectory, "GlobalUsings.cs");
+                string runtimePath = Path.Combine(runtimeDirectory, "BaseToolSchema.cs");
+                string runtimeSource = "public sealed class BaseToolSchema {}";
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(runtimePath, runtimeSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain("io.github.hatayama.UnityCliLoop.ToolContracts"));
+                Assert.That(File.ReadAllText(runtimePath), Is.EqualTo(runtimeSource));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsingAndSplitManualRegistration_AddsApplicationReference()
         {
             // Verifies that manual registration files relying on assembly-level legacy detection get required refs.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -522,6 +522,51 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesCurrentDomainGlobalUsingAndSplitMetadata_AddsDomainReference()
+        {
+            // Verifies that split V3 Domain metadata files receive their required asmdef references.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string metadataPath = Path.Combine(toolDirectory, "ToolMetadataProvider.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string globalUsingSource = "global using io.github.hatayama.UnityCliLoop.Domain;";
+                string metadataSource = @"public static class ToolMetadataProvider
+{
+    public static ToolInfo[] GetTools()
+    {
+        return new ToolInfo[0];
+    }
+}";
+                File.WriteAllText(globalUsingPath, globalUsingSource);
+                File.WriteAllText(metadataPath, metadataSource);
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(globalUsingPath), Is.EqualTo(globalUsingSource));
+                Assert.That(File.ReadAllText(metadataPath), Is.EqualTo(metadataSource));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesSplitContractFiles()
         {
             // Verifies that schema files relying on global legacy usings migrate with their assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -107,6 +107,41 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesSplitContractFiles()
+        {
+            // Verifies that schema files relying on global legacy usings migrate with their assembly.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string schemaPath = Path.Combine(toolDirectory, "HelloSchema.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(schemaPath, "public sealed class HelloSchema : BaseToolSchema {}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(3));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain("io.github.hatayama.UnityCliLoop.ToolContracts"));
+                Assert.That(File.ReadAllText(schemaPath), Does.Contain("UnityCliLoopToolSchema"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void PreviewMigration_WhenLegacyToolExistsUnderExcludedDirectory_IgnoresFile()
         {
             // Verifies that generated Unity folders are not scanned for third-party tools.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -293,6 +293,42 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesSplitBareToolAttributes()
+        {
+            // Verifies that attribute-only files relying on global legacy usings migrate with their assembly.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string toolAttributePath = Path.Combine(toolDirectory, "HelloTool.Attribute.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(
+                    toolAttributePath,
+                    "[McpTool]\npublic sealed partial class HelloTool\n{\n}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(3));
+                Assert.That(File.ReadAllText(toolAttributePath), Does.Contain("[UnityCliLoopTool]"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenLegacyToolExistsUnderAsmref_RewritesReferencedAsmdef()
         {
             // Verifies that asmref folders mark the referenced asmdef as the migrated assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -221,6 +221,56 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesFileScopedLegacyUsing_KeepsUnrelatedBareTypes()
+        {
+            // Verifies that file-scoped imports do not grant legacy type context to sibling files.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                string unrelatedPath = Path.Combine(toolDirectory, "UnrelatedMetadata.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string unrelatedSource =
+                    "public sealed class UnrelatedMetadata { public BaseToolResponse Response; }";
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+                File.WriteAllText(unrelatedPath, unrelatedSource);
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(toolPath), Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+                Assert.That(File.ReadAllText(unrelatedPath), Is.EqualTo(unrelatedSource));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesGenericSplitContractFiles()
         {
             // Verifies that collection-shaped legacy type references migrate with their assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -429,6 +429,56 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenLegacyDomainHelperExists_AddsDomainReference()
+        {
+            // Verifies that helpers moved to Domain migrate their source and asmdef dependency together.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string helperPath = Path.Combine(toolDirectory, "ToolHelper.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(helperPath, @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolHelper
+{
+    public static ServiceResult<int> CreateResult()
+    {
+        return ServiceResult<int>.SuccessResult(1);
+    }
+
+    public static ToolSettingsCatalogItem[] GetCatalog()
+    {
+        return new ToolSettingsCatalogItem[0];
+    }
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(helperPath), Does.Contain(
+                    "io.github.hatayama.UnityCliLoop.Domain.ServiceResult<int> CreateResult"));
+                Assert.That(File.ReadAllText(helperPath), Does.Contain(
+                    "io.github.hatayama.UnityCliLoop.Domain.ToolSettingsCatalogItem[] GetCatalog"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenCurrentDomainMetadataExistsWithLegacyAsmdefGuid_AddsDomainReference()
         {
             // Verifies that partially migrated metadata helpers receive the asmdef refs they already require.
@@ -621,6 +671,44 @@ public sealed class HelloResponse : BaseToolResponse
                 Assert.That(result.FileCount, Is.EqualTo(3));
                 Assert.That(File.ReadAllText(listPath), Does.Contain(
                     "System.Collections.Generic.List<IUnityCliLoopTool>"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesSplitDomainHelpers()
+        {
+            // Verifies that split Domain helper files receive source and asmdef migration through global usings.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string helperPath = Path.Combine(toolDirectory, "ToolHelper.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(
+                    helperPath,
+                    "public static class ToolHelper { public static ServiceResult<int> Create() => null; }");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(3));
+                Assert.That(File.ReadAllText(helperPath), Does.Contain(
+                    "io.github.hatayama.UnityCliLoop.Domain.ServiceResult<int> Create"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -221,6 +221,42 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsing_RewritesGenericSplitContractFiles()
+        {
+            // Verifies that collection-shaped legacy type references migrate with their assembly.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string globalUsingPath = Path.Combine(toolDirectory, "GlobalUsings.cs");
+                string listPath = Path.Combine(toolDirectory, "ToolList.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(
+                    listPath,
+                    "public sealed class ToolList { public System.Collections.Generic.List<IUnityTool> Tools; }");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(3));
+                Assert.That(File.ReadAllText(listPath), Does.Contain(
+                    "System.Collections.Generic.List<IUnityCliLoopTool>"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenLegacyToolExistsUnderAsmref_RewritesReferencedAsmdef()
         {
             // Verifies that asmref folders mark the referenced asmdef as the migrated assembly.
@@ -257,6 +293,56 @@ public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
                 Assert.That(File.ReadAllText(toolPath), Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenNestedAsmrefOverridesAncestorAsmdef_RewritesReferencedAsmdef()
+        {
+            // Verifies that nested asmref folders use their referenced assembly instead of an ancestor asmdef.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string ancestorDirectory = Path.Combine(projectRoot, "Assets", "OuterAssembly");
+                string asmrefDirectory = Path.Combine(ancestorDirectory, "VendorToolParts");
+                string targetDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(asmrefDirectory);
+                Directory.CreateDirectory(targetDirectory);
+                string ancestorAsmdefPath = Path.Combine(ancestorDirectory, "OuterAssembly.Editor.asmdef");
+                string toolPath = Path.Combine(asmrefDirectory, "HelloTool.cs");
+                string asmrefPath = Path.Combine(asmrefDirectory, "VendorTools.Editor.asmref");
+                string targetAsmdefPath = Path.Combine(targetDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(ancestorAsmdefPath, @"{
+    ""name"": ""OuterAssembly.Editor"",
+    ""references"": []
+}");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}");
+                File.WriteAllText(asmrefPath, @"{
+    ""reference"": ""VendorTools.Editor""
+}");
+                File.WriteAllText(targetAsmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(toolPath), Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+                Assert.That(File.ReadAllText(targetAsmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(ancestorAsmdefPath), Does.Not.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -144,7 +144,7 @@ public static class ManualToolRegistration
                     "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.RegisterCustomTool"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
-                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
             }
             finally
             {
@@ -202,7 +202,7 @@ public static class CurrentManualToolRegistration
                 Assert.That(File.ReadAllText(registrationPath), Does.Contain("UnityCliLoopToolRegistrar"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
-                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
             }
             finally
             {
@@ -245,7 +245,7 @@ public static class CurrentManualToolRegistration
                 Assert.That(File.ReadAllText(registrationPath), Is.EqualTo(registrationSource));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
-                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
             }
             finally
             {
@@ -289,7 +289,7 @@ public static class CurrentManualToolRegistration
                 Assert.That(File.ReadAllText(registrationPath), Is.EqualTo(registrationSource));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
-                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
             }
             finally
             {
@@ -336,7 +336,7 @@ public sealed class HelloResponse : UnityCliLoopToolResponse
                 Assert.That(result.FileCount, Is.EqualTo(1));
                 Assert.That(File.ReadAllText(toolPath), Is.EqualTo(toolSource));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
-                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
             }
             finally
             {
@@ -345,7 +345,7 @@ public sealed class HelloResponse : UnityCliLoopToolResponse
         }
 
         [Test]
-        public void ApplyMigration_WhenCurrentRegistrarExistsWithToolContractsAsmdefReference_AddsApplicationReferences()
+        public void ApplyMigration_WhenCurrentRegistrarExistsWithToolContractsAsmdefReference_AddsApplicationReference()
         {
             // Verifies that already-replaced asmdef refs still receive missing current assembly dependencies.
             string projectRoot = CreateProjectRoot();
@@ -380,7 +380,7 @@ public static class CurrentManualToolRegistration
                 Assert.That(File.ReadAllText(registrationPath), Is.EqualTo(registrationSource));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
-                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
             }
             finally
             {
@@ -516,7 +516,7 @@ public static class ToolMetadataProvider
                 Assert.That(File.ReadAllText(metadataPath), Is.EqualTo(metadataSource));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
-                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
             }
             finally
             {
@@ -561,7 +561,7 @@ public static class ToolMetadataProvider
                 Assert.That(File.ReadAllText(metadataPath), Is.EqualTo(metadataSource));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
-                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
             }
             finally
             {
@@ -1160,7 +1160,7 @@ public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
                     "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.RegisterCustomTool"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
                 Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
-                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Not.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
             }
             finally
             {
@@ -1425,6 +1425,50 @@ public sealed class HelloResponse : BaseToolResponse
                 Assert.That(firstPreview.HasTargets, Is.True);
                 Assert.That(cachedPreview.FileCount, Is.EqualTo(firstPreview.FileCount));
                 Assert.That(refreshedPreview.HasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void PreviewMigration_WhenCurrentApplicationGuidReferenceExists_KeepsAsmdef()
+        {
+            // Verifies that V3 Application references are not reported as legacy asmdef migration.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string registrationPath = Path.Combine(toolDirectory, "CurrentManualToolRegistration.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                string registrationSource = @"using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+public static class CurrentManualToolRegistration
+{
+    public static void Register(IUnityCliLoopTool tool)
+    {
+        UnityCliLoopToolRegistrar.RegisterCustomTool(tool);
+    }
+}";
+                string asmdefSource = @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d"",
+        ""GUID:fc3fd32eddbee40e39c2d76dc184957b""
+    ]
+}";
+                File.WriteAllText(registrationPath, registrationSource);
+                File.WriteAllText(asmdefPath, asmdefSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = service.PreviewMigration(projectRoot);
+
+                Assert.That(preview.HasTargets, Is.False);
+                Assert.That(File.ReadAllText(registrationPath), Is.EqualTo(registrationSource));
+                Assert.That(File.ReadAllText(asmdefPath), Is.EqualTo(asmdefSource));
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 
 using NUnit.Framework;
 
+using Newtonsoft.Json.Linq;
+
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 
@@ -47,6 +49,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             result.FilePaths[0] = "Assets/ChangedAgain.cs";
 
             Assert.That(result.FilePaths, Is.EqualTo(new[] { "Assets/VendorTools/HelloTool.cs" }));
+        }
+
+        [Test]
+        public void TryReadJsonObjectForMigration_WhenReadThrowsIOException_ReturnsFalse()
+        {
+            // Verifies that migration scans skip unreadable assembly JSON files.
+            bool success = ThirdPartyToolMigrationFileService.TryReadJsonObjectForMigration(
+                "Assets/VendorTools/VendorTools.Editor.asmdef",
+                _ => throw new IOException("locked"),
+                out JObject jsonObject);
+
+            Assert.That(success, Is.False);
+            Assert.That(jsonObject, Is.Null);
+        }
+
+        [Test]
+        public void TryReadJsonObjectForMigration_WhenReadThrowsUnauthorizedAccessException_ReturnsFalse()
+        {
+            // Verifies that migration scans skip assembly JSON files blocked by file permissions.
+            bool success = ThirdPartyToolMigrationFileService.TryReadJsonObjectForMigration(
+                "Assets/VendorTools/VendorTools.Editor.asmdef",
+                _ => throw new UnauthorizedAccessException("denied"),
+                out JObject jsonObject);
+
+            Assert.That(success, Is.False);
+            Assert.That(jsonObject, Is.Null);
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -64,6 +64,49 @@ public sealed class HelloResponse : BaseToolResponse
         }
 
         [Test]
+        public void ApplyMigration_WhenLegacyToolAsmdefHasNoReferencesArray_AddsAsmdefReference()
+        {
+            // Verifies that valid minimal asmdefs compile after project-wide migration.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor""
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(toolPath), Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain(@"""references"": ["));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenManualRegistrationExists_AddsApplicationReference()
         {
             // Verifies that migrated manual registration source keeps access to the V3 registrar assembly.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -509,6 +509,59 @@ public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
             }
         }
 
+        [Test]
+        public void ApplyMigration_WhenLegacyToolExistsUnderPackagesDirectory_KeepsPackageFiles()
+        {
+            // Verifies that Package Manager and embedded package contents are not rewritten in place.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string packageDirectory = Path.Combine(
+                    projectRoot,
+                    "Packages",
+                    "com.example.legacy-tool",
+                    "Editor");
+                Directory.CreateDirectory(packageDirectory);
+                string toolPath = Path.Combine(packageDirectory, "PackageTool.cs");
+                string asmdefPath = Path.Combine(packageDirectory, "LegacyPackageTool.Editor.asmdef");
+                string toolSource = @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class PackageTool : AbstractUnityTool<PackageToolSchema, PackageToolResponse>
+{
+}
+
+public sealed class PackageToolSchema : BaseToolSchema
+{
+}
+
+public sealed class PackageToolResponse : BaseToolResponse
+{
+}";
+                string asmdefSource = @"{
+    ""name"": ""LegacyPackageTool.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}";
+                File.WriteAllText(toolPath, toolSource);
+                File.WriteAllText(asmdefPath, asmdefSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationPreview preview = service.PreviewMigration(projectRoot);
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(preview.HasTargets, Is.False);
+                Assert.That(result.FileCount, Is.EqualTo(0));
+                Assert.That(File.ReadAllText(toolPath), Is.EqualTo(toolSource));
+                Assert.That(File.ReadAllText(asmdefPath), Is.EqualTo(asmdefSource));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
         private static string CreateProjectRoot()
         {
             string projectRoot = Path.Combine(

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -389,6 +389,49 @@ public static class CurrentManualToolRegistration
         }
 
         [Test]
+        public void ApplyMigration_WhenLegacyRegistrarReturnIsUsedWithoutExplicitToolInfo_AddsDomainReference()
+        {
+            // Verifies that registrar return types add the Domain dependency even without explicit ToolInfo usage.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string registrationPath = Path.Combine(toolDirectory, "ToolCountLabel.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(registrationPath, @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolCountLabel
+{
+    public static string GetLabel()
+    {
+        return $""Tools: {CustomToolManager.GetRegisteredCustomTools().Length}"";
+    }
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(registrationPath), Does.Contain(
+                    "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.GetRegisteredCustomTools"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenDomainMetadataExistsWithoutManualRegistration_AddsDomainReference()
         {
             // Verifies that ToolInfo-only metadata helpers migrate their asmdef dependency.
@@ -1660,6 +1703,48 @@ public static class CurrentManualToolRegistration
                 bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
 
                 Assert.That(hasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task HasMigrationTargetsAsync_WhenCurrentRegistrarReturnMissingDomainReference_ReturnsTrue()
+        {
+            // Verifies that startup detection catches registrar return calls that still need Domain asmdef refs.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "ToolCountLabel.cs"),
+                    @"using io.github.hatayama.UnityCliLoop.Application;
+
+public static class ToolCountLabel
+{
+    public static string GetLabel()
+    {
+        return $""Tools: {UnityCliLoopToolRegistrar.GetRegisteredCustomTools().Length}"";
+    }
+}");
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "VendorTools.Editor.asmdef"),
+                    @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d"",
+        ""GUID:fc3fd32eddbee40e39c2d76dc184957b""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
+
+                Assert.That(hasTargets, Is.True);
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -1439,6 +1439,52 @@ public sealed class PackageToolResponse : BaseToolResponse
         }
 
         [Test]
+        public async Task HasMigrationTargetsAsync_WhenCurrentToolContractsExistsWithLegacyAsmdefGuid_ReturnsTrue()
+        {
+            // Verifies that startup detection catches partially migrated tools that still need asmdef repair.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "CurrentHelloTool.cs"),
+                    @"using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+[UnityCliLoopTool]
+public sealed class CurrentHelloTool : UnityCliLoopTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : UnityCliLoopToolSchema
+{
+}
+
+public sealed class HelloResponse : UnityCliLoopToolResponse
+{
+}");
+                File.WriteAllText(
+                    Path.Combine(toolDirectory, "VendorTools.Editor.asmdef"),
+                    @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                bool hasTargets = await service.HasMigrationTargetsAsync(projectRoot, CancellationToken.None);
+
+                Assert.That(hasTargets, Is.True);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public async Task HasMigrationTargetsAsync_WhenCurrentApplicationGuidReferenceExists_ReturnsFalse()
         {
             // Verifies that current V3 Application references do not trigger the startup migration prompt.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -530,6 +530,68 @@ public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
         }
 
         [Test]
+        public void ApplyMigration_WhenNoAsmdefFirstPassRuntimeUsesGlobalLegacyUsing_KeepsRegularRuntimeFiles()
+        {
+            // Verifies that Unity predefined firstpass runtime scripts do not migrate regular runtime siblings.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string firstPassDirectory = Path.Combine(projectRoot, "Assets", "Plugins");
+                string runtimeDirectory = Path.Combine(projectRoot, "Assets", "Scripts");
+                Directory.CreateDirectory(firstPassDirectory);
+                Directory.CreateDirectory(runtimeDirectory);
+                string globalUsingPath = Path.Combine(firstPassDirectory, "GlobalUsings.cs");
+                string runtimePath = Path.Combine(runtimeDirectory, "UnrelatedMetadata.cs");
+                string runtimeSource =
+                    "public sealed class UnrelatedMetadata { public BaseToolResponse Response; }";
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(runtimePath, runtimeSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain("io.github.hatayama.UnityCliLoop.ToolContracts"));
+                Assert.That(File.ReadAllText(runtimePath), Is.EqualTo(runtimeSource));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenNoAsmdefFirstPassEditorUsesGlobalLegacyUsing_KeepsRegularEditorFiles()
+        {
+            // Verifies that Unity predefined firstpass editor scripts do not migrate regular editor siblings.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string firstPassEditorDirectory = Path.Combine(projectRoot, "Assets", "Plugins", "Editor");
+                string editorDirectory = Path.Combine(projectRoot, "Assets", "Editor");
+                Directory.CreateDirectory(firstPassEditorDirectory);
+                Directory.CreateDirectory(editorDirectory);
+                string globalUsingPath = Path.Combine(firstPassEditorDirectory, "GlobalUsings.cs");
+                string editorPath = Path.Combine(editorDirectory, "UnrelatedMetadata.cs");
+                string editorSource =
+                    "public sealed class UnrelatedMetadata { public BaseToolResponse Response; }";
+                File.WriteAllText(globalUsingPath, "global using io.github.hatayama.uLoopMCP;");
+                File.WriteAllText(editorPath, editorSource);
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(1));
+                Assert.That(File.ReadAllText(globalUsingPath), Does.Contain("io.github.hatayama.UnityCliLoop.ToolContracts"));
+                Assert.That(File.ReadAllText(editorPath), Is.EqualTo(editorSource));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void ApplyMigration_WhenAssemblyUsesGlobalLegacyUsingAndSplitManualRegistration_AddsApplicationReference()
         {
             // Verifies that manual registration files relying on assembly-level legacy detection get required refs.
@@ -624,6 +686,51 @@ public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
                 ThirdPartyToolMigrationPreview preview = service.PreviewMigration(projectRoot);
 
                 Assert.That(preview.HasTargets, Is.False);
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyMigration_WhenLegacyToolExistsUnderAssetsPackagesDirectory_RewritesAssetsFiles()
+        {
+            // Verifies that only Unity's project-root Packages directory is excluded from migration scans.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "Packages", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "HelloTool.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+}
+
+public sealed class HelloResponse : BaseToolResponse
+{
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(toolPath), Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -64,6 +64,48 @@ public sealed class HelloResponse : BaseToolResponse
         }
 
         [Test]
+        public void ApplyMigration_WhenManualRegistrationExists_AddsApplicationReference()
+        {
+            // Verifies that migrated manual registration source keeps access to the V3 registrar assembly.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string toolDirectory = Path.Combine(projectRoot, "Assets", "VendorTools");
+                Directory.CreateDirectory(toolDirectory);
+                string toolPath = Path.Combine(toolDirectory, "ManualToolRegistration.cs");
+                string asmdefPath = Path.Combine(toolDirectory, "VendorTools.Editor.asmdef");
+                File.WriteAllText(toolPath, @"using io.github.hatayama.uLoopMCP;
+
+public static class ManualToolRegistration
+{
+    public static void Register(IUnityTool tool)
+    {
+        CustomToolManager.RegisterCustomTool(tool);
+    }
+}");
+                File.WriteAllText(asmdefPath, @"{
+    ""name"": ""VendorTools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+                ThirdPartyToolMigrationResult result = service.ApplyMigration(projectRoot);
+
+                Assert.That(result.FileCount, Is.EqualTo(2));
+                Assert.That(File.ReadAllText(toolPath), Does.Contain(
+                    "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.RegisterCustomTool"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+                Assert.That(File.ReadAllText(asmdefPath), Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
         public void PreviewMigration_WhenLegacyToolExistsUnderExcludedDirectory_IgnoresFile()
         {
             // Verifies that generated Unity folders are not scanned for third-party tools.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a4d3c9261bd7430ea2876e1cc2881dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -334,6 +334,33 @@ public static class ToolCountLabel
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyTextIsUsedInsideNestedInterpolatedStringLiteral_KeepsNestedLiteral()
+        {
+            // Verifies that string literals inside interpolation holes do not get rewritten as executable code.
+            string source = "using io.github.hatayama.uLoopMCP;\n" +
+                "\n" +
+                "public static class ToolLabel\n" +
+                "{\n" +
+                "    public static string GetLabel()\n" +
+                "    {\n" +
+                "        return $\"{Log(\"CustomToolManager\")}\";\n" +
+                "    }\n" +
+                "\n" +
+                "    private static string Log(string value)\n" +
+                "    {\n" +
+                "        return value;\n" +
+                "    }\n" +
+                "}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("Log(\"CustomToolManager\")"));
+            Assert.That(result.Content, Does.Not.Contain("Log(\"io.github.hatayama.UnityCliLoop.Application"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyDomainMetadataIsUsedWithoutRegistrar_RewritesDomainMetadataType()
         {
             // Verifies that metadata helpers split away from registration code keep compiling after migration.
@@ -353,6 +380,29 @@ public static class ToolMetadataProvider
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("io.github.hatayama.UnityCliLoop.Domain.ToolInfo[]"));
             Assert.That(result.Content, Does.Not.Match(@"(?<!\.)\bToolInfo\b"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyToolInfoConstructorHasDescription_RemovesDescriptionArgument()
+        {
+            // Verifies that old registrar metadata construction keeps compiling after the V3 ToolInfo signature change.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo Create(ToolParameterSchema schema)
+    {
+        return new ToolInfo(""hello"", ""description"", schema);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema)"));
+            Assert.That(result.Content, Does.Not.Contain("\"description\", schema"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -121,6 +121,23 @@ namespace Samples
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolAttributeIsQualified_RewritesQualifiedAttribute()
+        {
+            // Verifies that tools without a namespace import still receive a compilable V3 attribute.
+            string source =
+                "[io.github.hatayama.uLoopMCP.McpToolAttribute(Description = \"hello\")] public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "[io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopTool]"));
+            Assert.That(result.Content, Does.Not.Contain("McpTool"));
+            Assert.That(result.Content, Does.Not.Contain("Description"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyApiExistsOnlyInComment_KeepsContent()
         {
             // Verifies that migration does not rewrite inert documentation comments inside C# files.
@@ -184,7 +201,10 @@ namespace Samples
 }";
 
             ThirdPartyToolMigrationContentResult result =
-                ThirdPartyToolMigrationRules.MigrateAsmdefSource(source, hasLegacyCSharpSource: false);
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: false,
+                    requiresApplicationReference: false);
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
@@ -204,7 +224,10 @@ namespace Samples
 }";
 
             ThirdPartyToolMigrationContentResult result =
-                ThirdPartyToolMigrationRules.MigrateAsmdefSource(source, hasLegacyCSharpSource: false);
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: false,
+                    requiresApplicationReference: false);
 
             Assert.That(result.Changed, Is.False);
             Assert.That(result.Content, Is.EqualTo(source));
@@ -222,11 +245,36 @@ namespace Samples
 }";
 
             ThirdPartyToolMigrationContentResult result =
-                ThirdPartyToolMigrationRules.MigrateAsmdefSource(source, hasLegacyCSharpSource: true);
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: true,
+                    requiresApplicationReference: false);
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
             Assert.That(result.Content, Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenManualRegistrationIsUsed_KeepsApplicationReference()
+        {
+            // Verifies that migrated manual registration code can reference the V3 registrar assembly.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: true,
+                    requiresApplicationReference: true);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            Assert.That(result.Content, Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -76,6 +76,62 @@ namespace Samples
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolAttributeHasSupportedArguments_PreservesSupportedArguments()
+        {
+            // Verifies that migration drops removed metadata without changing supported tool visibility metadata.
+            string source =
+                "[McpTool(Description = \"hello\", DisplayDevelopmentOnly = true)] public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("[UnityCliLoopTool(DisplayDevelopmentOnly = true)]"));
+            Assert.That(result.Content, Does.Not.Contain("Description"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyToolAttributeHasSecurityArgument_RewritesSecurityArgument()
+        {
+            // Verifies that supported security metadata keeps compiling after the enum rename.
+            string source =
+                "[McpTool(RequiredSecuritySetting = SecuritySettings.None)] public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "[UnityCliLoopTool(RequiredSecuritySetting = UnityCliLoopSecuritySetting.None)]"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyApiExistsOnlyInComment_KeepsContent()
+        {
+            // Verifies that migration does not rewrite inert documentation comments inside C# files.
+            string source = "// AbstractUnityTool should not be rewritten here";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyApiExistsOnlyInStringLiteral_KeepsContent()
+        {
+            // Verifies that migration does not rewrite test fixture strings or examples inside C# files.
+            string source = "public const string Example = \"IUnityTool\";";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyNamespaceLikeTextExists_KeepsContent()
         {
             // Verifies that namespace migration treats dots as literal characters.
@@ -154,6 +210,28 @@ namespace Samples
             bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
 
             Assert.That(containsLegacyApi, Is.True);
+        }
+
+        [Test]
+        public void ContainsLegacyCSharpApi_WhenLegacyToolApiExistsOnlyInStringLiteral_ReturnsFalse()
+        {
+            // Verifies that inert fixture text does not trigger project migration UI.
+            string source = "public const string Example = \"[McpTool]\";";
+
+            bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
+
+            Assert.That(containsLegacyApi, Is.False);
+        }
+
+        [Test]
+        public void ContainsLegacyCSharpApi_WhenLegacyToolApiExistsOnlyInComment_ReturnsFalse()
+        {
+            // Verifies that comments do not trigger project migration UI.
+            string source = "// CustomToolManager";
+
+            bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
+
+            Assert.That(containsLegacyApi, Is.False);
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -575,6 +575,30 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenCurrentDomainUsingHasLegacyToolInfoDescriptionVariable_RemovesDescriptionArgument()
+        {
+            // Verifies that mixed partially migrated files do not keep the removed V2 description argument.
+            string source = @"using io.github.hatayama.uLoopMCP;
+using io.github.hatayama.UnityCliLoop.Domain;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo Create(ToolParameterSchema schema, string description)
+    {
+        return new ToolInfo(""hello"", description, schema);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema)"));
+            Assert.That(result.Content, Does.Not.Contain("description, schema"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenCurrentToolInfoConstructorUsesArbitraryVariableNames_KeepsConstructorArguments()
         {
             // Verifies that current V3 metadata construction is not inferred from local variable names.
@@ -597,6 +621,32 @@ public static class ToolMetadataProvider
                 "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", parameters, includeDevTools)"));
             Assert.That(result.Content, Does.Not.Contain(
                 "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", includeDevTools)"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyFileHasMethodNameMatchingDomainType_KeepsIdentifier()
+        {
+            // Verifies that method names are not rewritten as migrated type references.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class ToolMetadataProvider
+{
+    public void ToolInfo()
+    {
+    }
+
+    public ToolInfo[] GetTools()
+    {
+        return new ToolInfo[0];
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("public void ToolInfo()"));
+            Assert.That(result.Content, Does.Not.Contain("public void io.github.hatayama.UnityCliLoop.Domain.ToolInfo"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -237,6 +237,29 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyApiIsUsedInsideInterpolatedString_RewritesInterpolationCode()
+        {
+            // Verifies that code inside interpolation holes migrates while literal text stays inert.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolCountLabel
+{
+    public static string GetLabel()
+    {
+        return $""Tools: {CustomToolManager.GetRegisteredCustomTools().Length}"";
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.GetRegisteredCustomTools"));
+            Assert.That(result.Content, Does.Not.Contain("{CustomToolManager"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyDomainMetadataIsUsedWithoutRegistrar_RewritesDomainMetadataType()
         {
             // Verifies that metadata helpers split away from registration code keep compiling after migration.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -1045,6 +1045,27 @@ public sealed class OtherTool
         }
 
         [Test]
+        public void MigrateAsmdefSource_WhenLegacySourceHasNoReferencesArray_AddsToolContractsReference()
+        {
+            // Verifies that valid minimal asmdefs receive references needed by migrated source files.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor""
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: true,
+                    requiresToolContractsReference: false,
+                    requiresApplicationReference: false,
+                    requiresDomainReference: false);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(@"""references"": ["));
+            Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+        }
+
+        [Test]
         public void MigrateAsmdefSource_WhenCurrentToolContractsUsesLegacyGuid_RewritesToToolContractsGuid()
         {
             // Verifies that partially migrated custom tool assemblies can resolve V3 ToolContracts.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -106,6 +106,21 @@ namespace Samples
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolAttributeSharesAttributeList_RewritesOnlyLegacyToolEntry()
+        {
+            // Verifies that valid C# attribute lists migrate the tool attribute without dropping sibling attributes.
+            string source = "[McpTool(Description = \"hello\"), System.Obsolete] public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("[UnityCliLoopTool, System.Obsolete]"));
+            Assert.That(result.Content, Does.Not.Contain("McpTool"));
+            Assert.That(result.Content, Does.Not.Contain("Description"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyApiExistsOnlyInComment_KeepsContent()
         {
             // Verifies that migration does not rewrite inert documentation comments inside C# files.
@@ -123,6 +138,19 @@ namespace Samples
         {
             // Verifies that migration does not rewrite test fixture strings or examples inside C# files.
             string source = "public const string Example = \"IUnityTool\";";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenGenericLegacyNameExistsWithoutLegacyMarker_KeepsContent()
+        {
+            // Verifies that unrelated project types are not migrated just because their names resemble old API names.
+            string source = "public sealed class CustomToolManager { public SecuritySettings Settings; }";
 
             ThirdPartyToolMigrationContentResult result =
                 ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
@@ -228,6 +256,17 @@ namespace Samples
         {
             // Verifies that comments do not trigger project migration UI.
             string source = "// CustomToolManager";
+
+            bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
+
+            Assert.That(containsLegacyApi, Is.False);
+        }
+
+        [Test]
+        public void ContainsLegacyCSharpApi_WhenGenericLegacyNameExistsWithoutLegacyMarker_ReturnsFalse()
+        {
+            // Verifies that unrelated source names do not trigger project migration UI.
+            string source = "public sealed class CustomToolManager {}";
 
             bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -657,6 +657,30 @@ public sealed class HelloResponse : BaseToolResponse {}";
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyFileHasUnrelatedToolInfoProperty_KeepsIdentifier()
+        {
+            // Verifies that metadata type migration does not rewrite member names.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+    public string ToolInfo { get; }
+}
+
+public sealed class HelloSchema : BaseToolSchema {}
+
+public sealed class HelloResponse : BaseToolResponse {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("public string ToolInfo { get; }"));
+            Assert.That(result.Content, Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+            Assert.That(result.Content, Does.Not.Contain("public string io.github.hatayama.UnityCliLoop.Domain.ToolInfo"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyContractTypeIsFullyQualified_RewritesFullyQualifiedType()
         {
             // Verifies that qualified legacy namespace usage still migrates after qualified unrelated types are ignored.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -337,6 +337,29 @@ public static class ToolHelper
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolSettingsCatalogItemConstructorHasDescription_RemovesDescriptionArgument()
+        {
+            // Verifies that old settings catalog metadata keeps compiling after the V3 constructor signature change.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolSettingsCatalogProvider
+{
+    public static ToolSettingsCatalogItem Create(bool displayDevelopmentOnly, bool isThirdParty)
+    {
+        return new ToolSettingsCatalogItem(""hello"", ""description"", displayDevelopmentOnly, isThirdParty);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolSettingsCatalogItem(\"hello\", displayDevelopmentOnly, isThirdParty)"));
+            Assert.That(result.Content, Does.Not.Contain("\"description\", displayDevelopmentOnly"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyDomainHelpersUseNamespaceAlias_RewritesDomainHelperTypes()
         {
             // Verifies that namespace aliases targeting V2 helpers do not survive as ToolContracts references.
@@ -1072,7 +1095,8 @@ public sealed class OtherTool
                 ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
                     source,
                     hasLegacyAssemblySource: true,
-                    legacyAssemblyAliases: System.Array.Empty<string>());
+                    legacyAssemblyAliases: System.Array.Empty<string>(),
+                    legacyAssemblyToolInfoAliases: System.Array.Empty<string>());
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("UnityCliLoopToolSchema"));
@@ -1089,7 +1113,8 @@ public sealed class OtherTool
                 ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
                     source,
                     hasLegacyAssemblySource: true,
-                    legacyAssemblyAliases: System.Array.Empty<string>());
+                    legacyAssemblyAliases: System.Array.Empty<string>(),
+                    legacyAssemblyToolInfoAliases: System.Array.Empty<string>());
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain(

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -153,6 +153,23 @@ namespace Samples
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolAttributeIsGlobalQualified_RewritesGlobalQualifiedAttribute()
+        {
+            // Verifies that global-qualified V2 attributes do not bypass argument cleanup.
+            string source =
+                "[global::io.github.hatayama.uLoopMCP.McpTool(Description = \"hello\")] public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "[io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopTool]"));
+            Assert.That(result.Content, Does.Not.Contain("McpTool"));
+            Assert.That(result.Content, Does.Not.Contain("Description"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyToolAttributeIsAliasQualified_RewritesAliasQualifiedAttribute()
         {
             // Verifies that namespace alias attribute shorthand migrates to a resolvable V3 attribute.
@@ -217,6 +234,28 @@ public static class ManualToolRegistration
             Assert.That(result.Content, Does.Contain("io.github.hatayama.UnityCliLoop.Domain.ToolInfo[]"));
             Assert.That(result.Content, Does.Contain(
                 "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.GetRegisteredCustomTools"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyDomainMetadataIsUsedWithoutRegistrar_RewritesDomainMetadataType()
+        {
+            // Verifies that metadata helpers split away from registration code keep compiling after migration.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo[] GetTools()
+    {
+        return new ToolInfo[0];
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("io.github.hatayama.UnityCliLoop.Domain.ToolInfo[]"));
+            Assert.That(result.Content, Does.Not.Match(@"(?<!\.)\bToolInfo\b"));
         }
 
         [Test]
@@ -328,7 +367,8 @@ public static class ManualToolRegistration
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: false,
-                    requiresApplicationReference: false);
+                    requiresApplicationReference: false,
+                    requiresDomainReference: false);
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
@@ -351,7 +391,8 @@ public static class ManualToolRegistration
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: false,
-                    requiresApplicationReference: false);
+                    requiresApplicationReference: false,
+                    requiresDomainReference: false);
 
             Assert.That(result.Changed, Is.False);
             Assert.That(result.Content, Is.EqualTo(source));
@@ -372,7 +413,8 @@ public static class ManualToolRegistration
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: true,
-                    requiresApplicationReference: false);
+                    requiresApplicationReference: false,
+                    requiresDomainReference: false);
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
@@ -394,12 +436,37 @@ public static class ManualToolRegistration
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: true,
-                    requiresApplicationReference: true);
+                    requiresApplicationReference: true,
+                    requiresDomainReference: false);
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
             Assert.That(result.Content, Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
             Assert.That(result.Content, Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenDomainMetadataIsUsed_AddsDomainReference()
+        {
+            // Verifies that ToolInfo-only helper assemblies can resolve the V3 Domain metadata type.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: true,
+                    requiresApplicationReference: false,
+                    requiresDomainReference: true);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            Assert.That(result.Content, Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            Assert.That(result.Content, Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -406,6 +406,29 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolInfoConstructorHasDevelopmentFlag_PreservesDevelopmentFlag()
+        {
+            // Verifies that old registrar metadata visibility keeps compiling after the V3 ToolInfo signature change.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo Create(ToolParameterSchema schema)
+    {
+        return new ToolInfo(""hello"", ""description"", schema, true);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema, true)"));
+            Assert.That(result.Content, Does.Not.Contain("\"description\", schema"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyRegistrarIsUsedThroughNamespaceAlias_RewritesRegistrar()
         {
             // Verifies that namespace aliases do not create invalid qualified registrar names.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -436,9 +436,9 @@ public static class ToolMetadataProvider
 
 public static class ToolMetadataProvider
 {
-    public static ToolInfo Create(ToolParameterSchema schema, string description)
+    public static ToolInfo Create(ToolParameterSchema parameters, string label)
     {
-        return new ToolInfo(""hello"", description, schema);
+        return new ToolInfo(""hello"", label, parameters);
     }
 }";
 
@@ -447,8 +447,32 @@ public static class ToolMetadataProvider
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain(
-                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema)"));
-            Assert.That(result.Content, Does.Not.Contain("description, schema"));
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", parameters)"));
+            Assert.That(result.Content, Does.Not.Contain("label, parameters"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyToolInfoConstructorUsesTypeAlias_RemovesDescriptionArgument()
+        {
+            // Verifies that constructor migration follows aliases that target the old ToolInfo type.
+            string source = @"using LegacyToolInfo = io.github.hatayama.uLoopMCP.ToolInfo;
+using io.github.hatayama.uLoopMCP;
+
+public static class ToolMetadataProvider
+{
+    public static LegacyToolInfo Create(ToolParameterSchema parameters, string label)
+    {
+        return new LegacyToolInfo(""hello"", label, parameters);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", parameters)"));
+            Assert.That(result.Content, Does.Not.Contain("new LegacyToolInfo(\"hello\", label, parameters)"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -64,7 +64,9 @@ namespace Samples
         public void MigrateCSharpSource_WhenLegacyToolAttributeSuffixHasArguments_DropsUnsupportedArguments()
         {
             // Verifies that old attribute suffix syntax does not keep removed V3 attribute arguments.
-            string source = "[McpToolAttribute(Description = \"hello\")] public sealed class HelloTool {}";
+            string source =
+                "using io.github.hatayama.uLoopMCP;\n" +
+                "[McpToolAttribute(Description = \"hello\")] public sealed class HelloTool {}";
 
             ThirdPartyToolMigrationContentResult result =
                 ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
@@ -79,7 +81,7 @@ namespace Samples
         public void MigrateCSharpSource_WhenLegacyToolAttributeHasSupportedArguments_PreservesSupportedArguments()
         {
             // Verifies that migration drops removed metadata without changing supported tool visibility metadata.
-            string source =
+            string source = "using io.github.hatayama.uLoopMCP;\n" +
                 "[McpTool(Description = \"hello\", DisplayDevelopmentOnly = true)] public sealed class HelloTool {}";
 
             ThirdPartyToolMigrationContentResult result =
@@ -94,7 +96,7 @@ namespace Samples
         public void MigrateCSharpSource_WhenLegacyToolAttributeHasSecurityArgument_RewritesSecurityArgument()
         {
             // Verifies that supported security metadata keeps compiling after the enum rename.
-            string source =
+            string source = "using io.github.hatayama.uLoopMCP;\n" +
                 "[McpTool(RequiredSecuritySetting = SecuritySettings.None)] public sealed class HelloTool {}";
 
             ThirdPartyToolMigrationContentResult result =
@@ -109,7 +111,8 @@ namespace Samples
         public void MigrateCSharpSource_WhenLegacyToolAttributeSharesAttributeList_RewritesOnlyLegacyToolEntry()
         {
             // Verifies that valid C# attribute lists migrate the tool attribute without dropping sibling attributes.
-            string source = "[McpTool(Description = \"hello\"), System.Obsolete] public sealed class HelloTool {}";
+            string source = "using io.github.hatayama.uLoopMCP;\n" +
+                "[McpTool(Description = \"hello\"), System.Obsolete] public sealed class HelloTool {}";
 
             ThirdPartyToolMigrationContentResult result =
                 ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
@@ -124,7 +127,8 @@ namespace Samples
         public void MigrateCSharpSource_WhenLegacyToolDescriptionContainsBracket_RewritesAttribute()
         {
             // Verifies that description text cannot terminate the attribute-list scan early.
-            string source = "[McpTool(Description = \"Use [foo]\")] public sealed class HelloTool {}";
+            string source = "using io.github.hatayama.uLoopMCP;\n" +
+                "[McpTool(Description = \"Use [foo]\")] public sealed class HelloTool {}";
 
             ThirdPartyToolMigrationContentResult result =
                 ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
@@ -462,6 +466,24 @@ public sealed class HelloResponse : io.github.hatayama.uLoopMCP.BaseToolResponse
         {
             // Verifies that unrelated project types are not migrated just because their names resemble old API names.
             string source = "public sealed class CustomToolManager { public SecuritySettings Settings; }";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenBareMcpToolHasNoLegacyMarker_KeepsContent()
+        {
+            // Verifies that unrelated attribute types with the same short name do not trigger migration.
+            string source = @"using Some.Other.Mcp;
+
+[McpTool]
+public sealed class OtherTool
+{
+}";
 
             ThirdPartyToolMigrationContentResult result =
                 ThirdPartyToolMigrationRules.MigrateCSharpSource(source);

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -1387,6 +1387,28 @@ public sealed class OtherTool
         }
 
         [Test]
+        public void ContainsMigrationCandidateText_WhenPlainSourceExists_ReturnsFalse()
+        {
+            // Verifies that unrelated source files can skip expensive migration parsing.
+            string source = "public sealed class PlainEditorUtility { public int Count; }";
+
+            bool containsCandidateText = ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source);
+
+            Assert.That(containsCandidateText, Is.False);
+        }
+
+        [Test]
+        public void ContainsMigrationCandidateText_WhenLegacyNamespaceExists_ReturnsTrue()
+        {
+            // Verifies that old custom tool API source still enters migration parsing.
+            string source = "using io.github.hatayama.uLoopMCP;";
+
+            bool containsCandidateText = ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source);
+
+            Assert.That(containsCandidateText, Is.True);
+        }
+
+        [Test]
         public void ContainsLegacyCSharpApi_WhenGenericLegacyNameExistsWithoutLegacyMarker_ReturnsFalse()
         {
             // Verifies that unrelated source names do not trigger project migration UI.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -373,9 +373,62 @@ public static class ManualToolRegistration
             Assert.That(result.Content, Does.Contain(
                 "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.RegisterCustomTool"));
             Assert.That(result.Content, Does.Contain("io.github.hatayama.UnityCliLoop.Domain.ToolInfo[]"));
+            Assert.That(result.Content, Does.Contain("Old.IUnityCliLoopTool tool"));
             Assert.That(result.Content, Does.Not.Contain("Old.io.github"));
             Assert.That(result.Content, Does.Not.Contain("Old.CustomToolManager"));
             Assert.That(result.Content, Does.Not.Contain("Old.ToolInfo"));
+            Assert.That(result.Content, Does.Not.Contain("Old.IUnityTool"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenQualifiedUnrelatedTypeNamesExist_KeepsQualifiedTypeNames()
+        {
+            // Verifies that migration does not rewrite unrelated project types behind another qualifier.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+    private Other.BaseToolResponse response;
+    private MyGame.SecuritySettings securitySettings;
+}
+
+public sealed class HelloSchema : BaseToolSchema {}
+
+public sealed class HelloResponse : BaseToolResponse {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("Other.BaseToolResponse"));
+            Assert.That(result.Content, Does.Contain("MyGame.SecuritySettings"));
+            Assert.That(result.Content, Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+            Assert.That(result.Content, Does.Contain("UnityCliLoopToolSchema"));
+            Assert.That(result.Content, Does.Contain("UnityCliLoopToolResponse"));
+            Assert.That(result.Content, Does.Not.Contain("Other.UnityCliLoopToolResponse"));
+            Assert.That(result.Content, Does.Not.Contain("MyGame.UnityCliLoopSecuritySetting"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyContractTypeIsFullyQualified_RewritesFullyQualifiedType()
+        {
+            // Verifies that qualified legacy namespace usage still migrates after qualified unrelated types are ignored.
+            string source = @"public sealed class HelloTool :
+    io.github.hatayama.uLoopMCP.AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloResponse : io.github.hatayama.uLoopMCP.BaseToolResponse {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopTool<HelloSchema, HelloResponse>"));
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopToolResponse"));
+            Assert.That(result.Content, Does.Not.Contain("uLoopMCP"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -681,6 +681,33 @@ public sealed class HelloResponse : BaseToolResponse {}";
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyFileHasMemberNameMatchingLegacyContractType_KeepsIdentifier()
+        {
+            // Verifies that contract type migration does not rewrite member names.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+{
+}
+
+public sealed class HelloSchema : BaseToolSchema
+{
+    public SecuritySettings SecuritySettings { get; set; }
+}
+
+public sealed class HelloResponse : BaseToolResponse {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "public UnityCliLoopSecuritySetting SecuritySettings { get; set; }"));
+            Assert.That(result.Content, Does.Not.Contain(
+                "UnityCliLoopSecuritySetting UnityCliLoopSecuritySetting"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyContractTypeIsFullyQualified_RewritesFullyQualifiedType()
         {
             // Verifies that qualified legacy namespace usage still migrates after qualified unrelated types are ignored.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -262,6 +262,74 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyDomainHelpersAreUsed_RewritesDomainHelperTypes()
+        {
+            // Verifies that legacy helpers moved to Domain keep compiling after namespace migration.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolHelper
+{
+    public static ServiceResult<int> CreateResult()
+    {
+        return ServiceResult<int>.SuccessResult(1);
+    }
+
+    public static ToolSettingsCatalogItem[] GetCatalog()
+    {
+        return new ToolSettingsCatalogItem[0];
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Domain.ServiceResult<int> CreateResult"));
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Domain.ServiceResult<int>.SuccessResult"));
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Domain.ToolSettingsCatalogItem[] GetCatalog"));
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolSettingsCatalogItem[0]"));
+            Assert.That(result.Content, Does.Not.Contain("ToolContracts.ServiceResult"));
+            Assert.That(result.Content, Does.Not.Contain("ToolContracts.ToolSettingsCatalogItem"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyDomainHelpersUseNamespaceAlias_RewritesDomainHelperTypes()
+        {
+            // Verifies that namespace aliases targeting V2 helpers do not survive as ToolContracts references.
+            string source = @"using Old = io.github.hatayama.uLoopMCP;
+
+public static class ToolHelper
+{
+    public static Old.ServiceResult<int> CreateResult()
+    {
+        return Old.ServiceResult<int>.SuccessResult(1);
+    }
+
+    public static Old.ToolSettingsCatalogItem[] GetCatalog()
+    {
+        return new Old.ToolSettingsCatalogItem[0];
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Domain.ServiceResult<int> CreateResult"));
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Domain.ServiceResult<int>.SuccessResult"));
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Domain.ToolSettingsCatalogItem[] GetCatalog"));
+            Assert.That(result.Content, Does.Not.Contain("Old.ServiceResult"));
+            Assert.That(result.Content, Does.Not.Contain("Old.ToolSettingsCatalogItem"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyApiIsUsedInsideInterpolatedString_RewritesInterpolationCode()
         {
             // Verifies that code inside interpolation holes migrates while literal text stays inert.
@@ -947,10 +1015,41 @@ public sealed class OtherTool
         }
 
         [Test]
+        public void MigrateCSharpSourceForLegacyAssembly_WhenFileReliesOnGlobalUsing_RewritesDomainHelpers()
+        {
+            // Verifies that split helper files relying on a legacy global using migrate to Domain types.
+            string source =
+                "public static class ToolHelper { public static ServiceResult<int> Create() => null; }";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
+                    source,
+                    hasLegacyAssemblySource: true,
+                    legacyAssemblyAliases: System.Array.Empty<string>());
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Domain.ServiceResult<int> Create"));
+        }
+
+        [Test]
         public void ContainsLegacyAssemblyScopedApi_WhenGenericLegacyTypesAreUsed_ReturnsTrue()
         {
             // Verifies that split files using collection-shaped legacy types are migrated with their assembly.
             string source = "public sealed class ToolList { public System.Collections.Generic.List<IUnityTool> Tools; }";
+
+            bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(
+                source,
+                System.Array.Empty<string>());
+
+            Assert.That(containsLegacyApi, Is.True);
+        }
+
+        [Test]
+        public void ContainsLegacyAssemblyScopedApi_WhenLegacyDomainHelpersAreUsed_ReturnsTrue()
+        {
+            // Verifies that split files using Domain helpers are migrated with their legacy assembly.
+            string source = "public static class ToolHelper { public static ServiceResult<int> Create() => null; }";
 
             bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(
                 source,

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -576,6 +576,29 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolInfoConstructorUsesNamespaceAlias_RemovesDescriptionArgument()
+        {
+            // Verifies that aliased legacy metadata constructors migrate before namespace alias rewrites.
+            string source = @"using Old = io.github.hatayama.uLoopMCP;
+
+public static class ToolMetadataProvider
+{
+    public static Old.ToolInfo Create(Old.ToolParameterSchema schema)
+    {
+        return new Old.ToolInfo(""hello"", ""description"", schema);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema)"));
+            Assert.That(result.Content, Does.Not.Contain("\"description\", schema"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyRegistrarIsUsedThroughNamespaceAlias_RewritesRegistrar()
         {
             // Verifies that namespace aliases do not create invalid qualified registrar names.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -893,6 +893,7 @@ public sealed class OtherTool
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: false,
+                    requiresToolContractsReference: false,
                     requiresApplicationReference: false,
                     requiresDomainReference: false);
 
@@ -917,6 +918,7 @@ public sealed class OtherTool
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: false,
+                    requiresToolContractsReference: false,
                     requiresApplicationReference: false,
                     requiresDomainReference: false);
 
@@ -939,6 +941,31 @@ public sealed class OtherTool
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: true,
+                    requiresToolContractsReference: false,
+                    requiresApplicationReference: false,
+                    requiresDomainReference: false);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            Assert.That(result.Content, Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenCurrentToolContractsUsesLegacyGuid_RewritesToToolContractsGuid()
+        {
+            // Verifies that partially migrated custom tool assemblies can resolve V3 ToolContracts.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: false,
+                    requiresToolContractsReference: true,
                     requiresApplicationReference: false,
                     requiresDomainReference: false);
 
@@ -962,6 +989,7 @@ public sealed class OtherTool
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: true,
+                    requiresToolContractsReference: false,
                     requiresApplicationReference: true,
                     requiresDomainReference: false);
 
@@ -986,6 +1014,7 @@ public sealed class OtherTool
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: true,
+                    requiresToolContractsReference: false,
                     requiresApplicationReference: false,
                     requiresDomainReference: true);
 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -283,6 +283,53 @@ public static class ToolCountLabel
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyApiIsUsedInsideInterpolatedRawString_RewritesInterpolationCode()
+        {
+            // Verifies that raw interpolation holes are treated as code.
+            string source = "using io.github.hatayama.uLoopMCP;\n" +
+                "\n" +
+                "public static class ToolCountLabel\n" +
+                "{\n" +
+                "    public static string GetLabel()\n" +
+                "    {\n" +
+                "        return $\"\"\"Tools: {CustomToolManager.GetRegisteredCustomTools().Length}\"\"\";\n" +
+                "    }\n" +
+                "}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.GetRegisteredCustomTools"));
+            Assert.That(result.Content, Does.Not.Contain("{CustomToolManager"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyApiIsUsedInsideMultiDollarRawString_RewritesInterpolationCode()
+        {
+            // Verifies that literal braces stay inert when multiple dollar signs are used.
+            string source = "using io.github.hatayama.uLoopMCP;\n" +
+                "\n" +
+                "public static class ToolCountLabel\n" +
+                "{\n" +
+                "    public static string GetLabel()\n" +
+                "    {\n" +
+                "        return $$\"\"\"Literal { braces } tools: {{CustomToolManager.GetRegisteredCustomTools().Length}}\"\"\";\n" +
+                "    }\n" +
+                "}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("Literal { braces }"));
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.GetRegisteredCustomTools"));
+            Assert.That(result.Content, Does.Not.Contain("{{CustomToolManager"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyDomainMetadataIsUsedWithoutRegistrar_RewritesDomainMetadataType()
         {
             // Verifies that metadata helpers split away from registration code keep compiling after migration.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -93,6 +93,23 @@ namespace Samples
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolAttributeDescriptionIsRawStringWithComma_DropsDescriptionArgument()
+        {
+            // Verifies that commas inside raw string literals do not split legacy attribute arguments.
+            string source = "using io.github.hatayama.uLoopMCP;\n" +
+                "[McpTool(Description = \"\"\"\"say \"hi\", world\"\"\"\", DisplayDevelopmentOnly = true)] " +
+                "public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("[UnityCliLoopTool(DisplayDevelopmentOnly = true)]"));
+            Assert.That(result.Content, Does.Not.Contain("Description"));
+            Assert.That(result.Content, Does.Not.Contain("\"\"\"\"say \"hi\", world\"\"\"\""));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyToolAttributeHasSecurityArgument_RewritesSecurityArgument()
         {
             // Verifies that supported security metadata keeps compiling after the enum rename.
@@ -515,6 +532,30 @@ public static class ToolMetadataProvider
             Assert.That(result.Content, Does.Contain(
                 "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema)"));
             Assert.That(result.Content, Does.Not.Contain("\"description\", schema"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyToolInfoDescriptionIsRawStringWithComma_RemovesDescriptionArgument()
+        {
+            // Verifies that commas inside raw string literals do not split legacy ToolInfo arguments.
+            string source =
+                "using io.github.hatayama.uLoopMCP;\n" +
+                "\n" +
+                "public static class ToolMetadataProvider\n" +
+                "{\n" +
+                "    public static ToolInfo Create(ToolParameterSchema schema)\n" +
+                "    {\n" +
+                "        return new ToolInfo(\"hello\", \"\"\"\"say \"hi\", world\"\"\"\", schema);\n" +
+                "    }\n" +
+                "}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema)"));
+            Assert.That(result.Content, Does.Not.Contain("\"\"\"\"say \"hi\", world\"\"\"\""));
         }
 
         [Test]
@@ -1251,6 +1292,29 @@ public sealed class OtherTool
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
                     hasLegacyCSharpSource: true,
+                    requiresToolContractsReference: false,
+                    requiresApplicationReference: false,
+                    requiresDomainReference: true);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            Assert.That(result.Content, Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            Assert.That(result.Content, Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenCurrentDomainMetadataRequiresDomainReference_AddsToolContractsReference()
+        {
+            // Verifies that direct V3 Domain consumers also receive transitive ToolContracts access.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor"",
+    ""references"": []
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: false,
                     requiresToolContractsReference: false,
                     requiresApplicationReference: false,
                     requiresDomainReference: true);

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -108,6 +108,27 @@ namespace Samples
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolAttributeUsesSecurityAlias_KeepsAliasIdentifier()
+        {
+            // Verifies that aliases containing the old enum name are not rewritten as partial identifiers.
+            string source = @"using LegacySecuritySettings = io.github.hatayama.uLoopMCP.SecuritySettings;
+using io.github.hatayama.uLoopMCP;
+
+[McpTool(RequiredSecuritySetting = LegacySecuritySettings.None)]
+public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "using LegacySecuritySettings = io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopSecuritySetting;"));
+            Assert.That(result.Content, Does.Contain(
+                "[UnityCliLoopTool(RequiredSecuritySetting = LegacySecuritySettings.None)]"));
+            Assert.That(result.Content, Does.Not.Contain("LegacyUnityCliLoopSecuritySetting"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyToolAttributeSharesAttributeList_RewritesOnlyLegacyToolEntry()
         {
             // Verifies that valid C# attribute lists migrate the tool attribute without dropping sibling attributes.
@@ -840,6 +861,29 @@ public sealed class HelloResponse : io.github.hatayama.uLoopMCP.BaseToolResponse
 
             Assert.That(result.Changed, Is.False);
             Assert.That(result.Content, Is.EqualTo(source));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyFileDeclaresCustomToolManagerIdentifier_KeepsIdentifier()
+        {
+            // Verifies that registrar migration does not rewrite unrelated declaration identifiers.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class CustomToolManager
+{
+    public void CustomToolManager()
+    {
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("public sealed class CustomToolManager"));
+            Assert.That(result.Content, Does.Contain("public void CustomToolManager()"));
+            Assert.That(result.Content, Does.Not.Contain(
+                "public sealed class io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -501,6 +501,31 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenCurrentToolInfoConstructorUsesArbitraryVariableNames_KeepsConstructorArguments()
+        {
+            // Verifies that current V3 metadata construction is not inferred from local variable names.
+            string source = @"using io.github.hatayama.uLoopMCP;
+using io.github.hatayama.UnityCliLoop.Domain;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo Create(ToolParameterSchema parameters, bool includeDevTools)
+    {
+        return new ToolInfo(""hello"", parameters, includeDevTools);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", parameters, includeDevTools)"));
+            Assert.That(result.Content, Does.Not.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", includeDevTools)"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyRegistrarIsUsedThroughNamespaceAlias_RewritesRegistrar()
         {
             // Verifies that namespace aliases do not create invalid qualified registrar names.
@@ -672,7 +697,8 @@ public sealed class OtherTool
             ThirdPartyToolMigrationContentResult result =
                 ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
                     source,
-                    hasLegacyAssemblySource: true);
+                    hasLegacyAssemblySource: true,
+                    legacyAssemblyAliases: System.Array.Empty<string>());
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("UnityCliLoopToolSchema"));
@@ -684,7 +710,9 @@ public sealed class OtherTool
             // Verifies that split files using collection-shaped legacy types are migrated with their assembly.
             string source = "public sealed class ToolList { public System.Collections.Generic.List<IUnityTool> Tools; }";
 
-            bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(source);
+            bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(
+                source,
+                System.Array.Empty<string>());
 
             Assert.That(containsLegacyApi, Is.True);
         }

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -493,6 +493,32 @@ public sealed class OtherTool
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenUnqualifiedLegacyLikeBaseTypeHasNoLegacyMarker_KeepsContent()
+        {
+            // Verifies that unrelated base types with the same short name do not trigger migration.
+            string source = "public sealed class MyResponse : BaseToolResponse {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyNamespacePrefixExists_KeepsContent()
+        {
+            // Verifies that namespace matching does not treat prefixes as the V2 namespace.
+            string source = "using io.github.hatayama.uLoopMCPExtensions;";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+        }
+
+        [Test]
         public void MigrateCSharpSourceForLegacyAssembly_WhenFileReliesOnGlobalUsing_RewritesContractTypes()
         {
             // Verifies that files split away from a legacy global using still migrate inside the same assembly.
@@ -652,7 +678,8 @@ public sealed class OtherTool
         public void ContainsLegacyCSharpApi_WhenLegacyToolApiExists_ReturnsTrue()
         {
             // Verifies that migration detection is based on public custom tool API usage.
-            string source = "[McpTool] public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse> {}";
+            string source = "using io.github.hatayama.uLoopMCP;\n" +
+                "[McpTool] public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse> {}";
 
             bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -1239,6 +1239,33 @@ public sealed class OtherTool
         }
 
         [Test]
+        public void MigrateAsmdefSource_WhenCurrentReferencesUseAssemblyNames_DoesNotAddDuplicateGuids()
+        {
+            // Verifies that name-based V3 references are treated as the same assemblies as their GUID references.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor"",
+    ""references"": [
+        ""UnityCLILoop.ToolContracts"",
+        ""UnityCLILoop.Application"",
+        ""UnityCLILoop.Domain""
+    ]
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: false,
+                    requiresToolContractsReference: true,
+                    requiresApplicationReference: true,
+                    requiresDomainReference: true);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+            Assert.That(result.Content, Does.Not.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            Assert.That(result.Content, Does.Not.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+        }
+
+        [Test]
         public void ContainsLegacyCSharpApi_WhenLegacyToolApiExists_ReturnsTrue()
         {
             // Verifies that migration detection is based on public custom tool API usage.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -1,0 +1,181 @@
+using System.Linq;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies V3 third-party tool migration rewrite rules.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationRulesTests
+    {
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyToolApiIsUsed_RewritesToV3Contracts()
+        {
+            // Verifies that V2 custom tool source is rewritten to the V3 public contract names.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+namespace Samples
+{
+    [McpTool(Description = ""hello"")]
+    public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse>
+    {
+    }
+
+    public sealed class HelloSchema : BaseToolSchema
+    {
+    }
+
+    public sealed class HelloResponse : BaseToolResponse
+    {
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("using io.github.hatayama.UnityCliLoop.ToolContracts;"));
+            Assert.That(result.Content, Does.Contain("[UnityCliLoopTool]"));
+            Assert.That(result.Content, Does.Contain("UnityCliLoopTool<HelloSchema, HelloResponse>"));
+            Assert.That(result.Content, Does.Contain("UnityCliLoopToolSchema"));
+            Assert.That(result.Content, Does.Contain("UnityCliLoopToolResponse"));
+            Assert.That(result.Content, Does.Not.Contain("uLoopMCP"));
+            Assert.That(result.ReplacementCount, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenNoLegacyToolApiIsUsed_KeepsContent()
+        {
+            // Verifies that unrelated C# files are not rewritten.
+            string source = "public sealed class PlainClass {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+            Assert.That(result.ReplacementCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyToolAttributeSuffixHasArguments_DropsUnsupportedArguments()
+        {
+            // Verifies that old attribute suffix syntax does not keep removed V3 attribute arguments.
+            string source = "[McpToolAttribute(Description = \"hello\")] public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("[UnityCliLoopTool]"));
+            Assert.That(result.Content, Does.Not.Contain("Description"));
+            Assert.That(result.Content, Does.Not.Contain("UnityCliLoopToolAttribute("));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyNamespaceLikeTextExists_KeepsContent()
+        {
+            // Verifies that namespace migration treats dots as literal characters.
+            string source = "using ioXgithubYhatayamaZUnityCliLoop;";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenLegacyReferenceIsUsed_RewritesToToolContractsGuid()
+        {
+            // Verifies that a custom tool asmdef points at the V3 ToolContracts assembly.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor"",
+    ""references"": [
+        ""uLoopMCP.Editor""
+    ]
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(source, hasLegacyCSharpSource: false);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            Assert.That(result.Content, Does.Not.Contain("uLoopMCP.Editor"));
+            Assert.That(result.ReplacementCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenOnlyLegacyGuidIsUsedWithoutLegacySource_KeepsContent()
+        {
+            // Verifies that package-owned Application references are not rewritten by GUID alone.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(source, hasLegacyCSharpSource: false);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenLegacyGuidIsUsedWithLegacySource_RewritesToToolContractsGuid()
+        {
+            // Verifies that old custom tool assemblies with GUID references are migrated when source confirms old API usage.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d""
+    ]
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(source, hasLegacyCSharpSource: true);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+            Assert.That(result.Content, Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+        }
+
+        [Test]
+        public void ContainsLegacyCSharpApi_WhenLegacyToolApiExists_ReturnsTrue()
+        {
+            // Verifies that migration detection is based on public custom tool API usage.
+            string source = "[McpTool] public sealed class HelloTool : AbstractUnityTool<HelloSchema, HelloResponse> {}";
+
+            bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
+
+            Assert.That(containsLegacyApi, Is.True);
+        }
+
+        [Test]
+        public void ContainsLegacyCSharpApi_WhenOnlyCurrentApiExists_ReturnsFalse()
+        {
+            // Verifies that already migrated V3 tools are not detected again.
+            string source = "[UnityCliLoopTool] public sealed class HelloTool : UnityCliLoopTool<HelloSchema, HelloResponse> {}";
+
+            bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
+
+            Assert.That(containsLegacyApi, Is.False);
+        }
+
+        [Test]
+        public void GetExcludedDirectoryNames_IncludesUnityGeneratedDirectories()
+        {
+            // Verifies that generated Unity folders are skipped during project-wide scans.
+            string[] names = ThirdPartyToolMigrationRules.GetExcludedDirectoryNames();
+
+            Assert.That(names.Contains("Library"), Is.True);
+            Assert.That(names.Contains("Temp"), Is.True);
+            Assert.That(names.Contains(".git"), Is.True);
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -429,6 +429,30 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenCurrentToolInfoConstructorExistsInMixedFile_KeepsConstructorArguments()
+        {
+            // Verifies that partially migrated metadata construction is not treated as the removed V2 signature.
+            string source = @"using io.github.hatayama.uLoopMCP;
+using io.github.hatayama.UnityCliLoop.Domain;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo Create(ToolParameterSchema schema)
+    {
+        return new ToolInfo(""hello"", schema, true);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema, true)"));
+            Assert.That(result.Content, Does.Not.Contain("new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", true)"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyRegistrarIsUsedThroughNamespaceAlias_RewritesRegistrar()
         {
             // Verifies that namespace aliases do not create invalid qualified registrar names.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -551,6 +551,30 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenCurrentDomainUsingHasLegacyToolInfoConstructor_RemovesDescriptionArgument()
+        {
+            // Verifies that partially migrated files still remove the deleted V2 description argument.
+            string source = @"using io.github.hatayama.uLoopMCP;
+using io.github.hatayama.UnityCliLoop.Domain;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo Create(ToolParameterSchema schema)
+    {
+        return new ToolInfo(""hello"", ""description"", schema, true);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema, true)"));
+            Assert.That(result.Content, Does.Not.Contain("\"description\""));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenCurrentToolInfoConstructorUsesArbitraryVariableNames_KeepsConstructorArguments()
         {
             // Verifies that current V3 metadata construction is not inferred from local variable names.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -121,6 +121,21 @@ namespace Samples
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolDescriptionContainsBracket_RewritesAttribute()
+        {
+            // Verifies that description text cannot terminate the attribute-list scan early.
+            string source = "[McpTool(Description = \"Use [foo]\")] public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("[UnityCliLoopTool]"));
+            Assert.That(result.Content, Does.Not.Contain("McpTool"));
+            Assert.That(result.Content, Does.Not.Contain("Description"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyToolAttributeIsQualified_RewritesQualifiedAttribute()
         {
             // Verifies that tools without a namespace import still receive a compilable V3 attribute.
@@ -135,6 +150,32 @@ namespace Samples
                 "[io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopTool]"));
             Assert.That(result.Content, Does.Not.Contain("McpTool"));
             Assert.That(result.Content, Does.Not.Contain("Description"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyPublicHelpersAreUsed_RewritesHelperTypes()
+        {
+            // Verifies that migrated custom tools keep compiling when they override helper-driven schema behavior.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class HelloTool
+{
+    public ToolParameterSchema ParameterSchema => ToolParameterSchemaGenerator.FromDto<HelloSchema>();
+
+    private void Fail()
+    {
+        throw new ParameterValidationException(""bad"");
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("UnityCliLoopToolParameterSchemaGenerator"));
+            Assert.That(result.Content, Does.Contain("UnityCliLoopToolParameterValidationException"));
+            Assert.That(result.Content, Does.Not.Match(@"\bToolParameterSchemaGenerator\b"));
+            Assert.That(result.Content, Does.Not.Match(@"\bParameterValidationException\b"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -202,6 +202,30 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyRegistrarIsUsedThroughNamespaceAlias_RewritesRegistrar()
+        {
+            // Verifies that namespace aliases do not create invalid qualified registrar names.
+            string source = @"using Old = io.github.hatayama.uLoopMCP;
+
+public static class ManualToolRegistration
+{
+    public static void Register(Old.IUnityTool tool)
+    {
+        Old.CustomToolManager.RegisterCustomTool(tool);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.RegisterCustomTool"));
+            Assert.That(result.Content, Does.Not.Contain("Old.io.github"));
+            Assert.That(result.Content, Does.Not.Contain("Old.CustomToolManager"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyApiExistsOnlyInComment_KeepsContent()
         {
             // Verifies that migration does not rewrite inert documentation comments inside C# files.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -476,6 +476,32 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolInfoConstructorUsesSameNameTypeAlias_KeepsAliasIdentifier()
+        {
+            // Verifies that unqualified type replacement does not rewrite the left side of using aliases.
+            string source = @"using ToolInfo = io.github.hatayama.uLoopMCP.ToolInfo;
+using io.github.hatayama.uLoopMCP;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo Create(ToolParameterSchema parameters, string label)
+    {
+        return new ToolInfo(""hello"", label, parameters);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "using ToolInfo = io.github.hatayama.UnityCliLoop.Domain.ToolInfo;"));
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", parameters)"));
+            Assert.That(result.Content, Does.Not.Contain("using io.github.hatayama.UnityCliLoop.Domain.ToolInfo ="));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyToolInfoConstructorUsesNamedDescription_RemovesDescriptionArgument()
         {
             // Verifies that named V2 description arguments are removed without reordering supported arguments.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -260,6 +260,29 @@ public static class ToolCountLabel
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyApiIsUsedInsideInterpolatedVerbatimString_RewritesInterpolationCode()
+        {
+            // Verifies that verbatim interpolation holes are treated as code.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolCountLabel
+{
+    public static string GetLabel()
+    {
+        return $@""Tools: {CustomToolManager.GetRegisteredCustomTools().Length}"";
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.GetRegisteredCustomTools"));
+            Assert.That(result.Content, Does.Not.Contain("{CustomToolManager"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyDomainMetadataIsUsedWithoutRegistrar_RewritesDomainMetadataType()
         {
             // Verifies that metadata helpers split away from registration code keep compiling after migration.
@@ -360,6 +383,17 @@ public static class ManualToolRegistration
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("UnityCliLoopToolSchema"));
+        }
+
+        [Test]
+        public void ContainsLegacyAssemblyScopedApi_WhenGenericLegacyTypesAreUsed_ReturnsTrue()
+        {
+            // Verifies that split files using collection-shaped legacy types are migrated with their assembly.
+            string source = "public sealed class ToolList { public System.Collections.Generic.List<IUnityTool> Tools; }";
+
+            bool containsLegacyApi = ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(source);
+
+            Assert.That(containsLegacyApi, Is.True);
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -241,6 +241,21 @@ public static class ManualToolRegistration
         }
 
         [Test]
+        public void MigrateCSharpSourceForLegacyAssembly_WhenFileReliesOnGlobalUsing_RewritesContractTypes()
+        {
+            // Verifies that files split away from a legacy global using still migrate inside the same assembly.
+            string source = "public sealed class HelloSchema : BaseToolSchema {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
+                    source,
+                    hasLegacyAssemblySource: true);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("UnityCliLoopToolSchema"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyNamespaceLikeTextExists_KeepsContent()
         {
             // Verifies that namespace migration treats dots as literal characters.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -179,6 +179,29 @@ public sealed class HelloTool
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyRegistrarMetadataIsUsed_RewritesDomainMetadataType()
+        {
+            // Verifies that explicit registrar metadata declarations keep compiling after namespace migration.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ManualToolRegistration
+{
+    public static ToolInfo[] GetTools()
+    {
+        return CustomToolManager.GetRegisteredCustomTools();
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("io.github.hatayama.UnityCliLoop.Domain.ToolInfo[]"));
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.GetRegisteredCustomTools"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyApiExistsOnlyInComment_KeepsContent()
         {
             // Verifies that migration does not rewrite inert documentation comments inside C# files.
@@ -316,6 +339,7 @@ public sealed class HelloTool
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
             Assert.That(result.Content, Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            Assert.That(result.Content, Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -153,6 +153,24 @@ namespace Samples
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolAttributeIsAliasQualified_RewritesAliasQualifiedAttribute()
+        {
+            // Verifies that namespace alias attribute shorthand migrates to a resolvable V3 attribute.
+            string source = @"using Old = io.github.hatayama.uLoopMCP;
+
+[Old.McpTool(DisplayDevelopmentOnly = true)]
+public sealed class HelloTool {}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "[io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopTool(DisplayDevelopmentOnly = true)]"));
+            Assert.That(result.Content, Does.Not.Contain("Old.McpTool"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyPublicHelpersAreUsed_RewritesHelperTypes()
         {
             // Verifies that migrated custom tools keep compiling when they override helper-driven schema behavior.
@@ -209,9 +227,10 @@ public static class ManualToolRegistration
 
 public static class ManualToolRegistration
 {
-    public static void Register(Old.IUnityTool tool)
+    public static Old.ToolInfo[] Register(Old.IUnityTool tool)
     {
         Old.CustomToolManager.RegisterCustomTool(tool);
+        return Old.CustomToolManager.GetRegisteredCustomTools();
     }
 }";
 
@@ -221,8 +240,10 @@ public static class ManualToolRegistration
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain(
                 "io.github.hatayama.UnityCliLoop.Application.UnityCliLoopToolRegistrar.RegisterCustomTool"));
+            Assert.That(result.Content, Does.Contain("io.github.hatayama.UnityCliLoop.Domain.ToolInfo[]"));
             Assert.That(result.Content, Does.Not.Contain("Old.io.github"));
             Assert.That(result.Content, Does.Not.Contain("Old.CustomToolManager"));
+            Assert.That(result.Content, Does.Not.Contain("Old.ToolInfo"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -1229,9 +1229,9 @@ public sealed class OtherTool
         }
 
         [Test]
-        public void MigrateAsmdefSource_WhenCurrentToolContractsUsesLegacyGuid_RewritesToToolContractsGuid()
+        public void MigrateAsmdefSource_WhenCurrentToolContractsUsesApplicationGuid_AddsToolContractsGuid()
         {
-            // Verifies that partially migrated custom tool assemblies can resolve V3 ToolContracts.
+            // Verifies that partially migrated custom tool assemblies keep current Application refs by GUID.
             string source = @"{
     ""name"": ""MyCompany.Tools.Editor"",
     ""references"": [
@@ -1249,7 +1249,32 @@ public sealed class OtherTool
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
-            Assert.That(result.Content, Does.Not.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+            Assert.That(result.Content, Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenCurrentApplicationGuidAlreadyExists_DoesNotAddDomainReference()
+        {
+            // Verifies that current V3 Application refs do not look like pending legacy migration.
+            string source = @"{
+    ""name"": ""MyCompany.Tools.Editor"",
+    ""references"": [
+        ""GUID:214998e563c124e8a88199b2dd1f522d"",
+        ""GUID:fc3fd32eddbee40e39c2d76dc184957b""
+    ]
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: false,
+                    requiresToolContractsReference: true,
+                    requiresApplicationReference: true,
+                    requiresDomainReference: false);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+            Assert.That(result.Content, Does.Not.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
         }
 
         [Test]
@@ -1274,7 +1299,7 @@ public sealed class OtherTool
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
             Assert.That(result.Content, Does.Contain("GUID:214998e563c124e8a88199b2dd1f522d"));
-            Assert.That(result.Content, Does.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
+            Assert.That(result.Content, Does.Not.Contain("GUID:5c4588558a3624eacbce0f50007cf1eb"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -239,6 +239,29 @@ public sealed class HelloTool
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyMcpConstantsAreUsed_RewritesConstantsType()
+        {
+            // Verifies that legacy public constants references resolve to the V3 constants type.
+            string source =
+                "using io.github.hatayama.uLoopMCP;\n" +
+                "\n" +
+                "public static class ToolConstants\n" +
+                "{\n" +
+                "    public const string Name = McpConstants.PROJECT_NAME;\n" +
+                "    public static string QualifiedName => io.github.hatayama.uLoopMCP.McpConstants.PROJECT_NAME;\n" +
+                "}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("UnityCliLoopConstants.PROJECT_NAME"));
+            Assert.That(result.Content, Does.Contain(
+                "io.github.hatayama.UnityCliLoop.ToolContracts.UnityCliLoopConstants.PROJECT_NAME"));
+            Assert.That(result.Content, Does.Not.Contain("McpConstants"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyRegistrarMetadataIsUsed_RewritesDomainMetadataType()
         {
             // Verifies that explicit registrar metadata declarations keep compiling after namespace migration.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -429,6 +429,52 @@ public static class ToolMetadataProvider
         }
 
         [Test]
+        public void MigrateCSharpSource_WhenLegacyToolInfoConstructorUsesDescriptionVariable_RemovesDescriptionArgument()
+        {
+            // Verifies that non-literal V2 description arguments do not survive into the V3 constructor call.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo Create(ToolParameterSchema schema, string description)
+    {
+        return new ToolInfo(""hello"", description, schema);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema)"));
+            Assert.That(result.Content, Does.Not.Contain("description, schema"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenLegacyToolInfoConstructorUsesNamedDescription_RemovesDescriptionArgument()
+        {
+            // Verifies that named V2 description arguments are removed without reordering supported arguments.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public static class ToolMetadataProvider
+{
+    public static ToolInfo Create(ToolParameterSchema schema, string description)
+    {
+        return new ToolInfo(name: ""hello"", description: description, parameterSchema: schema);
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(name: \"hello\", parameterSchema: schema)"));
+            Assert.That(result.Content, Does.Not.Contain("description: description"));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenCurrentToolInfoConstructorExistsInMixedFile_KeepsConstructorArguments()
         {
             // Verifies that partially migrated metadata construction is not treated as the removed V2 signature.
@@ -439,7 +485,8 @@ public static class ToolMetadataProvider
 {
     public static ToolInfo Create(ToolParameterSchema schema)
     {
-        return new ToolInfo(""hello"", schema, true);
+        bool displayDevelopmentOnly = true;
+        return new ToolInfo(""hello"", schema, displayDevelopmentOnly);
     }
 }";
 
@@ -448,8 +495,9 @@ public static class ToolMetadataProvider
 
             Assert.That(result.Changed, Is.True);
             Assert.That(result.Content, Does.Contain(
-                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema, true)"));
-            Assert.That(result.Content, Does.Not.Contain("new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", true)"));
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", schema, displayDevelopmentOnly)"));
+            Assert.That(result.Content, Does.Not.Contain(
+                "new io.github.hatayama.UnityCliLoop.Domain.ToolInfo(\"hello\", displayDevelopmentOnly)"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 421cf9412b7894ec5b5da141229f5598
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -58,14 +58,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Is.EqualTo("Scanning project for V3 custom tool migration...\n3/12 checks complete."));
         }
 
-        [TestCase(false, "Migrate")]
-        [TestCase(true, "Migrating...")]
+        [TestCase(false, true, "Migrate")]
+        [TestCase(true, true, "Migrating...")]
+        [TestCase(false, false, "Nothing to migrate")]
         public void GetMigrationButtonText_ReturnsExpectedLabel(
             bool isMigrating,
+            bool hasMigrationTargets,
             string expectedLabel)
         {
             // Verifies that the migration action communicates its current state.
-            string label = ThirdPartyToolMigrationWizardWindow.GetMigrationButtonText(isMigrating);
+            string label = ThirdPartyToolMigrationWizardWindow.GetMigrationButtonText(
+                isMigrating,
+                hasMigrationTargets);
 
             Assert.That(label, Is.EqualTo(expectedLabel));
         }

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -1,0 +1,105 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Presentation;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the dedicated V3 custom tool migration wizard.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationWizardWindowTests
+    {
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public void ShouldAutoShowForMigrationTargets_ReturnsDetectionResult(
+            bool hasMigrationTargets,
+            bool expected)
+        {
+            // Verifies that migration startup is controlled only by migration target detection.
+            bool shouldAutoShow =
+                ThirdPartyToolMigrationWizardWindow.ShouldAutoShowForMigrationTargets(hasMigrationTargets);
+
+            Assert.That(shouldAutoShow, Is.EqualTo(expected));
+        }
+
+        [TestCase(
+            1,
+            "1 file needs V3 custom tool migration.\n" +
+            "The Unity Console is showing errors because this file still uses the old custom tool API.\n\n" +
+            "Click Migrate to update it automatically. The errors should disappear after migration.")]
+        [TestCase(
+            3,
+            "3 files need V3 custom tool migration.\n" +
+            "The Unity Console is showing errors because these files still use the old custom tool API.\n\n" +
+            "Click Migrate to update them automatically. The errors should disappear after migration.")]
+        public void GetMigrationStatusText_WhenTargetsExist_ReturnsFileCount(
+            int fileCount,
+            string expectedText)
+        {
+            // Verifies that the migration wizard summarizes detected V2 custom tool files.
+            string text = ThirdPartyToolMigrationWizardWindow.GetMigrationStatusText(fileCount);
+
+            Assert.That(text, Is.EqualTo(expectedText));
+        }
+
+        [Test]
+        public void GetMigrationProgressText_WhenProgressExists_ReturnsCheckCount()
+        {
+            // Verifies that the migration wizard reports scan progress while migration targets are unknown.
+            ThirdPartyToolMigrationProgress progress = new(3, 12);
+
+            string text = ThirdPartyToolMigrationWizardWindow.GetMigrationProgressText(progress);
+
+            Assert.That(
+                text,
+                Is.EqualTo("Scanning project for V3 custom tool migration...\n3/12 checks complete."));
+        }
+
+        [TestCase(false, "Migrate")]
+        [TestCase(true, "Migrating...")]
+        public void GetMigrationButtonText_ReturnsExpectedLabel(
+            bool isMigrating,
+            string expectedLabel)
+        {
+            // Verifies that the migration action communicates its current state.
+            string label = ThirdPartyToolMigrationWizardWindow.GetMigrationButtonText(isMigrating);
+
+            Assert.That(label, Is.EqualTo(expectedLabel));
+        }
+
+        [Test]
+        public void PrepareForOpen_PopulatesWindowStateBeforeShowing()
+        {
+            // Verifies that startup-created migration windows can preview immediately after CreateGUI.
+            ThirdPartyToolMigrationWizardWindow window =
+                ScriptableObject.CreateInstance<ThirdPartyToolMigrationWizardWindow>();
+            try
+            {
+                Rect position = new(12f, 34f, 360f, 220f);
+
+                ThirdPartyToolMigrationWizardWindow.PrepareForOpen(
+                    window,
+                    "Unity CLI Loop Migration",
+                    position,
+                    true);
+
+                SerializedObject serializedWindow = new(window);
+                SerializedProperty refreshProperty =
+                    serializedWindow.FindProperty("_shouldRefreshAfterCreateGui");
+
+                Assert.That(window.titleContent.text, Is.EqualTo("Unity CLI Loop Migration"));
+                Assert.That(window.position, Is.EqualTo(position));
+                Assert.That(window.minSize, Is.EqualTo(new Vector2(360f, 220f)));
+                Assert.That(refreshProperty, Is.Not.Null);
+                Assert.That(refreshProperty.boolValue, Is.True);
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.UIElements;
 
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Presentation;
@@ -93,7 +92,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
                 Assert.That(window.titleContent.text, Is.EqualTo("Unity CLI Loop Migration"));
                 Assert.That(window.position, Is.EqualTo(position));
-                Assert.That(window.minSize, Is.EqualTo(new Vector2(300f, 120f)));
+                Assert.That(window.minSize, Is.EqualTo(new Vector2(360f, 120f)));
                 Assert.That(refreshProperty, Is.Not.Null);
                 Assert.That(refreshProperty.boolValue, Is.True);
             }
@@ -104,62 +103,45 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void WithContentSize_UsesMeasuredSizeAndPreservesCenter()
+        public void WithContentHeight_UsesMeasuredHeightAndPreservesCenter()
         {
-            // Verifies that the migration wizard resizes from measured content size.
+            // Verifies that the migration wizard resizes vertically from measured content height.
             Rect initialRect = new(123f, 456f, 400f, 220f);
-            Vector2 contentSize = new(260f, 180f);
             Vector2 frameSize = new(18f, 28f);
 
             Rect resizedRect =
-                ThirdPartyToolMigrationWizardWindow.WithContentSize(initialRect, contentSize, frameSize);
+                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 180f, frameSize);
 
             Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
-            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(300f, 208f)));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(360f, 208f)));
         }
 
         [Test]
-        public void WithContentSize_WhenMeasuredSizeIsSmall_ClampsToMinimumSize()
+        public void WithContentHeight_WhenMeasuredHeightIsSmall_ClampsToMinimumHeight()
         {
-            // Verifies that content fitting keeps the migration wizard from becoming unusably small.
+            // Verifies that content fitting keeps the migration wizard from becoming unusably short.
             Rect initialRect = new(123f, 456f, 400f, 220f);
-            Vector2 contentSize = new(12f, 12f);
             Vector2 frameSize = new(18f, 28f);
 
             Rect resizedRect =
-                ThirdPartyToolMigrationWizardWindow.WithContentSize(initialRect, contentSize, frameSize);
+                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 12f, frameSize);
 
             Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
-            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(300f, 120f)));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(360f, 120f)));
         }
 
         [Test]
-        public void WithContentSize_WhenMeasuredWidthIsLarge_UsesMeasuredWidth()
+        public void WithContentHeight_WhenCurrentWidthIsWide_UsesSetupWizardWidth()
         {
-            // Verifies that content fitting still expands when migration copy needs more width.
-            Rect initialRect = new(123f, 456f, 300f, 220f);
-            Vector2 contentSize = new(380f, 120f);
+            // Verifies that content fitting keeps the migration wizard at Setup Wizard width.
+            Rect initialRect = new(123f, 456f, 520f, 220f);
             Vector2 frameSize = new(18f, 28f);
 
             Rect resizedRect =
-                ThirdPartyToolMigrationWizardWindow.WithContentSize(initialRect, contentSize, frameSize);
+                ThirdPartyToolMigrationWizardWindow.WithContentHeight(initialRect, 120f, frameSize);
 
             Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
-            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(398f, 148f)));
-        }
-
-        [Test]
-        public void SelectPreferredTextWidth_WhenTextHasExplicitLineBreak_ReturnsMeasuredWidth()
-        {
-            // Verifies that manually wrapped copy keeps the longest explicit line visible.
-            float width = ThirdPartyToolMigrationWizardWindow.SelectPreferredTextWidth(
-                laidOutWidth: 220f,
-                measuredWidth: 340f,
-                lineCount: 3,
-                whiteSpace: WhiteSpace.Normal,
-                hasExplicitLineBreak: true);
-
-            Assert.That(width, Is.EqualTo(340f));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(360f, 148f)));
         }
     }
 }

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.UIElements;
 
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Presentation;
@@ -92,7 +93,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
                 Assert.That(window.titleContent.text, Is.EqualTo("Unity CLI Loop Migration"));
                 Assert.That(window.position, Is.EqualTo(position));
-                Assert.That(window.minSize, Is.EqualTo(new Vector2(360f, 220f)));
+                Assert.That(window.minSize, Is.EqualTo(new Vector2(300f, 120f)));
                 Assert.That(refreshProperty, Is.Not.Null);
                 Assert.That(refreshProperty.boolValue, Is.True);
             }
@@ -100,6 +101,65 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 Object.DestroyImmediate(window);
             }
+        }
+
+        [Test]
+        public void WithContentSize_UsesMeasuredSizeAndPreservesCenter()
+        {
+            // Verifies that the migration wizard resizes from measured content size.
+            Rect initialRect = new(123f, 456f, 400f, 220f);
+            Vector2 contentSize = new(260f, 180f);
+            Vector2 frameSize = new(18f, 28f);
+
+            Rect resizedRect =
+                ThirdPartyToolMigrationWizardWindow.WithContentSize(initialRect, contentSize, frameSize);
+
+            Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(300f, 208f)));
+        }
+
+        [Test]
+        public void WithContentSize_WhenMeasuredSizeIsSmall_ClampsToMinimumSize()
+        {
+            // Verifies that content fitting keeps the migration wizard from becoming unusably small.
+            Rect initialRect = new(123f, 456f, 400f, 220f);
+            Vector2 contentSize = new(12f, 12f);
+            Vector2 frameSize = new(18f, 28f);
+
+            Rect resizedRect =
+                ThirdPartyToolMigrationWizardWindow.WithContentSize(initialRect, contentSize, frameSize);
+
+            Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(300f, 120f)));
+        }
+
+        [Test]
+        public void WithContentSize_WhenMeasuredWidthIsLarge_UsesMeasuredWidth()
+        {
+            // Verifies that content fitting still expands when migration copy needs more width.
+            Rect initialRect = new(123f, 456f, 300f, 220f);
+            Vector2 contentSize = new(380f, 120f);
+            Vector2 frameSize = new(18f, 28f);
+
+            Rect resizedRect =
+                ThirdPartyToolMigrationWizardWindow.WithContentSize(initialRect, contentSize, frameSize);
+
+            Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
+            Assert.That(resizedRect.size, Is.EqualTo(new Vector2(398f, 148f)));
+        }
+
+        [Test]
+        public void SelectPreferredTextWidth_WhenTextHasExplicitLineBreak_ReturnsMeasuredWidth()
+        {
+            // Verifies that manually wrapped copy keeps the longest explicit line visible.
+            float width = ThirdPartyToolMigrationWizardWindow.SelectPreferredTextWidth(
+                laidOutWidth: 220f,
+                measuredWidth: 340f,
+                lineCount: 3,
+                whiteSpace: WhiteSpace.Normal,
+                hasExplicitLineBreak: true);
+
+            Assert.That(width, Is.EqualTo(340f));
         }
     }
 }

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e92d6d0c7ab84404aa057f047ce14328
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 using io.github.hatayama.UnityCliLoop.Domain;
 
@@ -24,6 +26,17 @@ namespace io.github.hatayama.UnityCliLoop.Application
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
             return _migrationPort.PreviewMigration(projectRoot);
+        }
+
+        public Task<ThirdPartyToolMigrationPreview> PreviewMigrationAsync(
+            string projectRoot,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(progress != null, "progress must not be null");
+
+            return _migrationPort.PreviewMigrationAsync(projectRoot, progress, ct);
         }
 
         public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)

--- a/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
@@ -39,6 +39,13 @@ namespace io.github.hatayama.UnityCliLoop.Application
             return _migrationPort.PreviewMigrationAsync(projectRoot, progress, ct);
         }
 
+        public Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            return _migrationPort.HasMigrationTargetsAsync(projectRoot, ct);
+        }
+
         public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");

--- a/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Diagnostics;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Application
+{
+    /// <summary>
+    /// Coordinates V3 migration for third-party custom tools without owning file-system details.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationUseCase
+    {
+        private readonly IThirdPartyToolMigrationPort _migrationPort;
+
+        public ThirdPartyToolMigrationUseCase(IThirdPartyToolMigrationPort migrationPort)
+        {
+            Debug.Assert(migrationPort != null, "migrationPort must not be null");
+
+            _migrationPort = migrationPort ?? throw new ArgumentNullException(nameof(migrationPort));
+        }
+
+        public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            return _migrationPort.PreviewMigration(projectRoot);
+        }
+
+        public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            return _migrationPort.ApplyMigration(projectRoot);
+        }
+    }
+}

--- a/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs.meta
+++ b/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 792cd64b3299949f9baf51e9a63eea8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCaseRegistry.cs
+++ b/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCaseRegistry.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.Application
+{
+    /// <summary>
+    /// Stores the third-party tool migration use case for Unity-created presentation objects.
+    /// </summary>
+    internal static class ThirdPartyToolMigrationUseCaseRegistry
+    {
+        private static ThirdPartyToolMigrationUseCase RegisteredUseCase;
+
+        internal static void Register(ThirdPartyToolMigrationUseCase useCase)
+        {
+            Debug.Assert(useCase != null, "useCase must not be null");
+
+            RegisteredUseCase = useCase ?? throw new ArgumentNullException(nameof(useCase));
+        }
+
+        internal static ThirdPartyToolMigrationUseCase GetRegisteredUseCase()
+        {
+            if (RegisteredUseCase == null)
+            {
+                throw new InvalidOperationException("Unity CLI Loop third-party tool migration use case is not registered.");
+            }
+
+            return RegisteredUseCase;
+        }
+    }
+}

--- a/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCaseRegistry.cs.meta
+++ b/Packages/src/Editor/Application/UseCases/ThirdPartyToolMigrationUseCaseRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7e9d9700538b41e0ae2cd7846439cab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -32,6 +32,8 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
                 toolRegistrarService));
             SkillSetupUseCase skillSetupUseCase = new(new SkillSetupService(new ToolSkillSetupService(toolSettingsService)));
             SkillSetupUseCaseRegistry.Register(skillSetupUseCase);
+            ThirdPartyToolMigrationUseCaseRegistry.Register(
+                new ThirdPartyToolMigrationUseCase(new ThirdPartyToolMigrationFileService()));
             CliSetupApplicationFacade.RegisterService(new CliSetupApplicationService(
                 new CliInstallationDetector(),
                 new NativeCliInstallerService()));

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
@@ -77,6 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             string projectRoot,
             IProgress<ThirdPartyToolMigrationProgress> progress,
             CancellationToken ct);
+        Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct);
         ThirdPartyToolMigrationResult ApplyMigration(string projectRoot);
     }
 }

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Describes pending V3 custom tool migration work found in the Unity project.
+    /// </summary>
+    public readonly struct ThirdPartyToolMigrationPreview
+    {
+        public ThirdPartyToolMigrationPreview(int fileCount, int replacementCount, string[] filePaths)
+        {
+            Debug.Assert(fileCount >= 0, "fileCount must not be negative");
+            Debug.Assert(replacementCount >= 0, "replacementCount must not be negative");
+            Debug.Assert(filePaths != null, "filePaths must not be null");
+
+            FileCount = fileCount;
+            ReplacementCount = replacementCount;
+            FilePaths = filePaths ?? Array.Empty<string>();
+        }
+
+        public int FileCount { get; }
+        public int ReplacementCount { get; }
+        public string[] FilePaths { get; }
+        public bool HasTargets => FileCount > 0;
+    }
+
+    /// <summary>
+    /// Describes the files rewritten by the V3 custom tool migration workflow.
+    /// </summary>
+    public readonly struct ThirdPartyToolMigrationResult
+    {
+        public ThirdPartyToolMigrationResult(int fileCount, int replacementCount, string[] filePaths)
+        {
+            Debug.Assert(fileCount >= 0, "fileCount must not be negative");
+            Debug.Assert(replacementCount >= 0, "replacementCount must not be negative");
+            Debug.Assert(filePaths != null, "filePaths must not be null");
+
+            FileCount = fileCount;
+            ReplacementCount = replacementCount;
+            FilePaths = filePaths ?? Array.Empty<string>();
+        }
+
+        public int FileCount { get; }
+        public int ReplacementCount { get; }
+        public string[] FilePaths { get; }
+        public bool Changed => FileCount > 0;
+    }
+
+    public interface IThirdPartyToolMigrationPort
+    {
+        ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot);
+        ThirdPartyToolMigrationResult ApplyMigration(string projectRoot);
+    }
+}

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
@@ -10,6 +10,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     /// </summary>
     public readonly struct ThirdPartyToolMigrationPreview
     {
+        private readonly string[] _filePaths;
+
         public ThirdPartyToolMigrationPreview(int fileCount, int replacementCount, string[] filePaths)
         {
             Debug.Assert(fileCount >= 0, "fileCount must not be negative");
@@ -18,12 +20,12 @@ namespace io.github.hatayama.UnityCliLoop.Domain
 
             FileCount = fileCount;
             ReplacementCount = replacementCount;
-            FilePaths = filePaths ?? Array.Empty<string>();
+            _filePaths = ThirdPartyToolMigrationFilePathSnapshot.Copy(filePaths);
         }
 
         public int FileCount { get; }
         public int ReplacementCount { get; }
-        public string[] FilePaths { get; }
+        public string[] FilePaths => ThirdPartyToolMigrationFilePathSnapshot.Copy(_filePaths);
         public bool HasTargets => FileCount > 0;
     }
 
@@ -53,6 +55,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     /// </summary>
     public readonly struct ThirdPartyToolMigrationResult
     {
+        private readonly string[] _filePaths;
+
         public ThirdPartyToolMigrationResult(int fileCount, int replacementCount, string[] filePaths)
         {
             Debug.Assert(fileCount >= 0, "fileCount must not be negative");
@@ -61,12 +65,12 @@ namespace io.github.hatayama.UnityCliLoop.Domain
 
             FileCount = fileCount;
             ReplacementCount = replacementCount;
-            FilePaths = filePaths ?? Array.Empty<string>();
+            _filePaths = ThirdPartyToolMigrationFilePathSnapshot.Copy(filePaths);
         }
 
         public int FileCount { get; }
         public int ReplacementCount { get; }
-        public string[] FilePaths { get; }
+        public string[] FilePaths => ThirdPartyToolMigrationFilePathSnapshot.Copy(_filePaths);
         public bool Changed => FileCount > 0;
     }
 
@@ -79,5 +83,23 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             CancellationToken ct);
         Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct);
         ThirdPartyToolMigrationResult ApplyMigration(string projectRoot);
+    }
+
+    /// <summary>
+    /// Creates stable migration file path snapshots before value objects store caller-owned arrays.
+    /// </summary>
+    internal static class ThirdPartyToolMigrationFilePathSnapshot
+    {
+        internal static string[] Copy(string[] filePaths)
+        {
+            if (filePaths == null || filePaths.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            string[] copy = new string[filePaths.Length];
+            Array.Copy(filePaths, copy, filePaths.Length);
+            return copy;
+        }
     }
 }

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.Domain
 {
@@ -23,6 +25,27 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public int ReplacementCount { get; }
         public string[] FilePaths { get; }
         public bool HasTargets => FileCount > 0;
+    }
+
+    /// <summary>
+    /// Reports preview scan progress so editor UI can repaint while project files are inspected.
+    /// </summary>
+    public readonly struct ThirdPartyToolMigrationProgress
+    {
+        public ThirdPartyToolMigrationProgress(int processedItemCount, int totalItemCount)
+        {
+            Debug.Assert(processedItemCount >= 0, "processedItemCount must not be negative");
+            Debug.Assert(totalItemCount >= 0, "totalItemCount must not be negative");
+            Debug.Assert(
+                processedItemCount <= totalItemCount || totalItemCount == 0,
+                "processedItemCount must not exceed totalItemCount");
+
+            ProcessedItemCount = processedItemCount;
+            TotalItemCount = totalItemCount;
+        }
+
+        public int ProcessedItemCount { get; }
+        public int TotalItemCount { get; }
     }
 
     /// <summary>
@@ -50,6 +73,10 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     public interface IThirdPartyToolMigrationPort
     {
         ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot);
+        Task<ThirdPartyToolMigrationPreview> PreviewMigrationAsync(
+            string projectRoot,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct);
         ThirdPartyToolMigrationResult ApplyMigration(string projectRoot);
     }
 }

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs.meta
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d34ccf1cea694100982036051096ac6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration.meta
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3977ef001d234ff59cf1e4d41a33793
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -183,6 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 CreateAssemblyReferenceDirectories(asmdefFilePaths, asmrefFilePaths);
             HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> assemblyScopedLegacyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> assemblyScopedCurrentDomainDirectories = new(StringComparer.Ordinal);
             Dictionary<string, HashSet<string>> assemblyScopedLegacyAliasesByDirectory =
                 new(StringComparer.Ordinal);
             HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
@@ -212,6 +213,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         assemblyScopedLegacyAliasesByDirectory,
                         assemblyDirectory,
                         ThirdPartyToolMigrationRules.GetLegacyGlobalNamespaceAliases(source));
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsCurrentDomainGlobalUsing(source))
+                {
+                    assemblyScopedCurrentDomainDirectories.Add(assemblyDirectory);
                 }
 
                 if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source) ||
@@ -260,6 +266,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         legacyAssemblyAliases))
                 {
                     domainMetadataAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApiForAssembly(
+                        source,
+                        assemblyScopedCurrentDomainDirectories.Contains(assemblyDirectory)))
+                {
+                    domainReferenceAssemblyDirectories.Add(assemblyDirectory);
                 }
             }
 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -210,7 +210,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         ThirdPartyToolMigrationRules.GetLegacyGlobalNamespaceAliases(source));
                 }
 
-                if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source))
+                if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source) ||
+                    ThirdPartyToolMigrationRules.ContainsCurrentRegistrarApi(source))
                 {
                     registrarAssemblyDirectories.Add(assemblyDirectory);
                 }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -111,24 +111,34 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 .OrderByDescending(path => path.Length)
                 .ToList();
             HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> applicationReferenceAssemblyDirectories = new(StringComparer.Ordinal);
 
             foreach (string csharpFilePath in csharpFilePaths)
             {
                 string source = File.ReadAllText(csharpFilePath);
-                if (!ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source))
+                string assemblyDirectory = FindNearestAssemblyDirectory(csharpFilePath, asmdefDirectories);
+                if (string.IsNullOrEmpty(assemblyDirectory))
                 {
                     continue;
                 }
 
-                string assemblyDirectory = FindNearestAssemblyDirectory(csharpFilePath, asmdefDirectories);
-                if (!string.IsNullOrEmpty(assemblyDirectory))
+                if (ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source))
                 {
                     legacyAssemblyDirectories.Add(assemblyDirectory);
-                    if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source))
-                    {
-                        applicationReferenceAssemblyDirectories.Add(assemblyDirectory);
-                    }
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source))
+                {
+                    registrarAssemblyDirectories.Add(assemblyDirectory);
+                }
+            }
+
+            foreach (string registrarAssemblyDirectory in registrarAssemblyDirectories)
+            {
+                if (legacyAssemblyDirectories.Contains(registrarAssemblyDirectory))
+                {
+                    applicationReferenceAssemblyDirectories.Add(registrarAssemblyDirectory);
                 }
             }
 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -70,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     assemblyUsage.AssemblyReferenceDirectories,
                     projectRoot);
                 bool hasLegacyAssemblySource =
-                    assemblyUsage.LegacyAssemblyDirectories.Contains(assemblyDirectory) &&
+                    assemblyUsage.AssemblyScopedLegacyDirectories.Contains(assemblyDirectory) &&
                     ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(source);
                 ThirdPartyToolMigrationContentResult result =
                     ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
@@ -166,6 +166,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             List<AssemblyReferenceDirectory> assemblyReferenceDirectories =
                 CreateAssemblyReferenceDirectories(asmdefFilePaths, asmrefFilePaths);
             HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> assemblyScopedLegacyDirectories = new(StringComparer.Ordinal);
             HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> domainMetadataAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> applicationReferenceAssemblyDirectories = new(StringComparer.Ordinal);
@@ -183,6 +184,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source))
                 {
                     legacyAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyGlobalUsing(source))
+                {
+                    assemblyScopedLegacyDirectories.Add(assemblyDirectory);
                 }
 
                 if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source))
@@ -216,6 +222,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 asmdefDirectories,
                 assemblyReferenceDirectories,
                 legacyAssemblyDirectories,
+                assemblyScopedLegacyDirectories,
                 applicationReferenceAssemblyDirectories,
                 domainReferenceAssemblyDirectories);
         }
@@ -459,6 +466,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 List<string> asmdefDirectories,
                 List<AssemblyReferenceDirectory> assemblyReferenceDirectories,
                 HashSet<string> legacyAssemblyDirectories,
+                HashSet<string> assemblyScopedLegacyDirectories,
                 HashSet<string> applicationReferenceAssemblyDirectories,
                 HashSet<string> domainReferenceAssemblyDirectories)
             {
@@ -467,6 +475,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     assemblyReferenceDirectories != null,
                     "assemblyReferenceDirectories must not be null");
                 Debug.Assert(legacyAssemblyDirectories != null, "legacyAssemblyDirectories must not be null");
+                Debug.Assert(
+                    assemblyScopedLegacyDirectories != null,
+                    "assemblyScopedLegacyDirectories must not be null");
                 Debug.Assert(
                     applicationReferenceAssemblyDirectories != null,
                     "applicationReferenceAssemblyDirectories must not be null");
@@ -477,6 +488,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 AsmdefDirectories = asmdefDirectories ?? new List<string>();
                 AssemblyReferenceDirectories = assemblyReferenceDirectories ?? new List<AssemblyReferenceDirectory>();
                 LegacyAssemblyDirectories = legacyAssemblyDirectories ?? new HashSet<string>(StringComparer.Ordinal);
+                AssemblyScopedLegacyDirectories = assemblyScopedLegacyDirectories ??
+                    new HashSet<string>(StringComparer.Ordinal);
                 ApplicationReferenceAssemblyDirectories = applicationReferenceAssemblyDirectories ??
                     new HashSet<string>(StringComparer.Ordinal);
                 DomainReferenceAssemblyDirectories = domainReferenceAssemblyDirectories ??
@@ -486,6 +499,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             public List<string> AsmdefDirectories { get; }
             public List<AssemblyReferenceDirectory> AssemblyReferenceDirectories { get; }
             public HashSet<string> LegacyAssemblyDirectories { get; }
+            public HashSet<string> AssemblyScopedLegacyDirectories { get; }
             public HashSet<string> ApplicationReferenceAssemblyDirectories { get; }
             public HashSet<string> DomainReferenceAssemblyDirectories { get; }
         }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -201,8 +201,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 bool requiresApplicationReference =
                     assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
                 bool requiresDomainReference =
-                    assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory) ||
-                    requiresApplicationReference;
+                    assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory);
                 ThirdPartyToolMigrationContentResult result =
                     ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                         source,
@@ -317,8 +316,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 bool requiresApplicationReference =
                     assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
                 bool requiresDomainReference =
-                    assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory) ||
-                    requiresApplicationReference;
+                    assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory);
                 ThirdPartyToolMigrationContentResult result =
                     ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                         source,

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -236,6 +236,33 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
+            foreach (string csharpFilePath in csharpFilePaths)
+            {
+                string source = File.ReadAllText(csharpFilePath);
+                string assemblyDirectory = FindNearestAssemblyDirectory(
+                    csharpFilePath,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    projectRoot);
+                string[] legacyAssemblyAliases = Array.Empty<string>();
+                if (assemblyScopedLegacyAliasesByDirectory.TryGetValue(
+                        assemblyDirectory,
+                        out HashSet<string> legacyAssemblyAliasSet))
+                {
+                    legacyAssemblyAliases = legacyAssemblyAliasSet
+                        .OrderBy(alias => alias, StringComparer.Ordinal)
+                        .ToArray();
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyDomainHelperApiForAssembly(
+                        source,
+                        assemblyScopedLegacyDirectories.Contains(assemblyDirectory),
+                        legacyAssemblyAliases))
+                {
+                    domainMetadataAssemblyDirectories.Add(assemblyDirectory);
+                }
+            }
+
             foreach (string registrarAssemblyDirectory in registrarAssemblyDirectories)
             {
                 applicationReferenceAssemblyDirectories.Add(registrarAssemblyDirectory);

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -31,8 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             MigrationPlan plan = CreateMigrationPlan(projectRoot);
             foreach (MigrationFileChange change in plan.Changes)
             {
-                AtomicFileWriter.Write(change.FilePath, change.Content);
-                AtomicFileWriter.CleanupBackup(change.FilePath + ".bak");
+                WriteMigrationFile(change.FilePath, change.Content);
             }
 
             return new ThirdPartyToolMigrationResult(
@@ -50,6 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             ProjectFileInventory inventory = ProjectFileInventory.Create(projectRoot);
             MigrationAssemblyUsage assemblyUsage = FindMigrationAssemblyUsage(
+                projectRoot,
                 inventory.CSharpFilePaths,
                 inventory.AsmdefFilePaths);
             List<MigrationFileChange> changes = new();
@@ -58,7 +58,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string csharpFilePath in inventory.CSharpFilePaths)
             {
                 string source = File.ReadAllText(csharpFilePath);
-                string assemblyDirectory = FindNearestAssemblyDirectory(csharpFilePath, assemblyUsage.AsmdefDirectories);
+                string assemblyDirectory = FindNearestAssemblyDirectory(
+                    csharpFilePath,
+                    assemblyUsage.AsmdefDirectories,
+                    projectRoot);
                 bool hasLegacyAssemblySource =
                     assemblyUsage.LegacyAssemblyDirectories.Contains(assemblyDirectory);
                 ThirdPartyToolMigrationContentResult result =
@@ -98,10 +101,46 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return new MigrationPlan(changes, replacementCount);
         }
 
+        private static void WriteMigrationFile(string filePath, string content)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+            Debug.Assert(content != null, "content must not be null");
+
+            string tempFilePath = CreateUniqueSidecarPath(filePath, ".tmp");
+            File.WriteAllText(tempFilePath, content);
+            if (!File.Exists(filePath))
+            {
+                File.Move(tempFilePath, filePath);
+                return;
+            }
+
+            string backupFilePath = CreateUniqueSidecarPath(filePath, ".bak");
+            File.Replace(tempFilePath, filePath, backupFilePath);
+            File.Delete(backupFilePath);
+        }
+
+        private static string CreateUniqueSidecarPath(string filePath, string extension)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(extension), "extension must not be null or empty");
+
+            string directory = Path.GetDirectoryName(filePath) ?? string.Empty;
+            string fileName = Path.GetFileName(filePath);
+            string sidecarPath = Path.Combine(directory, $"{fileName}.{Guid.NewGuid():N}{extension}");
+            while (File.Exists(sidecarPath))
+            {
+                sidecarPath = Path.Combine(directory, $"{fileName}.{Guid.NewGuid():N}{extension}");
+            }
+
+            return sidecarPath;
+        }
+
         private static MigrationAssemblyUsage FindMigrationAssemblyUsage(
+            string projectRoot,
             List<string> csharpFilePaths,
             List<string> asmdefFilePaths)
         {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
             Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
 
@@ -117,11 +156,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string csharpFilePath in csharpFilePaths)
             {
                 string source = File.ReadAllText(csharpFilePath);
-                string assemblyDirectory = FindNearestAssemblyDirectory(csharpFilePath, asmdefDirectories);
-                if (string.IsNullOrEmpty(assemblyDirectory))
-                {
-                    continue;
-                }
+                string assemblyDirectory = FindNearestAssemblyDirectory(
+                    csharpFilePath,
+                    asmdefDirectories,
+                    projectRoot);
 
                 if (ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source))
                 {
@@ -150,10 +188,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static string FindNearestAssemblyDirectory(
             string csharpFilePath,
-            List<string> asmdefDirectories)
+            List<string> asmdefDirectories,
+            string fallbackAssemblyDirectory)
         {
             Debug.Assert(!string.IsNullOrEmpty(csharpFilePath), "csharpFilePath must not be null or empty");
             Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
+            Debug.Assert(
+                !string.IsNullOrEmpty(fallbackAssemblyDirectory),
+                "fallbackAssemblyDirectory must not be null or empty");
 
             string csharpDirectory = Path.GetDirectoryName(csharpFilePath) ?? string.Empty;
             foreach (string asmdefDirectory in asmdefDirectories)
@@ -164,7 +206,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
-            return string.Empty;
+            return fallbackAssemblyDirectory;
         }
 
         private static bool IsSameOrChildPath(string childPath, string parentPath)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -829,7 +829,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 if (ThirdPartyToolMigrationRules.ContainsLegacyGlobalToolInfoTypeAlias(source))
                 {
-                    assemblyScopedLegacyDirectories.Add(assemblyDirectory);
                     AddAssemblyScopedLegacyAliases(
                         assemblyScopedLegacyToolInfoAliasesByDirectory,
                         assemblyDirectory,
@@ -1031,7 +1030,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 if (ThirdPartyToolMigrationRules.ContainsLegacyGlobalToolInfoTypeAlias(source))
                 {
-                    assemblyScopedLegacyDirectories.Add(assemblyDirectory);
                     AddAssemblyScopedLegacyAliases(
                         assemblyScopedLegacyToolInfoAliasesByDirectory,
                         assemblyDirectory,

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -103,6 +103,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 string source = File.ReadAllText(asmdefFilePath);
                 string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
                 bool hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
+                bool requiresToolContractsReference =
+                    assemblyUsage.ToolContractsReferenceAssemblyDirectories.Contains(asmdefDirectory);
                 bool requiresApplicationReference =
                     assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
                 bool requiresDomainReference =
@@ -112,6 +114,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                         source,
                         hasLegacyCSharpSource,
+                        requiresToolContractsReference,
                         requiresApplicationReference,
                         requiresDomainReference);
                 if (!result.Changed)
@@ -184,6 +187,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 new(StringComparer.Ordinal);
             HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> domainMetadataAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> toolContractsReferenceAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> applicationReferenceAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> domainReferenceAssemblyDirectories = new(StringComparer.Ordinal);
 
@@ -216,6 +220,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     registrarAssemblyDirectories.Add(assemblyDirectory);
                 }
 
+                if (ThirdPartyToolMigrationRules.ContainsCurrentToolContractsApi(source))
+                {
+                    toolContractsReferenceAssemblyDirectories.Add(assemblyDirectory);
+                }
+
                 if (ThirdPartyToolMigrationRules.ContainsLegacyDomainMetadataApi(source))
                 {
                     domainMetadataAssemblyDirectories.Add(assemblyDirectory);
@@ -246,6 +255,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 legacyAssemblyDirectories,
                 assemblyScopedLegacyDirectories,
                 CreateAssemblyScopedLegacyAliasesByDirectory(assemblyScopedLegacyAliasesByDirectory),
+                toolContractsReferenceAssemblyDirectories,
                 applicationReferenceAssemblyDirectories,
                 domainReferenceAssemblyDirectories);
         }
@@ -579,6 +589,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 HashSet<string> legacyAssemblyDirectories,
                 HashSet<string> assemblyScopedLegacyDirectories,
                 Dictionary<string, string[]> assemblyScopedLegacyAliasesByDirectory,
+                HashSet<string> toolContractsReferenceAssemblyDirectories,
                 HashSet<string> applicationReferenceAssemblyDirectories,
                 HashSet<string> domainReferenceAssemblyDirectories)
             {
@@ -594,6 +605,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     assemblyScopedLegacyAliasesByDirectory != null,
                     "assemblyScopedLegacyAliasesByDirectory must not be null");
                 Debug.Assert(
+                    toolContractsReferenceAssemblyDirectories != null,
+                    "toolContractsReferenceAssemblyDirectories must not be null");
+                Debug.Assert(
                     applicationReferenceAssemblyDirectories != null,
                     "applicationReferenceAssemblyDirectories must not be null");
                 Debug.Assert(
@@ -607,6 +621,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     new HashSet<string>(StringComparer.Ordinal);
                 AssemblyScopedLegacyAliasesByDirectory = assemblyScopedLegacyAliasesByDirectory ??
                     new Dictionary<string, string[]>(StringComparer.Ordinal);
+                ToolContractsReferenceAssemblyDirectories = toolContractsReferenceAssemblyDirectories ??
+                    new HashSet<string>(StringComparer.Ordinal);
                 ApplicationReferenceAssemblyDirectories = applicationReferenceAssemblyDirectories ??
                     new HashSet<string>(StringComparer.Ordinal);
                 DomainReferenceAssemblyDirectories = domainReferenceAssemblyDirectories ??
@@ -618,6 +634,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             public HashSet<string> LegacyAssemblyDirectories { get; }
             public HashSet<string> AssemblyScopedLegacyDirectories { get; }
             public Dictionary<string, string[]> AssemblyScopedLegacyAliasesByDirectory { get; }
+            public HashSet<string> ToolContractsReferenceAssemblyDirectories { get; }
             public HashSet<string> ApplicationReferenceAssemblyDirectories { get; }
             public HashSet<string> DomainReferenceAssemblyDirectories { get; }
         }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -220,6 +220,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 {
                     domainMetadataAssemblyDirectories.Add(assemblyDirectory);
                 }
+
+                if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApi(source))
+                {
+                    domainReferenceAssemblyDirectories.Add(assemblyDirectory);
+                }
             }
 
             foreach (string registrarAssemblyDirectory in registrarAssemblyDirectories)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
+using Newtonsoft.Json.Linq;
+
 using io.github.hatayama.UnityCliLoop.Domain;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
@@ -54,7 +56,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             MigrationAssemblyUsage assemblyUsage = FindMigrationAssemblyUsage(
                 projectRoot,
                 inventory.CSharpFilePaths,
-                inventory.AsmdefFilePaths);
+                inventory.AsmdefFilePaths,
+                inventory.AsmrefFilePaths);
             List<MigrationFileChange> changes = new();
             int replacementCount = 0;
 
@@ -64,9 +67,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 string assemblyDirectory = FindNearestAssemblyDirectory(
                     csharpFilePath,
                     assemblyUsage.AsmdefDirectories,
+                    assemblyUsage.AssemblyReferenceDirectories,
                     projectRoot);
                 bool hasLegacyAssemblySource =
-                    assemblyUsage.LegacyAssemblyDirectories.Contains(assemblyDirectory);
+                    assemblyUsage.LegacyAssemblyDirectories.Contains(assemblyDirectory) &&
+                    ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(source);
                 ThirdPartyToolMigrationContentResult result =
                     ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
                         source,
@@ -145,17 +150,21 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static MigrationAssemblyUsage FindMigrationAssemblyUsage(
             string projectRoot,
             List<string> csharpFilePaths,
-            List<string> asmdefFilePaths)
+            List<string> asmdefFilePaths,
+            List<string> asmrefFilePaths)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
             Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+            Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
 
             List<string> asmdefDirectories = asmdefFilePaths
                 .Select(path => Path.GetDirectoryName(path) ?? string.Empty)
                 .Where(path => !string.IsNullOrEmpty(path))
                 .OrderByDescending(path => path.Length)
                 .ToList();
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories =
+                CreateAssemblyReferenceDirectories(asmdefFilePaths, asmrefFilePaths);
             HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> domainMetadataAssemblyDirectories = new(StringComparer.Ordinal);
@@ -168,6 +177,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 string assemblyDirectory = FindNearestAssemblyDirectory(
                     csharpFilePath,
                     asmdefDirectories,
+                    assemblyReferenceDirectories,
                     projectRoot);
 
                 if (ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source))
@@ -204,18 +214,128 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             return new MigrationAssemblyUsage(
                 asmdefDirectories,
+                assemblyReferenceDirectories,
                 legacyAssemblyDirectories,
                 applicationReferenceAssemblyDirectories,
                 domainReferenceAssemblyDirectories);
         }
 
+        private static List<AssemblyReferenceDirectory> CreateAssemblyReferenceDirectories(
+            List<string> asmdefFilePaths,
+            List<string> asmrefFilePaths)
+        {
+            Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+            Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
+
+            Dictionary<string, string> asmdefDirectoriesByReference = CreateAsmdefDirectoryMap(asmdefFilePaths);
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new();
+            foreach (string asmrefFilePath in asmrefFilePaths)
+            {
+                JObject asmref = JObject.Parse(File.ReadAllText(asmrefFilePath));
+                string reference = asmref["reference"]?.Value<string>() ?? string.Empty;
+                if (reference.Length == 0)
+                {
+                    continue;
+                }
+
+                if (!asmdefDirectoriesByReference.TryGetValue(reference, out string targetAssemblyDirectory))
+                {
+                    continue;
+                }
+
+                string sourceDirectory = Path.GetDirectoryName(asmrefFilePath) ?? string.Empty;
+                if (sourceDirectory.Length == 0)
+                {
+                    continue;
+                }
+
+                assemblyReferenceDirectories.Add(
+                    new AssemblyReferenceDirectory(sourceDirectory, targetAssemblyDirectory));
+            }
+
+            return assemblyReferenceDirectories
+                .OrderByDescending(assemblyReferenceDirectory => assemblyReferenceDirectory.SourceDirectory.Length)
+                .ToList();
+        }
+
+        private static Dictionary<string, string> CreateAsmdefDirectoryMap(List<string> asmdefFilePaths)
+        {
+            Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+
+            Dictionary<string, string> asmdefDirectoriesByReference = new(StringComparer.Ordinal);
+            foreach (string asmdefFilePath in asmdefFilePaths)
+            {
+                string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? string.Empty;
+                if (asmdefDirectory.Length == 0)
+                {
+                    continue;
+                }
+
+                JObject asmdef = JObject.Parse(File.ReadAllText(asmdefFilePath));
+                string assemblyName = asmdef["name"]?.Value<string>() ?? string.Empty;
+                AddAsmdefDirectoryReference(asmdefDirectoriesByReference, assemblyName, asmdefDirectory);
+                AddAsmdefDirectoryReference(
+                    asmdefDirectoriesByReference,
+                    ReadAsmdefGuidReference(asmdefFilePath),
+                    asmdefDirectory);
+            }
+
+            return asmdefDirectoriesByReference;
+        }
+
+        private static void AddAsmdefDirectoryReference(
+            Dictionary<string, string> asmdefDirectoriesByReference,
+            string reference,
+            string asmdefDirectory)
+        {
+            Debug.Assert(asmdefDirectoriesByReference != null, "asmdefDirectoriesByReference must not be null");
+            Debug.Assert(reference != null, "reference must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(asmdefDirectory), "asmdefDirectory must not be null or empty");
+
+            if (reference.Length == 0 || asmdefDirectoriesByReference.ContainsKey(reference))
+            {
+                return;
+            }
+
+            asmdefDirectoriesByReference.Add(reference, asmdefDirectory);
+        }
+
+        private static string ReadAsmdefGuidReference(string asmdefFilePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(asmdefFilePath), "asmdefFilePath must not be null or empty");
+
+            string metaPath = asmdefFilePath + ".meta";
+            if (!File.Exists(metaPath))
+            {
+                return string.Empty;
+            }
+
+            foreach (string line in File.ReadLines(metaPath))
+            {
+                string trimmedLine = line.Trim();
+                if (!trimmedLine.StartsWith("guid:", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string guid = trimmedLine.Substring("guid:".Length).Trim();
+                return guid.Length == 0 ? string.Empty : $"GUID:{guid}";
+            }
+
+            return string.Empty;
+        }
+
         private static string FindNearestAssemblyDirectory(
             string csharpFilePath,
             List<string> asmdefDirectories,
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories,
             string projectRoot)
         {
             Debug.Assert(!string.IsNullOrEmpty(csharpFilePath), "csharpFilePath must not be null or empty");
             Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
+            Debug.Assert(
+                assemblyReferenceDirectories != null,
+                "assemblyReferenceDirectories must not be null");
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
             string csharpDirectory = Path.GetDirectoryName(csharpFilePath) ?? string.Empty;
@@ -224,6 +344,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (IsSameOrChildPath(csharpDirectory, asmdefDirectory))
                 {
                     return asmdefDirectory;
+                }
+            }
+
+            foreach (AssemblyReferenceDirectory assemblyReferenceDirectory in assemblyReferenceDirectories)
+            {
+                if (IsSameOrChildPath(csharpDirectory, assemblyReferenceDirectory.SourceDirectory))
+                {
+                    return assemblyReferenceDirectory.TargetAssemblyDirectory;
                 }
             }
 
@@ -313,11 +441,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             public MigrationAssemblyUsage(
                 List<string> asmdefDirectories,
+                List<AssemblyReferenceDirectory> assemblyReferenceDirectories,
                 HashSet<string> legacyAssemblyDirectories,
                 HashSet<string> applicationReferenceAssemblyDirectories,
                 HashSet<string> domainReferenceAssemblyDirectories)
             {
                 Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
+                Debug.Assert(
+                    assemblyReferenceDirectories != null,
+                    "assemblyReferenceDirectories must not be null");
                 Debug.Assert(legacyAssemblyDirectories != null, "legacyAssemblyDirectories must not be null");
                 Debug.Assert(
                     applicationReferenceAssemblyDirectories != null,
@@ -327,6 +459,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     "domainReferenceAssemblyDirectories must not be null");
 
                 AsmdefDirectories = asmdefDirectories ?? new List<string>();
+                AssemblyReferenceDirectories = assemblyReferenceDirectories ?? new List<AssemblyReferenceDirectory>();
                 LegacyAssemblyDirectories = legacyAssemblyDirectories ?? new HashSet<string>(StringComparer.Ordinal);
                 ApplicationReferenceAssemblyDirectories = applicationReferenceAssemblyDirectories ??
                     new HashSet<string>(StringComparer.Ordinal);
@@ -335,21 +468,44 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             public List<string> AsmdefDirectories { get; }
+            public List<AssemblyReferenceDirectory> AssemblyReferenceDirectories { get; }
             public HashSet<string> LegacyAssemblyDirectories { get; }
             public HashSet<string> ApplicationReferenceAssemblyDirectories { get; }
             public HashSet<string> DomainReferenceAssemblyDirectories { get; }
         }
 
+        private readonly struct AssemblyReferenceDirectory
+        {
+            public AssemblyReferenceDirectory(string sourceDirectory, string targetAssemblyDirectory)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(sourceDirectory), "sourceDirectory must not be null or empty");
+                Debug.Assert(
+                    !string.IsNullOrEmpty(targetAssemblyDirectory),
+                    "targetAssemblyDirectory must not be null or empty");
+
+                SourceDirectory = sourceDirectory;
+                TargetAssemblyDirectory = targetAssemblyDirectory;
+            }
+
+            public string SourceDirectory { get; }
+            public string TargetAssemblyDirectory { get; }
+        }
+
         private sealed class ProjectFileInventory
         {
-            private ProjectFileInventory(List<string> csharpFilePaths, List<string> asmdefFilePaths)
+            private ProjectFileInventory(
+                List<string> csharpFilePaths,
+                List<string> asmdefFilePaths,
+                List<string> asmrefFilePaths)
             {
                 CSharpFilePaths = csharpFilePaths;
                 AsmdefFilePaths = asmdefFilePaths;
+                AsmrefFilePaths = asmrefFilePaths;
             }
 
             public List<string> CSharpFilePaths { get; }
             public List<string> AsmdefFilePaths { get; }
+            public List<string> AsmrefFilePaths { get; }
 
             public static ProjectFileInventory Create(string projectRoot)
             {
@@ -357,20 +513,24 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 List<string> csharpFilePaths = new();
                 List<string> asmdefFilePaths = new();
-                CollectCandidateFiles(projectRoot, csharpFilePaths, asmdefFilePaths);
+                List<string> asmrefFilePaths = new();
+                CollectCandidateFiles(projectRoot, csharpFilePaths, asmdefFilePaths, asmrefFilePaths);
                 csharpFilePaths.Sort(StringComparer.Ordinal);
                 asmdefFilePaths.Sort(StringComparer.Ordinal);
-                return new ProjectFileInventory(csharpFilePaths, asmdefFilePaths);
+                asmrefFilePaths.Sort(StringComparer.Ordinal);
+                return new ProjectFileInventory(csharpFilePaths, asmdefFilePaths, asmrefFilePaths);
             }
 
             private static void CollectCandidateFiles(
                 string directoryPath,
                 List<string> csharpFilePaths,
-                List<string> asmdefFilePaths)
+                List<string> asmdefFilePaths,
+                List<string> asmrefFilePaths)
             {
                 Debug.Assert(!string.IsNullOrEmpty(directoryPath), "directoryPath must not be null or empty");
                 Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
                 Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+                Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
 
                 foreach (string filePath in Directory.EnumerateFiles(directoryPath))
                 {
@@ -384,6 +544,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     if (string.Equals(extension, ".asmdef", StringComparison.OrdinalIgnoreCase))
                     {
                         asmdefFilePaths.Add(filePath);
+                        continue;
+                    }
+
+                    if (string.Equals(extension, ".asmref", StringComparison.OrdinalIgnoreCase))
+                    {
+                        asmrefFilePaths.Add(filePath);
                     }
                 }
 
@@ -395,7 +561,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         continue;
                     }
 
-                    CollectCandidateFiles(childDirectoryPath, csharpFilePaths, asmdefFilePaths);
+                    CollectCandidateFiles(childDirectoryPath, csharpFilePaths, asmdefFilePaths, asmrefFilePaths);
                 }
             }
         }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Newtonsoft.Json.Linq;
 
@@ -21,23 +23,67 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             "__UnityCliLoopImplicitFirstPassEditorAssembly";
         private const string ImplicitFirstPassRuntimeAssemblyDirectoryName =
             "__UnityCliLoopImplicitFirstPassRuntimeAssembly";
+        private const int PreviewYieldBatchSize = 32;
+
+        private readonly object _previewCacheLock = new();
+        private bool _hasCachedPreview;
+        private string _cachedPreviewProjectRoot = string.Empty;
+        private ThirdPartyToolMigrationPreview _cachedPreview;
 
         public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            MigrationPlan plan = CreateMigrationPlan(projectRoot);
-            return new ThirdPartyToolMigrationPreview(
+            string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
+            if (TryGetCachedPreview(normalizedProjectRoot, out ThirdPartyToolMigrationPreview cachedPreview))
+            {
+                return cachedPreview;
+            }
+
+            MigrationPlan plan = CreateMigrationPlan(normalizedProjectRoot);
+            ThirdPartyToolMigrationPreview preview = new(
                 plan.ChangedFilePaths.Count,
                 plan.ReplacementCount,
                 plan.ChangedFilePaths.ToArray());
+            StoreCachedPreview(normalizedProjectRoot, preview);
+            return preview;
+        }
+
+        public async Task<ThirdPartyToolMigrationPreview> PreviewMigrationAsync(
+            string projectRoot,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(progress != null, "progress must not be null");
+
+            string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
+            if (TryGetCachedPreview(normalizedProjectRoot, out ThirdPartyToolMigrationPreview cachedPreview))
+            {
+                return cachedPreview;
+            }
+
+            MigrationPlan plan = await CreateMigrationPlanAsync(normalizedProjectRoot, progress, ct);
+            if (ct.IsCancellationRequested)
+            {
+                return new ThirdPartyToolMigrationPreview(0, 0, Array.Empty<string>());
+            }
+
+            ThirdPartyToolMigrationPreview preview = new(
+                plan.ChangedFilePaths.Count,
+                plan.ReplacementCount,
+                plan.ChangedFilePaths.ToArray());
+            StoreCachedPreview(normalizedProjectRoot, preview);
+            return preview;
         }
 
         public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            MigrationPlan plan = CreateMigrationPlan(projectRoot);
+            string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
+            InvalidatePreviewCache();
+            MigrationPlan plan = CreateMigrationPlan(normalizedProjectRoot);
             foreach (MigrationFileChange change in plan.Changes)
             {
                 WriteMigrationFile(change.FilePath, change.Content);
@@ -47,6 +93,48 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 plan.ChangedFilePaths.Count,
                 plan.ReplacementCount,
                 plan.ChangedFilePaths.ToArray());
+        }
+
+        internal void InvalidatePreviewCache()
+        {
+            lock (_previewCacheLock)
+            {
+                _hasCachedPreview = false;
+                _cachedPreviewProjectRoot = string.Empty;
+                _cachedPreview = default;
+            }
+        }
+
+        private bool TryGetCachedPreview(
+            string projectRoot,
+            out ThirdPartyToolMigrationPreview preview)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            lock (_previewCacheLock)
+            {
+                if (_hasCachedPreview &&
+                    string.Equals(_cachedPreviewProjectRoot, projectRoot, StringComparison.Ordinal))
+                {
+                    preview = _cachedPreview;
+                    return true;
+                }
+            }
+
+            preview = default;
+            return false;
+        }
+
+        private void StoreCachedPreview(string projectRoot, ThirdPartyToolMigrationPreview preview)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            lock (_previewCacheLock)
+            {
+                _cachedPreviewProjectRoot = projectRoot;
+                _cachedPreview = preview;
+                _hasCachedPreview = true;
+            }
         }
 
         private static MigrationPlan CreateMigrationPlan(string projectRoot)
@@ -68,6 +156,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string csharpFilePath in inventory.CSharpFilePaths)
             {
                 string source = File.ReadAllText(csharpFilePath);
+                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                {
+                    continue;
+                }
+
                 string assemblyDirectory = FindNearestAssemblyDirectory(
                     csharpFilePath,
                     assemblyUsage.AsmdefDirectories,
@@ -129,6 +222,132 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return new MigrationPlan(changes, replacementCount);
         }
 
+        private static async Task<MigrationPlan> CreateMigrationPlanAsync(
+            string projectRoot,
+            IProgress<ThirdPartyToolMigrationProgress> progress,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(progress != null, "progress must not be null");
+
+            if (!Directory.Exists(projectRoot))
+            {
+                throw new DirectoryNotFoundException(projectRoot);
+            }
+
+            ProjectFileInventory inventory = await ProjectFileInventory.CreateAsync(projectRoot, progress, ct);
+            if (ct.IsCancellationRequested)
+            {
+                return MigrationPlan.Empty;
+            }
+
+            MigrationProgressCounter progressCounter = new(GetPreviewWorkItemCount(inventory), progress);
+            MigrationAssemblyUsage assemblyUsage = await FindMigrationAssemblyUsageAsync(
+                projectRoot,
+                inventory.CSharpFilePaths,
+                inventory.AsmdefFilePaths,
+                inventory.AsmrefFilePaths,
+                progressCounter,
+                ct);
+            if (ct.IsCancellationRequested)
+            {
+                return MigrationPlan.Empty;
+            }
+
+            List<MigrationFileChange> changes = new();
+            int replacementCount = 0;
+
+            foreach (string csharpFilePath in inventory.CSharpFilePaths)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return MigrationPlan.Empty;
+                }
+
+                string source = File.ReadAllText(csharpFilePath);
+                await progressCounter.ReportProcessedItemAsync(ct);
+                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                {
+                    continue;
+                }
+
+                string assemblyDirectory = FindNearestAssemblyDirectory(
+                    csharpFilePath,
+                    assemblyUsage.AsmdefDirectories,
+                    assemblyUsage.AssemblyReferenceDirectories,
+                    projectRoot);
+                string[] legacyAssemblyAliases;
+                if (!assemblyUsage.AssemblyScopedLegacyAliasesByDirectory.TryGetValue(
+                        assemblyDirectory,
+                        out legacyAssemblyAliases))
+                {
+                    legacyAssemblyAliases = Array.Empty<string>();
+                }
+
+                bool hasLegacyAssemblySource =
+                    assemblyUsage.AssemblyScopedLegacyDirectories.Contains(assemblyDirectory) &&
+                    ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(source, legacyAssemblyAliases);
+                ThirdPartyToolMigrationContentResult result =
+                    ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
+                        source,
+                        hasLegacyAssemblySource,
+                        legacyAssemblyAliases);
+                if (!result.Changed)
+                {
+                    continue;
+                }
+
+                replacementCount += result.ReplacementCount;
+                changes.Add(new MigrationFileChange(csharpFilePath, result.Content));
+            }
+
+            foreach (string asmdefFilePath in inventory.AsmdefFilePaths)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return MigrationPlan.Empty;
+                }
+
+                string source = File.ReadAllText(asmdefFilePath);
+                await progressCounter.ReportProcessedItemAsync(ct);
+                string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
+                bool hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
+                bool requiresToolContractsReference =
+                    assemblyUsage.ToolContractsReferenceAssemblyDirectories.Contains(asmdefDirectory);
+                bool requiresApplicationReference =
+                    assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
+                bool requiresDomainReference =
+                    assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory) ||
+                    requiresApplicationReference;
+                ThirdPartyToolMigrationContentResult result =
+                    ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                        source,
+                        hasLegacyCSharpSource,
+                        requiresToolContractsReference,
+                        requiresApplicationReference,
+                        requiresDomainReference);
+                if (!result.Changed)
+                {
+                    continue;
+                }
+
+                replacementCount += result.ReplacementCount;
+                changes.Add(new MigrationFileChange(asmdefFilePath, result.Content));
+            }
+
+            progressCounter.ReportComplete();
+            return new MigrationPlan(changes, replacementCount);
+        }
+
+        private static int GetPreviewWorkItemCount(ProjectFileInventory inventory)
+        {
+            Debug.Assert(inventory != null, "inventory must not be null");
+
+            return (inventory.CSharpFilePaths.Count * 3) +
+                (inventory.AsmdefFilePaths.Count * 2) +
+                inventory.AsmrefFilePaths.Count;
+        }
+
         private static void WriteMigrationFile(string filePath, string content)
         {
             Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
@@ -163,6 +382,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return sidecarPath;
         }
 
+        private static string NormalizeProjectRoot(string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            return Path.GetFullPath(projectRoot)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+
         private static MigrationAssemblyUsage FindMigrationAssemblyUsage(
             string projectRoot,
             List<string> csharpFilePaths,
@@ -195,6 +422,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string csharpFilePath in csharpFilePaths)
             {
                 string source = File.ReadAllText(csharpFilePath);
+                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                {
+                    continue;
+                }
+
                 string assemblyDirectory = FindNearestAssemblyDirectory(
                     csharpFilePath,
                     asmdefDirectories,
@@ -245,6 +477,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string csharpFilePath in csharpFilePaths)
             {
                 string source = File.ReadAllText(csharpFilePath);
+                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                {
+                    continue;
+                }
+
                 string assemblyDirectory = FindNearestAssemblyDirectory(
                     csharpFilePath,
                     asmdefDirectories,
@@ -296,6 +533,238 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     domainReferenceAssemblyDirectories.Add(domainMetadataAssemblyDirectory);
                 }
             }
+
+            return new MigrationAssemblyUsage(
+                asmdefDirectories,
+                assemblyReferenceDirectories,
+                legacyAssemblyDirectories,
+                assemblyScopedLegacyDirectories,
+                CreateAssemblyScopedLegacyAliasesByDirectory(assemblyScopedLegacyAliasesByDirectory),
+                toolContractsReferenceAssemblyDirectories,
+                applicationReferenceAssemblyDirectories,
+                domainReferenceAssemblyDirectories);
+        }
+
+        private static async Task<MigrationAssemblyUsage> FindMigrationAssemblyUsageAsync(
+            string projectRoot,
+            List<string> csharpFilePaths,
+            List<string> asmdefFilePaths,
+            List<string> asmrefFilePaths,
+            MigrationProgressCounter progressCounter,
+            CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
+            Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+            Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
+            Debug.Assert(progressCounter != null, "progressCounter must not be null");
+
+            List<string> asmdefDirectories = asmdefFilePaths
+                .Select(path => Path.GetDirectoryName(path) ?? string.Empty)
+                .Where(path => !string.IsNullOrEmpty(path))
+                .OrderByDescending(path => path.Length)
+                .ToList();
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories =
+                await CreateAssemblyReferenceDirectoriesAsync(
+                    asmdefFilePaths,
+                    asmrefFilePaths,
+                    progressCounter,
+                    ct);
+            HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> assemblyScopedLegacyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> assemblyScopedCurrentDomainDirectories = new(StringComparer.Ordinal);
+            Dictionary<string, HashSet<string>> assemblyScopedLegacyAliasesByDirectory =
+                new(StringComparer.Ordinal);
+            HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> domainMetadataAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> toolContractsReferenceAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> applicationReferenceAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> domainReferenceAssemblyDirectories = new(StringComparer.Ordinal);
+
+            foreach (string csharpFilePath in csharpFilePaths)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return CreateMigrationAssemblyUsage(
+                        asmdefDirectories,
+                        assemblyReferenceDirectories,
+                        legacyAssemblyDirectories,
+                        assemblyScopedLegacyDirectories,
+                        assemblyScopedLegacyAliasesByDirectory,
+                        toolContractsReferenceAssemblyDirectories,
+                        applicationReferenceAssemblyDirectories,
+                        domainReferenceAssemblyDirectories);
+                }
+
+                string source = File.ReadAllText(csharpFilePath);
+                await progressCounter.ReportProcessedItemAsync(ct);
+                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                {
+                    continue;
+                }
+
+                string assemblyDirectory = FindNearestAssemblyDirectory(
+                    csharpFilePath,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    projectRoot);
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source))
+                {
+                    legacyAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyGlobalUsing(source))
+                {
+                    assemblyScopedLegacyDirectories.Add(assemblyDirectory);
+                    AddAssemblyScopedLegacyAliases(
+                        assemblyScopedLegacyAliasesByDirectory,
+                        assemblyDirectory,
+                        ThirdPartyToolMigrationRules.GetLegacyGlobalNamespaceAliases(source));
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsCurrentDomainGlobalUsing(source))
+                {
+                    assemblyScopedCurrentDomainDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source) ||
+                    ThirdPartyToolMigrationRules.ContainsCurrentRegistrarApi(source))
+                {
+                    registrarAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsCurrentToolContractsApi(source))
+                {
+                    toolContractsReferenceAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyDomainMetadataApi(source))
+                {
+                    domainMetadataAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApi(source))
+                {
+                    domainReferenceAssemblyDirectories.Add(assemblyDirectory);
+                }
+            }
+
+            foreach (string csharpFilePath in csharpFilePaths)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return CreateMigrationAssemblyUsage(
+                        asmdefDirectories,
+                        assemblyReferenceDirectories,
+                        legacyAssemblyDirectories,
+                        assemblyScopedLegacyDirectories,
+                        assemblyScopedLegacyAliasesByDirectory,
+                        toolContractsReferenceAssemblyDirectories,
+                        applicationReferenceAssemblyDirectories,
+                        domainReferenceAssemblyDirectories);
+                }
+
+                string source = File.ReadAllText(csharpFilePath);
+                await progressCounter.ReportProcessedItemAsync(ct);
+                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                {
+                    continue;
+                }
+
+                string assemblyDirectory = FindNearestAssemblyDirectory(
+                    csharpFilePath,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    projectRoot);
+                string[] legacyAssemblyAliases = Array.Empty<string>();
+                if (assemblyScopedLegacyAliasesByDirectory.TryGetValue(
+                        assemblyDirectory,
+                        out HashSet<string> legacyAssemblyAliasSet))
+                {
+                    legacyAssemblyAliases = legacyAssemblyAliasSet
+                        .OrderBy(alias => alias, StringComparer.Ordinal)
+                        .ToArray();
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyDomainHelperApiForAssembly(
+                        source,
+                        assemblyScopedLegacyDirectories.Contains(assemblyDirectory),
+                        legacyAssemblyAliases))
+                {
+                    domainMetadataAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApiForAssembly(
+                        source,
+                        assemblyScopedLegacyDirectories.Contains(assemblyDirectory),
+                        legacyAssemblyAliases))
+                {
+                    registrarAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApiForAssembly(
+                        source,
+                        assemblyScopedCurrentDomainDirectories.Contains(assemblyDirectory)))
+                {
+                    domainReferenceAssemblyDirectories.Add(assemblyDirectory);
+                }
+            }
+
+            foreach (string registrarAssemblyDirectory in registrarAssemblyDirectories)
+            {
+                applicationReferenceAssemblyDirectories.Add(registrarAssemblyDirectory);
+            }
+
+            foreach (string domainMetadataAssemblyDirectory in domainMetadataAssemblyDirectories)
+            {
+                if (legacyAssemblyDirectories.Contains(domainMetadataAssemblyDirectory))
+                {
+                    domainReferenceAssemblyDirectories.Add(domainMetadataAssemblyDirectory);
+                }
+            }
+
+            return CreateMigrationAssemblyUsage(
+                asmdefDirectories,
+                assemblyReferenceDirectories,
+                legacyAssemblyDirectories,
+                assemblyScopedLegacyDirectories,
+                assemblyScopedLegacyAliasesByDirectory,
+                toolContractsReferenceAssemblyDirectories,
+                applicationReferenceAssemblyDirectories,
+                domainReferenceAssemblyDirectories);
+        }
+
+        private static MigrationAssemblyUsage CreateMigrationAssemblyUsage(
+            List<string> asmdefDirectories,
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories,
+            HashSet<string> legacyAssemblyDirectories,
+            HashSet<string> assemblyScopedLegacyDirectories,
+            Dictionary<string, HashSet<string>> assemblyScopedLegacyAliasesByDirectory,
+            HashSet<string> toolContractsReferenceAssemblyDirectories,
+            HashSet<string> applicationReferenceAssemblyDirectories,
+            HashSet<string> domainReferenceAssemblyDirectories)
+        {
+            Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
+            Debug.Assert(
+                assemblyReferenceDirectories != null,
+                "assemblyReferenceDirectories must not be null");
+            Debug.Assert(legacyAssemblyDirectories != null, "legacyAssemblyDirectories must not be null");
+            Debug.Assert(
+                assemblyScopedLegacyDirectories != null,
+                "assemblyScopedLegacyDirectories must not be null");
+            Debug.Assert(
+                assemblyScopedLegacyAliasesByDirectory != null,
+                "assemblyScopedLegacyAliasesByDirectory must not be null");
+            Debug.Assert(
+                toolContractsReferenceAssemblyDirectories != null,
+                "toolContractsReferenceAssemblyDirectories must not be null");
+            Debug.Assert(
+                applicationReferenceAssemblyDirectories != null,
+                "applicationReferenceAssemblyDirectories must not be null");
+            Debug.Assert(
+                domainReferenceAssemblyDirectories != null,
+                "domainReferenceAssemblyDirectories must not be null");
 
             return new MigrationAssemblyUsage(
                 asmdefDirectories,
@@ -388,6 +857,57 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 .ToList();
         }
 
+        private static async Task<List<AssemblyReferenceDirectory>> CreateAssemblyReferenceDirectoriesAsync(
+            List<string> asmdefFilePaths,
+            List<string> asmrefFilePaths,
+            MigrationProgressCounter progressCounter,
+            CancellationToken ct)
+        {
+            Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+            Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
+            Debug.Assert(progressCounter != null, "progressCounter must not be null");
+
+            Dictionary<string, string> asmdefDirectoriesByReference =
+                await CreateAsmdefDirectoryMapAsync(asmdefFilePaths, progressCounter, ct);
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new();
+            foreach (string asmrefFilePath in asmrefFilePaths)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return assemblyReferenceDirectories
+                        .OrderByDescending(
+                            assemblyReferenceDirectory => assemblyReferenceDirectory.SourceDirectory.Length)
+                        .ToList();
+                }
+
+                JObject asmref = JObject.Parse(File.ReadAllText(asmrefFilePath));
+                await progressCounter.ReportProcessedItemAsync(ct);
+                string reference = asmref["reference"]?.Value<string>() ?? string.Empty;
+                if (reference.Length == 0)
+                {
+                    continue;
+                }
+
+                if (!asmdefDirectoriesByReference.TryGetValue(reference, out string targetAssemblyDirectory))
+                {
+                    continue;
+                }
+
+                string sourceDirectory = Path.GetDirectoryName(asmrefFilePath) ?? string.Empty;
+                if (sourceDirectory.Length == 0)
+                {
+                    continue;
+                }
+
+                assemblyReferenceDirectories.Add(
+                    new AssemblyReferenceDirectory(sourceDirectory, targetAssemblyDirectory));
+            }
+
+            return assemblyReferenceDirectories
+                .OrderByDescending(assemblyReferenceDirectory => assemblyReferenceDirectory.SourceDirectory.Length)
+                .ToList();
+        }
+
         private static Dictionary<string, string> CreateAsmdefDirectoryMap(List<string> asmdefFilePaths)
         {
             Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
@@ -402,6 +922,42 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 JObject asmdef = JObject.Parse(File.ReadAllText(asmdefFilePath));
+                string assemblyName = asmdef["name"]?.Value<string>() ?? string.Empty;
+                AddAsmdefDirectoryReference(asmdefDirectoriesByReference, assemblyName, asmdefDirectory);
+                AddAsmdefDirectoryReference(
+                    asmdefDirectoriesByReference,
+                    ReadAsmdefGuidReference(asmdefFilePath),
+                    asmdefDirectory);
+            }
+
+            return asmdefDirectoriesByReference;
+        }
+
+        private static async Task<Dictionary<string, string>> CreateAsmdefDirectoryMapAsync(
+            List<string> asmdefFilePaths,
+            MigrationProgressCounter progressCounter,
+            CancellationToken ct)
+        {
+            Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+            Debug.Assert(progressCounter != null, "progressCounter must not be null");
+
+            Dictionary<string, string> asmdefDirectoriesByReference = new(StringComparer.Ordinal);
+            foreach (string asmdefFilePath in asmdefFilePaths)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return asmdefDirectoriesByReference;
+                }
+
+                string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? string.Empty;
+                if (asmdefDirectory.Length == 0)
+                {
+                    await progressCounter.ReportProcessedItemAsync(ct);
+                    continue;
+                }
+
+                JObject asmdef = JObject.Parse(File.ReadAllText(asmdefFilePath));
+                await progressCounter.ReportProcessedItemAsync(ct);
                 string assemblyName = asmdef["name"]?.Value<string>() ?? string.Empty;
                 AddAsmdefDirectoryReference(asmdefDirectoriesByReference, assemblyName, asmdefDirectory);
                 AddAsmdefDirectoryReference(
@@ -611,6 +1167,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private readonly struct MigrationPlan
         {
+            public static MigrationPlan Empty => new(new List<MigrationFileChange>(), 0);
+
             public MigrationPlan(List<MigrationFileChange> changes, int replacementCount)
             {
                 Debug.Assert(changes != null, "changes must not be null");
@@ -627,6 +1185,56 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             public List<MigrationFileChange> Changes { get; }
             public int ReplacementCount { get; }
             public List<string> ChangedFilePaths { get; }
+        }
+
+        private sealed class MigrationProgressCounter
+        {
+            private readonly IProgress<ThirdPartyToolMigrationProgress> _progress;
+            private readonly int _totalItemCount;
+            private int _processedItemCount;
+
+            public MigrationProgressCounter(
+                int totalItemCount,
+                IProgress<ThirdPartyToolMigrationProgress> progress)
+            {
+                Debug.Assert(totalItemCount >= 0, "totalItemCount must not be negative");
+                Debug.Assert(progress != null, "progress must not be null");
+
+                _totalItemCount = totalItemCount;
+                _progress = progress;
+                Report();
+            }
+
+            public async Task ReportProcessedItemAsync(CancellationToken ct)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                _processedItemCount++;
+                Report();
+                if (_processedItemCount % PreviewYieldBatchSize != 0)
+                {
+                    return;
+                }
+
+                await Task.Yield();
+            }
+
+            public void ReportComplete()
+            {
+                _processedItemCount = _totalItemCount;
+                Report();
+            }
+
+            private void Report()
+            {
+                _progress.Report(
+                    new ThirdPartyToolMigrationProgress(
+                        Math.Min(_processedItemCount, _totalItemCount),
+                        _totalItemCount));
+            }
         }
 
         private readonly struct MigrationAssemblyUsage
@@ -744,6 +1352,36 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return new ProjectFileInventory(csharpFilePaths, asmdefFilePaths, asmrefFilePaths);
             }
 
+            public static async Task<ProjectFileInventory> CreateAsync(
+                string projectRoot,
+                IProgress<ThirdPartyToolMigrationProgress> progress,
+                CancellationToken ct)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+                Debug.Assert(progress != null, "progress must not be null");
+
+                List<string> csharpFilePaths = new();
+                List<string> asmdefFilePaths = new();
+                List<string> asmrefFilePaths = new();
+                string assetsDirectory = Path.Combine(projectRoot, "Assets");
+                if (Directory.Exists(assetsDirectory))
+                {
+                    await CollectCandidateFilesAsync(
+                        projectRoot,
+                        assetsDirectory,
+                        csharpFilePaths,
+                        asmdefFilePaths,
+                        asmrefFilePaths,
+                        progress,
+                        ct);
+                }
+
+                csharpFilePaths.Sort(StringComparer.Ordinal);
+                asmdefFilePaths.Sort(StringComparer.Ordinal);
+                asmrefFilePaths.Sort(StringComparer.Ordinal);
+                return new ProjectFileInventory(csharpFilePaths, asmdefFilePaths, asmrefFilePaths);
+            }
+
             private static void CollectCandidateFiles(
                 string projectRoot,
                 string directoryPath,
@@ -791,6 +1429,94 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         csharpFilePaths,
                         asmdefFilePaths,
                         asmrefFilePaths);
+                }
+            }
+
+            private static async Task CollectCandidateFilesAsync(
+                string projectRoot,
+                string assetsDirectory,
+                List<string> csharpFilePaths,
+                List<string> asmdefFilePaths,
+                List<string> asmrefFilePaths,
+                IProgress<ThirdPartyToolMigrationProgress> progress,
+                CancellationToken ct)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+                Debug.Assert(!string.IsNullOrEmpty(assetsDirectory), "assetsDirectory must not be null or empty");
+                Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
+                Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+                Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
+                Debug.Assert(progress != null, "progress must not be null");
+
+                Stack<string> pendingDirectories = new();
+                pendingDirectories.Push(assetsDirectory);
+                int inspectedEntryCount = 0;
+                progress.Report(new ThirdPartyToolMigrationProgress(0, 0));
+
+                while (pendingDirectories.Count > 0)
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    string directoryPath = pendingDirectories.Pop();
+                    foreach (string filePath in Directory.EnumerateFiles(directoryPath))
+                    {
+                        AddCandidateFilePath(filePath, csharpFilePaths, asmdefFilePaths, asmrefFilePaths);
+                        inspectedEntryCount++;
+                        if (inspectedEntryCount % PreviewYieldBatchSize == 0)
+                        {
+                            progress.Report(new ThirdPartyToolMigrationProgress(0, 0));
+                            await Task.Yield();
+                        }
+                    }
+
+                    foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
+                    {
+                        if (ShouldExcludeDirectory(projectRoot, childDirectoryPath))
+                        {
+                            continue;
+                        }
+
+                        pendingDirectories.Push(childDirectoryPath);
+                        inspectedEntryCount++;
+                        if (inspectedEntryCount % PreviewYieldBatchSize == 0)
+                        {
+                            progress.Report(new ThirdPartyToolMigrationProgress(0, 0));
+                            await Task.Yield();
+                        }
+                    }
+                }
+            }
+
+            private static void AddCandidateFilePath(
+                string filePath,
+                List<string> csharpFilePaths,
+                List<string> asmdefFilePaths,
+                List<string> asmrefFilePaths)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+                Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
+                Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+                Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
+
+                string extension = Path.GetExtension(filePath);
+                if (string.Equals(extension, ".cs", StringComparison.OrdinalIgnoreCase))
+                {
+                    csharpFilePaths.Add(filePath);
+                    return;
+                }
+
+                if (string.Equals(extension, ".asmdef", StringComparison.OrdinalIgnoreCase))
+                {
+                    asmdefFilePaths.Add(filePath);
+                    return;
+                }
+
+                if (string.Equals(extension, ".asmref", StringComparison.OrdinalIgnoreCase))
+                {
+                    asmrefFilePaths.Add(filePath);
                 }
             }
 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -594,12 +594,17 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 List<string> csharpFilePaths = new();
                 List<string> asmdefFilePaths = new();
                 List<string> asmrefFilePaths = new();
-                CollectCandidateFiles(
-                    projectRoot,
-                    projectRoot,
-                    csharpFilePaths,
-                    asmdefFilePaths,
-                    asmrefFilePaths);
+                string assetsDirectory = Path.Combine(projectRoot, "Assets");
+                if (Directory.Exists(assetsDirectory))
+                {
+                    CollectCandidateFiles(
+                        projectRoot,
+                        assetsDirectory,
+                        csharpFilePaths,
+                        asmdefFilePaths,
+                        asmrefFilePaths);
+                }
+
                 csharpFilePaths.Sort(StringComparer.Ordinal);
                 asmdefFilePaths.Sort(StringComparer.Ordinal);
                 asmrefFilePaths.Sort(StringComparer.Ordinal);

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Scans Unity project files and rewrites V2 custom tool source to the V3 public contract API.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationFileService : IThirdPartyToolMigrationPort
+    {
+        public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            MigrationPlan plan = CreateMigrationPlan(projectRoot);
+            return new ThirdPartyToolMigrationPreview(
+                plan.ChangedFilePaths.Count,
+                plan.ReplacementCount,
+                plan.ChangedFilePaths.ToArray());
+        }
+
+        public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            MigrationPlan plan = CreateMigrationPlan(projectRoot);
+            foreach (MigrationFileChange change in plan.Changes)
+            {
+                AtomicFileWriter.Write(change.FilePath, change.Content);
+                AtomicFileWriter.CleanupBackup(change.FilePath + ".bak");
+            }
+
+            return new ThirdPartyToolMigrationResult(
+                plan.ChangedFilePaths.Count,
+                plan.ReplacementCount,
+                plan.ChangedFilePaths.ToArray());
+        }
+
+        private static MigrationPlan CreateMigrationPlan(string projectRoot)
+        {
+            if (!Directory.Exists(projectRoot))
+            {
+                throw new DirectoryNotFoundException(projectRoot);
+            }
+
+            ProjectFileInventory inventory = ProjectFileInventory.Create(projectRoot);
+            HashSet<string> legacyAssemblyDirectories = FindLegacyAssemblyDirectories(
+                inventory.CSharpFilePaths,
+                inventory.AsmdefFilePaths);
+            List<MigrationFileChange> changes = new();
+            int replacementCount = 0;
+
+            foreach (string csharpFilePath in inventory.CSharpFilePaths)
+            {
+                string source = File.ReadAllText(csharpFilePath);
+                ThirdPartyToolMigrationContentResult result =
+                    ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+                if (!result.Changed)
+                {
+                    continue;
+                }
+
+                replacementCount += result.ReplacementCount;
+                changes.Add(new MigrationFileChange(csharpFilePath, result.Content));
+            }
+
+            foreach (string asmdefFilePath in inventory.AsmdefFilePaths)
+            {
+                string source = File.ReadAllText(asmdefFilePath);
+                string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
+                bool hasLegacyCSharpSource = legacyAssemblyDirectories.Contains(asmdefDirectory);
+                ThirdPartyToolMigrationContentResult result =
+                    ThirdPartyToolMigrationRules.MigrateAsmdefSource(source, hasLegacyCSharpSource);
+                if (!result.Changed)
+                {
+                    continue;
+                }
+
+                replacementCount += result.ReplacementCount;
+                changes.Add(new MigrationFileChange(asmdefFilePath, result.Content));
+            }
+
+            return new MigrationPlan(changes, replacementCount);
+        }
+
+        private static HashSet<string> FindLegacyAssemblyDirectories(
+            List<string> csharpFilePaths,
+            List<string> asmdefFilePaths)
+        {
+            Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
+            Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+
+            List<string> asmdefDirectories = asmdefFilePaths
+                .Select(path => Path.GetDirectoryName(path) ?? string.Empty)
+                .Where(path => !string.IsNullOrEmpty(path))
+                .OrderByDescending(path => path.Length)
+                .ToList();
+            HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
+
+            foreach (string csharpFilePath in csharpFilePaths)
+            {
+                string source = File.ReadAllText(csharpFilePath);
+                if (!ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source))
+                {
+                    continue;
+                }
+
+                string assemblyDirectory = FindNearestAssemblyDirectory(csharpFilePath, asmdefDirectories);
+                if (!string.IsNullOrEmpty(assemblyDirectory))
+                {
+                    legacyAssemblyDirectories.Add(assemblyDirectory);
+                }
+            }
+
+            return legacyAssemblyDirectories;
+        }
+
+        private static string FindNearestAssemblyDirectory(
+            string csharpFilePath,
+            List<string> asmdefDirectories)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(csharpFilePath), "csharpFilePath must not be null or empty");
+            Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
+
+            string csharpDirectory = Path.GetDirectoryName(csharpFilePath) ?? string.Empty;
+            foreach (string asmdefDirectory in asmdefDirectories)
+            {
+                if (IsSameOrChildPath(csharpDirectory, asmdefDirectory))
+                {
+                    return asmdefDirectory;
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static bool IsSameOrChildPath(string childPath, string parentPath)
+        {
+            Debug.Assert(childPath != null, "childPath must not be null");
+            Debug.Assert(parentPath != null, "parentPath must not be null");
+
+            if (string.Equals(childPath, parentPath, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            string parentWithSeparator = parentPath.TrimEnd(Path.DirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+            return childPath.StartsWith(parentWithSeparator, StringComparison.Ordinal);
+        }
+
+        private readonly struct MigrationFileChange
+        {
+            public MigrationFileChange(string filePath, string content)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+                Debug.Assert(content != null, "content must not be null");
+
+                FilePath = filePath;
+                Content = content ?? string.Empty;
+            }
+
+            public string FilePath { get; }
+            public string Content { get; }
+        }
+
+        private readonly struct MigrationPlan
+        {
+            public MigrationPlan(List<MigrationFileChange> changes, int replacementCount)
+            {
+                Debug.Assert(changes != null, "changes must not be null");
+                Debug.Assert(replacementCount >= 0, "replacementCount must not be negative");
+
+                Changes = changes ?? new List<MigrationFileChange>();
+                ReplacementCount = replacementCount;
+                ChangedFilePaths = Changes
+                    .Select(change => change.FilePath)
+                    .OrderBy(path => path, StringComparer.Ordinal)
+                    .ToList();
+            }
+
+            public List<MigrationFileChange> Changes { get; }
+            public int ReplacementCount { get; }
+            public List<string> ChangedFilePaths { get; }
+        }
+
+        private sealed class ProjectFileInventory
+        {
+            private ProjectFileInventory(List<string> csharpFilePaths, List<string> asmdefFilePaths)
+            {
+                CSharpFilePaths = csharpFilePaths;
+                AsmdefFilePaths = asmdefFilePaths;
+            }
+
+            public List<string> CSharpFilePaths { get; }
+            public List<string> AsmdefFilePaths { get; }
+
+            public static ProjectFileInventory Create(string projectRoot)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+                List<string> csharpFilePaths = new();
+                List<string> asmdefFilePaths = new();
+                CollectCandidateFiles(projectRoot, csharpFilePaths, asmdefFilePaths);
+                csharpFilePaths.Sort(StringComparer.Ordinal);
+                asmdefFilePaths.Sort(StringComparer.Ordinal);
+                return new ProjectFileInventory(csharpFilePaths, asmdefFilePaths);
+            }
+
+            private static void CollectCandidateFiles(
+                string directoryPath,
+                List<string> csharpFilePaths,
+                List<string> asmdefFilePaths)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(directoryPath), "directoryPath must not be null or empty");
+                Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
+                Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+
+                foreach (string filePath in Directory.EnumerateFiles(directoryPath))
+                {
+                    string extension = Path.GetExtension(filePath);
+                    if (string.Equals(extension, ".cs", StringComparison.OrdinalIgnoreCase))
+                    {
+                        csharpFilePaths.Add(filePath);
+                        continue;
+                    }
+
+                    if (string.Equals(extension, ".asmdef", StringComparison.OrdinalIgnoreCase))
+                    {
+                        asmdefFilePaths.Add(filePath);
+                    }
+                }
+
+                foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
+                {
+                    string directoryName = Path.GetFileName(childDirectoryPath);
+                    if (ThirdPartyToolMigrationRules.IsExcludedDirectoryName(directoryName))
+                    {
+                        continue;
+                    }
+
+                    CollectCandidateFiles(childDirectoryPath, csharpFilePaths, asmdefFilePaths);
+                }
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -131,7 +131,18 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return false;
             }
 
-            bool hasCurrentAssemblyReferenceCandidate = false;
+            List<string> asmdefDirectories = inventory.AsmdefFilePaths
+                .Select(path => Path.GetDirectoryName(path) ?? string.Empty)
+                .Where(path => !string.IsNullOrEmpty(path))
+                .OrderByDescending(path => path.Length)
+                .ToList();
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories = inventory.AsmrefFilePaths.Count == 0
+                ? new List<AssemblyReferenceDirectory>()
+                : CreateAssemblyReferenceDirectories(inventory.AsmdefFilePaths, inventory.AsmrefFilePaths);
+            HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> toolContractsReferenceAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> applicationReferenceAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> domainReferenceAssemblyDirectories = new(StringComparer.Ordinal);
             int inspectedEntryCount = 0;
             foreach (string csharpFilePath in inventory.CSharpFilePaths)
             {
@@ -146,8 +157,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return true;
                 }
 
-                hasCurrentAssemblyReferenceCandidate |=
-                    ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source);
+                if (ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                {
+                    string assemblyDirectory = FindNearestAssemblyDirectory(
+                        csharpFilePath,
+                        asmdefDirectories,
+                        assemblyReferenceDirectories,
+                        projectRoot);
+                    CollectFastAssemblyReferenceRequirements(
+                        source,
+                        assemblyDirectory,
+                        legacyAssemblyDirectories,
+                        toolContractsReferenceAssemblyDirectories,
+                        applicationReferenceAssemblyDirectories,
+                        domainReferenceAssemblyDirectories);
+                }
+
                 inspectedEntryCount++;
                 if (inspectedEntryCount % PreviewYieldBatchSize == 0)
                 {
@@ -175,25 +200,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
-            if (!hasCurrentAssemblyReferenceCandidate)
+            if (toolContractsReferenceAssemblyDirectories.Count == 0 &&
+                applicationReferenceAssemblyDirectories.Count == 0 &&
+                domainReferenceAssemblyDirectories.Count == 0)
             {
                 return false;
             }
 
-            MigrationProgressCounter progressCounter = new(
-                GetPreviewWorkItemCount(inventory),
-                new Progress<ThirdPartyToolMigrationProgress>());
-            MigrationAssemblyUsage assemblyUsage = await FindMigrationAssemblyUsageAsync(
-                projectRoot,
-                inventory.CSharpFilePaths,
-                inventory.AsmdefFilePaths,
-                inventory.AsmrefFilePaths,
-                progressCounter,
-                ct);
-            if (ct.IsCancellationRequested)
-            {
-                return false;
-            }
+            MigrationAssemblyUsage assemblyUsage = new(
+                asmdefDirectories,
+                assemblyReferenceDirectories,
+                legacyAssemblyDirectories,
+                new HashSet<string>(StringComparer.Ordinal),
+                new Dictionary<string, string[]>(StringComparer.Ordinal),
+                toolContractsReferenceAssemblyDirectories,
+                applicationReferenceAssemblyDirectories,
+                domainReferenceAssemblyDirectories);
 
             foreach (string asmdefFilePath in inventory.AsmdefFilePaths)
             {
@@ -211,6 +233,50 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return false;
         }
 
+        private static void CollectFastAssemblyReferenceRequirements(
+            string source,
+            string assemblyDirectory,
+            HashSet<string> legacyAssemblyDirectories,
+            HashSet<string> toolContractsReferenceAssemblyDirectories,
+            HashSet<string> applicationReferenceAssemblyDirectories,
+            HashSet<string> domainReferenceAssemblyDirectories)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyDirectory), "assemblyDirectory must not be null or empty");
+            Debug.Assert(legacyAssemblyDirectories != null, "legacyAssemblyDirectories must not be null");
+            Debug.Assert(
+                toolContractsReferenceAssemblyDirectories != null,
+                "toolContractsReferenceAssemblyDirectories must not be null");
+            Debug.Assert(
+                applicationReferenceAssemblyDirectories != null,
+                "applicationReferenceAssemblyDirectories must not be null");
+            Debug.Assert(domainReferenceAssemblyDirectories != null, "domainReferenceAssemblyDirectories must not be null");
+
+            if (ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source))
+            {
+                legacyAssemblyDirectories.Add(assemblyDirectory);
+            }
+
+            if (ThirdPartyToolMigrationRules.ContainsCurrentToolContractsApi(source))
+            {
+                toolContractsReferenceAssemblyDirectories.Add(assemblyDirectory);
+            }
+
+            if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source) ||
+                ThirdPartyToolMigrationRules.ContainsCurrentRegistrarApi(source))
+            {
+                applicationReferenceAssemblyDirectories.Add(assemblyDirectory);
+            }
+
+            if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApi(source) ||
+                ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApiForAssembly(
+                    source,
+                    ThirdPartyToolMigrationRules.ContainsCurrentDomainGlobalUsing(source)))
+            {
+                domainReferenceAssemblyDirectories.Add(assemblyDirectory);
+            }
+        }
+
         private static bool ContainsAsmdefMigrationTarget(
             string asmdefFilePath,
             string projectRoot,
@@ -219,7 +285,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(asmdefFilePath), "asmdefFilePath must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            string source = File.ReadAllText(asmdefFilePath);
             string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
             bool hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
             bool requiresToolContractsReference =
@@ -228,6 +293,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
             bool requiresDomainReference =
                 assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory);
+            if (!hasLegacyCSharpSource &&
+                !requiresToolContractsReference &&
+                !requiresApplicationReference &&
+                !requiresDomainReference)
+            {
+                return false;
+            }
+
+            string source = File.ReadAllText(asmdefFilePath);
             ThirdPartyToolMigrationContentResult result =
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -77,6 +77,25 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return preview;
         }
 
+        public async Task<bool> HasMigrationTargetsAsync(string projectRoot, CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
+            if (!Directory.Exists(normalizedProjectRoot))
+            {
+                throw new DirectoryNotFoundException(normalizedProjectRoot);
+            }
+
+            string assetsDirectory = Path.Combine(normalizedProjectRoot, "Assets");
+            if (!Directory.Exists(assetsDirectory))
+            {
+                return false;
+            }
+
+            return await FindFirstMigrationTargetAsync(assetsDirectory, ct);
+        }
+
         public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
@@ -103,6 +122,101 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 _cachedPreviewProjectRoot = string.Empty;
                 _cachedPreview = default;
             }
+        }
+
+        private static async Task<bool> FindFirstMigrationTargetAsync(string assetsDirectory, CancellationToken ct)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assetsDirectory), "assetsDirectory must not be null or empty");
+
+            Stack<string> pendingDirectories = new();
+            pendingDirectories.Push(assetsDirectory);
+            int inspectedEntryCount = 0;
+
+            while (pendingDirectories.Count > 0)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                string directoryPath = pendingDirectories.Pop();
+                foreach (string filePath in Directory.EnumerateFiles(directoryPath))
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        return false;
+                    }
+
+                    if (ContainsFastMigrationTarget(filePath))
+                    {
+                        return true;
+                    }
+
+                    inspectedEntryCount++;
+                    if (inspectedEntryCount % PreviewYieldBatchSize == 0)
+                    {
+                        await Task.Yield();
+                    }
+                }
+
+                foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
+                {
+                    if (ShouldExcludeFastScanDirectory(childDirectoryPath))
+                    {
+                        continue;
+                    }
+
+                    pendingDirectories.Push(childDirectoryPath);
+                    inspectedEntryCount++;
+                    if (inspectedEntryCount % PreviewYieldBatchSize == 0)
+                    {
+                        await Task.Yield();
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ContainsFastMigrationTarget(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            string extension = Path.GetExtension(filePath);
+            if (string.Equals(extension, ".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                return ContainsFastCSharpMigrationTarget(File.ReadAllText(filePath));
+            }
+
+            if (string.Equals(extension, ".asmdef", StringComparison.OrdinalIgnoreCase))
+            {
+                return ContainsFastAsmdefMigrationTarget(File.ReadAllText(filePath));
+            }
+
+            return false;
+        }
+
+        private static bool ContainsFastCSharpMigrationTarget(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return ThirdPartyToolMigrationRules.ContainsLegacyMigrationCandidateText(source) &&
+                ThirdPartyToolMigrationRules.ContainsLegacyCSharpApi(source);
+        }
+
+        private static bool ContainsFastAsmdefMigrationTarget(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return ThirdPartyToolMigrationRules.ContainsLegacyAsmdefNameReference(source);
+        }
+
+        private static bool ShouldExcludeFastScanDirectory(string directoryPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(directoryPath), "directoryPath must not be null or empty");
+
+            string directoryName = Path.GetFileName(directoryPath);
+            return ThirdPartyToolMigrationRules.IsExcludedDirectoryName(directoryName);
         }
 
         private bool TryGetCachedPreview(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 using io.github.hatayama.UnityCliLoop.Domain;
@@ -1276,7 +1277,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new();
             foreach (string asmrefFilePath in asmrefFilePaths)
             {
-                JObject asmref = JObject.Parse(File.ReadAllText(asmrefFilePath));
+                if (!TryReadJsonObject(asmrefFilePath, out JObject asmref))
+                {
+                    continue;
+                }
+
                 string reference = asmref["reference"]?.Value<string>() ?? string.Empty;
                 if (reference.Length == 0)
                 {
@@ -1331,7 +1336,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         .ToList();
                 }
 
-                JObject asmref = JObject.Parse(File.ReadAllText(asmrefFilePath));
+                if (!TryReadJsonObject(asmrefFilePath, out JObject asmref))
+                {
+                    await progressCounter.ReportProcessedItemAsync(ct);
+                    continue;
+                }
+
                 await progressCounter.ReportProcessedItemAsync(ct);
                 string reference = asmref["reference"]?.Value<string>() ?? string.Empty;
                 if (reference.Length == 0)
@@ -1372,7 +1382,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     continue;
                 }
 
-                JObject asmdef = JObject.Parse(File.ReadAllText(asmdefFilePath));
+                if (!TryReadJsonObject(asmdefFilePath, out JObject asmdef))
+                {
+                    continue;
+                }
+
                 string assemblyName = asmdef["name"]?.Value<string>() ?? string.Empty;
                 AddAsmdefDirectoryReference(asmdefDirectoriesByReference, assemblyName, asmdefDirectory);
                 AddAsmdefDirectoryReference(
@@ -1407,7 +1421,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     continue;
                 }
 
-                JObject asmdef = JObject.Parse(File.ReadAllText(asmdefFilePath));
+                if (!TryReadJsonObject(asmdefFilePath, out JObject asmdef))
+                {
+                    await progressCounter.ReportProcessedItemAsync(ct);
+                    continue;
+                }
+
                 await progressCounter.ReportProcessedItemAsync(ct);
                 string assemblyName = asmdef["name"]?.Value<string>() ?? string.Empty;
                 AddAsmdefDirectoryReference(asmdefDirectoriesByReference, assemblyName, asmdefDirectory);
@@ -1418,6 +1437,24 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return asmdefDirectoriesByReference;
+        }
+
+        private static bool TryReadJsonObject(string filePath, out JObject jsonObject)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            try
+            {
+                jsonObject = JObject.Parse(File.ReadAllText(filePath));
+                return true;
+            }
+            catch (JsonException ex)
+            {
+                UnityEngine.Debug.LogWarning(
+                    $"[UnityCliLoop] Skipping malformed assembly definition JSON at {filePath}: {ex.Message}");
+                jsonObject = null;
+                return false;
+            }
         }
 
         private static void AddAsmdefDirectoryReference(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -339,20 +339,36 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
             string csharpDirectory = Path.GetDirectoryName(csharpFilePath) ?? string.Empty;
+            string matchedAssemblyDirectory = string.Empty;
+            int matchedSourceDirectoryLength = -1;
             foreach (string asmdefDirectory in asmdefDirectories)
             {
-                if (IsSameOrChildPath(csharpDirectory, asmdefDirectory))
+                if (!IsSameOrChildPath(csharpDirectory, asmdefDirectory) ||
+                    asmdefDirectory.Length <= matchedSourceDirectoryLength)
                 {
-                    return asmdefDirectory;
+                    continue;
                 }
+
+                matchedAssemblyDirectory = asmdefDirectory;
+                matchedSourceDirectoryLength = asmdefDirectory.Length;
             }
 
             foreach (AssemblyReferenceDirectory assemblyReferenceDirectory in assemblyReferenceDirectories)
             {
-                if (IsSameOrChildPath(csharpDirectory, assemblyReferenceDirectory.SourceDirectory))
+                string sourceDirectory = assemblyReferenceDirectory.SourceDirectory;
+                if (!IsSameOrChildPath(csharpDirectory, sourceDirectory) ||
+                    sourceDirectory.Length <= matchedSourceDirectoryLength)
                 {
-                    return assemblyReferenceDirectory.TargetAssemblyDirectory;
+                    continue;
                 }
+
+                matchedAssemblyDirectory = assemblyReferenceDirectory.TargetAssemblyDirectory;
+                matchedSourceDirectoryLength = sourceDirectory.Length;
+            }
+
+            if (matchedAssemblyDirectory.Length > 0)
+            {
+                return matchedAssemblyDirectory;
             }
 
             return GetImplicitAssemblyDirectory(csharpFilePath, projectRoot);

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -87,11 +87,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 bool hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
                 bool requiresApplicationReference =
                     assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
+                bool requiresDomainReference =
+                    assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory) ||
+                    requiresApplicationReference;
                 ThirdPartyToolMigrationContentResult result =
                     ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                         source,
                         hasLegacyCSharpSource,
-                        requiresApplicationReference);
+                        requiresApplicationReference,
+                        requiresDomainReference);
                 if (!result.Changed)
                 {
                     continue;
@@ -154,7 +158,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 .ToList();
             HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> domainMetadataAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> applicationReferenceAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> domainReferenceAssemblyDirectories = new(StringComparer.Ordinal);
 
             foreach (string csharpFilePath in csharpFilePaths)
             {
@@ -173,6 +179,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 {
                     registrarAssemblyDirectories.Add(assemblyDirectory);
                 }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyDomainMetadataApi(source))
+                {
+                    domainMetadataAssemblyDirectories.Add(assemblyDirectory);
+                }
             }
 
             foreach (string registrarAssemblyDirectory in registrarAssemblyDirectories)
@@ -183,10 +194,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
+            foreach (string domainMetadataAssemblyDirectory in domainMetadataAssemblyDirectories)
+            {
+                if (legacyAssemblyDirectories.Contains(domainMetadataAssemblyDirectory))
+                {
+                    domainReferenceAssemblyDirectories.Add(domainMetadataAssemblyDirectory);
+                }
+            }
+
             return new MigrationAssemblyUsage(
                 asmdefDirectories,
                 legacyAssemblyDirectories,
-                applicationReferenceAssemblyDirectories);
+                applicationReferenceAssemblyDirectories,
+                domainReferenceAssemblyDirectories);
         }
 
         private static string FindNearestAssemblyDirectory(
@@ -294,23 +314,30 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             public MigrationAssemblyUsage(
                 List<string> asmdefDirectories,
                 HashSet<string> legacyAssemblyDirectories,
-                HashSet<string> applicationReferenceAssemblyDirectories)
+                HashSet<string> applicationReferenceAssemblyDirectories,
+                HashSet<string> domainReferenceAssemblyDirectories)
             {
                 Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
                 Debug.Assert(legacyAssemblyDirectories != null, "legacyAssemblyDirectories must not be null");
                 Debug.Assert(
                     applicationReferenceAssemblyDirectories != null,
                     "applicationReferenceAssemblyDirectories must not be null");
+                Debug.Assert(
+                    domainReferenceAssemblyDirectories != null,
+                    "domainReferenceAssemblyDirectories must not be null");
 
                 AsmdefDirectories = asmdefDirectories ?? new List<string>();
                 LegacyAssemblyDirectories = legacyAssemblyDirectories ?? new HashSet<string>(StringComparer.Ordinal);
                 ApplicationReferenceAssemblyDirectories = applicationReferenceAssemblyDirectories ??
+                    new HashSet<string>(StringComparer.Ordinal);
+                DomainReferenceAssemblyDirectories = domainReferenceAssemblyDirectories ??
                     new HashSet<string>(StringComparer.Ordinal);
             }
 
             public List<string> AsmdefDirectories { get; }
             public HashSet<string> LegacyAssemblyDirectories { get; }
             public HashSet<string> ApplicationReferenceAssemblyDirectories { get; }
+            public HashSet<string> DomainReferenceAssemblyDirectories { get; }
         }
 
         private sealed class ProjectFileInventory

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -58,8 +58,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string csharpFilePath in inventory.CSharpFilePaths)
             {
                 string source = File.ReadAllText(csharpFilePath);
+                string assemblyDirectory = FindNearestAssemblyDirectory(csharpFilePath, assemblyUsage.AsmdefDirectories);
+                bool hasLegacyAssemblySource =
+                    assemblyUsage.LegacyAssemblyDirectories.Contains(assemblyDirectory);
                 ThirdPartyToolMigrationContentResult result =
-                    ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+                    ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
+                        source,
+                        hasLegacyAssemblySource);
                 if (!result.Changed)
                 {
                     continue;
@@ -128,6 +133,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return new MigrationAssemblyUsage(
+                asmdefDirectories,
                 legacyAssemblyDirectories,
                 applicationReferenceAssemblyDirectories);
         }
@@ -204,19 +210,23 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly struct MigrationAssemblyUsage
         {
             public MigrationAssemblyUsage(
+                List<string> asmdefDirectories,
                 HashSet<string> legacyAssemblyDirectories,
                 HashSet<string> applicationReferenceAssemblyDirectories)
             {
+                Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
                 Debug.Assert(legacyAssemblyDirectories != null, "legacyAssemblyDirectories must not be null");
                 Debug.Assert(
                     applicationReferenceAssemblyDirectories != null,
                     "applicationReferenceAssemblyDirectories must not be null");
 
+                AsmdefDirectories = asmdefDirectories ?? new List<string>();
                 LegacyAssemblyDirectories = legacyAssemblyDirectories ?? new HashSet<string>(StringComparer.Ordinal);
                 ApplicationReferenceAssemblyDirectories = applicationReferenceAssemblyDirectories ??
                     new HashSet<string>(StringComparer.Ordinal);
             }
 
+            public List<string> AsmdefDirectories { get; }
             public HashSet<string> LegacyAssemblyDirectories { get; }
             public HashSet<string> ApplicationReferenceAssemblyDirectories { get; }
         }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -17,6 +17,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         private const string ImplicitEditorAssemblyDirectoryName = "__UnityCliLoopImplicitEditorAssembly";
         private const string ImplicitRuntimeAssemblyDirectoryName = "__UnityCliLoopImplicitRuntimeAssembly";
+        private const string ImplicitFirstPassEditorAssemblyDirectoryName =
+            "__UnityCliLoopImplicitFirstPassEditorAssembly";
+        private const string ImplicitFirstPassRuntimeAssemblyDirectoryName =
+            "__UnityCliLoopImplicitFirstPassRuntimeAssembly";
 
         public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
         {
@@ -386,10 +390,31 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(csharpFilePath), "csharpFilePath must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            string implicitAssemblyDirectoryName = IsEditorAssemblyPath(csharpFilePath, projectRoot)
+            bool isEditorAssemblyPath = IsEditorAssemblyPath(csharpFilePath, projectRoot);
+            bool isFirstPassAssemblyPath = IsFirstPassAssemblyPath(csharpFilePath, projectRoot);
+            string implicitAssemblyDirectoryName = GetImplicitAssemblyDirectoryName(
+                isEditorAssemblyPath,
+                isFirstPassAssemblyPath);
+            return Path.Combine(projectRoot, implicitAssemblyDirectoryName);
+        }
+
+        private static string GetImplicitAssemblyDirectoryName(
+            bool isEditorAssemblyPath,
+            bool isFirstPassAssemblyPath)
+        {
+            if (isEditorAssemblyPath && isFirstPassAssemblyPath)
+            {
+                return ImplicitFirstPassEditorAssemblyDirectoryName;
+            }
+
+            if (isFirstPassAssemblyPath)
+            {
+                return ImplicitFirstPassRuntimeAssemblyDirectoryName;
+            }
+
+            return isEditorAssemblyPath
                 ? ImplicitEditorAssemblyDirectoryName
                 : ImplicitRuntimeAssemblyDirectoryName;
-            return Path.Combine(projectRoot, implicitAssemblyDirectoryName);
         }
 
         private static bool IsEditorAssemblyPath(string csharpFilePath, string projectRoot)
@@ -397,17 +422,42 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(csharpFilePath), "csharpFilePath must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            string relativePath = csharpFilePath.StartsWith(projectRoot, StringComparison.Ordinal)
-                ? csharpFilePath.Substring(projectRoot.Length)
-                : csharpFilePath;
+            string[] pathSegments = GetRelativePathSegments(csharpFilePath, projectRoot);
+            return pathSegments.Any(
+                pathSegment => string.Equals(pathSegment, "Editor", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool IsFirstPassAssemblyPath(string csharpFilePath, string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(csharpFilePath), "csharpFilePath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            string[] pathSegments = GetRelativePathSegments(csharpFilePath, projectRoot);
+            if (pathSegments.Length < 2 ||
+                !string.Equals(pathSegments[0], "Assets", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return string.Equals(pathSegments[1], "Plugins", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(pathSegments[1], "Standard Assets", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(pathSegments[1], "Pro Standard Assets", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string[] GetRelativePathSegments(string filePath, string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            string relativePath = filePath.StartsWith(projectRoot, StringComparison.Ordinal)
+                ? filePath.Substring(projectRoot.Length)
+                : filePath;
             char[] separators =
             {
                 Path.DirectorySeparatorChar,
                 Path.AltDirectorySeparatorChar
             };
-            string[] pathSegments = relativePath.Split(separators, StringSplitOptions.RemoveEmptyEntries);
-            return pathSegments.Any(
-                pathSegment => string.Equals(pathSegment, "Editor", StringComparison.OrdinalIgnoreCase));
+            return relativePath.Split(separators, StringSplitOptions.RemoveEmptyEntries);
         }
 
         private static bool IsSameOrChildPath(string childPath, string parentPath)
@@ -544,7 +594,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 List<string> csharpFilePaths = new();
                 List<string> asmdefFilePaths = new();
                 List<string> asmrefFilePaths = new();
-                CollectCandidateFiles(projectRoot, csharpFilePaths, asmdefFilePaths, asmrefFilePaths);
+                CollectCandidateFiles(
+                    projectRoot,
+                    projectRoot,
+                    csharpFilePaths,
+                    asmdefFilePaths,
+                    asmrefFilePaths);
                 csharpFilePaths.Sort(StringComparer.Ordinal);
                 asmdefFilePaths.Sort(StringComparer.Ordinal);
                 asmrefFilePaths.Sort(StringComparer.Ordinal);
@@ -552,11 +607,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             private static void CollectCandidateFiles(
+                string projectRoot,
                 string directoryPath,
                 List<string> csharpFilePaths,
                 List<string> asmdefFilePaths,
                 List<string> asmrefFilePaths)
             {
+                Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
                 Debug.Assert(!string.IsNullOrEmpty(directoryPath), "directoryPath must not be null or empty");
                 Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
                 Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
@@ -585,14 +642,54 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
                 {
-                    string directoryName = Path.GetFileName(childDirectoryPath);
-                    if (ThirdPartyToolMigrationRules.IsExcludedDirectoryName(directoryName))
+                    if (ShouldExcludeDirectory(projectRoot, childDirectoryPath))
                     {
                         continue;
                     }
 
-                    CollectCandidateFiles(childDirectoryPath, csharpFilePaths, asmdefFilePaths, asmrefFilePaths);
+                    CollectCandidateFiles(
+                        projectRoot,
+                        childDirectoryPath,
+                        csharpFilePaths,
+                        asmdefFilePaths,
+                        asmrefFilePaths);
                 }
+            }
+
+            private static bool ShouldExcludeDirectory(string projectRoot, string directoryPath)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+                Debug.Assert(!string.IsNullOrEmpty(directoryPath), "directoryPath must not be null or empty");
+
+                if (IsProjectRootPackagesDirectory(projectRoot, directoryPath))
+                {
+                    return true;
+                }
+
+                string directoryName = Path.GetFileName(directoryPath);
+                return ThirdPartyToolMigrationRules.IsExcludedDirectoryName(directoryName);
+            }
+
+            private static bool IsProjectRootPackagesDirectory(string projectRoot, string directoryPath)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+                Debug.Assert(!string.IsNullOrEmpty(directoryPath), "directoryPath must not be null or empty");
+
+                string packagesDirectory = Path.Combine(projectRoot, "Packages");
+                string normalizedPackagesDirectory = NormalizeDirectoryPath(packagesDirectory);
+                string normalizedDirectoryPath = NormalizeDirectoryPath(directoryPath);
+                return string.Equals(
+                    normalizedDirectoryPath,
+                    normalizedPackagesDirectory,
+                    StringComparison.Ordinal);
+            }
+
+            private static string NormalizeDirectoryPath(string directoryPath)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(directoryPath), "directoryPath must not be null or empty");
+
+                return Path.GetFullPath(directoryPath)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             }
         }
     }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -140,6 +140,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 ? new List<AssemblyReferenceDirectory>()
                 : CreateAssemblyReferenceDirectories(inventory.AsmdefFilePaths, inventory.AsmrefFilePaths);
             HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> assemblyScopedCurrentDomainDirectories = new(StringComparer.Ordinal);
             HashSet<string> toolContractsReferenceAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> applicationReferenceAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> domainReferenceAssemblyDirectories = new(StringComparer.Ordinal);
@@ -164,9 +165,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         asmdefDirectories,
                         assemblyReferenceDirectories,
                         projectRoot);
+                    if (ThirdPartyToolMigrationRules.ContainsCurrentDomainGlobalUsing(source))
+                    {
+                        assemblyScopedCurrentDomainDirectories.Add(assemblyDirectory);
+                    }
+
                     CollectFastAssemblyReferenceRequirements(
                         source,
                         assemblyDirectory,
+                        assemblyScopedCurrentDomainDirectories.Contains(assemblyDirectory),
                         legacyAssemblyDirectories,
                         toolContractsReferenceAssemblyDirectories,
                         applicationReferenceAssemblyDirectories,
@@ -177,6 +184,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (inspectedEntryCount % PreviewYieldBatchSize == 0)
                 {
                     await Task.Yield();
+                }
+            }
+
+            if (assemblyScopedCurrentDomainDirectories.Count > 0)
+            {
+                await CollectFastAssemblyScopedCurrentDomainRequirementsAsync(
+                    inventory.CSharpFilePaths,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    projectRoot,
+                    assemblyScopedCurrentDomainDirectories,
+                    domainReferenceAssemblyDirectories,
+                    ct);
+                if (ct.IsCancellationRequested)
+                {
+                    return false;
                 }
             }
 
@@ -236,6 +259,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static void CollectFastAssemblyReferenceRequirements(
             string source,
             string assemblyDirectory,
+            bool hasAssemblyScopedCurrentDomainNamespaceUsage,
             HashSet<string> legacyAssemblyDirectories,
             HashSet<string> toolContractsReferenceAssemblyDirectories,
             HashSet<string> applicationReferenceAssemblyDirectories,
@@ -271,9 +295,62 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApi(source) ||
                 ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApiForAssembly(
                     source,
-                    ThirdPartyToolMigrationRules.ContainsCurrentDomainGlobalUsing(source)))
+                    hasAssemblyScopedCurrentDomainNamespaceUsage))
             {
                 domainReferenceAssemblyDirectories.Add(assemblyDirectory);
+            }
+        }
+
+        private static async Task CollectFastAssemblyScopedCurrentDomainRequirementsAsync(
+            List<string> csharpFilePaths,
+            List<string> asmdefDirectories,
+            List<AssemblyReferenceDirectory> assemblyReferenceDirectories,
+            string projectRoot,
+            HashSet<string> assemblyScopedCurrentDomainDirectories,
+            HashSet<string> domainReferenceAssemblyDirectories,
+            CancellationToken ct)
+        {
+            Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
+            Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
+            Debug.Assert(
+                assemblyReferenceDirectories != null,
+                "assemblyReferenceDirectories must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(
+                assemblyScopedCurrentDomainDirectories != null,
+                "assemblyScopedCurrentDomainDirectories must not be null");
+            Debug.Assert(domainReferenceAssemblyDirectories != null, "domainReferenceAssemblyDirectories must not be null");
+
+            int inspectedEntryCount = 0;
+            foreach (string csharpFilePath in csharpFilePaths)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                string source = File.ReadAllText(csharpFilePath);
+                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                {
+                    continue;
+                }
+
+                string assemblyDirectory = FindNearestAssemblyDirectory(
+                    csharpFilePath,
+                    asmdefDirectories,
+                    assemblyReferenceDirectories,
+                    projectRoot);
+                if (assemblyScopedCurrentDomainDirectories.Contains(assemblyDirectory) &&
+                    ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApiForAssembly(source, true))
+                {
+                    domainReferenceAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                inspectedEntryCount++;
+                if (inspectedEntryCount % PreviewYieldBatchSize == 0)
+                {
+                    await Task.Yield();
+                }
             }
         }
 
@@ -285,23 +362,25 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(asmdefFilePath), "asmdefFilePath must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
-            bool hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
-            bool requiresToolContractsReference =
-                assemblyUsage.ToolContractsReferenceAssemblyDirectories.Contains(asmdefDirectory);
-            bool requiresApplicationReference =
-                assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
-            bool requiresDomainReference =
-                assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory);
-            if (!hasLegacyCSharpSource &&
-                !requiresToolContractsReference &&
-                !requiresApplicationReference &&
-                !requiresDomainReference)
+            bool hasLegacyCSharpSource;
+            bool requiresToolContractsReference;
+            bool requiresApplicationReference;
+            bool requiresDomainReference;
+            bool hasAssemblyMigrationRequirement = TryGetAsmdefMigrationRequirements(
+                asmdefFilePath,
+                projectRoot,
+                assemblyUsage,
+                out hasLegacyCSharpSource,
+                out requiresToolContractsReference,
+                out requiresApplicationReference,
+                out requiresDomainReference);
+            string source = File.ReadAllText(asmdefFilePath);
+            if (!hasAssemblyMigrationRequirement &&
+                !ThirdPartyToolMigrationRules.ContainsLegacyMigrationCandidateText(source))
             {
                 return false;
             }
 
-            string source = File.ReadAllText(asmdefFilePath);
             ThirdPartyToolMigrationContentResult result =
                 ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                     source,
@@ -311,6 +390,32 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     requiresDomainReference);
 
             return result.Changed;
+        }
+
+        private static bool TryGetAsmdefMigrationRequirements(
+            string asmdefFilePath,
+            string projectRoot,
+            MigrationAssemblyUsage assemblyUsage,
+            out bool hasLegacyCSharpSource,
+            out bool requiresToolContractsReference,
+            out bool requiresApplicationReference,
+            out bool requiresDomainReference)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(asmdefFilePath), "asmdefFilePath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
+            hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
+            requiresToolContractsReference =
+                assemblyUsage.ToolContractsReferenceAssemblyDirectories.Contains(asmdefDirectory);
+            requiresApplicationReference =
+                assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
+            requiresDomainReference =
+                assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory);
+            return hasLegacyCSharpSource ||
+                requiresToolContractsReference ||
+                requiresApplicationReference ||
+                requiresDomainReference;
         }
 
         private static bool ContainsFastCSharpMigrationTarget(string source)
@@ -424,15 +529,25 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             foreach (string asmdefFilePath in inventory.AsmdefFilePaths)
             {
+                bool hasLegacyCSharpSource;
+                bool requiresToolContractsReference;
+                bool requiresApplicationReference;
+                bool requiresDomainReference;
+                bool hasAssemblyMigrationRequirement = TryGetAsmdefMigrationRequirements(
+                    asmdefFilePath,
+                    projectRoot,
+                    assemblyUsage,
+                    out hasLegacyCSharpSource,
+                    out requiresToolContractsReference,
+                    out requiresApplicationReference,
+                    out requiresDomainReference);
                 string source = File.ReadAllText(asmdefFilePath);
-                string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
-                bool hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
-                bool requiresToolContractsReference =
-                    assemblyUsage.ToolContractsReferenceAssemblyDirectories.Contains(asmdefDirectory);
-                bool requiresApplicationReference =
-                    assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
-                bool requiresDomainReference =
-                    assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory);
+                if (!hasAssemblyMigrationRequirement &&
+                    !ThirdPartyToolMigrationRules.ContainsLegacyMigrationCandidateText(source))
+                {
+                    continue;
+                }
+
                 ThirdPartyToolMigrationContentResult result =
                     ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                         source,
@@ -538,16 +653,26 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return MigrationPlan.Empty;
                 }
 
+                bool hasLegacyCSharpSource;
+                bool requiresToolContractsReference;
+                bool requiresApplicationReference;
+                bool requiresDomainReference;
+                bool hasAssemblyMigrationRequirement = TryGetAsmdefMigrationRequirements(
+                    asmdefFilePath,
+                    projectRoot,
+                    assemblyUsage,
+                    out hasLegacyCSharpSource,
+                    out requiresToolContractsReference,
+                    out requiresApplicationReference,
+                    out requiresDomainReference);
                 string source = File.ReadAllText(asmdefFilePath);
                 await progressCounter.ReportProcessedItemAsync(ct);
-                string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
-                bool hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
-                bool requiresToolContractsReference =
-                    assemblyUsage.ToolContractsReferenceAssemblyDirectories.Contains(asmdefDirectory);
-                bool requiresApplicationReference =
-                    assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
-                bool requiresDomainReference =
-                    assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory);
+                if (!hasAssemblyMigrationRequirement &&
+                    !ThirdPartyToolMigrationRules.ContainsLegacyMigrationCandidateText(source))
+                {
+                    continue;
+                }
+
                 ThirdPartyToolMigrationContentResult result =
                     ThirdPartyToolMigrationRules.MigrateAsmdefSource(
                         source,
@@ -1055,6 +1180,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
             Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
 
+            if (asmrefFilePaths.Count == 0)
+            {
+                return new List<AssemblyReferenceDirectory>();
+            }
+
             Dictionary<string, string> asmdefDirectoriesByReference = CreateAsmdefDirectoryMap(asmdefFilePaths);
             List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new();
             foreach (string asmrefFilePath in asmrefFilePaths)
@@ -1095,6 +1225,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
             Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
             Debug.Assert(progressCounter != null, "progressCounter must not be null");
+
+            if (asmrefFilePaths.Count == 0)
+            {
+                return new List<AssemblyReferenceDirectory>();
+            }
 
             Dictionary<string, string> asmdefDirectoriesByReference =
                 await CreateAsmdefDirectoryMapAsync(asmdefFilePaths, progressCounter, ct);

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -236,6 +236,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 legacyAssemblyDirectories,
                 new HashSet<string>(StringComparer.Ordinal),
                 new Dictionary<string, string[]>(StringComparer.Ordinal),
+                new Dictionary<string, string[]>(StringComparer.Ordinal),
                 toolContractsReferenceAssemblyDirectories,
                 applicationReferenceAssemblyDirectories,
                 domainReferenceAssemblyDirectories);
@@ -493,11 +494,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 inventory.AsmrefFilePaths);
             List<MigrationFileChange> changes = new();
             int replacementCount = 0;
+            string[] legacyToolInfoAliases = GetAllAssemblyScopedLegacyToolInfoAliases(assemblyUsage);
 
             foreach (string csharpFilePath in inventory.CSharpFilePaths)
             {
                 string source = File.ReadAllText(csharpFilePath);
-                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source) &&
+                    !ThirdPartyToolMigrationRules.ContainsLegacyTypeAliasReference(source, legacyToolInfoAliases))
                 {
                     continue;
                 }
@@ -514,7 +517,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 {
                     legacyAssemblyAliases = Array.Empty<string>();
                 }
-
+                string[] legacyAssemblyToolInfoAliases;
+                if (!assemblyUsage.AssemblyScopedLegacyToolInfoAliasesByDirectory.TryGetValue(
+                        assemblyDirectory,
+                        out legacyAssemblyToolInfoAliases))
+                {
+                    legacyAssemblyToolInfoAliases = Array.Empty<string>();
+                }
                 bool hasLegacyAssemblySource =
                     assemblyUsage.AssemblyScopedLegacyDirectories.Contains(assemblyDirectory) &&
                     ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(source, legacyAssemblyAliases);
@@ -522,7 +531,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
                         source,
                         hasLegacyAssemblySource,
-                        legacyAssemblyAliases);
+                        legacyAssemblyAliases,
+                        legacyAssemblyToolInfoAliases);
                 if (!result.Changed)
                 {
                     continue;
@@ -606,6 +616,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             List<MigrationFileChange> changes = new();
             int replacementCount = 0;
+            string[] legacyToolInfoAliases = GetAllAssemblyScopedLegacyToolInfoAliases(assemblyUsage);
 
             foreach (string csharpFilePath in inventory.CSharpFilePaths)
             {
@@ -616,7 +627,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 string source = File.ReadAllText(csharpFilePath);
                 await progressCounter.ReportProcessedItemAsync(ct);
-                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
+                if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source) &&
+                    !ThirdPartyToolMigrationRules.ContainsLegacyTypeAliasReference(source, legacyToolInfoAliases))
                 {
                     continue;
                 }
@@ -633,7 +645,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 {
                     legacyAssemblyAliases = Array.Empty<string>();
                 }
-
+                string[] legacyAssemblyToolInfoAliases;
+                if (!assemblyUsage.AssemblyScopedLegacyToolInfoAliasesByDirectory.TryGetValue(
+                        assemblyDirectory,
+                        out legacyAssemblyToolInfoAliases))
+                {
+                    legacyAssemblyToolInfoAliases = Array.Empty<string>();
+                }
                 bool hasLegacyAssemblySource =
                     assemblyUsage.AssemblyScopedLegacyDirectories.Contains(assemblyDirectory) &&
                     ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(source, legacyAssemblyAliases);
@@ -641,7 +659,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
                         source,
                         hasLegacyAssemblySource,
-                        legacyAssemblyAliases);
+                        legacyAssemblyAliases,
+                        legacyAssemblyToolInfoAliases);
                 if (!result.Changed)
                 {
                     continue;
@@ -772,6 +791,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             HashSet<string> assemblyScopedCurrentDomainDirectories = new(StringComparer.Ordinal);
             Dictionary<string, HashSet<string>> assemblyScopedLegacyAliasesByDirectory =
                 new(StringComparer.Ordinal);
+            Dictionary<string, HashSet<string>> assemblyScopedLegacyToolInfoAliasesByDirectory =
+                new(StringComparer.Ordinal);
             HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> domainMetadataAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> toolContractsReferenceAssemblyDirectories = new(StringComparer.Ordinal);
@@ -804,6 +825,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         assemblyScopedLegacyAliasesByDirectory,
                         assemblyDirectory,
                         ThirdPartyToolMigrationRules.GetLegacyGlobalNamespaceAliases(source));
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyGlobalToolInfoTypeAlias(source))
+                {
+                    assemblyScopedLegacyDirectories.Add(assemblyDirectory);
+                    AddAssemblyScopedLegacyAliases(
+                        assemblyScopedLegacyToolInfoAliasesByDirectory,
+                        assemblyDirectory,
+                        ThirdPartyToolMigrationRules.GetLegacyGlobalToolInfoTypeAliases(source));
                 }
 
                 if (ThirdPartyToolMigrationRules.ContainsCurrentDomainGlobalUsing(source))
@@ -912,6 +942,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 legacyAssemblyDirectories,
                 assemblyScopedLegacyDirectories,
                 CreateAssemblyScopedLegacyAliasesByDirectory(assemblyScopedLegacyAliasesByDirectory),
+                CreateAssemblyScopedLegacyAliasesByDirectory(assemblyScopedLegacyToolInfoAliasesByDirectory),
                 toolContractsReferenceAssemblyDirectories,
                 applicationReferenceAssemblyDirectories,
                 domainReferenceAssemblyDirectories);
@@ -947,6 +978,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             HashSet<string> assemblyScopedCurrentDomainDirectories = new(StringComparer.Ordinal);
             Dictionary<string, HashSet<string>> assemblyScopedLegacyAliasesByDirectory =
                 new(StringComparer.Ordinal);
+            Dictionary<string, HashSet<string>> assemblyScopedLegacyToolInfoAliasesByDirectory =
+                new(StringComparer.Ordinal);
             HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> domainMetadataAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> toolContractsReferenceAssemblyDirectories = new(StringComparer.Ordinal);
@@ -963,6 +996,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         legacyAssemblyDirectories,
                         assemblyScopedLegacyDirectories,
                         assemblyScopedLegacyAliasesByDirectory,
+                        assemblyScopedLegacyToolInfoAliasesByDirectory,
                         toolContractsReferenceAssemblyDirectories,
                         applicationReferenceAssemblyDirectories,
                         domainReferenceAssemblyDirectories);
@@ -993,6 +1027,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         assemblyScopedLegacyAliasesByDirectory,
                         assemblyDirectory,
                         ThirdPartyToolMigrationRules.GetLegacyGlobalNamespaceAliases(source));
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsLegacyGlobalToolInfoTypeAlias(source))
+                {
+                    assemblyScopedLegacyDirectories.Add(assemblyDirectory);
+                    AddAssemblyScopedLegacyAliases(
+                        assemblyScopedLegacyToolInfoAliasesByDirectory,
+                        assemblyDirectory,
+                        ThirdPartyToolMigrationRules.GetLegacyGlobalToolInfoTypeAliases(source));
                 }
 
                 if (ThirdPartyToolMigrationRules.ContainsCurrentDomainGlobalUsing(source))
@@ -1037,6 +1080,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         legacyAssemblyDirectories,
                         assemblyScopedLegacyDirectories,
                         assemblyScopedLegacyAliasesByDirectory,
+                        assemblyScopedLegacyToolInfoAliasesByDirectory,
                         toolContractsReferenceAssemblyDirectories,
                         applicationReferenceAssemblyDirectories,
                         domainReferenceAssemblyDirectories);
@@ -1115,6 +1159,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 legacyAssemblyDirectories,
                 assemblyScopedLegacyDirectories,
                 assemblyScopedLegacyAliasesByDirectory,
+                assemblyScopedLegacyToolInfoAliasesByDirectory,
                 toolContractsReferenceAssemblyDirectories,
                 applicationReferenceAssemblyDirectories,
                 domainReferenceAssemblyDirectories);
@@ -1126,6 +1171,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             HashSet<string> legacyAssemblyDirectories,
             HashSet<string> assemblyScopedLegacyDirectories,
             Dictionary<string, HashSet<string>> assemblyScopedLegacyAliasesByDirectory,
+            Dictionary<string, HashSet<string>> assemblyScopedLegacyToolInfoAliasesByDirectory,
             HashSet<string> toolContractsReferenceAssemblyDirectories,
             HashSet<string> applicationReferenceAssemblyDirectories,
             HashSet<string> domainReferenceAssemblyDirectories)
@@ -1142,6 +1188,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 assemblyScopedLegacyAliasesByDirectory != null,
                 "assemblyScopedLegacyAliasesByDirectory must not be null");
             Debug.Assert(
+                assemblyScopedLegacyToolInfoAliasesByDirectory != null,
+                "assemblyScopedLegacyToolInfoAliasesByDirectory must not be null");
+            Debug.Assert(
                 toolContractsReferenceAssemblyDirectories != null,
                 "toolContractsReferenceAssemblyDirectories must not be null");
             Debug.Assert(
@@ -1157,6 +1206,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 legacyAssemblyDirectories,
                 assemblyScopedLegacyDirectories,
                 CreateAssemblyScopedLegacyAliasesByDirectory(assemblyScopedLegacyAliasesByDirectory),
+                CreateAssemblyScopedLegacyAliasesByDirectory(assemblyScopedLegacyToolInfoAliasesByDirectory),
                 toolContractsReferenceAssemblyDirectories,
                 applicationReferenceAssemblyDirectories,
                 domainReferenceAssemblyDirectories);
@@ -1202,6 +1252,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return result;
+        }
+
+        private static string[] GetAllAssemblyScopedLegacyToolInfoAliases(MigrationAssemblyUsage assemblyUsage)
+        {
+            return assemblyUsage.AssemblyScopedLegacyToolInfoAliasesByDirectory.Values
+                .SelectMany(aliases => aliases)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
         }
 
         private static List<AssemblyReferenceDirectory> CreateAssemblyReferenceDirectories(
@@ -1640,6 +1698,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 HashSet<string> legacyAssemblyDirectories,
                 HashSet<string> assemblyScopedLegacyDirectories,
                 Dictionary<string, string[]> assemblyScopedLegacyAliasesByDirectory,
+                Dictionary<string, string[]> assemblyScopedLegacyToolInfoAliasesByDirectory,
                 HashSet<string> toolContractsReferenceAssemblyDirectories,
                 HashSet<string> applicationReferenceAssemblyDirectories,
                 HashSet<string> domainReferenceAssemblyDirectories)
@@ -1655,6 +1714,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 Debug.Assert(
                     assemblyScopedLegacyAliasesByDirectory != null,
                     "assemblyScopedLegacyAliasesByDirectory must not be null");
+                Debug.Assert(
+                    assemblyScopedLegacyToolInfoAliasesByDirectory != null,
+                    "assemblyScopedLegacyToolInfoAliasesByDirectory must not be null");
                 Debug.Assert(
                     toolContractsReferenceAssemblyDirectories != null,
                     "toolContractsReferenceAssemblyDirectories must not be null");
@@ -1672,6 +1734,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     new HashSet<string>(StringComparer.Ordinal);
                 AssemblyScopedLegacyAliasesByDirectory = assemblyScopedLegacyAliasesByDirectory ??
                     new Dictionary<string, string[]>(StringComparer.Ordinal);
+                AssemblyScopedLegacyToolInfoAliasesByDirectory = assemblyScopedLegacyToolInfoAliasesByDirectory ??
+                    new Dictionary<string, string[]>(StringComparer.Ordinal);
                 ToolContractsReferenceAssemblyDirectories = toolContractsReferenceAssemblyDirectories ??
                     new HashSet<string>(StringComparer.Ordinal);
                 ApplicationReferenceAssemblyDirectories = applicationReferenceAssemblyDirectories ??
@@ -1685,6 +1749,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             public HashSet<string> LegacyAssemblyDirectories { get; }
             public HashSet<string> AssemblyScopedLegacyDirectories { get; }
             public Dictionary<string, string[]> AssemblyScopedLegacyAliasesByDirectory { get; }
+            public Dictionary<string, string[]> AssemblyScopedLegacyToolInfoAliasesByDirectory { get; }
             public HashSet<string> ToolContractsReferenceAssemblyDirectories { get; }
             public HashSet<string> ApplicationReferenceAssemblyDirectories { get; }
             public HashSet<string> DomainReferenceAssemblyDirectories { get; }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -13,6 +13,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class ThirdPartyToolMigrationFileService : IThirdPartyToolMigrationPort
     {
+        private const string ImplicitEditorAssemblyDirectoryName = "__UnityCliLoopImplicitEditorAssembly";
+        private const string ImplicitRuntimeAssemblyDirectoryName = "__UnityCliLoopImplicitRuntimeAssembly";
+
         public ThirdPartyToolMigrationPreview PreviewMigration(string projectRoot)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
@@ -189,13 +192,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static string FindNearestAssemblyDirectory(
             string csharpFilePath,
             List<string> asmdefDirectories,
-            string fallbackAssemblyDirectory)
+            string projectRoot)
         {
             Debug.Assert(!string.IsNullOrEmpty(csharpFilePath), "csharpFilePath must not be null or empty");
             Debug.Assert(asmdefDirectories != null, "asmdefDirectories must not be null");
-            Debug.Assert(
-                !string.IsNullOrEmpty(fallbackAssemblyDirectory),
-                "fallbackAssemblyDirectory must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
             string csharpDirectory = Path.GetDirectoryName(csharpFilePath) ?? string.Empty;
             foreach (string asmdefDirectory in asmdefDirectories)
@@ -206,7 +207,36 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
-            return fallbackAssemblyDirectory;
+            return GetImplicitAssemblyDirectory(csharpFilePath, projectRoot);
+        }
+
+        private static string GetImplicitAssemblyDirectory(string csharpFilePath, string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(csharpFilePath), "csharpFilePath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            string implicitAssemblyDirectoryName = IsEditorAssemblyPath(csharpFilePath, projectRoot)
+                ? ImplicitEditorAssemblyDirectoryName
+                : ImplicitRuntimeAssemblyDirectoryName;
+            return Path.Combine(projectRoot, implicitAssemblyDirectoryName);
+        }
+
+        private static bool IsEditorAssemblyPath(string csharpFilePath, string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(csharpFilePath), "csharpFilePath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            string relativePath = csharpFilePath.StartsWith(projectRoot, StringComparison.Ordinal)
+                ? csharpFilePath.Substring(projectRoot.Length)
+                : csharpFilePath;
+            char[] separators =
+            {
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar
+            };
+            string[] pathSegments = relativePath.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            return pathSegments.Any(
+                pathSegment => string.Equals(pathSegment, "Editor", StringComparison.OrdinalIgnoreCase));
         }
 
         private static bool IsSameOrChildPath(string childPath, string parentPath)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -73,13 +73,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     assemblyUsage.AsmdefDirectories,
                     assemblyUsage.AssemblyReferenceDirectories,
                     projectRoot);
+                string[] legacyAssemblyAliases;
+                if (!assemblyUsage.AssemblyScopedLegacyAliasesByDirectory.TryGetValue(
+                        assemblyDirectory,
+                        out legacyAssemblyAliases))
+                {
+                    legacyAssemblyAliases = Array.Empty<string>();
+                }
+
                 bool hasLegacyAssemblySource =
                     assemblyUsage.AssemblyScopedLegacyDirectories.Contains(assemblyDirectory) &&
-                    ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(source);
+                    ThirdPartyToolMigrationRules.ContainsLegacyAssemblyScopedApi(source, legacyAssemblyAliases);
                 ThirdPartyToolMigrationContentResult result =
                     ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
                         source,
-                        hasLegacyAssemblySource);
+                        hasLegacyAssemblySource,
+                        legacyAssemblyAliases);
                 if (!result.Changed)
                 {
                     continue;
@@ -171,6 +180,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 CreateAssemblyReferenceDirectories(asmdefFilePaths, asmrefFilePaths);
             HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> assemblyScopedLegacyDirectories = new(StringComparer.Ordinal);
+            Dictionary<string, HashSet<string>> assemblyScopedLegacyAliasesByDirectory =
+                new(StringComparer.Ordinal);
             HashSet<string> registrarAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> domainMetadataAssemblyDirectories = new(StringComparer.Ordinal);
             HashSet<string> applicationReferenceAssemblyDirectories = new(StringComparer.Ordinal);
@@ -193,6 +204,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (ThirdPartyToolMigrationRules.ContainsLegacyGlobalUsing(source))
                 {
                     assemblyScopedLegacyDirectories.Add(assemblyDirectory);
+                    AddAssemblyScopedLegacyAliases(
+                        assemblyScopedLegacyAliasesByDirectory,
+                        assemblyDirectory,
+                        ThirdPartyToolMigrationRules.GetLegacyGlobalNamespaceAliases(source));
                 }
 
                 if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source))
@@ -227,8 +242,51 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 assemblyReferenceDirectories,
                 legacyAssemblyDirectories,
                 assemblyScopedLegacyDirectories,
+                CreateAssemblyScopedLegacyAliasesByDirectory(assemblyScopedLegacyAliasesByDirectory),
                 applicationReferenceAssemblyDirectories,
                 domainReferenceAssemblyDirectories);
+        }
+
+        private static void AddAssemblyScopedLegacyAliases(
+            Dictionary<string, HashSet<string>> aliasesByDirectory,
+            string assemblyDirectory,
+            string[] aliases)
+        {
+            Debug.Assert(aliasesByDirectory != null, "aliasesByDirectory must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyDirectory), "assemblyDirectory must not be null or empty");
+            Debug.Assert(aliases != null, "aliases must not be null");
+
+            if (aliases.Length == 0)
+            {
+                return;
+            }
+
+            if (!aliasesByDirectory.TryGetValue(assemblyDirectory, out HashSet<string> aliasSet))
+            {
+                aliasSet = new HashSet<string>(StringComparer.Ordinal);
+                aliasesByDirectory.Add(assemblyDirectory, aliasSet);
+            }
+
+            foreach (string alias in aliases)
+            {
+                aliasSet.Add(alias);
+            }
+        }
+
+        private static Dictionary<string, string[]> CreateAssemblyScopedLegacyAliasesByDirectory(
+            Dictionary<string, HashSet<string>> aliasesByDirectory)
+        {
+            Debug.Assert(aliasesByDirectory != null, "aliasesByDirectory must not be null");
+
+            Dictionary<string, string[]> result = new(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, HashSet<string>> aliasesForDirectory in aliasesByDirectory)
+            {
+                result.Add(
+                    aliasesForDirectory.Key,
+                    aliasesForDirectory.Value.OrderBy(alias => alias, StringComparer.Ordinal).ToArray());
+            }
+
+            return result;
         }
 
         private static List<AssemblyReferenceDirectory> CreateAssemblyReferenceDirectories(
@@ -517,6 +575,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 List<AssemblyReferenceDirectory> assemblyReferenceDirectories,
                 HashSet<string> legacyAssemblyDirectories,
                 HashSet<string> assemblyScopedLegacyDirectories,
+                Dictionary<string, string[]> assemblyScopedLegacyAliasesByDirectory,
                 HashSet<string> applicationReferenceAssemblyDirectories,
                 HashSet<string> domainReferenceAssemblyDirectories)
             {
@@ -529,6 +588,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     assemblyScopedLegacyDirectories != null,
                     "assemblyScopedLegacyDirectories must not be null");
                 Debug.Assert(
+                    assemblyScopedLegacyAliasesByDirectory != null,
+                    "assemblyScopedLegacyAliasesByDirectory must not be null");
+                Debug.Assert(
                     applicationReferenceAssemblyDirectories != null,
                     "applicationReferenceAssemblyDirectories must not be null");
                 Debug.Assert(
@@ -540,6 +602,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 LegacyAssemblyDirectories = legacyAssemblyDirectories ?? new HashSet<string>(StringComparer.Ordinal);
                 AssemblyScopedLegacyDirectories = assemblyScopedLegacyDirectories ??
                     new HashSet<string>(StringComparer.Ordinal);
+                AssemblyScopedLegacyAliasesByDirectory = assemblyScopedLegacyAliasesByDirectory ??
+                    new Dictionary<string, string[]>(StringComparer.Ordinal);
                 ApplicationReferenceAssemblyDirectories = applicationReferenceAssemblyDirectories ??
                     new HashSet<string>(StringComparer.Ordinal);
                 DomainReferenceAssemblyDirectories = domainReferenceAssemblyDirectories ??
@@ -550,6 +614,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             public List<AssemblyReferenceDirectory> AssemblyReferenceDirectories { get; }
             public HashSet<string> LegacyAssemblyDirectories { get; }
             public HashSet<string> AssemblyScopedLegacyDirectories { get; }
+            public Dictionary<string, string[]> AssemblyScopedLegacyAliasesByDirectory { get; }
             public HashSet<string> ApplicationReferenceAssemblyDirectories { get; }
             public HashSet<string> DomainReferenceAssemblyDirectories { get; }
         }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -292,6 +292,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 applicationReferenceAssemblyDirectories.Add(assemblyDirectory);
             }
 
+            if (ThirdPartyToolMigrationRules.ContainsRegistrarDomainReturnApi(source))
+            {
+                domainReferenceAssemblyDirectories.Add(assemblyDirectory);
+            }
+
             if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApi(source) ||
                 ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApiForAssembly(
                     source,
@@ -812,6 +817,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     registrarAssemblyDirectories.Add(assemblyDirectory);
                 }
 
+                if (ThirdPartyToolMigrationRules.ContainsRegistrarDomainReturnApi(source))
+                {
+                    domainReferenceAssemblyDirectories.Add(assemblyDirectory);
+                }
+
                 if (ThirdPartyToolMigrationRules.ContainsCurrentToolContractsApi(source))
                 {
                     toolContractsReferenceAssemblyDirectories.Add(assemblyDirectory);
@@ -865,6 +875,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         legacyAssemblyAliases))
                 {
                     registrarAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsRegistrarDomainReturnApiForAssembly(
+                        source,
+                        assemblyScopedLegacyDirectories.Contains(assemblyDirectory),
+                        legacyAssemblyAliases))
+                {
+                    domainReferenceAssemblyDirectories.Add(assemblyDirectory);
                 }
 
                 if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApiForAssembly(
@@ -988,6 +1006,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     registrarAssemblyDirectories.Add(assemblyDirectory);
                 }
 
+                if (ThirdPartyToolMigrationRules.ContainsRegistrarDomainReturnApi(source))
+                {
+                    domainReferenceAssemblyDirectories.Add(assemblyDirectory);
+                }
+
                 if (ThirdPartyToolMigrationRules.ContainsCurrentToolContractsApi(source))
                 {
                     toolContractsReferenceAssemblyDirectories.Add(assemblyDirectory);
@@ -1055,6 +1078,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         legacyAssemblyAliases))
                 {
                     registrarAssemblyDirectories.Add(assemblyDirectory);
+                }
+
+                if (ThirdPartyToolMigrationRules.ContainsRegistrarDomainReturnApiForAssembly(
+                        source,
+                        assemblyScopedLegacyDirectories.Contains(assemblyDirectory),
+                        legacyAssemblyAliases))
+                {
+                    domainReferenceAssemblyDirectories.Add(assemblyDirectory);
                 }
 
                 if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApiForAssembly(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -82,13 +82,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 throw new DirectoryNotFoundException(normalizedProjectRoot);
             }
 
-            string assetsDirectory = Path.Combine(normalizedProjectRoot, "Assets");
-            if (!Directory.Exists(assetsDirectory))
+            if (!Directory.Exists(Path.Combine(normalizedProjectRoot, "Assets")))
             {
                 return false;
             }
 
-            return await FindFirstMigrationTargetAsync(assetsDirectory, ct);
+            return await HasMigrationTargetAsync(normalizedProjectRoot, ct);
         }
 
         public ThirdPartyToolMigrationResult ApplyMigration(string projectRoot)
@@ -119,76 +118,125 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        private static async Task<bool> FindFirstMigrationTargetAsync(string assetsDirectory, CancellationToken ct)
+        private static async Task<bool> HasMigrationTargetAsync(string projectRoot, CancellationToken ct)
         {
-            Debug.Assert(!string.IsNullOrEmpty(assetsDirectory), "assetsDirectory must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            Stack<string> pendingDirectories = new();
-            pendingDirectories.Push(assetsDirectory);
+            ProjectFileInventory inventory = await ProjectFileInventory.CreateAsync(
+                projectRoot,
+                new Progress<ThirdPartyToolMigrationProgress>(),
+                ct);
+            if (ct.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            bool hasCurrentAssemblyReferenceCandidate = false;
             int inspectedEntryCount = 0;
-
-            while (pendingDirectories.Count > 0)
+            foreach (string csharpFilePath in inventory.CSharpFilePaths)
             {
                 if (ct.IsCancellationRequested)
                 {
                     return false;
                 }
 
-                string directoryPath = pendingDirectories.Pop();
-                foreach (string filePath in Directory.EnumerateFiles(directoryPath))
+                string source = File.ReadAllText(csharpFilePath);
+                if (ContainsFastCSharpMigrationTarget(source))
                 {
-                    if (ct.IsCancellationRequested)
-                    {
-                        return false;
-                    }
-
-                    if (ContainsFastMigrationTarget(filePath))
-                    {
-                        return true;
-                    }
-
-                    inspectedEntryCount++;
-                    if (inspectedEntryCount % PreviewYieldBatchSize == 0)
-                    {
-                        await Task.Yield();
-                    }
+                    return true;
                 }
 
-                foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
+                hasCurrentAssemblyReferenceCandidate |=
+                    ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source);
+                inspectedEntryCount++;
+                if (inspectedEntryCount % PreviewYieldBatchSize == 0)
                 {
-                    if (ShouldExcludeFastScanDirectory(childDirectoryPath))
-                    {
-                        continue;
-                    }
+                    await Task.Yield();
+                }
+            }
 
-                    pendingDirectories.Push(childDirectoryPath);
-                    inspectedEntryCount++;
-                    if (inspectedEntryCount % PreviewYieldBatchSize == 0)
-                    {
-                        await Task.Yield();
-                    }
+            foreach (string asmdefFilePath in inventory.AsmdefFilePaths)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                string source = File.ReadAllText(asmdefFilePath);
+                if (ContainsFastAsmdefMigrationTarget(source))
+                {
+                    return true;
+                }
+
+                inspectedEntryCount++;
+                if (inspectedEntryCount % PreviewYieldBatchSize == 0)
+                {
+                    await Task.Yield();
+                }
+            }
+
+            if (!hasCurrentAssemblyReferenceCandidate)
+            {
+                return false;
+            }
+
+            MigrationProgressCounter progressCounter = new(
+                GetPreviewWorkItemCount(inventory),
+                new Progress<ThirdPartyToolMigrationProgress>());
+            MigrationAssemblyUsage assemblyUsage = await FindMigrationAssemblyUsageAsync(
+                projectRoot,
+                inventory.CSharpFilePaths,
+                inventory.AsmdefFilePaths,
+                inventory.AsmrefFilePaths,
+                progressCounter,
+                ct);
+            if (ct.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            foreach (string asmdefFilePath in inventory.AsmdefFilePaths)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                if (ContainsAsmdefMigrationTarget(asmdefFilePath, projectRoot, assemblyUsage))
+                {
+                    return true;
                 }
             }
 
             return false;
         }
 
-        private static bool ContainsFastMigrationTarget(string filePath)
+        private static bool ContainsAsmdefMigrationTarget(
+            string asmdefFilePath,
+            string projectRoot,
+            MigrationAssemblyUsage assemblyUsage)
         {
-            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(asmdefFilePath), "asmdefFilePath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            string extension = Path.GetExtension(filePath);
-            if (string.Equals(extension, ".cs", StringComparison.OrdinalIgnoreCase))
-            {
-                return ContainsFastCSharpMigrationTarget(File.ReadAllText(filePath));
-            }
+            string source = File.ReadAllText(asmdefFilePath);
+            string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
+            bool hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
+            bool requiresToolContractsReference =
+                assemblyUsage.ToolContractsReferenceAssemblyDirectories.Contains(asmdefDirectory);
+            bool requiresApplicationReference =
+                assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
+            bool requiresDomainReference =
+                assemblyUsage.DomainReferenceAssemblyDirectories.Contains(asmdefDirectory);
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource,
+                    requiresToolContractsReference,
+                    requiresApplicationReference,
+                    requiresDomainReference);
 
-            if (string.Equals(extension, ".asmdef", StringComparison.OrdinalIgnoreCase))
-            {
-                return ContainsFastAsmdefMigrationTarget(File.ReadAllText(filePath));
-            }
-
-            return false;
+            return result.Changed;
         }
 
         private static bool ContainsFastCSharpMigrationTarget(string source)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -268,6 +268,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     domainMetadataAssemblyDirectories.Add(assemblyDirectory);
                 }
 
+                if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApiForAssembly(
+                        source,
+                        assemblyScopedLegacyDirectories.Contains(assemblyDirectory),
+                        legacyAssemblyAliases))
+                {
+                    registrarAssemblyDirectories.Add(assemblyDirectory);
+                }
+
                 if (ThirdPartyToolMigrationRules.ContainsCurrentDomainMetadataApiForAssembly(
                         source,
                         assemblyScopedCurrentDomainDirectories.Contains(assemblyDirectory)))

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -49,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             ProjectFileInventory inventory = ProjectFileInventory.Create(projectRoot);
-            HashSet<string> legacyAssemblyDirectories = FindLegacyAssemblyDirectories(
+            MigrationAssemblyUsage assemblyUsage = FindMigrationAssemblyUsage(
                 inventory.CSharpFilePaths,
                 inventory.AsmdefFilePaths);
             List<MigrationFileChange> changes = new();
@@ -73,9 +73,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 string source = File.ReadAllText(asmdefFilePath);
                 string asmdefDirectory = Path.GetDirectoryName(asmdefFilePath) ?? projectRoot;
-                bool hasLegacyCSharpSource = legacyAssemblyDirectories.Contains(asmdefDirectory);
+                bool hasLegacyCSharpSource = assemblyUsage.LegacyAssemblyDirectories.Contains(asmdefDirectory);
+                bool requiresApplicationReference =
+                    assemblyUsage.ApplicationReferenceAssemblyDirectories.Contains(asmdefDirectory);
                 ThirdPartyToolMigrationContentResult result =
-                    ThirdPartyToolMigrationRules.MigrateAsmdefSource(source, hasLegacyCSharpSource);
+                    ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                        source,
+                        hasLegacyCSharpSource,
+                        requiresApplicationReference);
                 if (!result.Changed)
                 {
                     continue;
@@ -88,7 +93,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return new MigrationPlan(changes, replacementCount);
         }
 
-        private static HashSet<string> FindLegacyAssemblyDirectories(
+        private static MigrationAssemblyUsage FindMigrationAssemblyUsage(
             List<string> csharpFilePaths,
             List<string> asmdefFilePaths)
         {
@@ -101,6 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 .OrderByDescending(path => path.Length)
                 .ToList();
             HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
+            HashSet<string> applicationReferenceAssemblyDirectories = new(StringComparer.Ordinal);
 
             foreach (string csharpFilePath in csharpFilePaths)
             {
@@ -114,10 +120,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (!string.IsNullOrEmpty(assemblyDirectory))
                 {
                     legacyAssemblyDirectories.Add(assemblyDirectory);
+                    if (ThirdPartyToolMigrationRules.ContainsLegacyRegistrarApi(source))
+                    {
+                        applicationReferenceAssemblyDirectories.Add(assemblyDirectory);
+                    }
                 }
             }
 
-            return legacyAssemblyDirectories;
+            return new MigrationAssemblyUsage(
+                legacyAssemblyDirectories,
+                applicationReferenceAssemblyDirectories);
         }
 
         private static string FindNearestAssemblyDirectory(
@@ -187,6 +199,26 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             public List<MigrationFileChange> Changes { get; }
             public int ReplacementCount { get; }
             public List<string> ChangedFilePaths { get; }
+        }
+
+        private readonly struct MigrationAssemblyUsage
+        {
+            public MigrationAssemblyUsage(
+                HashSet<string> legacyAssemblyDirectories,
+                HashSet<string> applicationReferenceAssemblyDirectories)
+            {
+                Debug.Assert(legacyAssemblyDirectories != null, "legacyAssemblyDirectories must not be null");
+                Debug.Assert(
+                    applicationReferenceAssemblyDirectories != null,
+                    "applicationReferenceAssemblyDirectories must not be null");
+
+                LegacyAssemblyDirectories = legacyAssemblyDirectories ?? new HashSet<string>(StringComparer.Ordinal);
+                ApplicationReferenceAssemblyDirectories = applicationReferenceAssemblyDirectories ??
+                    new HashSet<string>(StringComparer.Ordinal);
+            }
+
+            public HashSet<string> LegacyAssemblyDirectories { get; }
+            public HashSet<string> ApplicationReferenceAssemblyDirectories { get; }
         }
 
         private sealed class ProjectFileInventory

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -1277,7 +1277,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new();
             foreach (string asmrefFilePath in asmrefFilePaths)
             {
-                if (!TryReadJsonObject(asmrefFilePath, out JObject asmref))
+                if (!TryReadJsonObjectFromFile(asmrefFilePath, out JObject asmref))
                 {
                     continue;
                 }
@@ -1336,7 +1336,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         .ToList();
                 }
 
-                if (!TryReadJsonObject(asmrefFilePath, out JObject asmref))
+                if (!TryReadJsonObjectFromFile(asmrefFilePath, out JObject asmref))
                 {
                     await progressCounter.ReportProcessedItemAsync(ct);
                     continue;
@@ -1382,7 +1382,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     continue;
                 }
 
-                if (!TryReadJsonObject(asmdefFilePath, out JObject asmdef))
+                if (!TryReadJsonObjectFromFile(asmdefFilePath, out JObject asmdef))
                 {
                     continue;
                 }
@@ -1421,7 +1421,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     continue;
                 }
 
-                if (!TryReadJsonObject(asmdefFilePath, out JObject asmdef))
+                if (!TryReadJsonObjectFromFile(asmdefFilePath, out JObject asmdef))
                 {
                     await progressCounter.ReportProcessedItemAsync(ct);
                     continue;
@@ -1439,22 +1439,40 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return asmdefDirectoriesByReference;
         }
 
-        private static bool TryReadJsonObject(string filePath, out JObject jsonObject)
+        private static bool TryReadJsonObjectFromFile(string filePath, out JObject jsonObject)
+        {
+            return TryReadJsonObjectForMigration(filePath, File.ReadAllText, out jsonObject);
+        }
+
+        internal static bool TryReadJsonObjectForMigration(
+            string filePath,
+            Func<string, string> readAllText,
+            out JObject jsonObject)
         {
             Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+            Debug.Assert(readAllText != null, "readAllText must not be null");
 
             try
             {
-                jsonObject = JObject.Parse(File.ReadAllText(filePath));
+                jsonObject = JObject.Parse(readAllText(filePath));
                 return true;
             }
-            catch (JsonException ex)
+            catch (Exception ex) when (IsSkippableAssemblyJsonReadException(ex))
             {
                 UnityEngine.Debug.LogWarning(
-                    $"[UnityCliLoop] Skipping malformed assembly definition JSON at {filePath}: {ex.Message}");
+                    $"[UnityCliLoop] Skipping unreadable or malformed assembly JSON at {filePath}: {ex.Message}");
                 jsonObject = null;
                 return false;
             }
+        }
+
+        private static bool IsSkippableAssemblyJsonReadException(Exception ex)
+        {
+            Debug.Assert(ex != null, "ex must not be null");
+
+            return ex is JsonException ||
+                   ex is IOException ||
+                   ex is UnauthorizedAccessException;
         }
 
         private static void AddAsmdefDirectoryReference(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -58,11 +58,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(progress != null, "progress must not be null");
 
             string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
-            if (TryGetCachedPreview(normalizedProjectRoot, out ThirdPartyToolMigrationPreview cachedPreview))
-            {
-                return cachedPreview;
-            }
-
             MigrationPlan plan = await CreateMigrationPlanAsync(normalizedProjectRoot, progress, ct);
             if (ct.IsCancellationRequested)
             {

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -224,10 +224,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             foreach (string registrarAssemblyDirectory in registrarAssemblyDirectories)
             {
-                if (legacyAssemblyDirectories.Contains(registrarAssemblyDirectory))
-                {
-                    applicationReferenceAssemblyDirectories.Add(registrarAssemblyDirectory);
-                }
+                applicationReferenceAssemblyDirectories.Add(registrarAssemblyDirectory);
             }
 
             foreach (string domainMetadataAssemblyDirectory in domainMetadataAssemblyDirectories)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs.meta
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8dee7da723ba64861ba649d28577d373
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -37,11 +37,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             "Builds"
         };
 
-        private static readonly Regex LegacyToolAttributeWithArgumentsRegex =
-            new(@"\[\s*McpTool(?:Attribute)?\s*\((?<arguments>[\s\S]*?)\)\s*\]", RegexOptions.Compiled);
+        private static readonly Regex LegacyNamespaceRegex =
+            new(Regex.Escape(LegacyNamespace), RegexOptions.Compiled);
 
-        private static readonly Regex LegacyToolAttributeRegex =
-            new(@"\[\s*McpTool(?:Attribute)?\s*\]", RegexOptions.Compiled);
+        private static readonly Regex LegacyToolAttributeListRegex =
+            new(@"\[(?<attributes>[^\]]*\bMcpTool(?:Attribute)?\b[^\]]*)\]", RegexOptions.Compiled);
+
+        private static readonly Regex LegacyToolAttributeEntryRegex =
+            new(@"^\s*McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$", RegexOptions.Compiled);
 
         private static readonly ReplacementRule[] CSharpReplacementRules =
         {
@@ -60,25 +63,24 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             string migratedContent = source;
+            bool shouldApplyContractRenames = ContainsLegacyToolMigrationMarker(source);
             int replacementCount = 0;
             migratedContent = ReplaceRegexInCode(
                 migratedContent,
-                LegacyToolAttributeWithArgumentsRegex,
-                MigrateLegacyToolAttributeWithArguments,
-                ref replacementCount);
-            migratedContent = ReplaceRegexInCode(
-                migratedContent,
-                LegacyToolAttributeRegex,
-                _ => "[UnityCliLoopTool]",
+                LegacyToolAttributeListRegex,
+                MigrateLegacyToolAttributeList,
                 ref replacementCount);
 
-            foreach (ReplacementRule rule in CSharpReplacementRules)
+            if (shouldApplyContractRenames)
             {
-                migratedContent = ReplaceRegexInCode(
-                    migratedContent,
-                    rule.PatternRegex,
-                    _ => rule.Replacement,
-                    ref replacementCount);
+                foreach (ReplacementRule rule in CSharpReplacementRules)
+                {
+                    migratedContent = ReplaceRegexInCode(
+                        migratedContent,
+                        rule.PatternRegex,
+                        _ => rule.Replacement,
+                        ref replacementCount);
+                }
             }
 
             return new ThirdPartyToolMigrationContentResult(
@@ -134,10 +136,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(source != null, "source must not be null");
 
-            if (RegexMatchesCode(source, LegacyToolAttributeWithArgumentsRegex)) return true;
-            if (RegexMatchesCode(source, LegacyToolAttributeRegex)) return true;
-
-            return CSharpReplacementRules.Any(rule => RegexMatchesCode(source, rule.PatternRegex));
+            return ContainsLegacyToolMigrationMarker(source);
         }
 
         internal static bool IsExcludedDirectoryName(string directoryName)
@@ -174,18 +173,52 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return reference;
         }
 
-        private static string MigrateLegacyToolAttributeWithArguments(Match match)
+        private static string MigrateLegacyToolAttributeList(Match match)
         {
             Debug.Assert(match != null, "match must not be null");
 
-            string argumentsSource = match.Groups["arguments"].Value;
-            string[] migratedArguments = GetMigratedSupportedAttributeArguments(argumentsSource);
-            if (migratedArguments.Length == 0)
+            string attributesSource = match.Groups["attributes"].Value;
+            string[] attributes = SplitAttributeArguments(attributesSource);
+            List<string> migratedAttributes = new();
+            bool changed = false;
+            foreach (string attribute in attributes)
             {
-                return "[UnityCliLoopTool]";
+                string trimmedAttribute = attribute.Trim();
+                if (TryMigrateLegacyToolAttributeEntry(trimmedAttribute, out string migratedAttribute))
+                {
+                    migratedAttributes.Add(migratedAttribute);
+                    changed = true;
+                    continue;
+                }
+
+                migratedAttributes.Add(trimmedAttribute);
             }
 
-            return $"[UnityCliLoopTool({string.Join(", ", migratedArguments)})]";
+            if (!changed)
+            {
+                return match.Value;
+            }
+
+            return $"[{string.Join(", ", migratedAttributes)}]";
+        }
+
+        private static bool TryMigrateLegacyToolAttributeEntry(string attribute, out string migratedAttribute)
+        {
+            Debug.Assert(attribute != null, "attribute must not be null");
+
+            Match match = LegacyToolAttributeEntryRegex.Match(attribute);
+            if (!match.Success)
+            {
+                migratedAttribute = string.Empty;
+                return false;
+            }
+
+            string argumentsSource = match.Groups["arguments"].Value;
+            string[] migratedArguments = GetMigratedSupportedAttributeArguments(argumentsSource);
+            migratedAttribute = migratedArguments.Length == 0
+                ? "UnityCliLoopTool"
+                : $"UnityCliLoopTool({string.Join(", ", migratedArguments)})";
+            return true;
         }
 
         private static string[] GetMigratedSupportedAttributeArguments(string argumentsSource)
@@ -414,6 +447,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return false;
+        }
+
+        private static bool ContainsLegacyToolMigrationMarker(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            if (RegexMatchesCode(source, LegacyNamespaceRegex)) return true;
+
+            return RegexMatchesCode(source, LegacyToolAttributeListRegex);
         }
 
         private static bool StartsWith(string source, int startIndex, string value)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -255,8 +255,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             JObject asmdef = JObject.Parse(source);
-            JArray references = asmdef["references"] as JArray;
-            if (references == null)
+            JToken referencesToken = asmdef["references"];
+            JArray references = referencesToken == null ? new JArray() : referencesToken as JArray;
+            if (referencesToken != null && references == null)
             {
                 return new ThirdPartyToolMigrationContentResult(source, 0);
             }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -130,6 +130,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             new("SecuritySettings", CurrentSecuritySettingTypeName)
         };
 
+        private static readonly TypeReplacementRule[] DomainTypeReplacementRules =
+        {
+            new("ServiceResult", "ServiceResult"),
+            new("ToolSettingsCatalogItem", "ToolSettingsCatalogItem")
+        };
+
         private static readonly ReplacementRule[] CSharpReplacementRules =
         {
             new(
@@ -202,6 +208,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (shouldApplyContractRenames)
             {
+                migratedContent = ReplaceLegacyDomainTypeNamesInCode(
+                    migratedContent,
+                    legacyNamespaceAliases,
+                    ref replacementCount);
+
                 migratedContent = ReplaceLegacyContractTypeNamesInCode(
                     migratedContent,
                     legacyNamespaceAliases,
@@ -343,7 +354,26 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(source != null, "source must not be null");
 
-            return RegexMatchesCode(source, LegacyDomainMetadataRegex);
+            return RegexMatchesCode(source, LegacyDomainMetadataRegex) ||
+                ContainsLegacyDomainHelperApiForAssembly(
+                    source,
+                    hasLegacyAssemblySource: ContainsLegacyToolMigrationMarker(source),
+                    legacyAssemblyAliases: Array.Empty<string>());
+        }
+
+        internal static bool ContainsLegacyDomainHelperApiForAssembly(
+            string source,
+            bool hasLegacyAssemblySource,
+            string[] legacyAssemblyAliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
+
+            string[] legacyNamespaceAliases = GetCombinedLegacyNamespaceAliases(source, legacyAssemblyAliases);
+            return ContainsLegacyDomainHelperReference(
+                source,
+                hasLegacyAssemblySource,
+                legacyNamespaceAliases);
         }
 
         internal static bool ContainsCurrentDomainMetadataApi(string source)
@@ -351,6 +381,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return RegexMatchesCode(source, CurrentDomainMetadataRegex) ||
+                ContainsCurrentDomainHelperApi(source) ||
                 (RegexMatchesCode(source, CurrentDomainNamespaceRegex) &&
                     RegexMatchesCode(source, LegacyDomainMetadataRegex));
         }
@@ -881,6 +912,53 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return migratedContent;
         }
 
+        private static string ReplaceLegacyDomainTypeNamesInCode(
+            string source,
+            string[] aliases,
+            ref int replacementCount)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(aliases != null, "aliases must not be null");
+
+            string migratedContent = source;
+            foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
+            {
+                Regex fullyQualifiedRegex = new(
+                    $@"(?:(?:global::)?{Regex.Escape(LegacyNamespace)}\.){Regex.Escape(rule.LegacyName)}\b",
+                    RegexOptions.Compiled);
+                migratedContent = ReplaceRegexInCode(
+                    migratedContent,
+                    fullyQualifiedRegex,
+                    _ => $"{CurrentDomainNamespace}.{rule.CurrentName}",
+                    ref replacementCount);
+
+                foreach (string alias in aliases)
+                {
+                    Regex aliasRegex = new(
+                        $@"(?<!\w){Regex.Escape(alias)}\.{Regex.Escape(rule.LegacyName)}\b",
+                        RegexOptions.Compiled);
+                    migratedContent = ReplaceRegexInCode(
+                        migratedContent,
+                        aliasRegex,
+                        _ => $"{CurrentDomainNamespace}.{rule.CurrentName}",
+                        ref replacementCount);
+                }
+
+                Regex unqualifiedRegex = new(
+                    $@"(?<![\.:])\b{Regex.Escape(rule.LegacyName)}\b(?!\s*=)",
+                    RegexOptions.Compiled);
+                migratedContent = ReplaceRegexInCode(
+                    migratedContent,
+                    unqualifiedRegex,
+                    match => ShouldMigrateLegacyTypeReference(migratedContent, rule.LegacyName, match.Index)
+                        ? $"{CurrentDomainNamespace}.{rule.CurrentName}"
+                        : match.Value,
+                    ref replacementCount);
+            }
+
+            return migratedContent;
+        }
+
         private static string ReplaceLegacyToolInfoTypeReferencesInCode(string source, ref int replacementCount)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -1394,6 +1472,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
+            foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
+            {
+                if (ContainsLegacyAssemblyScopedTypeName(source, codeTextMask, rule.LegacyName))
+                {
+                    return true;
+                }
+            }
+
             return ContainsLegacyAssemblyScopedTypeName(source, codeTextMask, "ToolInfo");
         }
 
@@ -1407,6 +1493,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string alias in legacyAssemblyAliases)
             {
                 foreach (TypeReplacementRule rule in ToolContractTypeReplacementRules)
+                {
+                    if (ContainsLegacyAliasQualifiedName(source, alias, rule.LegacyName))
+                    {
+                        return true;
+                    }
+                }
+
+                foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
                 {
                     if (ContainsLegacyAliasQualifiedName(source, alias, rule.LegacyName))
                     {
@@ -1434,6 +1528,70 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 $@"(?<!\w){Regex.Escape(alias)}\.{Regex.Escape(typeName)}\b",
                 RegexOptions.Compiled);
             return RegexMatchesCode(source, aliasQualifiedRegex);
+        }
+
+        private static bool ContainsLegacyDomainHelperReference(
+            string source,
+            bool canMigrateBareLegacyDomainHelper,
+            string[] aliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(aliases != null, "aliases must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
+            {
+                Regex fullyQualifiedRegex = new(
+                    $@"(?:(?:global::)?{Regex.Escape(LegacyNamespace)}\.){Regex.Escape(rule.LegacyName)}\b",
+                    RegexOptions.Compiled);
+                if (RegexMatchesCode(source, fullyQualifiedRegex))
+                {
+                    return true;
+                }
+
+                foreach (string alias in aliases)
+                {
+                    if (ContainsLegacyAliasQualifiedName(source, alias, rule.LegacyName))
+                    {
+                        return true;
+                    }
+                }
+
+                if (canMigrateBareLegacyDomainHelper &&
+                    ContainsLegacyAssemblyScopedTypeName(source, codeTextMask, rule.LegacyName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ContainsCurrentDomainHelperApi(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            bool hasCurrentDomainNamespaceUsage = RegexMatchesCode(source, CurrentDomainNamespaceRegex);
+            foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
+            {
+                Regex fullyQualifiedRegex = new(
+                    $@"(?:(?:global::)?{Regex.Escape(CurrentDomainNamespace)}\.){Regex.Escape(rule.CurrentName)}\b",
+                    RegexOptions.Compiled);
+                if (RegexMatchesCode(source, fullyQualifiedRegex))
+                {
+                    return true;
+                }
+
+                Regex unqualifiedRegex = new(
+                    $@"(?<![\.:])\b{Regex.Escape(rule.CurrentName)}\b",
+                    RegexOptions.Compiled);
+                if (hasCurrentDomainNamespaceUsage && RegexMatchesCode(source, unqualifiedRegex))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool ContainsLegacyAssemblyScopedTypeName(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -345,6 +345,43 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return ContainsLegacyToolMigrationMarker(source);
         }
 
+        internal static bool ContainsMigrationCandidateText(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            if (ContainsTextFragment(source, LegacyNamespace) ||
+                ContainsTextFragment(source, CurrentNamespace) ||
+                ContainsTextFragment(source, CurrentApplicationNamespace) ||
+                ContainsTextFragment(source, CurrentDomainNamespace) ||
+                ContainsTextFragment(source, "McpTool") ||
+                ContainsTextFragment(source, "CustomToolManager") ||
+                ContainsTextFragment(source, "UnityCliLoopToolRegistrar") ||
+                ContainsTextFragment(source, "ToolInfo"))
+            {
+                return true;
+            }
+
+            foreach (TypeReplacementRule rule in ToolContractTypeReplacementRules)
+            {
+                if (ContainsTextFragment(source, rule.LegacyName) ||
+                    ContainsTextFragment(source, rule.CurrentName))
+                {
+                    return true;
+                }
+            }
+
+            foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
+            {
+                if (ContainsTextFragment(source, rule.LegacyName) ||
+                    ContainsTextFragment(source, rule.CurrentName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         internal static bool ContainsLegacyRegistrarApi(string source)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -1985,6 +2022,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return string.CompareOrdinal(source, startIndex, value, 0, value.Length) == 0;
+        }
+
+        private static bool ContainsTextFragment(string source, string text)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(text), "text must not be null or empty");
+
+            return source.IndexOf(text, StringComparison.Ordinal) >= 0;
         }
 
         private static bool IsRawStringStart(string source, int startIndex)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -906,6 +906,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private readonly struct CodeTextMask
         {
+            private const int MinimumRawStringDelimiterQuoteCount = 3;
+
             private readonly bool[] _codeCharacters;
 
             private CodeTextMask(bool[] codeCharacters)
@@ -928,6 +930,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int index = 0;
                 while (index < source.Length)
                 {
+                    if (IsInterpolatedRawStringStart(source, index))
+                    {
+                        index = MarkInterpolatedRawStringAsIgnored(codeCharacters, source, index);
+                        continue;
+                    }
+
                     if (StartsWith(source, index, "$@\"") || StartsWith(source, index, "@$\""))
                     {
                         index = MarkInterpolatedVerbatimStringAsIgnored(codeCharacters, source, index);
@@ -989,9 +997,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return FindVerbatimStringEndIndex(source, startIndex + 1);
                 }
 
-                if (StartsWith(source, startIndex, "$\"\"\""))
+                if (IsInterpolatedRawStringStart(source, startIndex))
                 {
-                    return FindRawStringEndIndex(source, startIndex + 1);
+                    int dollarCount = CountRepeatedCharacter(source, startIndex, '$');
+                    return FindRawStringEndIndex(source, startIndex + dollarCount);
                 }
 
                 if (StartsWith(source, startIndex, "$\""))
@@ -1091,17 +1100,78 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             private static int FindRawStringEndIndex(string source, int quoteIndex)
             {
-                int index = quoteIndex + 3;
-                while (index + 2 < source.Length)
+                int quoteCount = CountRepeatedCharacter(source, quoteIndex, '"');
+                Debug.Assert(
+                    quoteCount >= MinimumRawStringDelimiterQuoteCount,
+                    "quoteIndex must point to a raw string delimiter");
+
+                int index = quoteIndex + quoteCount;
+                while (index + quoteCount <= source.Length)
                 {
-                    if (StartsWith(source, index, "\"\"\""))
+                    if (HasRepeatedCharacterAt(source, index, '"', quoteCount))
                     {
-                        return index + 3;
+                        return index + quoteCount;
                     }
 
                     index++;
                 }
 
+                return source.Length;
+            }
+
+            private static int MarkInterpolatedRawStringAsIgnored(
+                bool[] codeCharacters,
+                string source,
+                int dollarIndex)
+            {
+                Debug.Assert(codeCharacters != null, "codeCharacters must not be null");
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(dollarIndex >= 0, "dollarIndex must not be negative");
+
+                int dollarCount = CountRepeatedCharacter(source, dollarIndex, '$');
+                int quoteIndex = dollarIndex + dollarCount;
+                int quoteCount = CountRepeatedCharacter(source, quoteIndex, '"');
+                Debug.Assert(dollarCount > 0, "dollarIndex must point to an interpolated raw string prefix");
+                Debug.Assert(
+                    quoteCount >= MinimumRawStringDelimiterQuoteCount,
+                    "quoteIndex must point to a raw string delimiter");
+
+                int literalStartIndex = dollarIndex;
+                int index = quoteIndex + quoteCount;
+                while (index < source.Length)
+                {
+                    if (HasRepeatedCharacterAt(source, index, '"', quoteCount))
+                    {
+                        MarkRangeAsIgnored(codeCharacters, literalStartIndex, index + quoteCount);
+                        return index + quoteCount;
+                    }
+
+                    if (source[index] == '{')
+                    {
+                        int braceCount = CountRepeatedCharacter(source, index, '{');
+                        if (braceCount < dollarCount)
+                        {
+                            index += braceCount;
+                            continue;
+                        }
+
+                        MarkRangeAsIgnored(codeCharacters, literalStartIndex, index);
+                        index = FindRawInterpolationHoleEndIndex(source, index, dollarCount);
+                        literalStartIndex = index;
+                        continue;
+                    }
+
+                    if (source[index] == '}')
+                    {
+                        int braceCount = CountRepeatedCharacter(source, index, '}');
+                        index += braceCount;
+                        continue;
+                    }
+
+                    index++;
+                }
+
+                MarkRangeAsIgnored(codeCharacters, literalStartIndex, source.Length);
                 return source.Length;
             }
 
@@ -1255,6 +1325,79 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return source.Length;
             }
 
+            private static int FindRawInterpolationHoleEndIndex(
+                string source,
+                int openBraceIndex,
+                int interpolationBraceCount)
+            {
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(openBraceIndex >= 0, "openBraceIndex must not be negative");
+                Debug.Assert(interpolationBraceCount > 0, "interpolationBraceCount must be positive");
+
+                int nestedBraceDepth = 0;
+                int index = openBraceIndex + interpolationBraceCount;
+                while (index < source.Length)
+                {
+                    if (IsInterpolatedRawStringStart(source, index))
+                    {
+                        int dollarCount = CountRepeatedCharacter(source, index, '$');
+                        index = FindRawStringEndIndex(source, index + dollarCount);
+                        continue;
+                    }
+
+                    if (CountRepeatedCharacter(source, index, '"') >= MinimumRawStringDelimiterQuoteCount)
+                    {
+                        index = FindRawStringEndIndex(source, index);
+                        continue;
+                    }
+
+                    if (StartsWith(source, index, "@\""))
+                    {
+                        index = FindVerbatimStringEndIndex(source, index + 1);
+                        continue;
+                    }
+
+                    if (source[index] == '"')
+                    {
+                        index = FindRegularStringEndIndex(source, index);
+                        continue;
+                    }
+
+                    if (source[index] == '\'')
+                    {
+                        index = FindCharLiteralEndIndex(source, index);
+                        continue;
+                    }
+
+                    if (source[index] == '{')
+                    {
+                        nestedBraceDepth++;
+                        index++;
+                        continue;
+                    }
+
+                    if (source[index] == '}')
+                    {
+                        bool isClosingInterpolation =
+                            nestedBraceDepth == 0 &&
+                            HasRepeatedCharacterAt(source, index, '}', interpolationBraceCount);
+                        if (isClosingInterpolation)
+                        {
+                            return index + interpolationBraceCount;
+                        }
+
+                        if (nestedBraceDepth > 0)
+                        {
+                            nestedBraceDepth--;
+                        }
+                    }
+
+                    index++;
+                }
+
+                return source.Length;
+            }
+
             private static int FindCharLiteralEndIndex(string source, int quoteIndex)
             {
                 int index = quoteIndex + 1;
@@ -1287,6 +1430,57 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 {
                     codeCharacters[i] = false;
                 }
+            }
+
+            private static bool IsInterpolatedRawStringStart(string source, int startIndex)
+            {
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+                if (startIndex >= source.Length || source[startIndex] != '$')
+                {
+                    return false;
+                }
+
+                int dollarCount = CountRepeatedCharacter(source, startIndex, '$');
+                int quoteIndex = startIndex + dollarCount;
+                return CountRepeatedCharacter(source, quoteIndex, '"') >= MinimumRawStringDelimiterQuoteCount;
+            }
+
+            private static int CountRepeatedCharacter(string source, int startIndex, char character)
+            {
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+                int index = startIndex;
+                while (index < source.Length && source[index] == character)
+                {
+                    index++;
+                }
+
+                return index - startIndex;
+            }
+
+            private static bool HasRepeatedCharacterAt(string source, int startIndex, char character, int count)
+            {
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+                Debug.Assert(count > 0, "count must be positive");
+
+                if (startIndex + count > source.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < count; i++)
+                {
+                    if (source[startIndex + i] != character)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
         }
     }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -16,8 +16,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         internal const string LegacyNamespace = "io.github.hatayama.uLoopMCP";
         internal const string CurrentNamespace = "io.github.hatayama.UnityCliLoop.ToolContracts";
+        internal const string CurrentApplicationNamespace = "io.github.hatayama.UnityCliLoop.Application";
         internal const string LegacyEditorAssemblyName = "uLoopMCP.Editor";
         internal const string LegacyEditorAssemblyGuidReference = "GUID:214998e563c124e8a88199b2dd1f522d";
+        internal const string CurrentApplicationGuidReference = "GUID:214998e563c124e8a88199b2dd1f522d";
         internal const string CurrentToolContractsGuidReference = "GUID:fc3fd32eddbee40e39c2d76dc184957b";
         private const string DescriptionAttributeArgumentName = "Description";
         private const string DisplayDevelopmentOnlyAttributeArgumentName = "DisplayDevelopmentOnly";
@@ -40,14 +42,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyNamespaceRegex =
             new(Regex.Escape(LegacyNamespace), RegexOptions.Compiled);
 
+        private static readonly Regex LegacyRegistrarRegex =
+            new(@"\bCustomToolManager\b", RegexOptions.Compiled);
+
         private static readonly Regex LegacyToolAttributeListRegex =
             new(@"\[(?<attributes>[^\]]*\bMcpTool(?:Attribute)?\b[^\]]*)\]", RegexOptions.Compiled);
 
         private static readonly Regex LegacyToolAttributeEntryRegex =
-            new(@"^\s*McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$", RegexOptions.Compiled);
+            new(
+                @"^\s*(?<qualifier>io\.github\.hatayama\.uLoopMCP\.)?McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$",
+                RegexOptions.Compiled);
 
         private static readonly ReplacementRule[] CSharpReplacementRules =
         {
+            new(
+                Regex.Escape($"{LegacyNamespace}.CustomToolManager"),
+                $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar"),
             new(Regex.Escape(LegacyNamespace), CurrentNamespace),
             new(@"\bMcpToolAttribute\b", "UnityCliLoopToolAttribute"),
             new(@"\bIUnityTool\b", "IUnityCliLoopTool"),
@@ -55,7 +65,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             new(@"\bBaseToolSchema\b", "UnityCliLoopToolSchema"),
             new(@"\bBaseToolResponse\b", "UnityCliLoopToolResponse"),
             new(@"\bSecuritySettings\b", CurrentSecuritySettingTypeName),
-            new(@"\bCustomToolManager\b", "UnityCliLoopToolRegistrar")
+            new(@"\bCustomToolManager\b", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
         };
 
         internal static ThirdPartyToolMigrationContentResult MigrateCSharpSource(string source)
@@ -90,7 +100,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         internal static ThirdPartyToolMigrationContentResult MigrateAsmdefSource(
             string source,
-            bool hasLegacyCSharpSource)
+            bool hasLegacyCSharpSource,
+            bool requiresApplicationReference)
         {
             Debug.Assert(source != null, "source must not be null");
 
@@ -107,18 +118,26 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (JToken referenceToken in references)
             {
                 string reference = referenceToken.Value<string>() ?? string.Empty;
-                string migratedReference = GetMigratedAsmdefReference(reference, hasLegacyCSharpSource);
-                if (!string.Equals(reference, migratedReference, StringComparison.Ordinal))
+                string[] migratedReferenceItems = GetMigratedAsmdefReferences(
+                    reference,
+                    hasLegacyCSharpSource,
+                    requiresApplicationReference);
+                bool referenceChanged = migratedReferenceItems.Length != 1 ||
+                    !string.Equals(migratedReferenceItems[0], reference, StringComparison.Ordinal);
+                if (referenceChanged)
                 {
                     replacementCount++;
                 }
 
-                if (!addedReferences.Add(migratedReference))
+                foreach (string migratedReference in migratedReferenceItems)
                 {
-                    continue;
-                }
+                    if (!addedReferences.Add(migratedReference))
+                    {
+                        continue;
+                    }
 
-                migratedReferences.Add(migratedReference);
+                    migratedReferences.Add(migratedReference);
+                }
             }
 
             if (replacementCount == 0)
@@ -139,6 +158,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return ContainsLegacyToolMigrationMarker(source);
         }
 
+        internal static bool ContainsLegacyRegistrarApi(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return ContainsLegacyToolMigrationMarker(source) && RegexMatchesCode(source, LegacyRegistrarRegex);
+        }
+
         internal static bool IsExcludedDirectoryName(string directoryName)
         {
             Debug.Assert(!string.IsNullOrEmpty(directoryName), "directoryName must not be null or empty");
@@ -157,20 +183,33 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return names;
         }
 
-        private static string GetMigratedAsmdefReference(string reference, bool hasLegacyCSharpSource)
+        private static string[] GetMigratedAsmdefReferences(
+            string reference,
+            bool hasLegacyCSharpSource,
+            bool requiresApplicationReference)
         {
             if (string.Equals(reference, LegacyEditorAssemblyName, StringComparison.Ordinal))
             {
-                return CurrentToolContractsGuidReference;
+                return GetMigratedLegacyEditorReferences(requiresApplicationReference);
             }
 
             if (hasLegacyCSharpSource
                 && string.Equals(reference, LegacyEditorAssemblyGuidReference, StringComparison.Ordinal))
             {
-                return CurrentToolContractsGuidReference;
+                return GetMigratedLegacyEditorReferences(requiresApplicationReference);
             }
 
-            return reference;
+            return new[] { reference };
+        }
+
+        private static string[] GetMigratedLegacyEditorReferences(bool requiresApplicationReference)
+        {
+            if (!requiresApplicationReference)
+            {
+                return new[] { CurrentToolContractsGuidReference };
+            }
+
+            return new[] { CurrentToolContractsGuidReference, CurrentApplicationGuidReference };
         }
 
         private static string MigrateLegacyToolAttributeList(Match match)
@@ -215,9 +254,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             string argumentsSource = match.Groups["arguments"].Value;
             string[] migratedArguments = GetMigratedSupportedAttributeArguments(argumentsSource);
+            string attributeName = match.Groups["qualifier"].Success
+                ? $"{CurrentNamespace}.UnityCliLoopTool"
+                : "UnityCliLoopTool";
             migratedAttribute = migratedArguments.Length == 0
-                ? "UnityCliLoopTool"
-                : $"UnityCliLoopTool({string.Join(", ", migratedArguments)})";
+                ? attributeName
+                : $"{attributeName}({string.Join(", ", migratedArguments)})";
             return true;
         }
 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -192,7 +192,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(source != null, "source must not be null");
 
-            return ContainsLegacyToolMigrationMarker(source) && RegexMatchesCode(source, LegacyRegistrarRegex);
+            return RegexMatchesCode(source, LegacyRegistrarRegex);
         }
 
         internal static bool IsExcludedDirectoryName(string directoryName)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -311,6 +311,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return RegexMatchesCode(source, LegacyBaseTypeUsageRegex) ||
                 RegexMatchesCode(source, LegacyAssemblyScopedApiUsageRegex) ||
                 ContainsLegacyAssemblyScopedTypeReference(source) ||
+                ContainsLegacyAliasQualifiedAssemblyScopedApi(source, legacyAssemblyAliases) ||
                 ContainsLegacyToolAttributeList(
                     source,
                     legacyAssemblyAliases,
@@ -360,7 +361,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return GetMigratedLegacyEditorReferences(requiresApplicationReference, requiresDomainReference);
             }
 
-            if (hasLegacyCSharpSource
+            if ((hasLegacyCSharpSource || requiresApplicationReference || requiresDomainReference)
                 && string.Equals(reference, LegacyEditorAssemblyGuidReference, StringComparison.Ordinal))
             {
                 return GetMigratedLegacyEditorReferences(requiresApplicationReference, requiresDomainReference);
@@ -1156,6 +1157,45 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return ContainsLegacyAssemblyScopedTypeName(source, codeTextMask, "ToolInfo");
+        }
+
+        private static bool ContainsLegacyAliasQualifiedAssemblyScopedApi(
+            string source,
+            string[] legacyAssemblyAliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
+
+            foreach (string alias in legacyAssemblyAliases)
+            {
+                foreach (TypeReplacementRule rule in ToolContractTypeReplacementRules)
+                {
+                    if (ContainsLegacyAliasQualifiedName(source, alias, rule.LegacyName))
+                    {
+                        return true;
+                    }
+                }
+
+                if (ContainsLegacyAliasQualifiedName(source, alias, "ToolInfo") ||
+                    ContainsLegacyAliasQualifiedName(source, alias, "CustomToolManager"))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ContainsLegacyAliasQualifiedName(string source, string alias, string typeName)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(alias), "alias must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(typeName), "typeName must not be null or empty");
+
+            Regex aliasQualifiedRegex = new(
+                $@"(?<!\w){Regex.Escape(alias)}\.{Regex.Escape(typeName)}\b",
+                RegexOptions.Compiled);
+            return RegexMatchesCode(source, aliasQualifiedRegex);
         }
 
         private static bool ContainsLegacyAssemblyScopedTypeName(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -85,6 +85,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyRegistrarRegex =
             new(@"\bCustomToolManager\b", RegexOptions.Compiled);
 
+        private static readonly Regex LegacyQualifiedRegistrarRegex =
+            new(
+                $@"(?<![\w.])(?:global::)?{Regex.Escape(LegacyNamespace)}\.CustomToolManager\b",
+                RegexOptions.Compiled);
+
         private static readonly Regex CurrentRegistrarRegex =
             new(@"\bUnityCliLoopToolRegistrar\b", RegexOptions.Compiled);
 
@@ -344,7 +349,29 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(source != null, "source must not be null");
 
-            return RegexMatchesCode(source, LegacyRegistrarRegex);
+            return ContainsLegacyRegistrarApiForAssembly(
+                source,
+                hasLegacyAssemblySource: ContainsLegacyToolMigrationMarker(source),
+                legacyAssemblyAliases: Array.Empty<string>());
+        }
+
+        internal static bool ContainsLegacyRegistrarApiForAssembly(
+            string source,
+            bool hasLegacyAssemblySource,
+            string[] legacyAssemblyAliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
+
+            string[] legacyNamespaceAliases = GetCombinedLegacyNamespaceAliases(source, legacyAssemblyAliases);
+            bool canMigrateBareLegacyRegistrar =
+                hasLegacyAssemblySource ||
+                ContainsLegacyToolMigrationMarker(source) ||
+                legacyNamespaceAliases.Length > 0;
+            return ContainsLegacyRegistrarReference(
+                source,
+                canMigrateBareLegacyRegistrar,
+                legacyNamespaceAliases);
         }
 
         internal static bool ContainsCurrentRegistrarApi(string source)
@@ -1626,6 +1653,48 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 $@"(?<!\w){Regex.Escape(alias)}\.{Regex.Escape(typeName)}\b",
                 RegexOptions.Compiled);
             return RegexMatchesCode(source, aliasQualifiedRegex);
+        }
+
+        private static bool ContainsLegacyRegistrarReference(
+            string source,
+            bool canMigrateBareLegacyRegistrar,
+            string[] aliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(aliases != null, "aliases must not be null");
+
+            if (RegexMatchesCode(source, LegacyQualifiedRegistrarRegex))
+            {
+                return true;
+            }
+
+            foreach (string alias in aliases)
+            {
+                if (ContainsLegacyAliasQualifiedName(source, alias, "CustomToolManager"))
+                {
+                    return true;
+                }
+            }
+
+            return canMigrateBareLegacyRegistrar && ContainsMigratableUnqualifiedLegacyRegistrarReference(source);
+        }
+
+        private static bool ContainsMigratableUnqualifiedLegacyRegistrarReference(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            MatchCollection matches = LegacyRegistrarRegex.Matches(source);
+            foreach (Match match in matches)
+            {
+                if (codeTextMask.IsCodeAt(match.Index) &&
+                    ShouldMigrateLegacyTypeReference(source, "CustomToolManager", match.Index))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool ContainsLegacyDomainHelperReference(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -20,6 +20,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal const string CurrentApplicationNamespace = "io.github.hatayama.UnityCliLoop.Application";
         internal const string CurrentDomainNamespace = "io.github.hatayama.UnityCliLoop.Domain";
         internal const string LegacyEditorAssemblyName = "uLoopMCP.Editor";
+        private const string CurrentApplicationAssemblyName = "UnityCLILoop.Application";
+        private const string CurrentDomainAssemblyName = "UnityCLILoop.Domain";
+        private const string CurrentToolContractsAssemblyName = "UnityCLILoop.ToolContracts";
         internal const string LegacyEditorAssemblyGuidReference = "GUID:214998e563c124e8a88199b2dd1f522d";
         internal const string CurrentApplicationGuidReference = "GUID:214998e563c124e8a88199b2dd1f522d";
         internal const string CurrentDomainGuidReference = "GUID:5c4588558a3624eacbce0f50007cf1eb";
@@ -294,7 +297,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 foreach (string migratedReference in migratedReferenceItems)
                 {
-                    if (!addedReferences.Add(migratedReference))
+                    string migratedReferenceKey = GetCurrentAsmdefReferenceKey(migratedReference);
+                    if (!addedReferences.Add(migratedReferenceKey))
                     {
                         continue;
                     }
@@ -528,13 +532,58 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(addedReferences != null, "addedReferences must not be null");
             Debug.Assert(!string.IsNullOrEmpty(reference), "reference must not be null or empty");
 
-            if (!addedReferences.Add(reference))
+            string referenceKey = GetCurrentAsmdefReferenceKey(reference);
+            if (!addedReferences.Add(referenceKey))
             {
                 return;
             }
 
             references.Add(reference);
             replacementCount++;
+        }
+
+        private static string GetCurrentAsmdefReferenceKey(string reference)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(reference), "reference must not be null or empty");
+
+            if (IsCurrentAsmdefReference(
+                    reference,
+                    CurrentToolContractsAssemblyName,
+                    CurrentToolContractsGuidReference))
+            {
+                return CurrentToolContractsAssemblyName;
+            }
+
+            if (IsCurrentAsmdefReference(
+                    reference,
+                    CurrentApplicationAssemblyName,
+                    CurrentApplicationGuidReference))
+            {
+                return CurrentApplicationAssemblyName;
+            }
+
+            if (IsCurrentAsmdefReference(
+                    reference,
+                    CurrentDomainAssemblyName,
+                    CurrentDomainGuidReference))
+            {
+                return CurrentDomainAssemblyName;
+            }
+
+            return reference;
+        }
+
+        private static bool IsCurrentAsmdefReference(
+            string reference,
+            string assemblyName,
+            string guidReference)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(reference), "reference must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(assemblyName), "assemblyName must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(guidReference), "guidReference must not be null or empty");
+
+            return string.Equals(reference, assemblyName, StringComparison.Ordinal) ||
+                string.Equals(reference, guidReference, StringComparison.Ordinal);
         }
 
         private static bool TryMigrateLegacyToolAttributeList(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -698,7 +698,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     openParenthesisIndex + 1,
                     closingParenthesisIndex - openParenthesisIndex - 1);
                 string[] arguments = SplitAttributeArguments(argumentsSource);
-                if (arguments.Length != 3)
+                if (arguments.Length != 3 && arguments.Length != 4)
                 {
                     continue;
                 }
@@ -708,6 +708,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 builder.Append(arguments[0].Trim());
                 builder.Append(", ");
                 builder.Append(arguments[2].Trim());
+                if (arguments.Length == 4)
+                {
+                    builder.Append(", ");
+                    builder.Append(arguments[3].Trim());
+                }
+
                 builder.Append(')');
                 sourceCopyIndex = closingParenthesisIndex + 1;
                 localReplacementCount++;

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -176,14 +176,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 legacyNamespaceAliases,
                 canMigrateBareLegacyToolAttribute,
                 ref replacementCount);
-            migratedContent = ReplaceLegacyRegistrarAliasesInCode(
-                migratedContent,
-                legacyNamespaceAliases,
-                ref replacementCount);
             migratedContent = ReplaceLegacyToolInfoConstructorsInCode(
                 migratedContent,
                 legacyNamespaceAliases,
                 canMigrateBareLegacyToolInfoConstructor,
+                ref replacementCount);
+            migratedContent = ReplaceLegacyRegistrarAliasesInCode(
+                migratedContent,
+                legacyNamespaceAliases,
                 ref replacementCount);
 
             if (shouldApplyContractRenames)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -861,6 +861,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int index = 0;
                 while (index < source.Length)
                 {
+                    if (StartsWith(source, index, "$\"") && !StartsWith(source, index, "$\"\"\""))
+                    {
+                        index = MarkInterpolatedRegularStringAsIgnored(codeCharacters, source, index);
+                        continue;
+                    }
+
                     int ignoredTextEndIndex = GetIgnoredTextEndIndex(source, index);
                     if (ignoredTextEndIndex == index)
                     {
@@ -1018,6 +1024,103 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     if (StartsWith(source, index, "\"\"\""))
                     {
                         return index + 3;
+                    }
+
+                    index++;
+                }
+
+                return source.Length;
+            }
+
+            private static int MarkInterpolatedRegularStringAsIgnored(
+                bool[] codeCharacters,
+                string source,
+                int dollarIndex)
+            {
+                Debug.Assert(codeCharacters != null, "codeCharacters must not be null");
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(dollarIndex >= 0, "dollarIndex must not be negative");
+
+                int quoteIndex = dollarIndex + 1;
+                int literalStartIndex = dollarIndex;
+                int index = quoteIndex + 1;
+                while (index < source.Length)
+                {
+                    if (source[index] == '\\')
+                    {
+                        index += 2;
+                        continue;
+                    }
+
+                    if (source[index] == '{')
+                    {
+                        if (index + 1 < source.Length && source[index + 1] == '{')
+                        {
+                            index += 2;
+                            continue;
+                        }
+
+                        MarkRangeAsIgnored(codeCharacters, literalStartIndex, index);
+                        index = FindInterpolationHoleEndIndex(source, index);
+                        literalStartIndex = index;
+                        continue;
+                    }
+
+                    if (source[index] == '"')
+                    {
+                        MarkRangeAsIgnored(codeCharacters, literalStartIndex, index + 1);
+                        return index + 1;
+                    }
+
+                    index++;
+                }
+
+                MarkRangeAsIgnored(codeCharacters, literalStartIndex, source.Length);
+                return source.Length;
+            }
+
+            private static int FindInterpolationHoleEndIndex(string source, int openBraceIndex)
+            {
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(openBraceIndex >= 0, "openBraceIndex must not be negative");
+
+                int nestedBraceDepth = 0;
+                int index = openBraceIndex + 1;
+                while (index < source.Length)
+                {
+                    if (StartsWith(source, index, "@\""))
+                    {
+                        index = FindVerbatimStringEndIndex(source, index + 1);
+                        continue;
+                    }
+
+                    if (source[index] == '"')
+                    {
+                        index = FindRegularStringEndIndex(source, index);
+                        continue;
+                    }
+
+                    if (source[index] == '\'')
+                    {
+                        index = FindCharLiteralEndIndex(source, index);
+                        continue;
+                    }
+
+                    if (source[index] == '{')
+                    {
+                        nestedBraceDepth++;
+                        index++;
+                        continue;
+                    }
+
+                    if (source[index] == '}')
+                    {
+                        if (nestedBraceDepth == 0)
+                        {
+                            return index + 1;
+                        }
+
+                        nestedBraceDepth--;
                     }
 
                     index++;

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -49,6 +49,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyNamespaceRegex =
             new(LegacyNamespacePattern, RegexOptions.Compiled);
 
+        private static readonly Regex LegacyGlobalUsingRegex =
+            new(
+                $@"\bglobal\s+using\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*=\s*)?(?:global::)?{Regex.Escape(LegacyNamespace)}\s*;",
+                RegexOptions.Compiled);
+
         private static readonly Regex LegacyRegistrarRegex =
             new(@"\bCustomToolManager\b", RegexOptions.Compiled);
 
@@ -274,6 +279,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 RegexMatchesCode(source, LegacyAssemblyScopedApiUsageRegex) ||
                 ContainsLegacyAssemblyScopedTypeReference(source) ||
                 ContainsLegacyToolAttributeList(source, canMigrateBareLegacyToolAttribute: true);
+        }
+
+        internal static bool ContainsLegacyGlobalUsing(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return RegexMatchesCode(source, LegacyGlobalUsingRegex);
         }
 
         internal static bool IsExcludedDirectoryName(string directoryName)
@@ -698,7 +710,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     openParenthesisIndex + 1,
                     closingParenthesisIndex - openParenthesisIndex - 1);
                 string[] arguments = SplitAttributeArguments(argumentsSource);
-                if (arguments.Length != 3 && arguments.Length != 4)
+                if (!ShouldDropLegacyToolInfoDescriptionArgument(arguments))
                 {
                     continue;
                 }
@@ -727,6 +739,26 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             builder.Append(source, sourceCopyIndex, source.Length - sourceCopyIndex);
             replacementCount += localReplacementCount;
             return builder.ToString();
+        }
+
+        private static bool ShouldDropLegacyToolInfoDescriptionArgument(string[] arguments)
+        {
+            Debug.Assert(arguments != null, "arguments must not be null");
+
+            return arguments.Length == 4 ||
+                (arguments.Length == 3 && IsStringLiteralExpression(arguments[1].Trim()));
+        }
+
+        private static bool IsStringLiteralExpression(string expression)
+        {
+            Debug.Assert(expression != null, "expression must not be null");
+
+            return expression.StartsWith("\"", StringComparison.Ordinal) ||
+                expression.StartsWith("@\"", StringComparison.Ordinal) ||
+                expression.StartsWith("$\"", StringComparison.Ordinal) ||
+                expression.StartsWith("$@\"", StringComparison.Ordinal) ||
+                expression.StartsWith("@$\"", StringComparison.Ordinal) ||
+                expression.StartsWith("\"\"\"", StringComparison.Ordinal);
         }
 
         private static int FindInvocationClosingParenthesisIndex(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -81,27 +81,31 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 @"McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$",
                 RegexOptions.Compiled);
 
+        private static readonly TypeReplacementRule[] ToolContractTypeReplacementRules =
+        {
+            new("ToolParameterSchemaGenerator", "UnityCliLoopToolParameterSchemaGenerator"),
+            new("ParameterValidationException", "UnityCliLoopToolParameterValidationException"),
+            new("McpToolAttribute", "UnityCliLoopToolAttribute"),
+            new("IUnityTool", "IUnityCliLoopTool"),
+            new("AbstractUnityTool", "UnityCliLoopTool"),
+            new("BaseToolSchema", "UnityCliLoopToolSchema"),
+            new("BaseToolResponse", "UnityCliLoopToolResponse"),
+            new("SecuritySettings", CurrentSecuritySettingTypeName)
+        };
+
         private static readonly ReplacementRule[] CSharpReplacementRules =
         {
             new(
                 Regex.Escape($"{LegacyNamespace}.CustomToolManager"),
                 $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar"),
             new(Regex.Escape(LegacyNamespace), CurrentNamespace),
-            new(@"\bToolParameterSchemaGenerator\b", "UnityCliLoopToolParameterSchemaGenerator"),
-            new(@"\bParameterValidationException\b", "UnityCliLoopToolParameterValidationException"),
-            new(@"\bMcpToolAttribute\b", "UnityCliLoopToolAttribute"),
-            new(@"\bIUnityTool\b", "IUnityCliLoopTool"),
-            new(@"\bAbstractUnityTool\b", "UnityCliLoopTool"),
-            new(@"\bBaseToolSchema\b", "UnityCliLoopToolSchema"),
-            new(@"\bBaseToolResponse\b", "UnityCliLoopToolResponse"),
-            new(@"\bSecuritySettings\b", CurrentSecuritySettingTypeName),
-            new(@"(?<!\.)\bCustomToolManager\b", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
+            new(@"(?<![\.:])\bCustomToolManager\b", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
         };
 
         private static readonly ReplacementRule[] RegistrarReplacementRules =
         {
             new(Regex.Escape($"{CurrentNamespace}.ToolInfo"), $"{CurrentDomainNamespace}.ToolInfo"),
-            new(@"(?<!\.)\bToolInfo\b", $"{CurrentDomainNamespace}.ToolInfo")
+            new(@"(?<![\.:])\bToolInfo\b", $"{CurrentDomainNamespace}.ToolInfo")
         };
 
         internal static ThirdPartyToolMigrationContentResult MigrateCSharpSource(string source)
@@ -139,6 +143,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (shouldApplyContractRenames)
             {
+                migratedContent = ReplaceLegacyContractTypeNamesInCode(
+                    migratedContent,
+                    legacyNamespaceAliases,
+                    ref replacementCount);
+
                 foreach (ReplacementRule rule in CSharpReplacementRules)
                 {
                     migratedContent = ReplaceRegexInCode(
@@ -586,6 +595,51 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return migratedContent;
         }
 
+        private static string ReplaceLegacyContractTypeNamesInCode(
+            string source,
+            string[] aliases,
+            ref int replacementCount)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(aliases != null, "aliases must not be null");
+
+            string migratedContent = source;
+            foreach (TypeReplacementRule rule in ToolContractTypeReplacementRules)
+            {
+                Regex fullyQualifiedRegex = new(
+                    $@"(?:(?:global::)?{Regex.Escape(LegacyNamespace)}\.){Regex.Escape(rule.LegacyName)}\b",
+                    RegexOptions.Compiled);
+                migratedContent = ReplaceRegexInCode(
+                    migratedContent,
+                    fullyQualifiedRegex,
+                    _ => $"{CurrentNamespace}.{rule.CurrentName}",
+                    ref replacementCount);
+
+                foreach (string alias in aliases)
+                {
+                    Regex aliasRegex = new(
+                        $@"(?<!\w){Regex.Escape(alias)}\.{Regex.Escape(rule.LegacyName)}\b",
+                        RegexOptions.Compiled);
+                    migratedContent = ReplaceRegexInCode(
+                        migratedContent,
+                        aliasRegex,
+                        _ => $"{alias}.{rule.CurrentName}",
+                        ref replacementCount);
+                }
+
+                Regex unqualifiedRegex = new(
+                    $@"(?<![\.:])\b{Regex.Escape(rule.LegacyName)}\b",
+                    RegexOptions.Compiled);
+                migratedContent = ReplaceRegexInCode(
+                    migratedContent,
+                    unqualifiedRegex,
+                    _ => rule.CurrentName,
+                    ref replacementCount);
+            }
+
+            return migratedContent;
+        }
+
         private static bool IsNamedAttributeArgument(string argument, string argumentName)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(argument), "argument must not be null or whitespace");
@@ -902,6 +956,21 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             public Regex PatternRegex { get; }
             public string Replacement { get; }
+        }
+
+        private readonly struct TypeReplacementRule
+        {
+            public TypeReplacementRule(string legacyName, string currentName)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(legacyName), "legacyName must not be null or empty");
+                Debug.Assert(!string.IsNullOrEmpty(currentName), "currentName must not be null or empty");
+
+                LegacyName = legacyName;
+                CurrentName = currentName;
+            }
+
+            public string LegacyName { get; }
+            public string CurrentName { get; }
         }
 
         private readonly struct CodeTextMask

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -51,6 +51,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyDomainMetadataRegex =
             new(@"\bToolInfo\b", RegexOptions.Compiled);
 
+        private static readonly Regex LegacyBaseTypeUsageRegex =
+            new(
+                @":\s*[^;{}=]*\b(?:AbstractUnityTool|BaseToolSchema|BaseToolResponse)\b",
+                RegexOptions.Compiled);
+
+        private static readonly Regex LegacyAssemblyScopedApiUsageRegex =
+            new(
+                @"\b(?:IUnityTool\s+[A-Za-z_][A-Za-z0-9_]*|" +
+                @"ToolParameterSchemaGenerator\s*\.|" +
+                @"new\s+ParameterValidationException\b|" +
+                @"CustomToolManager\s*\.|" +
+                @"ToolInfo\s*(?:\[\])?\s+[A-Za-z_][A-Za-z0-9_]*)",
+                RegexOptions.Compiled);
+
         private static readonly Regex LegacyNamespaceAliasRegex =
             new(
                 @"\busing\s+(?<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:global::)?" +
@@ -222,6 +236,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return RegexMatchesCode(source, LegacyDomainMetadataRegex);
+        }
+
+        internal static bool ContainsLegacyAssemblyScopedApi(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return RegexMatchesCode(source, LegacyBaseTypeUsageRegex) ||
+                RegexMatchesCode(source, LegacyAssemblyScopedApiUsageRegex);
         }
 
         internal static bool IsExcludedDirectoryName(string directoryName)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -81,6 +81,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 @"McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$",
                 RegexOptions.Compiled);
 
+        private static readonly Regex CurrentToolInfoConstructorRegex =
+            new(
+                $@"new\s+{Regex.Escape(CurrentDomainNamespace)}\.ToolInfo\s*\(",
+                RegexOptions.Compiled);
+
         private static readonly TypeReplacementRule[] ToolContractTypeReplacementRules =
         {
             new("ToolParameterSchemaGenerator", "UnityCliLoopToolParameterSchemaGenerator"),
@@ -174,6 +179,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         _ => rule.Replacement,
                         ref replacementCount);
                 }
+
+                migratedContent = ReplaceLegacyToolInfoConstructorsInCode(
+                    migratedContent,
+                    ref replacementCount);
             }
 
             return new ThirdPartyToolMigrationContentResult(
@@ -655,6 +664,101 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return migratedContent;
+        }
+
+        private static string ReplaceLegacyToolInfoConstructorsInCode(
+            string source,
+            ref int replacementCount)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            MatchCollection matches = CurrentToolInfoConstructorRegex.Matches(source);
+            StringBuilder builder = new(source.Length);
+            int sourceCopyIndex = 0;
+            int localReplacementCount = 0;
+            foreach (Match match in matches)
+            {
+                if (match.Index < sourceCopyIndex || !codeTextMask.IsCodeAt(match.Index))
+                {
+                    continue;
+                }
+
+                int openParenthesisIndex = match.Index + match.Length - 1;
+                int closingParenthesisIndex = FindInvocationClosingParenthesisIndex(
+                    source,
+                    codeTextMask,
+                    openParenthesisIndex);
+                if (closingParenthesisIndex < 0)
+                {
+                    continue;
+                }
+
+                string argumentsSource = source.Substring(
+                    openParenthesisIndex + 1,
+                    closingParenthesisIndex - openParenthesisIndex - 1);
+                string[] arguments = SplitAttributeArguments(argumentsSource);
+                if (arguments.Length != 3)
+                {
+                    continue;
+                }
+
+                builder.Append(source, sourceCopyIndex, match.Index - sourceCopyIndex);
+                builder.Append(source, match.Index, openParenthesisIndex - match.Index + 1);
+                builder.Append(arguments[0].Trim());
+                builder.Append(", ");
+                builder.Append(arguments[2].Trim());
+                builder.Append(')');
+                sourceCopyIndex = closingParenthesisIndex + 1;
+                localReplacementCount++;
+            }
+
+            if (localReplacementCount == 0)
+            {
+                return source;
+            }
+
+            builder.Append(source, sourceCopyIndex, source.Length - sourceCopyIndex);
+            replacementCount += localReplacementCount;
+            return builder.ToString();
+        }
+
+        private static int FindInvocationClosingParenthesisIndex(
+            string source,
+            CodeTextMask codeTextMask,
+            int openParenthesisIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(openParenthesisIndex >= 0, "openParenthesisIndex must not be negative");
+
+            int nestedParenthesisDepth = 0;
+            for (int i = openParenthesisIndex + 1; i < source.Length; i++)
+            {
+                if (!codeTextMask.IsCodeAt(i))
+                {
+                    continue;
+                }
+
+                if (source[i] == '(')
+                {
+                    nestedParenthesisDepth++;
+                    continue;
+                }
+
+                if (source[i] != ')')
+                {
+                    continue;
+                }
+
+                if (nestedParenthesisDepth == 0)
+                {
+                    return i;
+                }
+
+                nestedParenthesisDepth--;
+            }
+
+            return -1;
         }
 
         private static bool IsNamedAttributeArgument(string argument, string argumentName)
@@ -1270,7 +1374,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         }
 
                         MarkRangeAsIgnored(codeCharacters, literalStartIndex, index);
-                        index = FindRawInterpolationHoleEndIndex(source, index, dollarCount);
+                        index = MarkRawInterpolationHoleNestedTextAsIgnored(
+                            codeCharacters,
+                            source,
+                            index,
+                            dollarCount);
                         literalStartIndex = index;
                         continue;
                     }
@@ -1318,7 +1426,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         }
 
                         MarkRangeAsIgnored(codeCharacters, literalStartIndex, index);
-                        index = FindInterpolationHoleEndIndex(source, index);
+                        index = MarkInterpolationHoleNestedTextAsIgnored(codeCharacters, source, index);
                         literalStartIndex = index;
                         continue;
                     }
@@ -1371,7 +1479,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         }
 
                         MarkRangeAsIgnored(codeCharacters, literalStartIndex, index);
-                        index = FindInterpolationHoleEndIndex(source, index);
+                        index = MarkInterpolationHoleNestedTextAsIgnored(codeCharacters, source, index);
                         literalStartIndex = index;
                         continue;
                     }
@@ -1389,8 +1497,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return source.Length;
             }
 
-            private static int FindInterpolationHoleEndIndex(string source, int openBraceIndex)
+            private static int MarkInterpolationHoleNestedTextAsIgnored(
+                bool[] codeCharacters,
+                string source,
+                int openBraceIndex)
             {
+                Debug.Assert(codeCharacters != null, "codeCharacters must not be null");
                 Debug.Assert(source != null, "source must not be null");
                 Debug.Assert(openBraceIndex >= 0, "openBraceIndex must not be negative");
 
@@ -1398,21 +1510,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int index = openBraceIndex + 1;
                 while (index < source.Length)
                 {
-                    if (StartsWith(source, index, "@\""))
+                    int ignoredTextEndIndex = MarkIgnoredTextInInterpolationHole(
+                        codeCharacters,
+                        source,
+                        index);
+                    if (ignoredTextEndIndex != index)
                     {
-                        index = FindVerbatimStringEndIndex(source, index + 1);
-                        continue;
-                    }
-
-                    if (source[index] == '"')
-                    {
-                        index = FindRegularStringEndIndex(source, index);
-                        continue;
-                    }
-
-                    if (source[index] == '\'')
-                    {
-                        index = FindCharLiteralEndIndex(source, index);
+                        index = ignoredTextEndIndex;
                         continue;
                     }
 
@@ -1439,11 +1543,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return source.Length;
             }
 
-            private static int FindRawInterpolationHoleEndIndex(
+            private static int MarkRawInterpolationHoleNestedTextAsIgnored(
+                bool[] codeCharacters,
                 string source,
                 int openBraceIndex,
                 int interpolationBraceCount)
             {
+                Debug.Assert(codeCharacters != null, "codeCharacters must not be null");
                 Debug.Assert(source != null, "source must not be null");
                 Debug.Assert(openBraceIndex >= 0, "openBraceIndex must not be negative");
                 Debug.Assert(interpolationBraceCount > 0, "interpolationBraceCount must be positive");
@@ -1452,34 +1558,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int index = openBraceIndex + interpolationBraceCount;
                 while (index < source.Length)
                 {
-                    if (IsInterpolatedRawStringStart(source, index))
+                    int ignoredTextEndIndex = MarkIgnoredTextInInterpolationHole(
+                        codeCharacters,
+                        source,
+                        index);
+                    if (ignoredTextEndIndex != index)
                     {
-                        int dollarCount = CountRepeatedCharacter(source, index, '$');
-                        index = FindRawStringEndIndex(source, index + dollarCount);
-                        continue;
-                    }
-
-                    if (CountRepeatedCharacter(source, index, '"') >= MinimumRawStringDelimiterQuoteCount)
-                    {
-                        index = FindRawStringEndIndex(source, index);
-                        continue;
-                    }
-
-                    if (StartsWith(source, index, "@\""))
-                    {
-                        index = FindVerbatimStringEndIndex(source, index + 1);
-                        continue;
-                    }
-
-                    if (source[index] == '"')
-                    {
-                        index = FindRegularStringEndIndex(source, index);
-                        continue;
-                    }
-
-                    if (source[index] == '\'')
-                    {
-                        index = FindCharLiteralEndIndex(source, index);
+                        index = ignoredTextEndIndex;
                         continue;
                     }
 
@@ -1510,6 +1595,40 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 return source.Length;
+            }
+
+            private static int MarkIgnoredTextInInterpolationHole(
+                bool[] codeCharacters,
+                string source,
+                int startIndex)
+            {
+                Debug.Assert(codeCharacters != null, "codeCharacters must not be null");
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+                if (IsInterpolatedRawStringStart(source, startIndex))
+                {
+                    return MarkInterpolatedRawStringAsIgnored(codeCharacters, source, startIndex);
+                }
+
+                if (StartsWith(source, startIndex, "$@\"") || StartsWith(source, startIndex, "@$\""))
+                {
+                    return MarkInterpolatedVerbatimStringAsIgnored(codeCharacters, source, startIndex);
+                }
+
+                if (StartsWith(source, startIndex, "$\"") && !StartsWith(source, startIndex, "$\"\"\""))
+                {
+                    return MarkInterpolatedRegularStringAsIgnored(codeCharacters, source, startIndex);
+                }
+
+                int ignoredTextEndIndex = GetIgnoredTextEndIndex(source, startIndex);
+                if (ignoredTextEndIndex == startIndex)
+                {
+                    return startIndex;
+                }
+
+                MarkRangeAsIgnored(codeCharacters, startIndex, ignoredTextEndIndex);
+                return ignoredTextEndIndex;
             }
 
             private static int FindCharLiteralEndIndex(string source, int quoteIndex)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -48,6 +48,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyNamespaceRegex =
             new(LegacyNamespacePattern, RegexOptions.Compiled);
 
+        private static readonly Regex CurrentDomainNamespaceRegex =
+            new(
+                $@"(?<![\w.])(?:global::)?{Regex.Escape(CurrentDomainNamespace)}(?=\.|;|\s|$)",
+                RegexOptions.Compiled);
+
         private static readonly Regex LegacyGlobalUsingRegex =
             new(
                 $@"\bglobal\s+using\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*=\s*)?(?:global::)?{Regex.Escape(LegacyNamespace)}\s*;",
@@ -90,9 +95,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 @"McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$",
                 RegexOptions.Compiled);
 
-        private static readonly Regex CurrentToolInfoConstructorRegex =
+        private static readonly Regex LegacyToolInfoConstructorRegex =
             new(
-                $@"new\s+{Regex.Escape(CurrentDomainNamespace)}\.ToolInfo\s*\(",
+                $@"new\s+(?:(?<qualifier>(?:global::)?{Regex.Escape(LegacyNamespace)}\.)ToolInfo|(?<alias>[A-Za-z_][A-Za-z0-9_]*)\.ToolInfo|(?<toolInfo>ToolInfo)|(?<typeAlias>[A-Za-z_][A-Za-z0-9_]*))\s*\(",
+                RegexOptions.Compiled);
+
+        private static readonly Regex LegacyToolInfoTypeAliasRegex =
+            new(
+                $@"\busing\s+(?<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:global::)?{Regex.Escape(LegacyNamespace)}\.ToolInfo\s*;",
                 RegexOptions.Compiled);
 
         private static readonly TypeReplacementRule[] ToolContractTypeReplacementRules =
@@ -143,10 +153,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string migratedContent = source;
             string[] legacyNamespaceAliases = GetCombinedLegacyNamespaceAliases(source, legacyAssemblyAliases);
             bool hasLegacyNamespaceUsage = RegexMatchesCode(source, LegacyNamespaceRegex);
+            bool hasCurrentDomainNamespaceUsage = RegexMatchesCode(source, CurrentDomainNamespaceRegex);
             bool canMigrateBareLegacyToolAttribute =
                 hasLegacyAssemblySource ||
                 hasLegacyNamespaceUsage ||
                 legacyNamespaceAliases.Length > 0;
+            bool canMigrateBareLegacyToolInfoConstructor =
+                canMigrateBareLegacyToolAttribute &&
+                !hasCurrentDomainNamespaceUsage;
             bool hasLocalLegacyMarker = ContainsLegacyToolMigrationMarker(source);
             bool shouldApplyContractRenames = hasLegacyAssemblySource || hasLocalLegacyMarker;
             bool shouldApplyRegistrarRenames = shouldApplyContractRenames &&
@@ -162,6 +176,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             migratedContent = ReplaceLegacyRegistrarAliasesInCode(
                 migratedContent,
                 legacyNamespaceAliases,
+                ref replacementCount);
+            migratedContent = ReplaceLegacyToolInfoConstructorsInCode(
+                migratedContent,
+                legacyNamespaceAliases,
+                canMigrateBareLegacyToolInfoConstructor,
                 ref replacementCount);
 
             if (shouldApplyContractRenames)
@@ -191,10 +210,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         _ => rule.Replacement,
                         ref replacementCount);
                 }
-
-                migratedContent = ReplaceLegacyToolInfoConstructorsInCode(
-                    migratedContent,
-                    ref replacementCount);
             }
 
             return new ThirdPartyToolMigrationContentResult(
@@ -605,6 +620,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return GetRegexGroupValuesInCode(source, LegacyNamespaceAliasRegex, "alias");
         }
 
+        private static string[] GetLegacyToolInfoTypeAliases(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return GetRegexGroupValuesInCode(source, LegacyToolInfoTypeAliasRegex, "alias");
+        }
+
         private static string[] GetCombinedLegacyNamespaceAliases(
             string source,
             string[] legacyAssemblyAliases)
@@ -720,18 +742,28 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static string ReplaceLegacyToolInfoConstructorsInCode(
             string source,
+            string[] legacyNamespaceAliases,
+            bool canMigrateBareLegacyToolInfoConstructor,
             ref int replacementCount)
         {
             Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyNamespaceAliases != null, "legacyNamespaceAliases must not be null");
 
             CodeTextMask codeTextMask = CodeTextMask.Create(source);
-            MatchCollection matches = CurrentToolInfoConstructorRegex.Matches(source);
+            string[] legacyToolInfoTypeAliases = GetLegacyToolInfoTypeAliases(source);
+            MatchCollection matches = LegacyToolInfoConstructorRegex.Matches(source);
             StringBuilder builder = new(source.Length);
             int sourceCopyIndex = 0;
             int localReplacementCount = 0;
             foreach (Match match in matches)
             {
-                if (match.Index < sourceCopyIndex || !codeTextMask.IsCodeAt(match.Index))
+                if (match.Index < sourceCopyIndex ||
+                    !codeTextMask.IsCodeAt(match.Index) ||
+                    !IsLegacyToolInfoConstructorMatch(
+                        match,
+                        legacyNamespaceAliases,
+                        legacyToolInfoTypeAliases,
+                        canMigrateBareLegacyToolInfoConstructor))
                 {
                     continue;
                 }
@@ -757,7 +789,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 builder.Append(source, sourceCopyIndex, match.Index - sourceCopyIndex);
-                builder.Append(source, match.Index, openParenthesisIndex - match.Index + 1);
+                builder.Append($"new {CurrentDomainNamespace}.ToolInfo(");
                 builder.Append(string.Join(", ", migratedArguments));
                 builder.Append(')');
                 sourceCopyIndex = closingParenthesisIndex + 1;
@@ -772,6 +804,39 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             builder.Append(source, sourceCopyIndex, source.Length - sourceCopyIndex);
             replacementCount += localReplacementCount;
             return builder.ToString();
+        }
+
+        private static bool IsLegacyToolInfoConstructorMatch(
+            Match match,
+            string[] legacyNamespaceAliases,
+            string[] legacyToolInfoTypeAliases,
+            bool canMigrateBareLegacyToolInfoConstructor)
+        {
+            Debug.Assert(match != null, "match must not be null");
+            Debug.Assert(legacyNamespaceAliases != null, "legacyNamespaceAliases must not be null");
+            Debug.Assert(legacyToolInfoTypeAliases != null, "legacyToolInfoTypeAliases must not be null");
+
+            if (match.Groups["qualifier"].Success)
+            {
+                return true;
+            }
+
+            if (match.Groups["alias"].Success)
+            {
+                return legacyNamespaceAliases.Contains(match.Groups["alias"].Value);
+            }
+
+            if (match.Groups["typeAlias"].Success)
+            {
+                return legacyToolInfoTypeAliases.Contains(match.Groups["typeAlias"].Value);
+            }
+
+            if (match.Groups["toolInfo"].Success)
+            {
+                return canMigrateBareLegacyToolInfoConstructor;
+            }
+
+            return false;
         }
 
         private static string[] GetMigratedToolInfoConstructorArguments(string[] arguments)
@@ -796,7 +861,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 };
             }
 
-            if (arguments.Length == 3 && ShouldDropLegacyPositionalToolInfoDescriptionArgument(arguments))
+            if (arguments.Length == 3)
             {
                 return new[]
                 {
@@ -857,41 +922,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return migratedArguments.ToArray();
-        }
-
-        private static bool ShouldDropLegacyPositionalToolInfoDescriptionArgument(string[] arguments)
-        {
-            Debug.Assert(arguments != null, "arguments must not be null");
-            Debug.Assert(arguments.Length == 3, "arguments must contain three items");
-
-            string secondArgument = arguments[1].Trim();
-            string thirdArgument = arguments[2].Trim();
-            if (IsLikelyToolParameterSchemaExpression(secondArgument))
-            {
-                return false;
-            }
-
-            return IsStringLiteralExpression(secondArgument) ||
-                IsLikelyToolParameterSchemaExpression(thirdArgument);
-        }
-
-        private static bool IsStringLiteralExpression(string expression)
-        {
-            Debug.Assert(expression != null, "expression must not be null");
-
-            return expression.StartsWith("\"", StringComparison.Ordinal) ||
-                expression.StartsWith("@\"", StringComparison.Ordinal) ||
-                expression.StartsWith("$\"", StringComparison.Ordinal) ||
-                expression.StartsWith("$@\"", StringComparison.Ordinal) ||
-                expression.StartsWith("@$\"", StringComparison.Ordinal) ||
-                expression.StartsWith("\"\"\"", StringComparison.Ordinal);
-        }
-
-        private static bool IsLikelyToolParameterSchemaExpression(string expression)
-        {
-            Debug.Assert(expression != null, "expression must not be null");
-
-            return expression.IndexOf("schema", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private static int FindInvocationClosingParenthesisIndex(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -48,6 +48,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyRegistrarRegex =
             new(@"\bCustomToolManager\b", RegexOptions.Compiled);
 
+        private static readonly Regex LegacyDomainMetadataRegex =
+            new(@"\bToolInfo\b", RegexOptions.Compiled);
+
         private static readonly Regex LegacyNamespaceAliasRegex =
             new(
                 @"\busing\s+(?<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:global::)?" +
@@ -56,7 +59,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static readonly Regex LegacyToolAttributeEntryRegex =
             new(
-                @"^\s*(?:(?<qualifier>io\.github\.hatayama\.uLoopMCP\.)|(?<alias>[A-Za-z_][A-Za-z0-9_]*)\.)?" +
+                @"^\s*(?:(?<qualifier>(?:global::)?io\.github\.hatayama\.uLoopMCP\.)|(?<alias>[A-Za-z_][A-Za-z0-9_]*)\.)?" +
                 @"McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$",
                 RegexOptions.Compiled);
 
@@ -103,6 +106,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             bool shouldApplyContractRenames = hasLegacyAssemblySource || hasLocalLegacyMarker;
             bool shouldApplyRegistrarRenames = shouldApplyContractRenames &&
                 RegexMatchesCode(source, LegacyRegistrarRegex);
+            bool shouldApplyDomainMetadataRenames = shouldApplyContractRenames &&
+                RegexMatchesCode(source, LegacyDomainMetadataRegex);
             int replacementCount = 0;
             string[] legacyNamespaceAliases = GetLegacyNamespaceAliases(source);
             migratedContent = ReplaceLegacyToolAttributesInCode(
@@ -126,7 +131,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
-            if (shouldApplyRegistrarRenames)
+            if (shouldApplyRegistrarRenames || shouldApplyDomainMetadataRenames)
             {
                 foreach (ReplacementRule rule in RegistrarReplacementRules)
                 {
@@ -146,7 +151,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal static ThirdPartyToolMigrationContentResult MigrateAsmdefSource(
             string source,
             bool hasLegacyCSharpSource,
-            bool requiresApplicationReference)
+            bool requiresApplicationReference,
+            bool requiresDomainReference)
         {
             Debug.Assert(source != null, "source must not be null");
 
@@ -166,7 +172,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 string[] migratedReferenceItems = GetMigratedAsmdefReferences(
                     reference,
                     hasLegacyCSharpSource,
-                    requiresApplicationReference);
+                    requiresApplicationReference,
+                    requiresDomainReference);
                 bool referenceChanged = migratedReferenceItems.Length != 1 ||
                     !string.Equals(migratedReferenceItems[0], reference, StringComparison.Ordinal);
                 if (referenceChanged)
@@ -210,6 +217,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return RegexMatchesCode(source, LegacyRegistrarRegex);
         }
 
+        internal static bool ContainsLegacyDomainMetadataApi(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return RegexMatchesCode(source, LegacyDomainMetadataRegex);
+        }
+
         internal static bool IsExcludedDirectoryName(string directoryName)
         {
             Debug.Assert(!string.IsNullOrEmpty(directoryName), "directoryName must not be null or empty");
@@ -231,35 +245,43 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static string[] GetMigratedAsmdefReferences(
             string reference,
             bool hasLegacyCSharpSource,
-            bool requiresApplicationReference)
+            bool requiresApplicationReference,
+            bool requiresDomainReference)
         {
             if (string.Equals(reference, LegacyEditorAssemblyName, StringComparison.Ordinal))
             {
-                return GetMigratedLegacyEditorReferences(requiresApplicationReference);
+                return GetMigratedLegacyEditorReferences(requiresApplicationReference, requiresDomainReference);
             }
 
             if (hasLegacyCSharpSource
                 && string.Equals(reference, LegacyEditorAssemblyGuidReference, StringComparison.Ordinal))
             {
-                return GetMigratedLegacyEditorReferences(requiresApplicationReference);
+                return GetMigratedLegacyEditorReferences(requiresApplicationReference, requiresDomainReference);
             }
 
             return new[] { reference };
         }
 
-        private static string[] GetMigratedLegacyEditorReferences(bool requiresApplicationReference)
+        private static string[] GetMigratedLegacyEditorReferences(
+            bool requiresApplicationReference,
+            bool requiresDomainReference)
         {
-            if (!requiresApplicationReference)
+            List<string> references = new()
             {
-                return new[] { CurrentToolContractsGuidReference };
+                CurrentToolContractsGuidReference
+            };
+
+            if (requiresApplicationReference)
+            {
+                references.Add(CurrentApplicationGuidReference);
             }
 
-            return new[]
+            if (requiresApplicationReference || requiresDomainReference)
             {
-                CurrentToolContractsGuidReference,
-                CurrentApplicationGuidReference,
-                CurrentDomainGuidReference
-            };
+                references.Add(CurrentDomainGuidReference);
+            }
+
+            return references.ToArray();
         }
 
         private static bool TryMigrateLegacyToolAttributeList(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -539,11 +539,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return GetMigratedLegacyEditorReferences(requiresApplicationReference, requiresDomainReference);
             }
 
-            if ((hasLegacyCSharpSource ||
-                    requiresToolContractsReference ||
-                    requiresApplicationReference ||
-                    requiresDomainReference)
-                && string.Equals(reference, LegacyEditorAssemblyGuidReference, StringComparison.Ordinal))
+            if (hasLegacyCSharpSource &&
+                string.Equals(reference, LegacyEditorAssemblyGuidReference, StringComparison.Ordinal))
             {
                 return GetMigratedLegacyEditorReferences(requiresApplicationReference, requiresDomainReference);
             }
@@ -565,7 +562,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 references.Add(CurrentApplicationGuidReference);
             }
 
-            if (requiresApplicationReference || requiresDomainReference)
+            if (requiresDomainReference)
             {
                 references.Add(CurrentDomainGuidReference);
             }
@@ -602,7 +599,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     ref replacementCount);
             }
 
-            if (requiresApplicationReference || requiresDomainReference)
+            if (requiresDomainReference)
             {
                 AddRequiredCurrentAsmdefReference(
                     references,

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -32,6 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string RequiredSecuritySettingAttributeArgumentName = "RequiredSecuritySetting";
         private const string LegacySecuritySettingsTypeName = "SecuritySettings";
         private const string CurrentSecuritySettingTypeName = "UnityCliLoopSecuritySetting";
+        private const int MinimumRawStringDelimiterQuoteCount = 3;
 
         private static readonly string[] ExcludedDirectoryNames =
         {
@@ -69,6 +70,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyGlobalUsingRegex =
             new(
                 $@"\bglobal\s+using\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*=\s*)?(?:global::)?{Regex.Escape(LegacyNamespace)}\s*;",
+                RegexOptions.Compiled);
+
+        private static readonly Regex CurrentDomainGlobalUsingRegex =
+            new(
+                $@"\bglobal\s+using\s+(?:global::)?{Regex.Escape(CurrentDomainNamespace)}\s*;",
                 RegexOptions.Compiled);
 
         private static readonly Regex LegacyGlobalNamespaceAliasRegex =
@@ -385,10 +391,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(source != null, "source must not be null");
 
+            return ContainsCurrentDomainMetadataApiForAssembly(
+                source,
+                hasAssemblyScopedCurrentDomainUsing: false);
+        }
+
+        internal static bool ContainsCurrentDomainMetadataApiForAssembly(
+            string source,
+            bool hasAssemblyScopedCurrentDomainUsing)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            bool hasCurrentDomainNamespaceUsage = RegexMatchesCode(source, CurrentDomainNamespaceRegex);
+            bool canUseBareCurrentDomainType = hasAssemblyScopedCurrentDomainUsing || hasCurrentDomainNamespaceUsage;
             return RegexMatchesCode(source, CurrentDomainMetadataRegex) ||
-                ContainsCurrentDomainHelperApi(source) ||
-                (RegexMatchesCode(source, CurrentDomainNamespaceRegex) &&
-                    RegexMatchesCode(source, LegacyDomainMetadataRegex));
+                ContainsCurrentDomainHelperApiForAssembly(source, canUseBareCurrentDomainType) ||
+                (canUseBareCurrentDomainType && RegexMatchesCode(source, LegacyDomainMetadataRegex));
         }
 
         internal static bool ContainsLegacyAssemblyScopedApi(string source, string[] legacyAssemblyAliases)
@@ -411,6 +429,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return RegexMatchesCode(source, LegacyGlobalUsingRegex);
+        }
+
+        internal static bool ContainsCurrentDomainGlobalUsing(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return RegexMatchesCode(source, CurrentDomainGlobalUsingRegex);
         }
 
         internal static string[] GetLegacyGlobalNamespaceAliases(string source)
@@ -495,7 +520,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(references != null, "references must not be null");
             Debug.Assert(addedReferences != null, "addedReferences must not be null");
 
-            if (requiresToolContractsReference)
+            if (requiresToolContractsReference || requiresApplicationReference || requiresDomainReference)
             {
                 AddRequiredCurrentAsmdefReference(
                     references,
@@ -711,6 +736,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             bool isInRegularString = false;
             bool isInVerbatimString = false;
             bool isInCharLiteral = false;
+            bool isInRawString = false;
+            int rawStringQuoteCount = 0;
             for (int i = 0; i < argumentsSource.Length; i++)
             {
                 char current = argumentsSource[i];
@@ -747,6 +774,17 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     continue;
                 }
 
+                if (isInRawString)
+                {
+                    if (HasRepeatedCharacterAt(argumentsSource, i, '"', rawStringQuoteCount))
+                    {
+                        i += rawStringQuoteCount - 1;
+                        isInRawString = false;
+                    }
+
+                    continue;
+                }
+
                 if (isInCharLiteral)
                 {
                     if (current == '\\')
@@ -760,6 +798,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         isInCharLiteral = false;
                     }
 
+                    continue;
+                }
+
+                if (IsRawStringStart(argumentsSource, i))
+                {
+                    int dollarCount = CountRepeatedCharacter(argumentsSource, i, '$');
+                    int quoteIndex = i + dollarCount;
+                    rawStringQuoteCount = CountRepeatedCharacter(argumentsSource, quoteIndex, '"');
+                    isInRawString = true;
+                    i = quoteIndex + rawStringQuoteCount - 1;
                     continue;
                 }
 
@@ -1622,6 +1670,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             bool hasCurrentDomainNamespaceUsage = RegexMatchesCode(source, CurrentDomainNamespaceRegex);
+            return ContainsCurrentDomainHelperApiForAssembly(source, hasCurrentDomainNamespaceUsage);
+        }
+
+        private static bool ContainsCurrentDomainHelperApiForAssembly(
+            string source,
+            bool canUseBareCurrentDomainType)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
             foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
             {
                 Regex fullyQualifiedRegex = new(
@@ -1635,7 +1692,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 Regex unqualifiedRegex = new(
                     $@"(?<![\.:])\b{Regex.Escape(rule.CurrentName)}\b",
                     RegexOptions.Compiled);
-                if (hasCurrentDomainNamespaceUsage && RegexMatchesCode(source, unqualifiedRegex))
+                if (canUseBareCurrentDomainType && RegexMatchesCode(source, unqualifiedRegex))
                 {
                     return true;
                 }
@@ -1861,6 +1918,52 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return string.CompareOrdinal(source, startIndex, value, 0, value.Length) == 0;
         }
 
+        private static bool IsRawStringStart(string source, int startIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+            int dollarCount = CountRepeatedCharacter(source, startIndex, '$');
+            int quoteIndex = startIndex + dollarCount;
+            return CountRepeatedCharacter(source, quoteIndex, '"') >= MinimumRawStringDelimiterQuoteCount;
+        }
+
+        private static int CountRepeatedCharacter(string source, int startIndex, char character)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+            int index = startIndex;
+            while (index < source.Length && source[index] == character)
+            {
+                index++;
+            }
+
+            return index - startIndex;
+        }
+
+        private static bool HasRepeatedCharacterAt(string source, int startIndex, char character, int count)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+            Debug.Assert(count > 0, "count must be positive");
+
+            if (startIndex + count > source.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                if (source[startIndex + i] != character)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         private static int GetStringPrefixLength(string source, int startIndex)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -1906,8 +2009,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private readonly struct CodeTextMask
         {
-            private const int MinimumRawStringDelimiterQuoteCount = 3;
-
             private readonly bool[] _codeCharacters;
 
             private CodeTextMask(bool[] codeCharacters)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using Newtonsoft.Json;
@@ -45,9 +46,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyRegistrarRegex =
             new(@"\bCustomToolManager\b", RegexOptions.Compiled);
 
-        private static readonly Regex LegacyToolAttributeListRegex =
-            new(@"\[(?<attributes>[^\]]*\bMcpTool(?:Attribute)?\b[^\]]*)\]", RegexOptions.Compiled);
-
         private static readonly Regex LegacyToolAttributeEntryRegex =
             new(
                 @"^\s*(?<qualifier>io\.github\.hatayama\.uLoopMCP\.)?McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$",
@@ -59,6 +57,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 Regex.Escape($"{LegacyNamespace}.CustomToolManager"),
                 $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar"),
             new(Regex.Escape(LegacyNamespace), CurrentNamespace),
+            new(@"\bToolParameterSchemaGenerator\b", "UnityCliLoopToolParameterSchemaGenerator"),
+            new(@"\bParameterValidationException\b", "UnityCliLoopToolParameterValidationException"),
             new(@"\bMcpToolAttribute\b", "UnityCliLoopToolAttribute"),
             new(@"\bIUnityTool\b", "IUnityCliLoopTool"),
             new(@"\bAbstractUnityTool\b", "UnityCliLoopTool"),
@@ -75,11 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string migratedContent = source;
             bool shouldApplyContractRenames = ContainsLegacyToolMigrationMarker(source);
             int replacementCount = 0;
-            migratedContent = ReplaceRegexInCode(
-                migratedContent,
-                LegacyToolAttributeListRegex,
-                MigrateLegacyToolAttributeList,
-                ref replacementCount);
+            migratedContent = ReplaceLegacyToolAttributesInCode(migratedContent, ref replacementCount);
 
             if (shouldApplyContractRenames)
             {
@@ -212,33 +208,34 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return new[] { CurrentToolContractsGuidReference, CurrentApplicationGuidReference };
         }
 
-        private static string MigrateLegacyToolAttributeList(Match match)
+        private static bool TryMigrateLegacyToolAttributeList(string attributesSource, out string migratedAttributes)
         {
-            Debug.Assert(match != null, "match must not be null");
+            Debug.Assert(attributesSource != null, "attributesSource must not be null");
 
-            string attributesSource = match.Groups["attributes"].Value;
             string[] attributes = SplitAttributeArguments(attributesSource);
-            List<string> migratedAttributes = new();
+            List<string> migratedAttributeItems = new();
             bool changed = false;
             foreach (string attribute in attributes)
             {
                 string trimmedAttribute = attribute.Trim();
                 if (TryMigrateLegacyToolAttributeEntry(trimmedAttribute, out string migratedAttribute))
                 {
-                    migratedAttributes.Add(migratedAttribute);
+                    migratedAttributeItems.Add(migratedAttribute);
                     changed = true;
                     continue;
                 }
 
-                migratedAttributes.Add(trimmedAttribute);
+                migratedAttributeItems.Add(trimmedAttribute);
             }
 
             if (!changed)
             {
-                return match.Value;
+                migratedAttributes = string.Empty;
+                return false;
             }
 
-            return $"[{string.Join(", ", migratedAttributes)}]";
+            migratedAttributes = string.Join(", ", migratedAttributeItems);
+            return true;
         }
 
         private static bool TryMigrateLegacyToolAttributeEntry(string attribute, out string migratedAttribute)
@@ -473,6 +470,91 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return migrated;
         }
 
+        private static string ReplaceLegacyToolAttributesInCode(string source, ref int replacementCount)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            StringBuilder builder = new(source.Length);
+            int localReplacementCount = 0;
+            int index = 0;
+            while (index < source.Length)
+            {
+                if (source[index] != '[' || !codeTextMask.IsCodeAt(index))
+                {
+                    builder.Append(source[index]);
+                    index++;
+                    continue;
+                }
+
+                int closingBracketIndex = FindAttributeListClosingBracketIndex(
+                    source,
+                    codeTextMask,
+                    index + 1);
+                if (closingBracketIndex < 0)
+                {
+                    builder.Append(source[index]);
+                    index++;
+                    continue;
+                }
+
+                string attributesSource = source.Substring(index + 1, closingBracketIndex - index - 1);
+                if (!TryMigrateLegacyToolAttributeList(attributesSource, out string migratedAttributes))
+                {
+                    builder.Append(source, index, closingBracketIndex - index + 1);
+                    index = closingBracketIndex + 1;
+                    continue;
+                }
+
+                builder.Append('[');
+                builder.Append(migratedAttributes);
+                builder.Append(']');
+                localReplacementCount++;
+                index = closingBracketIndex + 1;
+            }
+
+            replacementCount += localReplacementCount;
+            return builder.ToString();
+        }
+
+        private static int FindAttributeListClosingBracketIndex(
+            string source,
+            CodeTextMask codeTextMask,
+            int startIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+            int nestedBracketDepth = 0;
+            for (int i = startIndex; i < source.Length; i++)
+            {
+                if (!codeTextMask.IsCodeAt(i))
+                {
+                    continue;
+                }
+
+                if (source[i] == '[')
+                {
+                    nestedBracketDepth++;
+                    continue;
+                }
+
+                if (source[i] != ']')
+                {
+                    continue;
+                }
+
+                if (nestedBracketDepth == 0)
+                {
+                    return i;
+                }
+
+                nestedBracketDepth--;
+            }
+
+            return -1;
+        }
+
         private static bool RegexMatchesCode(string source, Regex regex)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -497,7 +579,43 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (RegexMatchesCode(source, LegacyNamespaceRegex)) return true;
 
-            return RegexMatchesCode(source, LegacyToolAttributeListRegex);
+            return ContainsLegacyToolAttributeList(source);
+        }
+
+        private static bool ContainsLegacyToolAttributeList(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            int index = 0;
+            while (index < source.Length)
+            {
+                if (source[index] != '[' || !codeTextMask.IsCodeAt(index))
+                {
+                    index++;
+                    continue;
+                }
+
+                int closingBracketIndex = FindAttributeListClosingBracketIndex(
+                    source,
+                    codeTextMask,
+                    index + 1);
+                if (closingBracketIndex < 0)
+                {
+                    index++;
+                    continue;
+                }
+
+                string attributesSource = source.Substring(index + 1, closingBracketIndex - index - 1);
+                if (TryMigrateLegacyToolAttributeList(attributesSource, out _))
+                {
+                    return true;
+                }
+
+                index = closingBracketIndex + 1;
+            }
+
+            return false;
         }
 
         private static bool StartsWith(string source, int startIndex, string value)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -56,7 +56,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static readonly Regex LegacyToolAttributeEntryRegex =
             new(
-                @"^\s*(?<qualifier>io\.github\.hatayama\.uLoopMCP\.)?McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$",
+                @"^\s*(?:(?<qualifier>io\.github\.hatayama\.uLoopMCP\.)|(?<alias>[A-Za-z_][A-Za-z0-9_]*)\.)?" +
+                @"McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$",
                 RegexOptions.Compiled);
 
         private static readonly ReplacementRule[] CSharpReplacementRules =
@@ -103,10 +104,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             bool shouldApplyRegistrarRenames = shouldApplyContractRenames &&
                 RegexMatchesCode(source, LegacyRegistrarRegex);
             int replacementCount = 0;
-            migratedContent = ReplaceLegacyToolAttributesInCode(migratedContent, ref replacementCount);
+            string[] legacyNamespaceAliases = GetLegacyNamespaceAliases(source);
+            migratedContent = ReplaceLegacyToolAttributesInCode(
+                migratedContent,
+                legacyNamespaceAliases,
+                ref replacementCount);
             migratedContent = ReplaceLegacyRegistrarAliasesInCode(
                 migratedContent,
-                GetLegacyNamespaceAliases(source),
+                legacyNamespaceAliases,
                 ref replacementCount);
 
             if (shouldApplyContractRenames)
@@ -257,9 +262,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             };
         }
 
-        private static bool TryMigrateLegacyToolAttributeList(string attributesSource, out string migratedAttributes)
+        private static bool TryMigrateLegacyToolAttributeList(
+            string attributesSource,
+            string[] legacyNamespaceAliases,
+            out string migratedAttributes)
         {
             Debug.Assert(attributesSource != null, "attributesSource must not be null");
+            Debug.Assert(legacyNamespaceAliases != null, "legacyNamespaceAliases must not be null");
 
             string[] attributes = SplitAttributeArguments(attributesSource);
             List<string> migratedAttributeItems = new();
@@ -267,7 +276,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string attribute in attributes)
             {
                 string trimmedAttribute = attribute.Trim();
-                if (TryMigrateLegacyToolAttributeEntry(trimmedAttribute, out string migratedAttribute))
+                if (TryMigrateLegacyToolAttributeEntry(
+                        trimmedAttribute,
+                        legacyNamespaceAliases,
+                        out string migratedAttribute))
                 {
                     migratedAttributeItems.Add(migratedAttribute);
                     changed = true;
@@ -287,9 +299,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return true;
         }
 
-        private static bool TryMigrateLegacyToolAttributeEntry(string attribute, out string migratedAttribute)
+        private static bool TryMigrateLegacyToolAttributeEntry(
+            string attribute,
+            string[] legacyNamespaceAliases,
+            out string migratedAttribute)
         {
             Debug.Assert(attribute != null, "attribute must not be null");
+            Debug.Assert(legacyNamespaceAliases != null, "legacyNamespaceAliases must not be null");
 
             Match match = LegacyToolAttributeEntryRegex.Match(attribute);
             if (!match.Success)
@@ -298,9 +314,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return false;
             }
 
+            if (match.Groups["alias"].Success &&
+                !legacyNamespaceAliases.Contains(match.Groups["alias"].Value))
+            {
+                migratedAttribute = string.Empty;
+                return false;
+            }
+
             string argumentsSource = match.Groups["arguments"].Value;
             string[] migratedArguments = GetMigratedSupportedAttributeArguments(argumentsSource);
-            string attributeName = match.Groups["qualifier"].Success
+            string attributeName = match.Groups["qualifier"].Success || match.Groups["alias"].Success
                 ? $"{CurrentNamespace}.UnityCliLoopTool"
                 : "UnityCliLoopTool";
             migratedAttribute = migratedArguments.Length == 0
@@ -500,6 +523,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     aliasRegistrarRegex,
                     _ => $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar",
                     ref replacementCount);
+
+                Regex aliasToolInfoRegex = new(
+                    $@"(?<!\w){Regex.Escape(alias)}\.ToolInfo\b",
+                    RegexOptions.Compiled);
+                migratedContent = ReplaceRegexInCode(
+                    migratedContent,
+                    aliasToolInfoRegex,
+                    _ => $"{CurrentDomainNamespace}.ToolInfo",
+                    ref replacementCount);
             }
 
             return migratedContent;
@@ -563,9 +595,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return migrated;
         }
 
-        private static string ReplaceLegacyToolAttributesInCode(string source, ref int replacementCount)
+        private static string ReplaceLegacyToolAttributesInCode(
+            string source,
+            string[] legacyNamespaceAliases,
+            ref int replacementCount)
         {
             Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyNamespaceAliases != null, "legacyNamespaceAliases must not be null");
 
             CodeTextMask codeTextMask = CodeTextMask.Create(source);
             StringBuilder builder = new(source.Length);
@@ -592,7 +628,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 string attributesSource = source.Substring(index + 1, closingBracketIndex - index - 1);
-                if (!TryMigrateLegacyToolAttributeList(attributesSource, out string migratedAttributes))
+                if (!TryMigrateLegacyToolAttributeList(
+                        attributesSource,
+                        legacyNamespaceAliases,
+                        out string migratedAttributes))
                 {
                     builder.Append(source, index, closingBracketIndex - index + 1);
                     index = closingBracketIndex + 1;
@@ -680,6 +719,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            string[] legacyNamespaceAliases = GetLegacyNamespaceAliases(source);
             int index = 0;
             while (index < source.Length)
             {
@@ -700,7 +740,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 string attributesSource = source.Substring(index + 1, closingBracketIndex - index - 1);
-                if (TryMigrateLegacyToolAttributeList(attributesSource, out _))
+                if (TryMigrateLegacyToolAttributeList(attributesSource, legacyNamespaceAliases, out _))
                 {
                     return true;
                 }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -125,6 +125,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             new("ToolParameterSchemaGenerator", "UnityCliLoopToolParameterSchemaGenerator"),
             new("ParameterValidationException", "UnityCliLoopToolParameterValidationException"),
+            new("McpConstants", "UnityCliLoopConstants"),
             new("McpToolAttribute", "UnityCliLoopToolAttribute"),
             new("IUnityTool", "IUnityCliLoopTool"),
             new("AbstractUnityTool", "UnityCliLoopTool"),

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -382,6 +382,41 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return false;
         }
 
+        internal static bool ContainsLegacyMigrationCandidateText(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return ContainsTextFragment(source, LegacyNamespace) ||
+                ContainsTextFragment(source, LegacyEditorAssemblyName);
+        }
+
+        internal static bool ContainsLegacyAsmdefNameReference(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            if (!ContainsTextFragment(source, LegacyEditorAssemblyName))
+            {
+                return false;
+            }
+
+            JObject asmdef = JObject.Parse(source);
+            if (asmdef["references"] is not JArray references)
+            {
+                return false;
+            }
+
+            foreach (JToken reference in references)
+            {
+                string referenceValue = reference.Value<string>() ?? string.Empty;
+                if (string.Equals(referenceValue, LegacyEditorAssemblyName, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         internal static bool ContainsLegacyRegistrarApi(string source)
         {
             Debug.Assert(source != null, "source must not be null");

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -126,13 +126,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 $@"(?<![\w.])(?:global::)?{Regex.Escape(LegacyNamespace)}\.CustomToolManager\b",
                 $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar"),
             new(LegacyNamespacePattern, CurrentNamespace),
-            new(@"(?<![\.:])\bCustomToolManager\b", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
+            new(@"(?<![\.:])\bCustomToolManager\b(?!\s*=)", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
         };
 
         private static readonly ReplacementRule[] RegistrarReplacementRules =
         {
             new(Regex.Escape($"{CurrentNamespace}.ToolInfo"), $"{CurrentDomainNamespace}.ToolInfo"),
-            new(@"(?<![\.:])\bToolInfo\b", $"{CurrentDomainNamespace}.ToolInfo")
+            new(@"(?<![\.:])\bToolInfo\b(?!\s*=)", $"{CurrentDomainNamespace}.ToolInfo")
         };
 
         internal static ThirdPartyToolMigrationContentResult MigrateCSharpSource(string source)
@@ -738,7 +738,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 Regex unqualifiedRegex = new(
-                    $@"(?<![\.:])\b{Regex.Escape(rule.LegacyName)}\b",
+                    $@"(?<![\.:])\b{Regex.Escape(rule.LegacyName)}\b(?!\s*=)",
                     RegexOptions.Compiled);
                 migratedContent = ReplaceRegexInCode(
                     migratedContent,

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -709,22 +709,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     openParenthesisIndex + 1,
                     closingParenthesisIndex - openParenthesisIndex - 1);
                 string[] arguments = SplitAttributeArguments(argumentsSource);
-                if (!ShouldDropLegacyToolInfoDescriptionArgument(arguments))
+                string[] migratedArguments = GetMigratedToolInfoConstructorArguments(arguments);
+                if (migratedArguments.Length == arguments.Length)
                 {
                     continue;
                 }
 
                 builder.Append(source, sourceCopyIndex, match.Index - sourceCopyIndex);
                 builder.Append(source, match.Index, openParenthesisIndex - match.Index + 1);
-                builder.Append(arguments[0].Trim());
-                builder.Append(", ");
-                builder.Append(arguments[2].Trim());
-                if (arguments.Length == 4)
-                {
-                    builder.Append(", ");
-                    builder.Append(arguments[3].Trim());
-                }
-
+                builder.Append(string.Join(", ", migratedArguments));
                 builder.Append(')');
                 sourceCopyIndex = closingParenthesisIndex + 1;
                 localReplacementCount++;
@@ -740,12 +733,104 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return builder.ToString();
         }
 
-        private static bool ShouldDropLegacyToolInfoDescriptionArgument(string[] arguments)
+        private static string[] GetMigratedToolInfoConstructorArguments(string[] arguments)
         {
             Debug.Assert(arguments != null, "arguments must not be null");
 
-            return arguments.Length == 4 ||
-                (arguments.Length == 3 && IsStringLiteralExpression(arguments[1].Trim()));
+            int namedDescriptionArgumentIndex = FindNamedConstructorArgumentIndex(
+                arguments,
+                DescriptionAttributeArgumentName.ToLowerInvariant());
+            if (namedDescriptionArgumentIndex >= 0)
+            {
+                return RemoveArgumentAt(arguments, namedDescriptionArgumentIndex);
+            }
+
+            if (arguments.Length == 4)
+            {
+                return new[]
+                {
+                    arguments[0].Trim(),
+                    arguments[2].Trim(),
+                    arguments[3].Trim()
+                };
+            }
+
+            if (arguments.Length == 3 && ShouldDropLegacyPositionalToolInfoDescriptionArgument(arguments))
+            {
+                return new[]
+                {
+                    arguments[0].Trim(),
+                    arguments[2].Trim()
+                };
+            }
+
+            return arguments;
+        }
+
+        private static int FindNamedConstructorArgumentIndex(string[] arguments, string argumentName)
+        {
+            Debug.Assert(arguments != null, "arguments must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(argumentName), "argumentName must not be null or empty");
+
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                if (IsNamedConstructorArgument(arguments[i].Trim(), argumentName))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static bool IsNamedConstructorArgument(string argument, string argumentName)
+        {
+            Debug.Assert(argument != null, "argument must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(argumentName), "argumentName must not be null or empty");
+
+            int colonIndex = argument.IndexOf(':');
+            if (colonIndex <= 0)
+            {
+                return false;
+            }
+
+            string possibleArgumentName = argument.Substring(0, colonIndex).Trim();
+            return string.Equals(possibleArgumentName, argumentName, StringComparison.Ordinal);
+        }
+
+        private static string[] RemoveArgumentAt(string[] arguments, int removeIndex)
+        {
+            Debug.Assert(arguments != null, "arguments must not be null");
+            Debug.Assert(removeIndex >= 0, "removeIndex must not be negative");
+            Debug.Assert(removeIndex < arguments.Length, "removeIndex must be within arguments");
+
+            List<string> migratedArguments = new();
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                if (i == removeIndex)
+                {
+                    continue;
+                }
+
+                migratedArguments.Add(arguments[i].Trim());
+            }
+
+            return migratedArguments.ToArray();
+        }
+
+        private static bool ShouldDropLegacyPositionalToolInfoDescriptionArgument(string[] arguments)
+        {
+            Debug.Assert(arguments != null, "arguments must not be null");
+            Debug.Assert(arguments.Length == 3, "arguments must contain three items");
+
+            string secondArgument = arguments[1].Trim();
+            string thirdArgument = arguments[2].Trim();
+            if (IsLikelyToolParameterSchemaExpression(secondArgument))
+            {
+                return false;
+            }
+
+            return IsStringLiteralExpression(secondArgument) || !IsBooleanLikeExpression(thirdArgument);
         }
 
         private static bool IsStringLiteralExpression(string expression)
@@ -758,6 +843,64 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 expression.StartsWith("$@\"", StringComparison.Ordinal) ||
                 expression.StartsWith("@$\"", StringComparison.Ordinal) ||
                 expression.StartsWith("\"\"\"", StringComparison.Ordinal);
+        }
+
+        private static bool IsLikelyToolParameterSchemaExpression(string expression)
+        {
+            Debug.Assert(expression != null, "expression must not be null");
+
+            return expression.IndexOf("schema", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static bool IsBooleanLikeExpression(string expression)
+        {
+            Debug.Assert(expression != null, "expression must not be null");
+
+            string valueExpression = RemoveNamedArgumentPrefix(expression);
+            return string.Equals(valueExpression, "true", StringComparison.Ordinal) ||
+                string.Equals(valueExpression, "false", StringComparison.Ordinal) ||
+                valueExpression.IndexOf(
+                    DisplayDevelopmentOnlyAttributeArgumentName,
+                    StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static string RemoveNamedArgumentPrefix(string expression)
+        {
+            Debug.Assert(expression != null, "expression must not be null");
+
+            int colonIndex = expression.IndexOf(':');
+            if (colonIndex <= 0)
+            {
+                return expression;
+            }
+
+            string possibleArgumentName = expression.Substring(0, colonIndex).Trim();
+            if (!IsIdentifier(possibleArgumentName))
+            {
+                return expression;
+            }
+
+            return expression.Substring(colonIndex + 1).Trim();
+        }
+
+        private static bool IsIdentifier(string value)
+        {
+            Debug.Assert(value != null, "value must not be null");
+
+            if (value.Length == 0 || char.IsDigit(value[0]))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (!IsIdentifierCharacter(value[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static int FindInvocationClosingParenthesisIndex(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -48,6 +48,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyRegistrarRegex =
             new(@"\bCustomToolManager\b", RegexOptions.Compiled);
 
+        private static readonly Regex LegacyNamespaceAliasRegex =
+            new(
+                @"\busing\s+(?<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:global::)?" +
+                @"io\.github\.hatayama\.uLoopMCP\s*;",
+                RegexOptions.Compiled);
+
         private static readonly Regex LegacyToolAttributeEntryRegex =
             new(
                 @"^\s*(?<qualifier>io\.github\.hatayama\.uLoopMCP\.)?McpTool(?:Attribute)?\s*(?:\((?<arguments>[\s\S]*)\))?\s*$",
@@ -67,7 +73,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             new(@"\bBaseToolSchema\b", "UnityCliLoopToolSchema"),
             new(@"\bBaseToolResponse\b", "UnityCliLoopToolResponse"),
             new(@"\bSecuritySettings\b", CurrentSecuritySettingTypeName),
-            new(@"\bCustomToolManager\b", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
+            new(@"(?<!\.)\bCustomToolManager\b", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
         };
 
         private static readonly ReplacementRule[] RegistrarReplacementRules =
@@ -98,6 +104,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 RegexMatchesCode(source, LegacyRegistrarRegex);
             int replacementCount = 0;
             migratedContent = ReplaceLegacyToolAttributesInCode(migratedContent, ref replacementCount);
+            migratedContent = ReplaceLegacyRegistrarAliasesInCode(
+                migratedContent,
+                GetLegacyNamespaceAliases(source),
+                ref replacementCount);
 
             if (shouldApplyContractRenames)
             {
@@ -449,6 +459,50 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             arguments.Add(argumentsSource.Substring(argumentStartIndex));
             return arguments.ToArray();
+        }
+
+        private static string[] GetLegacyNamespaceAliases(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            List<string> aliases = new();
+            MatchCollection matches = LegacyNamespaceAliasRegex.Matches(source);
+            foreach (Match match in matches)
+            {
+                if (!codeTextMask.IsCodeAt(match.Index))
+                {
+                    continue;
+                }
+
+                aliases.Add(match.Groups["alias"].Value);
+            }
+
+            return aliases.ToArray();
+        }
+
+        private static string ReplaceLegacyRegistrarAliasesInCode(
+            string source,
+            string[] aliases,
+            ref int replacementCount)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(aliases != null, "aliases must not be null");
+
+            string migratedContent = source;
+            foreach (string alias in aliases)
+            {
+                Regex aliasRegistrarRegex = new(
+                    $@"(?<!\w){Regex.Escape(alias)}\.CustomToolManager\b",
+                    RegexOptions.Compiled);
+                migratedContent = ReplaceRegexInCode(
+                    migratedContent,
+                    aliasRegistrarRegex,
+                    _ => $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar",
+                    ref replacementCount);
+            }
+
+            return migratedContent;
         }
 
         private static bool IsNamedAttributeArgument(string argument, string argumentName)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -93,6 +93,17 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex CurrentRegistrarRegex =
             new(@"\bUnityCliLoopToolRegistrar\b", RegexOptions.Compiled);
 
+        private static readonly Regex LegacyQualifiedRegistrarDomainReturnRegex =
+            new(
+                $@"(?<![\w.])(?:global::)?{Regex.Escape(LegacyNamespace)}\.CustomToolManager\s*\.\s*GetRegisteredCustomTools\s*\(",
+                RegexOptions.Compiled);
+
+        private static readonly Regex LegacyRegistrarDomainReturnRegex =
+            new(@"\bCustomToolManager\s*\.\s*GetRegisteredCustomTools\s*\(", RegexOptions.Compiled);
+
+        private static readonly Regex CurrentRegistrarDomainReturnRegex =
+            new(@"\bUnityCliLoopToolRegistrar\s*\.\s*GetRegisteredCustomTools\s*\(", RegexOptions.Compiled);
+
         private static readonly Regex LegacyDomainMetadataRegex =
             new(@"\bToolInfo\b", RegexOptions.Compiled);
 
@@ -451,6 +462,40 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return RegexMatchesCode(source, CurrentRegistrarRegex);
+        }
+
+        internal static bool ContainsRegistrarDomainReturnApi(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return ContainsRegistrarDomainReturnApiForAssembly(
+                source,
+                hasLegacyAssemblySource: ContainsLegacyToolMigrationMarker(source),
+                legacyAssemblyAliases: Array.Empty<string>());
+        }
+
+        internal static bool ContainsRegistrarDomainReturnApiForAssembly(
+            string source,
+            bool hasLegacyAssemblySource,
+            string[] legacyAssemblyAliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
+
+            if (RegexMatchesCode(source, CurrentRegistrarDomainReturnRegex))
+            {
+                return true;
+            }
+
+            string[] legacyNamespaceAliases = GetCombinedLegacyNamespaceAliases(source, legacyAssemblyAliases);
+            bool canMigrateBareLegacyRegistrar =
+                hasLegacyAssemblySource ||
+                ContainsLegacyToolMigrationMarker(source) ||
+                legacyNamespaceAliases.Length > 0;
+            return ContainsLegacyRegistrarDomainReturnReference(
+                source,
+                canMigrateBareLegacyRegistrar,
+                legacyNamespaceAliases);
         }
 
         internal static bool ContainsCurrentToolContractsApi(string source)
@@ -1748,12 +1793,66 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return canMigrateBareLegacyRegistrar && ContainsMigratableUnqualifiedLegacyRegistrarReference(source);
         }
 
+        private static bool ContainsLegacyRegistrarDomainReturnReference(
+            string source,
+            bool canMigrateBareLegacyRegistrar,
+            string[] aliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(aliases != null, "aliases must not be null");
+
+            if (RegexMatchesCode(source, LegacyQualifiedRegistrarDomainReturnRegex))
+            {
+                return true;
+            }
+
+            foreach (string alias in aliases)
+            {
+                if (ContainsLegacyAliasQualifiedRegistrarDomainReturn(source, alias))
+                {
+                    return true;
+                }
+            }
+
+            return canMigrateBareLegacyRegistrar &&
+                ContainsMigratableUnqualifiedLegacyRegistrarDomainReturn(source);
+        }
+
+        private static bool ContainsLegacyAliasQualifiedRegistrarDomainReturn(string source, string alias)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(alias), "alias must not be null or empty");
+
+            Regex aliasQualifiedRegex = new(
+                $@"(?<!\w){Regex.Escape(alias)}\.CustomToolManager\s*\.\s*GetRegisteredCustomTools\s*\(",
+                RegexOptions.Compiled);
+            return RegexMatchesCode(source, aliasQualifiedRegex);
+        }
+
         private static bool ContainsMigratableUnqualifiedLegacyRegistrarReference(string source)
         {
             Debug.Assert(source != null, "source must not be null");
 
             CodeTextMask codeTextMask = CodeTextMask.Create(source);
             MatchCollection matches = LegacyRegistrarRegex.Matches(source);
+            foreach (Match match in matches)
+            {
+                if (codeTextMask.IsCodeAt(match.Index) &&
+                    ShouldMigrateLegacyTypeReference(source, "CustomToolManager", match.Index))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ContainsMigratableUnqualifiedLegacyRegistrarDomainReturn(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            MatchCollection matches = LegacyRegistrarDomainReturnRegex.Matches(source);
             foreach (Match match in matches)
             {
                 if (codeTextMask.IsCodeAt(match.Index) &&

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -43,8 +43,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             "Builds"
         };
 
+        private static readonly string LegacyNamespacePattern =
+            $@"(?<![\w.])(?:global::)?{Regex.Escape(LegacyNamespace)}(?=\.|;|\s|$)";
+
         private static readonly Regex LegacyNamespaceRegex =
-            new(Regex.Escape(LegacyNamespace), RegexOptions.Compiled);
+            new(LegacyNamespacePattern, RegexOptions.Compiled);
 
         private static readonly Regex LegacyRegistrarRegex =
             new(@"\bCustomToolManager\b", RegexOptions.Compiled);
@@ -93,9 +96,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly ReplacementRule[] CSharpReplacementRules =
         {
             new(
-                Regex.Escape($"{LegacyNamespace}.CustomToolManager"),
+                $@"(?<![\w.])(?:global::)?{Regex.Escape(LegacyNamespace)}\.CustomToolManager\b",
                 $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar"),
-            new(Regex.Escape(LegacyNamespace), CurrentNamespace),
+            new(LegacyNamespacePattern, CurrentNamespace),
             new(@"(?<![\.:])\bCustomToolManager\b", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
         };
 
@@ -911,10 +914,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             if (RegexMatchesCode(source, LegacyNamespaceRegex)) return true;
-
-            if (RegexMatchesCode(source, LegacyBaseTypeUsageRegex)) return true;
-
-            if (RegexMatchesCode(source, LegacyAssemblyScopedApiUsageRegex)) return true;
 
             return ContainsLegacyToolAttributeList(source, canMigrateBareLegacyToolAttribute: false);
         }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -18,9 +18,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal const string LegacyNamespace = "io.github.hatayama.uLoopMCP";
         internal const string CurrentNamespace = "io.github.hatayama.UnityCliLoop.ToolContracts";
         internal const string CurrentApplicationNamespace = "io.github.hatayama.UnityCliLoop.Application";
+        internal const string CurrentDomainNamespace = "io.github.hatayama.UnityCliLoop.Domain";
         internal const string LegacyEditorAssemblyName = "uLoopMCP.Editor";
         internal const string LegacyEditorAssemblyGuidReference = "GUID:214998e563c124e8a88199b2dd1f522d";
         internal const string CurrentApplicationGuidReference = "GUID:214998e563c124e8a88199b2dd1f522d";
+        internal const string CurrentDomainGuidReference = "GUID:5c4588558a3624eacbce0f50007cf1eb";
         internal const string CurrentToolContractsGuidReference = "GUID:fc3fd32eddbee40e39c2d76dc184957b";
         private const string DescriptionAttributeArgumentName = "Description";
         private const string DisplayDevelopmentOnlyAttributeArgumentName = "DisplayDevelopmentOnly";
@@ -68,18 +70,37 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             new(@"\bCustomToolManager\b", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
         };
 
+        private static readonly ReplacementRule[] RegistrarReplacementRules =
+        {
+            new(Regex.Escape($"{CurrentNamespace}.ToolInfo"), $"{CurrentDomainNamespace}.ToolInfo"),
+            new(@"(?<!\.)\bToolInfo\b", $"{CurrentDomainNamespace}.ToolInfo")
+        };
+
         internal static ThirdPartyToolMigrationContentResult MigrateCSharpSource(string source)
         {
             Debug.Assert(source != null, "source must not be null");
 
             string migratedContent = source;
             bool shouldApplyContractRenames = ContainsLegacyToolMigrationMarker(source);
+            bool shouldApplyRegistrarRenames = ContainsLegacyRegistrarApi(source);
             int replacementCount = 0;
             migratedContent = ReplaceLegacyToolAttributesInCode(migratedContent, ref replacementCount);
 
             if (shouldApplyContractRenames)
             {
                 foreach (ReplacementRule rule in CSharpReplacementRules)
+                {
+                    migratedContent = ReplaceRegexInCode(
+                        migratedContent,
+                        rule.PatternRegex,
+                        _ => rule.Replacement,
+                    ref replacementCount);
+                }
+            }
+
+            if (shouldApplyRegistrarRenames)
+            {
+                foreach (ReplacementRule rule in RegistrarReplacementRules)
                 {
                     migratedContent = ReplaceRegexInCode(
                         migratedContent,
@@ -205,7 +226,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return new[] { CurrentToolContractsGuidReference };
             }
 
-            return new[] { CurrentToolContractsGuidReference, CurrentApplicationGuidReference };
+            return new[]
+            {
+                CurrentToolContractsGuidReference,
+                CurrentApplicationGuidReference,
+                CurrentDomainGuidReference
+            };
         }
 
         private static bool TryMigrateLegacyToolAttributeList(string attributesSource, out string migratedAttributes)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -135,8 +135,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             new(
                 $@"(?<![\w.])(?:global::)?{Regex.Escape(LegacyNamespace)}\.CustomToolManager\b",
                 $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar"),
-            new(LegacyNamespacePattern, CurrentNamespace),
-            new(@"(?<![\.:])\bCustomToolManager\b(?!\s*=)", $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar")
+            new(LegacyNamespacePattern, CurrentNamespace)
         };
 
         private static readonly ReplacementRule[] RegistrarReplacementRules =
@@ -220,6 +219,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (shouldApplyRegistrarRenames || shouldApplyDomainMetadataRenames)
             {
+                if (shouldApplyRegistrarRenames)
+                {
+                    migratedContent = ReplaceUnqualifiedLegacyRegistrarReferencesInCode(
+                        migratedContent,
+                        ref replacementCount);
+                }
+
                 foreach (ReplacementRule rule in RegistrarReplacementRules)
                 {
                     migratedContent = ReplaceRegexInCode(
@@ -606,10 +612,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 if (IsNamedAttributeArgument(trimmedArgument, RequiredSecuritySettingAttributeArgumentName))
                 {
-                    migratedArguments.Add(
-                        trimmedArgument.Replace(
-                            LegacySecuritySettingsTypeName,
-                            CurrentSecuritySettingTypeName));
+                    migratedArguments.Add(trimmedArgument);
                 }
             }
 
@@ -811,6 +814,23 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return migratedContent;
+        }
+
+        private static string ReplaceUnqualifiedLegacyRegistrarReferencesInCode(
+            string source,
+            ref int replacementCount)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            Regex unqualifiedRegistrarRegex =
+                new(@"(?<![\.:])\bCustomToolManager\b(?!\s*=)", RegexOptions.Compiled);
+            return ReplaceRegexInCode(
+                source,
+                unqualifiedRegistrarRegex,
+                match => ShouldMigrateLegacyTypeReference(source, "CustomToolManager", match.Index)
+                    ? $"{CurrentApplicationNamespace}.UnityCliLoopToolRegistrar"
+                    : match.Value,
+                ref replacementCount);
         }
 
         private static string ReplaceLegacyContractTypeNamesInCode(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -169,6 +169,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 hasLegacyNamespaceUsage ||
                 legacyNamespaceAliases.Length > 0;
             bool canMigrateBareLegacyToolInfoConstructor =
+                canMigrateBareLegacyToolAttribute;
+            bool canMigrateAmbiguousBareLegacyToolInfoConstructor =
                 canMigrateBareLegacyToolAttribute &&
                 !hasCurrentDomainNamespaceUsage;
             bool hasLocalLegacyMarker = ContainsLegacyToolMigrationMarker(source);
@@ -187,6 +189,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 migratedContent,
                 legacyNamespaceAliases,
                 canMigrateBareLegacyToolInfoConstructor,
+                canMigrateAmbiguousBareLegacyToolInfoConstructor,
                 ref replacementCount);
             migratedContent = ReplaceLegacyRegistrarAliasesInCode(
                 migratedContent,
@@ -815,6 +818,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string source,
             string[] legacyNamespaceAliases,
             bool canMigrateBareLegacyToolInfoConstructor,
+            bool canMigrateAmbiguousBareLegacyToolInfoConstructor,
             ref int replacementCount)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -853,6 +857,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     openParenthesisIndex + 1,
                     closingParenthesisIndex - openParenthesisIndex - 1);
                 string[] arguments = SplitAttributeArguments(argumentsSource);
+                if (!ShouldMigrateLegacyToolInfoConstructorArguments(
+                        match,
+                        arguments,
+                        canMigrateAmbiguousBareLegacyToolInfoConstructor))
+                {
+                    continue;
+                }
+
                 string[] migratedArguments = GetMigratedToolInfoConstructorArguments(arguments);
                 if (migratedArguments.Length == arguments.Length)
                 {
@@ -875,6 +887,37 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             builder.Append(source, sourceCopyIndex, source.Length - sourceCopyIndex);
             replacementCount += localReplacementCount;
             return builder.ToString();
+        }
+
+        private static bool ShouldMigrateLegacyToolInfoConstructorArguments(
+            Match match,
+            string[] arguments,
+            bool canMigrateAmbiguousBareLegacyToolInfoConstructor)
+        {
+            Debug.Assert(match != null, "match must not be null");
+            Debug.Assert(arguments != null, "arguments must not be null");
+
+            if (!match.Groups["toolInfo"].Success)
+            {
+                return true;
+            }
+
+            return canMigrateAmbiguousBareLegacyToolInfoConstructor ||
+                HasUnambiguousLegacyToolInfoConstructorArguments(arguments);
+        }
+
+        private static bool HasUnambiguousLegacyToolInfoConstructorArguments(string[] arguments)
+        {
+            Debug.Assert(arguments != null, "arguments must not be null");
+
+            if (arguments.Length == 4)
+            {
+                return true;
+            }
+
+            return FindNamedConstructorArgumentIndex(
+                arguments,
+                DescriptionAttributeArgumentName.ToLowerInvariant()) >= 0;
         }
 
         private static bool IsLegacyToolInfoConstructorMatch(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -66,6 +66,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static readonly Regex LegacyRegistrarRegex =
             new(@"\bCustomToolManager\b", RegexOptions.Compiled);
 
+        private static readonly Regex CurrentRegistrarRegex =
+            new(@"\bUnityCliLoopToolRegistrar\b", RegexOptions.Compiled);
+
         private static readonly Regex LegacyDomainMetadataRegex =
             new(@"\bToolInfo\b", RegexOptions.Compiled);
 
@@ -284,6 +287,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return RegexMatchesCode(source, LegacyRegistrarRegex);
+        }
+
+        internal static bool ContainsCurrentRegistrarApi(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return RegexMatchesCode(source, CurrentRegistrarRegex);
         }
 
         internal static bool ContainsLegacyDomainMetadataApi(string source)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -38,6 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             "Logs",
             "obj",
             "bin",
+            "Packages",
             "Build",
             "Builds"
         };

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -764,7 +764,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 migratedContent = ReplaceRegexInCode(
                     migratedContent,
                     unqualifiedRegex,
-                    _ => rule.CurrentName,
+                    match => ShouldMigrateLegacyTypeReference(migratedContent, rule.LegacyName, match.Index)
+                        ? rule.CurrentName
+                        : match.Value,
                     ref replacementCount);
             }
 
@@ -789,15 +791,24 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
             Debug.Assert(toolInfoIndex >= 0, "toolInfoIndex must not be negative");
 
-            if (IsLegacyAssemblyScopedTypeDeclaration(source, toolInfoIndex))
+            return ShouldMigrateLegacyTypeReference(source, "ToolInfo", toolInfoIndex);
+        }
+
+        private static bool ShouldMigrateLegacyTypeReference(string source, string typeName, int typeNameIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(typeName), "typeName must not be empty");
+            Debug.Assert(typeNameIndex >= 0, "typeNameIndex must not be negative");
+
+            if (IsLegacyAssemblyScopedTypeDeclaration(source, typeNameIndex))
             {
                 return false;
             }
 
-            char nextCharacter = ReadNextNonWhitespaceCharacter(source, toolInfoIndex + "ToolInfo".Length);
-            return nextCharacter != '{' &&
-                nextCharacter != ';' &&
-                nextCharacter != '=';
+            char nextCharacter = ReadNextNonWhitespaceCharacter(source, typeNameIndex + typeName.Length);
+            char previousCharacter = ReadPreviousNonWhitespaceCharacter(source, typeNameIndex);
+            return !IsDeclarationIdentifierTerminator(nextCharacter) ||
+                !CanPrecedeDeclarationIdentifier(previousCharacter);
         }
 
         private static string ReplaceLegacyToolInfoConstructorsInCode(
@@ -1324,6 +1335,40 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return '\0';
+        }
+
+        private static char ReadPreviousNonWhitespaceCharacter(string source, int startIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+            for (int index = startIndex - 1; index >= 0; index--)
+            {
+                if (char.IsWhiteSpace(source[index]))
+                {
+                    continue;
+                }
+
+                return source[index];
+            }
+
+            return '\0';
+        }
+
+        private static bool IsDeclarationIdentifierTerminator(char value)
+        {
+            return value == '{' ||
+                value == ';' ||
+                value == '=' ||
+                value == ')' ||
+                value == ',';
+        }
+
+        private static bool CanPrecedeDeclarationIdentifier(char value)
+        {
+            return IsIdentifierCharacter(value) ||
+                value == ']' ||
+                value == '>';
         }
 
         private static bool IsIdentifierCharacter(char value)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Applies deterministic source rewrites for V2 custom tools that need the V3 public contract API.
+    /// </summary>
+    internal static class ThirdPartyToolMigrationRules
+    {
+        internal const string LegacyNamespace = "io.github.hatayama.uLoopMCP";
+        internal const string CurrentNamespace = "io.github.hatayama.UnityCliLoop.ToolContracts";
+        internal const string LegacyEditorAssemblyName = "uLoopMCP.Editor";
+        internal const string LegacyEditorAssemblyGuidReference = "GUID:214998e563c124e8a88199b2dd1f522d";
+        internal const string CurrentToolContractsGuidReference = "GUID:fc3fd32eddbee40e39c2d76dc184957b";
+
+        private static readonly string[] ExcludedDirectoryNames =
+        {
+            ".git",
+            "Library",
+            "Temp",
+            "Logs",
+            "obj",
+            "bin",
+            "Build",
+            "Builds"
+        };
+
+        private static readonly Regex LegacyToolAttributeWithArgumentsRegex =
+            new(@"\[\s*McpTool(?:Attribute)?\s*\([^\]]*\)\s*\]", RegexOptions.Compiled);
+
+        private static readonly Regex LegacyToolAttributeRegex =
+            new(@"\[\s*McpTool(?:Attribute)?\s*\]", RegexOptions.Compiled);
+
+        private static readonly ReplacementRule[] CSharpReplacementRules =
+        {
+            new(Regex.Escape(LegacyNamespace), CurrentNamespace),
+            new(@"\bMcpToolAttribute\b", "UnityCliLoopToolAttribute"),
+            new(@"\bIUnityTool\b", "IUnityCliLoopTool"),
+            new(@"\bAbstractUnityTool\b", "UnityCliLoopTool"),
+            new(@"\bBaseToolSchema\b", "UnityCliLoopToolSchema"),
+            new(@"\bBaseToolResponse\b", "UnityCliLoopToolResponse"),
+            new(@"\bCustomToolManager\b", "UnityCliLoopToolRegistrar")
+        };
+
+        internal static ThirdPartyToolMigrationContentResult MigrateCSharpSource(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            string migratedContent = source;
+            int replacementCount = 0;
+            migratedContent = ReplaceRegex(
+                migratedContent,
+                LegacyToolAttributeWithArgumentsRegex,
+                "[UnityCliLoopTool]",
+                ref replacementCount);
+            migratedContent = ReplaceRegex(
+                migratedContent,
+                LegacyToolAttributeRegex,
+                "[UnityCliLoopTool]",
+                ref replacementCount);
+
+            foreach (ReplacementRule rule in CSharpReplacementRules)
+            {
+                migratedContent = ReplaceRegex(
+                    migratedContent,
+                    rule.PatternRegex,
+                    rule.Replacement,
+                    ref replacementCount);
+            }
+
+            return new ThirdPartyToolMigrationContentResult(
+                migratedContent,
+                replacementCount);
+        }
+
+        internal static ThirdPartyToolMigrationContentResult MigrateAsmdefSource(
+            string source,
+            bool hasLegacyCSharpSource)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            JObject asmdef = JObject.Parse(source);
+            JArray references = asmdef["references"] as JArray;
+            if (references == null)
+            {
+                return new ThirdPartyToolMigrationContentResult(source, 0);
+            }
+
+            int replacementCount = 0;
+            HashSet<string> addedReferences = new(StringComparer.Ordinal);
+            JArray migratedReferences = new();
+            foreach (JToken referenceToken in references)
+            {
+                string reference = referenceToken.Value<string>() ?? string.Empty;
+                string migratedReference = GetMigratedAsmdefReference(reference, hasLegacyCSharpSource);
+                if (!string.Equals(reference, migratedReference, StringComparison.Ordinal))
+                {
+                    replacementCount++;
+                }
+
+                if (!addedReferences.Add(migratedReference))
+                {
+                    continue;
+                }
+
+                migratedReferences.Add(migratedReference);
+            }
+
+            if (replacementCount == 0)
+            {
+                return new ThirdPartyToolMigrationContentResult(source, 0);
+            }
+
+            asmdef["references"] = migratedReferences;
+            return new ThirdPartyToolMigrationContentResult(
+                asmdef.ToString(Formatting.Indented),
+                replacementCount);
+        }
+
+        internal static bool ContainsLegacyCSharpApi(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            if (source.Contains(LegacyNamespace)) return true;
+            if (LegacyToolAttributeWithArgumentsRegex.IsMatch(source)) return true;
+            if (LegacyToolAttributeRegex.IsMatch(source)) return true;
+
+            return CSharpReplacementRules.Any(rule => rule.PatternRegex.IsMatch(source));
+        }
+
+        internal static bool IsExcludedDirectoryName(string directoryName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(directoryName), "directoryName must not be null or empty");
+
+            return ExcludedDirectoryNames.Any(
+                excludedDirectoryName => string.Equals(
+                    excludedDirectoryName,
+                    directoryName,
+                    StringComparison.OrdinalIgnoreCase));
+        }
+
+        internal static string[] GetExcludedDirectoryNames()
+        {
+            string[] names = new string[ExcludedDirectoryNames.Length];
+            Array.Copy(ExcludedDirectoryNames, names, ExcludedDirectoryNames.Length);
+            return names;
+        }
+
+        private static string GetMigratedAsmdefReference(string reference, bool hasLegacyCSharpSource)
+        {
+            if (string.Equals(reference, LegacyEditorAssemblyName, StringComparison.Ordinal))
+            {
+                return CurrentToolContractsGuidReference;
+            }
+
+            if (hasLegacyCSharpSource
+                && string.Equals(reference, LegacyEditorAssemblyGuidReference, StringComparison.Ordinal))
+            {
+                return CurrentToolContractsGuidReference;
+            }
+
+            return reference;
+        }
+
+        private static string ReplaceRegex(
+            string source,
+            Regex regex,
+            string replacement,
+            ref int replacementCount)
+        {
+            int localReplacementCount = 0;
+            string migrated = regex.Replace(
+                source,
+                _ =>
+                {
+                    localReplacementCount++;
+                    return replacement;
+                });
+            replacementCount += localReplacementCount;
+            return migrated;
+        }
+
+        private readonly struct ReplacementRule
+        {
+            public ReplacementRule(string pattern, string replacement)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(pattern), "pattern must not be null or empty");
+                Debug.Assert(!string.IsNullOrEmpty(replacement), "replacement must not be null or empty");
+
+                PatternRegex = new Regex(pattern, RegexOptions.Compiled);
+                Replacement = replacement;
+            }
+
+            public Regex PatternRegex { get; }
+            public string Replacement { get; }
+        }
+    }
+
+    internal readonly struct ThirdPartyToolMigrationContentResult
+    {
+        public ThirdPartyToolMigrationContentResult(string content, int replacementCount)
+        {
+            Debug.Assert(content != null, "content must not be null");
+            Debug.Assert(replacementCount >= 0, "replacementCount must not be negative");
+
+            Content = content ?? string.Empty;
+            ReplacementCount = replacementCount;
+        }
+
+        public string Content { get; }
+        public int ReplacementCount { get; }
+        public bool Changed => ReplacementCount > 0;
+    }
+}

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -285,6 +285,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
+            AddRequiredCurrentAsmdefReferences(
+                migratedReferences,
+                addedReferences,
+                hasLegacyCSharpSource || requiresToolContractsReference,
+                requiresApplicationReference,
+                requiresDomainReference,
+                ref replacementCount);
+
             if (replacementCount == 0)
             {
                 return new ThirdPartyToolMigrationContentResult(source, 0);
@@ -431,6 +439,64 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return references.ToArray();
+        }
+
+        private static void AddRequiredCurrentAsmdefReferences(
+            JArray references,
+            HashSet<string> addedReferences,
+            bool requiresToolContractsReference,
+            bool requiresApplicationReference,
+            bool requiresDomainReference,
+            ref int replacementCount)
+        {
+            Debug.Assert(references != null, "references must not be null");
+            Debug.Assert(addedReferences != null, "addedReferences must not be null");
+
+            if (requiresToolContractsReference)
+            {
+                AddRequiredCurrentAsmdefReference(
+                    references,
+                    addedReferences,
+                    CurrentToolContractsGuidReference,
+                    ref replacementCount);
+            }
+
+            if (requiresApplicationReference)
+            {
+                AddRequiredCurrentAsmdefReference(
+                    references,
+                    addedReferences,
+                    CurrentApplicationGuidReference,
+                    ref replacementCount);
+            }
+
+            if (requiresApplicationReference || requiresDomainReference)
+            {
+                AddRequiredCurrentAsmdefReference(
+                    references,
+                    addedReferences,
+                    CurrentDomainGuidReference,
+                    ref replacementCount);
+            }
+        }
+
+        private static void AddRequiredCurrentAsmdefReference(
+            JArray references,
+            HashSet<string> addedReferences,
+            string reference,
+            ref int replacementCount)
+        {
+            Debug.Assert(references != null, "references must not be null");
+            Debug.Assert(addedReferences != null, "addedReferences must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(reference), "reference must not be null or empty");
+
+            if (!addedReferences.Add(reference))
+            {
+                return;
+            }
+
+            references.Add(reference);
+            replacementCount++;
         }
 
         private static bool TryMigrateLegacyToolAttributeList(
@@ -828,6 +894,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             char nextCharacter = ReadNextNonWhitespaceCharacter(source, typeNameIndex + typeName.Length);
             char previousCharacter = ReadPreviousNonWhitespaceCharacter(source, typeNameIndex);
+            if (nextCharacter == '(' && !PreviousCodeTokenEquals(source, typeNameIndex, "new"))
+            {
+                return false;
+            }
+
             return !IsDeclarationIdentifierTerminator(nextCharacter) ||
                 !CanPrecedeDeclarationIdentifier(previousCharacter);
         }
@@ -933,9 +1004,34 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return true;
             }
 
+            if (arguments.Length == 3 && IsLikelyLegacyDescriptionArgument(arguments[1]))
+            {
+                return true;
+            }
+
             return FindNamedConstructorArgumentIndex(
                 arguments,
                 DescriptionAttributeArgumentName.ToLowerInvariant()) >= 0;
+        }
+
+        private static bool IsLikelyLegacyDescriptionArgument(string argument)
+        {
+            Debug.Assert(argument != null, "argument must not be null");
+
+            string trimmedArgument = argument.Trim();
+            return IsStringLiteralArgument(trimmedArgument) ||
+                string.Equals(trimmedArgument, "description", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsStringLiteralArgument(string argument)
+        {
+            Debug.Assert(argument != null, "argument must not be null");
+
+            return argument.StartsWith("\"", StringComparison.Ordinal) ||
+                argument.StartsWith("@\"", StringComparison.Ordinal) ||
+                argument.StartsWith("$\"", StringComparison.Ordinal) ||
+                argument.StartsWith("$@\"", StringComparison.Ordinal) ||
+                argument.StartsWith("@$\"", StringComparison.Ordinal);
         }
 
         private static bool IsLegacyToolInfoConstructorMatch(
@@ -1423,6 +1519,34 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 value == '=' ||
                 value == ')' ||
                 value == ',';
+        }
+
+        private static bool PreviousCodeTokenEquals(string source, int endIndex, string token)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(endIndex >= 0, "endIndex must not be negative");
+            Debug.Assert(!string.IsNullOrEmpty(token), "token must not be null or empty");
+
+            int tokenEndIndex = endIndex - 1;
+            while (tokenEndIndex >= 0 && char.IsWhiteSpace(source[tokenEndIndex]))
+            {
+                tokenEndIndex--;
+            }
+
+            int tokenStartIndex = tokenEndIndex;
+            while (tokenStartIndex >= 0 && IsIdentifierCharacter(source[tokenStartIndex]))
+            {
+                tokenStartIndex--;
+            }
+
+            int tokenLength = tokenEndIndex - tokenStartIndex;
+            if (tokenLength <= 0)
+            {
+                return false;
+            }
+
+            string previousToken = source.Substring(tokenStartIndex + 1, tokenLength);
+            return string.Equals(previousToken, token, StringComparison.Ordinal);
         }
 
         private static bool CanPrecedeDeclarationIdentifier(char value)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -53,6 +53,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 $@"(?<![\w.])(?:global::)?{Regex.Escape(CurrentDomainNamespace)}(?=\.|;|\s|$)",
                 RegexOptions.Compiled);
 
+        private static readonly Regex CurrentToolContractsNamespaceRegex =
+            new(
+                $@"(?<![\w.])(?:global::)?{Regex.Escape(CurrentNamespace)}(?=\.|;|\s|$)",
+                RegexOptions.Compiled);
+
         private static readonly Regex CurrentDomainMetadataRegex =
             new(
                 $@"(?<![\w.])(?:global::)?{Regex.Escape(CurrentDomainNamespace)}\.ToolInfo\b",
@@ -237,6 +242,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal static ThirdPartyToolMigrationContentResult MigrateAsmdefSource(
             string source,
             bool hasLegacyCSharpSource,
+            bool requiresToolContractsReference,
             bool requiresApplicationReference,
             bool requiresDomainReference)
         {
@@ -258,6 +264,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 string[] migratedReferenceItems = GetMigratedAsmdefReferences(
                     reference,
                     hasLegacyCSharpSource,
+                    requiresToolContractsReference,
                     requiresApplicationReference,
                     requiresDomainReference);
                 bool referenceChanged = migratedReferenceItems.Length != 1 ||
@@ -308,6 +315,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return RegexMatchesCode(source, CurrentRegistrarRegex);
+        }
+
+        internal static bool ContainsCurrentToolContractsApi(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return RegexMatchesCode(source, CurrentToolContractsNamespaceRegex);
         }
 
         internal static bool ContainsLegacyDomainMetadataApi(string source)
@@ -376,6 +390,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static string[] GetMigratedAsmdefReferences(
             string reference,
             bool hasLegacyCSharpSource,
+            bool requiresToolContractsReference,
             bool requiresApplicationReference,
             bool requiresDomainReference)
         {
@@ -384,7 +399,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return GetMigratedLegacyEditorReferences(requiresApplicationReference, requiresDomainReference);
             }
 
-            if ((hasLegacyCSharpSource || requiresApplicationReference || requiresDomainReference)
+            if ((hasLegacyCSharpSource ||
+                    requiresToolContractsReference ||
+                    requiresApplicationReference ||
+                    requiresDomainReference)
                 && string.Equals(reference, LegacyEditorAssemblyGuidReference, StringComparison.Ordinal))
             {
                 return GetMigratedLegacyEditorReferences(requiresApplicationReference, requiresDomainReference);

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -53,6 +53,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 $@"(?<![\w.])(?:global::)?{Regex.Escape(CurrentDomainNamespace)}(?=\.|;|\s|$)",
                 RegexOptions.Compiled);
 
+        private static readonly Regex CurrentDomainMetadataRegex =
+            new(
+                $@"(?<![\w.])(?:global::)?{Regex.Escape(CurrentDomainNamespace)}\.ToolInfo\b",
+                RegexOptions.Compiled);
+
         private static readonly Regex LegacyGlobalUsingRegex =
             new(
                 $@"\bglobal\s+using\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*=\s*)?(?:global::)?{Regex.Escape(LegacyNamespace)}\s*;",
@@ -131,9 +136,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static readonly ReplacementRule[] RegistrarReplacementRules =
         {
-            new(Regex.Escape($"{CurrentNamespace}.ToolInfo"), $"{CurrentDomainNamespace}.ToolInfo"),
-            new(@"(?<![\.:])\bToolInfo\b(?!\s*=)", $"{CurrentDomainNamespace}.ToolInfo")
+            new(Regex.Escape($"{CurrentNamespace}.ToolInfo"), $"{CurrentDomainNamespace}.ToolInfo")
         };
+
+        private static readonly Regex UnqualifiedToolInfoRegex =
+            new(@"(?<![\.:])\bToolInfo\b(?!\s*=)", RegexOptions.Compiled);
 
         internal static ThirdPartyToolMigrationContentResult MigrateCSharpSource(string source)
         {
@@ -213,6 +220,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         _ => rule.Replacement,
                         ref replacementCount);
                 }
+
+                migratedContent = ReplaceLegacyToolInfoTypeReferencesInCode(
+                    migratedContent,
+                    ref replacementCount);
             }
 
             return new ThirdPartyToolMigrationContentResult(
@@ -301,6 +312,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return RegexMatchesCode(source, LegacyDomainMetadataRegex);
+        }
+
+        internal static bool ContainsCurrentDomainMetadataApi(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return RegexMatchesCode(source, CurrentDomainMetadataRegex) ||
+                (RegexMatchesCode(source, CurrentDomainNamespaceRegex) &&
+                    RegexMatchesCode(source, LegacyDomainMetadataRegex));
         }
 
         internal static bool ContainsLegacyAssemblyScopedApi(string source, string[] legacyAssemblyAliases)
@@ -749,6 +769,35 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return migratedContent;
+        }
+
+        private static string ReplaceLegacyToolInfoTypeReferencesInCode(string source, ref int replacementCount)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return ReplaceRegexInCode(
+                source,
+                UnqualifiedToolInfoRegex,
+                match => ShouldMigrateLegacyToolInfoTypeReference(source, match.Index)
+                    ? $"{CurrentDomainNamespace}.ToolInfo"
+                    : match.Value,
+                ref replacementCount);
+        }
+
+        private static bool ShouldMigrateLegacyToolInfoTypeReference(string source, int toolInfoIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(toolInfoIndex >= 0, "toolInfoIndex must not be negative");
+
+            if (IsLegacyAssemblyScopedTypeDeclaration(source, toolInfoIndex))
+            {
+                return false;
+            }
+
+            char nextCharacter = ReadNextNonWhitespaceCharacter(source, toolInfoIndex + "ToolInfo".Length);
+            return nextCharacter != '{' &&
+                nextCharacter != ';' &&
+                nextCharacter != '=';
         }
 
         private static string ReplaceLegacyToolInfoConstructorsInCode(
@@ -1257,6 +1306,24 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return source.Substring(index + 1, identifierEndIndex - index - 1);
+        }
+
+        private static char ReadNextNonWhitespaceCharacter(string source, int startIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+            for (int index = startIndex; index < source.Length; index++)
+            {
+                if (char.IsWhiteSpace(source[index]))
+                {
+                    continue;
+                }
+
+                return source[index];
+            }
+
+            return '\0';
         }
 
         private static bool IsIdentifierCharacter(char value)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -80,9 +80,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(source != null, "source must not be null");
 
+            return MigrateCSharpSourceForLegacyAssembly(
+                source,
+                hasLegacyAssemblySource: ContainsLegacyToolMigrationMarker(source));
+        }
+
+        internal static ThirdPartyToolMigrationContentResult MigrateCSharpSourceForLegacyAssembly(
+            string source,
+            bool hasLegacyAssemblySource)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
             string migratedContent = source;
-            bool shouldApplyContractRenames = ContainsLegacyToolMigrationMarker(source);
-            bool shouldApplyRegistrarRenames = ContainsLegacyRegistrarApi(source);
+            bool hasLocalLegacyMarker = ContainsLegacyToolMigrationMarker(source);
+            bool shouldApplyContractRenames = hasLegacyAssemblySource || hasLocalLegacyMarker;
+            bool shouldApplyRegistrarRenames = shouldApplyContractRenames &&
+                RegexMatchesCode(source, LegacyRegistrarRegex);
             int replacementCount = 0;
             migratedContent = ReplaceLegacyToolAttributesInCode(migratedContent, ref replacementCount);
 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -136,7 +136,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             new("ToolParameterSchemaGenerator", "UnityCliLoopToolParameterSchemaGenerator"),
             new("ParameterValidationException", "UnityCliLoopToolParameterValidationException"),
-            new("McpConstants", "UnityCliLoopConstants"),
+            new("Mcp" + "Constants", "UnityCliLoopConstants"),
             new("McpToolAttribute", "UnityCliLoopToolAttribute"),
             new("IUnityTool", "IUnityCliLoopTool"),
             new("AbstractUnityTool", "UnityCliLoopTool"),

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -38,7 +38,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             "Logs",
             "obj",
             "bin",
-            "Packages",
             "Build",
             "Builds"
         };

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -260,7 +260,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             return RegexMatchesCode(source, LegacyBaseTypeUsageRegex) ||
                 RegexMatchesCode(source, LegacyAssemblyScopedApiUsageRegex) ||
-                ContainsLegacyAssemblyScopedTypeReference(source);
+                ContainsLegacyAssemblyScopedTypeReference(source) ||
+                ContainsLegacyToolAttributeList(source, canMigrateBareLegacyToolAttribute: true);
         }
 
         internal static bool IsExcludedDirectoryName(string directoryName)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -53,6 +53,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 $@"\bglobal\s+using\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*=\s*)?(?:global::)?{Regex.Escape(LegacyNamespace)}\s*;",
                 RegexOptions.Compiled);
 
+        private static readonly Regex LegacyGlobalNamespaceAliasRegex =
+            new(
+                $@"\bglobal\s+using\s+(?<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:global::)?{Regex.Escape(LegacyNamespace)}\s*;",
+                RegexOptions.Compiled);
+
         private static readonly Regex LegacyRegistrarRegex =
             new(@"\bCustomToolManager\b", RegexOptions.Compiled);
 
@@ -123,17 +128,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             return MigrateCSharpSourceForLegacyAssembly(
                 source,
-                hasLegacyAssemblySource: ContainsLegacyToolMigrationMarker(source));
+                hasLegacyAssemblySource: ContainsLegacyToolMigrationMarker(source),
+                legacyAssemblyAliases: Array.Empty<string>());
         }
 
         internal static ThirdPartyToolMigrationContentResult MigrateCSharpSourceForLegacyAssembly(
             string source,
-            bool hasLegacyAssemblySource)
+            bool hasLegacyAssemblySource,
+            string[] legacyAssemblyAliases)
         {
             Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
 
             string migratedContent = source;
-            string[] legacyNamespaceAliases = GetLegacyNamespaceAliases(source);
+            string[] legacyNamespaceAliases = GetCombinedLegacyNamespaceAliases(source, legacyAssemblyAliases);
             bool hasLegacyNamespaceUsage = RegexMatchesCode(source, LegacyNamespaceRegex);
             bool canMigrateBareLegacyToolAttribute =
                 hasLegacyAssemblySource ||
@@ -270,14 +278,18 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return RegexMatchesCode(source, LegacyDomainMetadataRegex);
         }
 
-        internal static bool ContainsLegacyAssemblyScopedApi(string source)
+        internal static bool ContainsLegacyAssemblyScopedApi(string source, string[] legacyAssemblyAliases)
         {
             Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
 
             return RegexMatchesCode(source, LegacyBaseTypeUsageRegex) ||
                 RegexMatchesCode(source, LegacyAssemblyScopedApiUsageRegex) ||
                 ContainsLegacyAssemblyScopedTypeReference(source) ||
-                ContainsLegacyToolAttributeList(source, canMigrateBareLegacyToolAttribute: true);
+                ContainsLegacyToolAttributeList(
+                    source,
+                    legacyAssemblyAliases,
+                    canMigrateBareLegacyToolAttribute: true);
         }
 
         internal static bool ContainsLegacyGlobalUsing(string source)
@@ -285,6 +297,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return RegexMatchesCode(source, LegacyGlobalUsingRegex);
+        }
+
+        internal static string[] GetLegacyGlobalNamespaceAliases(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return GetRegexGroupValuesInCode(source, LegacyGlobalNamespaceAliasRegex, "alias");
         }
 
         internal static bool IsExcludedDirectoryName(string directoryName)
@@ -583,9 +602,31 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(source != null, "source must not be null");
 
+            return GetRegexGroupValuesInCode(source, LegacyNamespaceAliasRegex, "alias");
+        }
+
+        private static string[] GetCombinedLegacyNamespaceAliases(
+            string source,
+            string[] legacyAssemblyAliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
+
+            return GetLegacyNamespaceAliases(source)
+                .Concat(legacyAssemblyAliases)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string[] GetRegexGroupValuesInCode(string source, Regex regex, string groupName)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(regex != null, "regex must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(groupName), "groupName must not be null or empty");
+
             CodeTextMask codeTextMask = CodeTextMask.Create(source);
-            List<string> aliases = new();
-            MatchCollection matches = LegacyNamespaceAliasRegex.Matches(source);
+            List<string> values = new();
+            MatchCollection matches = regex.Matches(source);
             foreach (Match match in matches)
             {
                 if (!codeTextMask.IsCodeAt(match.Index))
@@ -593,10 +634,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     continue;
                 }
 
-                aliases.Add(match.Groups["alias"].Value);
+                values.Add(match.Groups[groupName].Value);
             }
 
-            return aliases.ToArray();
+            return values.ToArray();
         }
 
         private static string ReplaceLegacyRegistrarAliasesInCode(
@@ -830,7 +871,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return false;
             }
 
-            return IsStringLiteralExpression(secondArgument) || !IsBooleanLikeExpression(thirdArgument);
+            return IsStringLiteralExpression(secondArgument) ||
+                IsLikelyToolParameterSchemaExpression(thirdArgument);
         }
 
         private static bool IsStringLiteralExpression(string expression)
@@ -850,57 +892,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(expression != null, "expression must not be null");
 
             return expression.IndexOf("schema", StringComparison.OrdinalIgnoreCase) >= 0;
-        }
-
-        private static bool IsBooleanLikeExpression(string expression)
-        {
-            Debug.Assert(expression != null, "expression must not be null");
-
-            string valueExpression = RemoveNamedArgumentPrefix(expression);
-            return string.Equals(valueExpression, "true", StringComparison.Ordinal) ||
-                string.Equals(valueExpression, "false", StringComparison.Ordinal) ||
-                valueExpression.IndexOf(
-                    DisplayDevelopmentOnlyAttributeArgumentName,
-                    StringComparison.OrdinalIgnoreCase) >= 0;
-        }
-
-        private static string RemoveNamedArgumentPrefix(string expression)
-        {
-            Debug.Assert(expression != null, "expression must not be null");
-
-            int colonIndex = expression.IndexOf(':');
-            if (colonIndex <= 0)
-            {
-                return expression;
-            }
-
-            string possibleArgumentName = expression.Substring(0, colonIndex).Trim();
-            if (!IsIdentifier(possibleArgumentName))
-            {
-                return expression;
-            }
-
-            return expression.Substring(colonIndex + 1).Trim();
-        }
-
-        private static bool IsIdentifier(string value)
-        {
-            Debug.Assert(value != null, "value must not be null");
-
-            if (value.Length == 0 || char.IsDigit(value[0]))
-            {
-                return false;
-            }
-
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (!IsIdentifierCharacter(value[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         private static int FindInvocationClosingParenthesisIndex(
@@ -1199,17 +1190,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (RegexMatchesCode(source, LegacyNamespaceRegex)) return true;
 
-            return ContainsLegacyToolAttributeList(source, canMigrateBareLegacyToolAttribute: false);
+            return ContainsLegacyToolAttributeList(
+                source,
+                Array.Empty<string>(),
+                canMigrateBareLegacyToolAttribute: false);
         }
 
         private static bool ContainsLegacyToolAttributeList(
             string source,
+            string[] legacyAssemblyAliases,
             bool canMigrateBareLegacyToolAttribute)
         {
             Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
 
             CodeTextMask codeTextMask = CodeTextMask.Create(source);
-            string[] legacyNamespaceAliases = GetLegacyNamespaceAliases(source);
+            string[] legacyNamespaceAliases = GetCombinedLegacyNamespaceAliases(source, legacyAssemblyAliases);
             int index = 0;
             while (index < source.Length)
             {

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -65,6 +65,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 @"ToolInfo\s*(?:\[\])?\s+[A-Za-z_][A-Za-z0-9_]*)",
                 RegexOptions.Compiled);
 
+        private static readonly Regex LegacyAssemblyScopedTypeNameRegex =
+            new(@"\b(?:IUnityTool|ToolInfo)\b", RegexOptions.Compiled);
+
         private static readonly Regex LegacyNamespaceAliasRegex =
             new(
                 @"\busing\s+(?<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:global::)?" +
@@ -243,7 +246,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return RegexMatchesCode(source, LegacyBaseTypeUsageRegex) ||
-                RegexMatchesCode(source, LegacyAssemblyScopedApiUsageRegex);
+                RegexMatchesCode(source, LegacyAssemblyScopedApiUsageRegex) ||
+                ContainsLegacyAssemblyScopedTypeReference(source);
         }
 
         internal static bool IsExcludedDirectoryName(string directoryName)
@@ -749,6 +753,68 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return false;
         }
 
+        private static bool ContainsLegacyAssemblyScopedTypeReference(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            MatchCollection matches = LegacyAssemblyScopedTypeNameRegex.Matches(source);
+            foreach (Match match in matches)
+            {
+                if (!codeTextMask.IsCodeAt(match.Index))
+                {
+                    continue;
+                }
+
+                if (IsLegacyAssemblyScopedTypeDeclaration(source, match.Index))
+                {
+                    continue;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsLegacyAssemblyScopedTypeDeclaration(string source, int typeNameIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(typeNameIndex >= 0, "typeNameIndex must not be negative");
+
+            string previousIdentifier = ReadPreviousIdentifier(source, typeNameIndex);
+            return string.Equals(previousIdentifier, "class", StringComparison.Ordinal) ||
+                string.Equals(previousIdentifier, "struct", StringComparison.Ordinal) ||
+                string.Equals(previousIdentifier, "interface", StringComparison.Ordinal) ||
+                string.Equals(previousIdentifier, "enum", StringComparison.Ordinal) ||
+                string.Equals(previousIdentifier, "using", StringComparison.Ordinal);
+        }
+
+        private static string ReadPreviousIdentifier(string source, int startIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+            int index = startIndex - 1;
+            while (index >= 0 && char.IsWhiteSpace(source[index]))
+            {
+                index--;
+            }
+
+            int identifierEndIndex = index + 1;
+            while (index >= 0 && IsIdentifierCharacter(source[index]))
+            {
+                index--;
+            }
+
+            return source.Substring(index + 1, identifierEndIndex - index - 1);
+        }
+
+        private static bool IsIdentifierCharacter(char value)
+        {
+            return char.IsLetterOrDigit(value) || value == '_';
+        }
+
         private static bool ContainsLegacyToolMigrationMarker(string source)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -861,6 +927,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int index = 0;
                 while (index < source.Length)
                 {
+                    if (StartsWith(source, index, "$@\"") || StartsWith(source, index, "@$\""))
+                    {
+                        index = MarkInterpolatedVerbatimStringAsIgnored(codeCharacters, source, index);
+                        continue;
+                    }
+
                     if (StartsWith(source, index, "$\"") && !StartsWith(source, index, "$\"\"\""))
                     {
                         index = MarkInterpolatedRegularStringAsIgnored(codeCharacters, source, index);
@@ -1070,6 +1142,59 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     {
                         MarkRangeAsIgnored(codeCharacters, literalStartIndex, index + 1);
                         return index + 1;
+                    }
+
+                    index++;
+                }
+
+                MarkRangeAsIgnored(codeCharacters, literalStartIndex, source.Length);
+                return source.Length;
+            }
+
+            private static int MarkInterpolatedVerbatimStringAsIgnored(
+                bool[] codeCharacters,
+                string source,
+                int prefixIndex)
+            {
+                Debug.Assert(codeCharacters != null, "codeCharacters must not be null");
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(prefixIndex >= 0, "prefixIndex must not be negative");
+
+                int quoteIndex = prefixIndex + 2;
+                int literalStartIndex = prefixIndex;
+                int index = quoteIndex + 1;
+                while (index < source.Length)
+                {
+                    if (source[index] == '"')
+                    {
+                        if (index + 1 < source.Length && source[index + 1] == '"')
+                        {
+                            index += 2;
+                            continue;
+                        }
+
+                        MarkRangeAsIgnored(codeCharacters, literalStartIndex, index + 1);
+                        return index + 1;
+                    }
+
+                    if (source[index] == '{')
+                    {
+                        if (index + 1 < source.Length && source[index + 1] == '{')
+                        {
+                            index += 2;
+                            continue;
+                        }
+
+                        MarkRangeAsIgnored(codeCharacters, literalStartIndex, index);
+                        index = FindInterpolationHoleEndIndex(source, index);
+                        literalStartIndex = index;
+                        continue;
+                    }
+
+                    if (source[index] == '}' && index + 1 < source.Length && source[index + 1] == '}')
+                    {
+                        index += 2;
+                        continue;
                     }
 
                     index++;

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -143,6 +143,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 $@"\busing\s+(?<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:global::)?{Regex.Escape(LegacyNamespace)}\.ToolInfo\s*;",
                 RegexOptions.Compiled);
 
+        private static readonly Regex LegacyGlobalToolInfoTypeAliasRegex =
+            new(
+                $@"\bglobal\s+using\s+(?<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:global::)?{Regex.Escape(LegacyNamespace)}\.ToolInfo\s*;",
+                RegexOptions.Compiled);
+
+        private static readonly Regex LegacyToolSettingsCatalogItemConstructorRegex =
+            new(
+                $@"new\s+(?:(?<qualifier>(?:global::)?{Regex.Escape(LegacyNamespace)}\.)ToolSettingsCatalogItem|(?<alias>[A-Za-z_][A-Za-z0-9_]*)\.ToolSettingsCatalogItem|(?<toolSettingsCatalogItem>ToolSettingsCatalogItem))\s*\(",
+                RegexOptions.Compiled);
+
         private static readonly TypeReplacementRule[] ToolContractTypeReplacementRules =
         {
             new("ToolParameterSchemaGenerator", "UnityCliLoopToolParameterSchemaGenerator"),
@@ -185,16 +195,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return MigrateCSharpSourceForLegacyAssembly(
                 source,
                 hasLegacyAssemblySource: ContainsLegacyToolMigrationMarker(source),
-                legacyAssemblyAliases: Array.Empty<string>());
+                legacyAssemblyAliases: Array.Empty<string>(),
+                legacyAssemblyToolInfoAliases: Array.Empty<string>());
         }
 
         internal static ThirdPartyToolMigrationContentResult MigrateCSharpSourceForLegacyAssembly(
             string source,
             bool hasLegacyAssemblySource,
-            string[] legacyAssemblyAliases)
+            string[] legacyAssemblyAliases,
+            string[] legacyAssemblyToolInfoAliases)
         {
             Debug.Assert(source != null, "source must not be null");
             Debug.Assert(legacyAssemblyAliases != null, "legacyAssemblyAliases must not be null");
+            Debug.Assert(legacyAssemblyToolInfoAliases != null, "legacyAssemblyToolInfoAliases must not be null");
 
             string migratedContent = source;
             string[] legacyNamespaceAliases = GetCombinedLegacyNamespaceAliases(source, legacyAssemblyAliases);
@@ -226,6 +239,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 legacyNamespaceAliases,
                 canMigrateBareLegacyToolInfoConstructor,
                 canMigrateAmbiguousBareLegacyToolInfoConstructor,
+                legacyAssemblyToolInfoAliases,
+                ref replacementCount);
+            migratedContent = ReplaceLegacyToolSettingsCatalogItemConstructorsInCode(
+                migratedContent,
+                legacyNamespaceAliases,
+                canMigrateBareLegacyToolAttribute,
                 ref replacementCount);
             migratedContent = ReplaceLegacyRegistrarAliasesInCode(
                 migratedContent,
@@ -587,6 +606,42 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             return GetRegexGroupValuesInCode(source, LegacyGlobalNamespaceAliasRegex, "alias");
+        }
+
+        internal static string[] GetLegacyGlobalToolInfoTypeAliases(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return GetRegexGroupValuesInCode(source, LegacyGlobalToolInfoTypeAliasRegex, "alias");
+        }
+
+        internal static bool ContainsLegacyGlobalToolInfoTypeAlias(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return RegexMatchesCode(source, LegacyGlobalToolInfoTypeAliasRegex);
+        }
+
+        internal static bool ContainsLegacyTypeAliasReference(string source, string[] aliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(aliases != null, "aliases must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            foreach (string alias in aliases)
+            {
+                Regex aliasRegex = new($@"(?<![\w.]){Regex.Escape(alias)}\b", RegexOptions.Compiled);
+                MatchCollection matches = aliasRegex.Matches(source);
+                foreach (Match match in matches)
+                {
+                    if (codeTextMask.IsCodeAt(match.Index))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         internal static bool IsExcludedDirectoryName(string directoryName)
@@ -1032,6 +1087,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 .ToArray();
         }
 
+        private static string[] GetCombinedLegacyToolInfoTypeAliases(
+            string source,
+            string[] legacyAssemblyToolInfoAliases)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyAssemblyToolInfoAliases != null, "legacyAssemblyToolInfoAliases must not be null");
+
+            return GetLegacyToolInfoTypeAliases(source)
+                .Concat(legacyAssemblyToolInfoAliases)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+
         private static string[] GetRegexGroupValuesInCode(string source, Regex regex, string groupName)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -1246,13 +1314,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string[] legacyNamespaceAliases,
             bool canMigrateBareLegacyToolInfoConstructor,
             bool canMigrateAmbiguousBareLegacyToolInfoConstructor,
+            string[] legacyAssemblyToolInfoAliases,
             ref int replacementCount)
         {
             Debug.Assert(source != null, "source must not be null");
             Debug.Assert(legacyNamespaceAliases != null, "legacyNamespaceAliases must not be null");
+            Debug.Assert(legacyAssemblyToolInfoAliases != null, "legacyAssemblyToolInfoAliases must not be null");
 
             CodeTextMask codeTextMask = CodeTextMask.Create(source);
-            string[] legacyToolInfoTypeAliases = GetLegacyToolInfoTypeAliases(source);
+            string[] legacyToolInfoTypeAliases =
+                GetCombinedLegacyToolInfoTypeAliases(source, legacyAssemblyToolInfoAliases);
             MatchCollection matches = LegacyToolInfoConstructorRegex.Matches(source);
             StringBuilder builder = new(source.Length);
             int sourceCopyIndex = 0;
@@ -1314,6 +1385,91 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             builder.Append(source, sourceCopyIndex, source.Length - sourceCopyIndex);
             replacementCount += localReplacementCount;
             return builder.ToString();
+        }
+
+        private static string ReplaceLegacyToolSettingsCatalogItemConstructorsInCode(
+            string source,
+            string[] legacyNamespaceAliases,
+            bool canMigrateBareLegacyConstructor,
+            ref int replacementCount)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(legacyNamespaceAliases != null, "legacyNamespaceAliases must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            MatchCollection matches = LegacyToolSettingsCatalogItemConstructorRegex.Matches(source);
+            StringBuilder builder = new(source.Length);
+            int sourceCopyIndex = 0;
+            int localReplacementCount = 0;
+            foreach (Match match in matches)
+            {
+                if (match.Index < sourceCopyIndex ||
+                    !codeTextMask.IsCodeAt(match.Index) ||
+                    !IsLegacyToolSettingsCatalogItemConstructorMatch(
+                        match,
+                        legacyNamespaceAliases,
+                        canMigrateBareLegacyConstructor))
+                {
+                    continue;
+                }
+
+                int openParenthesisIndex = match.Index + match.Length - 1;
+                int closingParenthesisIndex = FindInvocationClosingParenthesisIndex(
+                    source,
+                    codeTextMask,
+                    openParenthesisIndex);
+                if (closingParenthesisIndex < 0)
+                {
+                    continue;
+                }
+
+                string argumentsSource = source.Substring(
+                    openParenthesisIndex + 1,
+                    closingParenthesisIndex - openParenthesisIndex - 1);
+                string[] arguments = SplitAttributeArguments(argumentsSource);
+                string[] migratedArguments = GetMigratedToolSettingsCatalogItemConstructorArguments(arguments);
+                if (migratedArguments.Length == arguments.Length)
+                {
+                    continue;
+                }
+
+                builder.Append(source, sourceCopyIndex, match.Index - sourceCopyIndex);
+                builder.Append($"new {CurrentDomainNamespace}.ToolSettingsCatalogItem(");
+                builder.Append(string.Join(", ", migratedArguments));
+                builder.Append(')');
+                sourceCopyIndex = closingParenthesisIndex + 1;
+                localReplacementCount++;
+            }
+
+            if (localReplacementCount == 0)
+            {
+                return source;
+            }
+
+            builder.Append(source, sourceCopyIndex, source.Length - sourceCopyIndex);
+            replacementCount += localReplacementCount;
+            return builder.ToString();
+        }
+
+        private static bool IsLegacyToolSettingsCatalogItemConstructorMatch(
+            Match match,
+            string[] legacyNamespaceAliases,
+            bool canMigrateBareLegacyConstructor)
+        {
+            Debug.Assert(match != null, "match must not be null");
+            Debug.Assert(legacyNamespaceAliases != null, "legacyNamespaceAliases must not be null");
+
+            if (match.Groups["qualifier"].Success)
+            {
+                return true;
+            }
+
+            if (match.Groups["alias"].Success)
+            {
+                return legacyNamespaceAliases.Contains(match.Groups["alias"].Value);
+            }
+
+            return match.Groups["toolSettingsCatalogItem"].Success && canMigrateBareLegacyConstructor;
         }
 
         private static bool ShouldMigrateLegacyToolInfoConstructorArguments(
@@ -1433,6 +1589,31 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 {
                     arguments[0].Trim(),
                     arguments[2].Trim()
+                };
+            }
+
+            return arguments;
+        }
+
+        private static string[] GetMigratedToolSettingsCatalogItemConstructorArguments(string[] arguments)
+        {
+            Debug.Assert(arguments != null, "arguments must not be null");
+
+            int namedDescriptionArgumentIndex = FindNamedConstructorArgumentIndex(
+                arguments,
+                DescriptionAttributeArgumentName.ToLowerInvariant());
+            if (namedDescriptionArgumentIndex >= 0)
+            {
+                return RemoveArgumentAt(arguments, namedDescriptionArgumentIndex);
+            }
+
+            if (arguments.Length == 4)
+            {
+                return new[]
+                {
+                    arguments[0].Trim(),
+                    arguments[2].Trim(),
+                    arguments[3].Trim()
                 };
             }
 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -19,6 +19,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal const string LegacyEditorAssemblyName = "uLoopMCP.Editor";
         internal const string LegacyEditorAssemblyGuidReference = "GUID:214998e563c124e8a88199b2dd1f522d";
         internal const string CurrentToolContractsGuidReference = "GUID:fc3fd32eddbee40e39c2d76dc184957b";
+        private const string DescriptionAttributeArgumentName = "Description";
+        private const string DisplayDevelopmentOnlyAttributeArgumentName = "DisplayDevelopmentOnly";
+        private const string RequiredSecuritySettingAttributeArgumentName = "RequiredSecuritySetting";
+        private const string LegacySecuritySettingsTypeName = "SecuritySettings";
+        private const string CurrentSecuritySettingTypeName = "UnityCliLoopSecuritySetting";
 
         private static readonly string[] ExcludedDirectoryNames =
         {
@@ -33,7 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         };
 
         private static readonly Regex LegacyToolAttributeWithArgumentsRegex =
-            new(@"\[\s*McpTool(?:Attribute)?\s*\([^\]]*\)\s*\]", RegexOptions.Compiled);
+            new(@"\[\s*McpTool(?:Attribute)?\s*\((?<arguments>[\s\S]*?)\)\s*\]", RegexOptions.Compiled);
 
         private static readonly Regex LegacyToolAttributeRegex =
             new(@"\[\s*McpTool(?:Attribute)?\s*\]", RegexOptions.Compiled);
@@ -46,6 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             new(@"\bAbstractUnityTool\b", "UnityCliLoopTool"),
             new(@"\bBaseToolSchema\b", "UnityCliLoopToolSchema"),
             new(@"\bBaseToolResponse\b", "UnityCliLoopToolResponse"),
+            new(@"\bSecuritySettings\b", CurrentSecuritySettingTypeName),
             new(@"\bCustomToolManager\b", "UnityCliLoopToolRegistrar")
         };
 
@@ -55,23 +61,23 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             string migratedContent = source;
             int replacementCount = 0;
-            migratedContent = ReplaceRegex(
+            migratedContent = ReplaceRegexInCode(
                 migratedContent,
                 LegacyToolAttributeWithArgumentsRegex,
-                "[UnityCliLoopTool]",
+                MigrateLegacyToolAttributeWithArguments,
                 ref replacementCount);
-            migratedContent = ReplaceRegex(
+            migratedContent = ReplaceRegexInCode(
                 migratedContent,
                 LegacyToolAttributeRegex,
-                "[UnityCliLoopTool]",
+                _ => "[UnityCliLoopTool]",
                 ref replacementCount);
 
             foreach (ReplacementRule rule in CSharpReplacementRules)
             {
-                migratedContent = ReplaceRegex(
+                migratedContent = ReplaceRegexInCode(
                     migratedContent,
                     rule.PatternRegex,
-                    rule.Replacement,
+                    _ => rule.Replacement,
                     ref replacementCount);
             }
 
@@ -128,11 +134,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(source != null, "source must not be null");
 
-            if (source.Contains(LegacyNamespace)) return true;
-            if (LegacyToolAttributeWithArgumentsRegex.IsMatch(source)) return true;
-            if (LegacyToolAttributeRegex.IsMatch(source)) return true;
+            if (RegexMatchesCode(source, LegacyToolAttributeWithArgumentsRegex)) return true;
+            if (RegexMatchesCode(source, LegacyToolAttributeRegex)) return true;
 
-            return CSharpReplacementRules.Any(rule => rule.PatternRegex.IsMatch(source));
+            return CSharpReplacementRules.Any(rule => RegexMatchesCode(source, rule.PatternRegex));
         }
 
         internal static bool IsExcludedDirectoryName(string directoryName)
@@ -169,22 +174,273 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return reference;
         }
 
-        private static string ReplaceRegex(
+        private static string MigrateLegacyToolAttributeWithArguments(Match match)
+        {
+            Debug.Assert(match != null, "match must not be null");
+
+            string argumentsSource = match.Groups["arguments"].Value;
+            string[] migratedArguments = GetMigratedSupportedAttributeArguments(argumentsSource);
+            if (migratedArguments.Length == 0)
+            {
+                return "[UnityCliLoopTool]";
+            }
+
+            return $"[UnityCliLoopTool({string.Join(", ", migratedArguments)})]";
+        }
+
+        private static string[] GetMigratedSupportedAttributeArguments(string argumentsSource)
+        {
+            Debug.Assert(argumentsSource != null, "argumentsSource must not be null");
+
+            List<string> migratedArguments = new();
+            string[] arguments = SplitAttributeArguments(argumentsSource);
+            foreach (string argument in arguments)
+            {
+                string trimmedArgument = argument.Trim();
+                if (trimmedArgument.Length == 0)
+                {
+                    continue;
+                }
+
+                if (IsNamedAttributeArgument(trimmedArgument, DescriptionAttributeArgumentName))
+                {
+                    continue;
+                }
+
+                if (IsNamedAttributeArgument(trimmedArgument, DisplayDevelopmentOnlyAttributeArgumentName))
+                {
+                    migratedArguments.Add(trimmedArgument);
+                    continue;
+                }
+
+                if (IsNamedAttributeArgument(trimmedArgument, RequiredSecuritySettingAttributeArgumentName))
+                {
+                    migratedArguments.Add(
+                        trimmedArgument.Replace(
+                            LegacySecuritySettingsTypeName,
+                            CurrentSecuritySettingTypeName));
+                }
+            }
+
+            return migratedArguments.ToArray();
+        }
+
+        private static string[] SplitAttributeArguments(string argumentsSource)
+        {
+            Debug.Assert(argumentsSource != null, "argumentsSource must not be null");
+
+            List<string> arguments = new();
+            int argumentStartIndex = 0;
+            int nestingDepth = 0;
+            bool isInRegularString = false;
+            bool isInVerbatimString = false;
+            bool isInCharLiteral = false;
+            for (int i = 0; i < argumentsSource.Length; i++)
+            {
+                char current = argumentsSource[i];
+                if (isInRegularString)
+                {
+                    if (current == '\\')
+                    {
+                        i++;
+                        continue;
+                    }
+
+                    if (current == '"')
+                    {
+                        isInRegularString = false;
+                    }
+
+                    continue;
+                }
+
+                if (isInVerbatimString)
+                {
+                    if (current != '"')
+                    {
+                        continue;
+                    }
+
+                    if (i + 1 < argumentsSource.Length && argumentsSource[i + 1] == '"')
+                    {
+                        i++;
+                        continue;
+                    }
+
+                    isInVerbatimString = false;
+                    continue;
+                }
+
+                if (isInCharLiteral)
+                {
+                    if (current == '\\')
+                    {
+                        i++;
+                        continue;
+                    }
+
+                    if (current == '\'')
+                    {
+                        isInCharLiteral = false;
+                    }
+
+                    continue;
+                }
+
+                if (StartsWith(argumentsSource, i, "@\"") ||
+                    StartsWith(argumentsSource, i, "$@\"") ||
+                    StartsWith(argumentsSource, i, "@$\""))
+                {
+                    isInVerbatimString = true;
+                    i += GetStringPrefixLength(argumentsSource, i);
+                    continue;
+                }
+
+                if (StartsWith(argumentsSource, i, "$\""))
+                {
+                    isInRegularString = true;
+                    i++;
+                    continue;
+                }
+
+                if (current == '"')
+                {
+                    isInRegularString = true;
+                    continue;
+                }
+
+                if (current == '\'')
+                {
+                    isInCharLiteral = true;
+                    continue;
+                }
+
+                if (current == '(' || current == '[' || current == '{')
+                {
+                    nestingDepth++;
+                    continue;
+                }
+
+                if (current == ')' || current == ']' || current == '}')
+                {
+                    nestingDepth = Math.Max(0, nestingDepth - 1);
+                    continue;
+                }
+
+                if (current != ',' || nestingDepth != 0)
+                {
+                    continue;
+                }
+
+                arguments.Add(argumentsSource.Substring(argumentStartIndex, i - argumentStartIndex));
+                argumentStartIndex = i + 1;
+            }
+
+            arguments.Add(argumentsSource.Substring(argumentStartIndex));
+            return arguments.ToArray();
+        }
+
+        private static bool IsNamedAttributeArgument(string argument, string argumentName)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(argument), "argument must not be null or whitespace");
+            Debug.Assert(!string.IsNullOrWhiteSpace(argumentName), "argumentName must not be null or whitespace");
+
+            if (!argument.StartsWith(argumentName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            for (int i = argumentName.Length; i < argument.Length; i++)
+            {
+                char current = argument[i];
+                if (char.IsWhiteSpace(current))
+                {
+                    continue;
+                }
+
+                return current == '=';
+            }
+
+            return false;
+        }
+
+        private static string ReplaceRegexInCode(
             string source,
             Regex regex,
-            string replacement,
+            Func<Match, string> replacementFactory,
             ref int replacementCount)
         {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(regex != null, "regex must not be null");
+            Debug.Assert(replacementFactory != null, "replacementFactory must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
             int localReplacementCount = 0;
             string migrated = regex.Replace(
                 source,
-                _ =>
+                match =>
                 {
+                    if (!codeTextMask.IsCodeAt(match.Index))
+                    {
+                        return match.Value;
+                    }
+
+                    string replacement = replacementFactory(match);
+                    if (string.Equals(match.Value, replacement, StringComparison.Ordinal))
+                    {
+                        return match.Value;
+                    }
+
                     localReplacementCount++;
                     return replacement;
                 });
             replacementCount += localReplacementCount;
             return migrated;
+        }
+
+        private static bool RegexMatchesCode(string source, Regex regex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(regex != null, "regex must not be null");
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
+            MatchCollection matches = regex.Matches(source);
+            foreach (Match match in matches)
+            {
+                if (codeTextMask.IsCodeAt(match.Index))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool StartsWith(string source, int startIndex, string value)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+            Debug.Assert(value != null, "value must not be null");
+
+            if (startIndex + value.Length > source.Length)
+            {
+                return false;
+            }
+
+            return string.CompareOrdinal(source, startIndex, value, 0, value.Length) == 0;
+        }
+
+        private static int GetStringPrefixLength(string source, int startIndex)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+            if (StartsWith(source, startIndex, "$@\"") || StartsWith(source, startIndex, "@$\""))
+            {
+                return 2;
+            }
+
+            return 1;
         }
 
         private readonly struct ReplacementRule
@@ -200,6 +456,230 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             public Regex PatternRegex { get; }
             public string Replacement { get; }
+        }
+
+        private readonly struct CodeTextMask
+        {
+            private readonly bool[] _codeCharacters;
+
+            private CodeTextMask(bool[] codeCharacters)
+            {
+                Debug.Assert(codeCharacters != null, "codeCharacters must not be null");
+
+                _codeCharacters = codeCharacters;
+            }
+
+            public static CodeTextMask Create(string source)
+            {
+                Debug.Assert(source != null, "source must not be null");
+
+                bool[] codeCharacters = new bool[source.Length];
+                for (int i = 0; i < codeCharacters.Length; i++)
+                {
+                    codeCharacters[i] = true;
+                }
+
+                int index = 0;
+                while (index < source.Length)
+                {
+                    int ignoredTextEndIndex = GetIgnoredTextEndIndex(source, index);
+                    if (ignoredTextEndIndex == index)
+                    {
+                        index++;
+                        continue;
+                    }
+
+                    MarkRangeAsIgnored(codeCharacters, index, ignoredTextEndIndex);
+                    index = ignoredTextEndIndex;
+                }
+
+                return new CodeTextMask(codeCharacters);
+            }
+
+            public bool IsCodeAt(int index)
+            {
+                if (index < 0 || index >= _codeCharacters.Length)
+                {
+                    return false;
+                }
+
+                return _codeCharacters[index];
+            }
+
+            private static int GetIgnoredTextEndIndex(string source, int startIndex)
+            {
+                Debug.Assert(source != null, "source must not be null");
+                Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+
+                if (StartsWith(source, startIndex, "//"))
+                {
+                    return FindLineCommentEndIndex(source, startIndex);
+                }
+
+                if (StartsWith(source, startIndex, "/*"))
+                {
+                    return FindBlockCommentEndIndex(source, startIndex);
+                }
+
+                if (StartsWith(source, startIndex, "$@\"") || StartsWith(source, startIndex, "@$\""))
+                {
+                    return FindVerbatimStringEndIndex(source, startIndex + 2);
+                }
+
+                if (StartsWith(source, startIndex, "@\""))
+                {
+                    return FindVerbatimStringEndIndex(source, startIndex + 1);
+                }
+
+                if (StartsWith(source, startIndex, "$\"\"\""))
+                {
+                    return FindRawStringEndIndex(source, startIndex + 1);
+                }
+
+                if (StartsWith(source, startIndex, "$\""))
+                {
+                    return FindRegularStringEndIndex(source, startIndex + 1);
+                }
+
+                if (StartsWith(source, startIndex, "\"\"\""))
+                {
+                    return FindRawStringEndIndex(source, startIndex);
+                }
+
+                if (source[startIndex] == '"')
+                {
+                    return FindRegularStringEndIndex(source, startIndex);
+                }
+
+                if (source[startIndex] == '\'')
+                {
+                    return FindCharLiteralEndIndex(source, startIndex);
+                }
+
+                return startIndex;
+            }
+
+            private static int FindLineCommentEndIndex(string source, int startIndex)
+            {
+                int index = startIndex;
+                while (index < source.Length && source[index] != '\n')
+                {
+                    index++;
+                }
+
+                return index;
+            }
+
+            private static int FindBlockCommentEndIndex(string source, int startIndex)
+            {
+                int index = startIndex + 2;
+                while (index + 1 < source.Length)
+                {
+                    if (source[index] == '*' && source[index + 1] == '/')
+                    {
+                        return index + 2;
+                    }
+
+                    index++;
+                }
+
+                return source.Length;
+            }
+
+            private static int FindRegularStringEndIndex(string source, int quoteIndex)
+            {
+                int index = quoteIndex + 1;
+                while (index < source.Length)
+                {
+                    if (source[index] == '\\')
+                    {
+                        index += 2;
+                        continue;
+                    }
+
+                    if (source[index] == '"')
+                    {
+                        return index + 1;
+                    }
+
+                    index++;
+                }
+
+                return source.Length;
+            }
+
+            private static int FindVerbatimStringEndIndex(string source, int quoteIndex)
+            {
+                int index = quoteIndex + 1;
+                while (index < source.Length)
+                {
+                    if (source[index] != '"')
+                    {
+                        index++;
+                        continue;
+                    }
+
+                    if (index + 1 < source.Length && source[index + 1] == '"')
+                    {
+                        index += 2;
+                        continue;
+                    }
+
+                    return index + 1;
+                }
+
+                return source.Length;
+            }
+
+            private static int FindRawStringEndIndex(string source, int quoteIndex)
+            {
+                int index = quoteIndex + 3;
+                while (index + 2 < source.Length)
+                {
+                    if (StartsWith(source, index, "\"\"\""))
+                    {
+                        return index + 3;
+                    }
+
+                    index++;
+                }
+
+                return source.Length;
+            }
+
+            private static int FindCharLiteralEndIndex(string source, int quoteIndex)
+            {
+                int index = quoteIndex + 1;
+                while (index < source.Length)
+                {
+                    if (source[index] == '\\')
+                    {
+                        index += 2;
+                        continue;
+                    }
+
+                    if (source[index] == '\'')
+                    {
+                        return index + 1;
+                    }
+
+                    index++;
+                }
+
+                return source.Length;
+            }
+
+            private static void MarkRangeAsIgnored(bool[] codeCharacters, int startIndex, int endIndex)
+            {
+                Debug.Assert(codeCharacters != null, "codeCharacters must not be null");
+                Debug.Assert(startIndex >= 0, "startIndex must not be negative");
+                Debug.Assert(endIndex >= startIndex, "endIndex must not be less than startIndex");
+
+                for (int i = startIndex; i < endIndex && i < codeCharacters.Length; i++)
+                {
+                    codeCharacters[i] = false;
+                }
+            }
         }
     }
 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -66,9 +66,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 @"ToolInfo\s*(?:\[\])?\s+[A-Za-z_][A-Za-z0-9_]*)",
                 RegexOptions.Compiled);
 
-        private static readonly Regex LegacyAssemblyScopedTypeNameRegex =
-            new(@"\b(?:IUnityTool|ToolInfo)\b", RegexOptions.Compiled);
-
         private static readonly Regex LegacyNamespaceAliasRegex =
             new(
                 @"\busing\s+(?<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:global::)?" +
@@ -124,6 +121,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             string migratedContent = source;
+            string[] legacyNamespaceAliases = GetLegacyNamespaceAliases(source);
+            bool hasLegacyNamespaceUsage = RegexMatchesCode(source, LegacyNamespaceRegex);
+            bool canMigrateBareLegacyToolAttribute =
+                hasLegacyAssemblySource ||
+                hasLegacyNamespaceUsage ||
+                legacyNamespaceAliases.Length > 0;
             bool hasLocalLegacyMarker = ContainsLegacyToolMigrationMarker(source);
             bool shouldApplyContractRenames = hasLegacyAssemblySource || hasLocalLegacyMarker;
             bool shouldApplyRegistrarRenames = shouldApplyContractRenames &&
@@ -131,10 +134,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             bool shouldApplyDomainMetadataRenames = shouldApplyContractRenames &&
                 RegexMatchesCode(source, LegacyDomainMetadataRegex);
             int replacementCount = 0;
-            string[] legacyNamespaceAliases = GetLegacyNamespaceAliases(source);
             migratedContent = ReplaceLegacyToolAttributesInCode(
                 migratedContent,
                 legacyNamespaceAliases,
+                canMigrateBareLegacyToolAttribute,
                 ref replacementCount);
             migratedContent = ReplaceLegacyRegistrarAliasesInCode(
                 migratedContent,
@@ -323,6 +326,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static bool TryMigrateLegacyToolAttributeList(
             string attributesSource,
             string[] legacyNamespaceAliases,
+            bool canMigrateBareLegacyToolAttribute,
             out string migratedAttributes)
         {
             Debug.Assert(attributesSource != null, "attributesSource must not be null");
@@ -337,6 +341,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (TryMigrateLegacyToolAttributeEntry(
                         trimmedAttribute,
                         legacyNamespaceAliases,
+                        canMigrateBareLegacyToolAttribute,
                         out string migratedAttribute))
                 {
                     migratedAttributeItems.Add(migratedAttribute);
@@ -360,6 +365,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static bool TryMigrateLegacyToolAttributeEntry(
             string attribute,
             string[] legacyNamespaceAliases,
+            bool canMigrateBareLegacyToolAttribute,
             out string migratedAttribute)
         {
             Debug.Assert(attribute != null, "attribute must not be null");
@@ -372,8 +378,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return false;
             }
 
-            if (match.Groups["alias"].Success &&
-                !legacyNamespaceAliases.Contains(match.Groups["alias"].Value))
+            bool hasQualifier = match.Groups["qualifier"].Success;
+            bool hasAlias = match.Groups["alias"].Success;
+            if (!hasQualifier && !hasAlias && !canMigrateBareLegacyToolAttribute)
+            {
+                migratedAttribute = string.Empty;
+                return false;
+            }
+
+            if (hasAlias && !legacyNamespaceAliases.Contains(match.Groups["alias"].Value))
             {
                 migratedAttribute = string.Empty;
                 return false;
@@ -381,7 +394,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             string argumentsSource = match.Groups["arguments"].Value;
             string[] migratedArguments = GetMigratedSupportedAttributeArguments(argumentsSource);
-            string attributeName = match.Groups["qualifier"].Success || match.Groups["alias"].Success
+            string attributeName = hasQualifier || hasAlias
                 ? $"{CurrentNamespace}.UnityCliLoopTool"
                 : "UnityCliLoopTool";
             migratedAttribute = migratedArguments.Length == 0
@@ -701,6 +714,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static string ReplaceLegacyToolAttributesInCode(
             string source,
             string[] legacyNamespaceAliases,
+            bool canMigrateBareLegacyToolAttribute,
             ref int replacementCount)
         {
             Debug.Assert(source != null, "source must not be null");
@@ -734,6 +748,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (!TryMigrateLegacyToolAttributeList(
                         attributesSource,
                         legacyNamespaceAliases,
+                        canMigrateBareLegacyToolAttribute,
                         out string migratedAttributes))
                 {
                     builder.Append(source, index, closingBracketIndex - index + 1);
@@ -813,7 +828,27 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
 
             CodeTextMask codeTextMask = CodeTextMask.Create(source);
-            MatchCollection matches = LegacyAssemblyScopedTypeNameRegex.Matches(source);
+            foreach (TypeReplacementRule rule in ToolContractTypeReplacementRules)
+            {
+                if (ContainsLegacyAssemblyScopedTypeName(source, codeTextMask, rule.LegacyName))
+                {
+                    return true;
+                }
+            }
+
+            return ContainsLegacyAssemblyScopedTypeName(source, codeTextMask, "ToolInfo");
+        }
+
+        private static bool ContainsLegacyAssemblyScopedTypeName(
+            string source,
+            CodeTextMask codeTextMask,
+            string typeName)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(typeName), "typeName must not be null or empty");
+
+            Regex typeNameRegex = new($@"(?<![\.:])\b{Regex.Escape(typeName)}\b", RegexOptions.Compiled);
+            MatchCollection matches = typeNameRegex.Matches(source);
             foreach (Match match in matches)
             {
                 if (!codeTextMask.IsCodeAt(match.Index))
@@ -876,10 +911,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (RegexMatchesCode(source, LegacyNamespaceRegex)) return true;
 
-            return ContainsLegacyToolAttributeList(source);
+            if (RegexMatchesCode(source, LegacyBaseTypeUsageRegex)) return true;
+
+            if (RegexMatchesCode(source, LegacyAssemblyScopedApiUsageRegex)) return true;
+
+            return ContainsLegacyToolAttributeList(source, canMigrateBareLegacyToolAttribute: false);
         }
 
-        private static bool ContainsLegacyToolAttributeList(string source)
+        private static bool ContainsLegacyToolAttributeList(
+            string source,
+            bool canMigrateBareLegacyToolAttribute)
         {
             Debug.Assert(source != null, "source must not be null");
 
@@ -905,7 +946,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 string attributesSource = source.Substring(index + 1, closingBracketIndex - index - 1);
-                if (TryMigrateLegacyToolAttributeList(attributesSource, legacyNamespaceAliases, out _))
+                if (TryMigrateLegacyToolAttributeList(
+                        attributesSource,
+                        legacyNamespaceAliases,
+                        canMigrateBareLegacyToolAttribute,
+                        out _))
                 {
                     return true;
                 }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs.meta
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18d9dfae996e44930809dad94d0255b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/PresentationEditorStartup.cs
+++ b/Packages/src/Editor/Presentation/PresentationEditorStartup.cs
@@ -11,6 +11,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             UnityCliLoopSettingsWindow.InitializeEditorServices(editorSettingsService);
             SetupWizardWindow.InitializeForEditorStartup(editorSettingsService);
+            ThirdPartyToolMigrationWizardWindow.InitializeForEditorStartup();
         }
     }
 }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -26,8 +26,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string GITHUB_ICON_RELATIVE_PATH = "Editor/Presentation/Setup/GitHub_Invertocat_White.png";
         private const int PreferredWrappedTextLineCount = 2;
         private const bool ForceFlatSkillInstall = true;
+        private const string ThirdPartyToolMigrationCheckingText =
+            "Scanning project for V3 custom tool migration...";
         private static readonly Vector2 MinimumWindowSize = new(360f, 380f);
         private static UnityCliLoopEditorSettingsService RegisteredEditorSettingsService;
+        private static readonly System.IProgress<ThirdPartyToolMigrationProgress> SilentMigrationProgress =
+            new SilentThirdPartyToolMigrationProgress();
 
         internal static void InitializeForEditorStartup(UnityCliLoopEditorSettingsService editorSettingsService)
         {
@@ -93,6 +97,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private static void TryShowOnVersionChange()
         {
+            TryShowOnVersionChangeAsync(CancellationToken.None);
+        }
+
+        private static async void TryShowOnVersionChangeAsync(CancellationToken ct)
+        {
             string currentVersion = UnityCliLoopConstants.PackageInfo.version;
             UnityCliLoopEditorSettingsService editorSettingsService = GetEditorSettingsService();
             bool suppressAutoShow = editorSettingsService.GetSuppressSetupWizardAutoShow();
@@ -101,7 +110,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                     currentVersion,
                     lastSeenVersion,
                     suppressAutoShow)
-                && HasThirdPartyToolMigrationTargets();
+                && await HasThirdPartyToolMigrationTargetsAsync(ct);
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (!ShouldAutoShowForVersion(
                 currentVersion,
                 lastSeenVersion,
@@ -115,11 +129,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             EditorApplication.delayCall += ShowWindowOnVersionChange;
         }
 
-        private static bool HasThirdPartyToolMigrationTargets()
+        private static async Task<bool> HasThirdPartyToolMigrationTargetsAsync(CancellationToken ct)
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             ThirdPartyToolMigrationPreview preview =
-                ThirdPartyToolMigrationUseCaseRegistry.GetRegisteredUseCase().PreviewMigration(projectRoot);
+                await ThirdPartyToolMigrationUseCaseRegistry
+                    .GetRegisteredUseCase()
+                    .PreviewMigrationAsync(projectRoot, SilentMigrationProgress, ct);
             return preview.HasTargets;
         }
 
@@ -245,6 +261,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         // V3 custom tool migration
         private VisualElement _thirdPartyToolMigrationSection;
         private Label _thirdPartyToolMigrationStatusLabel;
+        private ProgressBar _thirdPartyToolMigrationProgressBar;
         private Button _migrateThirdPartyToolsButton;
 
         // Footer
@@ -271,6 +288,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private IVisualElementScheduledItem _initialRefreshScheduledItem;
         private IVisualElementScheduledItem _resizeScheduledItem;
         private CancellationTokenSource _skillInstallStateRefreshCts;
+        private CancellationTokenSource _thirdPartyToolMigrationPreviewCts;
         private SkillsTarget _skillsTarget = SkillsTarget.Claude;
         private SkillSetupUseCase _skillSetupUseCase;
         private ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
@@ -315,6 +333,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             _initialRefreshScheduledItem?.Pause();
             CancelSkillInstallStateRefresh();
+            CancelThirdPartyToolMigrationPreview();
         }
 
         private void LoadLayout()
@@ -354,6 +373,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 rootVisualElement.Q<VisualElement>("third-party-tool-migration-section");
             _thirdPartyToolMigrationStatusLabel =
                 rootVisualElement.Q<Label>("third-party-tool-migration-status-label");
+            _thirdPartyToolMigrationProgressBar =
+                rootVisualElement.Q<ProgressBar>("third-party-tool-migration-progress-bar");
             _migrateThirdPartyToolsButton =
                 rootVisualElement.Q<Button>("migrate-third-party-tools-button");
 
@@ -462,6 +483,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.SetVisible(_skillsTargetList, !_shouldUseFirstInstallSkillsUi);
             _skillsTargetList.Clear();
             ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, false);
+            ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, false);
             _migrateThirdPartyToolsButton.SetEnabled(false);
             _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
                 _isMigratingThirdPartyTools);
@@ -496,6 +518,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private async void RefreshUI(bool refreshSkillsSection = true)
         {
             CancelSkillInstallStateRefresh();
+            CancelThirdPartyToolMigrationPreview();
             RefreshAutoShowToggle();
             ViewDataBinder.SetVisible(_nodejsWarning, false);
             ViewDataBinder.SetVisible(_nodejsOk, false);
@@ -516,6 +539,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _skillsTargetList.Clear();
             }
 
+            ShowThirdPartyToolMigrationCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
             await Task.Yield();
 
             ViewDataBinder.SetVisible(_nodejsWarning, false);
@@ -532,7 +556,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (!refreshSkillsSection)
             {
-                RefreshThirdPartyToolMigrationSection();
+                CancellationToken migrationPreviewCt = BeginThirdPartyToolMigrationPreview();
+                await RefreshThirdPartyToolMigrationSectionAsync(migrationPreviewCt);
+                if (migrationPreviewCt.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 ScheduleResizeToContent();
                 return;
             }
@@ -541,19 +571,33 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canManageSkills = CanManageSkills(cliInstalled);
             UpdateSkillsStep(canManageSkills, targets);
             BeginRefreshDisplayedSkillTargets(canManageSkills);
-            RefreshThirdPartyToolMigrationSection();
+            CancellationToken ct = BeginThirdPartyToolMigrationPreview();
+            await RefreshThirdPartyToolMigrationSectionAsync(ct);
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
             ScheduleResizeToContent();
         }
 
-        private void RefreshThirdPartyToolMigrationSection()
+        private async Task RefreshThirdPartyToolMigrationSectionAsync(CancellationToken ct)
         {
+            ShowThirdPartyToolMigrationCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            System.IProgress<ThirdPartyToolMigrationProgress> progress =
+                new ThirdPartyToolMigrationPreviewProgress(this, ct);
             ThirdPartyToolMigrationPreview preview =
-                _thirdPartyToolMigrationUseCase.PreviewMigration(projectRoot);
+                await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct);
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
 
             if (!preview.HasTargets)
             {
                 ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, false);
+                ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, false);
                 _thirdPartyToolMigrationStatusLabel.text = string.Empty;
                 _migrateThirdPartyToolsButton.SetEnabled(false);
                 _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
@@ -562,11 +606,52 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, true);
+            ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, false);
             _thirdPartyToolMigrationStatusLabel.text =
                 GetThirdPartyToolMigrationStatusText(preview.FileCount);
             _migrateThirdPartyToolsButton.SetEnabled(!_isMigratingThirdPartyTools);
             _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
                 _isMigratingThirdPartyTools);
+        }
+
+        private CancellationToken BeginThirdPartyToolMigrationPreview()
+        {
+            CancelThirdPartyToolMigrationPreview();
+            CancellationTokenSource cts = new();
+            _thirdPartyToolMigrationPreviewCts = cts;
+            return cts.Token;
+        }
+
+        private void CancelThirdPartyToolMigrationPreview()
+        {
+            if (_thirdPartyToolMigrationPreviewCts == null)
+            {
+                return;
+            }
+
+            _thirdPartyToolMigrationPreviewCts.Cancel();
+            _thirdPartyToolMigrationPreviewCts.Dispose();
+            _thirdPartyToolMigrationPreviewCts = null;
+        }
+
+        private void ShowThirdPartyToolMigrationCheckingState(ThirdPartyToolMigrationProgress progress)
+        {
+            ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, true);
+            ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, true);
+            _thirdPartyToolMigrationStatusLabel.text = GetThirdPartyToolMigrationProgressText(progress);
+            UpdateThirdPartyToolMigrationProgressBar(progress);
+            _migrateThirdPartyToolsButton.SetEnabled(false);
+            _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
+                _isMigratingThirdPartyTools);
+        }
+
+        private void UpdateThirdPartyToolMigrationProgressBar(ThirdPartyToolMigrationProgress progress)
+        {
+            int totalItemCount = Mathf.Max(progress.TotalItemCount, 1);
+            int processedItemCount = Mathf.Clamp(progress.ProcessedItemCount, 0, totalItemCount);
+            _thirdPartyToolMigrationProgressBar.lowValue = 0;
+            _thirdPartyToolMigrationProgressBar.highValue = totalItemCount;
+            _thirdPartyToolMigrationProgressBar.value = processedItemCount;
         }
 
         private List<SkillSetupTargetInfo> DetectDisplayedSkillTargets(string projectRoot)
@@ -647,9 +732,20 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string objectPronoun = fileCount == 1 ? "it" : "them";
 
             return $"{fileCount} {noun} {verb} V3 custom tool migration.\n" +
-                $"The Unity Console is showing errors because {subject} the old custom tool API.\n" +
+                $"The Unity Console is showing errors because {subject} the old custom tool API.\n\n" +
                 $"Click Migrate to update {objectPronoun} automatically. " +
                 "The errors should disappear after migration.";
+        }
+
+        internal static string GetThirdPartyToolMigrationProgressText(ThirdPartyToolMigrationProgress progress)
+        {
+            if (progress.TotalItemCount == 0)
+            {
+                return ThirdPartyToolMigrationCheckingText;
+            }
+
+            return $"{ThirdPartyToolMigrationCheckingText}\n" +
+                $"{progress.ProcessedItemCount}/{progress.TotalItemCount} checks complete.";
         }
 
         internal static string GetThirdPartyToolMigrationButtonText(bool isMigrating)
@@ -1065,7 +1161,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             _isMigratingThirdPartyTools = true;
-            RefreshThirdPartyToolMigrationSection();
+            ShowThirdPartyToolMigrationCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
 
             try
             {
@@ -1077,9 +1173,20 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             finally
             {
                 _isMigratingThirdPartyTools = false;
-                RefreshThirdPartyToolMigrationSection();
-                ScheduleResizeToContent();
+                CancellationToken ct = BeginThirdPartyToolMigrationPreview();
+                RefreshThirdPartyToolMigrationSectionAfterMigrationAsync(ct);
             }
+        }
+
+        private async void RefreshThirdPartyToolMigrationSectionAfterMigrationAsync(CancellationToken ct)
+        {
+            await RefreshThirdPartyToolMigrationSectionAsync(ct);
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            ScheduleResizeToContent();
         }
 
         private void HandleOpenSettings()
@@ -1293,5 +1400,37 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return !float.IsNaN(value) && !float.IsInfinity(value);
         }
 
+        private sealed class SilentThirdPartyToolMigrationProgress
+            : System.IProgress<ThirdPartyToolMigrationProgress>
+        {
+            public void Report(ThirdPartyToolMigrationProgress value)
+            {
+            }
+        }
+
+        private sealed class ThirdPartyToolMigrationPreviewProgress
+            : System.IProgress<ThirdPartyToolMigrationProgress>
+        {
+            private readonly SetupWizardWindow _window;
+            private readonly CancellationToken _ct;
+
+            public ThirdPartyToolMigrationPreviewProgress(SetupWizardWindow window, CancellationToken ct)
+            {
+                Debug.Assert(window != null, "window must not be null");
+
+                _window = window;
+                _ct = ct;
+            }
+
+            public void Report(ThirdPartyToolMigrationProgress value)
+            {
+                if (_ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                _window.ShowThirdPartyToolMigrationCheckingState(value);
+            }
+        }
     }
 }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -643,7 +643,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             string noun = fileCount == 1 ? "file" : "files";
             string verb = fileCount == 1 ? "needs" : "need";
-            return $"{fileCount} {noun} {verb} V3 custom tool migration.";
+            string subject = fileCount == 1 ? "this file still uses" : "these files still use";
+            string objectPronoun = fileCount == 1 ? "it" : "them";
+
+            return $"{fileCount} {noun} {verb} V3 custom tool migration.\n" +
+                $"The Unity Console is showing errors because {subject} the old custom tool API.\n" +
+                $"Click Migrate to update {objectPronoun} automatically. " +
+                "The errors should disappear after migration.";
         }
 
         internal static string GetThirdPartyToolMigrationButtonText(bool isMigrating)

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -26,8 +26,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string GITHUB_ICON_RELATIVE_PATH = "Editor/Presentation/Setup/GitHub_Invertocat_White.png";
         private const int PreferredWrappedTextLineCount = 2;
         private const bool ForceFlatSkillInstall = true;
-        private const string ThirdPartyToolMigrationCheckingText =
-            "Scanning project for V3 custom tool migration...";
         private static readonly Vector2 MinimumWindowSize = new(360f, 380f);
         private static UnityCliLoopEditorSettingsService RegisteredEditorSettingsService;
 
@@ -52,34 +50,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         [MenuItem("Window/Unity CLI Loop/Setup Wizard", priority = 3)]
         public static void ShowWindow()
         {
-            ShowWindowInternal(false, false);
+            ShowWindowInternal(false);
         }
 
         internal static bool ShouldAutoShowForVersion(
             string currentVersion,
             string lastSeenVersion,
-            bool suppressAutoShow,
-            bool hasThirdPartyToolMigrationTargets)
+            bool suppressAutoShow)
         {
             bool versionChanged = !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
             if (!versionChanged) return false;
-            if (hasThirdPartyToolMigrationTargets) return true;
 
             return !suppressAutoShow;
-        }
-
-        internal static bool ShouldCheckThirdPartyToolMigrationTargets(
-            string currentVersion,
-            string lastSeenVersion)
-        {
-            bool versionChanged = !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
-            return versionChanged;
-        }
-
-        internal static bool ShouldRefreshThirdPartyToolMigrationOnOpen(
-            bool hasThirdPartyToolMigrationTargets)
-        {
-            return hasThirdPartyToolMigrationTargets;
         }
 
         internal static void MaybeRecordLastSeenVersion(bool shouldRecordVersion, string version)
@@ -100,19 +82,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private static void TryShowOnVersionChange()
         {
-            TryShowOnVersionChangeAsync(CancellationToken.None);
+            EvaluateVersionChange(CancellationToken.None);
         }
 
-        private static async void TryShowOnVersionChangeAsync(CancellationToken ct)
+        private static void EvaluateVersionChange(CancellationToken ct)
         {
             string currentVersion = UnityCliLoopConstants.PackageInfo.version;
             UnityCliLoopEditorSettingsService editorSettingsService = GetEditorSettingsService();
             bool suppressAutoShow = editorSettingsService.GetSuppressSetupWizardAutoShow();
             string lastSeenVersion = editorSettingsService.GetLastSeenSetupWizardVersion();
-            bool hasThirdPartyToolMigrationTargets = ShouldCheckThirdPartyToolMigrationTargets(
-                    currentVersion,
-                    lastSeenVersion)
-                && await HasThirdPartyToolMigrationTargetsAsync(ct);
             if (ct.IsCancellationRequested)
             {
                 return;
@@ -121,34 +99,21 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             if (!ShouldAutoShowForVersion(
                 currentVersion,
                 lastSeenVersion,
-                suppressAutoShow,
-                hasThirdPartyToolMigrationTargets))
+                suppressAutoShow))
             {
                 MaybeRecordSuppressedVersion(suppressAutoShow, currentVersion);
                 return;
             }
 
-            EditorApplication.delayCall += () => ShowWindowOnVersionChange(hasThirdPartyToolMigrationTargets);
+            EditorApplication.delayCall += ShowWindowOnVersionChange;
         }
 
-        private static async Task<bool> HasThirdPartyToolMigrationTargetsAsync(CancellationToken ct)
+        private static void ShowWindowOnVersionChange()
         {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return await ThirdPartyToolMigrationUseCaseRegistry
-                    .GetRegisteredUseCase()
-                    .HasMigrationTargetsAsync(projectRoot, ct);
+            ShowWindowInternal(true);
         }
 
-        private static void ShowWindowOnVersionChange(bool hasThirdPartyToolMigrationTargets)
-        {
-            ShowWindowInternal(
-                true,
-                ShouldRefreshThirdPartyToolMigrationOnOpen(hasThirdPartyToolMigrationTargets));
-        }
-
-        private static void ShowWindowInternal(
-            bool shouldRecordVersion,
-            bool shouldRefreshThirdPartyToolMigrationAfterCreateGui)
+        private static void ShowWindowInternal(bool shouldRecordVersion)
         {
             string currentVersion = UnityCliLoopConstants.PackageInfo.version;
             if (TryReuseOpenWindow(
@@ -169,8 +134,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 WindowTitle,
                 windowPosition,
                 lastSeenSetupWizardVersionBeforeOpen,
-                shouldRecordVersion,
-                shouldRefreshThirdPartyToolMigrationAfterCreateGui);
+                shouldRecordVersion);
             window.ShowUtility();
             window.ScheduleResizeToContent();
         }
@@ -215,8 +179,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string title,
             Rect position,
             string lastSeenSetupWizardVersionBeforeOpen,
-            bool shouldRecordVersionAfterCreateGui,
-            bool shouldRefreshThirdPartyToolMigrationAfterCreateGui)
+            bool shouldRecordVersionAfterCreateGui)
         {
             Debug.Assert(window != null, "window must not be null");
             Debug.Assert(!string.IsNullOrEmpty(title), "title must not be null or empty");
@@ -226,8 +189,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             window._lastSeenSetupWizardVersionBeforeOpen =
                 lastSeenSetupWizardVersionBeforeOpen ?? string.Empty;
             window._shouldRecordLastSeenVersionAfterCreateGui = shouldRecordVersionAfterCreateGui;
-            window._shouldRefreshThirdPartyToolMigrationAfterCreateGui =
-                shouldRefreshThirdPartyToolMigrationAfterCreateGui;
         }
 
         private static void FocusExistingWindow()
@@ -266,12 +227,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private Label _skillsStatusLabel;
         private Button _installSkillsButton;
 
-        // V3 custom tool migration
-        private VisualElement _thirdPartyToolMigrationSection;
-        private Label _thirdPartyToolMigrationStatusLabel;
-        private ProgressBar _thirdPartyToolMigrationProgressBar;
-        private Button _migrateThirdPartyToolsButton;
-
         // Footer
         private Toggle _suppressAutoShowToggle;
         private Button _openSettingsButton;
@@ -284,7 +239,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         // State
         private bool _isInstallingCli;
         private bool _isInstallingSkills;
-        private bool _isMigratingThirdPartyTools;
         private bool _isApplyingContentSize;
         private bool _isSkillsTargetFieldInitialized;
         private bool _shouldUseFirstInstallSkillsUi;
@@ -293,15 +247,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private string _lastSeenSetupWizardVersionBeforeOpen = string.Empty;
         [SerializeField]
         private bool _shouldRecordLastSeenVersionAfterCreateGui;
-        [SerializeField]
-        private bool _shouldRefreshThirdPartyToolMigrationAfterCreateGui;
         private IVisualElementScheduledItem _initialRefreshScheduledItem;
         private IVisualElementScheduledItem _resizeScheduledItem;
         private CancellationTokenSource _skillInstallStateRefreshCts;
-        private CancellationTokenSource _thirdPartyToolMigrationPreviewCts;
         private SkillsTarget _skillsTarget = SkillsTarget.Claude;
         private SkillSetupUseCase _skillSetupUseCase;
-        private ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
         private UnityCliLoopEditorSettingsService _editorSettingsService;
 
         private void CreateGUI()
@@ -321,7 +271,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void InitializeApplicationServices()
         {
             _skillSetupUseCase = SkillSetupUseCaseRegistry.GetRegisteredUseCase();
-            _thirdPartyToolMigrationUseCase = ThirdPartyToolMigrationUseCaseRegistry.GetRegisteredUseCase();
             _editorSettingsService = GetEditorSettingsService();
         }
 
@@ -343,7 +292,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             _initialRefreshScheduledItem?.Pause();
             CancelSkillInstallStateRefresh();
-            CancelThirdPartyToolMigrationPreview();
         }
 
         private void LoadLayout()
@@ -379,15 +327,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
             _installSkillsButton = rootVisualElement.Q<Button>("install-skills-button");
 
-            _thirdPartyToolMigrationSection =
-                rootVisualElement.Q<VisualElement>("third-party-tool-migration-section");
-            _thirdPartyToolMigrationStatusLabel =
-                rootVisualElement.Q<Label>("third-party-tool-migration-status-label");
-            _thirdPartyToolMigrationProgressBar =
-                rootVisualElement.Q<ProgressBar>("third-party-tool-migration-progress-bar");
-            _migrateThirdPartyToolsButton =
-                rootVisualElement.Q<Button>("migrate-third-party-tools-button");
-
             _suppressAutoShowToggle = rootVisualElement.Q<Toggle>("suppress-auto-show-toggle");
             _openSettingsButton = rootVisualElement.Q<Button>("open-settings-button");
             _closeButton = rootVisualElement.Q<Button>("close-button");
@@ -402,7 +341,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _refreshButton.clicked += () => RefreshUI();
             _installCliButton.clicked += HandleInstallCli;
             _installSkillsButton.clicked += HandleInstallSkills;
-            _migrateThirdPartyToolsButton.clicked += HandleMigrateThirdPartyTools;
             InitializeSkillsTargetField();
             InitializeGroupSkillsToggle();
             _suppressAutoShowToggle.RegisterValueChangedCallback(evt => HandleSuppressAutoShowChanged(evt.newValue));
@@ -492,11 +430,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.SetVisible(_skillsTargetRow, _shouldUseFirstInstallSkillsUi);
             ViewDataBinder.SetVisible(_skillsTargetList, !_shouldUseFirstInstallSkillsUi);
             _skillsTargetList.Clear();
-            ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, false);
-            ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, false);
-            _migrateThirdPartyToolsButton.SetEnabled(false);
-            _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
-                _isMigratingThirdPartyTools);
         }
 
         private void UpdateSkillsStatusLabel(string text)
@@ -528,7 +461,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private async void RefreshUI(bool refreshSkillsSection = true)
         {
             CancelSkillInstallStateRefresh();
-            CancelThirdPartyToolMigrationPreview();
             RefreshAutoShowToggle();
             ViewDataBinder.SetVisible(_nodejsWarning, false);
             ViewDataBinder.SetVisible(_nodejsOk, false);
@@ -549,15 +481,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _skillsTargetList.Clear();
             }
 
-            if (_shouldRefreshThirdPartyToolMigrationAfterCreateGui)
-            {
-                ShowThirdPartyToolMigrationCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
-            }
-            else
-            {
-                HideThirdPartyToolMigrationSection();
-            }
-
             await Task.Yield();
 
             ViewDataBinder.SetVisible(_nodejsWarning, false);
@@ -574,20 +497,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (!refreshSkillsSection)
             {
-                if (_shouldRefreshThirdPartyToolMigrationAfterCreateGui)
-                {
-                    CancellationToken migrationPreviewCt = BeginThirdPartyToolMigrationPreview();
-                    await RefreshThirdPartyToolMigrationSectionAsync(migrationPreviewCt);
-                    if (migrationPreviewCt.IsCancellationRequested)
-                    {
-                        return;
-                    }
-                }
-                else
-                {
-                    HideThirdPartyToolMigrationSection();
-                }
-
                 ScheduleResizeToContent();
                 return;
             }
@@ -596,101 +505,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canManageSkills = CanManageSkills(cliInstalled);
             UpdateSkillsStep(canManageSkills, targets);
             BeginRefreshDisplayedSkillTargets(canManageSkills);
-            if (_shouldRefreshThirdPartyToolMigrationAfterCreateGui)
-            {
-                CancellationToken ct = BeginThirdPartyToolMigrationPreview();
-                await RefreshThirdPartyToolMigrationSectionAsync(ct);
-                if (ct.IsCancellationRequested)
-                {
-                    return;
-                }
-            }
-            else
-            {
-                HideThirdPartyToolMigrationSection();
-            }
 
             ScheduleResizeToContent();
-        }
-
-        private async Task RefreshThirdPartyToolMigrationSectionAsync(CancellationToken ct)
-        {
-            ShowThirdPartyToolMigrationCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            System.IProgress<ThirdPartyToolMigrationProgress> progress =
-                new ThirdPartyToolMigrationPreviewProgress(this, ct);
-            ThirdPartyToolMigrationPreview preview =
-                await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct);
-            if (ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            if (!preview.HasTargets)
-            {
-                _shouldRefreshThirdPartyToolMigrationAfterCreateGui = false;
-                HideThirdPartyToolMigrationSection();
-                return;
-            }
-
-            _shouldRefreshThirdPartyToolMigrationAfterCreateGui = true;
-            ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, true);
-            ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, false);
-            _thirdPartyToolMigrationStatusLabel.text =
-                GetThirdPartyToolMigrationStatusText(preview.FileCount);
-            _migrateThirdPartyToolsButton.SetEnabled(!_isMigratingThirdPartyTools);
-            _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
-                _isMigratingThirdPartyTools);
-        }
-
-        private void HideThirdPartyToolMigrationSection()
-        {
-            ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, false);
-            ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, false);
-            _thirdPartyToolMigrationStatusLabel.text = string.Empty;
-            _migrateThirdPartyToolsButton.SetEnabled(false);
-            _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
-                _isMigratingThirdPartyTools);
-        }
-
-        private CancellationToken BeginThirdPartyToolMigrationPreview()
-        {
-            CancelThirdPartyToolMigrationPreview();
-            CancellationTokenSource cts = new();
-            _thirdPartyToolMigrationPreviewCts = cts;
-            return cts.Token;
-        }
-
-        private void CancelThirdPartyToolMigrationPreview()
-        {
-            if (_thirdPartyToolMigrationPreviewCts == null)
-            {
-                return;
-            }
-
-            _thirdPartyToolMigrationPreviewCts.Cancel();
-            _thirdPartyToolMigrationPreviewCts.Dispose();
-            _thirdPartyToolMigrationPreviewCts = null;
-        }
-
-        private void ShowThirdPartyToolMigrationCheckingState(ThirdPartyToolMigrationProgress progress)
-        {
-            ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, true);
-            ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, true);
-            _thirdPartyToolMigrationStatusLabel.text = GetThirdPartyToolMigrationProgressText(progress);
-            UpdateThirdPartyToolMigrationProgressBar(progress);
-            _migrateThirdPartyToolsButton.SetEnabled(false);
-            _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
-                _isMigratingThirdPartyTools);
-        }
-
-        private void UpdateThirdPartyToolMigrationProgressBar(ThirdPartyToolMigrationProgress progress)
-        {
-            int totalItemCount = Mathf.Max(progress.TotalItemCount, 1);
-            int processedItemCount = Mathf.Clamp(progress.ProcessedItemCount, 0, totalItemCount);
-            _thirdPartyToolMigrationProgressBar.lowValue = 0;
-            _thirdPartyToolMigrationProgressBar.highValue = totalItemCount;
-            _thirdPartyToolMigrationProgressBar.value = processedItemCount;
         }
 
         private List<SkillSetupTargetInfo> DetectDisplayedSkillTargets(string projectRoot)
@@ -759,37 +575,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool CanManageSkills(bool cliInstalled)
         {
             return cliInstalled;
-        }
-
-        internal static string GetThirdPartyToolMigrationStatusText(int fileCount)
-        {
-            Debug.Assert(fileCount >= 0, "fileCount must not be negative");
-
-            string noun = fileCount == 1 ? "file" : "files";
-            string verb = fileCount == 1 ? "needs" : "need";
-            string subject = fileCount == 1 ? "this file still uses" : "these files still use";
-            string objectPronoun = fileCount == 1 ? "it" : "them";
-
-            return $"{fileCount} {noun} {verb} V3 custom tool migration.\n" +
-                $"The Unity Console is showing errors because {subject} the old custom tool API.\n\n" +
-                $"Click Migrate to update {objectPronoun} automatically. " +
-                "The errors should disappear after migration.";
-        }
-
-        internal static string GetThirdPartyToolMigrationProgressText(ThirdPartyToolMigrationProgress progress)
-        {
-            if (progress.TotalItemCount == 0)
-            {
-                return ThirdPartyToolMigrationCheckingText;
-            }
-
-            return $"{ThirdPartyToolMigrationCheckingText}\n" +
-                $"{progress.ProcessedItemCount}/{progress.TotalItemCount} checks complete.";
-        }
-
-        internal static string GetThirdPartyToolMigrationButtonText(bool isMigrating)
-        {
-            return isMigrating ? "Migrating..." : "Migrate";
         }
 
         internal static SkillSetupTargetInfo CreateFirstInstallSkillTarget(
@@ -1196,38 +981,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
         }
 
-        private void HandleMigrateThirdPartyTools()
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            _isMigratingThirdPartyTools = true;
-            ShowThirdPartyToolMigrationCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
-
-            try
-            {
-                ThirdPartyToolMigrationResult result =
-                    _thirdPartyToolMigrationUseCase.ApplyMigration(projectRoot);
-                Debug.Assert(result.Changed, "migration result should contain changed files");
-                AssetDatabase.Refresh();
-            }
-            finally
-            {
-                _isMigratingThirdPartyTools = false;
-                CancellationToken ct = BeginThirdPartyToolMigrationPreview();
-                RefreshThirdPartyToolMigrationSectionAfterMigrationAsync(ct);
-            }
-        }
-
-        private async void RefreshThirdPartyToolMigrationSectionAfterMigrationAsync(CancellationToken ct)
-        {
-            await RefreshThirdPartyToolMigrationSectionAsync(ct);
-            if (ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            ScheduleResizeToContent();
-        }
-
         private void HandleOpenSettings()
         {
             UnityCliLoopSettingsWindow.ShowWindow();
@@ -1439,29 +1192,5 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return !float.IsNaN(value) && !float.IsInfinity(value);
         }
 
-        private sealed class ThirdPartyToolMigrationPreviewProgress
-            : System.IProgress<ThirdPartyToolMigrationProgress>
-        {
-            private readonly SetupWizardWindow _window;
-            private readonly CancellationToken _ct;
-
-            public ThirdPartyToolMigrationPreviewProgress(SetupWizardWindow window, CancellationToken ct)
-            {
-                Debug.Assert(window != null, "window must not be null");
-
-                _window = window;
-                _ct = ct;
-            }
-
-            public void Report(ThirdPartyToolMigrationProgress value)
-            {
-                if (_ct.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                _window.ShowThirdPartyToolMigrationCheckingState(value);
-            }
-        }
     }
 }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -56,11 +56,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool ShouldAutoShowForVersion(
             string currentVersion,
             string lastSeenVersion,
-            bool suppressAutoShow)
+            bool suppressAutoShow,
+            bool hasThirdPartyToolMigrationTargets)
         {
-            if (suppressAutoShow) return false;
+            bool versionChanged = !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
+            if (!versionChanged) return false;
+            if (hasThirdPartyToolMigrationTargets) return true;
 
-            return !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
+            return !suppressAutoShow;
         }
 
         internal static void MaybeRecordLastSeenVersion(bool shouldRecordVersion, string version)
@@ -84,11 +87,28 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string currentVersion = UnityCliLoopConstants.PackageInfo.version;
             UnityCliLoopEditorSettingsService editorSettingsService = GetEditorSettingsService();
             bool suppressAutoShow = editorSettingsService.GetSuppressSetupWizardAutoShow();
-            MaybeRecordSuppressedVersion(suppressAutoShow, currentVersion);
             string lastSeenVersion = editorSettingsService.GetLastSeenSetupWizardVersion();
-            if (!ShouldAutoShowForVersion(currentVersion, lastSeenVersion, suppressAutoShow)) return;
+            bool hasThirdPartyToolMigrationTargets = suppressAutoShow
+                && HasThirdPartyToolMigrationTargets();
+            if (!ShouldAutoShowForVersion(
+                currentVersion,
+                lastSeenVersion,
+                suppressAutoShow,
+                hasThirdPartyToolMigrationTargets))
+            {
+                MaybeRecordSuppressedVersion(suppressAutoShow, currentVersion);
+                return;
+            }
 
             EditorApplication.delayCall += ShowWindowOnVersionChange;
+        }
+
+        private static bool HasThirdPartyToolMigrationTargets()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            ThirdPartyToolMigrationPreview preview =
+                ThirdPartyToolMigrationUseCaseRegistry.GetRegisteredUseCase().PreviewMigration(projectRoot);
+            return preview.HasTargets;
         }
 
         private static void ShowWindowOnVersionChange()
@@ -210,6 +230,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private Label _skillsStatusLabel;
         private Button _installSkillsButton;
 
+        // V3 custom tool migration
+        private VisualElement _thirdPartyToolMigrationSection;
+        private Label _thirdPartyToolMigrationStatusLabel;
+        private Button _migrateThirdPartyToolsButton;
+
         // Footer
         private Toggle _suppressAutoShowToggle;
         private Button _openSettingsButton;
@@ -222,6 +247,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         // State
         private bool _isInstallingCli;
         private bool _isInstallingSkills;
+        private bool _isMigratingThirdPartyTools;
         private bool _isApplyingContentSize;
         private bool _isSkillsTargetFieldInitialized;
         private bool _shouldUseFirstInstallSkillsUi;
@@ -235,6 +261,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private CancellationTokenSource _skillInstallStateRefreshCts;
         private SkillsTarget _skillsTarget = SkillsTarget.Claude;
         private SkillSetupUseCase _skillSetupUseCase;
+        private ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
         private UnityCliLoopEditorSettingsService _editorSettingsService;
 
         private void CreateGUI()
@@ -254,6 +281,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void InitializeApplicationServices()
         {
             _skillSetupUseCase = SkillSetupUseCaseRegistry.GetRegisteredUseCase();
+            _thirdPartyToolMigrationUseCase = ThirdPartyToolMigrationUseCaseRegistry.GetRegisteredUseCase();
             _editorSettingsService = GetEditorSettingsService();
         }
 
@@ -310,6 +338,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
             _installSkillsButton = rootVisualElement.Q<Button>("install-skills-button");
 
+            _thirdPartyToolMigrationSection =
+                rootVisualElement.Q<VisualElement>("third-party-tool-migration-section");
+            _thirdPartyToolMigrationStatusLabel =
+                rootVisualElement.Q<Label>("third-party-tool-migration-status-label");
+            _migrateThirdPartyToolsButton =
+                rootVisualElement.Q<Button>("migrate-third-party-tools-button");
+
             _suppressAutoShowToggle = rootVisualElement.Q<Toggle>("suppress-auto-show-toggle");
             _openSettingsButton = rootVisualElement.Q<Button>("open-settings-button");
             _closeButton = rootVisualElement.Q<Button>("close-button");
@@ -324,6 +359,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _refreshButton.clicked += () => RefreshUI();
             _installCliButton.clicked += HandleInstallCli;
             _installSkillsButton.clicked += HandleInstallSkills;
+            _migrateThirdPartyToolsButton.clicked += HandleMigrateThirdPartyTools;
             InitializeSkillsTargetField();
             InitializeGroupSkillsToggle();
             _suppressAutoShowToggle.RegisterValueChangedCallback(evt => HandleSuppressAutoShowChanged(evt.newValue));
@@ -413,6 +449,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.SetVisible(_skillsTargetRow, _shouldUseFirstInstallSkillsUi);
             ViewDataBinder.SetVisible(_skillsTargetList, !_shouldUseFirstInstallSkillsUi);
             _skillsTargetList.Clear();
+            ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, false);
+            _migrateThirdPartyToolsButton.SetEnabled(false);
+            _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
+                _isMigratingThirdPartyTools);
         }
 
         private void UpdateSkillsStatusLabel(string text)
@@ -480,6 +520,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (!refreshSkillsSection)
             {
+                RefreshThirdPartyToolMigrationSection();
                 ScheduleResizeToContent();
                 return;
             }
@@ -488,7 +529,32 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canManageSkills = CanManageSkills(cliInstalled);
             UpdateSkillsStep(canManageSkills, targets);
             BeginRefreshDisplayedSkillTargets(canManageSkills);
+            RefreshThirdPartyToolMigrationSection();
             ScheduleResizeToContent();
+        }
+
+        private void RefreshThirdPartyToolMigrationSection()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            ThirdPartyToolMigrationPreview preview =
+                _thirdPartyToolMigrationUseCase.PreviewMigration(projectRoot);
+
+            if (!preview.HasTargets)
+            {
+                ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, false);
+                _thirdPartyToolMigrationStatusLabel.text = string.Empty;
+                _migrateThirdPartyToolsButton.SetEnabled(false);
+                _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
+                    _isMigratingThirdPartyTools);
+                return;
+            }
+
+            ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, true);
+            _thirdPartyToolMigrationStatusLabel.text =
+                GetThirdPartyToolMigrationStatusText(preview.FileCount);
+            _migrateThirdPartyToolsButton.SetEnabled(!_isMigratingThirdPartyTools);
+            _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
+                _isMigratingThirdPartyTools);
         }
 
         private List<SkillSetupTargetInfo> DetectDisplayedSkillTargets(string projectRoot)
@@ -557,6 +623,20 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool CanManageSkills(bool cliInstalled)
         {
             return cliInstalled;
+        }
+
+        internal static string GetThirdPartyToolMigrationStatusText(int fileCount)
+        {
+            Debug.Assert(fileCount >= 0, "fileCount must not be negative");
+
+            string noun = fileCount == 1 ? "file" : "files";
+            string verb = fileCount == 1 ? "needs" : "need";
+            return $"{fileCount} {noun} {verb} V3 custom tool migration.";
+        }
+
+        internal static string GetThirdPartyToolMigrationButtonText(bool isMigrating)
+        {
+            return isMigrating ? "Migrating..." : "Migrate";
         }
 
         internal static SkillSetupTargetInfo CreateFirstInstallSkillTarget(
@@ -960,6 +1040,27 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 _isInstallingSkills = false;
                 RefreshSkillsSection();
+            }
+        }
+
+        private void HandleMigrateThirdPartyTools()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            _isMigratingThirdPartyTools = true;
+            RefreshThirdPartyToolMigrationSection();
+
+            try
+            {
+                ThirdPartyToolMigrationResult result =
+                    _thirdPartyToolMigrationUseCase.ApplyMigration(projectRoot);
+                Debug.Assert(result.Changed, "migration result should contain changed files");
+                AssetDatabase.Refresh();
+            }
+            finally
+            {
+                _isMigratingThirdPartyTools = false;
+                RefreshThirdPartyToolMigrationSection();
+                ScheduleResizeToContent();
             }
         }
 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -66,6 +66,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return !suppressAutoShow;
         }
 
+        internal static bool ShouldCheckThirdPartyToolMigrationTargets(
+            string currentVersion,
+            string lastSeenVersion,
+            bool suppressAutoShow)
+        {
+            bool versionChanged = !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
+            return suppressAutoShow && versionChanged;
+        }
+
         internal static void MaybeRecordLastSeenVersion(bool shouldRecordVersion, string version)
         {
             if (!shouldRecordVersion) return;
@@ -88,7 +97,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             UnityCliLoopEditorSettingsService editorSettingsService = GetEditorSettingsService();
             bool suppressAutoShow = editorSettingsService.GetSuppressSetupWizardAutoShow();
             string lastSeenVersion = editorSettingsService.GetLastSeenSetupWizardVersion();
-            bool hasThirdPartyToolMigrationTargets = suppressAutoShow
+            bool hasThirdPartyToolMigrationTargets = ShouldCheckThirdPartyToolMigrationTargets(
+                    currentVersion,
+                    lastSeenVersion,
+                    suppressAutoShow)
                 && HasThirdPartyToolMigrationTargets();
             if (!ShouldAutoShowForVersion(
                 currentVersion,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -30,8 +30,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             "Scanning project for V3 custom tool migration...";
         private static readonly Vector2 MinimumWindowSize = new(360f, 380f);
         private static UnityCliLoopEditorSettingsService RegisteredEditorSettingsService;
-        private static readonly System.IProgress<ThirdPartyToolMigrationProgress> SilentMigrationProgress =
-            new SilentThirdPartyToolMigrationProgress();
 
         internal static void InitializeForEditorStartup(UnityCliLoopEditorSettingsService editorSettingsService)
         {
@@ -54,7 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         [MenuItem("Window/Unity CLI Loop/Setup Wizard", priority = 3)]
         public static void ShowWindow()
         {
-            ShowWindowInternal(false);
+            ShowWindowInternal(false, false);
         }
 
         internal static bool ShouldAutoShowForVersion(
@@ -72,11 +70,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal static bool ShouldCheckThirdPartyToolMigrationTargets(
             string currentVersion,
-            string lastSeenVersion,
-            bool suppressAutoShow)
+            string lastSeenVersion)
         {
             bool versionChanged = !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
-            return suppressAutoShow && versionChanged;
+            return versionChanged;
+        }
+
+        internal static bool ShouldRefreshThirdPartyToolMigrationOnOpen(
+            bool hasThirdPartyToolMigrationTargets)
+        {
+            return hasThirdPartyToolMigrationTargets;
         }
 
         internal static void MaybeRecordLastSeenVersion(bool shouldRecordVersion, string version)
@@ -108,8 +111,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string lastSeenVersion = editorSettingsService.GetLastSeenSetupWizardVersion();
             bool hasThirdPartyToolMigrationTargets = ShouldCheckThirdPartyToolMigrationTargets(
                     currentVersion,
-                    lastSeenVersion,
-                    suppressAutoShow)
+                    lastSeenVersion)
                 && await HasThirdPartyToolMigrationTargetsAsync(ct);
             if (ct.IsCancellationRequested)
             {
@@ -126,25 +128,27 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
-            EditorApplication.delayCall += ShowWindowOnVersionChange;
+            EditorApplication.delayCall += () => ShowWindowOnVersionChange(hasThirdPartyToolMigrationTargets);
         }
 
         private static async Task<bool> HasThirdPartyToolMigrationTargetsAsync(CancellationToken ct)
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            ThirdPartyToolMigrationPreview preview =
-                await ThirdPartyToolMigrationUseCaseRegistry
+            return await ThirdPartyToolMigrationUseCaseRegistry
                     .GetRegisteredUseCase()
-                    .PreviewMigrationAsync(projectRoot, SilentMigrationProgress, ct);
-            return preview.HasTargets;
+                    .HasMigrationTargetsAsync(projectRoot, ct);
         }
 
-        private static void ShowWindowOnVersionChange()
+        private static void ShowWindowOnVersionChange(bool hasThirdPartyToolMigrationTargets)
         {
-            ShowWindowInternal(true);
+            ShowWindowInternal(
+                true,
+                ShouldRefreshThirdPartyToolMigrationOnOpen(hasThirdPartyToolMigrationTargets));
         }
 
-        private static void ShowWindowInternal(bool shouldRecordVersion)
+        private static void ShowWindowInternal(
+            bool shouldRecordVersion,
+            bool shouldRefreshThirdPartyToolMigrationAfterCreateGui)
         {
             string currentVersion = UnityCliLoopConstants.PackageInfo.version;
             if (TryReuseOpenWindow(
@@ -165,7 +169,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 WindowTitle,
                 windowPosition,
                 lastSeenSetupWizardVersionBeforeOpen,
-                shouldRecordVersion);
+                shouldRecordVersion,
+                shouldRefreshThirdPartyToolMigrationAfterCreateGui);
             window.ShowUtility();
             window.ScheduleResizeToContent();
         }
@@ -210,7 +215,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string title,
             Rect position,
             string lastSeenSetupWizardVersionBeforeOpen,
-            bool shouldRecordVersionAfterCreateGui)
+            bool shouldRecordVersionAfterCreateGui,
+            bool shouldRefreshThirdPartyToolMigrationAfterCreateGui)
         {
             Debug.Assert(window != null, "window must not be null");
             Debug.Assert(!string.IsNullOrEmpty(title), "title must not be null or empty");
@@ -220,6 +226,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             window._lastSeenSetupWizardVersionBeforeOpen =
                 lastSeenSetupWizardVersionBeforeOpen ?? string.Empty;
             window._shouldRecordLastSeenVersionAfterCreateGui = shouldRecordVersionAfterCreateGui;
+            window._shouldRefreshThirdPartyToolMigrationAfterCreateGui =
+                shouldRefreshThirdPartyToolMigrationAfterCreateGui;
         }
 
         private static void FocusExistingWindow()
@@ -285,6 +293,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private string _lastSeenSetupWizardVersionBeforeOpen = string.Empty;
         [SerializeField]
         private bool _shouldRecordLastSeenVersionAfterCreateGui;
+        [SerializeField]
+        private bool _shouldRefreshThirdPartyToolMigrationAfterCreateGui;
         private IVisualElementScheduledItem _initialRefreshScheduledItem;
         private IVisualElementScheduledItem _resizeScheduledItem;
         private CancellationTokenSource _skillInstallStateRefreshCts;
@@ -539,7 +549,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _skillsTargetList.Clear();
             }
 
-            ShowThirdPartyToolMigrationCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+            if (_shouldRefreshThirdPartyToolMigrationAfterCreateGui)
+            {
+                ShowThirdPartyToolMigrationCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+            }
+            else
+            {
+                HideThirdPartyToolMigrationSection();
+            }
+
             await Task.Yield();
 
             ViewDataBinder.SetVisible(_nodejsWarning, false);
@@ -556,11 +574,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (!refreshSkillsSection)
             {
-                CancellationToken migrationPreviewCt = BeginThirdPartyToolMigrationPreview();
-                await RefreshThirdPartyToolMigrationSectionAsync(migrationPreviewCt);
-                if (migrationPreviewCt.IsCancellationRequested)
+                if (_shouldRefreshThirdPartyToolMigrationAfterCreateGui)
                 {
-                    return;
+                    CancellationToken migrationPreviewCt = BeginThirdPartyToolMigrationPreview();
+                    await RefreshThirdPartyToolMigrationSectionAsync(migrationPreviewCt);
+                    if (migrationPreviewCt.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    HideThirdPartyToolMigrationSection();
                 }
 
                 ScheduleResizeToContent();
@@ -571,11 +596,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canManageSkills = CanManageSkills(cliInstalled);
             UpdateSkillsStep(canManageSkills, targets);
             BeginRefreshDisplayedSkillTargets(canManageSkills);
-            CancellationToken ct = BeginThirdPartyToolMigrationPreview();
-            await RefreshThirdPartyToolMigrationSectionAsync(ct);
-            if (ct.IsCancellationRequested)
+            if (_shouldRefreshThirdPartyToolMigrationAfterCreateGui)
             {
-                return;
+                CancellationToken ct = BeginThirdPartyToolMigrationPreview();
+                await RefreshThirdPartyToolMigrationSectionAsync(ct);
+                if (ct.IsCancellationRequested)
+                {
+                    return;
+                }
+            }
+            else
+            {
+                HideThirdPartyToolMigrationSection();
             }
 
             ScheduleResizeToContent();
@@ -596,20 +628,27 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (!preview.HasTargets)
             {
-                ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, false);
-                ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, false);
-                _thirdPartyToolMigrationStatusLabel.text = string.Empty;
-                _migrateThirdPartyToolsButton.SetEnabled(false);
-                _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
-                    _isMigratingThirdPartyTools);
+                _shouldRefreshThirdPartyToolMigrationAfterCreateGui = false;
+                HideThirdPartyToolMigrationSection();
                 return;
             }
 
+            _shouldRefreshThirdPartyToolMigrationAfterCreateGui = true;
             ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, true);
             ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, false);
             _thirdPartyToolMigrationStatusLabel.text =
                 GetThirdPartyToolMigrationStatusText(preview.FileCount);
             _migrateThirdPartyToolsButton.SetEnabled(!_isMigratingThirdPartyTools);
+            _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
+                _isMigratingThirdPartyTools);
+        }
+
+        private void HideThirdPartyToolMigrationSection()
+        {
+            ViewDataBinder.SetVisible(_thirdPartyToolMigrationSection, false);
+            ViewDataBinder.SetVisible(_thirdPartyToolMigrationProgressBar, false);
+            _thirdPartyToolMigrationStatusLabel.text = string.Empty;
+            _migrateThirdPartyToolsButton.SetEnabled(false);
             _migrateThirdPartyToolsButton.text = GetThirdPartyToolMigrationButtonText(
                 _isMigratingThirdPartyTools);
         }
@@ -1398,14 +1437,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private static bool IsFinite(float value)
         {
             return !float.IsNaN(value) && !float.IsInfinity(value);
-        }
-
-        private sealed class SilentThirdPartyToolMigrationProgress
-            : System.IProgress<ThirdPartyToolMigrationProgress>
-        {
-            public void Report(ThirdPartyToolMigrationProgress value)
-            {
-            }
         }
 
         private sealed class ThirdPartyToolMigrationPreviewProgress

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -85,6 +85,16 @@
     padding-left: 4px;
 }
 
+.setup-step--migration-alert {
+    background-color: #ffd54f;
+    border-color: #ffb300;
+}
+
+.setup-step--migration-alert .setup-step__title,
+.setup-step--migration-alert .setup-step__status-label {
+    color: #2f2500;
+}
+
 .setup-step__status-row {
     flex-direction: row;
     align-items: center;

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -88,7 +88,7 @@
 .setup-step--migration-alert {
     background-color: #5c4a00;
     border-color: #7a6400;
-    border-width: 4px;
+    border-width: 2px;
 }
 
 .setup-step--migration-alert .setup-step__title,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -86,14 +86,14 @@
 }
 
 .setup-step--migration-alert {
-    background-color: #ffe082;
-    border-color: #ffc247;
+    background-color: #5c4a00;
+    border-color: #7a6400;
     border-width: 4px;
 }
 
 .setup-step--migration-alert .setup-step__title,
 .setup-step--migration-alert .setup-step__status-label {
-    color: #2f2500;
+    color: var(--setup-color-warning);
 }
 
 .setup-step__status-row {

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -88,7 +88,7 @@
 .setup-step--migration-alert {
     background-color: #ffe082;
     border-color: #ffc247;
-    border-width: 2px;
+    border-width: 4px;
 }
 
 .setup-step--migration-alert .setup-step__title,
@@ -109,6 +109,12 @@
 .setup-step__status-label--standalone {
     margin-left: 0;
     white-space: normal;
+}
+
+.setup-progress-bar {
+    height: 14px;
+    margin-top: 6px;
+    margin-bottom: 2px;
 }
 
 /* ===========================================

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -88,6 +88,7 @@
 .setup-step--migration-alert {
     background-color: #ffe082;
     border-color: #ffc247;
+    border-width: 2px;
 }
 
 .setup-step--migration-alert .setup-step__title,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -95,6 +95,11 @@
     margin-left: 6px;
 }
 
+.setup-step__status-label--standalone {
+    margin-left: 0;
+    white-space: normal;
+}
+
 /* ===========================================
    Block: Status Icon
    =========================================== */

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uss
@@ -86,8 +86,8 @@
 }
 
 .setup-step--migration-alert {
-    background-color: #ffd54f;
-    border-color: #ffb300;
+    background-color: #ffe082;
+    border-color: #ffc247;
 }
 
 .setup-step--migration-alert .setup-step__title,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
@@ -11,6 +11,20 @@
             <ui:Label text="CLI installer ready" class="setup-prerequisite__title" />
         </ui:VisualElement>
 
+        <!-- V3 custom tool migration -->
+        <ui:VisualElement name="third-party-tool-migration-section" class="setup-step setup-step--migration-alert setup-hidden">
+            <ui:Label text="Custom Tool Migration" class="setup-step__title" />
+            <ui:VisualElement class="setup-step__content">
+                <ui:Label
+                    name="third-party-tool-migration-status-label"
+                    text=""
+                    class="setup-step__status-label setup-step__status-label--standalone" />
+                <ui:VisualElement class="setup-step__button-row">
+                    <ui:Button name="migrate-third-party-tools-button" text="Migrate" class="setup-button" />
+                </ui:VisualElement>
+            </ui:VisualElement>
+        </ui:VisualElement>
+
         <!-- Step 1: Install CLI -->
         <ui:VisualElement name="step-1" class="setup-step">
             <ui:Label text="Step 1: Install CLI" class="setup-step__title" />
@@ -45,20 +59,6 @@
                     <ui:Button name="install-skills-button" text="Install Skills" class="setup-button" />
                 </ui:VisualElement>
                 <ui:Label name="skills-hint-label" text="Install skills later from&#10;Window &gt; Unity CLI Loop &gt; Settings." class="setup-step__hint-label" />
-            </ui:VisualElement>
-        </ui:VisualElement>
-
-        <!-- V3 custom tool migration -->
-        <ui:VisualElement name="third-party-tool-migration-section" class="setup-step setup-hidden">
-            <ui:Label text="Custom Tool Migration" class="setup-step__title" />
-            <ui:VisualElement class="setup-step__content">
-                <ui:Label
-                    name="third-party-tool-migration-status-label"
-                    text=""
-                    class="setup-step__status-label setup-step__status-label--standalone" />
-                <ui:VisualElement class="setup-step__button-row">
-                    <ui:Button name="migrate-third-party-tools-button" text="Migrate" class="setup-button" />
-                </ui:VisualElement>
             </ui:VisualElement>
         </ui:VisualElement>
 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
@@ -11,23 +11,6 @@
             <ui:Label text="CLI installer ready" class="setup-prerequisite__title" />
         </ui:VisualElement>
 
-        <!-- V3 custom tool migration -->
-        <ui:VisualElement name="third-party-tool-migration-section" class="setup-step setup-step--migration-alert setup-hidden">
-            <ui:Label text="Custom Tool Migration" class="setup-step__title" />
-            <ui:VisualElement class="setup-step__content">
-                <ui:Label
-                    name="third-party-tool-migration-status-label"
-                    text=""
-                    class="setup-step__status-label setup-step__status-label--standalone" />
-                <ui:ProgressBar
-                    name="third-party-tool-migration-progress-bar"
-                    class="setup-progress-bar setup-hidden" />
-                <ui:VisualElement class="setup-step__button-row">
-                    <ui:Button name="migrate-third-party-tools-button" text="Migrate" class="setup-button" />
-                </ui:VisualElement>
-            </ui:VisualElement>
-        </ui:VisualElement>
-
         <!-- Step 1: Install CLI -->
         <ui:VisualElement name="step-1" class="setup-step">
             <ui:Label text="Step 1: Install CLI" class="setup-step__title" />

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
@@ -19,6 +19,9 @@
                     name="third-party-tool-migration-status-label"
                     text=""
                     class="setup-step__status-label setup-step__status-label--standalone" />
+                <ui:ProgressBar
+                    name="third-party-tool-migration-progress-bar"
+                    class="setup-progress-bar setup-hidden" />
                 <ui:VisualElement class="setup-step__button-row">
                     <ui:Button name="migrate-third-party-tools-button" text="Migrate" class="setup-button" />
                 </ui:VisualElement>

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.uxml
@@ -48,6 +48,20 @@
             </ui:VisualElement>
         </ui:VisualElement>
 
+        <!-- V3 custom tool migration -->
+        <ui:VisualElement name="third-party-tool-migration-section" class="setup-step setup-hidden">
+            <ui:Label text="Custom Tool Migration" class="setup-step__title" />
+            <ui:VisualElement class="setup-step__content">
+                <ui:Label
+                    name="third-party-tool-migration-status-label"
+                    text=""
+                    class="setup-step__status-label setup-step__status-label--standalone" />
+                <ui:VisualElement class="setup-step__button-row">
+                    <ui:Button name="migrate-third-party-tools-button" text="Migrate" class="setup-button" />
+                </ui:VisualElement>
+            </ui:VisualElement>
+        </ui:VisualElement>
+
         <!-- Footer -->
         <ui:VisualElement class="setup-footer">
             <ui:VisualElement class="setup-footer__button-row">

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -20,6 +20,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string USS_RELATIVE_PATH = "Editor/Presentation/Setup/SetupWizardWindow.uss";
         private const string MigrationCheckingText = "Scanning project for V3 custom tool migration...";
         private const string NoMigrationTargetsText = "No V3 custom tool migration is needed.";
+        private const string MigrationButtonReadyText = "Migrate";
+        private const string MigrationButtonMigratingText = "Migrating...";
+        private const string MigrationButtonNoTargetsText = "Nothing to migrate";
         private static readonly Vector2 InitialWindowSize = new(360f, 220f);
         private static readonly Vector2 MinimumWindowSize = new(360f, 120f);
 
@@ -116,9 +119,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 $"{progress.ProcessedItemCount}/{progress.TotalItemCount} checks complete.";
         }
 
-        internal static string GetMigrationButtonText(bool isMigrating)
+        internal static string GetMigrationButtonText(bool isMigrating, bool hasMigrationTargets)
         {
-            return isMigrating ? "Migrating..." : "Migrate";
+            if (isMigrating)
+            {
+                return MigrationButtonMigratingText;
+            }
+
+            return hasMigrationTargets ? MigrationButtonReadyText : MigrationButtonNoTargetsText;
         }
 
         private static void TryShowOnMigrationTargets()
@@ -228,7 +236,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             content.Add(migrationButtonRow);
 
             _migrateButton = new Button();
-            _migrateButton.text = GetMigrationButtonText(false);
+            _migrateButton.text = GetMigrationButtonText(false, true);
             _migrateButton.AddToClassList("setup-button");
             migrationButtonRow.Add(_migrateButton);
 
@@ -344,7 +352,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _migrationStatusLabel.text = GetMigrationStatusText(fileCount);
             ViewDataBinder.SetVisible(_migrationProgressBar, false);
             _migrateButton.SetEnabled(!_isMigrating);
-            _migrateButton.text = GetMigrationButtonText(_isMigrating);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating, true);
             ScheduleResizeToContent();
         }
 
@@ -353,7 +361,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _migrationStatusLabel.text = NoMigrationTargetsText;
             ViewDataBinder.SetVisible(_migrationProgressBar, false);
             _migrateButton.SetEnabled(false);
-            _migrateButton.text = GetMigrationButtonText(_isMigrating);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating, false);
             ScheduleResizeToContent();
         }
 
@@ -363,7 +371,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.SetVisible(_migrationProgressBar, true);
             UpdateMigrationProgressBar(progress);
             _migrateButton.SetEnabled(false);
-            _migrateButton.text = GetMigrationButtonText(_isMigrating);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating, true);
             ScheduleResizeToContent();
         }
 

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -231,6 +231,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _closeButton.text = "Close";
             _closeButton.AddToClassList("setup-button");
             footerButtonRow.Add(_closeButton);
+
+            Label reopenHintLabel = new(
+                "You can close this wizard and reopen it later from\n" +
+                "Window > Unity CLI Loop > Custom Tool Migration.");
+            reopenHintLabel.AddToClassList("setup-footer__hint-label");
+            footer.Add(reopenHintLabel);
         }
 
         private void BindEvents()

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -299,6 +299,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void ScheduleInitialRefresh()
         {
+            if (!_shouldRefreshAfterCreateGui)
+            {
+                return;
+            }
+
             rootVisualElement.schedule.Execute(RefreshUI).StartingIn(0);
         }
 
@@ -337,8 +342,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 ThirdPartyToolMigrationResult result =
                     _thirdPartyToolMigrationUseCase.ApplyMigration(projectRoot);
-                Debug.Assert(result.Changed, "migration result should contain changed files");
-                AssetDatabase.Refresh();
+                if (result.Changed)
+                {
+                    AssetDatabase.Refresh();
+                }
             }
             finally
             {

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -20,8 +20,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string USS_RELATIVE_PATH = "Editor/Presentation/Setup/SetupWizardWindow.uss";
         private const string MigrationCheckingText = "Scanning project for V3 custom tool migration...";
         private const string NoMigrationTargetsText = "No V3 custom tool migration is needed.";
-        private static readonly Vector2 MinimumWindowSize = new(360f, 220f);
+        private const int PreferredWrappedTextLineCount = 2;
+        private static readonly Vector2 InitialWindowSize = new(320f, 220f);
+        private static readonly Vector2 MinimumWindowSize = new(300f, 120f);
 
+        private ScrollView _mainScrollView;
         private VisualElement _migrationSection;
         private Label _migrationStatusLabel;
         private ProgressBar _migrationProgressBar;
@@ -30,8 +33,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private Button _closeButton;
 
         private bool _isMigrating;
+        private bool _isApplyingContentSize;
         [SerializeField]
         private bool _shouldRefreshAfterCreateGui;
+        private IVisualElementScheduledItem _resizeScheduledItem;
         private CancellationTokenSource _migrationPreviewCts;
         private ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
 
@@ -73,6 +78,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             Vector2 centeredPosition = bounds.center - (size * 0.5f);
             return new Rect(centeredPosition, size);
+        }
+
+        internal static Rect WithContentSize(Rect currentRect, Vector2 contentSize, Vector2 frameSize)
+        {
+            Debug.Assert(contentSize.x >= 0f, "contentSize.x must not be negative");
+            Debug.Assert(contentSize.y >= 0f, "contentSize.y must not be negative");
+
+            Vector2 measuredSize = contentSize + frameSize;
+            Vector2 targetSize = new(
+                Mathf.Max(measuredSize.x, MinimumWindowSize.x),
+                Mathf.Max(measuredSize.y, MinimumWindowSize.y));
+            return CreateCenteredRect(currentRect, targetSize);
         }
 
         internal static string GetMigrationStatusText(int fileCount)
@@ -145,11 +162,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             Rect windowPosition = CreateCenteredRect(
                 EditorGUIUtility.GetMainWindowPosition(),
-                MinimumWindowSize);
+                InitialWindowSize);
             ThirdPartyToolMigrationWizardWindow window =
                 CreateInstance<ThirdPartyToolMigrationWizardWindow>();
             PrepareForOpen(window, WindowTitle, windowPosition, shouldRefreshAfterCreateGui);
             window.ShowUtility();
+            window.ScheduleResizeToContent();
         }
 
         private void CreateGUI()
@@ -157,8 +175,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             InitializeApplicationServices();
             BuildLayout();
             BindEvents();
+            BindSizeUpdates();
             ShowInitialState();
             ScheduleInitialRefresh();
+            ScheduleResizeToContent();
         }
 
         private void InitializeApplicationServices()
@@ -168,6 +188,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void OnDisable()
         {
+            _resizeScheduledItem?.Pause();
             CancelMigrationPreview();
         }
 
@@ -178,14 +199,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(styleSheet != null, $"USS not found at {ussPath}");
             rootVisualElement.styleSheets.Add(styleSheet);
 
-            ScrollView mainContainer = new();
-            mainContainer.AddToClassList("setup-main-container");
-            rootVisualElement.Add(mainContainer);
+            _mainScrollView = new ScrollView();
+            _mainScrollView.AddToClassList("setup-main-container");
+            rootVisualElement.Add(_mainScrollView);
 
             _migrationSection = new VisualElement();
             _migrationSection.AddToClassList("setup-step");
             _migrationSection.AddToClassList("setup-step--migration-alert");
-            mainContainer.Add(_migrationSection);
+            _mainScrollView.Add(_migrationSection);
 
             Label titleLabel = new("Custom Tool Migration");
             titleLabel.AddToClassList("setup-step__title");
@@ -215,7 +236,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             VisualElement footer = new();
             footer.AddToClassList("setup-footer");
-            mainContainer.Add(footer);
+            _mainScrollView.Add(footer);
 
             VisualElement footerButtonRow = new();
             footerButtonRow.AddToClassList("setup-footer__button-row");
@@ -244,6 +265,19 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _refreshButton.clicked += RefreshUI;
             _migrateButton.clicked += HandleMigrateThirdPartyTools;
             _closeButton.clicked += Close;
+        }
+
+        private void BindSizeUpdates()
+        {
+            rootVisualElement.RegisterCallback<GeometryChangedEvent>(_ =>
+            {
+                if (_isApplyingContentSize)
+                {
+                    return;
+                }
+
+                ScheduleResizeToContent();
+            });
         }
 
         private void ShowInitialState()
@@ -313,6 +347,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.SetVisible(_migrationProgressBar, false);
             _migrateButton.SetEnabled(!_isMigrating);
             _migrateButton.text = GetMigrationButtonText(_isMigrating);
+            ScheduleResizeToContent();
         }
 
         private void ShowNoMigrationTargetsState()
@@ -321,6 +356,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.SetVisible(_migrationProgressBar, false);
             _migrateButton.SetEnabled(false);
             _migrateButton.text = GetMigrationButtonText(_isMigrating);
+            ScheduleResizeToContent();
         }
 
         private void ShowCheckingState(ThirdPartyToolMigrationProgress progress)
@@ -330,6 +366,194 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             UpdateMigrationProgressBar(progress);
             _migrateButton.SetEnabled(false);
             _migrateButton.text = GetMigrationButtonText(_isMigrating);
+            ScheduleResizeToContent();
+        }
+
+        private void ScheduleResizeToContent()
+        {
+            _resizeScheduledItem?.Pause();
+            _resizeScheduledItem = rootVisualElement.schedule.Execute(ResizeToContent).StartingIn(0);
+        }
+
+        private void ResizeToContent()
+        {
+            if (_mainScrollView == null) return;
+            if (rootVisualElement.layout.width <= 0f || rootVisualElement.layout.height <= 0f) return;
+
+            Vector2 contentSize = MeasurePreferredContentSize(_mainScrollView, _mainScrollView.contentContainer);
+            if (!HasFiniteSize(contentSize)) return;
+            if (contentSize.x <= 0f || contentSize.y <= 0f) return;
+
+            Vector2 frameSize = position.size - rootVisualElement.layout.size;
+            if (!HasFiniteSize(frameSize)) return;
+            Rect targetRect = WithContentSize(position, contentSize, frameSize);
+            if (!HasFiniteSize(targetRect.size)) return;
+            if (Approximately(position.size, targetRect.size))
+            {
+                minSize = targetRect.size;
+                maxSize = targetRect.size;
+                return;
+            }
+
+            _isApplyingContentSize = true;
+            minSize = targetRect.size;
+            maxSize = targetRect.size;
+            position = targetRect;
+            _isApplyingContentSize = false;
+        }
+
+        private static Vector2 MeasurePreferredContentSize(
+            ScrollView mainContainer,
+            VisualElement contentContainer)
+        {
+            float width = MeasurePreferredContentWidth(mainContainer, contentContainer);
+            float height = MeasurePreferredContentHeight(mainContainer, contentContainer);
+            return new Vector2(width, height);
+        }
+
+        private static float MeasurePreferredContentWidth(VisualElement mainContainer, VisualElement contentContainer)
+        {
+            float maxRight = 0f;
+            foreach (TextElement textElement in contentContainer.Query<TextElement>().Build())
+            {
+                if (!textElement.visible) continue;
+                if (string.IsNullOrEmpty(textElement.text)) continue;
+                if (!HasFiniteRect(textElement.worldBound)) continue;
+
+                float left = textElement.worldBound.xMin - contentContainer.worldBound.xMin;
+                float horizontalChrome =
+                    textElement.resolvedStyle.paddingLeft
+                    + textElement.resolvedStyle.paddingRight
+                    + textElement.resolvedStyle.borderLeftWidth
+                    + textElement.resolvedStyle.borderRightWidth;
+                float verticalChrome =
+                    textElement.resolvedStyle.paddingTop
+                    + textElement.resolvedStyle.paddingBottom
+                    + textElement.resolvedStyle.borderTopWidth
+                    + textElement.resolvedStyle.borderBottomWidth;
+                float laidOutWidth = textElement.worldBound.width;
+                Vector2 measuredTextSize = textElement.MeasureTextSize(
+                    textElement.text,
+                    0f,
+                    VisualElement.MeasureMode.Undefined,
+                    0f,
+                    VisualElement.MeasureMode.Undefined);
+                if (!IsFinite(left)) continue;
+                if (!IsFinite(horizontalChrome) || !IsFinite(verticalChrome)) continue;
+                if (!HasFiniteSize(measuredTextSize)) continue;
+                if (!IsFinite(laidOutWidth)) continue;
+                bool hasExplicitLineBreak = HasExplicitLineBreak(textElement.text);
+                float measuredWidth = hasExplicitLineBreak
+                    ? MeasureExplicitLinePreferredWidth(textElement, horizontalChrome)
+                    : measuredTextSize.x + horizontalChrome;
+                int lineCount = EstimateWrappedLineCount(
+                    textElement.worldBound.height - verticalChrome,
+                    measuredTextSize.y);
+                float preferredWidth = SelectPreferredTextWidth(
+                    laidOutWidth,
+                    measuredWidth,
+                    lineCount,
+                    textElement.resolvedStyle.whiteSpace,
+                    hasExplicitLineBreak);
+                if (!IsFinite(preferredWidth)) continue;
+                float right = left + preferredWidth;
+                maxRight = Mathf.Max(maxRight, right);
+            }
+
+            float width =
+                mainContainer.resolvedStyle.paddingLeft
+                + maxRight
+                + mainContainer.resolvedStyle.paddingRight;
+            return IsFinite(width) ? Mathf.Ceil(width) : 0f;
+        }
+
+        internal static int EstimateWrappedLineCount(float laidOutTextHeight, float singleLineTextHeight)
+        {
+            if (singleLineTextHeight <= 0f) return 1;
+
+            return Mathf.Max(1, Mathf.RoundToInt(laidOutTextHeight / singleLineTextHeight));
+        }
+
+        internal static float SelectPreferredTextWidth(
+            float laidOutWidth,
+            float measuredWidth,
+            int lineCount,
+            WhiteSpace whiteSpace,
+            bool hasExplicitLineBreak)
+        {
+            if (hasExplicitLineBreak) return measuredWidth;
+            if (whiteSpace != WhiteSpace.Normal) return measuredWidth;
+            if (lineCount <= PreferredWrappedTextLineCount) return Mathf.Min(laidOutWidth, measuredWidth);
+
+            return Mathf.Max(laidOutWidth, measuredWidth / PreferredWrappedTextLineCount);
+        }
+
+        private static bool HasExplicitLineBreak(string text)
+        {
+            return !string.IsNullOrEmpty(text) && text.IndexOf('\n') >= 0;
+        }
+
+        private static float MeasureExplicitLinePreferredWidth(TextElement textElement, float horizontalChrome)
+        {
+            float maxLineWidth = 0f;
+            string[] lines = textElement.text.Split('\n');
+            foreach (string rawLine in lines)
+            {
+                string line = rawLine.TrimEnd('\r');
+                Vector2 measuredLineSize = textElement.MeasureTextSize(
+                    line,
+                    0f,
+                    VisualElement.MeasureMode.Undefined,
+                    0f,
+                    VisualElement.MeasureMode.Undefined);
+                if (!HasFiniteSize(measuredLineSize)) continue;
+                maxLineWidth = Mathf.Max(maxLineWidth, measuredLineSize.x);
+            }
+
+            return maxLineWidth + horizontalChrome;
+        }
+
+        private static float MeasurePreferredContentHeight(VisualElement mainContainer, VisualElement contentContainer)
+        {
+            float maxBottom = 0f;
+            foreach (VisualElement child in contentContainer.Children())
+            {
+                if (!child.visible) continue;
+                if (!HasFiniteRect(child.worldBound)) continue;
+                float bottom = child.worldBound.yMax - contentContainer.worldBound.yMin;
+                if (!IsFinite(bottom)) continue;
+                maxBottom = Mathf.Max(maxBottom, bottom);
+            }
+
+            float height =
+                mainContainer.resolvedStyle.paddingTop
+                + maxBottom
+                + mainContainer.resolvedStyle.paddingBottom;
+            return IsFinite(height) ? Mathf.Ceil(height) : 0f;
+        }
+
+        private static bool Approximately(Vector2 left, Vector2 right)
+        {
+            const float Tolerance = 0.5f;
+            return Mathf.Abs(left.x - right.x) < Tolerance && Mathf.Abs(left.y - right.y) < Tolerance;
+        }
+
+        internal static bool HasFiniteSize(Vector2 size)
+        {
+            return IsFinite(size.x) && IsFinite(size.y);
+        }
+
+        private static bool HasFiniteRect(Rect rect)
+        {
+            return IsFinite(rect.xMin)
+                && IsFinite(rect.xMax)
+                && IsFinite(rect.yMin)
+                && IsFinite(rect.yMax);
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
         }
 
         private void UpdateMigrationProgressBar(ThirdPartyToolMigrationProgress progress)

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -20,9 +20,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string USS_RELATIVE_PATH = "Editor/Presentation/Setup/SetupWizardWindow.uss";
         private const string MigrationCheckingText = "Scanning project for V3 custom tool migration...";
         private const string NoMigrationTargetsText = "No V3 custom tool migration is needed.";
-        private const int PreferredWrappedTextLineCount = 2;
-        private static readonly Vector2 InitialWindowSize = new(320f, 220f);
-        private static readonly Vector2 MinimumWindowSize = new(300f, 120f);
+        private static readonly Vector2 InitialWindowSize = new(360f, 220f);
+        private static readonly Vector2 MinimumWindowSize = new(360f, 120f);
 
         private ScrollView _mainScrollView;
         private VisualElement _migrationSection;
@@ -80,15 +79,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return new Rect(centeredPosition, size);
         }
 
-        internal static Rect WithContentSize(Rect currentRect, Vector2 contentSize, Vector2 frameSize)
+        internal static Rect WithContentHeight(Rect currentRect, float contentHeight, Vector2 frameSize)
         {
-            Debug.Assert(contentSize.x >= 0f, "contentSize.x must not be negative");
-            Debug.Assert(contentSize.y >= 0f, "contentSize.y must not be negative");
+            Debug.Assert(contentHeight >= 0f, "contentHeight must not be negative");
 
-            Vector2 measuredSize = contentSize + frameSize;
+            float measuredHeight = contentHeight + frameSize.y;
             Vector2 targetSize = new(
-                Mathf.Max(measuredSize.x, MinimumWindowSize.x),
-                Mathf.Max(measuredSize.y, MinimumWindowSize.y));
+                MinimumWindowSize.x,
+                Mathf.Max(measuredHeight, MinimumWindowSize.y));
             return CreateCenteredRect(currentRect, targetSize);
         }
 
@@ -380,13 +378,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             if (_mainScrollView == null) return;
             if (rootVisualElement.layout.width <= 0f || rootVisualElement.layout.height <= 0f) return;
 
-            Vector2 contentSize = MeasurePreferredContentSize(_mainScrollView, _mainScrollView.contentContainer);
-            if (!HasFiniteSize(contentSize)) return;
-            if (contentSize.x <= 0f || contentSize.y <= 0f) return;
+            float contentHeight = MeasurePreferredContentHeight(_mainScrollView, _mainScrollView.contentContainer);
+            if (!IsFinite(contentHeight)) return;
+            if (contentHeight <= 0f) return;
 
             Vector2 frameSize = position.size - rootVisualElement.layout.size;
             if (!HasFiniteSize(frameSize)) return;
-            Rect targetRect = WithContentSize(position, contentSize, frameSize);
+            Rect targetRect = WithContentHeight(position, contentHeight, frameSize);
             if (!HasFiniteSize(targetRect.size)) return;
             if (Approximately(position.size, targetRect.size))
             {
@@ -400,117 +398,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             maxSize = targetRect.size;
             position = targetRect;
             _isApplyingContentSize = false;
-        }
-
-        private static Vector2 MeasurePreferredContentSize(
-            ScrollView mainContainer,
-            VisualElement contentContainer)
-        {
-            float width = MeasurePreferredContentWidth(mainContainer, contentContainer);
-            float height = MeasurePreferredContentHeight(mainContainer, contentContainer);
-            return new Vector2(width, height);
-        }
-
-        private static float MeasurePreferredContentWidth(VisualElement mainContainer, VisualElement contentContainer)
-        {
-            float maxRight = 0f;
-            foreach (TextElement textElement in contentContainer.Query<TextElement>().Build())
-            {
-                if (!textElement.visible) continue;
-                if (string.IsNullOrEmpty(textElement.text)) continue;
-                if (!HasFiniteRect(textElement.worldBound)) continue;
-
-                float left = textElement.worldBound.xMin - contentContainer.worldBound.xMin;
-                float horizontalChrome =
-                    textElement.resolvedStyle.paddingLeft
-                    + textElement.resolvedStyle.paddingRight
-                    + textElement.resolvedStyle.borderLeftWidth
-                    + textElement.resolvedStyle.borderRightWidth;
-                float verticalChrome =
-                    textElement.resolvedStyle.paddingTop
-                    + textElement.resolvedStyle.paddingBottom
-                    + textElement.resolvedStyle.borderTopWidth
-                    + textElement.resolvedStyle.borderBottomWidth;
-                float laidOutWidth = textElement.worldBound.width;
-                Vector2 measuredTextSize = textElement.MeasureTextSize(
-                    textElement.text,
-                    0f,
-                    VisualElement.MeasureMode.Undefined,
-                    0f,
-                    VisualElement.MeasureMode.Undefined);
-                if (!IsFinite(left)) continue;
-                if (!IsFinite(horizontalChrome) || !IsFinite(verticalChrome)) continue;
-                if (!HasFiniteSize(measuredTextSize)) continue;
-                if (!IsFinite(laidOutWidth)) continue;
-                bool hasExplicitLineBreak = HasExplicitLineBreak(textElement.text);
-                float measuredWidth = hasExplicitLineBreak
-                    ? MeasureExplicitLinePreferredWidth(textElement, horizontalChrome)
-                    : measuredTextSize.x + horizontalChrome;
-                int lineCount = EstimateWrappedLineCount(
-                    textElement.worldBound.height - verticalChrome,
-                    measuredTextSize.y);
-                float preferredWidth = SelectPreferredTextWidth(
-                    laidOutWidth,
-                    measuredWidth,
-                    lineCount,
-                    textElement.resolvedStyle.whiteSpace,
-                    hasExplicitLineBreak);
-                if (!IsFinite(preferredWidth)) continue;
-                float right = left + preferredWidth;
-                maxRight = Mathf.Max(maxRight, right);
-            }
-
-            float width =
-                mainContainer.resolvedStyle.paddingLeft
-                + maxRight
-                + mainContainer.resolvedStyle.paddingRight;
-            return IsFinite(width) ? Mathf.Ceil(width) : 0f;
-        }
-
-        internal static int EstimateWrappedLineCount(float laidOutTextHeight, float singleLineTextHeight)
-        {
-            if (singleLineTextHeight <= 0f) return 1;
-
-            return Mathf.Max(1, Mathf.RoundToInt(laidOutTextHeight / singleLineTextHeight));
-        }
-
-        internal static float SelectPreferredTextWidth(
-            float laidOutWidth,
-            float measuredWidth,
-            int lineCount,
-            WhiteSpace whiteSpace,
-            bool hasExplicitLineBreak)
-        {
-            if (hasExplicitLineBreak) return measuredWidth;
-            if (whiteSpace != WhiteSpace.Normal) return measuredWidth;
-            if (lineCount <= PreferredWrappedTextLineCount) return Mathf.Min(laidOutWidth, measuredWidth);
-
-            return Mathf.Max(laidOutWidth, measuredWidth / PreferredWrappedTextLineCount);
-        }
-
-        private static bool HasExplicitLineBreak(string text)
-        {
-            return !string.IsNullOrEmpty(text) && text.IndexOf('\n') >= 0;
-        }
-
-        private static float MeasureExplicitLinePreferredWidth(TextElement textElement, float horizontalChrome)
-        {
-            float maxLineWidth = 0f;
-            string[] lines = textElement.text.Split('\n');
-            foreach (string rawLine in lines)
-            {
-                string line = rawLine.TrimEnd('\r');
-                Vector2 measuredLineSize = textElement.MeasureTextSize(
-                    line,
-                    0f,
-                    VisualElement.MeasureMode.Undefined,
-                    0f,
-                    VisualElement.MeasureMode.Undefined);
-                if (!HasFiniteSize(measuredLineSize)) continue;
-                maxLineWidth = Mathf.Max(maxLineWidth, measuredLineSize.x);
-            }
-
-            return maxLineWidth + horizontalChrome;
         }
 
         private static float MeasurePreferredContentHeight(VisualElement mainContainer, VisualElement contentContainer)

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -1,0 +1,385 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Provides the dedicated Editor window for V3 third-party custom tool migration.
+    /// </summary>
+    public class ThirdPartyToolMigrationWizardWindow : EditorWindow
+    {
+        private const string WindowTitle = "Unity CLI Loop Migration";
+        private const string USS_RELATIVE_PATH = "Editor/Presentation/Setup/SetupWizardWindow.uss";
+        private const string MigrationCheckingText = "Scanning project for V3 custom tool migration...";
+        private const string NoMigrationTargetsText = "No V3 custom tool migration is needed.";
+        private static readonly Vector2 MinimumWindowSize = new(360f, 220f);
+
+        private VisualElement _migrationSection;
+        private Label _migrationStatusLabel;
+        private ProgressBar _migrationProgressBar;
+        private Button _migrateButton;
+        private Button _refreshButton;
+        private Button _closeButton;
+
+        private bool _isMigrating;
+        [SerializeField]
+        private bool _shouldRefreshAfterCreateGui;
+        private CancellationTokenSource _migrationPreviewCts;
+        private ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
+
+        internal static void InitializeForEditorStartup()
+        {
+            if (AssetDatabase.IsAssetImportWorkerProcess()) return;
+            if (UnityEngine.Application.isBatchMode) return;
+
+            EditorApplication.delayCall += TryShowOnMigrationTargets;
+        }
+
+        [MenuItem("Window/Unity CLI Loop/Custom Tool Migration", priority = 4)]
+        public static void ShowWindow()
+        {
+            ShowWindowInternal(true);
+        }
+
+        internal static bool ShouldAutoShowForMigrationTargets(bool hasMigrationTargets)
+        {
+            return hasMigrationTargets;
+        }
+
+        internal static void PrepareForOpen(
+            ThirdPartyToolMigrationWizardWindow window,
+            string title,
+            Rect position,
+            bool shouldRefreshAfterCreateGui)
+        {
+            Debug.Assert(window != null, "window must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(title), "title must not be null or empty");
+
+            window.titleContent = new GUIContent(title);
+            window.position = position;
+            window.minSize = MinimumWindowSize;
+            window._shouldRefreshAfterCreateGui = shouldRefreshAfterCreateGui;
+        }
+
+        internal static Rect CreateCenteredRect(Rect bounds, Vector2 size)
+        {
+            Vector2 centeredPosition = bounds.center - (size * 0.5f);
+            return new Rect(centeredPosition, size);
+        }
+
+        internal static string GetMigrationStatusText(int fileCount)
+        {
+            Debug.Assert(fileCount >= 0, "fileCount must not be negative");
+
+            string noun = fileCount == 1 ? "file" : "files";
+            string verb = fileCount == 1 ? "needs" : "need";
+            string subject = fileCount == 1 ? "this file still uses" : "these files still use";
+            string objectPronoun = fileCount == 1 ? "it" : "them";
+
+            return $"{fileCount} {noun} {verb} V3 custom tool migration.\n" +
+                $"The Unity Console is showing errors because {subject} the old custom tool API.\n\n" +
+                $"Click Migrate to update {objectPronoun} automatically. " +
+                "The errors should disappear after migration.";
+        }
+
+        internal static string GetMigrationProgressText(ThirdPartyToolMigrationProgress progress)
+        {
+            if (progress.TotalItemCount <= 0)
+            {
+                return MigrationCheckingText;
+            }
+
+            return $"{MigrationCheckingText}\n" +
+                $"{progress.ProcessedItemCount}/{progress.TotalItemCount} checks complete.";
+        }
+
+        internal static string GetMigrationButtonText(bool isMigrating)
+        {
+            return isMigrating ? "Migrating..." : "Migrate";
+        }
+
+        private static void TryShowOnMigrationTargets()
+        {
+            TryShowOnMigrationTargetsAsync(CancellationToken.None);
+        }
+
+        private static async void TryShowOnMigrationTargetsAsync(CancellationToken ct)
+        {
+            bool hasMigrationTargets = await HasMigrationTargetsAsync(ct);
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (!ShouldAutoShowForMigrationTargets(hasMigrationTargets))
+            {
+                return;
+            }
+
+            EditorApplication.delayCall += ShowWindow;
+        }
+
+        private static async Task<bool> HasMigrationTargetsAsync(CancellationToken ct)
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            return await ThirdPartyToolMigrationUseCaseRegistry
+                .GetRegisteredUseCase()
+                .HasMigrationTargetsAsync(projectRoot, ct);
+        }
+
+        private static void ShowWindowInternal(bool shouldRefreshAfterCreateGui)
+        {
+            if (HasOpenInstances<ThirdPartyToolMigrationWizardWindow>())
+            {
+                FocusWindowIfItsOpen<ThirdPartyToolMigrationWizardWindow>();
+                return;
+            }
+
+            Rect windowPosition = CreateCenteredRect(
+                EditorGUIUtility.GetMainWindowPosition(),
+                MinimumWindowSize);
+            ThirdPartyToolMigrationWizardWindow window =
+                CreateInstance<ThirdPartyToolMigrationWizardWindow>();
+            PrepareForOpen(window, WindowTitle, windowPosition, shouldRefreshAfterCreateGui);
+            window.ShowUtility();
+        }
+
+        private void CreateGUI()
+        {
+            InitializeApplicationServices();
+            BuildLayout();
+            BindEvents();
+            ShowInitialState();
+            ScheduleInitialRefresh();
+        }
+
+        private void InitializeApplicationServices()
+        {
+            _thirdPartyToolMigrationUseCase = ThirdPartyToolMigrationUseCaseRegistry.GetRegisteredUseCase();
+        }
+
+        private void OnDisable()
+        {
+            CancelMigrationPreview();
+        }
+
+        private void BuildLayout()
+        {
+            string ussPath = $"{UnityCliLoopConstants.PackageAssetPath}/{USS_RELATIVE_PATH}";
+            StyleSheet styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(ussPath);
+            Debug.Assert(styleSheet != null, $"USS not found at {ussPath}");
+            rootVisualElement.styleSheets.Add(styleSheet);
+
+            ScrollView mainContainer = new();
+            mainContainer.AddToClassList("setup-main-container");
+            rootVisualElement.Add(mainContainer);
+
+            _migrationSection = new VisualElement();
+            _migrationSection.AddToClassList("setup-step");
+            _migrationSection.AddToClassList("setup-step--migration-alert");
+            mainContainer.Add(_migrationSection);
+
+            Label titleLabel = new("Custom Tool Migration");
+            titleLabel.AddToClassList("setup-step__title");
+            _migrationSection.Add(titleLabel);
+
+            VisualElement content = new();
+            content.AddToClassList("setup-step__content");
+            _migrationSection.Add(content);
+
+            _migrationStatusLabel = new Label();
+            _migrationStatusLabel.AddToClassList("setup-step__status-label");
+            _migrationStatusLabel.AddToClassList("setup-step__status-label--standalone");
+            content.Add(_migrationStatusLabel);
+
+            _migrationProgressBar = new ProgressBar();
+            _migrationProgressBar.AddToClassList("setup-progress-bar");
+            content.Add(_migrationProgressBar);
+
+            VisualElement migrationButtonRow = new();
+            migrationButtonRow.AddToClassList("setup-step__button-row");
+            content.Add(migrationButtonRow);
+
+            _migrateButton = new Button();
+            _migrateButton.text = GetMigrationButtonText(false);
+            _migrateButton.AddToClassList("setup-button");
+            migrationButtonRow.Add(_migrateButton);
+
+            VisualElement footer = new();
+            footer.AddToClassList("setup-footer");
+            mainContainer.Add(footer);
+
+            VisualElement footerButtonRow = new();
+            footerButtonRow.AddToClassList("setup-footer__button-row");
+            footer.Add(footerButtonRow);
+
+            _refreshButton = new Button();
+            _refreshButton.text = "Refresh";
+            _refreshButton.AddToClassList("setup-button");
+            _refreshButton.AddToClassList("setup-button--primary");
+            footerButtonRow.Add(_refreshButton);
+
+            _closeButton = new Button();
+            _closeButton.text = "Close";
+            _closeButton.AddToClassList("setup-button");
+            footerButtonRow.Add(_closeButton);
+        }
+
+        private void BindEvents()
+        {
+            _refreshButton.clicked += RefreshUI;
+            _migrateButton.clicked += HandleMigrateThirdPartyTools;
+            _closeButton.clicked += Close;
+        }
+
+        private void ShowInitialState()
+        {
+            if (_shouldRefreshAfterCreateGui)
+            {
+                ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+                return;
+            }
+
+            ShowNoMigrationTargetsState();
+        }
+
+        private void ScheduleInitialRefresh()
+        {
+            rootVisualElement.schedule.Execute(RefreshUI).StartingIn(0);
+        }
+
+        private async void RefreshUI()
+        {
+            CancellationToken ct = BeginMigrationPreview();
+            ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+            await Task.Yield();
+
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            System.IProgress<ThirdPartyToolMigrationProgress> progress =
+                new ThirdPartyToolMigrationPreviewProgress(this, ct);
+            ThirdPartyToolMigrationPreview preview =
+                await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct);
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (!preview.HasTargets)
+            {
+                ShowNoMigrationTargetsState();
+                return;
+            }
+
+            ShowMigrationTargetsState(preview.FileCount);
+        }
+
+        private void HandleMigrateThirdPartyTools()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            _isMigrating = true;
+            ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+
+            try
+            {
+                ThirdPartyToolMigrationResult result =
+                    _thirdPartyToolMigrationUseCase.ApplyMigration(projectRoot);
+                Debug.Assert(result.Changed, "migration result should contain changed files");
+                AssetDatabase.Refresh();
+            }
+            finally
+            {
+                _isMigrating = false;
+                RefreshUI();
+            }
+        }
+
+        private void ShowMigrationTargetsState(int fileCount)
+        {
+            _migrationStatusLabel.text = GetMigrationStatusText(fileCount);
+            ViewDataBinder.SetVisible(_migrationProgressBar, false);
+            _migrateButton.SetEnabled(!_isMigrating);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating);
+        }
+
+        private void ShowNoMigrationTargetsState()
+        {
+            _migrationStatusLabel.text = NoMigrationTargetsText;
+            ViewDataBinder.SetVisible(_migrationProgressBar, false);
+            _migrateButton.SetEnabled(false);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating);
+        }
+
+        private void ShowCheckingState(ThirdPartyToolMigrationProgress progress)
+        {
+            _migrationStatusLabel.text = GetMigrationProgressText(progress);
+            ViewDataBinder.SetVisible(_migrationProgressBar, true);
+            UpdateMigrationProgressBar(progress);
+            _migrateButton.SetEnabled(false);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating);
+        }
+
+        private void UpdateMigrationProgressBar(ThirdPartyToolMigrationProgress progress)
+        {
+            int totalItemCount = Mathf.Max(progress.TotalItemCount, 1);
+            int processedItemCount = Mathf.Clamp(progress.ProcessedItemCount, 0, totalItemCount);
+            _migrationProgressBar.lowValue = 0;
+            _migrationProgressBar.highValue = totalItemCount;
+            _migrationProgressBar.value = processedItemCount;
+        }
+
+        private CancellationToken BeginMigrationPreview()
+        {
+            CancelMigrationPreview();
+            CancellationTokenSource cts = new();
+            _migrationPreviewCts = cts;
+            return cts.Token;
+        }
+
+        private void CancelMigrationPreview()
+        {
+            if (_migrationPreviewCts == null)
+            {
+                return;
+            }
+
+            _migrationPreviewCts.Cancel();
+            _migrationPreviewCts.Dispose();
+            _migrationPreviewCts = null;
+        }
+
+        private sealed class ThirdPartyToolMigrationPreviewProgress
+            : System.IProgress<ThirdPartyToolMigrationProgress>
+        {
+            private readonly ThirdPartyToolMigrationWizardWindow _window;
+            private readonly CancellationToken _ct;
+
+            public ThirdPartyToolMigrationPreviewProgress(
+                ThirdPartyToolMigrationWizardWindow window,
+                CancellationToken ct)
+            {
+                Debug.Assert(window != null, "window must not be null");
+
+                _window = window;
+                _ct = ct;
+            }
+
+            public void Report(ThirdPartyToolMigrationProgress value)
+            {
+                if (_ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                _window.ShowCheckingState(value);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs.meta
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5845b12ecd4f42239602418c7aa8461
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Adds a dedicated Custom Tool Migration wizard for projects that still contain older custom tool APIs.
- Shows migration guidance only when older custom tools are detected, and lets users rerun the check from the menu.

## User Impact
- Users who upgrade to V3 and see Unity Console errors from older custom tools get a clear migration prompt instead of having to patch files by hand.
- The migration wizard explains that clicking Migrate updates the affected files automatically and that the wizard can be reopened later from Window > Unity CLI Loop > Custom Tool Migration.
- Setup stays responsive by avoiding repeated full migration scans during normal setup wizard opens.

## Changes
- Adds V3 custom tool source and asmdef migration rules for legacy namespaces, aliases, metadata constructors, registrar usage, and split assembly patterns.
- Adds a separate migration wizard, startup check flow, cached preview handling, and scoped rescan behavior.
- Keeps migration scans limited to project Assets and avoids package/cache folders and unrelated asmdefs.

## Verification
- ./Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path /Users/a12115/ghq/hatayama/unity-cli-loop --force-recompile --wait-for-domain-reload
- ./Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path /Users/a12115/ghq/hatayama/unity-cli-loop --test-mode EditMode --filter-type regex --filter-value '^io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.(ThirdPartyToolMigrationRulesTests|ThirdPartyToolMigrationFileServiceTests)'
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1125)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->