### PR TITLE
fix: Input simulation no longer stalls when Run In Background is disabled

### DIFF
--- a/Assets/Tests/Editor/InputSimulationRunInBackgroundScopeTests.cs
+++ b/Assets/Tests/Editor/InputSimulationRunInBackgroundScopeTests.cs
@@ -1,0 +1,83 @@
+#nullable enable
+using System;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using NUnit.Framework;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    public class InputSimulationRunInBackgroundScopeTests
+    {
+        [Test]
+        public void Enable_Should_TemporarilyEnableRunInBackground_WhenDisabled()
+        {
+            // Verifies that input simulation enables background execution only while the scope is active.
+            bool originalRunInBackground = UnityEngine.Application.runInBackground;
+
+            try
+            {
+                UnityEngine.Application.runInBackground = false;
+
+                using (InputSimulationRunInBackgroundScope scope = InputSimulationRunInBackgroundScope.Enable())
+                {
+                    Assert.IsTrue(UnityEngine.Application.runInBackground);
+                }
+
+                Assert.IsFalse(UnityEngine.Application.runInBackground);
+            }
+            finally
+            {
+                UnityEngine.Application.runInBackground = originalRunInBackground;
+            }
+        }
+
+        [Test]
+        public void Enable_Should_KeepRunInBackgroundEnabled_WhenAlreadyEnabled()
+        {
+            // Verifies that input simulation preserves projects that already run in background.
+            bool originalRunInBackground = UnityEngine.Application.runInBackground;
+
+            try
+            {
+                UnityEngine.Application.runInBackground = true;
+
+                using (InputSimulationRunInBackgroundScope scope = InputSimulationRunInBackgroundScope.Enable())
+                {
+                    Assert.IsTrue(UnityEngine.Application.runInBackground);
+                }
+
+                Assert.IsTrue(UnityEngine.Application.runInBackground);
+            }
+            finally
+            {
+                UnityEngine.Application.runInBackground = originalRunInBackground;
+            }
+        }
+
+        [Test]
+        public void Dispose_Should_RestoreRunInBackground_WhenOperationFails()
+        {
+            // Verifies that failed input simulation cannot leave background execution enabled.
+            bool originalRunInBackground = UnityEngine.Application.runInBackground;
+
+            try
+            {
+                UnityEngine.Application.runInBackground = false;
+                InputSimulationRunInBackgroundScope scope = InputSimulationRunInBackgroundScope.Enable();
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (scope)
+                    {
+                        throw new InvalidOperationException("test failure");
+                    }
+                });
+
+                Assert.IsFalse(UnityEngine.Application.runInBackground);
+            }
+            finally
+            {
+                UnityEngine.Application.runInBackground = originalRunInBackground;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/InputSimulationRunInBackgroundScopeTests.cs.meta
+++ b/Assets/Tests/Editor/InputSimulationRunInBackgroundScopeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ecb0d39f6a3554e1ba356dbc90591a56
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -199,6 +199,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator Press_Should_RestoreRunInBackground_WhenOriginallyDisabled()
+        {
+            // Verifies that keyboard simulation keeps PlayMode running in the background only during execution.
+            yield return null;
+
+            bool originalRunInBackground = UnityEngine.Application.runInBackground;
+
+            try
+            {
+                UnityEngine.Application.runInBackground = false;
+                Task<UnityCliLoopToolResponse> task = tool.ExecuteAsync(new JObject
+                {
+                    ["action"] = KeyboardAction.Press.ToString(),
+                    ["key"] = "Space",
+                    ["duration"] = 0.2f
+                }, CancellationToken.None);
+
+                float toggleTimeoutAt = Time.realtimeSinceStartup + 2f;
+                yield return new WaitUntil(() =>
+                    UnityEngine.Application.runInBackground
+                    || task.IsCompleted
+                    || Time.realtimeSinceStartup >= toggleTimeoutAt);
+                Assert.IsTrue(
+                    UnityEngine.Application.runInBackground,
+                    "Keyboard simulation should enable Run In Background while executing.");
+
+                float completionTimeoutAt = Time.realtimeSinceStartup + 5f;
+                yield return new WaitUntil(() =>
+                    task.IsCompleted || Time.realtimeSinceStartup >= completionTimeoutAt);
+                Assert.IsTrue(task.IsCompleted, "Tool execution timed out.");
+                Assert.IsFalse(task.IsFaulted, $"Tool execution should not fault: {task.Exception}");
+
+                lastResponse = (SimulateKeyboardResponse)task.Result;
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsFalse(
+                    UnityEngine.Application.runInBackground,
+                    "Keyboard simulation should restore the original Run In Background value.");
+            }
+            finally
+            {
+                UnityEngine.Application.runInBackground = originalRunInBackground;
+            }
+        }
+
+        [UnityTest]
         public IEnumerator OverlayFade_Should_StartAfterPressRelease_And_NotDimHeldKeyBadge()
         {
             yield return null;

--- a/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
@@ -131,6 +131,52 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.IsFalse(lastResponse.Success, "LongPress with zero duration should fail");
         }
 
+        [UnityTest]
+        public IEnumerator LongPress_Should_RestoreRunInBackground_WhenOriginallyDisabled()
+        {
+            // Verifies that mouse input simulation keeps PlayMode running in the background only during execution.
+            yield return null;
+
+            bool originalRunInBackground = UnityEngine.Application.runInBackground;
+
+            try
+            {
+                UnityEngine.Application.runInBackground = false;
+                Task<UnityCliLoopToolResponse> task = tool.ExecuteAsync(new JObject
+                {
+                    ["action"] = MouseInputAction.LongPress.ToString(),
+                    ["x"] = 400,
+                    ["y"] = 300,
+                    ["duration"] = 0.2f
+                }, System.Threading.CancellationToken.None);
+
+                float toggleTimeoutAt = Time.realtimeSinceStartup + 2f;
+                yield return new WaitUntil(() =>
+                    UnityEngine.Application.runInBackground
+                    || task.IsCompleted
+                    || Time.realtimeSinceStartup >= toggleTimeoutAt);
+                Assert.IsTrue(
+                    UnityEngine.Application.runInBackground,
+                    "Mouse input simulation should enable Run In Background while executing.");
+
+                float completionTimeoutAt = Time.realtimeSinceStartup + 5f;
+                yield return new WaitUntil(() =>
+                    task.IsCompleted || Time.realtimeSinceStartup >= completionTimeoutAt);
+                Assert.IsTrue(task.IsCompleted, "Tool execution timed out.");
+                Assert.IsFalse(task.IsFaulted, $"Tool execution should not fault: {task.Exception}");
+
+                lastResponse = (SimulateMouseInputResponse)task.Result;
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsFalse(
+                    UnityEngine.Application.runInBackground,
+                    "Mouse input simulation should restore the original Run In Background value.");
+            }
+            finally
+            {
+                UnityEngine.Application.runInBackground = originalRunInBackground;
+            }
+        }
+
         #endregion
 
         #region MoveDelta Tests

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/InputSimulationRunInBackgroundScope.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/InputSimulationRunInBackgroundScope.cs
@@ -1,0 +1,41 @@
+#nullable enable
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Temporarily keeps PlayMode running while input simulation tools wait for runtime updates.
+    /// </summary>
+    internal sealed class InputSimulationRunInBackgroundScope : IDisposable
+    {
+        private readonly bool _originalRunInBackground;
+        private bool _isDisposed;
+
+        private InputSimulationRunInBackgroundScope(bool originalRunInBackground)
+        {
+            _originalRunInBackground = originalRunInBackground;
+        }
+
+        public static InputSimulationRunInBackgroundScope Enable()
+        {
+            bool originalRunInBackground = UnityEngine.Application.runInBackground;
+            if (!originalRunInBackground)
+            {
+                UnityEngine.Application.runInBackground = true;
+            }
+
+            return new InputSimulationRunInBackgroundScope(originalRunInBackground);
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            UnityEngine.Application.runInBackground = _originalRunInBackground;
+            _isDisposed = true;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/InputSimulationRunInBackgroundScope.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/InputSimulationRunInBackgroundScope.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11c23564a84c44a7f8600731a701a076
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -99,6 +99,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 correlationId: correlationId
             );
 
+            using InputSimulationRunInBackgroundScope runInBackgroundScope = InputSimulationRunInBackgroundScope.Enable();
+
             EnsureOverlayExists();
 
             UnityCliLoopKeyboardSimulationResult response;

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -99,6 +99,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 correlationId: correlationId
             );
 
+            using InputSimulationRunInBackgroundScope runInBackgroundScope = InputSimulationRunInBackgroundScope.Enable();
+
             EnsureOverlayExists();
 
             UnityCliLoopMouseInputSimulationResult response;


### PR DESCRIPTION
## Summary
- Input simulation now keeps Play Mode ticking while keyboard or mouse input commands are running, even when a project has Run In Background disabled.
- The original Run In Background value is restored after each command completes.

## User Impact
- Before, projects with Run In Background disabled could leave keyboard or mouse input simulation waiting forever when Unity was not focused.
- After, these commands complete normally without requiring users to permanently change project settings.

## Changes
- Add a temporary Run In Background guard around input simulation execution.
- Apply the guard to keyboard and mouse input simulation paths.
- Cover restoration behavior with focused EditMode and PlayMode tests.

## Verification
- `codex-review v3-beta`
- `Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.InputSimulationRunInBackgroundScopeTests"`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode PlayMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.PlayMode.SimulateKeyboardTests.Press_Should_RestoreRunInBackground_WhenOriginallyDisabled"`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode PlayMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.PlayMode.SimulateMouseInputTests.LongPress_Should_RestoreRunInBackground_WhenOriginallyDisabled"`