### PR TITLE
chore: Require explicit CLI compatibility decisions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Test release automation shell helpers
         run: |
@@ -36,6 +38,9 @@ jobs:
         with:
           go-version-file: Packages/src/Cli~/.go-version
           cache-dependency-path: Packages/src/Cli~/**/go.sum
+
+      - name: Check CLI minimum version compatibility
+        run: scripts/check-cli-minimum-version-compatibility.sh
 
       - name: Install golangci-lint
         run: |

--- a/Packages/src/Cli~/cmd/cli-minimum-version-guard/main.go
+++ b/Packages/src/Cli~/cmd/cli-minimum-version-guard/main.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/hatayama/unity-cli-loop/Packages/src/Cli/internal/version"
+)
+
+const (
+	minimumVersionFile = "Packages/src/Editor/Domain/CliConstants.cs"
+	contractFile       = "Packages/src/Cli~/contract.json"
+	decisionFile       = ".github/cli-minimum-version-decision.json"
+)
+
+var minimumVersionPattern = regexp.MustCompile(`MINIMUM_REQUIRED_CLI_VERSION\s*=\s*"([^"]+)"`)
+
+type cliContract struct {
+	CLIVersion string `json:"cliVersion"`
+}
+
+func main() {
+	repositoryRoot, err := gitOutput("", "rev-parse", "--show-toplevel")
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	repositoryRoot = strings.TrimSpace(repositoryRoot)
+	if err := check(repositoryRoot); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	_, _ = fmt.Fprintln(os.Stdout, "CLI minimum-version compatibility guard passed.")
+}
+
+func check(repositoryRoot string) error {
+	minimumVersion, err := minimumRequiredCLIVersion(repositoryRoot)
+	if err != nil {
+		return err
+	}
+	latestVersion, err := latestCLIContractVersion(repositoryRoot)
+	if err != nil {
+		return err
+	}
+	comparison, ok := version.Compare(minimumVersion, latestVersion)
+	if !ok {
+		return fmt.Errorf("invalid CLI version comparison: %s vs %s", minimumVersion, latestVersion)
+	}
+	if comparison > 0 {
+		return fmt.Errorf("MINIMUM_REQUIRED_CLI_VERSION (%s) must not be greater than CLI contract cliVersion (%s)", minimumVersion, latestVersion)
+	}
+
+	baseRef := resolveBaseRef(repositoryRoot)
+	changedFiles, err := changedFiles(repositoryRoot, baseRef)
+	if err != nil {
+		return err
+	}
+
+	minimumVersionChanged := false
+	if baseRef != "" {
+		baseMinimumVersion, err := baseMinimumRequiredCLIVersion(repositoryRoot, baseRef)
+		if err != nil {
+			return err
+		}
+		minimumVersionChanged = baseMinimumVersion != "" && baseMinimumVersion != minimumVersion
+	}
+
+	if _, err := os.Stat(path.Join(repositoryRoot, decisionFile)); err == nil {
+		if err := validateKeepDecision(repositoryRoot, minimumVersion); err != nil {
+			return err
+		}
+	}
+
+	sensitiveChange, decisionChanged := changedFileState(changedFiles)
+	if sensitiveChange && !minimumVersionChanged {
+		if !decisionChanged {
+			return fmt.Errorf("compatibility-sensitive CLI or Editor/CLI files changed without updating MINIMUM_REQUIRED_CLI_VERSION or %s", decisionFile)
+		}
+		return validateKeepDecision(repositoryRoot, minimumVersion)
+	}
+
+	return nil
+}
+
+func minimumRequiredCLIVersion(repositoryRoot string) (string, error) {
+	content, err := os.ReadFile(path.Join(repositoryRoot, minimumVersionFile))
+	if err != nil {
+		return "", err
+	}
+	match := minimumVersionPattern.FindStringSubmatch(string(content))
+	if len(match) != 2 {
+		return "", fmt.Errorf("missing MINIMUM_REQUIRED_CLI_VERSION in %s", minimumVersionFile)
+	}
+	return match[1], nil
+}
+
+func latestCLIContractVersion(repositoryRoot string) (string, error) {
+	content, err := os.ReadFile(path.Join(repositoryRoot, contractFile))
+	if err != nil {
+		return "", err
+	}
+	var contract cliContract
+	if err := json.Unmarshal(content, &contract); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(contract.CLIVersion) == "" {
+		return "", fmt.Errorf("missing cliVersion in %s", contractFile)
+	}
+	return contract.CLIVersion, nil
+}
+
+func resolveBaseRef(repositoryRoot string) string {
+	if baseRef := strings.TrimSpace(os.Getenv("CLI_MINIMUM_VERSION_BASE_REF")); baseRef != "" {
+		return baseRef
+	}
+	if baseRef := strings.TrimSpace(os.Getenv("GITHUB_BASE_REF")); baseRef != "" {
+		return "origin/" + baseRef
+	}
+	if _, err := gitOutput(repositoryRoot, "rev-parse", "--verify", "HEAD^"); err == nil {
+		return "HEAD^"
+	}
+	return ""
+}
+
+func changedFiles(repositoryRoot string, baseRef string) ([]string, error) {
+	if baseRef == "" {
+		return nil, nil
+	}
+	output, err := gitOutput(repositoryRoot, "diff", "--name-only", baseRef+"...HEAD", "--")
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(strings.TrimSpace(output), "\n"), nil
+}
+
+func baseMinimumRequiredCLIVersion(repositoryRoot string, baseRef string) (string, error) {
+	output, err := gitOutput(repositoryRoot, "show", baseRef+":"+minimumVersionFile)
+	if err != nil {
+		return "", err
+	}
+	match := minimumVersionPattern.FindStringSubmatch(output)
+	if len(match) != 2 {
+		return "", nil
+	}
+	return match[1], nil
+}
+
+func isCompatibilitySensitivePath(file string) bool {
+	switch file {
+	case contractFile,
+		"Packages/src/Cli~/layout-contract.json",
+		"scripts/install.sh",
+		"scripts/install.ps1",
+		"Packages/src/Editor/Application/CliSetupApplicationService.cs",
+		"Packages/src/Editor/CompositionRoot/UnityCliLoopFirstPartyServerLifecycleBinding.cs":
+		return true
+	}
+	if path.Dir(file) == "Packages/src/Cli~" && strings.HasSuffix(path.Base(file), ".go") {
+		return true
+	}
+	for _, prefix := range []string{
+		"Packages/src/Cli~/cmd/uloop/",
+		"Packages/src/Cli~/internal/",
+		"Packages/src/Editor/Infrastructure/Api/",
+		"Packages/src/Editor/Infrastructure/CLI/",
+	} {
+		if strings.HasPrefix(file, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func changedFileState(files []string) (bool, bool) {
+	sensitiveChange := false
+	decisionChanged := false
+	for _, file := range files {
+		if isCompatibilitySensitivePath(file) {
+			sensitiveChange = true
+		}
+		if file == decisionFile {
+			decisionChanged = true
+		}
+	}
+	return sensitiveChange, decisionChanged
+}
+
+func validateKeepDecision(repositoryRoot string, minimumVersion string) error {
+	content, err := os.ReadFile(path.Join(repositoryRoot, decisionFile))
+	if err != nil {
+		return fmt.Errorf("missing %s: add a keep decision or update MINIMUM_REQUIRED_CLI_VERSION", decisionFile)
+	}
+	var decision map[string]string
+	if err := json.Unmarshal(content, &decision); err != nil {
+		return err
+	}
+	if decision["minimumRequiredCliVersion"] != minimumVersion {
+		return fmt.Errorf("%s must document the current minimumRequiredCliVersion (%s)", decisionFile, minimumVersion)
+	}
+	if decision["decision"] != "keep" {
+		return fmt.Errorf("%s decision must be \"keep\"", decisionFile)
+	}
+	if strings.TrimSpace(decision["reason"]) == "" {
+		return fmt.Errorf("%s reason must not be empty", decisionFile)
+	}
+	return nil
+}
+
+func gitOutput(repositoryRoot string, args ...string) (string, error) {
+	command := exec.Command("git", args...)
+	if repositoryRoot != "" {
+		command.Dir = repositoryRoot
+	}
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s failed: %s", strings.Join(args, " "), strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}

--- a/Packages/src/Cli~/cmd/cli-minimum-version-guard/main_test.go
+++ b/Packages/src/Cli~/cmd/cli-minimum-version-guard/main_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestCheckMinimumVersionCompatibility(t *testing.T) {
+	// Verifies version ordering, sensitive-change decisions, and minimum-version updates.
+	const olderMinimumVersion = "3.0.0-beta.13"
+	const latestVersion = "3.0.0-beta.14"
+
+	cases := []struct {
+		name        string
+		minimum     string
+		mutate      func(t *testing.T, repositoryRoot string)
+		expectedErr string
+	}{
+		{
+			name: "lower minimum without sensitive change",
+			mutate: func(t *testing.T, repositoryRoot string) {
+				writeFile(t, repositoryRoot, "README.md", "documentation\n")
+			},
+		},
+		{
+			name:    "minimum greater than latest",
+			minimum: "3.0.0-beta.15",
+			mutate: func(t *testing.T, repositoryRoot string) {
+				writeFile(t, repositoryRoot, "README.md", "documentation\n")
+			},
+			expectedErr: "must not be greater",
+		},
+		{
+			name:        "sensitive change without decision",
+			mutate:      writeSensitiveCLIChange,
+			expectedErr: "compatibility-sensitive",
+		},
+		{
+			name: "guard command change",
+			mutate: func(t *testing.T, repositoryRoot string) {
+				writeFile(t, repositoryRoot, "Packages/src/Cli~/cmd/cli-minimum-version-guard/main.go", "package main\n")
+			},
+		},
+		{
+			name: "keep decision without reason",
+			mutate: func(t *testing.T, repositoryRoot string) {
+				writeSensitiveCLIChange(t, repositoryRoot)
+				writeKeepDecision(t, repositoryRoot, "3.0.0-beta.13", "")
+			},
+			expectedErr: "reason must not be empty",
+		},
+		{
+			name: "keep decision with reason",
+			mutate: func(t *testing.T, repositoryRoot string) {
+				writeSensitiveCLIChange(t, repositoryRoot)
+				writeKeepDecision(t, repositoryRoot, "3.0.0-beta.13", "The changed CLI behavior is additive.")
+			},
+		},
+		{
+			name: "minimum version updated",
+			mutate: func(t *testing.T, repositoryRoot string) {
+				writeSensitiveCLIChange(t, repositoryRoot)
+				writeMinimumVersion(t, repositoryRoot, "3.0.0-beta.14")
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			minimumVersion := olderMinimumVersion
+			if tt.minimum != "" {
+				minimumVersion = tt.minimum
+			}
+			repositoryRoot := createRepository(t, minimumVersion, latestVersion)
+			tt.mutate(t, repositoryRoot)
+			commitAll(t, repositoryRoot, tt.name)
+			t.Setenv("CLI_MINIMUM_VERSION_BASE_REF", "HEAD^")
+
+			err := check(repositoryRoot)
+			if tt.expectedErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {
+				t.Fatalf("expected %q error, got %v", tt.expectedErr, err)
+			}
+		})
+	}
+}
+
+func createRepository(t *testing.T, minimumVersion string, latestVersion string) string {
+	t.Helper()
+
+	repositoryRoot := t.TempDir()
+	runGit(t, repositoryRoot, "init", "-q")
+	runGit(t, repositoryRoot, "config", "user.email", "test@example.invalid")
+	runGit(t, repositoryRoot, "config", "user.name", "Test User")
+	writeMinimumVersion(t, repositoryRoot, minimumVersion)
+	writeContractVersion(t, repositoryRoot, latestVersion)
+	commitAll(t, repositoryRoot, "base")
+	return repositoryRoot
+}
+
+func writeMinimumVersion(t *testing.T, repositoryRoot string, value string) {
+	t.Helper()
+
+	writeFile(t, repositoryRoot, minimumVersionFile, `namespace Test { public static class CliConstants { public const string MINIMUM_REQUIRED_CLI_VERSION = "`+value+`"; } }`+"\n")
+}
+
+func writeContractVersion(t *testing.T, repositoryRoot string, value string) {
+	t.Helper()
+
+	writeFile(t, repositoryRoot, contractFile, `{ "schemaVersion": 1, "cliVersion": "`+value+`" }`+"\n")
+}
+
+func writeKeepDecision(t *testing.T, repositoryRoot string, value string, reason string) {
+	t.Helper()
+
+	writeFile(t, repositoryRoot, decisionFile, `{ "minimumRequiredCliVersion": "`+value+`", "decision": "keep", "reason": "`+reason+`" }`+"\n")
+}
+
+func writeSensitiveCLIChange(t *testing.T, repositoryRoot string) {
+	t.Helper()
+
+	writeFile(t, repositoryRoot, "Packages/src/Cli~/internal/cli/tool_readiness.go", "package cli\n")
+}
+
+func writeFile(t *testing.T, repositoryRoot string, file string, content string) {
+	t.Helper()
+
+	fullPath := path.Join(repositoryRoot, file)
+	if err := os.MkdirAll(path.Dir(fullPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func commitAll(t *testing.T, repositoryRoot string, message string) {
+	t.Helper()
+
+	runGit(t, repositoryRoot, "add", ".")
+	runGit(t, repositoryRoot, "commit", "-q", "-m", message)
+}
+
+func runGit(t *testing.T, repositoryRoot string, args ...string) {
+	t.Helper()
+
+	command := exec.Command("git", args...)
+	command.Dir = repositoryRoot
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %s", strings.Join(args, " "), strings.TrimSpace(string(output)))
+	}
+}

--- a/scripts/check-cli-minimum-version-compatibility.sh
+++ b/scripts/check-cli-minimum-version-compatibility.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+CLI_DIR="$ROOT_DIR/Packages/src/Cli~"
+
+. "$ROOT_DIR/scripts/go-cli-toolchain.sh"
+require_go_cli_toolchain "$ROOT_DIR"
+
+(cd "$CLI_DIR" && go run ./cmd/cli-minimum-version-guard)


### PR DESCRIPTION
## Summary
- PRs now fail fast when the Unity package minimum CLI version is newer than the bundled CLI contract.
- Compatibility-sensitive CLI or Editor/CLI changes now require either a minimum-version bump or a documented keep decision.

## User Impact
- Maintainers can keep the Unity package minimum below the latest bundled CLI when older CLIs remain compatible.
- Reviewers get an explicit reason when a change keeps accepting older CLIs, instead of relying on an implicit assumption.

## Changes
- Add a Go-based CI guard for CLI minimum-version compatibility decisions.
- Run the guard in build-and-test with full checkout history so PR diffs can be inspected against the base branch.
- Cover version ordering, sensitive-change detection, keep-decision validation, and minimum-version updates with focused tests.

## Verification
- go test ./cmd/cli-minimum-version-guard
- scripts/check-cli-minimum-version-compatibility.sh
- scripts/check-go-cli.sh
- git diff --check

Closes #1200
