### PR TITLE
fix: Input simulation commands no longer hang while showing overlays

### DIFF
--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -50,6 +50,69 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(canvas.ReplayInputOverlay, Is.Not.Null);
         }
 
+        [Test]
+        public void InputVisualizationCanvasPrefab_WhenInstantiated_HasRuntimeOverlayReferences()
+        {
+            // Verifies that stale prefab import artifacts do not leave runtime overlay references unassigned.
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PrefabPath);
+
+            Assert.That(prefab, Is.Not.Null);
+
+            GameObject instance = (GameObject)PrefabUtility.InstantiatePrefab(prefab);
+            try
+            {
+                InputVisualizationCanvas canvas = instance.GetComponent<InputVisualizationCanvas>();
+
+                Assert.That(canvas.KeyboardOverlay, Is.Not.Null);
+                Assert.That(canvas.MouseUiOverlay, Is.Not.Null);
+                Assert.That(canvas.MouseInputOverlay, Is.Not.Null);
+                Assert.That(canvas.RecordInputOverlayPresenter, Is.Not.Null);
+                Assert.That(canvas.ReplayInputOverlay, Is.Not.Null);
+
+                AssertSerializedReference(canvas.KeyboardOverlay, "_container");
+                AssertSerializedReference(canvas.KeyboardOverlay, "_containerImage");
+                AssertSerializedReference(canvas.MouseUiOverlay, "_canvasGroup");
+                AssertSerializedReference(canvas.MouseUiOverlay, "_cursorGroup");
+                AssertSerializedReference(canvas.MouseUiOverlay, "_circleImage");
+                AssertSerializedReference(canvas.MouseUiOverlay, "_crosshairH");
+                AssertSerializedReference(canvas.MouseUiOverlay, "_crosshairV");
+                AssertSerializedReference(canvas.MouseUiOverlay, "_longPressText");
+                AssertSerializedReference(canvas.MouseUiOverlay, "_dragStartMarker");
+                AssertSerializedReference(canvas.MouseUiOverlay, "_circleSprite");
+                AssertSerializedReference(canvas.MouseInputOverlay, "_leftButton");
+                AssertSerializedReference(canvas.MouseInputOverlay, "_rightButton");
+                AssertSerializedReference(canvas.MouseInputOverlay, "_scrollWheel");
+                AssertSerializedReference(canvas.MouseInputOverlay, "_scrollArrowTop");
+                AssertSerializedReference(canvas.MouseInputOverlay, "_scrollArrowBottom");
+                AssertSerializedReference(canvas.MouseInputOverlay, "_moveDirectionGroup");
+                AssertSerializedReference(canvas.RecordInputOverlayPresenter, "_view");
+
+                RecordInputOverlayView recordView =
+                    canvas.RecordInputOverlayPresenter.GetComponent<RecordInputOverlayView>();
+                AssertSerializedReference(recordView, "_canvasGroup");
+                AssertSerializedReference(recordView, "_countdownGroup");
+                AssertSerializedReference(recordView, "_countdownText");
+                AssertSerializedReference(recordView, "_recordingGroup");
+                AssertSerializedReference(recordView, "_recDotText");
+                AssertSerializedReference(recordView, "_statusText");
+                AssertSerializedReference(canvas.ReplayInputOverlay, "_statusText");
+                AssertSerializedReference(canvas.ReplayInputOverlay, "_progressBarFill");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(instance);
+            }
+        }
+
+        private static void AssertSerializedReference(UnityEngine.Object target, string propertyName)
+        {
+            SerializedObject serializedObject = new SerializedObject(target);
+            SerializedProperty property = serializedObject.FindProperty(propertyName);
+
+            Assert.That(property, Is.Not.Null, propertyName);
+            Assert.That(property.objectReferenceValue, Is.Not.Null, propertyName);
+        }
+
         private static string ReadText(string relativePath)
         {
             string absolutePath = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), relativePath);

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -63,6 +63,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 InputVisualizationCanvas canvas = instance.GetComponent<InputVisualizationCanvas>();
 
+                Assert.That(canvas, Is.Not.Null);
                 Assert.That(canvas.KeyboardOverlay, Is.Not.Null);
                 Assert.That(canvas.MouseUiOverlay, Is.Not.Null);
                 Assert.That(canvas.MouseInputOverlay, Is.Not.Null);
@@ -89,6 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
                 RecordInputOverlayView recordView =
                     canvas.RecordInputOverlayPresenter.GetComponent<RecordInputOverlayView>();
+                Assert.That(recordView, Is.Not.Null);
                 AssertSerializedReference(recordView, "_canvasGroup");
                 AssertSerializedReference(recordView, "_countdownGroup");
                 AssertSerializedReference(recordView, "_countdownText");

--- a/Packages/src/Runtime/Common/InputVisualizationCanvas.cs
+++ b/Packages/src/Runtime/Common/InputVisualizationCanvas.cs
@@ -24,11 +24,32 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         private void Awake()
         {
             EnsureUnitScaleCanvas();
+            RestoreMissingReferences();
+
             Debug.Assert(_keyboardOverlay != null, "_keyboardOverlay must be assigned in prefab");
             Debug.Assert(_mouseUiOverlay != null, "_mouseUiOverlay must be assigned in prefab");
             Debug.Assert(_mouseInputOverlay != null, "_mouseInputOverlay must be assigned in prefab");
             Debug.Assert(_recordInputOverlayPresenter != null, "_recordInputOverlayPresenter must be assigned in prefab");
             Debug.Assert(_replayInputOverlay != null, "_replayInputOverlay must be assigned in prefab");
+        }
+
+        private void RestoreMissingReferences()
+        {
+            RestoreMissingReference(ref _keyboardOverlay);
+            RestoreMissingReference(ref _mouseUiOverlay);
+            RestoreMissingReference(ref _mouseInputOverlay);
+            RestoreMissingReference(ref _recordInputOverlayPresenter);
+            RestoreMissingReference(ref _replayInputOverlay);
+        }
+
+        private void RestoreMissingReference<T>(ref T reference) where T : Component
+        {
+            if (reference != null)
+            {
+                return;
+            }
+
+            reference = GetComponentInChildren<T>(true);
         }
 
         private void EnsureUnitScaleCanvas()

--- a/Packages/src/Runtime/RecordInput/RecordInputOverlayPresenter.cs
+++ b/Packages/src/Runtime/RecordInput/RecordInputOverlayPresenter.cs
@@ -21,6 +21,11 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         private void Awake()
         {
+            if (_view == null)
+            {
+                _view = GetComponent<RecordInputOverlayView>();
+            }
+
             Debug.Assert(_view != null, "_view must be assigned in prefab");
         }
 

--- a/Packages/src/Runtime/RecordInput/RecordInputOverlayView.cs
+++ b/Packages/src/Runtime/RecordInput/RecordInputOverlayView.cs
@@ -8,6 +8,12 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
     /// </summary>
     public class RecordInputOverlayView : MonoBehaviour
     {
+        private const string CountdownGroupName = "CountdownGroup";
+        private const string CountdownTextName = "CountdownText";
+        private const string RecordingGroupName = "RecordingGroup";
+        private const string RecDotName = "RecDot";
+        private const string StatusTextName = "StatusText";
+
         [SerializeField] private CanvasGroup _canvasGroup;
         [SerializeField] private GameObject _countdownGroup;
         [SerializeField] private Text _countdownText;
@@ -17,6 +23,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         private void Awake()
         {
+            RestoreMissingReferences();
+
             Debug.Assert(_canvasGroup != null, "_canvasGroup must be assigned in prefab");
             Debug.Assert(_countdownGroup != null, "_countdownGroup must be assigned in prefab");
             Debug.Assert(_countdownText != null, "_countdownText must be assigned in prefab");
@@ -27,6 +35,55 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _canvasGroup.interactable = false;
             _canvasGroup.blocksRaycasts = false;
             Hide();
+        }
+
+        private void RestoreMissingReferences()
+        {
+            RestoreMissingReference(ref _canvasGroup, GetComponent<CanvasGroup>);
+            RestoreMissingReference(ref _countdownGroup, () => FindChildGameObject(CountdownGroupName));
+            RestoreMissingReference(ref _countdownText, () => FindChildComponent<Text>(CountdownTextName));
+            RestoreMissingReference(ref _recordingGroup, () => FindChildGameObject(RecordingGroupName));
+            RestoreMissingReference(ref _recDotText, () => FindChildComponent<Text>(RecDotName));
+            RestoreMissingReference(ref _statusText, () => FindChildComponent<Text>(StatusTextName));
+        }
+
+        private void RestoreMissingReference<T>(ref T reference, System.Func<T> resolveReference)
+            where T : UnityEngine.Object
+        {
+            if (reference != null)
+            {
+                return;
+            }
+
+            reference = resolveReference();
+        }
+
+        private GameObject FindChildGameObject(string childName)
+        {
+            Transform[] children = GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                if (children[i].name == childName)
+                {
+                    return children[i].gameObject;
+                }
+            }
+
+            return null;
+        }
+
+        private T FindChildComponent<T>(string childName) where T : Component
+        {
+            T[] children = GetComponentsInChildren<T>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                if (children[i].name == childName)
+                {
+                    return children[i];
+                }
+            }
+
+            return null;
         }
 
         public void ShowCountdown(int remainingSeconds)

--- a/Packages/src/Runtime/ReplayInput/ReplayInputOverlay.cs
+++ b/Packages/src/Runtime/ReplayInput/ReplayInputOverlay.cs
@@ -13,6 +13,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
     public class ReplayInputOverlay : MonoBehaviour
     {
         private const float FADE_OUT_DURATION = 0.5f;
+        private const string ProgressBarFillName = "ProgressBarFill";
+        private const string StatusTextName = "StatusText";
 
         [SerializeField] private Text? _statusText;
         [SerializeField] private Image? _progressBarFill;
@@ -24,6 +26,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         private void Awake()
         {
+            RestoreMissingReferences();
+
             _canvasGroup = GetComponent<CanvasGroup>();
             if (_canvasGroup == null)
             {
@@ -34,6 +38,33 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _canvasGroup.blocksRaycasts = false;
 
             SetVisible(false);
+        }
+
+        private void RestoreMissingReferences()
+        {
+            if (_statusText == null)
+            {
+                _statusText = FindChildComponent<Text>(StatusTextName);
+            }
+
+            if (_progressBarFill == null)
+            {
+                _progressBarFill = FindChildComponent<Image>(ProgressBarFillName);
+            }
+        }
+
+        private T FindChildComponent<T>(string childName) where T : Component
+        {
+            T[] children = GetComponentsInChildren<T>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                if (children[i].name == childName)
+                {
+                    return children[i];
+                }
+            }
+
+            return null!;
         }
 
         private void LateUpdate()

--- a/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.cs
+++ b/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
     {
         public const float CONTAINER_BACKGROUND_ALPHA = 0.8f;
 
+        private const string ContainerName = "Container";
         private const float PRESS_DISPLAY_DURATION = 0.5f;
         private const float FADE_DURATION = 0.2f;
         private const int FONT_SIZE = 48;
@@ -27,6 +28,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         private void Awake()
         {
+            RestoreMissingReferences();
+
             Debug.Assert(_container != null, "_container must be assigned in prefab");
             Debug.Assert(_containerImage != null, "_containerImage must be assigned in prefab");
 
@@ -37,6 +40,33 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
 
             _container.SetActive(false);
+        }
+
+        private void RestoreMissingReferences()
+        {
+            if (_container == null)
+            {
+                _container = FindChildGameObject(ContainerName);
+            }
+
+            if (_containerImage == null && _container != null)
+            {
+                _containerImage = _container.GetComponent<Image>();
+            }
+        }
+
+        private GameObject FindChildGameObject(string childName)
+        {
+            Transform[] children = GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                if (children[i].name == childName)
+                {
+                    return children[i].gameObject;
+                }
+            }
+
+            return null!;
         }
 
         private void LateUpdate()

--- a/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs
+++ b/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs
@@ -12,6 +12,12 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
     public class SimulateMouseInputOverlay : MonoBehaviour
     {
         private const float DISPLAY_DURATION = 1.0f;
+        private const string LeftButtonName = "LeftButton";
+        private const string MoveDirectionGroupName = "MoveDirectionGroup";
+        private const string RightButtonName = "RightButton";
+        private const string ScrollArrowBottomName = "ScrollArrowBottom";
+        private const string ScrollArrowTopName = "ScrollArrowTop";
+        private const string ScrollWheelName = "ScrollWheel";
 
         private static readonly Color BUTTON_PRESSED_COLOR = new Color(1f, 1f, 1f, 0.95f);
 
@@ -31,6 +37,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         private void Awake()
         {
+            RestoreMissingReferences();
+
             _canvasGroup = GetComponent<CanvasGroup>();
             if (_canvasGroup == null)
             {
@@ -42,6 +50,40 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
             SetVisible(false);
             CaptureIdleColors();
+        }
+
+        private void RestoreMissingReferences()
+        {
+            RestoreMissingReference(ref _leftButton, LeftButtonName);
+            RestoreMissingReference(ref _rightButton, RightButtonName);
+            RestoreMissingReference(ref _scrollWheel, ScrollWheelName);
+            RestoreMissingReference(ref _scrollArrowTop, ScrollArrowTopName);
+            RestoreMissingReference(ref _scrollArrowBottom, ScrollArrowBottomName);
+            RestoreMissingReference(ref _moveDirectionGroup, MoveDirectionGroupName);
+        }
+
+        private void RestoreMissingReference<T>(ref T? reference, string childName) where T : Component
+        {
+            if (reference != null)
+            {
+                return;
+            }
+
+            reference = FindChildComponent<T>(childName);
+        }
+
+        private T? FindChildComponent<T>(string childName) where T : Component
+        {
+            T[] children = GetComponentsInChildren<T>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                if (children[i].name == childName)
+                {
+                    return children[i];
+                }
+            }
+
+            return null;
         }
 
         private void LateUpdate()

--- a/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs
+++ b/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs
@@ -49,6 +49,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _canvasGroup.blocksRaycasts = false;
 
             SetVisible(false);
+            Debug.Assert(_scrollArrowTop != null, "_scrollArrowTop must be assigned before runtime updates");
+            Debug.Assert(_scrollArrowBottom != null, "_scrollArrowBottom must be assigned before runtime updates");
             CaptureIdleColors();
         }
 

--- a/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.cs
+++ b/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.cs
@@ -14,6 +14,12 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
     {
         private const float WAYPOINT_MARKER_DIAMETER = 12f;
         private const float LINE_THICKNESS = 2f;
+        private const string CircleName = "Circle";
+        private const string CrosshairHName = "CrosshairH";
+        private const string CrosshairVName = "CrosshairV";
+        private const string CursorGroupName = "CursorGroup";
+        private const string DragStartMarkerName = "DragStartMarker";
+        private const string LongPressTextName = "LongPressText";
 
         private static readonly Color CLICK_COLOR = new Color(0f, 1f, 0.4f, 0.9f);
         private static readonly Color DRAG_COLOR = new Color(1f, 0.6f, 0f, 0.9f);
@@ -40,6 +46,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         private void Awake()
         {
+            RestoreMissingReferences();
+
             Debug.Assert(_canvasGroup != null, "_canvasGroup must be assigned in prefab");
             Debug.Assert(_cursorGroup != null, "_cursorGroup must be assigned in prefab");
             Debug.Assert(_circleImage != null, "_circleImage must be assigned in prefab");
@@ -50,6 +58,47 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             Debug.Assert(_circleSprite != null, "_circleSprite must be assigned in prefab");
 
             _canvasGroup!.alpha = 0;
+        }
+
+        private void RestoreMissingReferences()
+        {
+            RestoreMissingReference(ref _canvasGroup, GetComponent<CanvasGroup>);
+            RestoreMissingReference(ref _cursorGroup, () => FindChildComponent<RectTransform>(CursorGroupName));
+            RestoreMissingReference(ref _circleImage, () => FindChildComponent<Image>(CircleName));
+            RestoreMissingReference(ref _crosshairH, () => FindChildComponent<Image>(CrosshairHName));
+            RestoreMissingReference(ref _crosshairV, () => FindChildComponent<Image>(CrosshairVName));
+            RestoreMissingReference(ref _longPressText, () => FindChildComponent<Text>(LongPressTextName));
+            RestoreMissingReference(ref _dragStartMarker, () => FindChildComponent<Image>(DragStartMarkerName));
+
+            if (_circleSprite == null && _circleImage != null)
+            {
+                _circleSprite = _circleImage.sprite;
+            }
+        }
+
+        private void RestoreMissingReference<T>(ref T reference, System.Func<T> resolveReference)
+            where T : UnityEngine.Object
+        {
+            if (reference != null)
+            {
+                return;
+            }
+
+            reference = resolveReference();
+        }
+
+        private T FindChildComponent<T>(string childName) where T : Component
+        {
+            T[] children = GetComponentsInChildren<T>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                if (children[i].name == childName)
+                {
+                    return children[i];
+                }
+            }
+
+            return null!;
         }
 
         private void LateUpdate()


### PR DESCRIPTION
## Summary
- Input simulation commands can now complete normally even when Unity has stale imported overlay references.
- Shared visualization overlays restore their required UI references before they are used.

## User Impact
- Before this change, commands such as `simulate-keyboard` could hang or leave a process behind during Play Mode when overlay setup hit unassigned prefab references.
- After this change, the command returns a JSON response instead of failing during overlay creation.

## Changes
- Restore required overlay references from the instantiated prefab hierarchy before existing runtime assertions run.
- Cover the instantiated visualization canvas contract with an EditMode test.

## Verification
- `Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path /Users/a12115/ghq/hatayama/unity-cli-loop`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path /Users/a12115/ghq/hatayama/unity-cli-loop --test-mode EditMode --filter-type regex --filter-value '.*InputVisualizationCanvasPrefabTests.*'`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path /Users/a12115/ghq/hatayama/unity-cli-loop --test-mode PlayMode --filter-type exact --filter-value 'io.github.hatayama.UnityCliLoop.Tests.PlayMode.SimulateKeyboardTests.Press_Should_CreateOverlayCanvas_WithUnitScale'`
- `Packages/src/Cli~/dist/darwin-arm64/uloop simulate-keyboard --project-path /Users/a12115/ghq/hatayama/unity-cli-loop --action Press --key W --duration 0.2`