### PR TITLE
fix: Startup no longer freezes during migration checks

### DIFF
--- a/Assets/Tests/Demo/Editor/uLoopMCP.Tests.Demo.Editor.asmdef
+++ b/Assets/Tests/Demo/Editor/uLoopMCP.Tests.Demo.Editor.asmdef
@@ -25,8 +25,10 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.inputsystem",

--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -123,6 +123,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void DemoEditorAsmdef_WhenLoaded_RequiresUnityIncludeTestsAndManualReference()
+        {
+            // Tests that demo editor startup hooks stay out of normal Editor startup.
+            string relativeAsmdefPath = "Assets/Tests/Demo/Editor/uLoopMCP.Tests.Demo.Editor.asmdef";
+            string[] defineConstraints = ReadDefineConstraints(relativeAsmdefPath);
+            bool autoReferenced = ReadAutoReferenced(relativeAsmdefPath);
+
+            Assert.That(defineConstraints, Does.Contain("UNITY_INCLUDE_TESTS"));
+            Assert.That(autoReferenced, Is.False);
+        }
+
+        [Test]
         public void CompilationDiagnosticMessageParser_WhenLoaded_CompilesUnderDomainAssembly()
         {
             // Tests that first-party dynamic-code parsing stays inside the bundled tool assembly.
@@ -1239,6 +1251,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             JObject asmdef = JObject.Parse(File.ReadAllText(asmdefPath));
             string[] defineConstraints = asmdef["defineConstraints"]?.Values<string>().ToArray() ?? new string[0];
             return defineConstraints.Contains("UNITY_INCLUDE_TESTS");
+        }
+
+        private static string[] ReadDefineConstraints(string relativeAsmdefPath)
+        {
+            string asmdefPath = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), relativeAsmdefPath);
+            JObject asmdef = JObject.Parse(File.ReadAllText(asmdefPath));
+            return asmdef["defineConstraints"]?.Values<string>().ToArray() ?? new string[0];
+        }
+
+        private static bool ReadAutoReferenced(string relativeAsmdefPath)
+        {
+            string asmdefPath = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), relativeAsmdefPath);
+            JObject asmdef = JObject.Parse(File.ReadAllText(asmdefPath));
+            return asmdef["autoReferenced"]?.Value<bool>() ?? true;
         }
 
         private static string[] ReadProductionAsmdefPaths()

--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -893,14 +893,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void MigrationWizardStartup_WhenLoaded_SchedulesTargetCheckInsteadOfPreviewingSynchronously()
+        public void MigrationWizardStartup_WhenLoaded_DoesNotScheduleTargetCheckOnEditorStartup()
         {
-            // Tests that migration target detection does not block the synchronous Editor startup hook.
+            // Tests that startup can open the migration window without scanning the project first.
+            string presentationStartupSource = ReadProductionSource(
+                "Packages/src/Editor/Presentation/PresentationEditorStartup.cs");
             string migrationWizardSource = ReadProductionSource(
                 "Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs");
 
-            Assert.That(migrationWizardSource, Does.Contain("EditorApplication.delayCall += TryShowOnMigrationTargets;"));
-            Assert.That(migrationWizardSource, Does.Not.Contain("\n            TryShowOnMigrationTargets();"));
+            Assert.That(
+                presentationStartupSource,
+                Does.Contain("ThirdPartyToolMigrationWizardWindow.InitializeEditorServices(sessionStateService);"));
+            Assert.That(
+                presentationStartupSource,
+                Does.Not.Contain("ThirdPartyToolMigrationWizardWindow.InitializeForEditorStartup"));
+            Assert.That(migrationWizardSource, Does.Not.Contain("TryShowOnMigrationTargets"));
+            Assert.That(migrationWizardSource, Does.Not.Contain("ShouldAutoShowForMigrationTargets"));
+            Assert.That(migrationWizardSource, Does.Not.Contain("EditorApplication.delayCall += TryShowOnMigrationTargets"));
+            Assert.That(migrationWizardSource, Does.Not.Contain("ripgrep"));
+            Assert.That(migrationWizardSource, Does.Not.Contain("\"rg\""));
         }
 
         [Test]

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -26,6 +26,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private string _settingsFileContent;
         private UnityCliLoopEditorSettingsService _editorSettingsService;
         private UnityCliLoopEditorSettingsRepository _editorSettingsRepository;
+        private UnityCliLoopEditorSessionStateService _sessionStateService;
+        private UnityCliLoopEditorSessionStateSnapshot _originalSessionState;
 
         [SetUp]
         public void SetUp()
@@ -41,7 +43,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             DeleteIfExists(SettingsFilePath);
             _editorSettingsService =
                 UnityCliLoopEditorSettingsTestFactory.CreateServiceWithRepository(out _editorSettingsRepository);
-            SetupWizardWindow.InitializeEditorServices(_editorSettingsService);
+            _sessionStateService = UnityCliLoopEditorSessionStateTestFactory.CreateService();
+            _originalSessionState = UnityCliLoopEditorSessionStateTestFactory.CaptureSnapshot(_sessionStateService);
+            _sessionStateService.ClearAll();
+            SetupWizardWindow.InitializeEditorServices(_editorSettingsService, _sessionStateService);
             _editorSettingsRepository.InvalidateCache();
         }
 
@@ -50,6 +55,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             RestoreFile(SettingsFilePath, _settingsFileExisted, _settingsFileContent);
             _editorSettingsRepository.InvalidateCache();
+            _originalSessionState.Restore(_sessionStateService);
         }
 
         [TestCase("", "1.7.3", false, true)]
@@ -71,6 +77,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     suppressAutoShow);
 
             Assert.That(shouldAutoShow, Is.EqualTo(expected));
+        }
+
+        [TestCase("2.1.1", "3.0.0-beta.7", true)]
+        [TestCase("1.9.0", "3.0.0", true)]
+        [TestCase("", "3.0.0-beta.7", false)]
+        [TestCase("3.0.0-beta.6", "3.0.0-beta.7", false)]
+        [TestCase("3.0.0-beta.7", "4.0.0", false)]
+        [TestCase("not-a-version", "3.0.0-beta.7", false)]
+        public void ShouldAutoScanThirdPartyToolMigration_ReturnsExpectedValue(
+            string lastSeenVersion,
+            string currentVersion,
+            bool expected)
+        {
+            // Verifies that only V2-or-older to V3 package upgrades request the migration scan.
+            bool shouldAutoScan =
+                SetupWizardWindow.ShouldAutoScanThirdPartyToolMigration(currentVersion, lastSeenVersion);
+
+            Assert.That(shouldAutoScan, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void MaybeMarkThirdPartyToolMigrationAutoScan_WhenEnabled_SetsSessionFlag()
+        {
+            // Verifies that the V2-to-V3 upgrade signal is stored only in the current Editor session.
+            SetupWizardWindow.MaybeMarkThirdPartyToolMigrationAutoScan(true);
+
+            Assert.That(_sessionStateService.GetShouldAutoScanThirdPartyToolMigration(), Is.True);
+        }
+
+        [Test]
+        public void MaybeMarkThirdPartyToolMigrationAutoScan_WhenDisabled_KeepsSessionFlagFalse()
+        {
+            // Verifies that non-upgrade version checks do not request migration scans.
+            SetupWizardWindow.MaybeMarkThirdPartyToolMigrationAutoScan(false);
+
+            Assert.That(_sessionStateService.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -52,6 +52,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void ThirdPartyToolMigrationSourceFileCache_WhenFileIsReadTwice_UsesCachedSource()
+        {
+            // Verifies that async preview phases can reuse source text without repeated disk reads.
+            int readCount = 0;
+            ThirdPartyToolMigrationSourceFileCache cache = new(filePath =>
+            {
+                readCount++;
+                return $"source:{filePath}";
+            });
+
+            string firstSource = cache.ReadAllText("Assets/VendorTools/HelloTool.cs");
+            string secondSource = cache.ReadAllText("Assets/VendorTools/HelloTool.cs");
+
+            Assert.That(firstSource, Is.EqualTo("source:Assets/VendorTools/HelloTool.cs"));
+            Assert.That(secondSource, Is.EqualTo(firstSource));
+            Assert.That(readCount, Is.EqualTo(1));
+        }
+
+        [Test]
         public void TryReadJsonObjectForMigration_WhenReadThrowsIOException_ReturnsFalse()
         {
             // Verifies that migration scans skip unreadable assembly JSON files.

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -62,20 +62,50 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Is.EqualTo("Scanning project for V3 custom tool migration...\n3/12 checks complete."));
         }
 
-        [TestCase(false, true, "Migrate")]
-        [TestCase(true, true, "Migrating...")]
-        [TestCase(false, false, "Nothing to migrate")]
+        [TestCase(false, false, false, "Check required")]
+        [TestCase(false, true, true, "Migrate")]
+        [TestCase(true, true, true, "Migrating...")]
+        [TestCase(false, false, true, "Nothing to migrate")]
         public void GetMigrationButtonText_ReturnsExpectedLabel(
             bool isMigrating,
             bool hasMigrationTargets,
+            bool hasCheckedMigrationStatus,
             string expectedLabel)
         {
             // Verifies that the migration action communicates its current state.
             string label = ThirdPartyToolMigrationWizardWindow.GetMigrationButtonText(
                 isMigrating,
-                hasMigrationTargets);
+                hasMigrationTargets,
+                hasCheckedMigrationStatus);
 
             Assert.That(label, Is.EqualTo(expectedLabel));
+        }
+
+        [TestCase(0, 1, 1, 4, 1000, 100, true)]
+        [TestCase(10, 50, 1, 4, 1000, 100, false)]
+        [TestCase(10, 110, 1, 4, 1000, 100, true)]
+        [TestCase(10, 11, 4, 4, 1000, 100, true)]
+        public void ShouldReportMigrationProgress_ReturnsExpectedValue(
+            long lastReportTimestamp,
+            long currentTimestamp,
+            int processedItemCount,
+            int totalItemCount,
+            long stopwatchFrequency,
+            int updateIntervalMilliseconds,
+            bool expected)
+        {
+            // Verifies that migration progress updates are throttled while still reporting completion.
+            ThirdPartyToolMigrationProgress progress =
+                new(processedItemCount, totalItemCount);
+
+            bool shouldReport = ThirdPartyToolMigrationWizardWindow.ShouldReportMigrationProgress(
+                lastReportTimestamp,
+                currentTimestamp,
+                progress,
+                stopwatchFrequency,
+                updateIntervalMilliseconds);
+
+            Assert.That(shouldReport, Is.EqualTo(expected));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -12,17 +12,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public sealed class ThirdPartyToolMigrationWizardWindowTests
     {
-        [TestCase(true, true)]
-        [TestCase(false, false)]
-        public void ShouldAutoShowForMigrationTargets_ReturnsDetectionResult(
-            bool hasMigrationTargets,
+        [TestCase(false, true, false)]
+        [TestCase(true, false, false)]
+        [TestCase(true, true, true)]
+        public void ShouldStartInitialRefresh_ReturnsExpectedValue(
+            bool shouldRefreshAfterCreateGui,
+            bool shouldAutoScanThirdPartyToolMigration,
             bool expected)
         {
-            // Verifies that migration startup is controlled only by migration target detection.
-            bool shouldAutoShow =
-                ThirdPartyToolMigrationWizardWindow.ShouldAutoShowForMigrationTargets(hasMigrationTargets);
+            // Verifies that automatic scanning requires both auto-open intent and the session scan flag.
+            bool shouldStartInitialRefresh =
+                ThirdPartyToolMigrationWizardWindow.ShouldStartInitialRefresh(
+                    shouldRefreshAfterCreateGui,
+                    shouldAutoScanThirdPartyToolMigration);
 
-            Assert.That(shouldAutoShow, Is.EqualTo(expected));
+            Assert.That(shouldStartInitialRefresh, Is.EqualTo(expected));
         }
 
         [TestCase(
@@ -77,7 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void PrepareForOpen_PopulatesWindowStateBeforeShowing()
         {
-            // Verifies that startup-created migration windows can preview immediately after CreateGUI.
+            // Verifies that auto-opened migration windows can request an initial session-gated scan.
             ThirdPartyToolMigrationWizardWindow window =
                 ScriptableObject.CreateInstance<ThirdPartyToolMigrationWizardWindow>();
             try
@@ -99,6 +103,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Assert.That(window.minSize, Is.EqualTo(new Vector2(360f, 120f)));
                 Assert.That(refreshProperty, Is.Not.Null);
                 Assert.That(refreshProperty.boolValue, Is.True);
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+
+        [Test]
+        public void PrepareForOpen_WhenManualOpen_PopulatesWindowStateWithoutInitialRefresh()
+        {
+            // Verifies that manually opened migration windows wait for the Check button.
+            ThirdPartyToolMigrationWizardWindow window =
+                ScriptableObject.CreateInstance<ThirdPartyToolMigrationWizardWindow>();
+            try
+            {
+                Rect position = new(12f, 34f, 360f, 220f);
+
+                ThirdPartyToolMigrationWizardWindow.PrepareForOpen(
+                    window,
+                    "Unity CLI Loop Migration",
+                    position,
+                    false);
+
+                SerializedObject serializedWindow = new(window);
+                SerializedProperty refreshProperty =
+                    serializedWindow.FindProperty("_shouldRefreshAfterCreateGui");
+
+                Assert.That(window.titleContent.text, Is.EqualTo("Unity CLI Loop Migration"));
+                Assert.That(window.position, Is.EqualTo(position));
+                Assert.That(window.minSize, Is.EqualTo(new Vector2(360f, 120f)));
+                Assert.That(refreshProperty, Is.Not.Null);
+                Assert.That(refreshProperty.boolValue, Is.False);
             }
             finally
             {

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -108,6 +108,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(shouldReport, Is.EqualTo(expected));
         }
 
+        [TestCase(false, true, true)]
+        [TestCase(true, true, false)]
+        [TestCase(false, false, false)]
+        public void ShouldApplyMigrationProgress_ReturnsExpectedValue(
+            bool isCancellationRequested,
+            bool hasActivePreview,
+            bool expected)
+        {
+            // Verifies that stale migration progress cannot overwrite a rendered preview result.
+            bool shouldApply = ThirdPartyToolMigrationWizardWindow.ShouldApplyMigrationProgress(
+                isCancellationRequested,
+                hasActivePreview);
+
+            Assert.That(shouldApply, Is.EqualTo(expected));
+        }
+
         [Test]
         public void PrepareForOpen_PopulatesWindowStateBeforeShowing()
         {

--- a/Assets/Tests/Editor/UnityCliLoopEditorSessionStateRepositoryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSessionStateRepositoryTests.cs
@@ -37,6 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(_sessionStateService.GetIsReconnecting(), Is.False);
             Assert.That(_sessionStateService.GetShowReconnectingUI(), Is.False);
             Assert.That(_sessionStateService.GetShowPostCompileReconnectingUI(), Is.False);
+            Assert.That(_sessionStateService.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
         }
 
         [Test]
@@ -57,10 +58,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void GetShouldAutoScanThirdPartyToolMigration_WhenServiceIsRecreated_ReadsExistingSessionValue()
+        {
+            // Verifies that the one-session migration scan request survives Domain Reload service recreation.
+            _sessionStateService.SetShouldAutoScanThirdPartyToolMigration(true);
+
+            UnityCliLoopEditorSessionStateService recreatedService =
+                UnityCliLoopEditorSessionStateTestFactory.CreateService();
+
+            Assert.That(recreatedService.GetShouldAutoScanThirdPartyToolMigration(), Is.True);
+        }
+
+        [Test]
+        public void ConsumeShouldAutoScanThirdPartyToolMigration_WhenFlagIsSet_ReturnsTrueOnce()
+        {
+            // Verifies that the startup migration scan request is consumed exactly once.
+            _sessionStateService.SetShouldAutoScanThirdPartyToolMigration(true);
+
+            bool firstConsume = _sessionStateService.ConsumeShouldAutoScanThirdPartyToolMigration();
+            bool secondConsume = _sessionStateService.ConsumeShouldAutoScanThirdPartyToolMigration();
+
+            Assert.That(firstConsume, Is.True);
+            Assert.That(secondConsume, Is.False);
+            Assert.That(_sessionStateService.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
+        }
+
+        [Test]
         public void ClearAll_WhenFlagsAreSet_ClearsEveryTransientFlag()
         {
             // Verifies that test and shutdown cleanup can reset all runtime SessionState flags together.
             _sessionStateService.MarkDomainReloadStarted(serverIsRunning: true);
+            _sessionStateService.SetShouldAutoScanThirdPartyToolMigration(true);
 
             _sessionStateService.ClearAll();
 
@@ -70,6 +98,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(_sessionStateService.GetIsReconnecting(), Is.False);
             Assert.That(_sessionStateService.GetShowReconnectingUI(), Is.False);
             Assert.That(_sessionStateService.GetShowPostCompileReconnectingUI(), Is.False);
+            Assert.That(_sessionStateService.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
         }
     }
 }

--- a/Assets/Tests/Editor/UnityCliLoopEditorSessionStateTestFactory.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSessionStateTestFactory.cs
@@ -31,6 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private readonly bool _isReconnecting;
         private readonly bool _showReconnectingUI;
         private readonly bool _showPostCompileReconnectingUI;
+        private readonly bool _shouldAutoScanThirdPartyToolMigration;
 
         private UnityCliLoopEditorSessionStateSnapshot(UnityCliLoopEditorSessionStateService service)
         {
@@ -40,6 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _isReconnecting = service.GetIsReconnecting();
             _showReconnectingUI = service.GetShowReconnectingUI();
             _showPostCompileReconnectingUI = service.GetShowPostCompileReconnectingUI();
+            _shouldAutoScanThirdPartyToolMigration = service.GetShouldAutoScanThirdPartyToolMigration();
         }
 
         internal static UnityCliLoopEditorSessionStateSnapshot Capture(
@@ -56,6 +58,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             service.SetIsReconnecting(_isReconnecting);
             service.SetShowReconnectingUI(_showReconnectingUI);
             service.SetShowPostCompileReconnectingUI(_showPostCompileReconnectingUI);
+            service.SetShouldAutoScanThirdPartyToolMigration(_shouldAutoScanThirdPartyToolMigration);
         }
     }
 }

--- a/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateService.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateService.cs
@@ -17,6 +17,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         void SetShowReconnectingUI(bool showReconnectingUI);
         bool GetShowPostCompileReconnectingUI();
         void SetShowPostCompileReconnectingUI(bool showPostCompileReconnectingUI);
+        bool GetShouldAutoScanThirdPartyToolMigration();
+        void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration);
     }
 
     /// <summary>
@@ -93,6 +95,27 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             _sessionStatePort.SetShowPostCompileReconnectingUI(showPostCompileReconnectingUI);
         }
 
+        public bool GetShouldAutoScanThirdPartyToolMigration()
+        {
+            return _sessionStatePort.GetShouldAutoScanThirdPartyToolMigration();
+        }
+
+        public void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration)
+        {
+            _sessionStatePort.SetShouldAutoScanThirdPartyToolMigration(shouldAutoScanThirdPartyToolMigration);
+        }
+
+        public bool ConsumeShouldAutoScanThirdPartyToolMigration()
+        {
+            if (!GetShouldAutoScanThirdPartyToolMigration())
+            {
+                return false;
+            }
+
+            SetShouldAutoScanThirdPartyToolMigration(false);
+            return true;
+        }
+
         public void MarkDomainReloadStarted(bool serverIsRunning)
         {
             SetIsDomainReloadInProgress(true);
@@ -147,6 +170,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         {
             ClearServerSession();
             ClearDomainReloadRecoveryFlags();
+            SetShouldAutoScanThirdPartyToolMigration(false);
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateRepository.cs
@@ -16,6 +16,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string IsReconnectingKey = KeyPrefix + "isReconnecting";
         private const string ShowReconnectingUIKey = KeyPrefix + "showReconnectingUI";
         private const string ShowPostCompileReconnectingUIKey = KeyPrefix + "showPostCompileReconnectingUI";
+        private const string ShouldAutoScanThirdPartyToolMigrationKey =
+            KeyPrefix + "shouldAutoScanThirdPartyToolMigration";
 
         public bool GetIsServerRunning()
         {
@@ -75,6 +77,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public void SetShowPostCompileReconnectingUI(bool showPostCompileReconnectingUI)
         {
             SetBool(ShowPostCompileReconnectingUIKey, showPostCompileReconnectingUI);
+        }
+
+        public bool GetShouldAutoScanThirdPartyToolMigration()
+        {
+            return GetBool(ShouldAutoScanThirdPartyToolMigrationKey);
+        }
+
+        public void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration)
+        {
+            SetBool(ShouldAutoScanThirdPartyToolMigrationKey, shouldAutoScanThirdPartyToolMigration);
         }
 
         private static bool GetBool(string key)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -14,6 +14,41 @@ using io.github.hatayama.UnityCliLoop.Domain;
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
     /// <summary>
+    /// Caches source text within one preview pass so analysis phases share a single disk read per file.
+    /// </summary>
+    internal sealed class ThirdPartyToolMigrationSourceFileCache
+    {
+        private readonly Func<string, string> _readAllText;
+        private readonly Dictionary<string, string> _sources = new(StringComparer.Ordinal);
+
+        internal ThirdPartyToolMigrationSourceFileCache()
+            : this(File.ReadAllText)
+        {
+        }
+
+        internal ThirdPartyToolMigrationSourceFileCache(Func<string, string> readAllText)
+        {
+            Debug.Assert(readAllText != null, "readAllText must not be null");
+
+            _readAllText = readAllText ?? throw new ArgumentNullException(nameof(readAllText));
+        }
+
+        internal string ReadAllText(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            if (_sources.TryGetValue(filePath, out string source))
+            {
+                return source;
+            }
+
+            string loadedSource = _readAllText(filePath);
+            _sources.Add(filePath, loadedSource);
+            return loadedSource;
+        }
+    }
+
+    /// <summary>
     /// Scans Unity project files and rewrites V2 custom tool source to the V3 public contract API.
     /// </summary>
     public sealed class ThirdPartyToolMigrationFileService : IThirdPartyToolMigrationPort
@@ -603,11 +638,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             MigrationProgressCounter progressCounter = new(GetPreviewWorkItemCount(inventory), progress);
+            ThirdPartyToolMigrationSourceFileCache sourceFileCache = new();
             MigrationAssemblyUsage assemblyUsage = await FindMigrationAssemblyUsageAsync(
                 projectRoot,
                 inventory.CSharpFilePaths,
                 inventory.AsmdefFilePaths,
                 inventory.AsmrefFilePaths,
+                sourceFileCache,
                 progressCounter,
                 ct);
             if (ct.IsCancellationRequested)
@@ -626,7 +663,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return MigrationPlan.Empty;
                 }
 
-                string source = File.ReadAllText(csharpFilePath);
+                string source = sourceFileCache.ReadAllText(csharpFilePath);
                 await progressCounter.ReportProcessedItemAsync(ct);
                 if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source) &&
                     !ThirdPartyToolMigrationRules.ContainsLegacyTypeAliasReference(source, legacyToolInfoAliases))
@@ -690,7 +727,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     out requiresToolContractsReference,
                     out requiresApplicationReference,
                     out requiresDomainReference);
-                string source = File.ReadAllText(asmdefFilePath);
+                string source = sourceFileCache.ReadAllText(asmdefFilePath);
                 await progressCounter.ReportProcessedItemAsync(ct);
                 if (!hasAssemblyMigrationRequirement &&
                     !ThirdPartyToolMigrationRules.ContainsLegacyMigrationCandidateText(source))
@@ -953,6 +990,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             List<string> csharpFilePaths,
             List<string> asmdefFilePaths,
             List<string> asmrefFilePaths,
+            ThirdPartyToolMigrationSourceFileCache sourceFileCache,
             MigrationProgressCounter progressCounter,
             CancellationToken ct)
         {
@@ -960,6 +998,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(csharpFilePaths != null, "csharpFilePaths must not be null");
             Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
             Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
+            Debug.Assert(sourceFileCache != null, "sourceFileCache must not be null");
             Debug.Assert(progressCounter != null, "progressCounter must not be null");
 
             List<string> asmdefDirectories = asmdefFilePaths
@@ -971,6 +1010,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 await CreateAssemblyReferenceDirectoriesAsync(
                     asmdefFilePaths,
                     asmrefFilePaths,
+                    sourceFileCache,
                     progressCounter,
                     ct);
             HashSet<string> legacyAssemblyDirectories = new(StringComparer.Ordinal);
@@ -1002,7 +1042,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         domainReferenceAssemblyDirectories);
                 }
 
-                string source = File.ReadAllText(csharpFilePath);
+                string source = sourceFileCache.ReadAllText(csharpFilePath);
                 await progressCounter.ReportProcessedItemAsync(ct);
                 if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
                 {
@@ -1085,7 +1125,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         domainReferenceAssemblyDirectories);
                 }
 
-                string source = File.ReadAllText(csharpFilePath);
+                string source = sourceFileCache.ReadAllText(csharpFilePath);
                 await progressCounter.ReportProcessedItemAsync(ct);
                 if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
                 {
@@ -1311,11 +1351,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static async Task<List<AssemblyReferenceDirectory>> CreateAssemblyReferenceDirectoriesAsync(
             List<string> asmdefFilePaths,
             List<string> asmrefFilePaths,
+            ThirdPartyToolMigrationSourceFileCache sourceFileCache,
             MigrationProgressCounter progressCounter,
             CancellationToken ct)
         {
             Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
             Debug.Assert(asmrefFilePaths != null, "asmrefFilePaths must not be null");
+            Debug.Assert(sourceFileCache != null, "sourceFileCache must not be null");
             Debug.Assert(progressCounter != null, "progressCounter must not be null");
 
             if (asmrefFilePaths.Count == 0)
@@ -1324,7 +1366,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             Dictionary<string, string> asmdefDirectoriesByReference =
-                await CreateAsmdefDirectoryMapAsync(asmdefFilePaths, progressCounter, ct);
+                await CreateAsmdefDirectoryMapAsync(asmdefFilePaths, sourceFileCache, progressCounter, ct);
             List<AssemblyReferenceDirectory> assemblyReferenceDirectories = new();
             foreach (string asmrefFilePath in asmrefFilePaths)
             {
@@ -1336,7 +1378,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         .ToList();
                 }
 
-                if (!TryReadJsonObjectFromFile(asmrefFilePath, out JObject asmref))
+                if (!TryReadJsonObjectFromCache(asmrefFilePath, sourceFileCache, out JObject asmref))
                 {
                     await progressCounter.ReportProcessedItemAsync(ct);
                     continue;
@@ -1400,10 +1442,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static async Task<Dictionary<string, string>> CreateAsmdefDirectoryMapAsync(
             List<string> asmdefFilePaths,
+            ThirdPartyToolMigrationSourceFileCache sourceFileCache,
             MigrationProgressCounter progressCounter,
             CancellationToken ct)
         {
             Debug.Assert(asmdefFilePaths != null, "asmdefFilePaths must not be null");
+            Debug.Assert(sourceFileCache != null, "sourceFileCache must not be null");
             Debug.Assert(progressCounter != null, "progressCounter must not be null");
 
             Dictionary<string, string> asmdefDirectoriesByReference = new(StringComparer.Ordinal);
@@ -1421,7 +1465,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     continue;
                 }
 
-                if (!TryReadJsonObjectFromFile(asmdefFilePath, out JObject asmdef))
+                if (!TryReadJsonObjectFromCache(asmdefFilePath, sourceFileCache, out JObject asmdef))
                 {
                     await progressCounter.ReportProcessedItemAsync(ct);
                     continue;
@@ -1442,6 +1486,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static bool TryReadJsonObjectFromFile(string filePath, out JObject jsonObject)
         {
             return TryReadJsonObjectForMigration(filePath, File.ReadAllText, out jsonObject);
+        }
+
+        private static bool TryReadJsonObjectFromCache(
+            string filePath,
+            ThirdPartyToolMigrationSourceFileCache sourceFileCache,
+            out JObject jsonObject)
+        {
+            Debug.Assert(sourceFileCache != null, "sourceFileCache must not be null");
+
+            return TryReadJsonObjectForMigration(filePath, sourceFileCache.ReadAllText, out jsonObject);
         }
 
         internal static bool TryReadJsonObjectForMigration(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationRules.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -33,6 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string LegacySecuritySettingsTypeName = "SecuritySettings";
         private const string CurrentSecuritySettingTypeName = "UnityCliLoopSecuritySetting";
         private const int MinimumRawStringDelimiterQuoteCount = 3;
+        private static readonly ConditionalWeakTable<string, CodeTextMaskHolder> CodeTextMaskCache = new();
 
         private static readonly string[] ExcludedDirectoryNames =
         {
@@ -1866,8 +1868,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(source != null, "source must not be null");
             Debug.Assert(regex != null, "regex must not be null");
 
-            CodeTextMask codeTextMask = CodeTextMask.Create(source);
             MatchCollection matches = regex.Matches(source);
+            if (matches.Count == 0)
+            {
+                return false;
+            }
+
+            CodeTextMask codeTextMask = CodeTextMask.Create(source);
             foreach (Match match in matches)
             {
                 if (codeTextMask.IsCodeAt(match.Index))
@@ -2448,6 +2455,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 Debug.Assert(source != null, "source must not be null");
 
+                return CodeTextMaskCache.GetValue(source, CreateCodeTextMaskHolder).Mask;
+            }
+
+            internal static CodeTextMask CreateUncached(string source)
+            {
+                Debug.Assert(source != null, "source must not be null");
+
                 bool[] codeCharacters = new bool[source.Length];
                 for (int i = 0; i < codeCharacters.Length; i++)
                 {
@@ -3024,6 +3038,23 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 return true;
             }
+        }
+
+        private sealed class CodeTextMaskHolder
+        {
+            public CodeTextMaskHolder(CodeTextMask mask)
+            {
+                Mask = mask;
+            }
+
+            public CodeTextMask Mask { get; }
+        }
+
+        private static CodeTextMaskHolder CreateCodeTextMaskHolder(string source)
+        {
+            Debug.Assert(source != null, "source must not be null");
+
+            return new CodeTextMaskHolder(CodeTextMask.CreateUncached(source));
         }
     }
 

--- a/Packages/src/Editor/Presentation/PresentationEditorStartup.cs
+++ b/Packages/src/Editor/Presentation/PresentationEditorStartup.cs
@@ -12,8 +12,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             UnityCliLoopEditorSessionStateService sessionStateService)
         {
             UnityCliLoopSettingsWindow.InitializeEditorServices(editorSettingsService, sessionStateService);
-            SetupWizardWindow.InitializeForEditorStartup(editorSettingsService);
-            ThirdPartyToolMigrationWizardWindow.InitializeForEditorStartup();
+            ThirdPartyToolMigrationWizardWindow.InitializeEditorServices(sessionStateService);
+            SetupWizardWindow.InitializeForEditorStartup(editorSettingsService, sessionStateService);
         }
     }
 }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -26,12 +26,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string GITHUB_ICON_RELATIVE_PATH = "Editor/Presentation/Setup/GitHub_Invertocat_White.png";
         private const int PreferredWrappedTextLineCount = 2;
         private const bool ForceFlatSkillInstall = true;
+        private static readonly char[] VersionMajorSeparators = { '.', '-' };
         private static readonly Vector2 MinimumWindowSize = new(360f, 380f);
         private static UnityCliLoopEditorSettingsService RegisteredEditorSettingsService;
+        private static UnityCliLoopEditorSessionStateService RegisteredSessionStateService;
 
-        internal static void InitializeForEditorStartup(UnityCliLoopEditorSettingsService editorSettingsService)
+        internal static void InitializeForEditorStartup(
+            UnityCliLoopEditorSettingsService editorSettingsService,
+            UnityCliLoopEditorSessionStateService sessionStateService)
         {
-            InitializeEditorServices(editorSettingsService);
+            InitializeEditorServices(editorSettingsService, sessionStateService);
 
             if (AssetDatabase.IsAssetImportWorkerProcess()) return;
             if (UnityEngine.Application.isBatchMode) return;
@@ -39,12 +43,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             EditorApplication.delayCall += TryShowOnVersionChange;
         }
 
-        internal static void InitializeEditorServices(UnityCliLoopEditorSettingsService editorSettingsService)
+        internal static void InitializeEditorServices(
+            UnityCliLoopEditorSettingsService editorSettingsService,
+            UnityCliLoopEditorSessionStateService sessionStateService)
         {
             Debug.Assert(editorSettingsService != null, "editorSettingsService must not be null");
+            Debug.Assert(sessionStateService != null, "sessionStateService must not be null");
 
             RegisteredEditorSettingsService = editorSettingsService
                 ?? throw new System.ArgumentNullException(nameof(editorSettingsService));
+            RegisteredSessionStateService = sessionStateService
+                ?? throw new System.ArgumentNullException(nameof(sessionStateService));
         }
 
         [MenuItem("Window/Unity CLI Loop/Setup Wizard", priority = 3)]
@@ -62,6 +71,36 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             if (!versionChanged) return false;
 
             return !suppressAutoShow;
+        }
+
+        internal static bool ShouldAutoScanThirdPartyToolMigration(string currentVersion, string lastSeenVersion)
+        {
+            if (string.IsNullOrEmpty(lastSeenVersion))
+            {
+                return false;
+            }
+
+            if (!TryGetMajorVersion(currentVersion, out int currentMajorVersion))
+            {
+                return false;
+            }
+
+            if (!TryGetMajorVersion(lastSeenVersion, out int lastSeenMajorVersion))
+            {
+                return false;
+            }
+
+            return lastSeenMajorVersion < 3 && currentMajorVersion == 3;
+        }
+
+        internal static void MaybeMarkThirdPartyToolMigrationAutoScan(bool shouldAutoScan)
+        {
+            if (!shouldAutoScan)
+            {
+                return;
+            }
+
+            GetSessionStateService().SetShouldAutoScanThirdPartyToolMigration(true);
         }
 
         internal static void MaybeRecordLastSeenVersion(bool shouldRecordVersion, string version)
@@ -96,10 +135,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
-            if (!ShouldAutoShowForVersion(
+            bool shouldAutoScanThirdPartyToolMigration = ShouldAutoScanThirdPartyToolMigration(
+                currentVersion,
+                lastSeenVersion);
+            MaybeScheduleThirdPartyToolMigrationAutoScan(shouldAutoScanThirdPartyToolMigration);
+
+            bool shouldAutoShow = ShouldAutoShowForVersion(
                 currentVersion,
                 lastSeenVersion,
-                suppressAutoShow))
+                suppressAutoShow);
+
+            if (!shouldAutoShow)
             {
                 MaybeRecordSuppressedVersion(suppressAutoShow, currentVersion);
                 return;
@@ -204,6 +250,40 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             return RegisteredEditorSettingsService;
+        }
+
+        private static UnityCliLoopEditorSessionStateService GetSessionStateService()
+        {
+            if (RegisteredSessionStateService == null)
+            {
+                throw new System.InvalidOperationException("Setup Wizard session-state service is not initialized.");
+            }
+
+            return RegisteredSessionStateService;
+        }
+
+        private static void MaybeScheduleThirdPartyToolMigrationAutoScan(bool shouldAutoScan)
+        {
+            MaybeMarkThirdPartyToolMigrationAutoScan(shouldAutoScan);
+            if (!shouldAutoScan)
+            {
+                return;
+            }
+
+            EditorApplication.delayCall += ThirdPartyToolMigrationWizardWindow.ShowWindowForAutoScan;
+        }
+
+        private static bool TryGetMajorVersion(string version, out int majorVersion)
+        {
+            majorVersion = 0;
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                return false;
+            }
+
+            int separatorIndex = version.IndexOfAny(VersionMajorSeparators);
+            string majorText = separatorIndex < 0 ? version : version.Substring(0, separatorIndex);
+            return int.TryParse(majorText, out majorVersion);
         }
 
         // Prerequisite

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -321,6 +321,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
+            CompleteMigrationPreview(ct);
+
             if (!preview.HasTargets)
             {
                 ShowNoMigrationTargetsState();
@@ -576,6 +578,29 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return elapsedTicks >= requiredTicks;
         }
 
+        internal static bool ShouldApplyMigrationProgress(
+            bool isCancellationRequested,
+            bool hasActivePreview)
+        {
+            return !isCancellationRequested && hasActivePreview;
+        }
+
+        private void CompleteMigrationPreview(CancellationToken ct)
+        {
+            if (!IsMigrationPreviewActive(ct))
+            {
+                return;
+            }
+
+            _migrationPreviewCts.Dispose();
+            _migrationPreviewCts = null;
+        }
+
+        private bool IsMigrationPreviewActive(CancellationToken ct)
+        {
+            return _migrationPreviewCts != null && _migrationPreviewCts.Token.Equals(ct);
+        }
+
         private sealed class ThirdPartyToolMigrationPreviewProgress
             : System.IProgress<ThirdPartyToolMigrationProgress>
         {
@@ -618,7 +643,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             private async Task ReportAsync(ThirdPartyToolMigrationProgress value, CancellationToken ct)
             {
                 await MainThreadSwitcher.SwitchToMainThread();
-                if (ct.IsCancellationRequested)
+                if (!ShouldApplyMigrationProgress(
+                        ct.IsCancellationRequested,
+                        _window.IsMigrationPreviewActive(ct)))
                 {
                     return;
                 }

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -24,6 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string MigrationButtonReadyText = "Migrate";
         private const string MigrationButtonMigratingText = "Migrating...";
         private const string MigrationButtonNoTargetsText = "Nothing to migrate";
+        private const string MigrationButtonCheckRequiredText = "Check required";
+        private const int MigrationProgressUiUpdateIntervalMilliseconds = 100;
         private static readonly Vector2 InitialWindowSize = new(360f, 220f);
         private static readonly Vector2 MinimumWindowSize = new(360f, 120f);
         private static UnityCliLoopEditorSessionStateService RegisteredSessionStateService;
@@ -128,8 +130,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 $"{progress.ProcessedItemCount}/{progress.TotalItemCount} checks complete.";
         }
 
-        internal static string GetMigrationButtonText(bool isMigrating, bool hasMigrationTargets)
+        internal static string GetMigrationButtonText(
+            bool isMigrating,
+            bool hasMigrationTargets,
+            bool hasCheckedMigrationStatus)
         {
+            if (!hasCheckedMigrationStatus)
+            {
+                return MigrationButtonCheckRequiredText;
+            }
+
             if (isMigrating)
             {
                 return MigrationButtonMigratingText;
@@ -217,7 +227,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             content.Add(migrationButtonRow);
 
             _migrateButton = new Button();
-            _migrateButton.text = GetMigrationButtonText(false, true);
+            _migrateButton.text = GetMigrationButtonText(false, false, false);
             _migrateButton.AddToClassList("setup-button");
             migrationButtonRow.Add(_migrateButton);
 
@@ -347,7 +357,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _migrationStatusLabel.text = MigrationNotCheckedText;
             ViewDataBinder.SetVisible(_migrationProgressBar, false);
             _migrateButton.SetEnabled(false);
-            _migrateButton.text = GetMigrationButtonText(_isMigrating, false);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating, false, false);
             ScheduleResizeToContent();
         }
 
@@ -356,7 +366,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _migrationStatusLabel.text = GetMigrationStatusText(fileCount);
             ViewDataBinder.SetVisible(_migrationProgressBar, false);
             _migrateButton.SetEnabled(!_isMigrating);
-            _migrateButton.text = GetMigrationButtonText(_isMigrating, true);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating, true, true);
             ScheduleResizeToContent();
         }
 
@@ -365,7 +375,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _migrationStatusLabel.text = NoMigrationTargetsText;
             ViewDataBinder.SetVisible(_migrationProgressBar, false);
             _migrateButton.SetEnabled(false);
-            _migrateButton.text = GetMigrationButtonText(_isMigrating, false);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating, false, true);
             ScheduleResizeToContent();
         }
 
@@ -375,7 +385,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.SetVisible(_migrationProgressBar, true);
             UpdateMigrationProgressBar(progress);
             _migrateButton.SetEnabled(false);
-            _migrateButton.text = GetMigrationButtonText(_isMigrating, true);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating, true, true);
             ScheduleResizeToContent();
         }
 
@@ -540,11 +550,38 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             rootVisualElement.schedule.Execute(RefreshUI).StartingIn(0);
         }
 
+        internal static bool ShouldReportMigrationProgress(
+            long lastReportTimestamp,
+            long currentTimestamp,
+            ThirdPartyToolMigrationProgress progress,
+            long stopwatchFrequency,
+            int updateIntervalMilliseconds)
+        {
+            Debug.Assert(currentTimestamp >= 0, "currentTimestamp must not be negative");
+            Debug.Assert(stopwatchFrequency > 0, "stopwatchFrequency must be positive");
+            Debug.Assert(updateIntervalMilliseconds >= 0, "updateIntervalMilliseconds must not be negative");
+
+            if (lastReportTimestamp == 0)
+            {
+                return true;
+            }
+
+            if (progress.TotalItemCount > 0 && progress.ProcessedItemCount >= progress.TotalItemCount)
+            {
+                return true;
+            }
+
+            long elapsedTicks = currentTimestamp - lastReportTimestamp;
+            long requiredTicks = stopwatchFrequency * updateIntervalMilliseconds / 1000;
+            return elapsedTicks >= requiredTicks;
+        }
+
         private sealed class ThirdPartyToolMigrationPreviewProgress
             : System.IProgress<ThirdPartyToolMigrationProgress>
         {
             private readonly ThirdPartyToolMigrationWizardWindow _window;
             private readonly CancellationToken _ct;
+            private long _lastReportTimestamp;
 
             public ThirdPartyToolMigrationPreviewProgress(
                 ThirdPartyToolMigrationWizardWindow window,
@@ -563,6 +600,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                     return;
                 }
 
+                long currentTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+                if (!ShouldReportMigrationProgress(
+                        _lastReportTimestamp,
+                        currentTimestamp,
+                        value,
+                        System.Diagnostics.Stopwatch.Frequency,
+                        MigrationProgressUiUpdateIntervalMilliseconds))
+                {
+                    return;
+                }
+
+                _lastReportTimestamp = currentTimestamp;
                 _ = ReportAsync(value, _ct);
             }
 

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -18,6 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     {
         private const string WindowTitle = "Unity CLI Loop Migration";
         private const string USS_RELATIVE_PATH = "Editor/Presentation/Setup/SetupWizardWindow.uss";
+        private const string MigrationNotCheckedText = "Migration status has not been checked.";
         private const string MigrationCheckingText = "Scanning project for V3 custom tool migration...";
         private const string NoMigrationTargetsText = "No V3 custom tool migration is needed.";
         private const string MigrationButtonReadyText = "Migrate";
@@ -25,6 +26,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string MigrationButtonNoTargetsText = "Nothing to migrate";
         private static readonly Vector2 InitialWindowSize = new(360f, 220f);
         private static readonly Vector2 MinimumWindowSize = new(360f, 120f);
+        private static UnityCliLoopEditorSessionStateService RegisteredSessionStateService;
 
         private ScrollView _mainScrollView;
         private VisualElement _migrationSection;
@@ -42,23 +44,30 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private CancellationTokenSource _migrationPreviewCts;
         private ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
 
-        internal static void InitializeForEditorStartup()
+        internal static void InitializeEditorServices(UnityCliLoopEditorSessionStateService sessionStateService)
         {
-            if (AssetDatabase.IsAssetImportWorkerProcess()) return;
-            if (UnityEngine.Application.isBatchMode) return;
+            Debug.Assert(sessionStateService != null, "sessionStateService must not be null");
 
-            EditorApplication.delayCall += TryShowOnMigrationTargets;
+            RegisteredSessionStateService = sessionStateService
+                ?? throw new System.ArgumentNullException(nameof(sessionStateService));
         }
 
         [MenuItem("Window/Unity CLI Loop/Custom Tool Migration", priority = 4)]
         public static void ShowWindow()
         {
+            ShowWindowInternal(false);
+        }
+
+        internal static void ShowWindowForAutoScan()
+        {
             ShowWindowInternal(true);
         }
 
-        internal static bool ShouldAutoShowForMigrationTargets(bool hasMigrationTargets)
+        internal static bool ShouldStartInitialRefresh(
+            bool shouldRefreshAfterCreateGui,
+            bool shouldAutoScanThirdPartyToolMigration)
         {
-            return hasMigrationTargets;
+            return shouldRefreshAfterCreateGui && shouldAutoScanThirdPartyToolMigration;
         }
 
         internal static void PrepareForOpen(
@@ -129,40 +138,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return hasMigrationTargets ? MigrationButtonReadyText : MigrationButtonNoTargetsText;
         }
 
-        private static void TryShowOnMigrationTargets()
-        {
-            TryShowOnMigrationTargetsAsync(CancellationToken.None);
-        }
-
-        private static async void TryShowOnMigrationTargetsAsync(CancellationToken ct)
-        {
-            bool hasMigrationTargets = await HasMigrationTargetsAsync(ct);
-            if (ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            if (!ShouldAutoShowForMigrationTargets(hasMigrationTargets))
-            {
-                return;
-            }
-
-            EditorApplication.delayCall += ShowWindow;
-        }
-
-        private static async Task<bool> HasMigrationTargetsAsync(CancellationToken ct)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return await ThirdPartyToolMigrationUseCaseRegistry
-                .GetRegisteredUseCase()
-                .HasMigrationTargetsAsync(projectRoot, ct);
-        }
-
         private static void ShowWindowInternal(bool shouldRefreshAfterCreateGui)
         {
             if (HasOpenInstances<ThirdPartyToolMigrationWizardWindow>())
             {
-                FocusWindowIfItsOpen<ThirdPartyToolMigrationWizardWindow>();
+                FocusExistingWindow(shouldRefreshAfterCreateGui);
                 return;
             }
 
@@ -182,8 +162,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             BuildLayout();
             BindEvents();
             BindSizeUpdates();
-            ShowInitialState();
-            ScheduleInitialRefresh();
+            bool shouldStartInitialRefresh = ConsumeShouldStartInitialRefresh();
+            ShowInitialState(shouldStartInitialRefresh);
+            ScheduleInitialRefresh(shouldStartInitialRefresh);
             ScheduleResizeToContent();
         }
 
@@ -249,7 +230,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             footer.Add(footerButtonRow);
 
             _refreshButton = new Button();
-            _refreshButton.text = "Refresh";
+            _refreshButton.text = "Check";
             _refreshButton.AddToClassList("setup-button");
             _refreshButton.AddToClassList("setup-button--primary");
             footerButtonRow.Add(_refreshButton);
@@ -286,20 +267,20 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             });
         }
 
-        private void ShowInitialState()
+        private void ShowInitialState(bool shouldStartInitialRefresh)
         {
-            if (_shouldRefreshAfterCreateGui)
+            if (shouldStartInitialRefresh)
             {
                 ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
                 return;
             }
 
-            ShowNoMigrationTargetsState();
+            ShowNotCheckedState();
         }
 
-        private void ScheduleInitialRefresh()
+        private void ScheduleInitialRefresh(bool shouldStartInitialRefresh)
         {
-            if (!_shouldRefreshAfterCreateGui)
+            if (!shouldStartInitialRefresh)
             {
                 return;
             }
@@ -317,7 +298,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             System.IProgress<ThirdPartyToolMigrationProgress> progress =
                 new ThirdPartyToolMigrationPreviewProgress(this, ct);
             ThirdPartyToolMigrationPreview preview =
-                await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct);
+                await Task.Run(async () =>
+                    await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct));
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await MainThreadSwitcher.SwitchToMainThread();
             if (ct.IsCancellationRequested)
             {
                 return;
@@ -352,6 +340,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _isMigrating = false;
                 RefreshUI();
             }
+        }
+
+        private void ShowNotCheckedState()
+        {
+            _migrationStatusLabel.text = MigrationNotCheckedText;
+            ViewDataBinder.SetVisible(_migrationProgressBar, false);
+            _migrateButton.SetEnabled(false);
+            _migrateButton.text = GetMigrationButtonText(_isMigrating, false);
+            ScheduleResizeToContent();
         }
 
         private void ShowMigrationTargetsState(int fileCount)
@@ -487,6 +484,62 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _migrationPreviewCts = null;
         }
 
+        private static UnityCliLoopEditorSessionStateService GetSessionStateService()
+        {
+            if (RegisteredSessionStateService == null)
+            {
+                throw new System.InvalidOperationException(
+                    "Migration Wizard session-state service is not initialized.");
+            }
+
+            return RegisteredSessionStateService;
+        }
+
+        private static void FocusExistingWindow(bool shouldRefreshAfterCreateGui)
+        {
+            ThirdPartyToolMigrationWizardWindow[] windows =
+                Resources.FindObjectsOfTypeAll<ThirdPartyToolMigrationWizardWindow>();
+            if (windows.Length == 0)
+            {
+                return;
+            }
+
+            ThirdPartyToolMigrationWizardWindow window = windows[0];
+            window.Focus();
+            if (!shouldRefreshAfterCreateGui)
+            {
+                return;
+            }
+
+            window._shouldRefreshAfterCreateGui = true;
+            window.TryStartInitialRefresh();
+        }
+
+        private bool ConsumeShouldStartInitialRefresh()
+        {
+            if (!_shouldRefreshAfterCreateGui)
+            {
+                return false;
+            }
+
+            _shouldRefreshAfterCreateGui = false;
+            bool shouldAutoScanThirdPartyToolMigration =
+                GetSessionStateService().ConsumeShouldAutoScanThirdPartyToolMigration();
+            return ShouldStartInitialRefresh(true, shouldAutoScanThirdPartyToolMigration);
+        }
+
+        private void TryStartInitialRefresh()
+        {
+            bool shouldStartInitialRefresh = ConsumeShouldStartInitialRefresh();
+            if (!shouldStartInitialRefresh)
+            {
+                return;
+            }
+
+            ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+            rootVisualElement.schedule.Execute(RefreshUI).StartingIn(0);
+        }
+
         private sealed class ThirdPartyToolMigrationPreviewProgress
             : System.IProgress<ThirdPartyToolMigrationProgress>
         {
@@ -506,6 +559,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             public void Report(ThirdPartyToolMigrationProgress value)
             {
                 if (_ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                _ = ReportAsync(value, _ct);
+            }
+
+            private async Task ReportAsync(ThirdPartyToolMigrationProgress value, CancellationToken ct)
+            {
+                await MainThreadSwitcher.SwitchToMainThread();
+                if (ct.IsCancellationRequested)
                 {
                     return;
                 }


### PR DESCRIPTION
## Summary
- Unity startup no longer runs a blocking migration scan during ordinary version checks.
- The migration window now starts in an unchecked state and stays responsive while scans run.

## User Impact
- Projects no longer freeze at startup just because the package version check runs.
- Upgrading from V2 to V3 can still surface the migration window, but manual checks wait until the user presses Check.
- Long migration previews avoid repeated source-file reads and ignore stale progress updates after results are already shown.

## Changes
- Gate automatic migration scans behind the V2-to-V3 upgrade session signal.
- Move migration preview work off the Unity main thread, throttle progress updates, and cache source-file content during preview.
- Keep demo editor startup hooks out of normal startup and add focused EditMode coverage for setup, migration, session state, and dependency behavior.

## Verification
- `Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` (0 errors, 0 warnings)
- Focused EditMode migration/setup/session tests via the checked-in local uloop binary; wizard tests were rerun after the final progress-state fix.
- `codex-review v3-beta` (no actionable findings after the stale progress issue was fixed)
