### PR TITLE
chore: Surface CLI minimum version reminders on PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: read
 
 jobs:
   build-cli:
@@ -17,9 +19,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Test release automation shell helpers
         run: |
+          scripts/test-comment-cli-minimum-version-warning.sh
           scripts/test-resolve-native-cli-release-target.sh
           scripts/test-is-release-please-release-commit.sh
           scripts/test-release-please-config.sh
@@ -30,6 +35,15 @@ jobs:
           scripts/test-notify-release-workflow-failure.sh
           scripts/test-native-cli-publish-workflow.sh
           scripts/test-install-release-filter.sh
+
+      - name: Comment on CLI minimum version check
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CLI_MINIMUM_VERSION_BASE_REF: origin/${{ github.base_ref }}
+        run: scripts/comment-cli-minimum-version-warning.sh
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,12 +9,14 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
 
 jobs:
   build-cli:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
 
     steps:
       - name: Checkout repository

--- a/scripts/comment-cli-minimum-version-warning.sh
+++ b/scripts/comment-cli-minimum-version-warning.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=${ULOOP_REPOSITORY_ROOT:-$(CDPATH= cd "$(dirname "$0")/.." && pwd)}
+MINIMUM_VERSION_FILE="Packages/src/Editor/Domain/CliConstants.cs"
+MARKER="<!-- uloop-cli-minimum-version-warning -->"
+PR_NUMBER=${PR_NUMBER:-}
+REPOSITORY=${GITHUB_REPOSITORY:-}
+BASE_REF=${CLI_MINIMUM_VERSION_BASE_REF:-}
+
+if [ -z "$PR_NUMBER" ]; then
+  echo "Skipping CLI minimum version comment because no PR number was provided."
+  exit 0
+fi
+
+if [ -z "$REPOSITORY" ]; then
+  REPOSITORY=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+fi
+
+if [ -z "$BASE_REF" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  BASE_REF="origin/$GITHUB_BASE_REF"
+fi
+
+if [ -z "$BASE_REF" ]; then
+  echo "Skipping CLI minimum version comment because no base ref was provided."
+  exit 0
+fi
+
+CHANGED_FILES=$(git -C "$ROOT_DIR" diff --name-only "$BASE_REF...HEAD" --)
+
+has_changed_file() {
+  expected=$1
+
+  for changed_file in $CHANGED_FILES; do
+    if [ "$changed_file" = "$expected" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+has_go_cli_change() {
+  for changed_file in $CHANGED_FILES; do
+    case "$changed_file" in
+      Packages/src/Cli~/CHANGELOG.md|Packages/src/Cli~/dist/*)
+        ;;
+      Packages/src/Cli~/*.go|Packages/src/Cli~/go.mod|Packages/src/Cli~/go.sum|Packages/src/Cli~/contract.json|Packages/src/Cli~/layout-contract.json|Packages/src/Cli~/cmd/*|Packages/src/Cli~/internal/*)
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+existing_comment_id() {
+  gh api --paginate "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+    --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" |
+    tail -n 1
+}
+
+write_body_json() {
+  body_file=$1
+  json_file=$2
+
+  jq -n --rawfile body "$body_file" '{body: $body}' > "$json_file"
+}
+
+upsert_comment() {
+  body_file=$1
+  json_file=$(mktemp)
+  comment_id=$(existing_comment_id)
+
+  write_body_json "$body_file" "$json_file"
+
+  if [ -n "$comment_id" ]; then
+    gh api --method PATCH "repos/$REPOSITORY/issues/comments/$comment_id" --input "$json_file" >/dev/null
+    rm -f "$json_file"
+    echo "Updated CLI minimum version comment."
+    return
+  fi
+
+  gh api --method POST "repos/$REPOSITORY/issues/$PR_NUMBER/comments" --input "$json_file" >/dev/null
+  rm -f "$json_file"
+  echo "Posted CLI minimum version comment."
+}
+
+update_existing_comment() {
+  body_file=$1
+  json_file=$(mktemp)
+  comment_id=$(existing_comment_id)
+
+  if [ -z "$comment_id" ]; then
+    return
+  fi
+
+  write_body_json "$body_file" "$json_file"
+  gh api --method PATCH "repos/$REPOSITORY/issues/comments/$comment_id" --input "$json_file" >/dev/null
+  rm -f "$json_file"
+  echo "Resolved CLI minimum version comment."
+}
+
+WARNING_BODY=$(mktemp)
+RESOLVED_BODY=$(mktemp)
+
+cleanup() {
+  rm -f "$WARNING_BODY" "$RESOLVED_BODY"
+}
+
+trap cleanup EXIT INT HUP TERM
+
+cat > "$WARNING_BODY" <<EOF_WARNING
+$MARKER
+Warning: Go CLI files changed, but \`MINIMUM_REQUIRED_CLI_VERSION\` was not updated.
+
+Please confirm whether the Unity package can still accept older CLI versions. If the package now depends on new CLI behavior, update \`Packages/src/Editor/Domain/CliConstants.cs\`.
+EOF_WARNING
+
+cat > "$RESOLVED_BODY" <<EOF_RESOLVED
+$MARKER
+Resolved: this PR no longer has Go CLI changes without a \`MINIMUM_REQUIRED_CLI_VERSION\` update.
+EOF_RESOLVED
+
+if has_go_cli_change && ! has_changed_file "$MINIMUM_VERSION_FILE"; then
+  upsert_comment "$WARNING_BODY"
+  exit 0
+fi
+
+update_existing_comment "$RESOLVED_BODY"

--- a/scripts/test-comment-cli-minimum-version-warning.sh
+++ b/scripts/test-comment-cli-minimum-version-warning.sh
@@ -1,0 +1,192 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/comment-cli-minimum-version-warning.sh"
+TMP_DIR=$(mktemp -d)
+ORIGINAL_PATH=$PATH
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT HUP TERM
+
+write_mock_gh() {
+  work_dir=$1
+  mock_bin="$work_dir/bin"
+  mkdir -p "$mock_bin"
+
+  cat > "$mock_bin/gh" <<'MOCK_GH'
+#!/bin/sh
+set -eu
+
+method=GET
+path=
+input=
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    api)
+      ;;
+    --method)
+      shift
+      method=$1
+      ;;
+    --input)
+      shift
+      input=$1
+      ;;
+    --jq)
+      shift
+      ;;
+    --*)
+      ;;
+    *)
+      if [ -z "$path" ]; then
+        path=$1
+      fi
+      ;;
+  esac
+  shift
+done
+
+printf '%s %s\n' "$method" "$path" >> "$GH_LOG"
+
+if [ "$method" = "GET" ]; then
+  if [ -n "$GH_EXISTING_COMMENT_ID" ]; then
+    printf '%s\n' "$GH_EXISTING_COMMENT_ID"
+  fi
+  exit 0
+fi
+
+if [ -n "$input" ]; then
+  cat "$input" >> "$GH_BODY_LOG"
+fi
+MOCK_GH
+
+  chmod +x "$mock_bin/gh"
+}
+
+assert_contains() {
+  file=$1
+  expected=$2
+
+  if ! grep -F "$expected" "$file" >/dev/null; then
+    echo "Expected $file to contain: $expected" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  file=$1
+  unexpected=$2
+
+  if grep -F "$unexpected" "$file" >/dev/null; then
+    echo "Expected $file not to contain: $unexpected" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+write_file() {
+  file=$1
+  content=$2
+
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$content" > "$file"
+}
+
+create_repository() {
+  work_dir=$1
+
+  git init -q "$work_dir/repo"
+  (
+    cd "$work_dir/repo"
+    git config user.email test@example.invalid
+    git config user.name "Test User"
+    write_file Packages/src/Cli~/internal/cli/run.go "package cli"
+    write_file Packages/src/Editor/Domain/CliConstants.cs "public const string MINIMUM_REQUIRED_CLI_VERSION = \"3.0.0-beta.14\";"
+    git add .
+    git commit -q -m base
+  )
+}
+
+run_case() {
+  name=$1
+  existing_comment_id=$2
+  mutation=$3
+
+  work_dir="$TMP_DIR/$name"
+  mkdir -p "$work_dir"
+  write_mock_gh "$work_dir"
+  touch "$work_dir/gh.log" "$work_dir/body.log"
+  create_repository "$work_dir"
+
+  (
+    cd "$work_dir/repo"
+    case "$mutation" in
+      go-cli)
+        write_file Packages/src/Cli~/internal/cli/run.go "package cli // changed"
+        ;;
+      go-cli-and-minimum)
+        write_file Packages/src/Cli~/internal/cli/run.go "package cli // changed"
+        write_file Packages/src/Editor/Domain/CliConstants.cs "public const string MINIMUM_REQUIRED_CLI_VERSION = \"3.0.0-beta.15\";"
+        ;;
+      docs)
+        write_file README.md "documentation"
+        ;;
+    esac
+    git add .
+    git commit -q -m "$mutation"
+
+    PATH="$work_dir/bin:$ORIGINAL_PATH" \
+      GH_LOG="$work_dir/gh.log" \
+      GH_BODY_LOG="$work_dir/body.log" \
+      GH_EXISTING_COMMENT_ID="$existing_comment_id" \
+      ULOOP_REPOSITORY_ROOT="$work_dir/repo" \
+      PR_NUMBER=123 \
+      GITHUB_REPOSITORY=hatayama/unity-cli-loop \
+      CLI_MINIMUM_VERSION_BASE_REF=HEAD^ \
+      "$SCRIPT" > "$work_dir/output.txt"
+  )
+}
+
+# Verifies a Go CLI change without a minimum-version change creates a warning comment.
+run_case posts-warning "" go-cli
+assert_contains "$TMP_DIR/posts-warning/gh.log" "POST repos/hatayama/unity-cli-loop/issues/123/comments"
+assert_contains "$TMP_DIR/posts-warning/body.log" "Go CLI files changed"
+
+# Verifies a matching existing comment is updated instead of duplicated.
+run_case updates-warning 456 go-cli
+assert_contains "$TMP_DIR/updates-warning/gh.log" "PATCH repos/hatayama/unity-cli-loop/issues/comments/456"
+assert_contains "$TMP_DIR/updates-warning/body.log" "Go CLI files changed"
+assert_not_contains "$TMP_DIR/updates-warning/gh.log" "POST"
+
+# Verifies a minimum-version update resolves the existing reminder.
+run_case resolves-existing-warning 456 go-cli-and-minimum
+assert_contains "$TMP_DIR/resolves-existing-warning/gh.log" "PATCH repos/hatayama/unity-cli-loop/issues/comments/456"
+assert_contains "$TMP_DIR/resolves-existing-warning/body.log" "Resolved:"
+
+# Verifies unrelated changes do not create a new comment.
+run_case ignores-docs "" docs
+assert_not_contains "$TMP_DIR/ignores-docs/gh.log" "POST"
+assert_not_contains "$TMP_DIR/ignores-docs/gh.log" "PATCH"
+
+# Verifies non-PR runs do not call GitHub.
+work_dir="$TMP_DIR/no-pr"
+mkdir -p "$work_dir"
+write_mock_gh "$work_dir"
+touch "$work_dir/gh.log" "$work_dir/body.log"
+create_repository "$work_dir"
+(
+  cd "$work_dir/repo"
+  PATH="$work_dir/bin:$ORIGINAL_PATH" \
+    GH_LOG="$work_dir/gh.log" \
+    GH_BODY_LOG="$work_dir/body.log" \
+    ULOOP_REPOSITORY_ROOT="$work_dir/repo" \
+    "$SCRIPT" > "$work_dir/output.txt"
+)
+assert_contains "$work_dir/output.txt" "no PR number"
+assert_not_contains "$work_dir/gh.log" "repos/"


### PR DESCRIPTION
## Summary
- Pull requests now get a visible reminder when Go CLI files change without a matching Unity package minimum-version update.
- The reminder is updated in place, so repeated pushes do not create duplicate comments.

## User Impact
- Reviewers and review-comment automation can see the compatibility check directly in the PR conversation.
- Maintainers can intentionally keep supporting older CLIs without failing CI, while still getting a reminder to verify the decision.

## Changes
- Add a marker-based PR comment helper for Go CLI minimum-version reminders.
- Update the existing reminder to a resolved message when the minimum-version update appears later.
- Run the helper from the build-and-test workflow as a non-blocking pull request step.

## Verification
- scripts/test-comment-cli-minimum-version-warning.sh
- build-and-test shell helper suite
- sh -n scripts/comment-cli-minimum-version-warning.sh
- sh -n scripts/test-comment-cli-minimum-version-warning.sh
- git diff --check

Closes #1200
