### PR TITLE
fix: Compile fails fast on asmdef and asmref import errors

### DIFF
--- a/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
+++ b/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
@@ -69,5 +69,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.HasErrors, Is.False);
             Assert.That(result.Errors, Is.Empty);
         }
+
+        [Test]
+        public void FindErrors_WhenGenericErrorMentionsAsmdefPath_ReturnsNoIssues()
+        {
+            // Tests that stale generic Console errors mentioning .asmdef paths do not block compilation.
+            AssemblyDefinitionConsoleErrorValidationService service = new();
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(
+                    UnityCliLoopLogType.Error,
+                    "Tool failed while reading Assets/Editor/Sample.asmdef",
+                    "")
+            };
+
+            AssemblyDefinitionConsoleErrorResult result = service.FindErrors(entries);
+
+            Assert.That(result.HasErrors, Is.False);
+            Assert.That(result.Errors, Is.Empty);
+        }
     }
 }

--- a/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
+++ b/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
@@ -13,7 +13,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void FindErrors_WhenAsmdefErrorMessageExists_ReturnsIssueWithFile()
         {
             // Tests that current Console errors with .asmdef paths are converted into compile issues.
-            AssemblyDefinitionConsoleErrorValidationService service = new();
+            AssemblyDefinitionConsoleErrorValidationService service = new(
+                (assetPath, message) => true);
             UnityCliLoopConsoleLogEntry[] entries =
             {
                 new(
@@ -35,7 +36,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void FindErrors_WhenAsmrefErrorMessageExists_ReturnsIssueWithFile()
         {
             // Tests that Assembly Reference import failures are detected with the same Console path rule.
-            AssemblyDefinitionConsoleErrorValidationService service = new();
+            AssemblyDefinitionConsoleErrorValidationService service = new(
+                (assetPath, message) => true);
             UnityCliLoopConsoleLogEntry[] entries =
             {
                 new(
@@ -68,6 +70,47 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(result.HasErrors, Is.False);
             Assert.That(result.Errors, Is.Empty);
+        }
+
+        [Test]
+        public void FindErrors_WhenImporterErrorIsNotCurrent_ReturnsNoIssues()
+        {
+            // Tests that retained importer Console logs do not block compile after the asset state is valid.
+            AssemblyDefinitionConsoleErrorValidationService service = new(
+                (assetPath, message) => false);
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(
+                    UnityCliLoopLogType.Error,
+                    "Assembly has duplicate references: Unity.InputSystem (Assets/Editor/Sample.asmdef)",
+                    "")
+            };
+
+            AssemblyDefinitionConsoleErrorResult result = service.FindErrors(entries);
+
+            Assert.That(result.HasErrors, Is.False);
+            Assert.That(result.Errors, Is.Empty);
+        }
+
+        [Test]
+        public void FindErrors_WhenGenericAsmrefImportErrorIsCurrent_ReturnsIssueWithFile()
+        {
+            // Tests that asmref import errors are detected even when Unity uses generic parse wording.
+            AssemblyDefinitionConsoleErrorValidationService service = new(
+                (assetPath, message) => true);
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(
+                    UnityCliLoopLogType.Error,
+                    "JSON parse error in Assets/Tests/Sample.asmref",
+                    "")
+            };
+
+            AssemblyDefinitionConsoleErrorResult result = service.FindErrors(entries);
+
+            Assert.That(result.HasErrors, Is.True);
+            Assert.That(result.Errors, Has.Length.EqualTo(1));
+            Assert.That(result.Errors[0].File, Is.EqualTo("Assets/Tests/Sample.asmref"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
+++ b/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
@@ -114,6 +114,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void FindErrors_WhenAssetPathContainsParentheses_ReturnsIssueWithFile()
+        {
+            // Tests that Unity asset paths with parentheses are still parsed from Console errors.
+            AssemblyDefinitionConsoleErrorValidationService service = new(
+                (assetPath, message) => true);
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(
+                    UnityCliLoopLogType.Error,
+                    "JSON parse error: Missing a name for object member. (Assets/Foo (Editor)/Bad.asmref)",
+                    "")
+            };
+
+            AssemblyDefinitionConsoleErrorResult result = service.FindErrors(entries);
+
+            Assert.That(result.HasErrors, Is.True);
+            Assert.That(result.Errors, Has.Length.EqualTo(1));
+            Assert.That(result.Errors[0].File, Is.EqualTo("Assets/Foo (Editor)/Bad.asmref"));
+        }
+
+        [Test]
         public void FindErrors_WhenGenericErrorMentionsAsmdefPath_ReturnsNoIssues()
         {
             // Tests that stale generic Console errors mentioning .asmdef paths do not block compilation.

--- a/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
+++ b/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using UnityEditor;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
@@ -144,6 +145,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new(
                     UnityCliLoopLogType.Error,
                     "Tool failed while reading Assets/Editor/Sample.asmdef",
+                    "")
+            };
+
+            AssemblyDefinitionConsoleErrorResult result = service.FindErrors(entries);
+
+            Assert.That(result.HasErrors, Is.False);
+            Assert.That(result.Errors, Is.Empty);
+        }
+
+        [Test]
+        public void FindErrors_WhenValidRegistryPackageAsmdefPathIsMentioned_ReturnsNoIssues()
+        {
+            // Tests that Package Manager virtual asset paths resolve before checking current file contents.
+            const string packageAsmdefPath = "Packages/com.unity.cinemachine/Runtime/com.unity.cinemachine.asmdef";
+            Assert.That(AssetImporter.GetAtPath(packageAsmdefPath), Is.Not.Null);
+            AssemblyDefinitionConsoleErrorValidationService service = new();
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(
+                    UnityCliLoopLogType.Error,
+                    $"JSON parse error in {packageAsmdefPath}",
                     "")
             };
 

--- a/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
+++ b/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies Assembly Definition and Assembly Reference Console error detection before compile waits.
+    /// </summary>
+    public sealed class AssemblyDefinitionConsoleErrorValidationServiceTests
+    {
+        [Test]
+        public void FindErrors_WhenAsmdefErrorMessageExists_ReturnsIssueWithFile()
+        {
+            // Tests that current Console errors with .asmdef paths are converted into compile issues.
+            AssemblyDefinitionConsoleErrorValidationService service = new();
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(
+                    UnityCliLoopLogType.Error,
+                    "Assembly has duplicate references: Unity.InputSystem (Assets/Editor/Sample.asmdef)",
+                    "")
+            };
+
+            AssemblyDefinitionConsoleErrorResult result = service.FindErrors(entries);
+
+            Assert.That(result.HasErrors, Is.True);
+            Assert.That(result.Errors, Has.Length.EqualTo(1));
+            Assert.That(result.Errors[0].File, Is.EqualTo("Assets/Editor/Sample.asmdef"));
+            Assert.That(result.Errors[0].Line, Is.EqualTo(0));
+            Assert.That(result.Errors[0].Message, Is.EqualTo(entries[0].Message));
+        }
+
+        [Test]
+        public void FindErrors_WhenAsmrefErrorMessageExists_ReturnsIssueWithFile()
+        {
+            // Tests that Assembly Reference import failures are detected with the same Console path rule.
+            AssemblyDefinitionConsoleErrorValidationService service = new();
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(
+                    UnityCliLoopLogType.Error,
+                    "Assembly Reference has an invalid target (Assets/Tests/Sample.asmref)",
+                    "")
+            };
+
+            AssemblyDefinitionConsoleErrorResult result = service.FindErrors(entries);
+
+            Assert.That(result.HasErrors, Is.True);
+            Assert.That(result.Errors, Has.Length.EqualTo(1));
+            Assert.That(result.Errors[0].File, Is.EqualTo("Assets/Tests/Sample.asmref"));
+        }
+
+        [Test]
+        public void FindErrors_WhenOnlyNonErrorEntriesMentionAsmdef_ReturnsNoIssues()
+        {
+            // Tests that visible non-error Console notes do not block compilation.
+            AssemblyDefinitionConsoleErrorValidationService service = new();
+            UnityCliLoopConsoleLogEntry[] entries =
+            {
+                new(
+                    UnityCliLoopLogType.Warning,
+                    "Package inspected Assets/Editor/Sample.asmdef",
+                    "")
+            };
+
+            AssemblyDefinitionConsoleErrorResult result = service.FindErrors(entries);
+
+            Assert.That(result.HasErrors, Is.False);
+            Assert.That(result.Errors, Is.Empty);
+        }
+    }
+}

--- a/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs.meta
+++ b/Assets/Tests/Editor/AssemblyDefinitionConsoleErrorValidationServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b900e4c47f4741c7be00eaa4475aa7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
@@ -20,6 +20,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             RegexOptions.Compiled | RegexOptions.IgnoreCase
         );
 
+        private static readonly string[] AssemblyDefinitionImporterErrorMarkers =
+        {
+            "Assembly has duplicate references:",
+            "Assembly Reference",
+            "Assembly Definition",
+            "Assembly with name '",
+            "assembly definition files"
+        };
+
         /// <summary>
         /// Finds Assembly Definition and Assembly Reference errors from the current Unity Console.
         /// </summary>
@@ -68,6 +77,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
+                if (!IsAssemblyDefinitionImporterError(searchableText))
+                {
+                    continue;
+                }
+
                 string file = pathMatch.Groups["path"].Value;
                 string issueMessage = string.IsNullOrWhiteSpace(message)
                     ? searchableText.Trim()
@@ -91,6 +105,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             return entry != null &&
                    string.Equals(entry.Type, UnityCliLoopLogType.Error, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Checks whether a Console error has Unity's Assembly Definition or Assembly Reference importer wording.
+        /// </summary>
+        private static bool IsAssemblyDefinitionImporterError(string message)
+        {
+            foreach (string marker in AssemblyDefinitionImporterErrorMarkers)
+            {
+                if (message.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
@@ -376,16 +376,64 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         private static string ToAbsolutePath(string assetPath)
         {
+            Debug.Assert(!string.IsNullOrWhiteSpace(assetPath), "assetPath must not be null or empty");
+
+            if (assetPath.StartsWith("Packages/", StringComparison.Ordinal))
+            {
+                string packagePath = ToPackageAbsolutePath(assetPath);
+                if (!string.IsNullOrEmpty(packagePath))
+                {
+                    return packagePath;
+                }
+            }
+
             return Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), assetPath);
         }
 
         /// <summary>
-        /// Checks whether Unity still exposes an import log for the asset.
+        /// Converts a Package Manager virtual asset path to the package file path on disk.
+        /// </summary>
+        private static string ToPackageAbsolutePath(string assetPath)
+        {
+            UnityEditor.PackageManager.PackageInfo packageInfo =
+                UnityEditor.PackageManager.PackageInfo.FindForAssetPath(assetPath);
+            if (packageInfo == null ||
+                string.IsNullOrEmpty(packageInfo.assetPath) ||
+                string.IsNullOrEmpty(packageInfo.resolvedPath))
+            {
+                return string.Empty;
+            }
+
+            if (!assetPath.StartsWith(packageInfo.assetPath, StringComparison.Ordinal))
+            {
+                return string.Empty;
+            }
+
+            string relativePath = assetPath.Substring(packageInfo.assetPath.Length)
+                .TrimStart('/', '\\');
+            return Path.Combine(packageInfo.resolvedPath, relativePath);
+        }
+
+        /// <summary>
+        /// Checks whether Unity still exposes an error import log for the asset.
         /// </summary>
         private static bool HasAssetImportLog(string assetPath)
         {
             ImportLog importLog = AssetImporter.GetImportLog(assetPath);
-            return importLog != null;
+            if (importLog == null)
+            {
+                return false;
+            }
+
+            foreach (ImportLog.ImportLogEntry entry in importLog.logEntries)
+            {
+                if ((entry.flags & ImportLogFlags.Error) != 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
@@ -21,7 +21,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly Func<string, string, bool> _isCurrentImportError;
 
         private static readonly Regex AssemblyDefinitionAssetPathRegex = new(
-            "(?<path>(?:Assets|Packages)/[^\\r\\n()]*?\\.(?:asmdef|asmref))",
+            "(?<path>(?:Assets|Packages)/[^\\r\\n]*?\\.(?:asmdef|asmref))",
             RegexOptions.Compiled | RegexOptions.IgnoreCase
         );
 
@@ -157,7 +157,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (assetPath.EndsWith(".asmdef", StringComparison.OrdinalIgnoreCase))
             {
-                return HasDuplicateReferences(assetPath) ||
+                return HasMalformedAssemblyDefinition(assetPath) ||
+                       HasDuplicateReferences(assetPath) ||
                        HasMultipleAssemblyDefinitionFilesInFolder(assetPath) ||
                        HasDuplicateAssemblyName(assetPath, message) ||
                        HasAssetImportLog(assetPath);
@@ -183,13 +184,35 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             foreach (Match referenceMatch in referenceMatches)
             {
                 string reference = referenceMatch.Groups["value"].Value;
-                if (!references.Add(reference))
+                string referenceIdentity = ResolveAssemblyReferenceIdentity(reference);
+                if (!references.Add(referenceIdentity))
                 {
                     return true;
                 }
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Checks whether an asmdef is missing the minimum JSON shape Unity's importer requires.
+        /// </summary>
+        private static bool HasMalformedAssemblyDefinition(string assetPath)
+        {
+            string source = ReadAssetText(assetPath).Trim();
+            if (string.IsNullOrEmpty(source))
+            {
+                return true;
+            }
+
+            if (!source.StartsWith("{", StringComparison.Ordinal) ||
+                !source.EndsWith("}", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            Match nameMatch = AssemblyNameRegex.Match(source);
+            return !nameMatch.Success;
         }
 
         /// <summary>
@@ -271,6 +294,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             string reference = referenceMatch.Groups["reference"].Value;
             return !AssemblyReferenceTargetExists(reference);
+        }
+
+        /// <summary>
+        /// Resolves an asmdef reference string to the assembly identity Unity uses for duplicate checks.
+        /// </summary>
+        private static string ResolveAssemblyReferenceIdentity(string reference)
+        {
+            if (!reference.StartsWith(GuidReferencePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return reference;
+            }
+
+            string guid = reference.Substring(GuidReferencePrefix.Length);
+            string path = AssetDatabase.GUIDToAssetPath(guid);
+            if (!path.EndsWith(".asmdef", StringComparison.OrdinalIgnoreCase))
+            {
+                return reference;
+            }
+
+            return ReadAssemblyDefinitionName(path);
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEditor.AssetImporters;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -14,20 +17,47 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public sealed class AssemblyDefinitionConsoleErrorValidationService
     {
         private const int MaxDisplayedIssueCount = 10;
+        private const string GuidReferencePrefix = "GUID:";
+        private readonly Func<string, string, bool> _isCurrentImportError;
 
         private static readonly Regex AssemblyDefinitionAssetPathRegex = new(
             "(?<path>(?:Assets|Packages)/[^\\r\\n()]*?\\.(?:asmdef|asmref))",
             RegexOptions.Compiled | RegexOptions.IgnoreCase
         );
 
-        private static readonly string[] AssemblyDefinitionImporterErrorMarkers =
+        private static readonly Regex ReferencesBlockRegex = new(
+            "\"references\"\\s*:\\s*\\[(?<references>[^\\]]*)\\]",
+            RegexOptions.Compiled | RegexOptions.Singleline
+        );
+
+        private static readonly Regex QuotedValueRegex = new(
+            "\"(?<value>[^\"]+)\"",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex AssemblyNameRegex = new(
+            "\"name\"\\s*:\\s*\"(?<name>[^\"]+)\"",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex AssemblyReferenceRegex = new(
+            "\"reference\"\\s*:\\s*\"(?<reference>[^\"]+)\"",
+            RegexOptions.Compiled
+        );
+
+        private static readonly Regex DuplicateAssemblyNameMessageRegex = new(
+            "^Assembly with name '(?<name>[^']+)'",
+            RegexOptions.Compiled
+        );
+
+        /// <summary>
+        /// Creates a validator that confirms Console importer errors against the current asset state.
+        /// </summary>
+        public AssemblyDefinitionConsoleErrorValidationService(
+            Func<string, string, bool> isCurrentImportError = null)
         {
-            "Assembly has duplicate references:",
-            "Assembly Reference",
-            "Assembly Definition",
-            "Assembly with name '",
-            "assembly definition files"
-        };
+            _isCurrentImportError = isCurrentImportError ?? IsCurrentImportError;
+        }
 
         /// <summary>
         /// Finds Assembly Definition and Assembly Reference errors from the current Unity Console.
@@ -77,12 +107,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                if (!IsAssemblyDefinitionImporterError(searchableText))
+                string file = pathMatch.Groups["path"].Value;
+                if (!_isCurrentImportError(file, searchableText))
                 {
                     continue;
                 }
 
-                string file = pathMatch.Groups["path"].Value;
                 string issueMessage = string.IsNullOrWhiteSpace(message)
                     ? searchableText.Trim()
                     : message;
@@ -108,19 +138,218 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Checks whether a Console error has Unity's Assembly Definition or Assembly Reference importer wording.
+        /// Checks whether the referenced asset still satisfies the importer error reported in Console.
         /// </summary>
-        private static bool IsAssemblyDefinitionImporterError(string message)
+        private static bool IsCurrentImportError(string assetPath, string message)
         {
-            foreach (string marker in AssemblyDefinitionImporterErrorMarkers)
+            AssetImporter importer = AssetImporter.GetAtPath(assetPath);
+            if (importer == null)
             {
-                if (message.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0)
+                return false;
+            }
+
+            if (assetPath.EndsWith(".asmref", StringComparison.OrdinalIgnoreCase))
+            {
+                return HasMalformedAssemblyReference(assetPath) ||
+                       (ContainsText(message, "Assembly Reference") && HasMissingAssemblyReferenceTarget(assetPath)) ||
+                       HasAssetImportLog(assetPath);
+            }
+
+            if (assetPath.EndsWith(".asmdef", StringComparison.OrdinalIgnoreCase))
+            {
+                return HasDuplicateReferences(assetPath) ||
+                       HasMultipleAssemblyDefinitionFilesInFolder(assetPath) ||
+                       HasDuplicateAssemblyName(assetPath, message) ||
+                       HasAssetImportLog(assetPath);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether an asmdef still declares duplicate reference strings.
+        /// </summary>
+        private static bool HasDuplicateReferences(string assetPath)
+        {
+            string source = ReadAssetText(assetPath);
+            Match referencesBlock = ReferencesBlockRegex.Match(source);
+            if (!referencesBlock.Success)
+            {
+                return false;
+            }
+
+            HashSet<string> references = new(StringComparer.OrdinalIgnoreCase);
+            MatchCollection referenceMatches = QuotedValueRegex.Matches(referencesBlock.Groups["references"].Value);
+            foreach (Match referenceMatch in referenceMatches)
+            {
+                string reference = referenceMatch.Groups["value"].Value;
+                if (!references.Add(reference))
                 {
                     return true;
                 }
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Checks whether a directory still contains more than one assembly definition source file.
+        /// </summary>
+        private static bool HasMultipleAssemblyDefinitionFilesInFolder(string assetPath)
+        {
+            string absolutePath = ToAbsolutePath(assetPath);
+            string directoryPath = Path.GetDirectoryName(absolutePath);
+            if (string.IsNullOrEmpty(directoryPath) || !Directory.Exists(directoryPath))
+            {
+                return false;
+            }
+
+            int asmdefCount = Directory.GetFiles(directoryPath, "*.asmdef", SearchOption.TopDirectoryOnly).Length;
+            return asmdefCount > 1;
+        }
+
+        /// <summary>
+        /// Checks whether the duplicate assembly name from Console still exists in current asmdef assets.
+        /// </summary>
+        private static bool HasDuplicateAssemblyName(string assetPath, string message)
+        {
+            string expectedName = ReadAssemblyDefinitionName(assetPath);
+            Match messageMatch = DuplicateAssemblyNameMessageRegex.Match(message);
+            if (messageMatch.Success)
+            {
+                expectedName = messageMatch.Groups["name"].Value;
+            }
+
+            if (string.IsNullOrWhiteSpace(expectedName))
+            {
+                return false;
+            }
+
+            int matchCount = 0;
+            string[] asmdefGuids = AssetDatabase.FindAssets("t:AssemblyDefinitionAsset");
+            foreach (string guid in asmdefGuids)
+            {
+                string asmdefPath = AssetDatabase.GUIDToAssetPath(guid);
+                string assemblyName = ReadAssemblyDefinitionName(asmdefPath);
+                if (!string.Equals(assemblyName, expectedName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                matchCount++;
+                if (matchCount > 1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether an asmref is missing its reference value.
+        /// </summary>
+        private static bool HasMalformedAssemblyReference(string assetPath)
+        {
+            string source = ReadAssetText(assetPath);
+            Match referenceMatch = AssemblyReferenceRegex.Match(source);
+            return !referenceMatch.Success;
+        }
+
+        /// <summary>
+        /// Checks whether an asmref still points at a missing assembly definition target.
+        /// </summary>
+        private static bool HasMissingAssemblyReferenceTarget(string assetPath)
+        {
+            string source = ReadAssetText(assetPath);
+            Match referenceMatch = AssemblyReferenceRegex.Match(source);
+            if (!referenceMatch.Success)
+            {
+                return false;
+            }
+
+            string reference = referenceMatch.Groups["reference"].Value;
+            return !AssemblyReferenceTargetExists(reference);
+        }
+
+        /// <summary>
+        /// Checks whether an asmref reference string resolves to a current asmdef.
+        /// </summary>
+        private static bool AssemblyReferenceTargetExists(string reference)
+        {
+            if (reference.StartsWith(GuidReferencePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                string guid = reference.Substring(GuidReferencePrefix.Length);
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                return path.EndsWith(".asmdef", StringComparison.OrdinalIgnoreCase);
+            }
+
+            string[] asmdefGuids = AssetDatabase.FindAssets("t:AssemblyDefinitionAsset");
+            foreach (string guid in asmdefGuids)
+            {
+                string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                string assemblyName = ReadAssemblyDefinitionName(assetPath);
+                if (string.Equals(assemblyName, reference, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Reads the assembly name declared by an asmdef file.
+        /// </summary>
+        private static string ReadAssemblyDefinitionName(string assetPath)
+        {
+            string source = ReadAssetText(assetPath);
+            Match nameMatch = AssemblyNameRegex.Match(source);
+            if (nameMatch.Success)
+            {
+                return nameMatch.Groups["name"].Value;
+            }
+
+            return Path.GetFileNameWithoutExtension(assetPath);
+        }
+
+        /// <summary>
+        /// Reads project-relative asset text from disk.
+        /// </summary>
+        private static string ReadAssetText(string assetPath)
+        {
+            string absolutePath = ToAbsolutePath(assetPath);
+            if (!File.Exists(absolutePath))
+            {
+                return string.Empty;
+            }
+
+            return File.ReadAllText(absolutePath);
+        }
+
+        /// <summary>
+        /// Converts a Unity project-relative asset path to an absolute file path.
+        /// </summary>
+        private static string ToAbsolutePath(string assetPath)
+        {
+            return Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), assetPath);
+        }
+
+        /// <summary>
+        /// Checks whether Unity still exposes an import log for the asset.
+        /// </summary>
+        private static bool HasAssetImportLog(string assetPath)
+        {
+            ImportLog importLog = AssetImporter.GetImportLog(assetPath);
+            return importLog != null;
+        }
+
+        /// <summary>
+        /// Checks for case-insensitive marker text.
+        /// </summary>
+        private static bool ContainsText(string value, string marker)
+        {
+            return value.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
@@ -205,7 +205,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             int asmdefCount = Directory.GetFiles(directoryPath, "*.asmdef", SearchOption.TopDirectoryOnly).Length;
-            return asmdefCount > 1;
+            int asmrefCount = Directory.GetFiles(directoryPath, "*.asmref", SearchOption.TopDirectoryOnly).Length;
+            return asmdefCount + asmrefCount > 1;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Detects current Unity Console errors that point at Assembly Definition or Assembly Reference assets.
+    /// </summary>
+    public sealed class AssemblyDefinitionConsoleErrorValidationService
+    {
+        private const int MaxDisplayedIssueCount = 10;
+
+        private static readonly Regex AssemblyDefinitionAssetPathRegex = new(
+            "(?<path>(?:Assets|Packages)/[^\\r\\n()]*?\\.(?:asmdef|asmref))",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase
+        );
+
+        /// <summary>
+        /// Finds Assembly Definition and Assembly Reference errors from the current Unity Console.
+        /// </summary>
+        public AssemblyDefinitionConsoleErrorResult FindCurrentErrors()
+        {
+            LogRetrievalService retrievalService = new();
+            LogDisplayDto logData = retrievalService.GetLogs(UnityCliLoopLogType.Error);
+            LogEntryDto[] logEntries = logData?.LogEntries ?? Array.Empty<LogEntryDto>();
+            UnityCliLoopConsoleLogEntry[] entries = new UnityCliLoopConsoleLogEntry[logEntries.Length];
+
+            for (int i = 0; i < logEntries.Length; i++)
+            {
+                LogEntryDto entry = logEntries[i];
+                entries[i] = new UnityCliLoopConsoleLogEntry(
+                    entry.LogType,
+                    entry.Message,
+                    entry.StackTrace);
+            }
+
+            return FindErrors(entries);
+        }
+
+        /// <summary>
+        /// Finds Assembly Definition and Assembly Reference errors from a Console snapshot.
+        /// </summary>
+        public AssemblyDefinitionConsoleErrorResult FindErrors(UnityCliLoopConsoleLogEntry[] entries)
+        {
+            Debug.Assert(entries != null, "entries must not be null");
+
+            List<AssemblyDefinitionConsoleError> errors = new();
+            HashSet<string> seenKeys = new(StringComparer.Ordinal);
+
+            foreach (UnityCliLoopConsoleLogEntry entry in entries)
+            {
+                if (!IsErrorEntry(entry))
+                {
+                    continue;
+                }
+
+                string message = entry.Message ?? string.Empty;
+                string stackTrace = entry.StackTrace ?? string.Empty;
+                string searchableText = $"{message}\n{stackTrace}";
+                Match pathMatch = AssemblyDefinitionAssetPathRegex.Match(searchableText);
+                if (!pathMatch.Success)
+                {
+                    continue;
+                }
+
+                string file = pathMatch.Groups["path"].Value;
+                string issueMessage = string.IsNullOrWhiteSpace(message)
+                    ? searchableText.Trim()
+                    : message;
+                string key = $"{file}\n{issueMessage}";
+                if (!seenKeys.Add(key))
+                {
+                    continue;
+                }
+
+                errors.Add(new AssemblyDefinitionConsoleError(issueMessage, file, 0));
+            }
+
+            return new AssemblyDefinitionConsoleErrorResult(errors.ToArray());
+        }
+
+        /// <summary>
+        /// Checks whether a Console snapshot entry belongs to the error family.
+        /// </summary>
+        private static bool IsErrorEntry(UnityCliLoopConsoleLogEntry entry)
+        {
+            return entry != null &&
+                   string.Equals(entry.Type, UnityCliLoopLogType.Error, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Creates the compile failure message shown when Assembly Definition or Assembly Reference errors are present.
+        /// </summary>
+        internal static string CreateFailureMessage(AssemblyDefinitionConsoleError[] errors)
+        {
+            Debug.Assert(errors != null, "errors must not be null");
+
+            string details = string.Join(
+                "\n",
+                errors
+                    .Take(MaxDisplayedIssueCount)
+                    .Select(error => string.IsNullOrWhiteSpace(error.File)
+                        ? $"- {error.Message}"
+                        : $"- {error.File}: {error.Message}")
+            );
+
+            return $"{UnityCliLoopConstants.ERROR_MESSAGE_ASSEMBLY_DEFINITION_IMPORT_ERROR}\n{details}";
+        }
+    }
+
+    /// <summary>
+    /// Immutable Console error snapshot for one Assembly Definition or Assembly Reference issue.
+    /// </summary>
+    public sealed class AssemblyDefinitionConsoleError
+    {
+        public string Message { get; }
+        public string File { get; }
+        public int Line { get; }
+
+        public AssemblyDefinitionConsoleError(string message, string file, int line)
+        {
+            Message = message ?? string.Empty;
+            File = file ?? string.Empty;
+            Line = line;
+        }
+    }
+
+    /// <summary>
+    /// Immutable result for Assembly Definition and Assembly Reference Console error detection.
+    /// </summary>
+    public sealed class AssemblyDefinitionConsoleErrorResult
+    {
+        public AssemblyDefinitionConsoleError[] Errors { get; }
+        public bool HasErrors => Errors.Length > 0;
+        public string Message { get; }
+
+        public AssemblyDefinitionConsoleErrorResult(AssemblyDefinitionConsoleError[] errors)
+        {
+            Errors = errors ?? Array.Empty<AssemblyDefinitionConsoleError>();
+            Message = HasErrors
+                ? AssemblyDefinitionConsoleErrorValidationService.CreateFailureMessage(Errors)
+                : null;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/AssemblyDefinitionConsoleErrorValidationService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b691433aaf71c4a289798eac34b621a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilationStateValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilationStateValidationService.cs
@@ -30,13 +30,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 );
             }
 
-            AssemblyDefinitionDuplicationValidationService asmdefValidationService = new();
-            ValidationResult asmdefValidation = asmdefValidationService.ValidateNoDuplicateAsmdefNamesFromConsoleErrors();
-            if (!asmdefValidation.IsValid)
-            {
-                return asmdefValidation;
-            }
-            
             return ValidationResult.Success();
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -96,72 +96,97 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             _isCompiling = true;
             _compileMessages.Clear();
-            _currentCompileTask = new TaskCompletionSource<CompileResult>();
+            TaskCompletionSource<CompileResult> compileTask = new();
+            _currentCompileTask = compileTask;
             _isForceCompile = forceRecompile;
+            bool eventsRegistered = false;
+            bool compileTaskTransferred = false;
 
-            // Execute asset refresh.
-            VibeLogger.LogInfo(
-                "compile_asset_refresh_start",
-                "Calling AssetDatabase.Refresh before compile.",
-                new { force_recompile = forceRecompile });
-            AssetDatabase.Refresh();
-            VibeLogger.LogInfo(
-                "compile_asset_refresh_complete",
-                "AssetDatabase.Refresh returned before compile.",
-                new { force_recompile = forceRecompile });
-
-            AssemblyDefinitionConsoleErrorValidationService assemblyDefinitionValidationService = new();
-            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors =
-                assemblyDefinitionValidationService.FindCurrentErrors();
-            if (assemblyDefinitionErrors.HasErrors)
+            try
             {
-                CompileResult result = CreateAssemblyDefinitionFailureResult(assemblyDefinitionErrors);
-                VibeLogger.LogWarning(
-                    "compile_asset_refresh_assembly_definition_error",
-                    assemblyDefinitionErrors.Message,
-                    new
+                // Execute asset refresh.
+                VibeLogger.LogInfo(
+                    "compile_asset_refresh_start",
+                    "Calling AssetDatabase.Refresh before compile.",
+                    new { force_recompile = forceRecompile });
+                AssetDatabase.Refresh();
+                VibeLogger.LogInfo(
+                    "compile_asset_refresh_complete",
+                    "AssetDatabase.Refresh returned before compile.",
+                    new { force_recompile = forceRecompile });
+
+                AssemblyDefinitionConsoleErrorValidationService assemblyDefinitionValidationService = new();
+                AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors =
+                    assemblyDefinitionValidationService.FindCurrentErrors();
+                if (assemblyDefinitionErrors.HasErrors)
+                {
+                    CompileResult result = CreateAssemblyDefinitionFailureResult(assemblyDefinitionErrors);
+                    VibeLogger.LogWarning(
+                        "compile_asset_refresh_assembly_definition_error",
+                        assemblyDefinitionErrors.Message,
+                        new
+                        {
+                            force_recompile = forceRecompile,
+                            error_count = assemblyDefinitionErrors.Errors.Length
+                        });
+                    CompleteCompileWithoutRequest(result);
+                    return result;
+                }
+
+                // Register events.
+                CompilationPipeline.compilationFinished += HandleCompileFinished;
+                CompilationPipeline.assemblyCompilationFinished += HandleAssemblyFinished;
+                eventsRegistered = true;
+                VibeLogger.LogInfo(
+                    "compile_event_handlers_registered",
+                    "Registered Unity compilation callbacks.",
+                    new { force_recompile = forceRecompile });
+
+                string startMessage = forceRecompile ? "Forced recompile started after asset refresh..." : "Compilation started after asset refresh...";
+                OnCompileStarted?.Invoke(startMessage);
+
+                VibeLogger.LogInfo(
+                    "compile_request_script_compilation",
+                    "Requesting Unity script compilation.",
+                    new { force_recompile = forceRecompile });
+                if (forceRecompile)
+                {
+                    CompilationPipeline.RequestScriptCompilation(RequestScriptCompilationOptions.CleanBuildCache);
+                }
+                else
+                {
+                    CompilationPipeline.RequestScriptCompilation();
+                }
+                VibeLogger.LogInfo(
+                    "compile_request_script_compilation_returned",
+                    "Unity script compilation request returned.",
+                    new { force_recompile = forceRecompile });
+
+                _ = WatchCompileStartAsync(ct);
+                VibeLogger.LogInfo(
+                    "compile_controller_waiting_for_finish",
+                    "Waiting for Unity compilationFinished callback.",
+                    new { force_recompile = forceRecompile });
+                compileTaskTransferred = true;
+                return await compileTask.Task;
+            }
+            finally
+            {
+                if (!compileTaskTransferred &&
+                    ReferenceEquals(_currentCompileTask, compileTask) &&
+                    !compileTask.Task.IsCompleted)
+                {
+                    if (eventsRegistered)
                     {
-                        force_recompile = forceRecompile,
-                        error_count = assemblyDefinitionErrors.Errors.Length
-                    });
-                CompleteCompileWithoutRequest(result);
-                return result;
+                        UnregisterCompilationEvents();
+                    }
+
+                    _currentCompileTask = null;
+                    _isCompiling = false;
+                    _isForceCompile = false;
+                    compileTask.TrySetCanceled();
+                }
             }
-
-            // Register events.
-            CompilationPipeline.compilationFinished += HandleCompileFinished;
-            CompilationPipeline.assemblyCompilationFinished += HandleAssemblyFinished;
-            VibeLogger.LogInfo(
-                "compile_event_handlers_registered",
-                "Registered Unity compilation callbacks.",
-                new { force_recompile = forceRecompile });
-
-            string startMessage = forceRecompile ? "Forced recompile started after asset refresh..." : "Compilation started after asset refresh...";
-            OnCompileStarted?.Invoke(startMessage);
-
-            VibeLogger.LogInfo(
-                "compile_request_script_compilation",
-                "Requesting Unity script compilation.",
-                new { force_recompile = forceRecompile });
-            if (forceRecompile)
-            {
-                CompilationPipeline.RequestScriptCompilation(RequestScriptCompilationOptions.CleanBuildCache);
-            }
-            else
-            {
-                CompilationPipeline.RequestScriptCompilation();
-            }
-            VibeLogger.LogInfo(
-                "compile_request_script_compilation_returned",
-                "Unity script compilation request returned.",
-                new { force_recompile = forceRecompile });
-
-            _ = WatchCompileStartAsync(ct);
-            VibeLogger.LogInfo(
-                "compile_controller_waiting_for_finish",
-                "Waiting for Unity compilationFinished callback.",
-                new { force_recompile = forceRecompile });
-            return await _currentCompileTask.Task;
         }
 
         private async Task WatchCompileStartAsync(CancellationToken ct)

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -110,6 +110,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 "AssetDatabase.Refresh returned before compile.",
                 new { force_recompile = forceRecompile });
 
+            AssemblyDefinitionConsoleErrorValidationService assemblyDefinitionValidationService = new();
+            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors =
+                assemblyDefinitionValidationService.FindCurrentErrors();
+            if (assemblyDefinitionErrors.HasErrors)
+            {
+                CompileResult result = CreateAssemblyDefinitionFailureResult(assemblyDefinitionErrors);
+                VibeLogger.LogWarning(
+                    "compile_asset_refresh_assembly_definition_error",
+                    assemblyDefinitionErrors.Message,
+                    new
+                    {
+                        force_recompile = forceRecompile,
+                        error_count = assemblyDefinitionErrors.Errors.Length
+                    });
+                CompleteCompileWithoutRequest(result);
+                return result;
+            }
+
             // Register events.
             CompilationPipeline.compilationFinished += HandleCompileFinished;
             CompilationPipeline.assemblyCompilationFinished += HandleAssemblyFinished;
@@ -178,6 +196,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 waitedMs += UnityCliLoopConstants.COMPILE_START_POLL_INTERVAL_MS;
             }
 
+            AssemblyDefinitionConsoleErrorValidationService assemblyDefinitionValidationService = new();
+            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors =
+                assemblyDefinitionValidationService.FindCurrentErrors();
+            if (assemblyDefinitionErrors.HasErrors)
+            {
+                VibeLogger.LogWarning(
+                    "compile_start_timeout_assembly_definition_error",
+                    assemblyDefinitionErrors.Message,
+                    new { waited_ms = waitedMs });
+                AbortCompileWithResult(CreateAssemblyDefinitionFailureResult(assemblyDefinitionErrors));
+                return;
+            }
+
             AssemblyDefinitionDuplicationValidationService asmdefValidationService = new();
             ValidationResult asmdefValidation = asmdefValidationService.ValidateNoDuplicateAsmdefNames();
             if (!asmdefValidation.IsValid)
@@ -197,6 +228,52 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             AbortCompile(
                 "Compilation did not start. Possible causes: editor update/reload locks, Auto Refresh disabled, or no script changes."
             );
+        }
+
+        /// <summary>
+        /// Completes an active compile request with a prepared failure result before Unity reports compilationFinished.
+        /// </summary>
+        private void AbortCompileWithResult(CompileResult result)
+        {
+            if (_currentCompileTask == null || _currentCompileTask.Task.IsCompleted)
+            {
+                return;
+            }
+
+            VibeLogger.LogWarning(
+                "compile_aborted",
+                result.Message,
+                new { force_recompile = _isForceCompile });
+
+            // Unregister events.
+            CompilationPipeline.compilationFinished -= HandleCompileFinished;
+            CompilationPipeline.assemblyCompilationFinished -= HandleAssemblyFinished;
+
+            _isCompiling = false;
+
+            OnCompileCompleted?.Invoke(result);
+
+            TaskCompletionSource<CompileResult> task = _currentCompileTask;
+            _currentCompileTask = null;
+            task.SetResult(result);
+
+            _isForceCompile = false;
+        }
+
+        /// <summary>
+        /// Completes a compile request that stopped before RequestScriptCompilation was called.
+        /// </summary>
+        private void CompleteCompileWithoutRequest(CompileResult result)
+        {
+            _isCompiling = false;
+
+            OnCompileCompleted?.Invoke(result);
+
+            TaskCompletionSource<CompileResult> task = _currentCompileTask;
+            _currentCompileTask = null;
+            task?.SetResult(result);
+
+            _isForceCompile = false;
         }
 
         private void AbortCompile(string reason)
@@ -343,6 +420,47 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 errors: errors,
                 warnings: warnings
             );
+        }
+
+        /// <summary>
+        /// Creates a failed compile result from Assembly Definition and Assembly Reference Console errors.
+        /// </summary>
+        private static CompileResult CreateAssemblyDefinitionFailureResult(
+            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors)
+        {
+            CompilerMessage[] errors = CreateAssemblyDefinitionCompilerMessages(assemblyDefinitionErrors.Errors);
+            return new CompileResult(
+                success: false,
+                errorCount: errors.Length,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: errors,
+                errors: errors,
+                warnings: Array.Empty<CompilerMessage>(),
+                message: assemblyDefinitionErrors.Message
+            );
+        }
+
+        /// <summary>
+        /// Converts Assembly Definition and Assembly Reference Console errors into compiler messages.
+        /// </summary>
+        private static CompilerMessage[] CreateAssemblyDefinitionCompilerMessages(
+            AssemblyDefinitionConsoleError[] assemblyDefinitionErrors)
+        {
+            CompilerMessage[] messages = new CompilerMessage[assemblyDefinitionErrors.Length];
+            for (int i = 0; i < assemblyDefinitionErrors.Length; i++)
+            {
+                AssemblyDefinitionConsoleError error = assemblyDefinitionErrors[i];
+                messages[i] = new CompilerMessage
+                {
+                    type = CompilerMessageType.Error,
+                    message = error.Message,
+                    file = error.File,
+                    line = error.Line
+                };
+            }
+
+            return messages;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -245,19 +245,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 result.Message,
                 new { force_recompile = _isForceCompile });
 
-            // Unregister events.
-            CompilationPipeline.compilationFinished -= HandleCompileFinished;
-            CompilationPipeline.assemblyCompilationFinished -= HandleAssemblyFinished;
-
-            _isCompiling = false;
-
-            OnCompileCompleted?.Invoke(result);
-
-            TaskCompletionSource<CompileResult> task = _currentCompileTask;
-            _currentCompileTask = null;
-            task.SetResult(result);
-
-            _isForceCompile = false;
+            CompleteCompileRequest(result, unregisterEvents: true);
         }
 
         /// <summary>
@@ -265,15 +253,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         private void CompleteCompileWithoutRequest(CompileResult result)
         {
-            _isCompiling = false;
-
-            OnCompileCompleted?.Invoke(result);
-
-            TaskCompletionSource<CompileResult> task = _currentCompileTask;
-            _currentCompileTask = null;
-            task?.SetResult(result);
-
-            _isForceCompile = false;
+            CompleteCompileRequest(result, unregisterEvents: false);
         }
 
         private void AbortCompile(string reason)
@@ -288,12 +268,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 reason,
                 new { force_recompile = _isForceCompile });
 
-            // Unregister events.
-            CompilationPipeline.compilationFinished -= HandleCompileFinished;
-            CompilationPipeline.assemblyCompilationFinished -= HandleAssemblyFinished;
-
-            _isCompiling = false;
-
             CompileResult result = new(
                 success: false,
                 errorCount: 0,
@@ -306,11 +280,50 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 message: reason
             );
 
-            OnCompileCompleted?.Invoke(result);
+            CompleteCompileRequest(result, unregisterEvents: true);
+        }
+
+        /// <summary>
+        /// Completes the active compile task while guaranteeing controller state cleanup.
+        /// </summary>
+        private void CompleteCompileRequest(CompileResult result, bool unregisterEvents)
+        {
+            UnityEngine.Debug.Assert(result != null, "result must not be null");
 
             TaskCompletionSource<CompileResult> task = _currentCompileTask;
-            _currentCompileTask = null;
-            task.SetResult(result);
+
+            // Completion subscribers are outside this controller, so state cleanup cannot depend on them returning.
+            try
+            {
+                if (unregisterEvents)
+                {
+                    UnregisterCompilationEvents();
+                }
+
+                _isCompiling = false;
+                _isForceCompile = false;
+                OnCompileCompleted?.Invoke(result);
+            }
+            finally
+            {
+                if (ReferenceEquals(_currentCompileTask, task))
+                {
+                    _currentCompileTask = null;
+                    _isCompiling = false;
+                    _isForceCompile = false;
+                }
+
+                task?.TrySetResult(result);
+            }
+        }
+
+        /// <summary>
+        /// Removes Unity compilation callbacks for the current compile request.
+        /// </summary>
+        private void UnregisterCompilationEvents()
+        {
+            CompilationPipeline.compilationFinished -= HandleCompileFinished;
+            CompilationPipeline.assemblyCompilationFinished -= HandleAssemblyFinished;
         }
 
         /// <summary>
@@ -327,12 +340,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <param name="context">The compilation context.</param>
         private void HandleCompileFinished(object context)
         {
-            // Unregister events.
-            CompilationPipeline.compilationFinished -= HandleCompileFinished;
-            CompilationPipeline.assemblyCompilationFinished -= HandleAssemblyFinished;
-
-            _isCompiling = false;
-
             CompileResult result = CreateCompileResult();
             VibeLogger.LogInfo(
                 "compile_finished_event",
@@ -345,15 +352,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     warning_count = result.WarningCount,
                     message_count = _compileMessages.Count
                 });
-            OnCompileCompleted?.Invoke(result);
 
-            // Set the result on the TaskCompletionSource.
-            TaskCompletionSource<CompileResult> task = _currentCompileTask;
-            _currentCompileTask = null;
-            task?.SetResult(result);
-
-            // Reset force compile flag for future compilations
-            _isForceCompile = false;
+            CompleteCompileRequest(result, unregisterEvents: true);
         }
 
         /// <summary>

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -83,6 +83,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string GUID_FORMAT_NO_HYPHENS = "N";
         
         public const string ERROR_MESSAGE_DUPLICATE_ASMDEF = "Duplicate asmdef assembly name detected. Unity may not start compilation until duplicates are removed.";
+        public const string ERROR_MESSAGE_ASSEMBLY_DEFINITION_IMPORT_ERROR = "Assembly Definition or Assembly Reference import error detected. Unity may not start compilation until asmdef or asmref errors are removed.";
         
         public const string ERROR_MESSAGE_EXECUTION_IN_PROGRESS = "Another execution is already in progress";
         public const string ERROR_MESSAGE_EXECUTION_CANCELLED = "Execution was cancelled or timed out";


### PR DESCRIPTION
## Summary
- `uloop compile` now fails quickly when current Unity Console contains Assembly Definition or Assembly Reference import errors.
- The error response points to the affected `.asmdef` or `.asmref` file instead of waiting for compilation that Unity never starts.

## User Impact
- Before this change, import errors in assembly definition files could leave `uloop compile` waiting indefinitely because Unity did not enter script compilation.
- After this change, users get a structured failure with the current Console error and can fix the asset immediately. Stale Console entries from already fixed or deleted assets do not keep blocking compile.

## Changes
- Check current Unity Console entries after asset refresh and again when compilation fails to start.
- Confirm asmdef and asmref Console errors against current asset state, including malformed JSON, duplicate references, duplicate assembly names, missing asmref targets, folder conflicts, and GUID/name duplicate references.
- Keep the existing duplicate asmdef fallback for compile-start timeout and add focused EditMode coverage.

## Verification
- `Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.AssemblyDefinitionConsoleErrorValidationServiceTests"`
- `~/.codex/skills/codex-review/scripts/codex-review --parallel-tests '<compile && focused EditMode tests>' v3-beta`
- Manual repros for malformed asmdef, duplicate asmdef references, GUID/name duplicate references, malformed asmref, asmref folder conflict, and asset paths containing parentheses.
