### PR TITLE
chore: Enforce GitHub Actions security policy

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: Packages/src/Cli~/.go-version
           cache: false
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Test install release filter in Git Bash
         shell: bash
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Validate Unity Package structure
         run: |

--- a/.github/workflows/cli-minimum-version-warning.yml
+++ b/.github/workflows/cli-minimum-version-warning.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout base repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -53,7 +53,7 @@ jobs:
           echo "Checkout ref: ${CHECKOUT_REF}"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ steps.checkout.outputs.ref }}
           fetch-depth: 0
@@ -72,7 +72,7 @@ jobs:
 
       - name: Setup Go
         if: steps.release.outputs.publish == 'true'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: Packages/src/Cli~/.go-version
           cache-dependency-path: Packages/src/Cli~/**/go.sum
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload packaged release assets artifact
         if: steps.release.outputs.publish == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: native-cli-release-assets-${{ steps.release.outputs.tag }}
           path: Packages/src/Cli~/release/*

--- a/.github/workflows/release-failure-notify.yml
+++ b/.github/workflows/release-failure-notify.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Create or update release failure issue
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.inputs.branch || github.ref_name }}
           fetch-depth: 0 # Required for tag fetching
@@ -88,7 +88,7 @@ jobs:
       - name: 🚀 Run release‑please
         if: steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -98,7 +98,7 @@ jobs:
 
       - name: Setup Go for release PR binary sync
         if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: Packages/src/Cli~/.go-version
           cache-dependency-path: Packages/src/Cli~/**/go.sum

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: '6.0.x'
 
@@ -90,14 +90,14 @@ jobs:
         fi
 
     - name: Upload SARIF results to GitHub
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
       if: always() && hashFiles('security-results.sarif') != ''
       with:
         sarif_file: security-results.sarif
         category: "SecurityCodeScan"
 
     - name: Upload security scan results as artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       if: always()
       with:
         name: security-scan-results
@@ -109,13 +109,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: Packages/src/Cli~/.go-version
-        cache-dependency-path: Packages/src/Cli~/**/go.sum
+        cache: false
 
     - name: Install golangci-lint
       run: |

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -25,12 +25,12 @@ jobs:
       HAS_UNITY_LICENSE: ${{ secrets.UNITY_LICENSE != '' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           lfs: true
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: 10.0.x
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: Library
           key: Library-2022.3.62f1-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs', 'Packages/manifest.json', 'Packages/packages-lock.json') }}
@@ -49,7 +49,7 @@ jobs:
       - name: Compile Unity project
         if: env.HAS_UNITY_LICENSE == 'true'
         id: compile
-        uses: game-ci/unity-builder@v4
+        uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2
         timeout-minutes: 30
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -17,12 +17,12 @@ jobs:
       HAS_UNITY_LICENSE: ${{ secrets.UNITY_LICENSE != '' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           lfs: true
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: 10.0.x
 
@@ -31,7 +31,7 @@ jobs:
 
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: Library
           key: Library-2022.3.62f1-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs', 'Packages/manifest.json', 'Packages/packages-lock.json') }}
@@ -41,7 +41,7 @@ jobs:
       - name: Compile Unity project
         if: env.HAS_UNITY_LICENSE == 'true'
         id: compile
-        uses: game-ci/unity-builder@v4
+        uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2
         timeout-minutes: 30
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Run EditMode tests
         if: env.HAS_UNITY_LICENSE == 'true'
-        uses: game-ci/unity-test-runner@v4
+        uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9
         timeout-minutes: 30
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -121,7 +121,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always() && env.HAS_UNITY_LICENSE == 'true'
         with:
           name: Unity test results

--- a/Packages/src/Cli~/internal/architecture/github_actions_security_test.go
+++ b/Packages/src/Cli~/internal/architecture/github_actions_security_test.go
@@ -1,0 +1,201 @@
+package architecture
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+var githubActionCommitRefPattern = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+
+// Tests that remote GitHub Actions are pinned to immutable commit SHAs.
+func TestWorkflowActionsUseCommitPins(t *testing.T) {
+	repositoryRoot := findRepositoryRoot(t, findModuleRoot(t))
+	violations := []string{}
+	for _, workflowPath := range workflowFilePaths(t, repositoryRoot) {
+		lines := readWorkflowLines(t, workflowPath)
+		for lineIndex, line := range lines {
+			actionRef, ok := parseUsesAction(line)
+			if !ok || isLocalAction(actionRef) {
+				continue
+			}
+			if githubActionCommitRefPattern.MatchString(actionReference(actionRef)) {
+				continue
+			}
+			violations = append(violations, workflowViolation(repositoryRoot, workflowPath, lineIndex, actionRef, "pin remote actions to a full commit SHA"))
+		}
+	}
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("workflow action pinning policy violations:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+// Tests that setup-go does not use cache in pull request workflows.
+func TestPullRequestWorkflowsDisableSetupGoCache(t *testing.T) {
+	repositoryRoot := findRepositoryRoot(t, findModuleRoot(t))
+	violations := []string{}
+	for _, workflowPath := range workflowFilePaths(t, repositoryRoot) {
+		lines := readWorkflowLines(t, workflowPath)
+		if !workflowRunsOnPullRequest(lines) {
+			continue
+		}
+		for lineIndex, line := range lines {
+			actionRef, ok := parseUsesAction(line)
+			if !ok || actionRepository(actionRef) != "actions/setup-go" {
+				continue
+			}
+			if stepContains(lines, lineIndex, "cache: false") {
+				continue
+			}
+			violations = append(violations, workflowViolation(repositoryRoot, workflowPath, lineIndex, actionRef, "set cache: false for setup-go in pull request workflows"))
+		}
+	}
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("pull request setup-go cache policy violations:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+// Tests that pull request workflow cache actions are guarded behind trusted Unity secrets.
+func TestPullRequestWorkflowCacheActionsRequireTrustedUnitySecrets(t *testing.T) {
+	repositoryRoot := findRepositoryRoot(t, findModuleRoot(t))
+	violations := []string{}
+	for _, workflowPath := range workflowFilePaths(t, repositoryRoot) {
+		lines := readWorkflowLines(t, workflowPath)
+		if !workflowRunsOnPullRequest(lines) {
+			continue
+		}
+		for lineIndex, line := range lines {
+			actionRef, ok := parseUsesAction(line)
+			if !ok || actionRepository(actionRef) != "actions/cache" {
+				continue
+			}
+			if stepContains(lines, lineIndex, "if: env.HAS_UNITY_LICENSE == 'true'") {
+				continue
+			}
+			violations = append(violations, workflowViolation(repositoryRoot, workflowPath, lineIndex, actionRef, "guard pull request cache actions behind Unity license secrets"))
+		}
+	}
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("pull request cache action policy violations:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func workflowFilePaths(t *testing.T, repositoryRoot string) []string {
+	t.Helper()
+	workflowRoot := filepath.Join(repositoryRoot, ".github", "workflows")
+	entries, err := os.ReadDir(workflowRoot)
+	if err != nil {
+		t.Fatalf("failed to read workflow directory: %v", err)
+	}
+	paths := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml") {
+			paths = append(paths, filepath.Join(workflowRoot, name))
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func readWorkflowLines(t *testing.T, workflowPath string) []string {
+	t.Helper()
+	content, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("failed to read workflow %s: %v", workflowPath, err)
+	}
+	return strings.Split(string(content), "\n")
+}
+
+func parseUsesAction(line string) (string, bool) {
+	trimmedLine := strings.TrimSpace(stripYamlComment(line))
+	if !strings.HasPrefix(trimmedLine, "uses:") {
+		return "", false
+	}
+	actionRef := strings.TrimSpace(strings.TrimPrefix(trimmedLine, "uses:"))
+	actionRef = strings.Trim(actionRef, `"'`)
+	return actionRef, actionRef != ""
+}
+
+func workflowRunsOnPullRequest(lines []string) bool {
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(stripYamlComment(line))
+		if strings.HasPrefix(trimmedLine, "pull_request:") || strings.HasPrefix(trimmedLine, "pull_request_target:") {
+			return true
+		}
+	}
+	return false
+}
+
+func stripYamlComment(line string) string {
+	beforeComment, _, _ := strings.Cut(line, "#")
+	return beforeComment
+}
+
+func isLocalAction(actionRef string) bool {
+	return strings.HasPrefix(actionRef, "./") || strings.HasPrefix(actionRef, "docker://")
+}
+
+func actionReference(actionRef string) string {
+	atIndex := strings.LastIndex(actionRef, "@")
+	if atIndex < 0 {
+		return ""
+	}
+	return actionRef[atIndex+1:]
+}
+
+func actionRepository(actionRef string) string {
+	atIndex := strings.LastIndex(actionRef, "@")
+	if atIndex < 0 {
+		return ""
+	}
+	pathParts := strings.Split(actionRef[:atIndex], "/")
+	if len(pathParts) < 2 {
+		return ""
+	}
+	return pathParts[0] + "/" + pathParts[1]
+}
+
+func stepContains(lines []string, lineIndex int, expectedLine string) bool {
+	startIndex := stepStartIndex(lines, lineIndex)
+	for index := startIndex; index < len(lines); index++ {
+		if index > startIndex && isStepStart(lines[index]) {
+			return false
+		}
+		if strings.TrimSpace(stripYamlComment(lines[index])) == expectedLine {
+			return true
+		}
+	}
+	return false
+}
+
+func stepStartIndex(lines []string, lineIndex int) int {
+	for index := lineIndex; index >= 0; index-- {
+		if isStepStart(lines[index]) {
+			return index
+		}
+	}
+	return lineIndex
+}
+
+func isStepStart(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(stripYamlComment(line)), "- name:")
+}
+
+func workflowViolation(repositoryRoot string, workflowPath string, lineIndex int, actionRef string, message string) string {
+	relativePath, err := filepath.Rel(repositoryRoot, workflowPath)
+	if err != nil {
+		relativePath = workflowPath
+	}
+	return fmt.Sprintf("%s:%d uses %q; %s", filepath.ToSlash(relativePath), lineIndex+1, actionRef, message)
+}

--- a/Packages/src/Cli~/internal/architecture/github_actions_security_test.go
+++ b/Packages/src/Cli~/internal/architecture/github_actions_security_test.go
@@ -131,6 +131,11 @@ func TestWorkflowRunsOnPullRequestDetectsInlineOnSyntax(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "inline trigger map",
+			lines:    []string{"on: {pull_request: {}}"},
+			expected: true,
+		},
+		{
 			name:     "single inline pull_request_target",
 			lines:    []string{"on: pull_request_target"},
 			expected: true,
@@ -141,6 +146,11 @@ func TestWorkflowRunsOnPullRequestDetectsInlineOnSyntax(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "block trigger map",
+			lines:    []string{"on:", "  push:", "  pull_request:", "    branches: [main]"},
+			expected: true,
+		},
+		{
 			name:     "unrelated pull request trigger",
 			lines:    []string{"on: pull_request_review"},
 			expected: false,
@@ -148,6 +158,16 @@ func TestWorkflowRunsOnPullRequestDetectsInlineOnSyntax(t *testing.T) {
 		{
 			name:     "unrelated inline trigger list",
 			lines:    []string{"on: [push, pull_request_review]"},
+			expected: false,
+		},
+		{
+			name:     "unrelated inline trigger map nested value",
+			lines:    []string{"on: {workflow_run: {workflows: [pull_request]}}"},
+			expected: false,
+		},
+		{
+			name:     "unrelated block trigger nested value",
+			lines:    []string{"on:", "  workflow_run:", "    workflows: [pull_request]"},
 			expected: false,
 		},
 	}
@@ -203,6 +223,7 @@ func parseUsesAction(line string) (string, bool) {
 
 func workflowRunsOnPullRequest(lines []string) bool {
 	inOnBlock := false
+	onChildIndent := -1
 	for _, line := range lines {
 		lineWithoutComment := stripYamlComment(line)
 		trimmedLine := strings.TrimSpace(lineWithoutComment)
@@ -212,9 +233,10 @@ func workflowRunsOnPullRequest(lines []string) bool {
 		if strings.HasPrefix(trimmedLine, "on:") {
 			onValue := strings.TrimSpace(strings.TrimPrefix(trimmedLine, "on:"))
 			if onValue != "" {
-				return workflowTriggerListContainsPullRequest(onValue)
+				return workflowInlineTriggerContainsPullRequest(onValue)
 			}
 			inOnBlock = true
+			onChildIndent = -1
 			continue
 		}
 		if !inOnBlock {
@@ -223,7 +245,14 @@ func workflowRunsOnPullRequest(lines []string) bool {
 		if isTopLevelYamlKey(lineWithoutComment) {
 			return false
 		}
-		if workflowTriggerListContainsPullRequest(trimmedLine) {
+		lineIndent := leadingWhitespaceCount(lineWithoutComment)
+		if onChildIndent < 0 {
+			onChildIndent = lineIndent
+		}
+		if lineIndent != onChildIndent {
+			continue
+		}
+		if workflowBlockTriggerLineContainsPullRequest(trimmedLine) {
 			return true
 		}
 	}
@@ -294,13 +323,88 @@ func isStepStart(line string) bool {
 func workflowTriggerListContainsPullRequest(value string) bool {
 	value = strings.TrimSpace(value)
 	value = strings.TrimPrefix(value, "- ")
-	normalizedValue := strings.NewReplacer("[", " ", "]", " ", ",", " ", ":", " ", `"`, " ", `'`, " ").Replace(value)
+	normalizedValue := strings.NewReplacer("[", " ", "]", " ", "{", " ", "}", " ", ",", " ", ":", " ", `"`, " ", `'`, " ").Replace(value)
 	for _, token := range strings.Fields(normalizedValue) {
 		if token == "pull_request" || token == "pull_request_target" {
 			return true
 		}
 	}
 	return false
+}
+
+func workflowInlineTriggerContainsPullRequest(value string) bool {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "{") {
+		return workflowInlineMapContainsPullRequest(value)
+	}
+	return workflowTriggerListContainsPullRequest(value)
+}
+
+func workflowInlineMapContainsPullRequest(value string) bool {
+	content := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "{"), "}"))
+	for _, entry := range splitTopLevelCommaEntries(content) {
+		key := topLevelMapKey(entry)
+		if key == "pull_request" || key == "pull_request_target" {
+			return true
+		}
+	}
+	return false
+}
+
+func splitTopLevelCommaEntries(value string) []string {
+	entries := []string{}
+	startIndex := 0
+	nestingDepth := 0
+	for index, char := range value {
+		switch char {
+		case '{', '[':
+			nestingDepth++
+		case '}', ']':
+			if nestingDepth > 0 {
+				nestingDepth--
+			}
+		case ',':
+			if nestingDepth == 0 {
+				entries = append(entries, value[startIndex:index])
+				startIndex = index + 1
+			}
+		}
+	}
+	entries = append(entries, value[startIndex:])
+	return entries
+}
+
+func topLevelMapKey(entry string) string {
+	nestingDepth := 0
+	for index, char := range entry {
+		switch char {
+		case '{', '[':
+			nestingDepth++
+		case '}', ']':
+			if nestingDepth > 0 {
+				nestingDepth--
+			}
+		case ':':
+			if nestingDepth == 0 {
+				return trimWorkflowToken(entry[:index])
+			}
+		}
+	}
+	return ""
+}
+
+func workflowBlockTriggerLineContainsPullRequest(value string) bool {
+	value = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(value), "- "))
+	key, _, hasKey := strings.Cut(value, ":")
+	if hasKey {
+		value = key
+	}
+	value = trimWorkflowToken(value)
+	return value == "pull_request" || value == "pull_request_target"
+}
+
+func trimWorkflowToken(value string) string {
+	return strings.Trim(strings.TrimSpace(value), `"'`)
 }
 
 func isTopLevelYamlKey(line string) bool {
@@ -310,6 +414,11 @@ func isTopLevelYamlKey(line string) bool {
 	}
 	key, _, hasKey := strings.Cut(trimmedLine, ":")
 	return hasKey && key != ""
+}
+
+func leadingWhitespaceCount(value string) int {
+	trimmedValue := strings.TrimLeft(value, " \t")
+	return len(value) - len(trimmedValue)
 }
 
 func workflowViolation(repositoryRoot string, workflowPath string, lineIndex int, actionRef string, message string) string {

--- a/Packages/src/Cli~/internal/architecture/github_actions_security_test.go
+++ b/Packages/src/Cli~/internal/architecture/github_actions_security_test.go
@@ -87,6 +87,79 @@ func TestPullRequestWorkflowCacheActionsRequireTrustedUnitySecrets(t *testing.T)
 	}
 }
 
+// Tests that unnamed action steps are still parsed as remote action uses.
+func TestParseUsesActionAcceptsUnnamedSteps(t *testing.T) {
+	actionRef, ok := parseUsesAction("      - uses: actions/checkout@v6")
+	if !ok {
+		t.Fatal("expected unnamed uses step to be parsed")
+	}
+	if actionRef != "actions/checkout@v6" {
+		t.Fatalf("unexpected action ref: %s", actionRef)
+	}
+}
+
+// Tests that step-local checks do not read settings from neighboring unnamed steps.
+func TestStepContainsStopsAtUnnamedStepBoundaries(t *testing.T) {
+	lines := []string{
+		"      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c",
+		"        with:",
+		"          go-version-file: Packages/src/Cli~/.go-version",
+		"      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae",
+		"        with:",
+		"          cache: false",
+	}
+	if stepContains(lines, 0, "cache: false") {
+		t.Fatal("expected cache setting in a neighboring unnamed step to be ignored")
+	}
+}
+
+// Tests that inline pull request triggers are recognized without matching unrelated triggers.
+func TestWorkflowRunsOnPullRequestDetectsInlineOnSyntax(t *testing.T) {
+	testCases := []struct {
+		name     string
+		lines    []string
+		expected bool
+	}{
+		{
+			name:     "single inline pull_request",
+			lines:    []string{"on: pull_request"},
+			expected: true,
+		},
+		{
+			name:     "inline trigger list",
+			lines:    []string{"on: [push, pull_request]"},
+			expected: true,
+		},
+		{
+			name:     "single inline pull_request_target",
+			lines:    []string{"on: pull_request_target"},
+			expected: true,
+		},
+		{
+			name:     "block trigger list",
+			lines:    []string{"on:", "  - push", "  - pull_request"},
+			expected: true,
+		},
+		{
+			name:     "unrelated pull request trigger",
+			lines:    []string{"on: pull_request_review"},
+			expected: false,
+		},
+		{
+			name:     "unrelated inline trigger list",
+			lines:    []string{"on: [push, pull_request_review]"},
+			expected: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if workflowRunsOnPullRequest(testCase.lines) != testCase.expected {
+				t.Fatalf("pull request trigger detection mismatch for %v", testCase.lines)
+			}
+		})
+	}
+}
+
 func workflowFilePaths(t *testing.T, repositoryRoot string) []string {
 	t.Helper()
 	workflowRoot := filepath.Join(repositoryRoot, ".github", "workflows")
@@ -119,6 +192,7 @@ func readWorkflowLines(t *testing.T, workflowPath string) []string {
 
 func parseUsesAction(line string) (string, bool) {
 	trimmedLine := strings.TrimSpace(stripYamlComment(line))
+	trimmedLine = strings.TrimPrefix(trimmedLine, "- ")
 	if !strings.HasPrefix(trimmedLine, "uses:") {
 		return "", false
 	}
@@ -128,9 +202,28 @@ func parseUsesAction(line string) (string, bool) {
 }
 
 func workflowRunsOnPullRequest(lines []string) bool {
+	inOnBlock := false
 	for _, line := range lines {
-		trimmedLine := strings.TrimSpace(stripYamlComment(line))
-		if strings.HasPrefix(trimmedLine, "pull_request:") || strings.HasPrefix(trimmedLine, "pull_request_target:") {
+		lineWithoutComment := stripYamlComment(line)
+		trimmedLine := strings.TrimSpace(lineWithoutComment)
+		if trimmedLine == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmedLine, "on:") {
+			onValue := strings.TrimSpace(strings.TrimPrefix(trimmedLine, "on:"))
+			if onValue != "" {
+				return workflowTriggerListContainsPullRequest(onValue)
+			}
+			inOnBlock = true
+			continue
+		}
+		if !inOnBlock {
+			continue
+		}
+		if isTopLevelYamlKey(lineWithoutComment) {
+			return false
+		}
+		if workflowTriggerListContainsPullRequest(trimmedLine) {
 			return true
 		}
 	}
@@ -189,7 +282,34 @@ func stepStartIndex(lines []string, lineIndex int) int {
 }
 
 func isStepStart(line string) bool {
-	return strings.HasPrefix(strings.TrimSpace(stripYamlComment(line)), "- name:")
+	trimmedLine := strings.TrimSpace(stripYamlComment(line))
+	if !strings.HasPrefix(trimmedLine, "- ") {
+		return false
+	}
+	stepContent := strings.TrimSpace(strings.TrimPrefix(trimmedLine, "- "))
+	stepKey, _, hasStepKey := strings.Cut(stepContent, ":")
+	return hasStepKey && stepKey != "" && !strings.ContainsAny(stepKey, " []{}")
+}
+
+func workflowTriggerListContainsPullRequest(value string) bool {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "- ")
+	normalizedValue := strings.NewReplacer("[", " ", "]", " ", ",", " ", ":", " ", `"`, " ", `'`, " ").Replace(value)
+	for _, token := range strings.Fields(normalizedValue) {
+		if token == "pull_request" || token == "pull_request_target" {
+			return true
+		}
+	}
+	return false
+}
+
+func isTopLevelYamlKey(line string) bool {
+	trimmedLine := strings.TrimSpace(line)
+	if trimmedLine == "" || strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+		return false
+	}
+	key, _, hasKey := strings.Cut(trimmedLine, ":")
+	return hasKey && key != ""
 }
 
 func workflowViolation(repositoryRoot string, workflowPath string, lineIndex int, actionRef string, message string) string {

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -1,0 +1,21 @@
+# GitHub Actions security policy
+
+Remote GitHub Actions must be pinned to full commit SHAs. Version tags such as
+`actions/checkout@v6` are not allowed in workflow files because tag movement can
+change CI behavior without a repository diff.
+
+When updating a pinned action:
+
+1. Resolve the intended upstream tag to a commit SHA.
+2. Replace the workflow `uses:` ref with the full 40-character SHA.
+3. Run `go test ./internal/architecture -run 'TestWorkflowActions|TestPullRequestWorkflow' -count=1` from `Packages/src/Cli~`.
+
+For nested action paths such as `github/codeql-action/upload-sarif`, resolve the
+tag against the action repository, not the nested action path.
+
+Pull request workflows must not restore Go module caches through `setup-go`.
+Use `cache: false` for `actions/setup-go` in workflows triggered by
+`pull_request` or `pull_request_target`.
+
+Unity `actions/cache` steps in pull request workflows must stay behind the Unity
+license secret guard so forked pull requests cannot use those cache entries.


### PR DESCRIPTION
## Summary
- Pin GitHub Actions workflow dependencies to immutable commit SHAs.
- Add CI coverage that rejects unpinned workflow actions and unsafe pull request cache settings.

## User Impact
- Pull request and release workflows become less vulnerable to upstream tag drift.
- Future workflow changes fail locally and in CI when they reintroduce unpinned actions or unsafe pull request Go caching.

## Changes
- Replaced remote workflow action version tags with full commit SHAs.
- Disabled setup-go caching in the pull request security scan workflow.
- Added Go architecture tests for workflow action pinning and pull request cache policy.
- Documented the repository policy and update flow in docs/github-actions-security.md.

## Verification
- go test ./internal/architecture -run 'TestWorkflowActions|TestPullRequestWorkflow' -count=1
- scripts/test-cli-minimum-version-warning-workflow.sh
- scripts/test-native-cli-publish-workflow.sh
- scripts/test-release-please-config.sh
- git diff --check
- scripts/check-go-cli.sh

Closes #1221

Out of scope: moving the CLI minimum warning comment implementation to Go is tracked separately in #1222.