### PR TITLE
fix: Keep Run Tests available without extra Editor startup hooks

### DIFF
--- a/Assets/Tests/Editor/UnityTestFrameworkOptionalGuardTests.cs
+++ b/Assets/Tests/Editor/UnityTestFrameworkOptionalGuardTests.cs
@@ -18,10 +18,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string UnityEditorTestRunnerAssemblyName = "UnityEditor.TestRunner";
         private const string UnityEngineTestRunnerAssemblyName = "UnityEngine.TestRunner";
         private const string TestAssembliesOptionalReference = "TestAssemblies";
+        private const string FirstPartyToolsAsmdefPath =
+            "Packages/src/Editor/FirstPartyTools/UnityCLILoop.FirstPartyTools.Editor.asmdef";
+        private const string FirstPartyToolsEditorStartupPath =
+            "Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs";
         private const string RunTestsAsmdefPath =
             "Packages/src/Editor/FirstPartyTools/RunTests/UnityCLILoop.FirstPartyTools.RunTests.Editor.asmdef";
         private const string RunTestsTestFrameworkAsmdefPath =
             "Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor.asmdef";
+        private const string RunTestsTestFrameworkGuidReference = "GUID:a338f3f8ae84147109d351d16d557552";
         private static readonly string[] UnityTestRunnerApiFiles =
         {
             "Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs",
@@ -57,6 +62,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ?.Any(DefinesUnityTestFrameworkSymbol) == true;
 
             Assert.That(hasVersionDefine, Is.True);
+        }
+
+        [Test]
+        public void FirstPartyToolsAssemblyDefinition_WhenScanned_GatesOptionalTestFrameworkAdapterReference()
+        {
+            // Verifies that the startup facade can reach the optional Test Framework adapter only when available.
+            JObject asmdef = ReadJson(FirstPartyToolsAsmdefPath);
+            string[] references = ReadStringArray(asmdef, "references");
+            bool hasVersionDefine = asmdef["versionDefines"]
+                ?.Any(DefinesUnityTestFrameworkSymbol) == true;
+
+            Assert.That(references, Does.Contain(RunTestsTestFrameworkGuidReference));
+            Assert.That(hasVersionDefine, Is.True);
+        }
+
+        [Test]
+        public void FirstPartyToolsEditorStartup_WhenScanned_InitializesOptionalTestFrameworkAdapter()
+        {
+            // Verifies that optional Test Framework registration is owned by the composition-root startup path.
+            string content = ReadText(FirstPartyToolsEditorStartupPath);
+
+            Assert.That(content, Does.Contain("#if " + UnityCliLoopConstants.SCRIPTING_DEFINE_HAS_TEST_FRAMEWORK));
+            Assert.That(content, Does.Contain("RunTestsTestFrameworkStartup.Initialize();"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/UnityTestFrameworkOptionalGuardTests.cs
+++ b/Assets/Tests/Editor/UnityTestFrameworkOptionalGuardTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
@@ -82,9 +83,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies that optional Test Framework registration is owned by the composition-root startup path.
             string content = ReadText(FirstPartyToolsEditorStartupPath);
+            string guard = "#if " + UnityCliLoopConstants.SCRIPTING_DEFINE_HAS_TEST_FRAMEWORK;
+            string initCall = "RunTestsTestFrameworkStartup.Initialize();";
+            int guardIndex = content.IndexOf(guard, StringComparison.Ordinal);
+            int initCallIndex = content.IndexOf(initCall, StringComparison.Ordinal);
 
-            Assert.That(content, Does.Contain("#if " + UnityCliLoopConstants.SCRIPTING_DEFINE_HAS_TEST_FRAMEWORK));
-            Assert.That(content, Does.Contain("RunTestsTestFrameworkStartup.Initialize();"));
+            Assert.That(guardIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(initCallIndex, Is.GreaterThan(guardIndex));
+            int endIfIndex = content.IndexOf("#endif", initCallIndex, StringComparison.Ordinal);
+            Assert.That(endIfIndex, Is.GreaterThan(initCallIndex));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
@@ -10,6 +10,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             ExecuteDynamicCodeEditorStartup.Initialize();
             GetLogsEditorStartup.Initialize();
+#if ULOOP_HAS_TEST_FRAMEWORK
+            RunTestsTestFrameworkStartup.Initialize();
+#endif
 #if ULOOP_HAS_INPUT_SYSTEM
             RecordInputEditorStartup.Initialize();
             ReplayInputEditorStartup.Initialize();

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -1,20 +1,21 @@
 #if ULOOP_HAS_TEST_FRAMEWORK
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using UnityEditor;
 using UnityEditor.TestTools.TestRunner.Api;
 using UnityEngine;
+
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
     /// Registers and executes Unity Test Runner work when the Test Framework package is installed.
     /// </summary>
-    [InitializeOnLoad]
     internal static class RunTestsTestFrameworkStartup
     {
-        static RunTestsTestFrameworkStartup()
+        internal static void Initialize()
         {
             UnityTestFrameworkExecutionServiceRegistry.Register(new UnityTestFrameworkExecutionService());
         }

--- a/Packages/src/Editor/FirstPartyTools/UnityCLILoop.FirstPartyTools.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/UnityCLILoop.FirstPartyTools.Editor.asmdef
@@ -12,6 +12,7 @@
         "GUID:dc412b2cd951d452b8dcec99c3adeb19",
         "GUID:3b7aa330d87dc452293296dd5830859b",
         "GUID:9ed21973545c44e28af522b049dec47d",
+        "GUID:a338f3f8ae84147109d351d16d557552",
         "GUID:a0bdbd2c5705643fbb9aef9fac8fd46a",
         "GUID:679888bc3e9c44c19ab0d62ff8701dcf",
         "GUID:9c34b9a25e1464dec91601291eade23f",
@@ -31,6 +32,11 @@
             "name": "com.unity.inputsystem",
             "expression": "",
             "define": "ULOOP_HAS_INPUT_SYSTEM"
+        },
+        {
+            "name": "com.unity.test-framework",
+            "expression": "",
+            "define": "ULOOP_HAS_TEST_FRAMEWORK"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
## Summary
- Keeps Run Tests support available through the controlled Editor startup path.
- Removes the extra production Editor startup hook that made the full Onion assembly dependency suite fail.

## User Impact
- The architecture test suite no longer reports a production Editor startup hook outside the composition-root startup owner.
- Run Tests remains available when Unity Test Framework is installed, while projects without that package keep the optional dependency contract.

## Changes
- Registers the optional Test Framework adapter from the first-party startup facade.
- Gates the adapter reference with Unity Test Framework version defines.
- Adds guard tests for the optional adapter startup path.

## Verification
- `Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value ".*(OnionAssemblyDependencyTests|UnityTestFrameworkOptionalGuardTests).*"`
- `~/.codex/skills/codex-review/scripts/codex-review --parallel-tests <focused EditMode test> v3-beta`

Closes #1198