### PR TITLE
fix: Input overlays load without auto-referencing runtime assemblies

### DIFF
--- a/Assets/Tests/Demo/uLoopMCP.Tests.Demo.asmdef
+++ b/Assets/Tests/Demo/uLoopMCP.Tests.Demo.asmdef
@@ -6,15 +6,15 @@
         "GUID:c956a21f824994ef087b6de566690b3d",
         "GUID:4307f53044263cf4b835bd812fc161a4"
     ],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.inputsystem",

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -28,6 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(asmdef["autoReferenced"]?.Value<bool>(), Is.False);
             Assert.That(includePlatforms, Is.Not.Null);
+            Assert.That(includePlatforms!.Type, Is.EqualTo(JTokenType.Array));
             Assert.That(includePlatforms!.HasValues, Is.False);
         }
 

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -1,0 +1,59 @@
+using System.IO;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the shared input visualization prefab contract.
+    /// </summary>
+    public sealed class InputVisualizationCanvasPrefabTests
+    {
+        private const string PrefabPath =
+            "Packages/io.github.hatayama.uloopmcp/Runtime/Common/InputVisualizationCanvas.prefab";
+        private const string RuntimeAssemblyDefinitionPath =
+            "Packages/src/Runtime/uLoopMCP.Runtime.asmdef";
+
+        [Test]
+        public void RuntimeAssemblyDefinition_WhenScanned_IsAttachableAndNotAutoReferenced()
+        {
+            // Verifies the overlay MonoBehaviours can attach to prefabs without becoming player auto-references.
+            JObject asmdef = JObject.Parse(ReadText(RuntimeAssemblyDefinitionPath));
+            JToken includePlatforms = asmdef["includePlatforms"];
+
+            Assert.That(asmdef["autoReferenced"]?.Value<bool>(), Is.False);
+            Assert.That(includePlatforms, Is.Not.Null);
+            Assert.That(includePlatforms!.HasValues, Is.False);
+        }
+
+        [Test]
+        public void InputVisualizationCanvasPrefab_WhenLoaded_HasRuntimeOverlayReferences()
+        {
+            // Verifies that overlay tools can instantiate the shared visualization canvas.
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PrefabPath);
+
+            Assert.That(prefab, Is.Not.Null);
+
+            InputVisualizationCanvas canvas = prefab.GetComponent<InputVisualizationCanvas>();
+
+            Assert.That(canvas, Is.Not.Null);
+            Assert.That(canvas.KeyboardOverlay, Is.Not.Null);
+            Assert.That(canvas.MouseUiOverlay, Is.Not.Null);
+            Assert.That(canvas.MouseInputOverlay, Is.Not.Null);
+            Assert.That(canvas.RecordInputOverlayPresenter, Is.Not.Null);
+            Assert.That(canvas.ReplayInputOverlay, Is.Not.Null);
+        }
+
+        private static string ReadText(string relativePath)
+        {
+            string absolutePath = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), relativePath);
+
+            return File.ReadAllText(absolutePath);
+        }
+    }
+}

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs.meta
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b972268c6169d42d38cd31b59622a00a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/uLoopMCP.Tests.Editor.asmdef
+++ b/Assets/Tests/Editor/uLoopMCP.Tests.Editor.asmdef
@@ -30,6 +30,7 @@
         "GUID:679888bc3e9c44c19ab0d62ff8701dcf",
         "GUID:9c34b9a25e1464dec91601291eade23f",
         "GUID:32708dd5a1f18474e8a4deddc56e8806",
+        "GUID:c956a21f824994ef087b6de566690b3d",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:616b0fafa8621452d8d1ae18a41bab94",
         "GUID:0acc523941302664db1f4e527237feb3",

--- a/Assets/Tests/PlayMode/InputReplayVerificationE2ETests.cs
+++ b/Assets/Tests/PlayMode/InputReplayVerificationE2ETests.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.IO;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.Tests.Demo;
 using NUnit.Framework;
 using UnityEditor.SceneManagement;
@@ -26,6 +27,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         public IEnumerator SetUp()
         {
             _replayCompleted = false;
+            CleanupOverlayCanvases();
             InputReplayer.AddReplayCompletedHandler(OnReplayCompleted);
 
             AsyncOperation loadOp = EditorSceneManager.LoadSceneAsyncInPlayMode(
@@ -59,8 +61,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             CleanupLogFile(Path.Combine(
                 ReplayVerificationControllerBase.LOG_OUTPUT_DIR,
                 ReplayVerificationControllerBase.REPLAY_LOG_FILE));
+            CleanupOverlayCanvases();
 
             yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator StartReplay_WithShowOverlay_Should_CreateOverlayCanvas()
+        {
+            // Verifies direct input replay creates the shared overlay prefab when overlays are enabled.
+            string fixtureRecordingJson = Path.Combine(FIXTURE_DIR, "recording.json");
+
+            Assert.IsTrue(File.Exists(fixtureRecordingJson),
+                $"Fixture recording JSON not found: {fixtureRecordingJson}");
+
+            InputRecordingData recordingData = InputRecordingFileHelper.Load(fixtureRecordingJson);
+            Debug.Assert(recordingData != null, $"Failed to load fixture: {fixtureRecordingJson}");
+
+            InputReplayer.StartReplay(recordingData, loop: false, showOverlay: true);
+
+            yield return null;
+            yield return null;
+
+            InputVisualizationCanvas canvas =
+                Object.FindAnyObjectByType<InputVisualizationCanvas>();
+            Assert.IsNotNull(canvas, "InputVisualizationCanvas must exist when replay overlay is enabled.");
+
+            ReplayInputOverlay replayOverlay = canvas.ReplayInputOverlay;
+            Assert.IsNotNull(replayOverlay, "ReplayInputOverlay must exist on the visualization canvas.");
+
+            CanvasGroup replayCanvasGroup = replayOverlay.GetComponent<CanvasGroup>();
+            Assert.IsNotNull(replayCanvasGroup, "ReplayInputOverlay must include a CanvasGroup.");
+            Assert.Greater(replayCanvasGroup.alpha, 0f, "ReplayInputOverlay should be visible while replay is active.");
         }
 
         [UnityTest]
@@ -114,6 +146,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             if (File.Exists(path))
             {
                 File.Delete(path);
+            }
+        }
+
+        private static void CleanupOverlayCanvases()
+        {
+            InputVisualizationCanvas[] canvases =
+                Object.FindObjectsByType<InputVisualizationCanvas>(FindObjectsSortMode.None);
+            for (int i = 0; i < canvases.Length; i++)
+            {
+                Object.DestroyImmediate(canvases[i].gameObject);
             }
         }
     }

--- a/Assets/Tests/PlayMode/SimulateMouseDemoE2ETests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseDemoE2ETests.cs
@@ -21,7 +21,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
     {
         private const string SCENE_PATH = "Assets/Scenes/SimulateMouseDemoScene.unity";
         private const string FIXTURE_DIR = "Assets/Tests/PlayMode/Fixtures/SimulateMouseDemoScene";
-        private const string FIXTURE_GAME_VIEW_SIZE = "2048x1152";
+        private const string FIXTURE_GAME_VIEW_SIZE = "1920x1080";
         private const float REPLAY_TIMEOUT_SECONDS = 30f;
 
         private bool _replayCompleted;

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayer.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayer.cs
@@ -89,6 +89,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _currentFrame = 0;
             _loop = loop;
             _showOverlay = showOverlay;
+            if (_showOverlay)
+            {
+                RecordReplayOverlayFactory.EnsureReplayOverlay();
+            }
+
             _replayHeldKeys.Clear();
             _replayHeldButtons.Clear();
             _hasMousePosition = DetectMousePositionEvents(data!);

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/UnityCLILoop.FirstPartyTools.Common.InputRecording.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/UnityCLILoop.FirstPartyTools.Common.InputRecording.Editor.asmdef
@@ -5,6 +5,7 @@
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:45d3617c96fa64d3e95383450e67f25a",
         "GUID:a2d87883023de4cf59b7d1962d5dd8aa",
+        "GUID:aa7cf56cc5f074e57ba35272b877e116",
         "GUID:c956a21f824994ef087b6de566690b3d",
         "GUID:75469ad4d38634e559750d17036d5f7c"
     ],

--- a/Packages/src/Editor/FirstPartyTools/Common/Overlay/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/Overlay/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Common.InputRecording.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.RecordInput.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.ReplayInput.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor")]

--- a/Packages/src/Runtime/uLoopMCP.Runtime.asmdef
+++ b/Packages/src/Runtime/uLoopMCP.Runtime.asmdef
@@ -2,14 +2,12 @@
     "name": "uLoopMCP.Runtime",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.Runtime",
     "references": [],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false


### PR DESCRIPTION
## Summary
- Restore the shared input visualization prefab so record, replay, and simulate input overlays can be instantiated from the package again.
- Keep the runtime assembly out of automatic player references by making it player-compatible but not auto-referenced.
- Ensure direct input replay creates the visualization canvas when overlays are enabled, and keep the mouse UI replay E2E fixture on its recorded Game View resolution.

## User Impact
- Before this change, making the runtime assembly Editor-only prevented the package prefab from keeping valid MonoBehaviour references.
- After this change, Editor-side input overlay tools can load the shared prefab, while normal player builds can still strip the runtime assembly when it has no incoming player references.
- Direct replay paths now show the replay overlay prefab instead of relying on the higher-level replay-input use case to instantiate it first.

## Relation to PR #1120
- This follows up on https://github.com/hatayama/unity-cli-loop/pull/1120.
- PR #1120 addressed two separate player-build issues: `uLoopMCP.Runtime.dll` being eligible for player builds, and Roslyn-related DLLs being enabled for non-Editor targets.
- On the current v3-beta layout, the Roslyn-related DLLs are already under Editor tooling and did not appear in the tested consumer builds.
- For `uLoopMCP.Runtime.dll`, this PR intentionally does not make the assembly Editor-only again, because the shared prefab needs the runtime MonoBehaviour types to keep valid references. Instead, the assembly remains player-compatible and `autoReferenced: false`, so the prefab contract works while unused player builds can still strip the physical DLL.

## Changes
- Clear `includePlatforms` on `uLoopMCP.Runtime.asmdef` so package prefabs can reference the runtime MonoBehaviours.
- Set `autoReferenced` to false so player assemblies do not reference the runtime assembly unless they explicitly need it.
- Add focused EditMode coverage for the runtime asmdef contract and the shared input visualization prefab references.
- Make the demo fixture assembly available to PlayMode test players under `UNITY_INCLUDE_TESTS`.
- Create the replay overlay canvas from `InputReplayer.StartReplay` when overlays are enabled.
- Run the UI replay fixture at `1920x1080`, which matches the recorded fixture coordinates.

## Verification
- `Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path <UNITY_CLI_LOOP_ROOT>`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <UNITY_CLI_LOOP_ROOT> --test-mode EditMode --filter-type regex --filter-value ".*InputVisualizationCanvasPrefabTests.*"`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <UNITY_CLI_LOOP_ROOT> --test-mode PlayMode --filter-type regex --filter-value ".*(InputReplayVerificationE2ETests|SimulateMouseDemoE2ETests).*"`
- Consumer project smoke build: macOS Mono with Managed Stripping Low succeeded, and the physical `uLoopMCP.Runtime.dll` plus Roslyn-related DLLs were not present in the app output.
- Consumer project smoke build: macOS IL2CPP with Managed Stripping Low succeeded, and no physical managed `uLoopMCP.Runtime.dll` or Roslyn-related DLLs were present in the app output.