### PR TITLE
fix: Make bundled skill guidance more concise

### DIFF
--- a/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-focus-window/Skill/SKILL.md
+++ b/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-focus-window/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-focus-window
-description: "Bring Unity Editor window to front via uloop CLI. Use when you need to: (1) Focus Unity Editor before capturing screenshots, (2) Ensure Unity window is visible for visual checks, (3) Bring Unity to foreground for user interaction."
+description: "Bring the Unity Editor window to front. Use when Unity must be visible for visual checks or user-facing interaction."
 ---
 
 # uloop focus-window

--- a/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
+++ b/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-launch
-description: "Launch Unity project with matching Editor version via uloop CLI. Use when you need to: (1) Open a Unity project with the correct Editor version, (2) Restart Unity to apply changes, (3) Switch build target when launching."
+description: "Launch or restart Unity Editor. Use when Unity needs to be opened or restarted."
 ---
 
 # uloop launch

--- a/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
+++ b/Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-launch
-description: "Launch or restart Unity Editor. Use when Unity needs to be opened or restarted."
+description: "Use when Unity Editor is not running or needs a clean restart."
 ---
 
 # uloop launch

--- a/Packages/src/Editor/Api/McpTools/ClearConsole/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ClearConsole/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-clear-console
-description: "Clear all Unity Console log entries. Use when you need to: (1) Clear console before running tests or compilation, (2) Start a fresh debugging session, (3) Remove noisy logs to isolate specific output."
+description: "Clear Unity Console entries. Use before compile, tests, or debugging when stale logs would hide the current result."
 ---
 
 # uloop clear-console

--- a/Packages/src/Editor/Api/McpTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Compile/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-compile
-description: "Compile Unity project and report errors/warnings. Use when you need to: (1) Verify code compiles after C# file edits, (2) Check for compile errors before testing, (3) Force full recompilation with Domain Reload. Returns error and warning counts."
+description: "Compile the Unity project and report errors/warnings. Use after C# edits or when a full Domain Reload compile is needed."
 ---
 
 # uloop compile

--- a/Packages/src/Editor/Api/McpTools/ControlPlayMode/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ControlPlayMode/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-control-play-mode
-description: "Control Unity Editor play mode (play/stop/pause). Use when you need to: (1) Start play mode to test game behavior, (2) Stop play mode to return to edit mode, (3) Pause play mode for frame-by-frame inspection."
+description: "Control Unity Editor Play Mode. Use to start, stop, or pause Play Mode for runtime behavior checks and frame inspection."
 ---
 
 # uloop control-play-mode

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-execute-dynamic-code
-description: "Execute C# code dynamically in Unity Editor. Use find-game-objects first for basic selected GameObject discovery or property inspection. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) Execute Unity Editor menu commands through EditorApplication.ExecuteMenuItem, (5) PlayMode automation (click buttons, invoke methods, tweak runtime state), (6) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (7) PlayMode inspection that requires custom Unity API code beyond existing tools. NOT for file I/O or script authoring."
+description: "Execute C# with Unity APIs when existing uloop tools cannot inspect or edit enough. Use for scene, prefab, SerializedObject, AssetDatabase refresh/.meta generation, menu, or PlayMode automation."
 context: fork
 ---
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/asset-operations.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/asset-operations.md
@@ -184,6 +184,8 @@ return $"Asset has {dependencies.Length} dependencies";
 
 ## Refresh AssetDatabase
 
+Use this after terminal-based asset file changes when Unity needs to import them and generate `.meta` files.
+
 ```csharp
 using UnityEditor;
 

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -177,7 +177,7 @@ Use `find-game-objects` to discover buttons with their hierarchy paths, then cli
 **Step 1**: Find all GameObjects with Button component
 
 ```powershell
-uloop find-game-objects --required-components UnityEngine.UI.Button --include-inactive false
+uloop find-game-objects --required-components UnityEngine.UI.Button
 ```
 
 **Step 2**: Click the target button using the path from Step 1
@@ -203,7 +203,7 @@ Use `get-hierarchy` to explore the UI tree structure, then target the right elem
 **Step 1**: Get Canvas hierarchy to understand UI structure
 
 ```powershell
-uloop get-hierarchy --root-path 'Canvas' --max-depth 3 --include-components true
+uloop get-hierarchy --root-path 'Canvas' --max-depth 3
 ```
 
 **Step 2**: Based on the hierarchy JSON, click the desired button

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
@@ -146,7 +146,7 @@ Use `find-game-objects` to discover buttons with their hierarchy paths, then cli
 **Step 1**: Find all GameObjects with Button component
 
 ```zsh
-uloop find-game-objects --required-components UnityEngine.UI.Button --include-inactive false
+uloop find-game-objects --required-components UnityEngine.UI.Button
 ```
 
 **Step 2**: Click the target button using the path from Step 1
@@ -172,7 +172,7 @@ Use `get-hierarchy` to explore the UI tree structure, then target the right elem
 **Step 1**: Get Canvas hierarchy to understand UI structure
 
 ```zsh
-uloop get-hierarchy --root-path "Canvas" --max-depth 3 --include-components true
+uloop get-hierarchy --root-path "Canvas" --max-depth 3
 ```
 
 **Step 2**: Based on the hierarchy JSON, click the desired button

--- a/Packages/src/Editor/Api/McpTools/FindGameObjects/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/FindGameObjects/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-find-game-objects
-description: "Use first when the user asks about the currently selected GameObject in the Unity Hierarchy. Inspect selected object details with `--search-mode Selected` before using `execute-dynamic-code`. Use when you need to: (1) Get details and component properties for selected GameObject(s), (2) Search for objects by name, regex, or path, (3) Find objects with specific components, tags, or layers. Use get-hierarchy when the child tree under the selection is needed. Returns hierarchy paths, active state, tags, layers, and components (or writes to a file when multiple GameObjects are selected)."
+description: "Find or inspect Unity GameObjects, especially objects the user currently selected in the Hierarchy. Use for details, components, tags, layers, or name/path searches."
 ---
 
 # uloop find-game-objects

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-hierarchy
-description: "Get Unity scene hierarchy as a structured tree from all roots, a root path, or the current Hierarchy selection. Use this when you need the child tree, parent-child structure, or descendants under selected GameObject(s) with `--use-selection`. Use find-game-objects for selected object details and component properties. Hierarchy data is written to a JSON file on disk and the response returns the file path (not the tree inline) — open the file to read the structure."
+description: "Get the Unity scene hierarchy as a structured tree. Use for parent-child structure, descendants, roots, or subtrees under objects the user currently selected."
 ---
 
 # uloop get-hierarchy

--- a/Packages/src/Editor/Api/McpTools/GetLogs/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/GetLogs/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-get-logs
-description: "Retrieve current Unity Console entries via uloop CLI. Use when you need to: (1) inspect errors, warnings, or logs after compile, tests, PlayMode, or dynamic code execution, (2) search current Console messages or stack traces, (3) confirm whether a recent Unity operation emitted logs. Prefer this over reading Editor.log or Unity log files for normal Console contents; use log files only for startup, crash, freeze, or uloop connection failures."
+description: "Read current Unity Console entries from a running Editor. Use during bug investigation after compile, tests, PlayMode, or dynamic code to inspect logs, warnings, errors, and stack traces."
 ---
 
 # uloop get-logs

--- a/Packages/src/Editor/Api/McpTools/RecordInput/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/RecordInput/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-record-input
-description: "Record keyboard and mouse input during PlayMode into a JSON file. Use when you need to: (1) Capture human gameplay input for later replay, (2) Record input sequences for E2E testing, (3) Save input for bug reproduction. Captures Input System device-state diffs frame-by-frame in PlayMode and serializes them to JSON when stopped. Requires PlayMode and the New Input System."
+description: "Record PlayMode keyboard and mouse input to JSON. Use to capture gameplay, bug repro, or E2E input sequences for replay."
 ---
 
 # uloop record-input
@@ -39,7 +39,7 @@ Replay injects input frame-by-frame, so the game must also be deterministic to p
 
 - Unity must be in **PlayMode**
 - **Input System package** must be installed (`com.unity.inputsystem`)
-- Active Input Handling must be set to `Input System Package (New)` or `Both` in Player Settings
+- Use this only when the project already uses the New Input System.
 
 ## Output
 

--- a/Packages/src/Editor/Api/McpTools/ReplayInput/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ReplayInput/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-replay-input
-description: "Replay recorded input during PlayMode with frame-precise injection. Use when you need to: (1) Reproduce recorded gameplay exactly, (2) Run E2E tests from recorded input, (3) Generate demo videos with consistent input. Deserializes the JSON recording and pushes captured device states back into Mouse.current / Keyboard.current frame-by-frame in PlayMode. Requires PlayMode and the New Input System."
+description: "Replay recorded PlayMode keyboard and mouse input. Use for exact gameplay reproduction, E2E runs, or consistent demos from JSON recordings."
 ---
 
 # uloop replay-input
@@ -38,6 +38,12 @@ uloop replay-input --action Stop
 ## Deterministic Replay
 
 Replay injects the exact same input frame-by-frame, but the game must also be deterministic to produce identical results. If replay output must be compared across runs, read [references/deterministic-replay.md](references/deterministic-replay.md) before interpreting failures.
+
+## Prerequisites
+
+- Unity must be in **PlayMode**
+- **Input System package** must be installed (`com.unity.inputsystem`)
+- Use this only when the project already uses the New Input System.
 
 ## Output
 

--- a/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-run-tests
-description: "Execute Unity Test Runner and get detailed results. Use when you need to: (1) Run EditMode or PlayMode unit tests, (2) Verify code changes pass all tests, (3) Diagnose test failures with error messages and stack traces. Single-flight only — never run multiple `uloop run-tests` in parallel."
+description: "Run Unity Test Runner and report detailed results. Use for EditMode/PlayMode tests, change verification, or failure diagnosis."
 ---
 
 # uloop run-tests

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-screenshot
-description: "Capture screenshots of Unity Editor windows as PNG files. Use when you need to: (1) Screenshot Game View, Scene View, Console, Inspector, or other windows, (2) Capture current visual state for debugging or documentation, (3) Save editor window appearance as PNG files with optional UI element annotations. Writes PNG files via uloop CLI."
+description: "Capture Unity Editor windows or Game View rendering as PNG. Use for visual checks, debugging, documentation, or annotated UI element coordinates."
 ---
 
 # uloop screenshot

--- a/Packages/src/Editor/Api/McpTools/SimulateKeyboard/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/SimulateKeyboard/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-simulate-keyboard
-description: "Simulate keyboard key input in PlayMode via Input System. Use when you need to: (1) Press game control keys like WASD, Space, or Shift during PlayMode, (2) Hold keys down for continuous movement or actions, (3) Combine multiple held keys for complex input like Shift+W for sprint. Injects into Unity Input System (`Keyboard.current`); requires PlayMode and the New Input System."
+description: "Simulate keyboard input in PlayMode through Unity Input System. Use for key presses, holds, releases, and game controls such as WASD or Space."
 context: fork
 ---
 
@@ -82,6 +82,6 @@ Returns JSON with:
 ## Prerequisites
 
 - Unity must be in **PlayMode**
-- **Input System package** (`com.unity.inputsystem`) must be installed
-- Active Input Handling must be set to **Input System Package (New)** or **Both** in Player Settings
+- **Input System package** must be installed (`com.unity.inputsystem`)
+- Use this only when the project already uses the New Input System.
 - Game code must read input via Input System API (e.g. `Keyboard.current[Key.W].isPressed`), not legacy `Input.GetKey()`

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseInput/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-simulate-mouse-input
-description: "Simulate mouse input in PlayMode for gameplay code that reads Unity Input System Mouse.current. Use when you need to: (1) Click or right-click in games that read Mouse.current button state, (2) Inject mouse delta for FPS camera control, (3) Inject scroll wheel for hotbar switching or zoom. Requires PlayMode and the New Input System; for EventSystem UI elements, use simulate-mouse-ui instead."
+description: "Simulate Mouse.current input in PlayMode through Unity Input System. Use for gameplay clicks, mouse delta, or scroll; use simulate-mouse-ui for EventSystem UI elements."
 context: fork
 ---
 
@@ -58,7 +58,7 @@ uloop simulate-mouse-input --action <action> [options]
 | Scenario | Tool |
 |----------|------|
 | Click a Unity UI Button (IPointerClickHandler) | `simulate-mouse-ui` |
-| Destroy a block in Minecraft (reads `Mouse.current.leftButton`) | `simulate-mouse-input` when the project uses the New Input System; otherwise prefer `execute-dynamic-code` for a project-specific workaround |
+| Destroy a block in Minecraft (reads `Mouse.current.leftButton`) | `simulate-mouse-input` when the project uses the New Input System |
 | Place a block with right-click | `simulate-mouse-input --button Right` when the project uses the New Input System |
 | Drag a UI slider | `simulate-mouse-ui --action Drag` |
 | Look around with mouse (FPS camera) | `simulate-mouse-input --action MoveDelta` when the project uses the New Input System |
@@ -94,7 +94,7 @@ uloop simulate-mouse-input --action SmoothDelta --delta-x 300 --delta-y 0 --dura
 - Unity must be in **PlayMode**
 - **Input System package** must be installed (`com.unity.inputsystem`)
 - Game code must read input via Input System API (e.g. `Mouse.current.leftButton.wasPressedThisFrame`)
-- If the target project cannot use the New Input System, prefer `execute-dynamic-code` for a project-specific workaround instead of changing project settings just to use this tool
+- Use this only when the project already uses the New Input System.
 
 ## Output
 

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-simulate-mouse-ui
-description: "Simulate mouse click, long-press, and drag on PlayMode UI elements via EventSystem screen coordinates from annotated screenshots. Use when you need to: (1) Click buttons or interactive UI elements during PlayMode testing, (2) Drag UI elements between annotated screen positions, (3) Long-press or hold a drag for sustained pointer interactions. First get target coordinates with `uloop screenshot --capture-mode rendering --annotate-elements --elements-only` and use `AnnotatedElements[].SimX` / `SimY`; for gameplay code that reads Mouse.current, use simulate-mouse-input instead."
+description: "Simulate PlayMode EventSystem UI mouse actions using screen coordinates. Use for UI clicks, long-presses, or drags from annotated screenshots."
 context: fork
 ---
 


### PR DESCRIPTION
## Summary
- Shorten bundled uloop skill descriptions so agents see concise routing guidance.
- Soften Input System prerequisites so skills describe when to use the tools instead of telling users to change Player Settings.

## User Impact
- Agents reading the source skill definitions get clearer, less prescriptive guidance when choosing uloop commands.
- Input recording and simulation guidance now points agents toward projects that already use the New Input System, avoiding advice that could sound like a required project setting change.

## Changes
- Port concise v3-beta descriptions into the v2 source SKILL.md files.
- Align ExecuteDynamicCode reference examples and AssetDatabase refresh guidance with v3-beta.
- Keep generated .claude, .agents, and .codex copies out of this PR; they can be regenerated separately.

## Verification
- npm --prefix Packages/src/Cli~ run build
- npm --prefix Packages/src/Cli~ run test:cli -- --runTestsByPath src/__tests__/skills-manager.test.ts src/__tests__/skills-command.test.ts
- git diff --check
- Checked that the final diff contains only source skill definition files and no generated skill copies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR shortens and refines bundled uloop skill descriptions across source SKILL.md files to give agents more concise, actionable routing guidance and to soften prescriptive language around Input System prerequisites.

## Key Changes

- Shortened descriptions across multiple skills to be more concise and action-focused.
- Ports concise v3-beta wording into v2 source SKILL.md files.
- Softened Input System prerequisites: RecordInput, ReplayInput, SimulateKeyboard, and SimulateMouseInput now instruct agents to use those tools only when a project already uses the New Input System instead of recommending Player Settings changes.
- ExecuteDynamicCode docs aligned with v3-beta:
  - Clarified AssetDatabase refresh guidance (asset-operations.md).
  - Simplified PlayMode automation examples in PowerShell and zsh by removing explicit default flags (--include-inactive false, --include-components true).

## Files Modified (source SKILL.md only)

- Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-focus-window/Skill/SKILL.md
- Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
- Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-get-version/Skill/SKILL.md
- Packages/src/Cli~/src/skills/skill-definitions/cli-only/uloop-get-project-info/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/ClearConsole/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/Compile/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/ControlPlayMode/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/asset-operations.md
- Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
- Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/references/playmode-automation-zsh.md
- Packages/src/Editor/Api/McpTools/FindGameObjects/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/GetHierarchy/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/GetLogs/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/RecordInput/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/ReplayInput/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/RunTests/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/SimulateKeyboard/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/SimulateMouseInput/Skill/SKILL.md
- Packages/src/Editor/Api/McpTools/SimulateMouseUi/Skill/SKILL.md

## User Impact

- Agents reading source skill definitions receive clearer, less prescriptive guidance for choosing uloop commands.
- Input recording and simulation guidance now directs agents toward projects that already use the New Input System rather than implying required project setting changes.

## Verification

- Build and tests run: npm --prefix Packages/src/Cli~ run build; npm --prefix Packages/src/Cli~ run test:cli -- --runTestsByPath src/__tests__/skills-manager.test.ts src/__tests__/skills-command.test.ts
- Performed git diff --check and confirmed final diff contains only source skill definition files (no generated .claude/.agents/.codex copies).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hatayama/unity-cli-loop/pull/1178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->