### PR TITLE
fix: Simplify compile skill guidance

### DIFF
--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-compile
 toolName: compile
-description: "Compile the Unity project and report errors/warnings. Use after C# edits or when a full Domain Reload compile is needed."
+description: "Compile the Unity project and report errors/warnings. Use after C# edits."
 ---
 
 # uloop compile
@@ -18,7 +18,7 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--force-recompile` | boolean | `false` | Force full recompilation (triggers Domain Reload) |
+| `--force-recompile` | boolean | `false` | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
 | `--no-wait-for-domain-reload` | boolean | `false` | Return before Domain Reload completion |
 
 ## Global Options
@@ -33,9 +33,6 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 # Check compilation
 uloop compile
 
-# Force full recompilation and wait for Domain Reload completion
-uloop compile --force-recompile
-
 # Start compilation without waiting for Domain Reload completion
 uloop compile --no-wait-for-domain-reload
 ```
@@ -46,23 +43,3 @@ Returns JSON:
 - `Success`: boolean
 - `ErrorCount`: number
 - `WarningCount`: number
-
-## Troubleshooting
-
-Diagnose the failure mode before retrying.
-
-**Stale recovery state** (CLI hangs or shows recovery/startup state while Unity Editor *is* running):
-
-```bash
-uloop fix
-```
-
-This removes stale Unity CLI Loop readiness state files from the Unity project's Temp directory. Then retry `uloop compile`.
-
-**Unity Editor not running** (CLI returns a connection failure and no Unity process is alive):
-
-```bash
-uloop launch
-```
-
-`uloop launch` auto-detects the project at the current working directory and opens it in the matching Unity Editor version. After Unity finishes launching, retry `uloop compile`.

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-compile
 toolName: compile
-description: "Compile the Unity project and report errors/warnings. Use after C# edits or when a full Domain Reload compile is needed."
+description: "Compile the Unity project and report errors/warnings. Use after C# edits."
 ---
 
 # uloop compile
@@ -18,7 +18,7 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--force-recompile` | boolean | `false` | Force full recompilation (triggers Domain Reload) |
+| `--force-recompile` | boolean | `false` | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
 | `--no-wait-for-domain-reload` | boolean | `false` | Return before Domain Reload completion |
 
 ## Global Options
@@ -33,9 +33,6 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 # Check compilation
 uloop compile
 
-# Force full recompilation and wait for Domain Reload completion
-uloop compile --force-recompile
-
 # Start compilation without waiting for Domain Reload completion
 uloop compile --no-wait-for-domain-reload
 ```
@@ -46,23 +43,3 @@ Returns JSON:
 - `Success`: boolean
 - `ErrorCount`: number
 - `WarningCount`: number
-
-## Troubleshooting
-
-Diagnose the failure mode before retrying.
-
-**Stale recovery state** (CLI hangs or shows recovery/startup state while Unity Editor *is* running):
-
-```bash
-uloop fix
-```
-
-This removes stale Unity CLI Loop readiness state files from the Unity project's Temp directory. Then retry `uloop compile`.
-
-**Unity Editor not running** (CLI returns a connection failure and no Unity process is alive):
-
-```bash
-uloop launch
-```
-
-`uloop launch` auto-detects the project at the current working directory and opens it in the matching Unity Editor version. After Unity finishes launching, retry `uloop compile`.

--- a/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-compile
 toolName: compile
-description: "Compile the Unity project and report errors/warnings. Use after C# edits or when a full Domain Reload compile is needed."
+description: "Compile the Unity project and report errors/warnings. Use after C# edits."
 ---
 
 # uloop compile
@@ -18,7 +18,7 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--force-recompile` | boolean | `false` | Force full recompilation (triggers Domain Reload) |
+| `--force-recompile` | boolean | `false` | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
 | `--no-wait-for-domain-reload` | boolean | `false` | Return before Domain Reload completion |
 
 ## Global Options
@@ -33,9 +33,6 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 # Check compilation
 uloop compile
 
-# Force full recompilation and wait for Domain Reload completion
-uloop compile --force-recompile
-
 # Start compilation without waiting for Domain Reload completion
 uloop compile --no-wait-for-domain-reload
 ```
@@ -46,23 +43,3 @@ Returns JSON:
 - `Success`: boolean
 - `ErrorCount`: number
 - `WarningCount`: number
-
-## Troubleshooting
-
-Diagnose the failure mode before retrying.
-
-**Unity Editor running but not responding** (CLI cannot reach the project IPC server while a Unity process is alive):
-
-```bash
-uloop launch -r
-```
-
-This restarts the target Unity project. After Unity finishes launching, retry `uloop compile`.
-
-**Unity Editor not running** (CLI returns a connection failure and no Unity process is alive):
-
-```bash
-uloop launch
-```
-
-`uloop launch` auto-detects the project at the current working directory and opens it in the matching Unity Editor version. After Unity finishes launching, retry `uloop compile`.


### PR DESCRIPTION
## Summary
- Simplifies the compile skill guidance so agents see only the commands and output fields they need.
- Clarifies that `--force-recompile` is a slower, broader validation path for cases such as warnings hidden by other asmdefs.

## User Impact
- Agents are no longer steered toward stale recovery or Unity restart steps from the compile skill.
- The force-recompile option is described as a broader validation tool without making Domain Reload behavior the focus.

## Changes
- Trimmed the source compile skill.
- Regenerated the Claude and Agents project skill copies.

## Verification
- `git diff --check origin/v3-beta...HEAD`
- `rg -n "Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile|Use to find warnings hidden|Force full recompilation|triggers Domain Reload|full Domain Reload compile|Troubleshooting|uloop launch|uloop fix" Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md .agents/skills/uloop-compile/SKILL.md .claude/skills/uloop-compile/SKILL.md`
- Unity compile not run because this change only edits Markdown skill files.