### PR TITLE
fix: Windows CLI updates no longer fail when upgrading from older versions

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -132,8 +132,15 @@ function Test-UloopNativeInstallSupported {
         [string]$UloopPath
     )
 
-    & $UloopPath install --help > $null 2> $null
-    return $LASTEXITCODE -eq 0
+    $PreviousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        & $UloopPath install --help > $null 2> $null
+        return $LASTEXITCODE -eq 0
+    }
+    finally {
+        $ErrorActionPreference = $PreviousErrorActionPreference
+    }
 }
 
 function ConvertTo-NormalizedPath {

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -941,6 +941,12 @@ test_powershell_installer_uses_non_installer_staged_executable_name() {
   assert_not_contains "$ROOT_DIR/scripts/install.ps1" '"uloop-install-"'
 }
 
+test_powershell_native_probe_restores_error_action_preference() {
+  assert_contains "$ROOT_DIR/scripts/install.ps1" '$PreviousErrorActionPreference = $ErrorActionPreference'
+  assert_contains "$ROOT_DIR/scripts/install.ps1" '$ErrorActionPreference = "Continue"'
+  assert_contains "$ROOT_DIR/scripts/install.ps1" '$ErrorActionPreference = $PreviousErrorActionPreference'
+}
+
 test_posix_latest_skips_prerelease_assets
 test_posix_latest_beta_selects_prerelease_assets
 test_posix_invokes_native_install_setup
@@ -960,3 +966,4 @@ test_powershell_latest_skips_prerelease_assets
 test_git_bash_latest_installs_windows_zip_asset
 test_powershell_installer_avoids_optional_archive_cmdlets
 test_powershell_installer_uses_non_installer_staged_executable_name
+test_powershell_native_probe_restores_error_action_preference


### PR DESCRIPTION
## Summary
- Windows CLI updates now continue through compatibility setup when the downloaded CLI does not support native install setup yet.
- This prevents Setup and Settings update failures caused by stderr from older staged CLIs.

## User Impact
- Before, upgrading an older CLI to v3 could fail with a PowerShell NativeCommandError during the installer probe.
- After, the installer treats that probe as unsupported and falls back to the compatibility setup path so the update can complete.

## Changes
- Temporarily relax PowerShell ErrorActionPreference only while probing `install --help`, then restore it in `finally`.
- Add installer harness coverage that pins the ErrorActionPreference restoration.

## Verification
- `bash scripts/test-install-release-filter.sh`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "[scriptblock]::Create((Get-Content -Raw 'scripts/install.ps1')) > `$null"`
- `pwsh -NoProfile -Command "[scriptblock]::Create((Get-Content -Raw 'scripts/install.ps1')) > `$null"`
- Manual Windows PowerShell probe against the local 3.0.0-beta.9 binary returned `result=False` and restored `ErrorActionPreference=Stop`.
