### PR TITLE
chore: Stop CodeRabbit from rewriting pull request descriptions

### DIFF
--- a/.agents/skills/uloop-clear-console/SKILL.md
+++ b/.agents/skills/uloop-clear-console/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-clear-console
+toolName: clear-console
 description: "Clear all Unity Console log entries. Use when you need to: (1) Clear console before running tests or compilation, (2) Start a fresh debugging session, (3) Remove noisy logs to isolate specific output."
 ---
 

--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-compile
+toolName: compile
 description: "Compile Unity project and report errors/warnings. Use when you need to: (1) Verify code compiles after C# file edits, (2) Check for compile errors before testing, (3) Force full recompilation with Domain Reload. Returns error and warning counts."
 ---
 
@@ -10,7 +11,7 @@ Execute Unity project compilation.
 ## Usage
 
 ```bash
-uloop compile [--force-recompile] [--wait-for-domain-reload]
+uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 ```
 
 ## Parameters
@@ -18,7 +19,7 @@ uloop compile [--force-recompile] [--wait-for-domain-reload]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--force-recompile` | boolean | `false` | Force full recompilation (triggers Domain Reload) |
-| `--wait-for-domain-reload` | boolean | `false` | Wait until Domain Reload completes before returning |
+| `--no-wait-for-domain-reload` | boolean | `false` | Return before Domain Reload completion |
 
 ## Global Options
 
@@ -32,14 +33,11 @@ uloop compile [--force-recompile] [--wait-for-domain-reload]
 # Check compilation
 uloop compile
 
-# Force full recompilation
+# Force full recompilation and wait for Domain Reload completion
 uloop compile --force-recompile
 
-# Force recompilation and wait for Domain Reload completion
-uloop compile --force-recompile --wait-for-domain-reload
-
-# Wait for Domain Reload completion even without force recompilation
-uloop compile --wait-for-domain-reload
+# Start compilation without waiting for Domain Reload completion
+uloop compile --no-wait-for-domain-reload
 ```
 
 ## Output
@@ -53,13 +51,13 @@ Returns JSON:
 
 Diagnose the failure mode before retrying.
 
-**Stale lock files** (CLI hangs or shows "Unity is busy" while Unity Editor *is* running):
+**Stale recovery state** (CLI hangs or shows recovery/startup state while Unity Editor *is* running):
 
 ```bash
 uloop fix
 ```
 
-This removes any leftover lock files (`compiling.lock`, `domainreload.lock`, `serverstarting.lock`) from the Unity project's Temp directory. Then retry `uloop compile`.
+This removes stale Unity CLI Loop readiness state files from the Unity project's Temp directory. Then retry `uloop compile`.
 
 **Unity Editor not running** (CLI returns a connection failure and no Unity process is alive):
 

--- a/.agents/skills/uloop-find-game-objects/SKILL.md
+++ b/.agents/skills/uloop-find-game-objects/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-find-game-objects
+toolName: find-game-objects
 description: "Use first when the user asks about the currently selected GameObject in the Unity Hierarchy. Inspect selected object details with `--search-mode Selected` before using `execute-dynamic-code`. Use when you need to: (1) Get details and component properties for selected GameObject(s), (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Use get-hierarchy when the child tree under the selection is needed. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
 ---
 

--- a/.agents/skills/uloop-get-hierarchy/SKILL.md
+++ b/.agents/skills/uloop-get-hierarchy/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-get-hierarchy
+toolName: get-hierarchy
 description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use this when you need the child tree, parent-child structure, or descendants under selected GameObject(s) with `--use-selection`. Use find-game-objects for selected object details and component properties. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
 ---
 

--- a/.agents/skills/uloop-get-logs/SKILL.md
+++ b/.agents/skills/uloop-get-logs/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-get-logs
+toolName: get-logs
 description: "Retrieve current Unity Console entries via uloop CLI. Use when you need to: (1) inspect errors, warnings, or logs after compile, tests, PlayMode, or dynamic code execution, (2) search current Console messages or stack traces, (3) confirm whether a recent Unity operation emitted logs. Prefer this over reading Editor.log or Unity log files for normal Console contents; use log files only for startup, crash, freeze, or uloop connection failures."
 ---
 

--- a/.agents/skills/uloop-record-input/SKILL.md
+++ b/.agents/skills/uloop-record-input/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-record-input
+toolName: record-input
 description: "Record keyboard and mouse input during PlayMode into a JSON file. Use when you need to: (1) Capture human gameplay input for later replay, (2) Record input sequences for E2E testing, (3) Save input for bug reproduction. Captures Input System device-state diffs frame-by-frame in PlayMode and serializes them to JSON when stopped. Requires PlayMode and the New Input System."
 ---
 

--- a/.agents/skills/uloop-replay-input/SKILL.md
+++ b/.agents/skills/uloop-replay-input/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-replay-input
+toolName: replay-input
 description: "Replay recorded input during PlayMode with frame-precise injection. Use when you need to: (1) Reproduce recorded gameplay exactly, (2) Run E2E tests from recorded input, (3) Generate demo videos with consistent input. Deserializes the JSON recording and pushes captured device states back into Mouse.current / Keyboard.current frame-by-frame in PlayMode. Requires PlayMode and the New Input System."
 ---
 

--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-run-tests
+toolName: run-tests
 description: "Execute Unity Test Runner and get detailed results. Use when you need to: (1) Run EditMode or PlayMode unit tests, (2) Verify code changes pass all tests, (3) Diagnose test failures with error messages and stack traces. Single-flight only — never run multiple `uloop run-tests` in parallel."
 ---
 

--- a/.agents/skills/uloop-screenshot/SKILL.md
+++ b/.agents/skills/uloop-screenshot/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-screenshot
+toolName: screenshot
 description: "Capture screenshots of Unity Editor windows as PNG files. Use when you need to: (1) Screenshot Game View, Scene View, Console, Inspector, or other windows, (2) Capture current visual state for debugging or documentation, (3) Save editor window appearance as PNG files with optional UI element annotations. Writes PNG files via uloop CLI."
 ---
 

--- a/.agents/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.agents/skills/uloop-simulate-keyboard/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-simulate-keyboard
+toolName: simulate-keyboard
 description: "Simulate keyboard key input in PlayMode via Input System. Use when you need to: (1) Press game control keys like WASD, Space, or Shift during PlayMode, (2) Hold keys down for continuous movement or actions, (3) Combine multiple held keys for complex input like Shift+W for sprint. Injects into Unity Input System (`Keyboard.current`); requires PlayMode and the New Input System."
 context: fork
 ---

--- a/.agents/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-input/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-simulate-mouse-input
+toolName: simulate-mouse-input
 description: "Simulate mouse input in PlayMode for gameplay code that reads Unity Input System Mouse.current. Use when you need to: (1) Click or right-click in games that read Mouse.current button state, (2) Inject mouse delta for FPS camera control, (3) Inject scroll wheel for hotbar switching or zoom. Requires PlayMode and the New Input System; for EventSystem UI elements, use simulate-mouse-ui instead."
 context: fork
 ---

--- a/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-simulate-mouse-ui
+toolName: simulate-mouse-ui
 description: "Simulate mouse click, long-press, and drag on PlayMode UI elements via EventSystem screen coordinates from annotated screenshots. Use when you need to: (1) Click buttons or interactive UI elements during PlayMode testing, (2) Drag UI elements between annotated screen positions, (3) Long-press or hold a drag for sustained pointer interactions. First get target coordinates with `uloop screenshot --capture-mode rendering --annotate-elements --elements-only` and use `AnnotatedElements[].SimX` / `SimY`; for gameplay code that reads Mouse.current, use simulate-mouse-input instead."
 context: fork
 ---

--- a/.claude/skills/uloop-clear-console/SKILL.md
+++ b/.claude/skills/uloop-clear-console/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-clear-console
+toolName: clear-console
 description: "Clear all Unity Console log entries. Use when you need to: (1) Clear console before running tests or compilation, (2) Start a fresh debugging session, (3) Remove noisy logs to isolate specific output."
 ---
 

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-compile
+toolName: compile
 description: "Compile Unity project and report errors/warnings. Use when you need to: (1) Verify code compiles after C# file edits, (2) Check for compile errors before testing, (3) Force full recompilation with Domain Reload. Returns error and warning counts."
 ---
 
@@ -10,7 +11,7 @@ Execute Unity project compilation.
 ## Usage
 
 ```bash
-uloop compile [--force-recompile] [--wait-for-domain-reload]
+uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 ```
 
 ## Parameters
@@ -18,7 +19,7 @@ uloop compile [--force-recompile] [--wait-for-domain-reload]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--force-recompile` | boolean | `false` | Force full recompilation (triggers Domain Reload) |
-| `--wait-for-domain-reload` | boolean | `false` | Wait until Domain Reload completes before returning |
+| `--no-wait-for-domain-reload` | boolean | `false` | Return before Domain Reload completion |
 
 ## Global Options
 
@@ -32,14 +33,11 @@ uloop compile [--force-recompile] [--wait-for-domain-reload]
 # Check compilation
 uloop compile
 
-# Force full recompilation
+# Force full recompilation and wait for Domain Reload completion
 uloop compile --force-recompile
 
-# Force recompilation and wait for Domain Reload completion
-uloop compile --force-recompile --wait-for-domain-reload
-
-# Wait for Domain Reload completion even without force recompilation
-uloop compile --wait-for-domain-reload
+# Start compilation without waiting for Domain Reload completion
+uloop compile --no-wait-for-domain-reload
 ```
 
 ## Output
@@ -53,13 +51,13 @@ Returns JSON:
 
 Diagnose the failure mode before retrying.
 
-**Stale lock files** (CLI hangs or shows "Unity is busy" while Unity Editor *is* running):
+**Stale recovery state** (CLI hangs or shows recovery/startup state while Unity Editor *is* running):
 
 ```bash
 uloop fix
 ```
 
-This removes any leftover lock files (`compiling.lock`, `domainreload.lock`, `serverstarting.lock`) from the Unity project's Temp directory. Then retry `uloop compile`.
+This removes stale Unity CLI Loop readiness state files from the Unity project's Temp directory. Then retry `uloop compile`.
 
 **Unity Editor not running** (CLI returns a connection failure and no Unity process is alive):
 

--- a/.claude/skills/uloop-find-game-objects/SKILL.md
+++ b/.claude/skills/uloop-find-game-objects/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-find-game-objects
+toolName: find-game-objects
 description: "Use first when the user asks about the currently selected GameObject in the Unity Hierarchy. Inspect selected object details with `--search-mode Selected` before using `execute-dynamic-code`. Use when you need to: (1) Get details and component properties for selected GameObject(s), (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Use get-hierarchy when the child tree under the selection is needed. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
 ---
 

--- a/.claude/skills/uloop-get-hierarchy/SKILL.md
+++ b/.claude/skills/uloop-get-hierarchy/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-get-hierarchy
+toolName: get-hierarchy
 description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use this when you need the child tree, parent-child structure, or descendants under selected GameObject(s) with `--use-selection`. Use find-game-objects for selected object details and component properties. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
 ---
 

--- a/.claude/skills/uloop-get-logs/SKILL.md
+++ b/.claude/skills/uloop-get-logs/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-get-logs
+toolName: get-logs
 description: "Retrieve current Unity Console entries via uloop CLI. Use when you need to: (1) inspect errors, warnings, or logs after compile, tests, PlayMode, or dynamic code execution, (2) search current Console messages or stack traces, (3) confirm whether a recent Unity operation emitted logs. Prefer this over reading Editor.log or Unity log files for normal Console contents; use log files only for startup, crash, freeze, or uloop connection failures."
 ---
 

--- a/.claude/skills/uloop-record-input/SKILL.md
+++ b/.claude/skills/uloop-record-input/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-record-input
+toolName: record-input
 description: "Record keyboard and mouse input during PlayMode into a JSON file. Use when you need to: (1) Capture human gameplay input for later replay, (2) Record input sequences for E2E testing, (3) Save input for bug reproduction. Captures Input System device-state diffs frame-by-frame in PlayMode and serializes them to JSON when stopped. Requires PlayMode and the New Input System."
 ---
 

--- a/.claude/skills/uloop-replay-input/SKILL.md
+++ b/.claude/skills/uloop-replay-input/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-replay-input
+toolName: replay-input
 description: "Replay recorded input during PlayMode with frame-precise injection. Use when you need to: (1) Reproduce recorded gameplay exactly, (2) Run E2E tests from recorded input, (3) Generate demo videos with consistent input. Deserializes the JSON recording and pushes captured device states back into Mouse.current / Keyboard.current frame-by-frame in PlayMode. Requires PlayMode and the New Input System."
 ---
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-run-tests
+toolName: run-tests
 description: "Execute Unity Test Runner and get detailed results. Use when you need to: (1) Run EditMode or PlayMode unit tests, (2) Verify code changes pass all tests, (3) Diagnose test failures with error messages and stack traces. Single-flight only — never run multiple `uloop run-tests` in parallel."
 ---
 

--- a/.claude/skills/uloop-screenshot/SKILL.md
+++ b/.claude/skills/uloop-screenshot/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-screenshot
+toolName: screenshot
 description: "Capture screenshots of Unity Editor windows as PNG files. Use when you need to: (1) Screenshot Game View, Scene View, Console, Inspector, or other windows, (2) Capture current visual state for debugging or documentation, (3) Save editor window appearance as PNG files with optional UI element annotations. Writes PNG files via uloop CLI."
 ---
 

--- a/.claude/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.claude/skills/uloop-simulate-keyboard/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-simulate-keyboard
+toolName: simulate-keyboard
 description: "Simulate keyboard key input in PlayMode via Input System. Use when you need to: (1) Press game control keys like WASD, Space, or Shift during PlayMode, (2) Hold keys down for continuous movement or actions, (3) Combine multiple held keys for complex input like Shift+W for sprint. Injects into Unity Input System (`Keyboard.current`); requires PlayMode and the New Input System."
 context: fork
 ---

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-simulate-mouse-input
+toolName: simulate-mouse-input
 description: "Simulate mouse input in PlayMode for gameplay code that reads Unity Input System Mouse.current. Use when you need to: (1) Click or right-click in games that read Mouse.current button state, (2) Inject mouse delta for FPS camera control, (3) Inject scroll wheel for hotbar switching or zoom. Requires PlayMode and the New Input System; for EventSystem UI elements, use simulate-mouse-ui instead."
 context: fork
 ---

--- a/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uloop-simulate-mouse-ui
+toolName: simulate-mouse-ui
 description: "Simulate mouse click, long-press, and drag on PlayMode UI elements via EventSystem screen coordinates from annotated screenshots. Use when you need to: (1) Click buttons or interactive UI elements during PlayMode testing, (2) Drag UI elements between annotated screen positions, (3) Long-press or hold a drag for sustained pointer interactions. First get target coordinates with `uloop screenshot --capture-mode rendering --annotate-elements --elements-only` and use `AnnotatedElements[].SimX` / `SimY`; for gameplay code that reads Mouse.current, use simulate-mouse-input instead."
 context: fork
 ---

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,8 +7,7 @@ early_access: true
 reviews:
   profile: "chill"
   request_changes_workflow: true
-  high_level_summary: true
-  high_level_summary_instructions: "Do not add colors to mermaid diagrams. Use Class diagrams."
+  high_level_summary: false
   poem: false
   auto_review:
     enabled: true


### PR DESCRIPTION
## Summary
- CodeRabbit no longer generates high-level PR summary text that rewrites pull request descriptions.
- Local skill copies now carry updated tool metadata and current command guidance.

## User Impact
- PR authors can keep their PR descriptions intact while CodeRabbit still performs review comments.
- Agents using the local skill files get current `uloop compile` examples and tool metadata.

## Changes
- Disable CodeRabbit high-level summary generation in `.coderabbit.yaml`.
- Refresh generated `.agents` and `.claude` skill markdown copies with `toolName` metadata and updated compile/recovery wording.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml"); puts "ok"'`
- `git diff --check origin/v3-beta...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Configuration Changes

### CodeRabbit Review Settings
Disabled high-level summary generation in `.coderabbit.yaml` by setting `reviews.high_level_summary` to `false`, preventing CodeRabbit from rewriting pull request descriptions while maintaining review comment functionality.

## Skill Documentation Updates

### Metadata Enrichment
Added explicit `toolName` metadata fields across all 12 skill files in both `.agents/skills/` and `.claude/skills/` directories:
- `uloop-clear-console` → `toolName: clear-console`
- `uloop-find-game-objects` → `toolName: find-game-objects`
- `uloop-get-hierarchy` → `toolName: get-hierarchy`
- `uloop-get-logs` → `toolName: get-logs`
- `uloop-record-input` → `toolName: record-input`
- `uloop-replay-input` → `toolName: replay-input`
- `uloop-run-tests` → `toolName: run-tests`
- `uloop-screenshot` → `toolName: screenshot`
- `uloop-simulate-keyboard` → `toolName: simulate-keyboard`
- `uloop-simulate-mouse-input` → `toolName: simulate-mouse-input`
- `uloop-simulate-mouse-ui` → `toolName: simulate-mouse-ui`

### Command Contract Updates (uloop-compile)
Updated both `.agents/skills/uloop-compile/SKILL.md` and `.claude/skills/uloop-compile/SKILL.md`:
- Replaced CLI flag from `--wait-for-domain-reload` to `--no-wait-for-domain-reload` in command usage signature and parameters table
- Added example demonstrating compilation without waiting for domain reload completion
- Updated troubleshooting section from "Stale lock files" to "Stale recovery state" with refreshed description text
- `uloop fix` recovery command remains consistent across updated wording

## Impact
- PR authors' original descriptions are preserved during code review
- Local skill files now provide accurate toolName metadata for agent routing
- Updated compile command guidance reflects current CLI contract and failure-mode handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->