### PR TITLE
fix: Setup recognizes existing npm CLI installs

### DIFF
--- a/Assets/Tests/Editor/CliInstallationDetectorTests.cs
+++ b/Assets/Tests/Editor/CliInstallationDetectorTests.cs
@@ -114,6 +114,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(command, Does.Contain("command -v uloop"));
             Assert.That(command, Does.Contain("uloop -v"));
+            Assert.That(command, Does.Contain("uloop_version_status=$?"));
+            Assert.That(command, Does.Contain("__ULOOP_VERSION_STATUS_START__"));
             Assert.That(command, Does.Not.Contain("uloop --version"));
         }
 
@@ -127,7 +129,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                             + "__ULOOP_PATH_END__\n"
                             + "__ULOOP_VERSION_START__\n"
                             + "2.1.1\n"
-                            + "__ULOOP_VERSION_END__\n";
+                            + "__ULOOP_VERSION_END__\n"
+                            + "__ULOOP_VERSION_STATUS_START__\n"
+                            + "0\n"
+                            + "__ULOOP_VERSION_STATUS_END__\n";
 
             CliInstallationDetection detection =
                 CliInstallationDetector.ParseShellCliInstallationOutput(output);
@@ -144,7 +149,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                             + "__ULOOP_PATH_END__\n"
                             + "__ULOOP_VERSION_START__\n"
                             + "2.1.1\n"
-                            + "__ULOOP_VERSION_END__\n";
+                            + "__ULOOP_VERSION_END__\n"
+                            + "__ULOOP_VERSION_STATUS_START__\n"
+                            + "0\n"
+                            + "__ULOOP_VERSION_STATUS_END__\n";
 
             CliInstallationDetection detection =
                 CliInstallationDetector.ParseShellCliInstallationOutput(output);
@@ -154,10 +162,54 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void ParseShellCliInstallationOutput_WhenVersionCommandFails_ReturnsPathWithoutVersion()
+        {
+            // Verifies that failed shell probes do not treat stdout usage text as a CLI version.
+            string output = "__ULOOP_PATH_START__\n"
+                            + "/Users/masamichi/.npm-global/bin/uloop\n"
+                            + "__ULOOP_PATH_END__\n"
+                            + "__ULOOP_VERSION_START__\n"
+                            + "usage: broken uloop\n"
+                            + "__ULOOP_VERSION_END__\n"
+                            + "__ULOOP_VERSION_STATUS_START__\n"
+                            + "1\n"
+                            + "__ULOOP_VERSION_STATUS_END__\n";
+
+            CliInstallationDetection detection =
+                CliInstallationDetector.ParseShellCliInstallationOutput(output);
+
+            Assert.That(detection.Version, Is.Null);
+            Assert.That(detection.ExecutablePath, Is.EqualTo("/Users/masamichi/.npm-global/bin/uloop"));
+        }
+
+        [Test]
         public void KillProcessIfRunning_WhenProcessAlreadyExited_DoesNotThrow()
         {
             // Verifies that process cleanup tolerates the race where the child exits before Kill.
-            ProcessStartInfo startInfo = new()
+            ProcessStartInfo startInfo = BuildImmediateExitProcessStartInfo();
+
+            using Process process = Process.Start(startInfo);
+            process.WaitForExit();
+
+            Assert.DoesNotThrow(() => CliInstallationDetector.KillProcessIfRunning(process));
+        }
+
+        private static ProcessStartInfo BuildImmediateExitProcessStartInfo()
+        {
+            if (UnityEngine.Application.platform == UnityEngine.RuntimePlatform.WindowsEditor)
+            {
+                return new ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    Arguments = "/c exit 0",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+            }
+
+            return new ProcessStartInfo
             {
                 FileName = "/bin/sh",
                 Arguments = "-c \"exit 0\"",
@@ -166,11 +218,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 RedirectStandardError = true,
                 CreateNoWindow = true
             };
-
-            using Process process = Process.Start(startInfo);
-            process.WaitForExit();
-
-            Assert.DoesNotThrow(() => CliInstallationDetector.KillProcessIfRunning(process));
         }
     }
 }

--- a/Assets/Tests/Editor/CliInstallationDetectorTests.cs
+++ b/Assets/Tests/Editor/CliInstallationDetectorTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Infrastructure;
@@ -149,6 +151,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(detection.Version, Is.EqualTo("2.1.1"));
             Assert.That(detection.ExecutablePath, Is.Null);
+        }
+
+        [Test]
+        public void KillProcessIfRunning_WhenProcessAlreadyExited_DoesNotThrow()
+        {
+            // Verifies that process cleanup tolerates the race where the child exits before Kill.
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = "/bin/sh",
+                Arguments = "-c \"exit 0\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using Process process = Process.Start(startInfo);
+            process.WaitForExit();
+
+            Assert.DoesNotThrow(() => CliInstallationDetector.KillProcessIfRunning(process));
         }
     }
 }

--- a/Assets/Tests/Editor/CliInstallationDetectorTests.cs
+++ b/Assets/Tests/Editor/CliInstallationDetectorTests.cs
@@ -84,5 +84,71 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.Version, Is.EqualTo("2.1.0"));
             Assert.That(result.ExecutablePath, Is.EqualTo("/Users/masamichi/.npm-global/bin/uloop"));
         }
+
+        [Test]
+        public void SelectPreferredDetection_WhenShellVersionExistsWithoutPathUsesShellVersion()
+        {
+            // Verifies that installed state does not depend on command path availability.
+            CliInstallationDetection packageOwnedDetection = new(
+                "3.0.0-beta.3",
+                "/Users/masamichi/.local/bin/uloop");
+            CliInstallationDetection shellDetection = new(
+                "2.1.0",
+                null);
+
+            CliInstallationDetection result = CliInstallationDetector.SelectPreferredDetection(
+                packageOwnedDetection,
+                shellDetection);
+
+            Assert.That(result.Version, Is.EqualTo("2.1.0"));
+            Assert.That(result.ExecutablePath, Is.Null);
+        }
+
+        [Test]
+        public void BuildShellCliDetectionCommand_UsesShortVersionFlag()
+        {
+            // Verifies that shell detection asks the command itself for its terminal-visible version.
+            string command = CliInstallationDetector.BuildShellCliDetectionCommand("uloop");
+
+            Assert.That(command, Does.Contain("command -v uloop"));
+            Assert.That(command, Does.Contain("uloop -v"));
+            Assert.That(command, Does.Not.Contain("uloop --version"));
+        }
+
+        [Test]
+        public void ParseShellCliInstallationOutput_WhenPathAndVersionExist_ReturnsDetection()
+        {
+            // Verifies that shell detection keeps terminal-visible path data as auxiliary UI context.
+            string output = "banner\n"
+                            + "__ULOOP_PATH_START__\n"
+                            + "/Users/masamichi/.npm-global/bin/uloop\n"
+                            + "__ULOOP_PATH_END__\n"
+                            + "__ULOOP_VERSION_START__\n"
+                            + "2.1.1\n"
+                            + "__ULOOP_VERSION_END__\n";
+
+            CliInstallationDetection detection =
+                CliInstallationDetector.ParseShellCliInstallationOutput(output);
+
+            Assert.That(detection.Version, Is.EqualTo("2.1.1"));
+            Assert.That(detection.ExecutablePath, Is.EqualTo("/Users/masamichi/.npm-global/bin/uloop"));
+        }
+
+        [Test]
+        public void ParseShellCliInstallationOutput_WhenOnlyVersionExists_ReturnsInstalledDetection()
+        {
+            // Verifies that installation state depends on version output, not path availability.
+            string output = "__ULOOP_PATH_START__\n"
+                            + "__ULOOP_PATH_END__\n"
+                            + "__ULOOP_VERSION_START__\n"
+                            + "2.1.1\n"
+                            + "__ULOOP_VERSION_END__\n";
+
+            CliInstallationDetection detection =
+                CliInstallationDetector.ParseShellCliInstallationOutput(output);
+
+            Assert.That(detection.Version, Is.EqualTo("2.1.1"));
+            Assert.That(detection.ExecutablePath, Is.Null);
+        }
     }
 }

--- a/Assets/Tests/Editor/NodeEnvironmentResolverTests.cs
+++ b/Assets/Tests/Editor/NodeEnvironmentResolverTests.cs
@@ -232,5 +232,52 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.AreEqual("/usr/local/bin/node", result);
         }
+
+        [Test]
+        public void ExtractDirectoryServiceUserShell_WhenUserShellLineExists_ReturnsShellPath()
+        {
+            // Verifies that macOS directory service output can recover the user's login shell.
+            string output = "UserShell: /bin/zsh\n";
+
+            string result = NodeEnvironmentResolver.ExtractDirectoryServiceUserShell(output);
+
+            Assert.AreEqual("/bin/zsh", result);
+        }
+
+        [Test]
+        public void SelectUserShell_WhenEnvironmentShellIsMissing_UsesDirectoryServiceShell()
+        {
+            // Verifies that GUI-launched Unity can still resolve terminal PATH through the user's login shell.
+            string result = NodeEnvironmentResolver.SelectUserShell(
+                null,
+                "/bin/zsh",
+                path => path == "/bin/zsh");
+
+            Assert.AreEqual("/bin/zsh", result);
+        }
+
+        [Test]
+        public void SelectUserShell_WhenEnvironmentShellExists_PrefersEnvironmentShell()
+        {
+            // Verifies that an inherited SHELL remains authoritative when it points to a real shell.
+            string result = NodeEnvironmentResolver.SelectUserShell(
+                "/bin/bash",
+                "/bin/zsh",
+                path => path == "/bin/bash" || path == "/bin/zsh");
+
+            Assert.AreEqual("/bin/bash", result);
+        }
+
+        [Test]
+        public void SelectUserShell_WhenNoCandidateExists_ReturnsPosixFallbackShell()
+        {
+            // Verifies that shell resolution keeps a deterministic fallback when no user shell is available.
+            string result = NodeEnvironmentResolver.SelectUserShell(
+                null,
+                null,
+                path => false);
+
+            Assert.AreEqual("/bin/sh", result);
+        }
     }
 }

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -315,6 +315,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(canManageSkills, Is.True);
         }
 
+        [Test]
+        public void ShouldShowSkillsTargetRow_WhenFirstInstallAndCliMissing_ReturnsTrue()
+        {
+            // Verifies that first-time setup can choose a skill target before CLI installation.
+            bool shouldShow = SetupWizardWindow.ShouldShowSkillsTargetRowForSetupWizard(
+                shouldUseFirstInstallSkillsUi: true);
+
+            Assert.That(shouldShow, Is.True);
+        }
+
+        [Test]
+        public void ShouldShowSkillsTargetRow_WhenNotFirstInstall_ReturnsFalse()
+        {
+            // Verifies that returning setup keeps the compact target row hidden.
+            bool shouldShow = SetupWizardWindow.ShouldShowSkillsTargetRowForSetupWizard(
+                shouldUseFirstInstallSkillsUi: false);
+
+            Assert.That(shouldShow, Is.False);
+        }
+
+        [Test]
+        public void ShouldShowSkillsTargetList_WhenCliMissing_ReturnsFalse()
+        {
+            // Verifies that multi-target status rows stay hidden until the CLI can inspect skill state.
+            bool shouldShow = SetupWizardWindow.ShouldShowSkillsTargetListForSetupWizard(
+                canManageSkills: false,
+                shouldUseFirstInstallSkillsUi: false);
+
+            Assert.That(shouldShow, Is.False);
+        }
+
+        [Test]
+        public void ShouldShowSkillsTargetList_WhenCliInstalledAndNotFirstInstall_ReturnsTrue()
+        {
+            // Verifies that returning users keep the multi-target skill status view.
+            bool shouldShow = SetupWizardWindow.ShouldShowSkillsTargetListForSetupWizard(
+                canManageSkills: true,
+                shouldUseFirstInstallSkillsUi: false);
+
+            Assert.That(shouldShow, Is.True);
+        }
+
         [TestCase(false, false, false, false, null, "3.0.0", "Install CLI")]
         [TestCase(true, false, false, false, "3.0.0", "3.0.0", "Installed")]
         [TestCase(true, false, false, true, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]

--- a/Assets/Tests/Editor/UnityCliLoopPackageRemovalSettingsResetterTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopPackageRemovalSettingsResetterTests.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.IO;
+
+using NUnit.Framework;
+using Newtonsoft.Json.Linq;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    public sealed class UnityCliLoopPackageRemovalSettingsResetterTests
+    {
+        private static readonly string SettingsFilePath =
+            Path.Combine(UnityCliLoopConstants.USER_SETTINGS_FOLDER, UnityCliLoopConstants.SETTINGS_FILE_NAME);
+
+        private bool _settingsFileExisted;
+        private string _settingsFileContent;
+        private UnityCliLoopEditorSettingsService _editorSettingsService;
+        private UnityCliLoopEditorSettingsRepository _editorSettingsRepository;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _settingsFileExisted = File.Exists(SettingsFilePath);
+            _settingsFileContent = _settingsFileExisted ? File.ReadAllText(SettingsFilePath) : null;
+
+            if (!Directory.Exists(UnityCliLoopConstants.USER_SETTINGS_FOLDER))
+            {
+                Directory.CreateDirectory(UnityCliLoopConstants.USER_SETTINGS_FOLDER);
+            }
+
+            DeleteIfExists(SettingsFilePath);
+            _editorSettingsService =
+                UnityCliLoopEditorSettingsTestFactory.CreateServiceWithRepository(out _editorSettingsRepository);
+            _editorSettingsRepository.InvalidateCache();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            RestoreFile(SettingsFilePath, _settingsFileExisted, _settingsFileContent);
+            _editorSettingsRepository.InvalidateCache();
+        }
+
+        [Test]
+        public void PackageNameConstant_WhenComparedWithPackageManifest_Matches()
+        {
+            // Verifies that uninstall detection uses the package manifest identity.
+            string packageJson = File.ReadAllText("Packages/src/package.json");
+            JObject packageManifest = JObject.Parse(packageJson);
+
+            Assert.That(UnityCliLoopConstants.PACKAGE_NAME, Is.EqualTo(packageManifest["name"]?.Value<string>()));
+        }
+
+        [Test]
+        public void ShouldResetSetupWizardState_WhenOwnPackageRemoved_ReturnsTrue()
+        {
+            // Verifies that uninstall detection matches this package name.
+            List<string> removedPackageNames = new()
+            {
+                UnityCliLoopConstants.PACKAGE_NAME
+            };
+
+            bool shouldReset = UnityCliLoopPackageRemovalSettingsResetter.ShouldResetSetupWizardState(
+                removedPackageNames,
+                UnityCliLoopConstants.PACKAGE_NAME);
+
+            Assert.That(shouldReset, Is.True);
+        }
+
+        [Test]
+        public void ShouldResetSetupWizardState_WhenOtherPackageRemoved_ReturnsFalse()
+        {
+            // Verifies that unrelated package removals do not reset setup state.
+            List<string> removedPackageNames = new()
+            {
+                "com.unity.textmeshpro"
+            };
+
+            bool shouldReset = UnityCliLoopPackageRemovalSettingsResetter.ShouldResetSetupWizardState(
+                removedPackageNames,
+                UnityCliLoopConstants.PACKAGE_NAME);
+
+            Assert.That(shouldReset, Is.False);
+        }
+
+        [Test]
+        public void ResetSetupWizardState_WhenWizardStateExists_ClearsOnlyWizardFields()
+        {
+            // Verifies that package uninstall resets auto-show state without discarding user settings.
+            UnityCliLoopEditorSettingsData settings = CreateSettingsWithNonWizardPreferences();
+
+            UnityCliLoopEditorSettingsData resetSettings =
+                UnityCliLoopPackageRemovalSettingsResetter.ResetSetupWizardState(settings);
+
+            Assert.That(resetSettings.lastSeenSetupWizardVersion, Is.Empty);
+            Assert.That(resetSettings.suppressSetupWizardAutoShow, Is.False);
+            Assert.That(resetSettings.showDeveloperTools, Is.EqualTo(settings.showDeveloperTools));
+            Assert.That(resetSettings.showToolSettings, Is.EqualTo(settings.showToolSettings));
+            Assert.That(resetSettings.installSkillsFlat, Is.EqualTo(settings.installSkillsFlat));
+            Assert.That(resetSettings.isServerRunning, Is.EqualTo(settings.isServerRunning));
+        }
+
+        [Test]
+        public void ResetSetupWizardStateIfPackageRemoved_WhenOwnPackageRemoved_ClearsStoredWizardFields()
+        {
+            // Verifies that the removal handler persists the setup wizard reset.
+            UnityCliLoopEditorSettingsData settings = CreateSettingsWithNonWizardPreferences();
+            _editorSettingsService.SaveSettings(settings);
+
+            UnityCliLoopPackageRemovalSettingsResetter.ResetSetupWizardStateIfPackageRemoved(
+                _editorSettingsService,
+                new List<string> { UnityCliLoopConstants.PACKAGE_NAME },
+                UnityCliLoopConstants.PACKAGE_NAME);
+
+            UnityCliLoopEditorSettingsData updatedSettings = _editorSettingsService.GetSettings();
+            Assert.That(updatedSettings.lastSeenSetupWizardVersion, Is.Empty);
+            Assert.That(updatedSettings.suppressSetupWizardAutoShow, Is.False);
+            Assert.That(updatedSettings.showDeveloperTools, Is.EqualTo(settings.showDeveloperTools));
+            Assert.That(updatedSettings.showToolSettings, Is.EqualTo(settings.showToolSettings));
+            Assert.That(updatedSettings.installSkillsFlat, Is.EqualTo(settings.installSkillsFlat));
+            Assert.That(updatedSettings.isServerRunning, Is.EqualTo(settings.isServerRunning));
+        }
+
+        private static UnityCliLoopEditorSettingsData CreateSettingsWithNonWizardPreferences()
+        {
+            return new UnityCliLoopEditorSettingsData
+            {
+                showDeveloperTools = true,
+                lastSeenSetupWizardVersion = "3.0.0-beta.7",
+                suppressSetupWizardAutoShow = true,
+                showUnityCliLoopSecuritySetting = false,
+                showToolSettings = false,
+                installSkillsFlat = false,
+                isServerRunning = false,
+                isAfterCompile = true,
+                isDomainReloadInProgress = true,
+                isReconnecting = true,
+                showReconnectingUI = true,
+                showPostCompileReconnectingUI = true
+            };
+        }
+
+        private static void DeleteIfExists(string path)
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+
+        private static void RestoreFile(string path, bool existed, string content)
+        {
+            if (existed)
+            {
+                File.WriteAllText(path, content);
+                return;
+            }
+
+            DeleteIfExists(path);
+        }
+    }
+}

--- a/Assets/Tests/Editor/UnityCliLoopPackageRemovalSettingsResetterTests.cs.meta
+++ b/Assets/Tests/Editor/UnityCliLoopPackageRemovalSettingsResetterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3fdb5491fd48e4aabb43ad491cf88d29
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -8,6 +8,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string EXECUTABLE_NAME = "uloop";
         public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.7";
         public const string VERSION_FLAG = "--version";
+        public const string SHORT_VERSION_FLAG = "-v";
         public const string RAW_CONTENT_BASE_URL = "https://raw.githubusercontent.com/hatayama/unity-cli-loop";
         public const string STABLE_INSTALLER_SOURCE_REF = "main";
         public const string BETA_INSTALLER_SOURCE_REF = "v3-beta";

--- a/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
@@ -222,16 +222,29 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
 
-                using CancellationTokenRegistration registration = ct.Register(() => process.Kill());
+                using CancellationTokenRegistration registration = ct.Register(() => KillProcessIfRunning(process));
                 bool exited = process.WaitForExit(PROCESS_TIMEOUT_MS);
                 if (!exited)
                 {
-                    process.Kill();
+                    KillProcessIfRunning(process);
                     return null;
                 }
 
                 process.WaitForExit();
                 return outputBuilder.ToString().Trim();
+            }
+        }
+
+        internal static void KillProcessIfRunning(Process process)
+        {
+            UnityEngine.Debug.Assert(process != null, "process must not be null");
+
+            try
+            {
+                process.Kill();
+            }
+            catch (System.InvalidOperationException)
+            {
             }
         }
 
@@ -299,7 +312,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             using CancellationTokenRegistration registration = ct.Register(() =>
             {
-                try { process.Kill(); } catch (System.InvalidOperationException) { }
+                KillProcessIfRunning(process);
             });
 
             try
@@ -308,7 +321,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 if (!exited)
                 {
-                    try { process.Kill(); } catch (System.InvalidOperationException) { }
+                    KillProcessIfRunning(process);
                     process.Dispose();
                     return new CliInstallationDetection(null, executablePath);
                 }

--- a/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
@@ -34,6 +34,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string SHELL_PATH_END_MARKER = "__ULOOP_PATH_END__";
         private const string SHELL_VERSION_START_MARKER = "__ULOOP_VERSION_START__";
         private const string SHELL_VERSION_END_MARKER = "__ULOOP_VERSION_END__";
+        private const string SHELL_VERSION_STATUS_START_MARKER = "__ULOOP_VERSION_STATUS_START__";
+        private const string SHELL_VERSION_STATUS_END_MARKER = "__ULOOP_VERSION_STATUS_END__";
+        private const string SHELL_SUCCESS_EXIT_CODE = "0";
 
         private string _cachedCliVersion;
         private string _cachedCliExecutablePath;
@@ -154,7 +157,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static CliInstallationDetection DetectShellCliInstallationFromLoginShell(CancellationToken ct)
         {
             string shell = NodeEnvironmentResolver.GetUserShell();
-            ProcessStartInfo startInfo = new()            {
+            ProcessStartInfo startInfo = new()
+            {
                 FileName = shell,
                 Arguments = "-l -i -c " + QuoteProcessArgument(BuildShellCliDetectionCommand(CliConstants.EXECUTABLE_NAME)),
                 UseShellExecute = false,
@@ -176,7 +180,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 + "echo " + SHELL_PATH_END_MARKER + "\n"
                 + "echo " + SHELL_VERSION_START_MARKER + "\n"
                 + executableName + " " + CliConstants.SHORT_VERSION_FLAG + "\n"
-                + "echo " + SHELL_VERSION_END_MARKER;
+                + "uloop_version_status=$?\n"
+                + "echo " + SHELL_VERSION_END_MARKER + "\n"
+                + "echo " + SHELL_VERSION_STATUS_START_MARKER + "\n"
+                + "echo $uloop_version_status\n"
+                + "echo " + SHELL_VERSION_STATUS_END_MARKER;
         }
 
         internal static CliInstallationDetection ParseShellCliInstallationOutput(string output)
@@ -189,8 +197,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 output,
                 SHELL_VERSION_START_MARKER,
                 SHELL_VERSION_END_MARKER);
+            string versionStatusBlock = NodeEnvironmentResolver.ExtractBetweenMarkers(
+                output,
+                SHELL_VERSION_STATUS_START_MARKER,
+                SHELL_VERSION_STATUS_END_MARKER);
             string executablePath = NodeEnvironmentResolver.ExtractAbsolutePathLine(pathBlock);
-            string version = ExtractFirstNonEmptyLine(versionBlock);
+            string version = IsSuccessfulShellStatus(versionStatusBlock)
+                ? ExtractFirstNonEmptyLine(versionBlock)
+                : null;
             return new CliInstallationDetection(version, executablePath);
         }
 
@@ -246,6 +260,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             catch (System.InvalidOperationException)
             {
             }
+        }
+
+        private static bool IsSuccessfulShellStatus(string statusBlock)
+        {
+            string status = ExtractFirstNonEmptyLine(statusBlock);
+            return string.Equals(status, SHELL_SUCCESS_EXIT_CODE, StringComparison.Ordinal);
         }
 
         private static string ExtractFirstNonEmptyLine(string block)

--- a/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
@@ -30,6 +30,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     public sealed class CliInstallationDetector : ICliInstallationDetector
     {
         private const int PROCESS_TIMEOUT_MS = 5000;
+        private const string SHELL_PATH_START_MARKER = "__ULOOP_PATH_START__";
+        private const string SHELL_PATH_END_MARKER = "__ULOOP_PATH_END__";
+        private const string SHELL_VERSION_START_MARKER = "__ULOOP_VERSION_START__";
+        private const string SHELL_VERSION_END_MARKER = "__ULOOP_VERSION_END__";
 
         private string _cachedCliVersion;
         private string _cachedCliExecutablePath;
@@ -115,7 +119,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             CliInstallationDetection packageOwnedDetection,
             CliInstallationDetection shellDetection)
         {
-            return !string.IsNullOrEmpty(shellDetection.ExecutablePath)
+            return !string.IsNullOrEmpty(shellDetection.Version)
+                || !string.IsNullOrEmpty(shellDetection.ExecutablePath)
                 ? shellDetection
                 : packageOwnedDetection;
         }
@@ -135,10 +140,126 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static CliInstallationDetection DetectShellCliInstallationBlocking(RuntimePlatform platform, CancellationToken ct)
         {
+            if (platform != RuntimePlatform.WindowsEditor)
+            {
+                return DetectShellCliInstallationFromLoginShell(ct);
+            }
+
             string executablePath = NodeEnvironmentResolver.FindExecutablePathAtPlatform(
                 CliConstants.EXECUTABLE_NAME,
                 platform);
             return DetectCliInstallationAtExecutablePath(executablePath, ct);
+        }
+
+        private static CliInstallationDetection DetectShellCliInstallationFromLoginShell(CancellationToken ct)
+        {
+            string shell = NodeEnvironmentResolver.GetUserShell();
+            ProcessStartInfo startInfo = new()            {
+                FileName = shell,
+                Arguments = "-l -i -c " + QuoteProcessArgument(BuildShellCliDetectionCommand(CliConstants.EXECUTABLE_NAME)),
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            string output = ExecuteAndGetOutput(startInfo, ct);
+            return ParseShellCliInstallationOutput(output);
+        }
+
+        internal static string BuildShellCliDetectionCommand(string executableName)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(executableName), "executableName must not be null or empty");
+
+            return "echo " + SHELL_PATH_START_MARKER + "\n"
+                + "command -v " + executableName + "\n"
+                + "echo " + SHELL_PATH_END_MARKER + "\n"
+                + "echo " + SHELL_VERSION_START_MARKER + "\n"
+                + executableName + " " + CliConstants.SHORT_VERSION_FLAG + "\n"
+                + "echo " + SHELL_VERSION_END_MARKER;
+        }
+
+        internal static CliInstallationDetection ParseShellCliInstallationOutput(string output)
+        {
+            string pathBlock = NodeEnvironmentResolver.ExtractBetweenMarkers(
+                output,
+                SHELL_PATH_START_MARKER,
+                SHELL_PATH_END_MARKER);
+            string versionBlock = NodeEnvironmentResolver.ExtractBetweenMarkers(
+                output,
+                SHELL_VERSION_START_MARKER,
+                SHELL_VERSION_END_MARKER);
+            string executablePath = NodeEnvironmentResolver.ExtractAbsolutePathLine(pathBlock);
+            string version = ExtractFirstNonEmptyLine(versionBlock);
+            return new CliInstallationDetection(version, executablePath);
+        }
+
+        private static string ExecuteAndGetOutput(ProcessStartInfo startInfo, CancellationToken ct)
+        {
+            UnityEngine.Debug.Assert(startInfo != null, "startInfo must not be null");
+            UnityEngine.Debug.Assert(startInfo.RedirectStandardOutput, "RedirectStandardOutput must be true");
+            UnityEngine.Debug.Assert(startInfo.RedirectStandardError, "RedirectStandardError must be true");
+
+            Process process = ProcessStartHelper.TryStart(startInfo);
+            if (process == null)
+            {
+                return null;
+            }
+
+            using (process)
+            {
+                StringBuilder outputBuilder = new();
+
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if (e.Data != null)
+                    {
+                        outputBuilder.AppendLine(e.Data);
+                    }
+                };
+                process.ErrorDataReceived += (sender, e) => { };
+
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
+                using CancellationTokenRegistration registration = ct.Register(() => process.Kill());
+                bool exited = process.WaitForExit(PROCESS_TIMEOUT_MS);
+                if (!exited)
+                {
+                    process.Kill();
+                    return null;
+                }
+
+                process.WaitForExit();
+                return outputBuilder.ToString().Trim();
+            }
+        }
+
+        private static string ExtractFirstNonEmptyLine(string block)
+        {
+            if (string.IsNullOrEmpty(block))
+            {
+                return null;
+            }
+
+            string[] lines = block.Split('\n');
+            foreach (string rawLine in lines)
+            {
+                string line = rawLine.Trim();
+                if (!string.IsNullOrEmpty(line))
+                {
+                    return line;
+                }
+            }
+
+            return null;
+        }
+
+        private static string QuoteProcessArgument(string value)
+        {
+            UnityEngine.Debug.Assert(value != null, "value must not be null");
+
+            return "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
         }
 
         private static CliInstallationDetection DetectCliInstallationAtExecutablePath(

--- a/Packages/src/Editor/Infrastructure/InfrastructureEditorStartup.cs
+++ b/Packages/src/Editor/Infrastructure/InfrastructureEditorStartup.cs
@@ -11,6 +11,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         internal static void Initialize(UnityCliLoopEditorSettingsService editorSettingsService)
         {
+            UnityCliLoopPackageRemovalSettingsResetter packageRemovalSettingsResetter = new(editorSettingsService);
+            packageRemovalSettingsResetter.RegisterForEditorStartup();
             UnityCliLoopEditorSettingsRecoveryScheduler.ScheduleForEditorStartup(editorSettingsService);
             CompilationLockService.RegisterForEditorStartup();
         }

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPackageRemovalSettingsResetter.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPackageRemovalSettingsResetter.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using UnityEditor;
+using UnityEditor.PackageManager;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+using Debug = System.Diagnostics.Debug;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Resets Setup Wizard state when Unity removes this package from the project.
+    /// </summary>
+    internal sealed class UnityCliLoopPackageRemovalSettingsResetter
+    {
+        private readonly UnityCliLoopEditorSettingsService _editorSettingsService;
+
+        internal UnityCliLoopPackageRemovalSettingsResetter(UnityCliLoopEditorSettingsService editorSettingsService)
+        {
+            Debug.Assert(editorSettingsService != null, "editorSettingsService must not be null");
+
+            _editorSettingsService = editorSettingsService
+                ?? throw new ArgumentNullException(nameof(editorSettingsService));
+        }
+
+        internal void RegisterForEditorStartup()
+        {
+            if (AssetDatabase.IsAssetImportWorkerProcess())
+            {
+                return;
+            }
+
+            if (UnityEngine.Application.isBatchMode)
+            {
+                return;
+            }
+
+            Events.registeringPackages += HandleRegisteringPackages;
+        }
+
+        internal static bool ShouldResetSetupWizardState(
+            IEnumerable<string> removedPackageNames,
+            string packageName)
+        {
+            Debug.Assert(removedPackageNames != null, "removedPackageNames must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(packageName), "packageName must not be null or empty");
+
+            return removedPackageNames.Any(
+                removedPackageName => string.Equals(removedPackageName, packageName, StringComparison.Ordinal));
+        }
+
+        internal static UnityCliLoopEditorSettingsData ResetSetupWizardState(UnityCliLoopEditorSettingsData settings)
+        {
+            Debug.Assert(settings != null, "settings must not be null");
+
+            return settings with
+            {
+                lastSeenSetupWizardVersion = string.Empty,
+                suppressSetupWizardAutoShow = false
+            };
+        }
+
+        internal static void ResetSetupWizardStateIfPackageRemoved(
+            UnityCliLoopEditorSettingsService editorSettingsService,
+            IEnumerable<string> removedPackageNames,
+            string packageName)
+        {
+            Debug.Assert(editorSettingsService != null, "editorSettingsService must not be null");
+            Debug.Assert(removedPackageNames != null, "removedPackageNames must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(packageName), "packageName must not be null or empty");
+
+            if (!ShouldResetSetupWizardState(removedPackageNames, packageName))
+            {
+                return;
+            }
+
+            editorSettingsService.UpdateSettings(ResetSetupWizardState);
+        }
+
+        private void HandleRegisteringPackages(PackageRegistrationEventArgs args)
+        {
+            Debug.Assert(args != null, "args must not be null");
+
+            IEnumerable<string> removedPackageNames = GetRemovedPackageNames(args);
+            ResetSetupWizardStateIfPackageRemoved(
+                _editorSettingsService,
+                removedPackageNames,
+                UnityCliLoopConstants.PACKAGE_NAME);
+        }
+
+        private static IEnumerable<string> GetRemovedPackageNames(PackageRegistrationEventArgs args)
+        {
+            Debug.Assert(args != null, "args must not be null");
+
+            return args.removed.Select(packageInfo => packageInfo.name);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPackageRemovalSettingsResetter.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPackageRemovalSettingsResetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9432fa43f890411cb65c2cdd0cc92b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
+++ b/Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs
@@ -181,6 +181,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string PATH_END_MARKER = "__PATH_END__";
         private const string WHICH_START_MARKER = "__WHICH_START__";
         private const string WHICH_END_MARKER = "__WHICH_END__";
+        private const string POSIX_FALLBACK_SHELL_PATH = "/bin/sh";
+        private const string DIRECTORY_SERVICE_EXECUTABLE_PATH = "/usr/bin/dscl";
+        private const string DIRECTORY_SERVICE_USERS_PATH_PREFIX = "/Users/";
+        private const string DIRECTORY_SERVICE_USER_SHELL_ATTRIBUTE = "UserShell";
+        private const string DIRECTORY_SERVICE_USER_SHELL_PREFIX = DIRECTORY_SERVICE_USER_SHELL_ATTRIBUTE + ":";
 
         // Uses markers to extract PATH value, ignoring any banner/echo output from shell startup files
         internal static string GetLoginShellPathAtPlatform(RuntimePlatform platform)
@@ -247,20 +252,106 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return null;
         }
 
-        // Falls back to /bin/sh when $SHELL is unset or invalid. /bin/sh won't load
-        // .zshrc/.bashrc, so version-manager paths may be missed — but $SHELL being unset
-        // is extremely rare on macOS/Linux and there is no reliable way to detect the user's
-        // preferred shell without it.
         internal static string GetUserShell()
         {
-            string shell = System.Environment.GetEnvironmentVariable("SHELL");
-            // $SHELL is external input — validate the path exists to avoid Process.Start exceptions
-            if (!string.IsNullOrEmpty(shell) && File.Exists(shell))
+            string environmentShell = System.Environment.GetEnvironmentVariable("SHELL");
+            if (IsExistingShell(environmentShell, File.Exists))
             {
-                return shell;
+                return environmentShell;
             }
 
-            return "/bin/sh";
+            string directoryServiceShell = TryReadDirectoryServiceUserShell(System.Environment.UserName);
+            return SelectUserShell(null, directoryServiceShell, File.Exists);
+        }
+
+        internal static string SelectUserShell(
+            string environmentShell,
+            string directoryServiceShell,
+            System.Func<string, bool> fileExists)
+        {
+            UnityEngine.Debug.Assert(fileExists != null, "fileExists must not be null");
+
+            if (IsExistingShell(environmentShell, fileExists))
+            {
+                return environmentShell;
+            }
+
+            if (IsExistingShell(directoryServiceShell, fileExists))
+            {
+                return directoryServiceShell;
+            }
+
+            return POSIX_FALLBACK_SHELL_PATH;
+        }
+
+        internal static string ExtractDirectoryServiceUserShell(string output)
+        {
+            if (string.IsNullOrEmpty(output))
+            {
+                return null;
+            }
+
+            string[] lines = output.Split('\n');
+            foreach (string rawLine in lines)
+            {
+                string line = rawLine.Trim();
+                if (!line.StartsWith(DIRECTORY_SERVICE_USER_SHELL_PREFIX, System.StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string shell = line.Substring(DIRECTORY_SERVICE_USER_SHELL_PREFIX.Length).Trim();
+                return string.IsNullOrEmpty(shell) ? null : shell;
+            }
+
+            return null;
+        }
+
+        private static bool IsExistingShell(
+            string shell,
+            System.Func<string, bool> fileExists)
+        {
+            return !string.IsNullOrEmpty(shell) && fileExists(shell);
+        }
+
+        private static string TryReadDirectoryServiceUserShell(string userName)
+        {
+            if (!File.Exists(DIRECTORY_SERVICE_EXECUTABLE_PATH) || !IsSafeDirectoryServiceUserName(userName))
+            {
+                return null;
+            }
+
+            ProcessStartInfo startInfo = new()            {
+                FileName = DIRECTORY_SERVICE_EXECUTABLE_PATH,
+                Arguments = ". -read " + DIRECTORY_SERVICE_USERS_PATH_PREFIX + userName
+                    + " " + DIRECTORY_SERVICE_USER_SHELL_ATTRIBUTE,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            return ExtractDirectoryServiceUserShell(ExecuteAndGetOutput(startInfo));
+        }
+
+        private static bool IsSafeDirectoryServiceUserName(string userName)
+        {
+            if (string.IsNullOrEmpty(userName))
+            {
+                return false;
+            }
+
+            foreach (char character in userName)
+            {
+                if (char.IsLetterOrDigit(character) || character == '_' || character == '-' || character == '.')
+                {
+                    continue;
+                }
+
+                return false;
+            }
+
+            return true;
         }
 
         private static bool IsWindowsEditor(RuntimePlatform platform)

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -577,6 +577,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return cliInstalled;
         }
 
+        internal static bool ShouldShowSkillsTargetRowForSetupWizard(bool shouldUseFirstInstallSkillsUi)
+        {
+            return shouldUseFirstInstallSkillsUi;
+        }
+
+        internal static bool ShouldShowSkillsTargetListForSetupWizard(
+            bool canManageSkills,
+            bool shouldUseFirstInstallSkillsUi)
+        {
+            return canManageSkills && !shouldUseFirstInstallSkillsUi;
+        }
+
         internal static SkillSetupTargetInfo CreateFirstInstallSkillTarget(
             SkillsTarget target,
             bool groupSkillsUnderUnityCliLoop)
@@ -736,6 +748,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             List<SkillSetupTargetInfo> targets)
         {
             _skillsTargetList.Clear();
+            bool useFirstInstallSkillsUi = _shouldUseFirstInstallSkillsUi;
+            ViewDataBinder.SetVisible(
+                _skillsTargetRow,
+                ShouldShowSkillsTargetRowForSetupWizard(useFirstInstallSkillsUi));
+            ViewDataBinder.SetVisible(
+                _skillsTargetList,
+                ShouldShowSkillsTargetListForSetupWizard(canManageSkills, useFirstInstallSkillsUi));
 
             if (!canManageSkills)
             {
@@ -746,16 +765,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                     _isInstallingSkills,
                     hasOutdatedSkills: false);
                 _groupSkillsToggle.SetEnabled(false);
-                ViewDataBinder.SetVisible(_skillsTargetRow, false);
-                ViewDataBinder.SetVisible(_skillsTargetList, false);
                 return;
             }
 
             _groupSkillsToggle.SetEnabled(!_isInstallingSkills);
-
-            bool useFirstInstallSkillsUi = _shouldUseFirstInstallSkillsUi;
-            ViewDataBinder.SetVisible(_skillsTargetRow, useFirstInstallSkillsUi);
-            ViewDataBinder.SetVisible(_skillsTargetList, !useFirstInstallSkillsUi);
 
             if (useFirstInstallSkillsUi)
             {

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -32,6 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public static string PackageResolvedPath => PackageInfo.resolvedPath;
 
         public const string PROJECT_NAME = "UnityCliLoop";
+        public const string PACKAGE_NAME = "io.github.hatayama.uloopmcp";
         
         // Editor settings
         public const string SETTINGS_FILE_NAME = "UnityCliLoopSettings.json";


### PR DESCRIPTION
## Summary
- Setup now recognizes an existing npm-installed uloop CLI instead of showing it as missing.
- Older CLI versions are surfaced as update candidates, so new projects can guide users to upgrade accurately.

## User Impact
- Before this change, Unity projects launched from a GUI environment could show "Not installed" even when the user's terminal already had uloop-cli 2.1.x installed.
- After this change, Setup runs CLI version detection through the user's login shell, matching the terminal environment where npm shims and node are available.

## Changes
- Resolve the user's login shell when Unity does not inherit SHELL.
- Run shell command discovery and uloop -v in the same login shell for macOS/Linux CLI detection.
- Treat version output as the installed-state signal while keeping the executable path as optional UI context.

## Verification
- go run ./cmd/uloop --project-path /Users/a12115/ghq/hatayama/unity-cli-loop-fix-npm-cli-detection compile
- go run ./cmd/uloop --project-path /Users/a12115/ghq/hatayama/unity-cli-loop-fix-npm-cli-detection run-tests --test-mode EditMode --filter-type regex --filter-value '.*(CliInstallationDetectorTests|NodeEnvironmentResolverTests).*'
- Verified in Unity dynamic code that SHELL=null still returns Installed=True, Version=2.1.1, and Path=/Users/a12115/.npm-global/bin/uloop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1131)

<!-- review_stack_entry_end -->

Summary
- Setup now recognizes an existing npm-installed uloop CLI by running the user’s login shell (macOS/Linux) and using the CLI's version output as the installed-state signal; the executable path remains optional UI context.
- Older CLI versions discovered via the shell are surfaced as update candidates so new projects can advise upgrades.
- Detection resolves the login shell even when Unity does not inherit SHELL (including a macOS dscl lookup fallback) and executes discovery and `uloop -v` within the same login shell environment.

User impact
- Fixes cases where Unity launched from a GUI incorrectly showed "Not installed" despite `uloop-cli` being available in the user’s terminal (e.g., npm global shims and terminal node).
- After this change, Setup reports Installed/Version/Path consistent with the terminal environment.

Key changes
- NodeEnvironmentResolver
  - Added macOS Directory Service (dscl) lookup to derive UserShell when $SHELL is missing/invalid.
  - New helpers: SelectUserShell and ExtractDirectoryServiceUserShell; GetUserShell now uses dscl fallback instead of unconditionally returning /bin/sh.
- CliInstallationDetector
  - Introduces login-shell detection on non-Windows platforms: builds a quoted login-shell command that emits start/end markers and runs it with stdout/stderr capture, a 5s timeout, and guarded process-kill behavior on cancellation/timeouts.
  - Parses marker-delimited stdout to extract an optional executable path and the CLI version; selection logic now prefers shell detection when the shell-reported version is present even if the path is absent.
  - Added a short version flag constant and uses `-v` for shell commands.
  - Refactored process-kill handling to tolerate races where the child has already exited.
- SetupWizardWindow
  - Added internal helpers to centralize skills-target UI visibility logic and updated UpdateSkillsStep to use them.
- Package removal handling
  - New UnityCliLoopPackageRemovalSettingsResetter resets only setup-wizard related settings when the package is removed; wired into InfrastructureEditorStartup so removal clears wizard auto-show state while preserving other preferences.
- Constants
  - Added CliConstants.SHORT_VERSION_FLAG = "-v".
  - Added UnityCliLoopConstants.PACKAGE_NAME = "io.github.hatayama.uloopmcp".

Tests
- Extensive new/updated NUnit tests:
  - CliInstallationDetectorTests: selection when shell version exists without path, short `-v` usage, parsing shell output (path+version and version-only), and guarded process-kill race test.
  - NodeEnvironmentResolverTests: dscl parsing and SelectUserShell behavior (env shell vs directory service vs deterministic POSIX fallback).
  - SetupWizardWindowTests: skills-target row/list visibility under first-time/setup conditions.
  - UnityCliLoopPackageRemovalSettingsResetterTests: package-name match, ShouldResetSetupWizardState behavior, and ResetSetupWizardState/ResetSetupWizardStateIfPackageRemoved persistence semantics.
  - General test hygiene: setup/teardown for editor settings file manipulation.

Verification
- Provided `go run`/test runs demonstrating scenario where SHELL=null returns Installed=True, Version=2.1.1, Path=/Users/a12115/.npm-global/bin/uloop (shell-based detection succeeds even when Unity's environment lacked SHELL).

Files touched (high level)
- Packages/src/Editor/Infrastructure/Utils/NodeEnvironmentResolver.cs (+ tests)
- Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs (+ tests)
- Packages/src/Editor/Domain/CliConstants.cs
- Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs (+ tests)
- Packages/src/Editor/Settings/UnityCliLoopPackageRemovalSettingsResetter.cs (+ tests)
- Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
- Assets/Tests/Editor/* (multiple new/updated tests)
- InfrastructureEditorStartup wiring updated to register the package-removal resetter.

Review notes / risk
- Subprocess invocation, shell-quoting, dscl invocation, and timeout/kill logic are platform-sensitive; review escaping, deterministic behavior across shells, cancellation/timeout handling, and macOS dscl invocation safety (username validation already added).
- Ensure the short `-v` flag is appropriate across supported CLI versions and platforms.
- Tests increase coverage for edge cases but review runtime impacts in editor contexts (timeouts, blocking behavior).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1131)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1131)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->