### PR TITLE
fix: Simulated key presses now reach gameplay polling

### DIFF
--- a/.agents/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.agents/skills/uloop-simulate-keyboard/SKILL.md
@@ -38,6 +38,10 @@ uloop simulate-keyboard --action <action> --key <key> [options]
 | `KeyDown` | KeyDown only (held until KeyUp) | Start continuous movement, hold sprint |
 | `KeyUp` | KeyUp only (release held key) | Stop movement, release sprint |
 
+Use `Press` for edge-triggered gameplay code such as `Keyboard.current.spaceKey.wasPressedThisFrame`.
+If a successful `Press` does not change game state, verify PlayMode, Input System settings, and the follow-up observation timing before changing the user's gameplay code.
+Use `KeyDown` / `KeyUp` when the scenario intentionally needs a held key.
+
 ### KeyDown/KeyUp Rules
 
 - `KeyDown` fails if the key is already held

--- a/.agents/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.agents/skills/uloop-simulate-keyboard/SKILL.md
@@ -39,7 +39,8 @@ uloop simulate-keyboard --action <action> --key <key> [options]
 | `KeyUp` | KeyUp only (release held key) | Stop movement, release sprint |
 
 Use `Press` for edge-triggered gameplay code such as `Keyboard.current.spaceKey.wasPressedThisFrame`.
-If a successful `Press` does not change game state, verify PlayMode, Input System settings, and the follow-up observation timing before changing the user's gameplay code.
+`KeyDown` emits one initial press edge, then only keeps the key held. It does not keep `wasPressedThisFrame` true while the key remains held.
+If a successful `Press` or `KeyDown` leaves `Keyboard.current.<key>.isPressed` true but the game state does not change, do not immediately rewrite the user's gameplay code to `isPressed`. First verify that the gameplay component is active during the command, that it polls input in the configured Input System update phase, and that a missed `KeyDown` edge is followed by `KeyUp` before retrying.
 Use `KeyDown` / `KeyUp` when the scenario intentionally needs a held key.
 
 ### KeyDown/KeyUp Rules

--- a/.claude/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.claude/skills/uloop-simulate-keyboard/SKILL.md
@@ -38,6 +38,10 @@ uloop simulate-keyboard --action <action> --key <key> [options]
 | `KeyDown` | KeyDown only (held until KeyUp) | Start continuous movement, hold sprint |
 | `KeyUp` | KeyUp only (release held key) | Stop movement, release sprint |
 
+Use `Press` for edge-triggered gameplay code such as `Keyboard.current.spaceKey.wasPressedThisFrame`.
+If a successful `Press` does not change game state, verify PlayMode, Input System settings, and the follow-up observation timing before changing the user's gameplay code.
+Use `KeyDown` / `KeyUp` when the scenario intentionally needs a held key.
+
 ### KeyDown/KeyUp Rules
 
 - `KeyDown` fails if the key is already held

--- a/.claude/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.claude/skills/uloop-simulate-keyboard/SKILL.md
@@ -39,7 +39,8 @@ uloop simulate-keyboard --action <action> --key <key> [options]
 | `KeyUp` | KeyUp only (release held key) | Stop movement, release sprint |
 
 Use `Press` for edge-triggered gameplay code such as `Keyboard.current.spaceKey.wasPressedThisFrame`.
-If a successful `Press` does not change game state, verify PlayMode, Input System settings, and the follow-up observation timing before changing the user's gameplay code.
+`KeyDown` emits one initial press edge, then only keeps the key held. It does not keep `wasPressedThisFrame` true while the key remains held.
+If a successful `Press` or `KeyDown` leaves `Keyboard.current.<key>.isPressed` true but the game state does not change, do not immediately rewrite the user's gameplay code to `isPressed`. First verify that the gameplay component is active during the command, that it polls input in the configured Input System update phase, and that a missed `KeyDown` edge is followed by `KeyUp` before retrying.
 Use `KeyDown` / `KeyUp` when the scenario intentionally needs a held key.
 
 ### KeyDown/KeyUp Rules

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -31,6 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         private FramePressObserver framePressObserver = null!;
         private UpdateFramePressObserver updateFramePressObserver = null!;
         private FrameStateObserver frameStateObserver = null!;
+        private WasPressedGameplayJumpController gameplayJumpController = null!;
         private ManualModeFramePressObserver manualModeFramePressObserver = null!;
         private InputSettings.UpdateMode originalUpdateMode;
         private float originalTimeScale;
@@ -49,6 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             framePressObserver = framePressObserverGo.AddComponent<FramePressObserver>();
             updateFramePressObserver = framePressObserverGo.AddComponent<UpdateFramePressObserver>();
             frameStateObserver = framePressObserverGo.AddComponent<FrameStateObserver>();
+            gameplayJumpController = framePressObserverGo.AddComponent<WasPressedGameplayJumpController>();
             manualModeFramePressObserver = framePressObserverGo.AddComponent<ManualModeFramePressObserver>();
 
             tool = new TestableSimulateKeyboardTool();
@@ -176,6 +178,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             });
 
             Assert.GreaterOrEqual(updateFramePressObserver.SpaceHeldUpdateCount, 2, "Default Press should stay held across gameplay observation frames");
+        }
+
+        [UnityTest]
+        public IEnumerator Press_WithoutDuration_Should_TriggerGameplayJumpFromWasPressedThisFrame()
+        {
+            // Verifies that default Press drives gameplay state transitions that poll wasPressedThisFrame in Update.
+            yield return null;
+
+            gameplayJumpController.ResetState();
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "Space"
+            });
+
+            Assert.AreEqual(1, gameplayJumpController.JumpCount, "Default Press should trigger a single gameplay jump.");
+            Assert.IsFalse(gameplayJumpController.Grounded, "Gameplay state should become airborne after the jump.");
+            Assert.Greater(gameplayJumpController.VerticalPosition, 0f, "Gameplay jump should move the controller upward.");
         }
 
         [UnityTest]
@@ -464,6 +485,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.IsTrue(lastResponse.Success);
             Assert.IsFalse(KeyboardKeyState.IsKeyHeld(Key.W), "Key should be released after KeyUp");
             Assert.Greater(frameStateObserver.WReleasedUpdateCount, 0, "KeyUp should wait until Update observed the released key");
+        }
+
+        [UnityTest]
+        public IEnumerator KeyDown_Should_TriggerGameplayJumpFromWasPressedThisFrame()
+        {
+            // Verifies that KeyDown exposes its initial edge to gameplay before returning as a held key.
+            yield return null;
+
+            gameplayJumpController.ResetState();
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.KeyDown.ToString(),
+                ["key"] = "Space"
+            });
+
+            Assert.AreEqual(1, gameplayJumpController.JumpCount, "KeyDown should trigger a single gameplay jump on the initial edge.");
+            Assert.IsFalse(gameplayJumpController.Grounded, "Gameplay state should become airborne after KeyDown.");
+            Assert.IsTrue(keyboard[Key.Space].isPressed, "KeyDown should remain held after gameplay observes the edge.");
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.KeyUp.ToString(),
+                ["key"] = "Space"
+            });
+            Assert.IsTrue(lastResponse.Success);
         }
 
         [UnityTest]
@@ -823,6 +870,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         {
             WPressedUpdateCount = 0;
             WReleasedUpdateCount = 0;
+        }
+    }
+
+    /// <summary>
+    /// Test support type used by editor and play mode fixtures.
+    /// </summary>
+    public class WasPressedGameplayJumpController : MonoBehaviour
+    {
+        private const float JumpVelocity = 8f;
+        private const float SimulatedFrameSeconds = 0.016f;
+
+        public bool Grounded { get; private set; } = true;
+        public int JumpCount { get; private set; }
+        public float VerticalPosition { get; private set; }
+        public float VerticalVelocity { get; private set; }
+
+        private void Update()
+        {
+            Keyboard keyboard = Keyboard.current;
+            if (keyboard == null)
+            {
+                return;
+            }
+
+            if (Grounded && keyboard.spaceKey.wasPressedThisFrame)
+            {
+                Grounded = false;
+                JumpCount++;
+                VerticalVelocity = JumpVelocity;
+            }
+
+            if (!Grounded)
+            {
+                VerticalPosition += VerticalVelocity * SimulatedFrameSeconds;
+            }
+        }
+
+        public void ResetState()
+        {
+            Grounded = true;
+            JumpCount = 0;
+            VerticalPosition = 0f;
+            VerticalVelocity = 0f;
         }
     }
 

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -29,6 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         private SimulateKeyboardResponse lastResponse = null!;
         private Keyboard keyboard = null!;
         private FramePressObserver framePressObserver = null!;
+        private UpdateFramePressObserver updateFramePressObserver = null!;
         private FrameStateObserver frameStateObserver = null!;
         private ManualModeFramePressObserver manualModeFramePressObserver = null!;
         private InputSettings.UpdateMode originalUpdateMode;
@@ -46,6 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             eventSystemGo.AddComponent<EventSystem>();
             framePressObserverGo = new GameObject("FramePressObserver");
             framePressObserver = framePressObserverGo.AddComponent<FramePressObserver>();
+            updateFramePressObserver = framePressObserverGo.AddComponent<UpdateFramePressObserver>();
             frameStateObserver = framePressObserverGo.AddComponent<FrameStateObserver>();
             manualModeFramePressObserver = framePressObserverGo.AddComponent<ManualModeFramePressObserver>();
 
@@ -140,6 +142,60 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
 
             Assert.Greater(framePressObserver.SpacePressedFrameCount, 0, "Zero-duration press should still be visible as a tap");
             Assert.IsFalse(keyboard[Key.Space].isPressed, "Zero-duration press should release the key after the tap");
+        }
+
+        [UnityTest]
+        public IEnumerator Press_WithoutDuration_Should_BeVisibleToGameplayUpdate()
+        {
+            // Verifies that default Press stays alive long enough for Update polling to observe wasPressedThisFrame.
+            yield return null;
+
+            updateFramePressObserver.ResetCount();
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "Space"
+            });
+
+            Assert.Greater(updateFramePressObserver.SpacePressedUpdateCount, 0, "Default Press should be visible to MonoBehaviour.Update via wasPressedThisFrame");
+        }
+
+        [UnityTest]
+        public IEnumerator Press_WithoutDuration_Should_StayHeldForGameplayObservationFrames()
+        {
+            // Verifies that default Press is not released before gameplay Update can observe the held state.
+            yield return null;
+
+            updateFramePressObserver.ResetCount();
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "Space"
+            });
+
+            Assert.GreaterOrEqual(updateFramePressObserver.SpaceHeldUpdateCount, 2, "Default Press should stay held across gameplay observation frames");
+        }
+
+        [UnityTest]
+        public IEnumerator Press_InFixedMode_Should_BeVisibleToGameplayUpdate()
+        {
+            // Verifies that Press still reaches Update polling when the project processes input in FixedUpdate.
+            yield return null;
+
+            InputSettings settings = RequireInputSettings();
+            settings.updateMode = InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
+            updateFramePressObserver.ResetCount();
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = KeyboardAction.Press.ToString(),
+                ["key"] = "Space",
+                ["duration"] = 0.2f
+            });
+
+            Assert.Greater(updateFramePressObserver.SpacePressedUpdateCount, 0, "Fixed-update input processing should still be visible to MonoBehaviour.Update via wasPressedThisFrame");
         }
 
         [UnityTest]
@@ -701,6 +757,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         {
             SpacePressedFrameCount = 0;
             EnterPressedFrameCount = 0;
+        }
+    }
+
+    /// <summary>
+    /// Test support type used by editor and play mode fixtures.
+    /// </summary>
+    public class UpdateFramePressObserver : MonoBehaviour
+    {
+        public int SpacePressedUpdateCount { get; private set; }
+        public int SpaceHeldUpdateCount { get; private set; }
+
+        private void Update()
+        {
+            Keyboard keyboard = Keyboard.current;
+            if (keyboard == null)
+            {
+                return;
+            }
+
+            if (keyboard.spaceKey.wasPressedThisFrame)
+            {
+                SpacePressedUpdateCount++;
+            }
+
+            if (keyboard.spaceKey.isPressed)
+            {
+                SpaceHeldUpdateCount++;
+            }
+        }
+
+        public void ResetCount()
+        {
+            SpacePressedUpdateCount = 0;
+            SpaceHeldUpdateCount = 0;
         }
     }
 

--- a/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
@@ -21,17 +21,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         private SimulateMouseInputTool tool = null!;
         private SimulateMouseInputResponse lastResponse = null!;
         private Mouse mouse = null!;
+        private GameObject mouseObserverGo = null!;
+        private MouseUpdateFramePressObserver mouseUpdateFramePressObserver = null!;
 
         public override void Setup()
         {
             base.Setup();
             tool = new SimulateMouseInputTool();
             mouse = InputSystem.AddDevice<Mouse>();
+            mouseObserverGo = new GameObject("MouseUpdateFramePressObserver");
+            mouseUpdateFramePressObserver = mouseObserverGo.AddComponent<MouseUpdateFramePressObserver>();
         }
 
         public override void TearDown()
         {
             MouseInputState.ReleaseAllButtons();
+            Object.DestroyImmediate(mouseObserverGo);
             base.TearDown();
         }
 
@@ -40,7 +45,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         [UnityTest]
         public IEnumerator Click_Should_SetWasPressedThisFrame()
         {
+            // Verifies that Click is visible to gameplay Update polling through wasPressedThisFrame.
             yield return null;
+
+            mouseUpdateFramePressObserver.ResetCount();
 
             yield return RunTool(new JObject
             {
@@ -52,6 +60,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.IsTrue(lastResponse.Success);
             Assert.AreEqual("Click", lastResponse.Action);
             Assert.AreEqual("Left", lastResponse.Button);
+            Assert.Greater(mouseUpdateFramePressObserver.LeftButtonPressedUpdateCount, 0, "Click should be visible to MonoBehaviour.Update via wasPressedThisFrame");
             // After click completes, button should be released
             Assert.IsFalse(mouse.leftButton.isPressed, "Left button should be released after click");
         }
@@ -246,6 +255,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// Test support type used by play mode mouse input fixtures.
+    /// </summary>
+    public class MouseUpdateFramePressObserver : MonoBehaviour
+    {
+        public int LeftButtonPressedUpdateCount { get; private set; }
+
+        private void Update()
+        {
+            Mouse mouse = Mouse.current;
+            if (mouse == null)
+            {
+                return;
+            }
+
+            if (mouse.leftButton.wasPressedThisFrame)
+            {
+                LeftButtonPressedUpdateCount++;
+            }
+        }
+
+        public void ResetCount()
+        {
+            LeftButtonPressedUpdateCount = 0;
+        }
     }
 }
 #endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateHelper.cs
@@ -19,6 +19,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class InputSystemUpdateHelper
     {
+        private const int StandardPressObservationFrames = 2;
+        private const int ManualPressObservationFrames = 3;
+
         public static Task ApplyOnNextConfiguredUpdate(Action apply, CancellationToken ct)
         {
             InputUpdateType targetUpdateType = InputUpdateTypeResolver.Resolve();
@@ -64,18 +67,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (!InputUpdateTypeResolver.RequiresExplicitUpdate())
             {
-                return 1;
+                // Press must survive more than the input update that injected it.
+                // CLI follow-up commands can run immediately after completion, so
+                // gameplay Update polling needs a second runtime frame before release.
+                return StandardPressObservationFrames;
             }
 
             InputUpdateType targetUpdateType = InputUpdateTypeResolver.Resolve();
             if (targetUpdateType != InputUpdateType.Manual)
             {
-                return 2;
+                return StandardPressObservationFrames;
             }
 
             // Manual-mode projects often call InputSystem.Update from their own Update loop,
             // so zero-duration taps need one extra frame to remain visible to gameplay code.
-            return 3;
+            return ManualPressObservationFrames;
         }
 
         public static async Task WaitForObservationFrames(CancellationToken ct)

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
@@ -38,6 +38,10 @@ uloop simulate-keyboard --action <action> --key <key> [options]
 | `KeyDown` | KeyDown only (held until KeyUp) | Start continuous movement, hold sprint |
 | `KeyUp` | KeyUp only (release held key) | Stop movement, release sprint |
 
+Use `Press` for edge-triggered gameplay code such as `Keyboard.current.spaceKey.wasPressedThisFrame`.
+If a successful `Press` does not change game state, verify PlayMode, Input System settings, and the follow-up observation timing before changing the user's gameplay code.
+Use `KeyDown` / `KeyUp` when the scenario intentionally needs a held key.
+
 ### KeyDown/KeyUp Rules
 
 - `KeyDown` fails if the key is already held

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
@@ -39,7 +39,8 @@ uloop simulate-keyboard --action <action> --key <key> [options]
 | `KeyUp` | KeyUp only (release held key) | Stop movement, release sprint |
 
 Use `Press` for edge-triggered gameplay code such as `Keyboard.current.spaceKey.wasPressedThisFrame`.
-If a successful `Press` does not change game state, verify PlayMode, Input System settings, and the follow-up observation timing before changing the user's gameplay code.
+`KeyDown` emits one initial press edge, then only keeps the key held. It does not keep `wasPressedThisFrame` true while the key remains held.
+If a successful `Press` or `KeyDown` leaves `Keyboard.current.<key>.isPressed` true but the game state does not change, do not immediately rewrite the user's gameplay code to `isPressed`. First verify that the gameplay component is active during the command, that it polls input in the configured Input System update phase, and that a missed `KeyDown` edge is followed by `KeyUp` before retrying.
 Use `KeyDown` / `KeyUp` when the scenario intentionally needs a held key.
 
 ### KeyDown/KeyUp Rules

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Supports 5 actions: Click, LongPress, MoveDelta, SmoothDelta, Scroll.
 ### 13. simulate-keyboard - Simulate Keyboard Input in PlayMode
 Simulate keyboard key input in PlayMode via Input System. Supports single key taps, sustained holds, and multi-key combinations (e.g. Shift+W for sprinting). This tool is available only when the Input System package is installed, and Active Input Handling must be set to `Input System Package (New)` or `Both` in Player Settings. Game code must read input via Input System API (e.g. `Keyboard.current[Key.W].isPressed`), not legacy `Input.GetKey()`.
 
-Supports 3 actions: Press (one-shot tap or timed hold), KeyDown (hold key down), KeyUp (release held key).
+Supports 3 actions: Press (one-shot tap or timed hold), KeyDown (hold key down), KeyUp (release held key). Use Press for edge-triggered gameplay such as `Keyboard.current.spaceKey.wasPressedThisFrame`; use KeyDown/KeyUp only when the test intentionally needs a held key.
 
 ```text
 → simulate-keyboard (Action: Press, Key: Space)

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Supports 5 actions: Click, LongPress, MoveDelta, SmoothDelta, Scroll.
 ### 13. simulate-keyboard - Simulate Keyboard Input in PlayMode
 Simulate keyboard key input in PlayMode via Input System. Supports single key taps, sustained holds, and multi-key combinations (e.g. Shift+W for sprinting). This tool is available only when the Input System package is installed, and Active Input Handling must be set to `Input System Package (New)` or `Both` in Player Settings. Game code must read input via Input System API (e.g. `Keyboard.current[Key.W].isPressed`), not legacy `Input.GetKey()`.
 
-Supports 3 actions: Press (one-shot tap or timed hold), KeyDown (hold key down), KeyUp (release held key). Use Press for edge-triggered gameplay such as `Keyboard.current.spaceKey.wasPressedThisFrame`; use KeyDown/KeyUp only when the test intentionally needs a held key.
+Supports 3 actions: Press (one-shot tap or timed hold), KeyDown (hold key down), KeyUp (release held key). Use Press for edge-triggered gameplay such as `Keyboard.current.spaceKey.wasPressedThisFrame`; KeyDown emits only one initial press edge and then becomes held state, so use KeyDown/KeyUp only when the test intentionally needs a held key.
 
 ```text
 → simulate-keyboard (Action: Press, Key: Space)

--- a/README_ja.md
+++ b/README_ja.md
@@ -442,7 +442,7 @@ Input System経由でPlayMode中のマウス入力をシミュレーションし
 ### 13. simulate-keyboard - PlayModeでのキーボード入力シミュレーション
 Input System経由でPlayMode中のキーボード入力をシミュレーションします。単発のキータップ、長押し、複数キーの同時押し（例：Shift+Wでスプリント）に対応しています。このツールは Input System パッケージ導入時のみ利用可能で、Player SettingsのActive Input Handlingを `Input System Package (New)` または `Both` に設定する必要があります。ゲームコードがInput System API（例: `Keyboard.current[Key.W].isPressed`）で入力を読み取っている必要があり、レガシーの `Input.GetKey()` には対応していません。
 
-3つのアクションに対応: Press（ワンショットタップまたは時間指定ホールド）、KeyDown（キーを押し続ける）、KeyUp（押下中のキーを解放）
+3つのアクションに対応: Press（ワンショットタップまたは時間指定ホールド）、KeyDown（キーを押し続ける）、KeyUp（押下中のキーを解放）。`Keyboard.current.spaceKey.wasPressedThisFrame` のような立ち上がり検出には Press を使い、意図的にキーを保持したい場合だけ KeyDown/KeyUp を使います。
 
 ```text
 → simulate-keyboard (Action: Press, Key: Space)

--- a/README_ja.md
+++ b/README_ja.md
@@ -442,7 +442,7 @@ Input System経由でPlayMode中のマウス入力をシミュレーションし
 ### 13. simulate-keyboard - PlayModeでのキーボード入力シミュレーション
 Input System経由でPlayMode中のキーボード入力をシミュレーションします。単発のキータップ、長押し、複数キーの同時押し（例：Shift+Wでスプリント）に対応しています。このツールは Input System パッケージ導入時のみ利用可能で、Player SettingsのActive Input Handlingを `Input System Package (New)` または `Both` に設定する必要があります。ゲームコードがInput System API（例: `Keyboard.current[Key.W].isPressed`）で入力を読み取っている必要があり、レガシーの `Input.GetKey()` には対応していません。
 
-3つのアクションに対応: Press（ワンショットタップまたは時間指定ホールド）、KeyDown（キーを押し続ける）、KeyUp（押下中のキーを解放）。`Keyboard.current.spaceKey.wasPressedThisFrame` のような立ち上がり検出には Press を使い、意図的にキーを保持したい場合だけ KeyDown/KeyUp を使います。
+3つのアクションに対応: Press（ワンショットタップまたは時間指定ホールド）、KeyDown（キーを押し続ける）、KeyUp（押下中のキーを解放）。`Keyboard.current.spaceKey.wasPressedThisFrame` のような立ち上がり検出には Press を使います。KeyDown は最初の押下エッジを1回だけ発行し、その後は押下状態を保つだけなので、意図的にキーを保持したい場合だけ KeyDown/KeyUp を使います。
 
 ```text
 → simulate-keyboard (Action: Press, Key: Space)


### PR DESCRIPTION
## Summary
- Simulated keyboard taps now stay observable long enough for gameplay code that polls `wasPressedThisFrame` in `Update()`.
- Agent-facing guidance now points tap scenarios to `Press` and reserves `KeyDown` / `KeyUp` for intentional holds.

## User Impact
- Before, `simulate-keyboard --action Press --key Space` could report success while a game that used `Keyboard.current.spaceKey.wasPressedThisFrame` missed the jump/start action.
- After this change, simulated taps are held across gameplay observation frames so normal Input System edge checks can see them without rewriting game code to held-state polling.

## Changes
- Keep simulated press inputs alive for a second standard observation frame before release.
- Add PlayMode coverage for keyboard and mouse `wasPressedThisFrame` polling from `MonoBehaviour.Update()`.
- Update README and bundled skill guidance for tap vs held-key scenarios.

## Verification
- `Packages/src/Cli~/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --test-mode PlayMode --filter-type regex --filter-value "^io\.github\.hatayama\.UnityCliLoop\.Tests\.PlayMode\.SimulateKeyboardTests\." --project-path <PROJECT_ROOT>`
- `Packages/src/Cli~/dist/darwin-arm64/uloop run-tests --test-mode PlayMode --filter-type regex --filter-value "^io\.github\.hatayama\.UnityCliLoop\.Tests\.PlayMode\.SimulateMouseInputTests\." --project-path <PROJECT_ROOT>`
- `git diff --check`
- `~/.codex/skills/codex-review/scripts/codex-review v3-beta`