### PR TITLE
fix: Internal assemblies no longer leak into project scripts

### DIFF
--- a/Assets/Editor/CustomCommandSamples/UnityCLILoop.CustomCommandSamples.Editor.asmdef
+++ b/Assets/Editor/CustomCommandSamples/UnityCLILoop.CustomCommandSamples.Editor.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Assets/Tests/Demo/uLoopMCP.Tests.Demo.asmdef
+++ b/Assets/Tests/Demo/uLoopMCP.Tests.Demo.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],

--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -94,12 +94,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void RuntimeAsmdef_WhenLoaded_TargetsEditorOnly()
+        public void RuntimeAsmdef_WhenLoaded_AllowsPrefabAttachmentWithoutAutoReference()
         {
-            // Tests that runtime overlay code remains excluded from player builds.
+            // Tests that runtime overlay code can attach to prefabs without implicit project references.
             string[] includePlatforms = ReadIncludePlatforms("Packages/src/Runtime/uLoopMCP.Runtime.asmdef");
+            bool autoReferenced = ReadAutoReferenced("Packages/src/Runtime/uLoopMCP.Runtime.asmdef");
 
-            Assert.That(includePlatforms, Is.EquivalentTo(new[] { "Editor" }));
+            Assert.That(includePlatforms, Is.Empty);
+            Assert.That(autoReferenced, Is.False);
+        }
+
+        [Test]
+        public void ProjectAsmdefs_WhenLoaded_AutoReferenceOnlyPublicToolContracts()
+        {
+            // Tests that internal assemblies require explicit asmdef references.
+            string[] offendingAssemblyNames = ReadProjectAsmdefPaths()
+                .Where(ReadAutoReferencedFromAbsolutePath)
+                .Select(ReadAsmdefName)
+                .Where(assemblyName => !string.Equals(
+                    assemblyName,
+                    ToolContractsAssemblyName,
+                    StringComparison.Ordinal))
+                .OrderBy(assemblyName => assemblyName)
+                .ToArray();
+
+            Assert.That(offendingAssemblyNames, Is.Empty);
         }
 
         [Test]
@@ -1274,6 +1293,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private static bool ReadAutoReferenced(string relativeAsmdefPath)
         {
             string asmdefPath = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), relativeAsmdefPath);
+            return ReadAutoReferencedFromAbsolutePath(asmdefPath);
+        }
+
+        private static bool ReadAutoReferencedFromAbsolutePath(string asmdefPath)
+        {
             JObject asmdef = JObject.Parse(File.ReadAllText(asmdefPath));
             return asmdef["autoReferenced"]?.Value<bool>() ?? true;
         }

--- a/Packages/src/Editor/Application/UnityCLILoop.Application.asmdef
+++ b/Packages/src/Editor/Application/UnityCLILoop.Application.asmdef
@@ -15,7 +15,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {

--- a/Packages/src/Editor/CompositionRoot/UnityCLILoop.CompositionRoot.Editor.asmdef
+++ b/Packages/src/Editor/CompositionRoot/UnityCLILoop.CompositionRoot.Editor.asmdef
@@ -16,7 +16,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/Domain/UnityCLILoop.Domain.asmdef
+++ b/Packages/src/Editor/Domain/UnityCLILoop.Domain.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {

--- a/Packages/src/Editor/FirstPartyTools/ClearConsole/UnityCLILoop.FirstPartyTools.ClearConsole.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ClearConsole/UnityCLILoop.FirstPartyTools.ClearConsole.Editor.asmdef
@@ -12,7 +12,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/Common/Console/UnityCLILoop.FirstPartyTools.Common.Console.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/Console/UnityCLILoop.FirstPartyTools.Common.Console.Editor.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/UnityCLILoop.FirstPartyTools.Common.EditorUtility.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/UnityCLILoop.FirstPartyTools.Common.EditorUtility.Editor.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/UnityCLILoop.FirstPartyTools.Common.InputRecording.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/UnityCLILoop.FirstPartyTools.Common.InputRecording.Editor.asmdef
@@ -16,7 +16,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/UnityCLILoop.FirstPartyTools.Common.InputSimulation.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/UnityCLILoop.FirstPartyTools.Common.InputSimulation.Editor.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/UnityCLILoop.FirstPartyTools.Common.InputSystem.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/UnityCLILoop.FirstPartyTools.Common.InputSystem.Editor.asmdef
@@ -13,7 +13,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {

--- a/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UnityCLILoop.FirstPartyTools.Common.MouseUi.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UnityCLILoop.FirstPartyTools.Common.MouseUi.Editor.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/Common/Overlay/UnityCLILoop.FirstPartyTools.Common.Overlay.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/Overlay/UnityCLILoop.FirstPartyTools.Common.Overlay.Editor.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/Compile/UnityCLILoop.FirstPartyTools.Compile.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Compile/UnityCLILoop.FirstPartyTools.Compile.Editor.asmdef
@@ -13,7 +13,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/MetadataValidation/UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.MetadataValidation.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/MetadataValidation/UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.MetadataValidation.Editor.asmdef
@@ -15,7 +15,7 @@
         "System.Runtime.CompilerServices.Unsafe.dll",
         "System.Reflection.Metadata.dll"
     ],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor.asmdef
@@ -13,7 +13,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/UnityCLILoop.FirstPartyTools.FindGameObjects.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/UnityCLILoop.FirstPartyTools.FindGameObjects.Editor.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/GetHierarchy/UnityCLILoop.FirstPartyTools.GetHierarchy.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/GetHierarchy/UnityCLILoop.FirstPartyTools.GetHierarchy.Editor.asmdef
@@ -11,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/GetLogs/UnityCLILoop.FirstPartyTools.GetLogs.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/GetLogs/UnityCLILoop.FirstPartyTools.GetLogs.Editor.asmdef
@@ -12,7 +12,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/UnityCLILoop.FirstPartyTools.RecordInput.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/UnityCLILoop.FirstPartyTools.RecordInput.Editor.asmdef
@@ -16,7 +16,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/UnityCLILoop.FirstPartyTools.ReplayInput.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/UnityCLILoop.FirstPartyTools.ReplayInput.Editor.asmdef
@@ -17,7 +17,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor.asmdef
@@ -16,7 +16,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [
         "ULOOP_HAS_TEST_FRAMEWORK"
     ],

--- a/Packages/src/Editor/FirstPartyTools/RunTests/UnityCLILoop.FirstPartyTools.RunTests.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/UnityCLILoop.FirstPartyTools.RunTests.Editor.asmdef
@@ -13,7 +13,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
@@ -13,7 +13,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor.asmdef
@@ -16,7 +16,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor.asmdef
@@ -16,7 +16,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor.asmdef
@@ -15,7 +15,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/FirstPartyTools/UnityCLILoop.FirstPartyTools.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/UnityCLILoop.FirstPartyTools.Editor.asmdef
@@ -24,7 +24,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {

--- a/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
+++ b/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
@@ -14,7 +14,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/Editor/Presentation/UnityCLILoop.Presentation.asmdef
+++ b/Packages/src/Editor/Presentation/UnityCLILoop.Presentation.asmdef
@@ -13,7 +13,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [
         {


### PR DESCRIPTION
## Summary
- Internal package, sample, and test assemblies are no longer implicitly visible to project scripts.
- The public custom-tool contract remains available to predefined Editor scripts.

## User Impact
- Projects are less likely to accidentally depend on Unity CLI Loop internal assemblies.
- Existing custom tools without their own asmdef can still reference the public tool contract API.

## Changes
- Disabled Auto Referenced for package, sample, and test asmdefs except UnityCLILoop.ToolContracts.
- Added an assembly boundary test that only permits ToolContracts to stay auto-referenced.
- Updated the runtime asmdef contract test to match the prefab-compatible runtime assembly setup.

## Verification
- Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>
- Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value '.*(ProjectAsmdefs_WhenLoaded_AutoReferenceOnlyPublicToolContracts|RuntimeAsmdef_WhenLoaded_AllowsPrefabAttachmentWithoutAutoReference).*'
- Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value '.*InputVisualizationCanvasPrefabTests.*'
- Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value '.*(MigrateAsmdefSource_WhenCurrentToolContractsUsesApplicationGuid_AddsToolContractsGuid|ApplyMigration_WhenCurrentToolContractsExistsWithLegacyAsmdefGuid_RewritesToToolContractsReference).*'

Known unrelated: the full OnionAssemblyDependencyTests suite still reports an existing startup-hook ownership failure that is already present on origin/v3-beta; the focused contract tests above pass.