### PR TITLE
fix: Dynamic code snippets can use Unity Object without ambiguity

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/PreUsingResolverTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/PreUsingResolverTests.cs
@@ -359,6 +359,95 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         [Test]
+        public async Task CompileAsync_ScriptMode_NakedObject_ShouldUseUnityObjectAlias()
+        {
+            // Verifies that wrapper-provided Object resolves to UnityEngine.Object while C# object remains available.
+            DynamicCodeCompiler compiler = new(DynamicCodeSecurityLevel.Restricted);
+            CompilationRequest request = new()            {
+                Code = @"
+                    Object[] unityObjects = new Object[0];
+                    object boxedObject = new object();
+                    System.Object systemObject = boxedObject;
+                    return unityObjects.Length == 0 && systemObject != null ? ""ok"" : ""unexpected"";
+                ",
+                ClassName = "NakedObjectAliasCommand",
+                Namespace = "TestNamespace"
+            };
+
+            CompilationResult result = await compiler.CompileAsync(request, CancellationToken.None);
+
+            Assert.IsTrue(result.Success,
+                result.Errors != null && result.Errors.Count > 0 ? result.Errors[0].Message : "Object alias should compile");
+            StringAssert.Contains("using Object = UnityEngine.Object;", result.UpdatedCode);
+        }
+
+        [Test]
+        public async Task CompileAsync_ScriptMode_UserObjectAlias_ShouldKeepExplicitAlias()
+        {
+            // Verifies that an explicit user Object alias is not shadowed by the wrapper default.
+            DynamicCodeCompiler compiler = new(DynamicCodeSecurityLevel.Restricted);
+            CompilationRequest request = new()            {
+                Code = @"
+                    using Object = System.Object;
+                    Object boxedObject = new object();
+                    return boxedObject != null ? ""ok"" : ""unexpected"";
+                ",
+                ClassName = "UserObjectAliasCommand",
+                Namespace = "TestNamespace"
+            };
+
+            CompilationResult result = await compiler.CompileAsync(request, CancellationToken.None);
+
+            Assert.IsTrue(result.Success,
+                result.Errors != null && result.Errors.Count > 0 ? result.Errors[0].Message : "User Object alias should compile");
+            StringAssert.DoesNotContain("using Object = UnityEngine.Object;", result.UpdatedCode);
+        }
+
+        [Test]
+        public async Task CompileAsync_ScriptMode_UserObjectAliasWithCompactSpacing_ShouldKeepExplicitAlias()
+        {
+            // Verifies that compact alias spacing is still treated as an explicit Object alias.
+            DynamicCodeCompiler compiler = new(DynamicCodeSecurityLevel.Restricted);
+            CompilationRequest request = new()            {
+                Code = @"
+                    using Object=System.Object;
+                    Object boxedObject = new object();
+                    return boxedObject != null ? ""ok"" : ""unexpected"";
+                ",
+                ClassName = "CompactUserObjectAliasCommand",
+                Namespace = "TestNamespace"
+            };
+
+            CompilationResult result = await compiler.CompileAsync(request, CancellationToken.None);
+
+            Assert.IsTrue(result.Success,
+                result.Errors != null && result.Errors.Count > 0 ? result.Errors[0].Message : "Compact user Object alias should compile");
+            StringAssert.DoesNotContain("using Object = UnityEngine.Object;", result.UpdatedCode);
+        }
+
+        [Test]
+        public async Task CompileAsync_ScriptMode_UserObjectAliasWithTokenComment_ShouldKeepExplicitAlias()
+        {
+            // Verifies that comments between alias tokens do not hide an explicit Object alias.
+            DynamicCodeCompiler compiler = new(DynamicCodeSecurityLevel.Restricted);
+            CompilationRequest request = new()            {
+                Code = @"
+                    using Object /* explicit */ = System.Object;
+                    Object boxedObject = new object();
+                    return boxedObject != null ? ""ok"" : ""unexpected"";
+                ",
+                ClassName = "CommentedUserObjectAliasCommand",
+                Namespace = "TestNamespace"
+            };
+
+            CompilationResult result = await compiler.CompileAsync(request, CancellationToken.None);
+
+            Assert.IsTrue(result.Success,
+                result.Errors != null && result.Errors.Count > 0 ? result.Errors[0].Message : "Commented user Object alias should compile");
+            StringAssert.DoesNotContain("using Object = UnityEngine.Object;", result.UpdatedCode);
+        }
+
+        [Test]
         public async Task CompileAsync_ScriptMode_MultipleMissingUsings_ShouldPreInjectAllAndSucceed()
         {
             DynamicCodeCompiler compiler = new(DynamicCodeSecurityLevel.Restricted);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrapperTemplate.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrapperTemplate.cs
@@ -30,6 +30,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             sb.AppendLine("using System.Threading.Tasks;");
             sb.AppendLine("using UnityEngine;");
             sb.AppendLine("using UnityEditor;");
+            if (!HasObjectAlias(usingDirectives))
+            {
+                sb.AppendLine("using Object = UnityEngine.Object;");
+            }
 
             foreach (string directive in usingDirectives)
             {
@@ -74,6 +78,72 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             sb.AppendLine("}");
 
             return sb.ToString();
+        }
+
+        private static bool HasObjectAlias(IReadOnlyList<string> usingDirectives)
+        {
+            if (usingDirectives == null)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < usingDirectives.Count; index++)
+            {
+                string directive = usingDirectives[index]?.TrimStart();
+                if (string.IsNullOrEmpty(directive))
+                {
+                    continue;
+                }
+
+                if (IsObjectAliasDirective(directive))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsObjectAliasDirective(string directive)
+        {
+            int usingPosition = 0;
+            if (SourceShaper.StartsWithKeyword(directive, usingPosition, "global"))
+            {
+                usingPosition = SkipWhitespaceAndComments(directive, usingPosition + "global".Length);
+            }
+
+            if (!SourceShaper.StartsWithKeyword(directive, usingPosition, "using"))
+            {
+                return false;
+            }
+
+            int aliasStart = SkipWhitespaceAndComments(directive, usingPosition + "using".Length);
+            if (!SourceShaper.StartsWithKeyword(directive, aliasStart, "Object"))
+            {
+                return false;
+            }
+
+            int equalsPosition = SkipWhitespaceAndComments(directive, aliasStart + "Object".Length);
+            return equalsPosition < directive.Length && directive[equalsPosition] == '=';
+        }
+
+        private static int SkipWhitespaceAndComments(string source, int position)
+        {
+            int currentPosition = SourceShaper.SkipWhitespace(source, position);
+            while (IsCommentStart(source, currentPosition))
+            {
+                int nextPosition = SourceShaper.AdvanceOneTokenPublic(source, currentPosition);
+                currentPosition = SourceShaper.SkipWhitespace(source, nextPosition);
+            }
+
+            return currentPosition;
+        }
+
+        private static bool IsCommentStart(string source, int position)
+        {
+            return position + 1 < source.Length &&
+                   source[position] == '/' &&
+                   (source[position + 1] == '/' || source[position + 1] == '*');
         }
     }
 }


### PR DESCRIPTION
## Summary
- Dynamic code snippets can use Unity Object APIs without hitting the CS0104 ambiguous Object compile error.
- Existing snippets that explicitly alias Object continue to keep their chosen alias.

## User Impact
- Before, common Unity snippets that referenced Object could fail because System and UnityEngine both expose Object.
- Now script-mode snippets default Object to UnityEngine.Object, while object and System.Object remain available when users need them.

## Changes
- Add a wrapper-level Object alias for script-mode dynamic code.
- Detect explicit user Object aliases, including compact spacing and comments between alias tokens, and avoid injecting the default alias in those cases.
- Add EditMode coverage for Unity Object, System.Object, compact alias, and commented alias snippets.

## Verification
- Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>
- Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value "io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.DynamicCodeToolTests\.(PreUsingResolver.*|AutoInjectedNamespaces.*)"
- ~/.codex/skills/codex-review/scripts/codex-review v3-beta --parallel-tests <dynamic-code EditMode test command>