### PR TITLE
fix: Windows CLI install no longer fails during binary verification

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -246,7 +246,7 @@ function Expand-UloopArchive {
     [System.IO.Compression.ZipFile]::ExtractToDirectory($ArchivePath, $DestinationPath)
 }
 
-$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("uloop-install-" + [System.Guid]::NewGuid().ToString("N"))
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("uloop-stage-" + [System.Guid]::NewGuid().ToString("N"))
 $StagedUloopPath = $null
 $LegacyUloopBeforeInstallCommand = Get-Command uloop -ErrorAction SilentlyContinue | Select-Object -First 1
 New-Item -ItemType Directory -Path $TempDir | Out-Null
@@ -265,7 +265,7 @@ try {
     Expand-UloopArchive -ArchivePath $ArchivePath -DestinationPath $TempDir
 
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-    $StagedUloopPath = Join-Path $InstallDir ("uloop-install-" + [System.Guid]::NewGuid().ToString("N") + ".exe")
+    $StagedUloopPath = Join-Path $InstallDir ("uloop-staged-" + [System.Guid]::NewGuid().ToString("N") + ".exe")
     Copy-Item -Path (Join-Path $TempDir "uloop.exe") -Destination $StagedUloopPath -Force
     Assert-UloopVersionSucceeds -UloopPath $StagedUloopPath -Quiet
     $FinalUloopPath = Join-Path $InstallDir "uloop.exe"

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -598,6 +598,11 @@ test_powershell_installer_avoids_optional_archive_cmdlets() {
   assert_not_contains "$ROOT_DIR/scripts/install.ps1" "Expand-Archive"
 }
 
+test_powershell_installer_uses_non_installer_staged_executable_name() {
+  assert_contains "$ROOT_DIR/scripts/install.ps1" '"uloop-staged-"'
+  assert_not_contains "$ROOT_DIR/scripts/install.ps1" '"uloop-install-"'
+}
+
 test_posix_latest_skips_prerelease_assets
 test_posix_latest_beta_selects_prerelease_assets
 test_posix_skips_default_npm_cleanup_when_native_command_is_first
@@ -608,3 +613,4 @@ test_posix_removes_npm_package_before_replacing_same_bin_path
 test_powershell_latest_skips_prerelease_assets
 test_git_bash_latest_installs_windows_zip_asset
 test_powershell_installer_avoids_optional_archive_cmdlets
+test_powershell_installer_uses_non_installer_staged_executable_name


### PR DESCRIPTION
## Summary
- Windows CLI install and update now avoid a staged executable name that Windows can treat as an installer.
- Added focused installer harness coverage so the PowerShell installer keeps using a neutral staged executable name.

## User Impact
- Before, Windows CLI install could fail with `uloop binary verification failed` when the staged executable triggered Windows installer elevation behavior.
- After, binary verification runs under a neutral staged filename, so the install can complete without an unexpected admin prompt.

## Changes
- Rename the PowerShell installer temporary directory prefix to `uloop-stage-`.
- Rename the staged executable prefix from `uloop-install-` to `uloop-staged-`.
- Add a regression check to the installer release-filter harness.

## Verification
- `bash scripts/test-install-release-filter.sh`
- Windows PowerShell parse check for `scripts/install.ps1`
- `pwsh` parse check for `scripts/install.ps1`
- Local `latest-beta` PowerShell install smoke test
- `codex review --base origin/v3-beta`
