### PR TITLE
fix: Busy responses no longer create Unity Console errors

### DIFF
--- a/Assets/Tests/Editor/JsonRpcProcessorCliVersionGateTests.cs
+++ b/Assets/Tests/Editor/JsonRpcProcessorCliVersionGateTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -108,10 +107,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
                 Assert.That(dispatcher.PendingContinuationCount, Is.EqualTo(1));
 
-                LogAssert.Expect(
-                    LogType.Error,
-                    new Regex("\\[JsonRpcProcessor\\] Error: Unity tool execution is busy running 'single-flight-test'"));
-
                 secondResponseTask = JsonRpcProcessor.ProcessRequestWithEarlyResponseAsync(
                     BuildToolRequest(SingleFlightTestTool.Name, 2),
                     CancellationToken.None,
@@ -123,6 +118,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Assert.That(data["type"]?.ToString(), Is.EqualTo("server_busy"));
                 Assert.That(data["runningToolName"]?.ToString(), Is.EqualTo(SingleFlightTestTool.Name));
                 Assert.That(data["requestedToolName"]?.ToString(), Is.EqualTo(SingleFlightTestTool.Name));
+                LogAssert.NoUnexpectedReceived();
             }
             finally
             {
@@ -171,10 +167,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Assert.That(dispatcher.PendingContinuationCount, Is.EqualTo(2));
                 Assert.That(secondDynamicCodeTask.IsCompleted, Is.False);
 
-                LogAssert.Expect(
-                    LogType.Error,
-                    new Regex("\\[JsonRpcProcessor\\] Error: Unity tool execution is busy running 'execute-dynamic-code'"));
-
                 otherToolTask = JsonRpcProcessor.ProcessRequestWithEarlyResponseAsync(
                     BuildToolRequest(SingleFlightTestTool.Name, 3),
                     CancellationToken.None,
@@ -186,6 +178,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Assert.That(data["type"]?.ToString(), Is.EqualTo("server_busy"));
                 Assert.That(data["runningToolName"]?.ToString(), Is.EqualTo(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE));
                 Assert.That(data["requestedToolName"]?.ToString(), Is.EqualTo(SingleFlightTestTool.Name));
+                LogAssert.NoUnexpectedReceived();
             }
             finally
             {

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcProcessor.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcProcessor.cs
@@ -191,9 +191,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
             catch (Exception ex) when (!(ex is OperationCanceledException))
             {
-                UnityEngine.Debug.LogError($"[JsonRpcProcessor] Error: {ex.Message}\nStack trace: {ex.StackTrace}");
+                LogRpcExceptionIfNeeded(ex);
                 return CreateErrorResponse(request.Id, ex);
             }
+        }
+
+        private static void LogRpcExceptionIfNeeded(Exception ex)
+        {
+            if (ex is UnityCliLoopToolBusyException)
+            {
+                return;
+            }
+
+            UnityEngine.Debug.LogError($"[JsonRpcProcessor] Error: {ex.Message}\nStack trace: {ex.StackTrace}");
         }
 
         private static bool IsCliUpdateRequired(string currentCliVersion)


### PR DESCRIPTION
## Summary
- Expected busy responses now return through the command result without adding Unity Console errors.
- Existing JSON-RPC server_busy payloads remain unchanged so CLI clients can keep treating them as retryable.

## User Impact
- When another command arrives while Unity is already running a command, users still receive the busy response.
- The Unity Console no longer shows an error for this expected single-flight rejection, so real Editor errors are easier to notice.

## Changes
- Skip Unity Console error logging for UnityCliLoopToolBusyException in the JSON-RPC request path.
- Update busy-response coverage to assert the server_busy payload and no unexpected Console log output.

## Verification
- Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path /Users/a12115/ghq/hatayama/unity-cli-loop
- Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value JsonRpcProcessorCliVersionGateTests --project-path /Users/a12115/ghq/hatayama/unity-cli-loop
- Packages/src/Cli~/dist/darwin-arm64/uloop get-logs --log-type Error --max-count 10 --project-path /Users/a12115/ghq/hatayama/unity-cli-loop
- ~/.codex/skills/codex-review/scripts/codex-review v3-beta