### PR TITLE
Respect endpoint network on Windows IPC dial

### DIFF
--- a/Packages/src/Cli~/internal/unityipc/dial_windows.go
+++ b/Packages/src/Cli~/internal/unityipc/dial_windows.go
@@ -10,5 +10,10 @@ import (
 )
 
 func dialEndpoint(ctx context.Context, endpoint Endpoint) (net.Conn, error) {
+	if endpoint.Network != "" && endpoint.Network != "pipe" && endpoint.Network != "npipe" {
+		dialer := net.Dialer{}
+		return dialer.DialContext(ctx, endpoint.Network, endpoint.Address)
+	}
+
 	return winio.DialPipeContext(ctx, endpoint.Address)
 }


### PR DESCRIPTION
## Summary
- Respect non-pipe Endpoint.Network values in the Windows IPC dialer.
- Keep existing named pipe behavior for normal Windows Unity project connections.
- Allows TCP-backed mock endpoints used by CLI tests to run on Windows instead of being treated as named pipe paths.

## Test
- go test ./internal/cli ./internal/unityipc
