### PR TITLE
fix: Make skill instructions use CLI flag syntax

### DIFF
--- a/.agents/skills/uloop-clear-console/SKILL.md
+++ b/.agents/skills/uloop-clear-console/SKILL.md
@@ -18,7 +18,7 @@ uloop clear-console [--add-confirmation-message]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--add-confirmation-message` | boolean | `false` | Add confirmation message after clearing |
+| `--add-confirmation-message` | flag | - | Add confirmation message after clearing |
 
 ## Global Options
 

--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -18,8 +18,8 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--force-recompile` | boolean | `false` | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
-| `--no-wait-for-domain-reload` | boolean | `false` | Return before Domain Reload completion |
+| `--force-recompile` | flag | - | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
+| `--no-wait-for-domain-reload` | flag | - | Return before Domain Reload completion |
 
 ## Global Options
 

--- a/.agents/skills/uloop-find-game-objects/SKILL.md
+++ b/.agents/skills/uloop-find-game-objects/SKILL.md
@@ -26,8 +26,8 @@ uloop find-game-objects [options]
 | `--tag` | string | - | Tag filter |
 | `--layer` | integer | - | Layer filter (layer number) |
 | `--max-results` | integer | `20` | Maximum number of results |
-| `--include-inactive` | boolean | `false` | Include inactive GameObjects |
-| `--include-inherited-properties` | boolean | `false` | Include inherited properties in results |
+| `--include-inactive` | flag | - | Include inactive GameObjects |
+| `--include-inherited-properties` | flag | - | Include inherited properties in results |
 
 ## Search Modes
 

--- a/.agents/skills/uloop-get-hierarchy/SKILL.md
+++ b/.agents/skills/uloop-get-hierarchy/SKILL.md
@@ -22,11 +22,11 @@ uloop get-hierarchy [options]
 |-----------|------|---------|-------------|
 | `--root-path` | string | - | Root GameObject path to start from |
 | `--max-depth` | integer | `-1` | Maximum depth (-1 for unlimited) |
-| `--no-include-components` | flag | off | Exclude component information |
-| `--no-include-inactive` | flag | off | Exclude inactive GameObjects |
-| `--include-paths` | boolean | `false` | Include full path information |
+| `--no-include-components` | flag | - | Exclude component information |
+| `--no-include-inactive` | flag | - | Exclude inactive GameObjects |
+| `--include-paths` | flag | - | Include full path information |
 | `--use-components-lut` | string | `auto` | Use LUT for components (`auto`, `true`, `false`) |
-| `--use-selection` | boolean | `false` | Use selected GameObject(s) as root(s). When true, `--root-path` is ignored. |
+| `--use-selection` | flag | - | Use selected GameObject(s) as root(s). When set, `--root-path` is ignored. |
 
 ## Global Options
 

--- a/.agents/skills/uloop-get-logs/SKILL.md
+++ b/.agents/skills/uloop-get-logs/SKILL.md
@@ -21,9 +21,9 @@ uloop get-logs [options]
 | `--log-type` | string | `All` | Log type filter: `Error`, `Warning`, `Log`, `All` |
 | `--max-count` | integer | `100` | Maximum number of logs to retrieve |
 | `--search-text` | string | - | Text to search within logs |
-| `--include-stack-trace` | boolean | `false` | Include stack trace in output |
-| `--use-regex` | boolean | `false` | Use regex for search |
-| `--search-in-stack-trace` | boolean | `false` | Search within stack trace |
+| `--include-stack-trace` | flag | - | Include stack trace in output |
+| `--use-regex` | flag | - | Use regex for search |
+| `--search-in-stack-trace` | flag | - | Search within stack trace |
 
 ## Global Options
 

--- a/.agents/skills/uloop-hello-world/SKILL.md
+++ b/.agents/skills/uloop-hello-world/SKILL.md
@@ -19,7 +19,7 @@ uloop hello-world [options]
 |-----------|------|---------|-------------|
 | `--name` | string | `World` | Name to greet |
 | `--language` | string | `english` | Language for greeting: `english`, `japanese`, `spanish`, `french` |
-| `--include-timestamp` | boolean | `true` | Whether to include timestamp in response |
+| `--no-include-timestamp` | flag | - | Exclude timestamp from response |
 
 ## Examples
 
@@ -34,7 +34,7 @@ uloop hello-world --name "Alice"
 uloop hello-world --name "太郎" --language japanese
 
 # Spanish greeting without timestamp
-uloop hello-world --name "Carlos" --language spanish --include-timestamp false
+uloop hello-world --name "Carlos" --language spanish --no-include-timestamp
 ```
 
 ## Output
@@ -49,5 +49,5 @@ Returns JSON with:
 This is a sample custom tool demonstrating:
 - Type-safe parameter handling with Schema
 - Enum parameters for language selection
-- Boolean flag parameters
+- Value-less flag parameters
 - Multi-language support

--- a/.agents/skills/uloop-launch/SKILL.md
+++ b/.agents/skills/uloop-launch/SKILL.md
@@ -21,8 +21,8 @@ uloop launch [project-path] [options]
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `project-path` | string | Optional. Use only when the target Unity project is not in the current directory. |
-| `-r, --restart` | boolean | Kill running Unity and restart |
-| `-q, --quit` | boolean | Kill an existing Unity process for the project without launching |
+| `-r, --restart` | flag | Kill running Unity and restart |
+| `-q, --quit` | flag | Kill an existing Unity process for the project without launching |
 | `-p, --platform <P>` | string | Build target (e.g., StandaloneOSX, Android, iOS) |
 | `--max-depth <N>` | number | Search depth when project-path is omitted (default: 3, -1 for unlimited) |
 

--- a/.agents/skills/uloop-replay-input/SKILL.md
+++ b/.agents/skills/uloop-replay-input/SKILL.md
@@ -33,8 +33,8 @@ uloop replay-input --action Stop
 |-----------|------|---------|-------------|
 | `--action` | enum | `Start` | `Start`, `Stop`, `Status` |
 | `--input-path` | string | auto | JSON path. Auto-detects latest in `.uloop/outputs/InputRecordings/` |
-| `--no-show-overlay` | flag | off | Hide replay progress overlay |
-| `--loop` | boolean | `false` | Loop continuously |
+| `--no-show-overlay` | flag | - | Hide replay progress overlay |
+| `--loop` | flag | - | Loop continuously |
 
 ## Deterministic Replay
 

--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -25,7 +25,7 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--save-before-run` | boolean | `false` | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
+| `--save-before-run` | flag | - | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
 
 ## Global Options
 

--- a/.agents/skills/uloop-screenshot/SKILL.md
+++ b/.agents/skills/uloop-screenshot/SKILL.md
@@ -23,8 +23,8 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 | `--match-mode` | enum | `exact` | Window name matching mode: `exact`, `prefix`, or `contains`. Ignored when `--capture-mode rendering`. |
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
 | `--output-directory` | string | `""` | Output directory path for saving screenshots. When empty, uses default path (.uloop/outputs/Screenshots/). Accepts absolute paths. |
-| `--annotate-elements` | boolean | `false` | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
-| `--elements-only` | boolean | `false` | Return only annotated element JSON without capturing a screenshot image. Requires `--annotate-elements` and `--capture-mode rendering` in PlayMode. |
+| `--annotate-elements` | flag | - | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
+| `--elements-only` | flag | - | Return only annotated element JSON without capturing a screenshot image. Requires `--annotate-elements` and `--capture-mode rendering` in PlayMode. |
 
 ## Match Modes
 

--- a/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -36,7 +36,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 | `--drag-speed` | number | `2000` | Drag speed in pixels per second (0 for instant). 2000 is fast (default), 200 is slow enough to watch. Applies to Drag, DragMove, and DragEnd actions. |
 | `--duration` | number | `0.5` | Hold duration in seconds for LongPress action. |
 | `--button` | enum | `Left` | Mouse button. `Click` and `LongPress` support `Left`, `Right`, and `Middle`. Drag actions support `Left` only; other buttons return an error. |
-| `--bypass-raycast` | boolean | `false` | For `Click`, `LongPress`, `Drag`, and `DragStart`, bypass EventSystem raycast and dispatch pointer events directly to `--target-path`. Use when a raycast-blocking overlay visually covers the intended target. |
+| `--bypass-raycast` | flag | - | For `Click`, `LongPress`, `Drag`, and `DragStart`, bypass EventSystem raycast and dispatch pointer events directly to `--target-path`. Use when a raycast-blocking overlay visually covers the intended target. |
 | `--target-path` | string | `""` | Hierarchy path of the target GameObject, for example `Canvas/Panel/Button`. Required when `--bypass-raycast` is used with `Click`, `LongPress`, `Drag`, or `DragStart`; prefer `AnnotatedElements[].Path` from screenshot JSON. |
 | `--drop-target-path` | string | `""` | Optional hierarchy path of a drop target for `Drag` or `DragEnd`, for example `Canvas/DropZone`. Use this when the drop zone is also behind a raycast blocker. |
 

--- a/.claude/skills/simulate-mouse-demo/SKILL.md
+++ b/.claude/skills/simulate-mouse-demo/SKILL.md
@@ -33,7 +33,7 @@ If PlayMode is not active, start it with `uloop control-play-mode --action Play`
 Take an annotated screenshot to get exact coordinates for each interactive element:
 
 ```bash
-uloop screenshot --capture-mode rendering --annotate-elements true
+uloop screenshot --capture-mode rendering --annotate-elements
 ```
 
 From the `AnnotatedElements` array in the response, extract `SimX` and `SimY` for:

--- a/.claude/skills/uloop-clear-console/SKILL.md
+++ b/.claude/skills/uloop-clear-console/SKILL.md
@@ -18,7 +18,7 @@ uloop clear-console [--add-confirmation-message]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--add-confirmation-message` | boolean | `false` | Add confirmation message after clearing |
+| `--add-confirmation-message` | flag | - | Add confirmation message after clearing |
 
 ## Global Options
 

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -18,8 +18,8 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--force-recompile` | boolean | `false` | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
-| `--no-wait-for-domain-reload` | boolean | `false` | Return before Domain Reload completion |
+| `--force-recompile` | flag | - | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
+| `--no-wait-for-domain-reload` | flag | - | Return before Domain Reload completion |
 
 ## Global Options
 

--- a/.claude/skills/uloop-find-game-objects/SKILL.md
+++ b/.claude/skills/uloop-find-game-objects/SKILL.md
@@ -26,8 +26,8 @@ uloop find-game-objects [options]
 | `--tag` | string | - | Tag filter |
 | `--layer` | integer | - | Layer filter (layer number) |
 | `--max-results` | integer | `20` | Maximum number of results |
-| `--include-inactive` | boolean | `false` | Include inactive GameObjects |
-| `--include-inherited-properties` | boolean | `false` | Include inherited properties in results |
+| `--include-inactive` | flag | - | Include inactive GameObjects |
+| `--include-inherited-properties` | flag | - | Include inherited properties in results |
 
 ## Search Modes
 

--- a/.claude/skills/uloop-get-hierarchy/SKILL.md
+++ b/.claude/skills/uloop-get-hierarchy/SKILL.md
@@ -22,11 +22,11 @@ uloop get-hierarchy [options]
 |-----------|------|---------|-------------|
 | `--root-path` | string | - | Root GameObject path to start from |
 | `--max-depth` | integer | `-1` | Maximum depth (-1 for unlimited) |
-| `--no-include-components` | flag | off | Exclude component information |
-| `--no-include-inactive` | flag | off | Exclude inactive GameObjects |
-| `--include-paths` | boolean | `false` | Include full path information |
+| `--no-include-components` | flag | - | Exclude component information |
+| `--no-include-inactive` | flag | - | Exclude inactive GameObjects |
+| `--include-paths` | flag | - | Include full path information |
 | `--use-components-lut` | string | `auto` | Use LUT for components (`auto`, `true`, `false`) |
-| `--use-selection` | boolean | `false` | Use selected GameObject(s) as root(s). When true, `--root-path` is ignored. |
+| `--use-selection` | flag | - | Use selected GameObject(s) as root(s). When set, `--root-path` is ignored. |
 
 ## Global Options
 

--- a/.claude/skills/uloop-get-logs/SKILL.md
+++ b/.claude/skills/uloop-get-logs/SKILL.md
@@ -21,9 +21,9 @@ uloop get-logs [options]
 | `--log-type` | string | `All` | Log type filter: `Error`, `Warning`, `Log`, `All` |
 | `--max-count` | integer | `100` | Maximum number of logs to retrieve |
 | `--search-text` | string | - | Text to search within logs |
-| `--include-stack-trace` | boolean | `false` | Include stack trace in output |
-| `--use-regex` | boolean | `false` | Use regex for search |
-| `--search-in-stack-trace` | boolean | `false` | Search within stack trace |
+| `--include-stack-trace` | flag | - | Include stack trace in output |
+| `--use-regex` | flag | - | Use regex for search |
+| `--search-in-stack-trace` | flag | - | Search within stack trace |
 
 ## Global Options
 

--- a/.claude/skills/uloop-hello-world/SKILL.md
+++ b/.claude/skills/uloop-hello-world/SKILL.md
@@ -19,7 +19,7 @@ uloop hello-world [options]
 |-----------|------|---------|-------------|
 | `--name` | string | `World` | Name to greet |
 | `--language` | string | `english` | Language for greeting: `english`, `japanese`, `spanish`, `french` |
-| `--include-timestamp` | boolean | `true` | Whether to include timestamp in response |
+| `--no-include-timestamp` | flag | - | Exclude timestamp from response |
 
 ## Examples
 
@@ -34,7 +34,7 @@ uloop hello-world --name "Alice"
 uloop hello-world --name "太郎" --language japanese
 
 # Spanish greeting without timestamp
-uloop hello-world --name "Carlos" --language spanish --include-timestamp false
+uloop hello-world --name "Carlos" --language spanish --no-include-timestamp
 ```
 
 ## Output
@@ -49,5 +49,5 @@ Returns JSON with:
 This is a sample custom tool demonstrating:
 - Type-safe parameter handling with Schema
 - Enum parameters for language selection
-- Boolean flag parameters
+- Value-less flag parameters
 - Multi-language support

--- a/.claude/skills/uloop-launch/SKILL.md
+++ b/.claude/skills/uloop-launch/SKILL.md
@@ -21,8 +21,8 @@ uloop launch [project-path] [options]
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `project-path` | string | Optional. Use only when the target Unity project is not in the current directory. |
-| `-r, --restart` | boolean | Kill running Unity and restart |
-| `-q, --quit` | boolean | Kill an existing Unity process for the project without launching |
+| `-r, --restart` | flag | Kill running Unity and restart |
+| `-q, --quit` | flag | Kill an existing Unity process for the project without launching |
 | `-p, --platform <P>` | string | Build target (e.g., StandaloneOSX, Android, iOS) |
 | `--max-depth <N>` | number | Search depth when project-path is omitted (default: 3, -1 for unlimited) |
 

--- a/.claude/skills/uloop-replay-input/SKILL.md
+++ b/.claude/skills/uloop-replay-input/SKILL.md
@@ -33,8 +33,8 @@ uloop replay-input --action Stop
 |-----------|------|---------|-------------|
 | `--action` | enum | `Start` | `Start`, `Stop`, `Status` |
 | `--input-path` | string | auto | JSON path. Auto-detects latest in `.uloop/outputs/InputRecordings/` |
-| `--no-show-overlay` | flag | off | Hide replay progress overlay |
-| `--loop` | boolean | `false` | Loop continuously |
+| `--no-show-overlay` | flag | - | Hide replay progress overlay |
+| `--loop` | flag | - | Loop continuously |
 
 ## Deterministic Replay
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -25,7 +25,7 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--save-before-run` | boolean | `false` | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
+| `--save-before-run` | flag | - | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
 
 ## Global Options
 

--- a/.claude/skills/uloop-screenshot/SKILL.md
+++ b/.claude/skills/uloop-screenshot/SKILL.md
@@ -23,8 +23,8 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 | `--match-mode` | enum | `exact` | Window name matching mode: `exact`, `prefix`, or `contains`. Ignored when `--capture-mode rendering`. |
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
 | `--output-directory` | string | `""` | Output directory path for saving screenshots. When empty, uses default path (.uloop/outputs/Screenshots/). Accepts absolute paths. |
-| `--annotate-elements` | boolean | `false` | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
-| `--elements-only` | boolean | `false` | Return only annotated element JSON without capturing a screenshot image. Requires `--annotate-elements` and `--capture-mode rendering` in PlayMode. |
+| `--annotate-elements` | flag | - | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
+| `--elements-only` | flag | - | Return only annotated element JSON without capturing a screenshot image. Requires `--annotate-elements` and `--capture-mode rendering` in PlayMode. |
 
 ## Match Modes
 

--- a/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -36,7 +36,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 | `--drag-speed` | number | `2000` | Drag speed in pixels per second (0 for instant). 2000 is fast (default), 200 is slow enough to watch. Applies to Drag, DragMove, and DragEnd actions. |
 | `--duration` | number | `0.5` | Hold duration in seconds for LongPress action. |
 | `--button` | enum | `Left` | Mouse button. `Click` and `LongPress` support `Left`, `Right`, and `Middle`. Drag actions support `Left` only; other buttons return an error. |
-| `--bypass-raycast` | boolean | `false` | For `Click`, `LongPress`, `Drag`, and `DragStart`, bypass EventSystem raycast and dispatch pointer events directly to `--target-path`. Use when a raycast-blocking overlay visually covers the intended target. |
+| `--bypass-raycast` | flag | - | For `Click`, `LongPress`, `Drag`, and `DragStart`, bypass EventSystem raycast and dispatch pointer events directly to `--target-path`. Use when a raycast-blocking overlay visually covers the intended target. |
 | `--target-path` | string | `""` | Hierarchy path of the target GameObject, for example `Canvas/Panel/Button`. Required when `--bypass-raycast` is used with `Click`, `LongPress`, `Drag`, or `DragStart`; prefer `AnnotatedElements[].Path` from screenshot JSON. |
 | `--drop-target-path` | string | `""` | Optional hierarchy path of a drop target for `Drag` or `DragEnd`, for example `Canvas/DropZone`. Use this when the drop zone is also behind a raycast blocker. |
 

--- a/Assets/Editor/CustomCommandSamples/HelloWorld/Skill/SKILL.md
+++ b/Assets/Editor/CustomCommandSamples/HelloWorld/Skill/SKILL.md
@@ -19,7 +19,7 @@ uloop hello-world [options]
 |-----------|------|---------|-------------|
 | `--name` | string | `World` | Name to greet |
 | `--language` | string | `english` | Language for greeting: `english`, `japanese`, `spanish`, `french` |
-| `--include-timestamp` | boolean | `true` | Whether to include timestamp in response |
+| `--no-include-timestamp` | flag | - | Exclude timestamp from response |
 
 ## Examples
 
@@ -34,7 +34,7 @@ uloop hello-world --name "Alice"
 uloop hello-world --name "太郎" --language japanese
 
 # Spanish greeting without timestamp
-uloop hello-world --name "Carlos" --language spanish --include-timestamp false
+uloop hello-world --name "Carlos" --language spanish --no-include-timestamp
 ```
 
 ## Output
@@ -49,5 +49,5 @@ Returns JSON with:
 This is a sample custom tool demonstrating:
 - Type-safe parameter handling with Schema
 - Enum parameters for language selection
-- Boolean flag parameters
+- Value-less flag parameters
 - Multi-language support

--- a/Packages/src/Cli~/internal/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
+++ b/Packages/src/Cli~/internal/skills/skill-definitions/cli-only/uloop-launch/Skill/SKILL.md
@@ -21,8 +21,8 @@ uloop launch [project-path] [options]
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `project-path` | string | Optional. Use only when the target Unity project is not in the current directory. |
-| `-r, --restart` | boolean | Kill running Unity and restart |
-| `-q, --quit` | boolean | Kill an existing Unity process for the project without launching |
+| `-r, --restart` | flag | Kill running Unity and restart |
+| `-q, --quit` | flag | Kill an existing Unity process for the project without launching |
 | `-p, --platform <P>` | string | Build target (e.g., StandaloneOSX, Android, iOS) |
 | `--max-depth <N>` | number | Search depth when project-path is omitted (default: 3, -1 for unlimited) |
 

--- a/Packages/src/Editor/FirstPartyTools/ClearConsole/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ClearConsole/Skill/SKILL.md
@@ -18,7 +18,7 @@ uloop clear-console [--add-confirmation-message]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--add-confirmation-message` | boolean | `false` | Add confirmation message after clearing |
+| `--add-confirmation-message` | flag | - | Add confirmation message after clearing |
 
 ## Global Options
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
@@ -18,8 +18,8 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--force-recompile` | boolean | `false` | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
-| `--no-wait-for-domain-reload` | boolean | `false` | Return before Domain Reload completion |
+| `--force-recompile` | flag | - | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
+| `--no-wait-for-domain-reload` | flag | - | Return before Domain Reload completion |
 
 ## Global Options
 

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/Skill/SKILL.md
@@ -26,8 +26,8 @@ uloop find-game-objects [options]
 | `--tag` | string | - | Tag filter |
 | `--layer` | integer | - | Layer filter (layer number) |
 | `--max-results` | integer | `20` | Maximum number of results |
-| `--include-inactive` | boolean | `false` | Include inactive GameObjects |
-| `--include-inherited-properties` | boolean | `false` | Include inherited properties in results |
+| `--include-inactive` | flag | - | Include inactive GameObjects |
+| `--include-inherited-properties` | flag | - | Include inherited properties in results |
 
 ## Search Modes
 

--- a/Packages/src/Editor/FirstPartyTools/GetHierarchy/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/GetHierarchy/Skill/SKILL.md
@@ -22,11 +22,11 @@ uloop get-hierarchy [options]
 |-----------|------|---------|-------------|
 | `--root-path` | string | - | Root GameObject path to start from |
 | `--max-depth` | integer | `-1` | Maximum depth (-1 for unlimited) |
-| `--no-include-components` | flag | off | Exclude component information |
-| `--no-include-inactive` | flag | off | Exclude inactive GameObjects |
-| `--include-paths` | boolean | `false` | Include full path information |
+| `--no-include-components` | flag | - | Exclude component information |
+| `--no-include-inactive` | flag | - | Exclude inactive GameObjects |
+| `--include-paths` | flag | - | Include full path information |
 | `--use-components-lut` | string | `auto` | Use LUT for components (`auto`, `true`, `false`) |
-| `--use-selection` | boolean | `false` | Use selected GameObject(s) as root(s). When true, `--root-path` is ignored. |
+| `--use-selection` | flag | - | Use selected GameObject(s) as root(s). When set, `--root-path` is ignored. |
 
 ## Global Options
 

--- a/Packages/src/Editor/FirstPartyTools/GetLogs/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/GetLogs/Skill/SKILL.md
@@ -21,9 +21,9 @@ uloop get-logs [options]
 | `--log-type` | string | `All` | Log type filter: `Error`, `Warning`, `Log`, `All` |
 | `--max-count` | integer | `100` | Maximum number of logs to retrieve |
 | `--search-text` | string | - | Text to search within logs |
-| `--include-stack-trace` | boolean | `false` | Include stack trace in output |
-| `--use-regex` | boolean | `false` | Use regex for search |
-| `--search-in-stack-trace` | boolean | `false` | Search within stack trace |
+| `--include-stack-trace` | flag | - | Include stack trace in output |
+| `--use-regex` | flag | - | Use regex for search |
+| `--search-in-stack-trace` | flag | - | Search within stack trace |
 
 ## Global Options
 

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/Skill/SKILL.md
@@ -33,8 +33,8 @@ uloop replay-input --action Stop
 |-----------|------|---------|-------------|
 | `--action` | enum | `Start` | `Start`, `Stop`, `Status` |
 | `--input-path` | string | auto | JSON path. Auto-detects latest in `.uloop/outputs/InputRecordings/` |
-| `--no-show-overlay` | flag | off | Hide replay progress overlay |
-| `--loop` | boolean | `false` | Loop continuously |
+| `--no-show-overlay` | flag | - | Hide replay progress overlay |
+| `--loop` | flag | - | Loop continuously |
 
 ## Deterministic Replay
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -25,7 +25,7 @@ uloop run-tests [options]
 | `--test-mode` | string | `EditMode` | Test mode: `EditMode`, `PlayMode` |
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
-| `--save-before-run` | boolean | `false` | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
+| `--save-before-run` | flag | - | Save unsaved loaded Scene changes and current Prefab Stage changes before running tests |
 
 ## Global Options
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
@@ -23,8 +23,8 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 | `--match-mode` | enum | `exact` | Window name matching mode: `exact`, `prefix`, or `contains`. Ignored when `--capture-mode rendering`. |
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
 | `--output-directory` | string | `""` | Output directory path for saving screenshots. When empty, uses default path (.uloop/outputs/Screenshots/). Accepts absolute paths. |
-| `--annotate-elements` | boolean | `false` | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
-| `--elements-only` | boolean | `false` | Return only annotated element JSON without capturing a screenshot image. Requires `--annotate-elements` and `--capture-mode rendering` in PlayMode. |
+| `--annotate-elements` | flag | - | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
+| `--elements-only` | flag | - | Return only annotated element JSON without capturing a screenshot image. Requires `--annotate-elements` and `--capture-mode rendering` in PlayMode. |
 
 ## Match Modes
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
@@ -36,7 +36,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 | `--drag-speed` | number | `2000` | Drag speed in pixels per second (0 for instant). 2000 is fast (default), 200 is slow enough to watch. Applies to Drag, DragMove, and DragEnd actions. |
 | `--duration` | number | `0.5` | Hold duration in seconds for LongPress action. |
 | `--button` | enum | `Left` | Mouse button. `Click` and `LongPress` support `Left`, `Right`, and `Middle`. Drag actions support `Left` only; other buttons return an error. |
-| `--bypass-raycast` | boolean | `false` | For `Click`, `LongPress`, `Drag`, and `DragStart`, bypass EventSystem raycast and dispatch pointer events directly to `--target-path`. Use when a raycast-blocking overlay visually covers the intended target. |
+| `--bypass-raycast` | flag | - | For `Click`, `LongPress`, `Drag`, and `DragStart`, bypass EventSystem raycast and dispatch pointer events directly to `--target-path`. Use when a raycast-blocking overlay visually covers the intended target. |
 | `--target-path` | string | `""` | Hierarchy path of the target GameObject, for example `Canvas/Panel/Button`. Required when `--bypass-raycast` is used with `Click`, `LongPress`, `Drag`, or `DragStart`; prefer `AnnotatedElements[].Path` from screenshot JSON. |
 | `--drop-target-path` | string | `""` | Optional hierarchy path of a drop target for `Drag` or `DragEnd`, for example `Canvas/DropZone`. Use this when the drop zone is also behind a raycast blocker. |
 

--- a/README.md
+++ b/README.md
@@ -325,11 +325,11 @@ Retrieve objects and examine component parameters. Also retrieve information abo
 ### 6. get-hierarchy - Analyze Scene Structure
 Retrieve information about the currently active Hierarchy in nested JSON format. Works at runtime as well.
 **Automatic File Export**: Retrieved hierarchy data is always saved as JSON in `{project_root}/.uloop/outputs/HierarchyResults/` directory. The response only returns the file path, minimizing token consumption even for large datasets.
-**Selection Mode**: Use `UseSelection: true` to get hierarchy starting from currently selected GameObject(s) in Unity Editor. Supports multiple selection - when parent and child are both selected, only the parent is used as root to avoid duplicate traversal.
+**Selection Mode**: Use `uloop get-hierarchy --use-selection` to get hierarchy starting from currently selected GameObject(s) in Unity Editor. Supports multiple selection - when parent and child are both selected, only the parent is used as root to avoid duplicate traversal.
 ```text
 → Understand parent-child relationships between GameObjects, discover and fix structural issues
 → Regardless of scene size, hierarchy data is saved to a file and the path is returned instead of raw JSON
-→ get-hierarchy (UseSelection: true)
+→ uloop get-hierarchy --use-selection
 → Get hierarchy of currently selected GameObjects without specifying paths manually
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -326,11 +326,11 @@ log検索時、ノイズのとなるlogをクリアする事ができます。
 ### 6. get-hierarchy - シーン構造の解析
 現在アクティブなHierarchyの情報をネストされたJSON形式で取得します。ランタイムでも動作します。
 **自動ファイル出力**: 取得したHierarchyは常に`{project_root}/.uloop/outputs/HierarchyResults/`ディレクトリにJSONとして保存されます。レスポンスにはファイルパスのみが返るため、大量データでもトークン消費を最小限に抑えられます。
-**選択モード**: `UseSelection: true` を指定すると、Unity Editorで選択中のGameObjectから階層を取得できます。複数選択にも対応 - 親子両方が選択されている場合、重複を避けるため親のみがルートとして使用されます。
+**選択モード**: `uloop get-hierarchy --use-selection` を指定すると、Unity Editorで選択中のGameObjectから階層を取得できます。複数選択にも対応 - 親子両方が選択されている場合、重複を避けるため親のみがルートとして使用されます。
 ```text
 → GameObject間の親子関係を理解。構造的な問題を発見・修正
 → シーンの規模にかかわらず、Hierarchyデータはファイルに保存され、生のJSONの代わりにパスが返されます
-→ get-hierarchy (UseSelection: true)
+→ uloop get-hierarchy --use-selection
 → パスを手動で指定せずに、選択中のGameObjectの階層を取得
 ```
 


### PR DESCRIPTION
## Summary
- Skill instructions now describe CLI flags as `flag` instead of `boolean`, so agents are less likely to add true/false values.
- README examples now use the actual `uloop get-hierarchy --use-selection` command syntax.

## User Impact
- Agents reading the generated skills get command examples that match current CLI help.
- Value-less flags such as `--include-paths` and `--use-selection` no longer look like options that accept `true` or `false`.

## Changes
- Updated source skill definitions and regenerated `.claude` / `.agents` project skill copies.
- Replaced stale boolean-value examples with value-less flag syntax.
- Kept return payload boolean descriptions unchanged.

## Verification
- `git diff --check`
- `Packages/src/Cli~/dist/darwin-arm64/uloop skills list --claude --agents`
- Targeted `rg` checks for boolean option table rows, `flag, no value`, `flag | off`, and stale true/false examples.