### PR TITLE
fix: Settings makes installed CLI uninstall action appear inactive

### DIFF
--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -124,11 +124,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool enabled = IsInstallCliButtonEnabled(
                 data.IsInstallingCli,
                 data.IsChecking);
-            bool useDisabledStyle = !enabled || IsUninstallCliAction(
+            bool isUninstallStyle = !data.NeedsCliPathSetup && IsUninstallCliAction(
                 data.IsCliInstalled,
                 data.NeedsUpdate,
                 data.NeedsDowngrade,
                 data.CanUninstallCli);
+            bool useDisabledStyle = !enabled || isUninstallStyle;
             SetCliButton(label, enabled, useDisabledStyle);
         }
 

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -124,14 +124,19 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool enabled = IsInstallCliButtonEnabled(
                 data.IsInstallingCli,
                 data.IsChecking);
-            SetCliButton(label, enabled);
+            bool useDisabledStyle = !enabled || IsUninstallCliAction(
+                data.IsCliInstalled,
+                data.NeedsUpdate,
+                data.NeedsDowngrade,
+                data.CanUninstallCli);
+            SetCliButton(label, enabled, useDisabledStyle);
         }
 
-        private void SetCliButton(string text, bool enabled)
+        private void SetCliButton(string text, bool enabled, bool useDisabledStyle)
         {
             _installCliButton.text = text;
             _installCliButton.SetEnabled(enabled);
-            ViewDataBinder.ToggleClass(_installCliButton, "unity-cli-loop-button--disabled", !enabled);
+            ViewDataBinder.ToggleClass(_installCliButton, "unity-cli-loop-button--disabled", useDisabledStyle);
         }
 
         private void InitializeTargetFieldIfNeeded(CliSetupData data)

--- a/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
+++ b/Packages/src/Editor/Presentation/UIToolkit/UnityCliLoopSettingsWindow.uss
@@ -200,6 +200,12 @@
     opacity: 1;
 }
 
+.unity-cli-loop-button--disabled:hover {
+    background-color: #4a4a4a;
+    border-color: rgba(128, 128, 128, 0.5);
+    color: #999999;
+}
+
 /* ===========================================
    Block: Toggle Row
    =========================================== */


### PR DESCRIPTION
## Summary
- The Settings window now shows the installed CLI uninstall action with muted disabled-style styling.
- The action remains available, but no longer looks like the main active install/update action.

## User Impact
- Previously, the Uninstall CLI button looked visually identical to an active primary action when the CLI was already installed.
- Now it appears muted, making the installed state less visually confusing while still allowing uninstall.

## Changes
- Apply the disabled button style to the installed CLI uninstall state.
- Keep hover styling muted so the button does not brighten like a normal action.

## Verification
- `Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> ErrorCount: 0, WarningCount: 0
- Captured the Unity CLI Loop Settings window screenshot and confirmed Uninstall CLI appears muted.