### PR TITLE
fix: Player builds stay free of editor-only uLoop tooling

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/CodeAnalysisPluginImporterTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CodeAnalysisPluginImporterTests.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Test fixture that verifies bundled Roslyn support plugins stay editor-only.
+    /// </summary>
+    public sealed class CodeAnalysisPluginImporterTests
+    {
+        private static readonly string[] CodeAnalysisPluginPaths =
+        {
+            "Packages/io.github.hatayama.uloopmcp/Editor/FirstPartyTools/ExecuteDynamicCode/Plugins/CodeAnalysis/System.Collections.Immutable.dll",
+            "Packages/io.github.hatayama.uloopmcp/Editor/FirstPartyTools/ExecuteDynamicCode/Plugins/CodeAnalysis/System.Reflection.Metadata.dll",
+            "Packages/io.github.hatayama.uloopmcp/Editor/FirstPartyTools/ExecuteDynamicCode/Plugins/CodeAnalysis/System.Runtime.CompilerServices.Unsafe.dll"
+        };
+
+        [Test]
+        public void CodeAnalysisPlugins_WhenLoaded_AreEditorOnly()
+        {
+            // Tests that Roslyn support plugins cannot leak into player assembly resolution.
+            for (int pathIndex = 0; pathIndex < CodeAnalysisPluginPaths.Length; pathIndex++)
+            {
+                PluginImporter importer = AssetImporter.GetAtPath(CodeAnalysisPluginPaths[pathIndex]) as PluginImporter;
+
+                Assert.That(importer, Is.Not.Null, CodeAnalysisPluginPaths[pathIndex]);
+                Assert.That(importer!.GetCompatibleWithAnyPlatform(), Is.False, CodeAnalysisPluginPaths[pathIndex]);
+                Assert.That(importer.GetCompatibleWithEditor(), Is.True, CodeAnalysisPluginPaths[pathIndex]);
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CodeAnalysisPluginImporterTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CodeAnalysisPluginImporterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1889ec4bff15a43b9991b6c48643034b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -39,6 +39,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Runtime/ReplayInput/ReplayInputOverlay.prefab"
         };
 
+        private static readonly string[] EditorOnlyOverlayComponentSourcePaths =
+        {
+            "Packages/src/Runtime/Common/InputVisualizationCanvas.cs",
+            "Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs",
+            "Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.cs",
+            "Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.cs",
+            "Packages/src/Runtime/RecordInput/RecordInputOverlayPresenter.cs",
+            "Packages/src/Runtime/RecordInput/RecordInputOverlayView.cs",
+            "Packages/src/Runtime/ReplayInput/ReplayInputOverlay.cs"
+        };
+
         [Test]
         public void RuntimeAssemblyDefinition_WhenScanned_IsAttachableAndNotAutoReferenced()
         {
@@ -173,6 +184,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                         Does.Not.StartWith("Assets/"),
                         $"{OverlayPrefabFilePaths[pathIndex]} references project script GUID {guid} at {assetPath}");
                 }
+            }
+        }
+
+        [Test]
+        public void InputVisualizationOverlayComponents_WhenScanned_AreEditorOnly()
+        {
+            // Verifies that prefab-attached overlay components cannot compile into Player assemblies.
+            for (int pathIndex = 0; pathIndex < EditorOnlyOverlayComponentSourcePaths.Length; pathIndex++)
+            {
+                string contents = ReadText(EditorOnlyOverlayComponentSourcePaths[pathIndex]);
+
+                Assert.That(
+                    contents.TrimStart(),
+                    Does.StartWith("#if UNITY_EDITOR"),
+                    EditorOnlyOverlayComponentSourcePaths[pathIndex]);
             }
         }
 

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -19,6 +19,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/io.github.hatayama.uloopmcp/Runtime/Common/InputVisualizationCanvas.prefab";
         private const string RuntimeAssemblyDefinitionPath =
             "Packages/src/Runtime/uLoopMCP.Runtime.asmdef";
+        private const string RuntimeSourceDirectoryPath =
+            "Packages/src/Runtime";
         private static readonly string[] OverlayPrefabPaths =
         {
             "Packages/io.github.hatayama.uloopmcp/Runtime/Common/InputVisualizationCanvas.prefab",
@@ -37,17 +39,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.prefab",
             "Packages/src/Runtime/RecordInput/RecordInputOverlay.prefab",
             "Packages/src/Runtime/ReplayInput/ReplayInputOverlay.prefab"
-        };
-
-        private static readonly string[] EditorOnlyOverlayComponentSourcePaths =
-        {
-            "Packages/src/Runtime/Common/InputVisualizationCanvas.cs",
-            "Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs",
-            "Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.cs",
-            "Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.cs",
-            "Packages/src/Runtime/RecordInput/RecordInputOverlayPresenter.cs",
-            "Packages/src/Runtime/RecordInput/RecordInputOverlayView.cs",
-            "Packages/src/Runtime/ReplayInput/ReplayInputOverlay.cs"
         };
 
         [Test]
@@ -201,17 +192,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void InputVisualizationOverlayComponents_WhenScanned_AreEditorOnly()
+        public void RuntimeSources_WhenScanned_AreEditorOnly()
         {
-            // Verifies that prefab-attached overlay components cannot compile into Player assemblies.
-            for (int pathIndex = 0; pathIndex < EditorOnlyOverlayComponentSourcePaths.Length; pathIndex++)
+            // Verifies that Runtime assembly sources cannot compile into Player assemblies.
+            string runtimeSourceDirectory = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), RuntimeSourceDirectoryPath);
+            string[] runtimeSourcePaths = Directory.GetFiles(runtimeSourceDirectory, "*.cs", SearchOption.AllDirectories);
+            System.Array.Sort(runtimeSourcePaths);
+
+            for (int pathIndex = 0; pathIndex < runtimeSourcePaths.Length; pathIndex++)
             {
-                string contents = ReadText(EditorOnlyOverlayComponentSourcePaths[pathIndex]);
+                string contents = File.ReadAllText(runtimeSourcePaths[pathIndex]);
 
                 Assert.That(
                     contents.TrimStart(),
                     Does.StartWith("#if UNITY_EDITOR"),
-                    EditorOnlyOverlayComponentSourcePaths[pathIndex]);
+                    runtimeSourcePaths[pathIndex]);
             }
         }
 

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -161,6 +161,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void InputVisualizationPrefabs_WhenLoaded_AreEditorOnly()
+        {
+            // Verifies that package Overlay prefabs are excluded from Player builds by Unity's EditorOnly tag.
+            for (int pathIndex = 0; pathIndex < OverlayPrefabPaths.Length; pathIndex++)
+            {
+                GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(OverlayPrefabPaths[pathIndex]);
+
+                Assert.That(prefab, Is.Not.Null, OverlayPrefabPaths[pathIndex]);
+                AssertEditorOnlyTags(prefab, OverlayPrefabPaths[pathIndex]);
+            }
+        }
+
+        [Test]
         public void InputVisualizationPrefabs_WhenScanned_DoNotReferenceProjectScripts()
         {
             // Verifies that package Overlay prefabs do not depend on scripts outside the package.
@@ -199,6 +212,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     contents.TrimStart(),
                     Does.StartWith("#if UNITY_EDITOR"),
                     EditorOnlyOverlayComponentSourcePaths[pathIndex]);
+            }
+        }
+
+        private static void AssertEditorOnlyTags(GameObject root, string prefabPath)
+        {
+            Transform[] transforms = root.GetComponentsInChildren<Transform>(true);
+            for (int transformIndex = 0; transformIndex < transforms.Length; transformIndex++)
+            {
+                GameObject gameObject = transforms[transformIndex].gameObject;
+
+                Assert.That(
+                    gameObject.CompareTag("EditorOnly"),
+                    Is.True,
+                    $"{prefabPath} has non-EditorOnly tag on {gameObject.name}");
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Plugins/CodeAnalysis/System.Collections.Immutable.dll.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Plugins/CodeAnalysis/System.Collections.Immutable.dll.meta
@@ -14,12 +14,12 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Plugins/CodeAnalysis/System.Reflection.Metadata.dll.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Plugins/CodeAnalysis/System.Reflection.Metadata.dll.meta
@@ -14,12 +14,12 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Plugins/CodeAnalysis/System.Runtime.CompilerServices.Unsafe.dll.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Plugins/CodeAnalysis/System.Runtime.CompilerServices.Unsafe.dll.meta
@@ -14,12 +14,12 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         DefaultValueInitialized: true
   - first:

--- a/Packages/src/Runtime/Common/InputVisualizationCanvas.cs
+++ b/Packages/src/Runtime/Common/InputVisualizationCanvas.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -61,3 +62,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/Common/InputVisualizationCanvas.prefab
+++ b/Packages/src/Runtime/Common/InputVisualizationCanvas.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5473869302179759802}
   m_Layer: 0
   m_Name: InputVisualizationCanvas
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Packages/src/Runtime/Common/MouseButton.cs
+++ b/Packages/src/Runtime/Common/MouseButton.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 namespace io.github.hatayama.UnityCliLoop.Runtime
 {
     public enum MouseButton
@@ -7,3 +8,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         Middle = 2
     }
 }
+#endif

--- a/Packages/src/Runtime/RecordInput/RecordInputOverlay.prefab
+++ b/Packages/src/Runtime/RecordInput/RecordInputOverlay.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 7892078462694320466}
   m_Layer: 0
   m_Name: RecordingGroup
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -118,7 +118,7 @@ GameObject:
   - component: {fileID: 7304014939787943379}
   m_Layer: 0
   m_Name: RecordInputOverlay
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -200,7 +200,7 @@ GameObject:
   - component: {fileID: 681519330149296984}
   m_Layer: 0
   m_Name: StatusText
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -279,7 +279,7 @@ GameObject:
   - component: {fileID: 8821962787790114429}
   m_Layer: 0
   m_Name: RecDot
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -358,7 +358,7 @@ GameObject:
   - component: {fileID: 5505213563100565343}
   m_Layer: 0
   m_Name: CountdownText
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -437,7 +437,7 @@ GameObject:
   - component: {fileID: 2701087203241486620}
   m_Layer: 0
   m_Name: CountdownGroup
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Packages/src/Runtime/RecordInput/RecordInputOverlayPresenter.cs
+++ b/Packages/src/Runtime/RecordInput/RecordInputOverlayPresenter.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System.Globalization;
 using UnityEngine;
 
@@ -95,3 +96,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/RecordInput/RecordInputOverlayState.cs
+++ b/Packages/src/Runtime/RecordInput/RecordInputOverlayState.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.Runtime
@@ -94,3 +95,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/RecordInput/RecordInputOverlayView.cs
+++ b/Packages/src/Runtime/RecordInput/RecordInputOverlayView.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -131,3 +132,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/ReplayInput/ReplayInputOverlay.cs
+++ b/Packages/src/Runtime/ReplayInput/ReplayInputOverlay.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using UnityEngine;
 using UnityEngine.UI;
@@ -139,3 +140,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/ReplayInput/ReplayInputOverlay.prefab
+++ b/Packages/src/Runtime/ReplayInput/ReplayInputOverlay.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7305657527396605225}
   m_Layer: 0
   m_Name: StatusText
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -94,7 +94,7 @@ GameObject:
   - component: {fileID: 750881311793061267}
   m_Layer: 0
   m_Name: ReplayInputOverlay
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -198,7 +198,7 @@ GameObject:
   - component: {fileID: 699221967987577222}
   m_Layer: 0
   m_Name: ProgressBarBg
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -274,7 +274,7 @@ GameObject:
   - component: {fileID: 5900655728717313438}
   m_Layer: 0
   m_Name: ProgressBarFill
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Packages/src/Runtime/ReplayInput/ReplayInputOverlayState.cs
+++ b/Packages/src/Runtime/ReplayInput/ReplayInputOverlayState.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 
 namespace io.github.hatayama.UnityCliLoop.Runtime
@@ -66,3 +67,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateKeyboard/KeySymbolMap.cs
+++ b/Packages/src/Runtime/SimulateKeyboard/KeySymbolMap.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using System.Collections.Generic;
 using UnityEngine;
@@ -78,3 +79,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateKeyboard/KeyboardAction.cs
+++ b/Packages/src/Runtime/SimulateKeyboard/KeyboardAction.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 namespace io.github.hatayama.UnityCliLoop.Runtime
 {
     public enum KeyboardAction
@@ -7,3 +8,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         KeyUp = 2
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.cs
+++ b/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using System.Collections.Generic;
 using UnityEngine;
@@ -233,3 +234,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.prefab
+++ b/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6066404719234391660}
   m_Layer: 0
   m_Name: PreviewBadge
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -112,7 +112,7 @@ GameObject:
   - component: {fileID: 8555974250771983990}
   m_Layer: 0
   m_Name: Container
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -229,7 +229,7 @@ GameObject:
   - component: {fileID: 6622544667456466176}
   m_Layer: 0
   m_Name: KeyText
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -323,7 +323,7 @@ GameObject:
   - component: {fileID: 7943424075059165438}
   m_Layer: 0
   m_Name: SimulateKeyboardOverlay
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlayState.cs
+++ b/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlayState.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using System.Collections.Generic;
 
@@ -107,3 +108,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateMouseInput/MouseInputAction.cs
+++ b/Packages/src/Runtime/SimulateMouseInput/MouseInputAction.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 namespace io.github.hatayama.UnityCliLoop.Runtime
 {
     public enum MouseInputAction
@@ -9,3 +10,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         SmoothDelta = 4
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs
+++ b/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using UnityEngine;
 using UnityEngine.UI;
@@ -192,3 +193,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.prefab
+++ b/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 833440402481600460}
   m_Layer: 0
   m_Name: ScrollWheel
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -88,7 +88,7 @@ GameObject:
   - component: {fileID: 3062289549238960786}
   m_Layer: 0
   m_Name: ChevronBg
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -165,7 +165,7 @@ GameObject:
   - component: {fileID: 1745363758329991082}
   m_Layer: 0
   m_Name: MouseBody
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -260,7 +260,7 @@ GameObject:
   - component: {fileID: 8237013949146870878}
   m_Layer: 0
   m_Name: SimulateMouseInputOverlay
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -328,7 +328,7 @@ GameObject:
   - component: {fileID: 4269098931396339987}
   m_Layer: 0
   m_Name: RightButton
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -402,7 +402,7 @@ GameObject:
   - component: {fileID: 3667878836297973193}
   m_Layer: 0
   m_Name: CanvasGroup
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -453,7 +453,7 @@ GameObject:
   - component: {fileID: 6545894353452666225}
   m_Layer: 0
   m_Name: ScrollArrowBottom
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -528,7 +528,7 @@ GameObject:
   - component: {fileID: 4893873975114215188}
   m_Layer: 0
   m_Name: ScrollArrowTop
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -603,7 +603,7 @@ GameObject:
   - component: {fileID: 7338358790227330862}
   m_Layer: 0
   m_Name: Divider
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -676,7 +676,7 @@ GameObject:
   - component: {fileID: 5622481146988834445}
   m_Layer: 0
   m_Name: MoveDirectionGroup
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -714,7 +714,7 @@ GameObject:
   - component: {fileID: 9067186644091917110}
   m_Layer: 0
   m_Name: LeftButton
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -789,7 +789,7 @@ GameObject:
   - component: {fileID: 8349798665654410308}
   m_Layer: 0
   m_Name: WheelOutline
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -864,7 +864,7 @@ GameObject:
   - component: {fileID: 4677096323163002241}
   m_Layer: 0
   m_Name: Chevron1
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlayState.cs
+++ b/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlayState.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using UnityEngine;
 
@@ -174,3 +175,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateMouseUi/MouseAction.cs
+++ b/Packages/src/Runtime/SimulateMouseUi/MouseAction.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 namespace io.github.hatayama.UnityCliLoop.Runtime
 {
     public enum MouseAction
@@ -10,3 +11,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         LongPress = 5
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiAnimationConstants.cs
+++ b/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiAnimationConstants.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 namespace io.github.hatayama.UnityCliLoop.Runtime
 {
     /// <summary>
@@ -10,3 +11,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public const float DISSIPATE_DURATION = 0.1f;
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.cs
+++ b/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using System.Collections.Generic;
 using UnityEngine;
@@ -366,3 +367,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.prefab
+++ b/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 2204762901719864460}
   m_Layer: 0
   m_Name: DragStartMarker
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -86,7 +86,7 @@ GameObject:
   - component: {fileID: 1795238667056386859}
   m_Layer: 0
   m_Name: CursorGroup
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -127,7 +127,7 @@ GameObject:
   - component: {fileID: 3118357298515763328}
   m_Layer: 0
   m_Name: CrosshairV
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -202,7 +202,7 @@ GameObject:
   - component: {fileID: 1668577853838809154}
   m_Layer: 0
   m_Name: Circle
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -277,7 +277,7 @@ GameObject:
   - component: {fileID: 2445404945182483613}
   m_Layer: 0
   m_Name: CrosshairH
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -353,7 +353,7 @@ GameObject:
   - component: {fileID: 7159060278707641568}
   m_Layer: 0
   m_Name: LongPressText
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -447,7 +447,7 @@ GameObject:
   - component: {fileID: 6021016629897285075}
   m_Layer: 0
   m_Name: SimulateMouseUiOverlay
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlayState.cs
+++ b/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlayState.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using System.Collections.Generic;
 using UnityEngine;
@@ -187,3 +188,4 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
     }
 }
+#endif

--- a/Packages/src/THIRD-PARTY-NOTICES.md
+++ b/Packages/src/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,52 @@
+# Third-Party Notices
+
+Unity CLI Loop includes the following Microsoft .NET assemblies for the
+Editor-only dynamic code metadata validation pipeline:
+
+| Component | NuGet package | Package version | Assembly version | Package asset |
+| --- | --- | --- | --- | --- |
+| System.Collections.Immutable.dll | System.Collections.Immutable | 8.0.0 | 8.0.0.0 | lib/net462/System.Collections.Immutable.dll |
+| System.Reflection.Metadata.dll | System.Reflection.Metadata | 8.0.1 | 8.0.0.1 | lib/net462/System.Reflection.Metadata.dll |
+| System.Runtime.CompilerServices.Unsafe.dll | System.Runtime.CompilerServices.Unsafe | 6.1.1 | 6.0.2.0 | lib/net462/System.Runtime.CompilerServices.Unsafe.dll |
+
+These assemblies are distributed under the MIT License.
+
+Package metadata also contains the copyright notice
+"Copyright (c) Microsoft Corporation. All rights reserved."
+
+Project pages:
+
+- https://www.nuget.org/packages/System.Collections.Immutable/8.0.0
+- https://www.nuget.org/packages/System.Reflection.Metadata/8.0.1
+- https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe/6.1.1
+
+Repository sources:
+
+- https://github.com/dotnet/runtime
+- https://github.com/dotnet/maintenance-packages
+
+## Microsoft .NET MIT License
+
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Packages/src/THIRD-PARTY-NOTICES.md.meta
+++ b/Packages/src/THIRD-PARTY-NOTICES.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5b93114a30c3a48bf86ed85dfa4b0bfe
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Player builds now avoid pulling in editor-only input visualization components and bundled code-analysis assemblies.
- Third-party notices now document the bundled .NET assemblies used by editor code execution tooling.

## User Impact
- Before this change, Mono player builds with managed stripping disabled could include editor-only overlay components and code-analysis DLLs from the package.
- After this change, input overlay tooling remains available in the Editor while player builds exclude the editor-only component implementations and code-analysis plugins.
- A local consumer project was file-referenced to this package and built successfully for macOS with Mono and managed stripping disabled.

## Changes
- Compile input visualization and simulation overlay runtime sources only in the Unity Editor.
- Mark input visualization prefabs as EditorOnly so Unity excludes them from player builds.
- Restrict bundled code-analysis plugin importers to the Editor platform and add focused importer tests.
- Add third-party notices for the bundled .NET assemblies.

## Verification
- Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path <PACKAGE_PROJECT_ROOT>
- Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <PACKAGE_PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value ".*(InputVisualizationCanvasPrefabTests|CodeAnalysisPluginImporterTests).*"
- codex-review v3-beta with compile and focused EditMode tests: clean, no accepted/actionable findings
- Local consumer validation: file-referenced this package, compiled with 0 errors / 0 warnings, and built a macOS Mono player with managed stripping disabled successfully
