### PR TITLE
fix: Release PRs resume after branch-scoped releases are published

### DIFF
--- a/scripts/sync-published-release-pr-labels.sh
+++ b/scripts/sync-published-release-pr-labels.sh
@@ -15,6 +15,27 @@ release_version_from_title() {
   '
 }
 
+release_version_from_body() {
+  body=$1
+
+  printf '%s\n' "$body" | jq -R -s -r '
+    try capture("<summary>(?<version>[0-9][A-Za-z0-9._-]*)</summary>").version catch ""
+  '
+}
+
+release_version_from_pr() {
+  title=$1
+  body=$2
+  release_version=$(release_version_from_title "$title")
+
+  if [ -n "$release_version" ]; then
+    printf '%s\n' "$release_version"
+    return
+  fi
+
+  release_version_from_body "$body"
+}
+
 release_is_published_at_sha() {
   release_tag=$1
   expected_sha=$2
@@ -47,7 +68,7 @@ PENDING_RELEASE_PRS=$(gh pr list \
   --state merged \
   --base "$TARGET_BRANCH" \
   --label "$PENDING_LABEL" \
-  --json number,title,mergeCommit)
+  --json number,title,body,mergeCommit)
 
 PENDING_RELEASE_PR_COUNT=$(printf '%s\n' "$PENDING_RELEASE_PRS" | jq 'length')
 if [ "$PENDING_RELEASE_PR_COUNT" -eq 0 ]; then
@@ -58,8 +79,9 @@ fi
 printf '%s\n' "$PENDING_RELEASE_PRS" | jq -c '.[]' | while IFS= read -r release_pr_json; do
   release_pr_number=$(printf '%s\n' "$release_pr_json" | jq -r '.number')
   release_pr_title=$(printf '%s\n' "$release_pr_json" | jq -r '.title')
+  release_pr_body=$(printf '%s\n' "$release_pr_json" | jq -r '.body // ""')
   release_pr_sha=$(printf '%s\n' "$release_pr_json" | jq -r '.mergeCommit.oid')
-  release_version=$(release_version_from_title "$release_pr_title")
+  release_version=$(release_version_from_pr "$release_pr_title" "$release_pr_body")
 
   if [ -z "$release_version" ]; then
     echo "Skipping pending PR #$release_pr_number because the title is not a release-please release title: $release_pr_title"

--- a/scripts/test-sync-published-release-pr-labels.sh
+++ b/scripts/test-sync-published-release-pr-labels.sh
@@ -131,6 +131,17 @@ test_marks_stale_pending_release_pr() {
   assert_contains "$TMP_DIR/marks-stale/output.txt" "Marked release PR #1082 as tagged for v3.0.0-beta.3."
 }
 
+# Verifies branch-scoped release titles use the release-please body version before staying pending.
+test_marks_branch_title_release_pr_from_body() {
+  run_case branch-title \
+    '[{"number":1105,"title":"chore: release v3-beta","body":"<details><summary>3.0.0-beta.7</summary></details>","mergeCommit":{"oid":"abc123"}}]' \
+    '{"v3.0.0-beta.7":{"isDraft":false,"targetCommitish":"abc123"}}'
+
+  assert_file_equals "$TMP_DIR/branch-title/status.txt" "0"
+  assert_contains "$TMP_DIR/branch-title/gh.log" "pr edit 1105 --repo hatayama/unity-cli-loop --remove-label autorelease: pending --add-label autorelease: tagged"
+  assert_contains "$TMP_DIR/branch-title/output.txt" "Marked release PR #1105 as tagged for v3.0.0-beta.7."
+}
+
 # Verifies draft releases remain pending so release completion is not hidden.
 test_keeps_draft_release_pending() {
   run_case draft-release \
@@ -175,6 +186,7 @@ test_fails_when_release_lookup_fails_unexpectedly() {
 }
 
 test_marks_stale_pending_release_pr
+test_marks_branch_title_release_pr_from_body
 test_keeps_draft_release_pending
 test_keeps_mismatched_release_pending
 test_exits_when_no_pending_release_pr_exists


### PR DESCRIPTION
## Summary
- Release automation can now clear stale pending labels even when release-please uses a branch-scoped release title.
- Future fix and feat merges to v3-beta can open the next release PR instead of being blocked by the previous published release.

## User Impact
- Before this change, a published beta release could still leave its merged release PR marked as pending.
- After this change, the label sync can identify the published release from the release PR body and mark it as tagged when the release points at the merge commit.

## Changes
- Fall back to the release PR body when the release version is not present in the title.
- Keep the existing release-target check before updating release PR labels.
- Add coverage for branch-scoped release titles such as chore: release v3-beta.

## Verification
- scripts/test-sync-published-release-pr-labels.sh
- scripts/test-mark-release-pr-tagged.sh
- scripts/test-release-please-config.sh
- scripts/test-sync-release-please-package-releases.sh
- scripts/test-is-release-please-release-commit.sh