### PR TITLE
chore: Ensure release PRs pass checks after generated updates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -99,7 +99,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Go for release PR automation
-        if: steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
+        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: Packages/src/Cli~/.go-version
@@ -120,7 +120,7 @@ jobs:
         run: scripts/sync-release-please-go-cli-dist.sh
 
       - name: Dispatch release PR checks
-        if: steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
+        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
         working-directory: Packages/src/Cli~
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,8 @@ on:
         required: false
 
 permissions:
+  actions: write
+  checks: read
   contents: write
   pull-requests: write
   issues: write
@@ -96,8 +98,8 @@ jobs:
           skip-github-release: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Go for release PR binary sync
-        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
+      - name: Setup Go for release PR automation
+        if: steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: Packages/src/Cli~/.go-version
@@ -116,3 +118,12 @@ jobs:
           TARGET_BRANCH: ${{ steps.target.outputs.branch }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: scripts/sync-release-please-go-cli-dist.sh
+
+      - name: Dispatch release PR checks
+        if: steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'
+        working-directory: Packages/src/Cli~
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: ${{ steps.target.outputs.branch }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: go run ./cmd/dispatch-release-please-pr-checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@ If the minimum CLI version stays unchanged, make sure that decision is intention
 Do not directly edit skill files under the project-root `.agents/` or `.claude/` directories.
 These files are generated copies. Update the source skill definitions instead, then regenerate the copies through the normal workflow.
 
+## CI Automation Language
+
+Write GitHub Actions and release automation logic in Go when it needs JSON parsing, workflow polling, state transitions, or non-trivial branching.
+Shell scripts are acceptable only as thin wrappers or simple command sequences.
+
 ## Dead Code Scanner
 
 Use the C# dead-code scanner before deleting apparently unreferenced C# code or before adding comments to explain why an apparently unreferenced type must stay.

--- a/Packages/src/Cli~/cmd/dispatch-release-please-pr-checks/main.go
+++ b/Packages/src/Cli~/cmd/dispatch-release-please-pr-checks/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/Packages/src/Cli/internal/automation"
+)
+
+func main() {
+	os.Exit(automation.RunReleasePleasePRChecks(context.Background(), os.Stdout, os.Stderr))
+}

--- a/Packages/src/Cli~/internal/automation/minimum_version_warning.go
+++ b/Packages/src/Cli~/internal/automation/minimum_version_warning.go
@@ -232,6 +232,7 @@ func minimumVersionWarningIsGoCliFile(changedFile string) bool {
 	if changedFile == goCliPackageRoot+"CHANGELOG.md" ||
 		strings.HasPrefix(changedFile, goCliPackageRoot+"dist/") ||
 		strings.HasPrefix(changedFile, goCliPackageRoot+"cmd/comment-cli-minimum-version-warning/") ||
+		strings.HasPrefix(changedFile, goCliPackageRoot+"cmd/dispatch-release-please-pr-checks/") ||
 		strings.HasPrefix(changedFile, goCliPackageRoot+"internal/automation/") ||
 		strings.HasSuffix(changedFile, "_test.go") {
 		return false

--- a/Packages/src/Cli~/internal/automation/minimum_version_warning_test.go
+++ b/Packages/src/Cli~/internal/automation/minimum_version_warning_test.go
@@ -92,6 +92,11 @@ func TestMinimumVersionWarningRequiresCommentForGoCliSourceChanges(t *testing.T)
 			shouldWarn:  false,
 		},
 		{
+			name:        "release check command source",
+			changedFile: goCliPackageRoot + "cmd/dispatch-release-please-pr-checks/main.go",
+			shouldWarn:  false,
+		},
+		{
 			name:        "warning automation source",
 			changedFile: goCliPackageRoot + "internal/automation/minimum_version_warning.go",
 			shouldWarn:  false,

--- a/Packages/src/Cli~/internal/automation/release_pr_checks.go
+++ b/Packages/src/Cli~/internal/automation/release_pr_checks.go
@@ -72,7 +72,7 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 	}
 	writeReleasePRCheckLine(stdout, fmt.Sprintf("Marked release PR #%d as draft while checks run.", releasePR.Number))
 
-	dispatchedAt := releasePRCheckNow().UTC()
+	dispatchedAt := releasePRCheckNow().UTC().Truncate(time.Second)
 	writeReleasePRCheckLine(stdout, fmt.Sprintf("Dispatching %s for release PR #%d: %s", config.workflow, releasePR.Number, releasePR.URL))
 	err = dispatchReleasePRCheckWorkflow(ctx, config, releasePR)
 	if err != nil {
@@ -88,6 +88,12 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 
 	writeReleasePRCheckLine(stdout, fmt.Sprintf("Watching %s run %d for release PR #%d.", config.workflow, runID, releasePR.Number))
 	err = watchReleasePRCheckRun(ctx, config, runID)
+	if err != nil {
+		writeReleasePRCheckLine(stderr, err)
+		return 1
+	}
+
+	err = verifyReleasePRCheckHeadUnchanged(ctx, config, releasePR)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
@@ -322,6 +328,23 @@ func watchReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, ru
 		strconv.Itoa(config.watchIntervalSeconds),
 	)
 	return err
+}
+
+func verifyReleasePRCheckHeadUnchanged(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) error {
+	currentReleasePR, found, err := findReleasePRCheckPullRequest(ctx, config)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("release PR #%d is no longer pending before marking ready", releasePR.Number)
+	}
+	if currentReleasePR.Number != releasePR.Number {
+		return fmt.Errorf("pending release PR changed from #%d to #%d before marking ready", releasePR.Number, currentReleasePR.Number)
+	}
+	if currentReleasePR.HeadRefOID != releasePR.HeadRefOID {
+		return fmt.Errorf("release PR #%d head changed from %s to %s before marking ready", releasePR.Number, releasePR.HeadRefOID, currentReleasePR.HeadRefOID)
+	}
+	return nil
 }
 
 func runReleasePRCheckOutput(ctx context.Context, name string, args ...string) (string, error) {

--- a/Packages/src/Cli~/internal/automation/release_pr_checks.go
+++ b/Packages/src/Cli~/internal/automation/release_pr_checks.go
@@ -1,0 +1,343 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultReleasePRCheckWorkflow              = "build-and-test.yml"
+	defaultReleasePRCheckLookupAttempts        = 30
+	defaultReleasePRCheckLookupIntervalSeconds = 10
+	defaultReleasePRCheckWatchIntervalSeconds  = 10
+)
+
+var (
+	releasePRCheckNow   = time.Now
+	releasePRCheckSleep = time.Sleep
+)
+
+type releasePRCheckConfig struct {
+	repository            string
+	targetBranch          string
+	workflow              string
+	lookupAttempts        int
+	lookupIntervalSeconds int
+	watchIntervalSeconds  int
+}
+
+type releasePullRequest struct {
+	Number      int    `json:"number"`
+	HeadRefName string `json:"headRefName"`
+	HeadRefOID  string `json:"headRefOid"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+}
+
+type releaseWorkflowRun struct {
+	DatabaseID int64  `json:"databaseId"`
+	HeadSHA    string `json:"headSha"`
+	CreatedAt  string `json:"createdAt"`
+}
+
+func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.Writer) int {
+	config, err := releasePRCheckConfigFromEnvironment()
+	if err != nil {
+		writeReleasePRCheckLine(stderr, err)
+		return 1
+	}
+
+	releasePR, found, err := findReleasePRCheckPullRequest(ctx, config)
+	if err != nil {
+		writeReleasePRCheckLine(stderr, err)
+		return 1
+	}
+	if !found {
+		writeReleasePRCheckLine(stdout, "No pending release-please PR found for "+config.targetBranch+".")
+		return 0
+	}
+
+	err = markReleasePRCheckDraft(ctx, config, releasePR)
+	if err != nil {
+		writeReleasePRCheckLine(stderr, err)
+		return 1
+	}
+	writeReleasePRCheckLine(stdout, fmt.Sprintf("Marked release PR #%d as draft while checks run.", releasePR.Number))
+
+	dispatchedAt := releasePRCheckNow().UTC()
+	writeReleasePRCheckLine(stdout, fmt.Sprintf("Dispatching %s for release PR #%d: %s", config.workflow, releasePR.Number, releasePR.URL))
+	err = dispatchReleasePRCheckWorkflow(ctx, config, releasePR)
+	if err != nil {
+		writeReleasePRCheckLine(stderr, err)
+		return 1
+	}
+
+	runID, err := findDispatchedReleasePRCheckRun(ctx, config, releasePR, dispatchedAt)
+	if err != nil {
+		writeReleasePRCheckLine(stderr, err)
+		return 1
+	}
+
+	writeReleasePRCheckLine(stdout, fmt.Sprintf("Watching %s run %d for release PR #%d.", config.workflow, runID, releasePR.Number))
+	err = watchReleasePRCheckRun(ctx, config, runID)
+	if err != nil {
+		writeReleasePRCheckLine(stderr, err)
+		return 1
+	}
+
+	err = markReleasePRCheckReady(ctx, config, releasePR)
+	if err != nil {
+		writeReleasePRCheckLine(stderr, err)
+		return 1
+	}
+	writeReleasePRCheckLine(stdout, fmt.Sprintf("Marked release PR #%d as ready after checks passed.", releasePR.Number))
+	return 0
+}
+
+func releasePRCheckConfigFromEnvironment() (releasePRCheckConfig, error) {
+	repository := os.Getenv("GITHUB_REPOSITORY")
+	if repository == "" {
+		return releasePRCheckConfig{}, fmt.Errorf("GITHUB_REPOSITORY is required")
+	}
+	targetBranch := os.Getenv("TARGET_BRANCH")
+	if targetBranch == "" {
+		return releasePRCheckConfig{}, fmt.Errorf("TARGET_BRANCH is required")
+	}
+
+	workflow := os.Getenv("RELEASE_PR_CHECK_WORKFLOW")
+	if workflow == "" {
+		workflow = defaultReleasePRCheckWorkflow
+	}
+
+	lookupAttempts, err := releasePRCheckPositiveIntFromEnvironment("RELEASE_PR_CHECK_LOOKUP_ATTEMPTS", defaultReleasePRCheckLookupAttempts)
+	if err != nil {
+		return releasePRCheckConfig{}, err
+	}
+	lookupIntervalSeconds, err := releasePRCheckPositiveIntFromEnvironment("RELEASE_PR_CHECK_LOOKUP_INTERVAL_SECONDS", defaultReleasePRCheckLookupIntervalSeconds)
+	if err != nil {
+		return releasePRCheckConfig{}, err
+	}
+	watchIntervalSeconds, err := releasePRCheckPositiveIntFromEnvironment("RELEASE_PR_CHECK_WATCH_INTERVAL_SECONDS", defaultReleasePRCheckWatchIntervalSeconds)
+	if err != nil {
+		return releasePRCheckConfig{}, err
+	}
+
+	return releasePRCheckConfig{
+		repository:            repository,
+		targetBranch:          targetBranch,
+		workflow:              workflow,
+		lookupAttempts:        lookupAttempts,
+		lookupIntervalSeconds: lookupIntervalSeconds,
+		watchIntervalSeconds:  watchIntervalSeconds,
+	}, nil
+}
+
+func releasePRCheckPositiveIntFromEnvironment(name string, defaultValue int) (int, error) {
+	value := os.Getenv(name)
+	if value == "" {
+		return defaultValue, nil
+	}
+	parsedValue, err := strconv.Atoi(value)
+	if err != nil || parsedValue <= 0 {
+		return 0, fmt.Errorf("%s must be a positive integer", name)
+	}
+	return parsedValue, nil
+}
+
+func findReleasePRCheckPullRequest(ctx context.Context, config releasePRCheckConfig) (releasePullRequest, bool, error) {
+	output, err := runReleasePRCheckOutput(
+		ctx,
+		"gh",
+		"pr",
+		"list",
+		"--repo",
+		config.repository,
+		"--state",
+		"open",
+		"--base",
+		config.targetBranch,
+		"--label",
+		"autorelease: pending",
+		"--json",
+		"number,headRefName,headRefOid,title,url",
+	)
+	if err != nil {
+		return releasePullRequest{}, false, err
+	}
+
+	releasePRs := []releasePullRequest{}
+	err = json.Unmarshal([]byte(output), &releasePRs)
+	if err != nil {
+		return releasePullRequest{}, false, fmt.Errorf("failed to parse release PR list: %w", err)
+	}
+
+	matchingPRs := []releasePullRequest{}
+	for _, releasePR := range releasePRs {
+		if releasePRCheckMatches(releasePR, config.targetBranch) {
+			matchingPRs = append(matchingPRs, releasePR)
+		}
+	}
+
+	if len(matchingPRs) == 0 {
+		return releasePullRequest{}, false, nil
+	}
+	if len(matchingPRs) > 1 {
+		return releasePullRequest{}, false, fmt.Errorf("expected one pending release-please PR for %s, found %d", config.targetBranch, len(matchingPRs))
+	}
+	if matchingPRs[0].HeadRefOID == "" {
+		return releasePullRequest{}, false, fmt.Errorf("release PR #%d has no head SHA", matchingPRs[0].Number)
+	}
+	return matchingPRs[0], true, nil
+}
+
+func releasePRCheckMatches(releasePR releasePullRequest, targetBranch string) bool {
+	releasePRBranch := "release-please--branches--" + targetBranch
+	if releasePR.HeadRefName != releasePRBranch && !strings.HasPrefix(releasePR.HeadRefName, releasePRBranch+"--components--") {
+		return false
+	}
+	return releasePRCheckTitleMatches(releasePR.Title)
+}
+
+func releasePRCheckTitleMatches(title string) bool {
+	if title == "chore: release" || strings.HasPrefix(title, "chore: release ") {
+		return true
+	}
+	if !strings.HasPrefix(title, "chore(") {
+		return false
+	}
+	closeIndex := strings.Index(title, "):")
+	if closeIndex == -1 {
+		return false
+	}
+	rest := strings.TrimSpace(title[closeIndex+2:])
+	return rest == "release" || strings.HasPrefix(rest, "release ")
+}
+
+func markReleasePRCheckDraft(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) error {
+	_, err := runReleasePRCheckOutput(ctx, "gh", "pr", "ready", strconv.Itoa(releasePR.Number), "--repo", config.repository, "--undo")
+	return err
+}
+
+func markReleasePRCheckReady(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) error {
+	_, err := runReleasePRCheckOutput(ctx, "gh", "pr", "ready", strconv.Itoa(releasePR.Number), "--repo", config.repository)
+	return err
+}
+
+func dispatchReleasePRCheckWorkflow(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) error {
+	_, err := runReleasePRCheckOutput(ctx, "gh", "workflow", "run", config.workflow, "--repo", config.repository, "--ref", releasePR.HeadRefName)
+	return err
+}
+
+func findDispatchedReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest, dispatchedAt time.Time) (int64, error) {
+	for attempt := 0; attempt < config.lookupAttempts; attempt++ {
+		runID, found, err := latestReleasePRCheckRun(ctx, config, releasePR, dispatchedAt)
+		if err != nil {
+			return 0, err
+		}
+		if found {
+			return runID, nil
+		}
+		if attempt+1 < config.lookupAttempts {
+			releasePRCheckSleep(time.Duration(config.lookupIntervalSeconds) * time.Second)
+		}
+	}
+	return 0, fmt.Errorf("could not find dispatched %s workflow run for %s", config.workflow, releasePR.HeadRefOID)
+}
+
+func latestReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest, dispatchedAt time.Time) (int64, bool, error) {
+	output, err := runReleasePRCheckOutput(
+		ctx,
+		"gh",
+		"run",
+		"list",
+		"--repo",
+		config.repository,
+		"--workflow",
+		config.workflow,
+		"--branch",
+		releasePR.HeadRefName,
+		"--event",
+		"workflow_dispatch",
+		"--json",
+		"databaseId,status,conclusion,headSha,createdAt,url",
+		"--limit",
+		"20",
+	)
+	if err != nil {
+		return 0, false, err
+	}
+
+	runs := []releaseWorkflowRun{}
+	err = json.Unmarshal([]byte(output), &runs)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to parse workflow runs: %w", err)
+	}
+
+	var latestRun releaseWorkflowRun
+	var latestCreatedAt time.Time
+	found := false
+	for _, run := range runs {
+		if run.HeadSHA != releasePR.HeadRefOID {
+			continue
+		}
+		createdAt, err := time.Parse(time.RFC3339, run.CreatedAt)
+		if err != nil {
+			return 0, false, fmt.Errorf("failed to parse workflow run createdAt %q: %w", run.CreatedAt, err)
+		}
+		if createdAt.Before(dispatchedAt) {
+			continue
+		}
+		if !found || createdAt.After(latestCreatedAt) {
+			latestRun = run
+			latestCreatedAt = createdAt
+			found = true
+		}
+	}
+	if !found {
+		return 0, false, nil
+	}
+	return latestRun.DatabaseID, true, nil
+}
+
+func watchReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, runID int64) error {
+	_, err := runReleasePRCheckOutput(
+		ctx,
+		"gh",
+		"run",
+		"watch",
+		strconv.FormatInt(runID, 10),
+		"--repo",
+		config.repository,
+		"--exit-status",
+		"--compact",
+		"--interval",
+		strconv.Itoa(config.watchIntervalSeconds),
+	)
+	return err
+}
+
+func runReleasePRCheckOutput(ctx context.Context, name string, args ...string) (string, error) {
+	command := exec.CommandContext(ctx, name, args...)
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	if err != nil {
+		return "", fmt.Errorf("%s %s failed: %w\n%s%s", name, strings.Join(args, " "), err, stderr.String(), stdout.String())
+	}
+	return stdout.String(), nil
+}
+
+func writeReleasePRCheckLine(writer io.Writer, values ...any) {
+	// CI status output failures cannot be recovered after the command outcome is known.
+	_, _ = fmt.Fprintln(writer, values...)
+}

--- a/Packages/src/Cli~/internal/automation/release_pr_checks_test.go
+++ b/Packages/src/Cli~/internal/automation/release_pr_checks_test.go
@@ -58,6 +58,22 @@ func TestReleasePRChecksDispatchAndMarkReady(t *testing.T) {
 	assertReleasePRCheckLogContainsLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
 }
 
+// Verifies that same-second workflow runs are accepted when GitHub rounds createdAt timestamps.
+func TestReleasePRChecksAcceptSameSecondRunAfterDispatch(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore(v3-beta): release 3.0.0-beta.5","url":"https://example.test/pr/1043"}]`,
+		runListJSON:    `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:00Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
+		runWatchStatus: "0",
+		now:            time.Date(2026, 5, 30, 1, 0, 0, 500000000, time.UTC),
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertReleasePRCheckLogContains(t, result.stdout, "Watching build-and-test.yml run 4242 for release PR #1043.")
+	assertReleasePRCheckLogContainsLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
+}
+
 // Verifies that release-looking PRs are ignored without a release-please branch.
 func TestReleasePRChecksIgnoreManualReleasePR(t *testing.T) {
 	result := runReleasePRCheckCase(t, releasePRCheckCase{
@@ -108,10 +124,29 @@ func TestReleasePRChecksFailWhenWatchedRunFails(t *testing.T) {
 	assertReleasePRCheckLogDoesNotContainLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
 }
 
+// Verifies that a changed release PR head is not marked ready after stale checks pass.
+func TestReleasePRChecksFailWhenHeadChangesBeforeReady(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:           `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		prListJSONAfterWatch: `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"def456","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		runListJSON:          `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"completed","conclusion":"success","url":"https://example.test/run/4242"}]`,
+		runWatchStatus:       "0",
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	}
+	assertReleasePRCheckLogContains(t, result.stderr, "release PR #1043 head changed from abc123 to def456 before marking ready")
+	assertReleasePRCheckLogContains(t, result.ghLog, "pr ready 1043 --repo owner/repository --undo")
+	assertReleasePRCheckLogDoesNotContainLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
+}
+
 type releasePRCheckCase struct {
-	prListJSON     string
-	runListJSON    string
-	runWatchStatus string
+	prListJSON           string
+	prListJSONAfterWatch string
+	runListJSON          string
+	runWatchStatus       string
+	now                  time.Time
 }
 
 func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRCheckRunResult {
@@ -125,6 +160,7 @@ func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRC
 	}
 
 	ghLogPath := filepath.Join(workDir, "gh.log")
+	prListCountPath := filepath.Join(workDir, "pr-list-count")
 	writeReleasePRCheckMockGH(t, filepath.Join(mockBin, "gh"))
 
 	t.Setenv("PATH", mockBin+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -134,6 +170,8 @@ func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRC
 	t.Setenv("RELEASE_PR_CHECK_LOOKUP_INTERVAL_SECONDS", "1")
 	t.Setenv("RELEASE_PR_CHECK_WATCH_INTERVAL_SECONDS", "1")
 	t.Setenv("GH_PR_LIST_JSON", testCase.prListJSON)
+	t.Setenv("GH_PR_LIST_JSON_AFTER_WATCH", testCase.prListJSONAfterWatch)
+	t.Setenv("GH_PR_LIST_COUNT_PATH", prListCountPath)
 	t.Setenv("GH_RUN_LIST_JSON", testCase.runListJSON)
 	t.Setenv("GH_RUN_WATCH_STATUS", testCase.runWatchStatus)
 	t.Setenv("GH_LOG", ghLogPath)
@@ -141,8 +179,12 @@ func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRC
 	originalNow := releasePRCheckNow
 	originalSleep := releasePRCheckSleep
 	sleeps := []time.Duration{}
+	now := testCase.now
+	if now.IsZero() {
+		now = time.Date(2026, 5, 30, 1, 0, 0, 0, time.UTC)
+	}
 	releasePRCheckNow = func() time.Time {
-		return time.Date(2026, 5, 30, 1, 0, 0, 0, time.UTC)
+		return now
 	}
 	releasePRCheckSleep = func(duration time.Duration) {
 		sleeps = append(sleeps, duration)
@@ -178,6 +220,18 @@ set -eu
 printf '%s\n' "$*" >> "$GH_LOG"
 
 if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  count=0
+  if [ -f "$GH_PR_LIST_COUNT_PATH" ]; then
+    count=$(cat "$GH_PR_LIST_COUNT_PATH")
+  fi
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$GH_PR_LIST_COUNT_PATH"
+
+  if [ "$count" -gt 1 ] && [ -n "$GH_PR_LIST_JSON_AFTER_WATCH" ]; then
+    printf '%s\n' "$GH_PR_LIST_JSON_AFTER_WATCH"
+    exit 0
+  fi
+
   printf '%s\n' "$GH_PR_LIST_JSON"
   exit 0
 fi

--- a/Packages/src/Cli~/internal/automation/release_pr_checks_test.go
+++ b/Packages/src/Cli~/internal/automation/release_pr_checks_test.go
@@ -1,0 +1,242 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type releasePRCheckRunResult struct {
+	exitCode int
+	stdout   string
+	stderr   string
+	ghLog    string
+	sleeps   []time.Duration
+}
+
+// Verifies that missing release PRs skip without dispatching checks.
+func TestReleasePRChecksSkipWhenNoReleasePRExists(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     "[]",
+		runListJSON:    "[]",
+		runWatchStatus: "0",
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	if result.stdout != "No pending release-please PR found for v3-beta.\n" {
+		t.Fatalf("expected no-release skip message, got %q", result.stdout)
+	}
+	assertReleasePRCheckLogDoesNotContain(t, result.ghLog, "workflow run")
+	assertReleasePRCheckLogDoesNotContain(t, result.ghLog, "pr ready")
+}
+
+// Verifies that the matching release PR is drafted, dispatched, watched, and marked ready.
+func TestReleasePRChecksDispatchAndMarkReady(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore(v3-beta): release 3.0.0-beta.5","url":"https://example.test/pr/1043"}]`,
+		runListJSON:    `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
+		runWatchStatus: "0",
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertReleasePRCheckLogContains(t, result.stdout, "Marked release PR #1043 as draft while checks run.")
+	assertReleasePRCheckLogContains(t, result.stdout, "Dispatching build-and-test.yml for release PR #1043: https://example.test/pr/1043")
+	assertReleasePRCheckLogContains(t, result.stdout, "Watching build-and-test.yml run 4242 for release PR #1043.")
+	assertReleasePRCheckLogContains(t, result.stdout, "Marked release PR #1043 as ready after checks passed.")
+	assertReleasePRCheckLogContains(t, result.ghLog, "pr ready 1043 --repo owner/repository --undo")
+	assertReleasePRCheckLogContains(t, result.ghLog, "workflow run build-and-test.yml --repo owner/repository --ref release-please--branches--v3-beta")
+	assertReleasePRCheckLogContains(t, result.ghLog, "run list --repo owner/repository --workflow build-and-test.yml --branch release-please--branches--v3-beta --event workflow_dispatch --json databaseId,status,conclusion,headSha,createdAt,url --limit 20")
+	assertReleasePRCheckLogContains(t, result.ghLog, "run watch 4242 --repo owner/repository --exit-status --compact --interval 1")
+	assertReleasePRCheckLogContainsLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
+}
+
+// Verifies that release-looking PRs are ignored without a release-please branch.
+func TestReleasePRChecksIgnoreManualReleasePR(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     `[{"number":1042,"headRefName":"feature/manual-release","headRefOid":"abc123","title":"chore(v3-beta): release 3.0.0-beta.5","url":"https://example.test/pr/1042"}]`,
+		runListJSON:    "[]",
+		runWatchStatus: "0",
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertReleasePRCheckLogContains(t, result.stdout, "No pending release-please PR found for v3-beta.")
+	assertReleasePRCheckLogDoesNotContain(t, result.ghLog, "workflow run")
+}
+
+// Verifies that missing dispatched runs fail while leaving the PR drafted.
+func TestReleasePRChecksFailWhenDispatchedRunIsMissing(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		runListJSON:    "[]",
+		runWatchStatus: "0",
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	}
+	assertReleasePRCheckLogContains(t, result.stderr, "could not find dispatched build-and-test.yml workflow run for abc123")
+	assertReleasePRCheckLogContains(t, result.ghLog, "pr ready 1043 --repo owner/repository --undo")
+	assertReleasePRCheckLogDoesNotContainLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
+	if len(result.sleeps) != 0 {
+		t.Fatalf("expected no sleep after the final lookup attempt, got %v", result.sleeps)
+	}
+}
+
+// Verifies that failed watched runs fail while leaving the PR drafted.
+func TestReleasePRChecksFailWhenWatchedRunFails(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		runListJSON:    `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"completed","conclusion":"failure","url":"https://example.test/run/4242"}]`,
+		runWatchStatus: "1",
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	}
+	assertReleasePRCheckLogContains(t, result.stderr, "gh run watch 4242 --repo owner/repository --exit-status --compact --interval 1 failed")
+	assertReleasePRCheckLogContains(t, result.ghLog, "pr ready 1043 --repo owner/repository --undo")
+	assertReleasePRCheckLogDoesNotContainLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
+}
+
+type releasePRCheckCase struct {
+	prListJSON     string
+	runListJSON    string
+	runWatchStatus string
+}
+
+func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRCheckRunResult {
+	t.Helper()
+
+	workDir := t.TempDir()
+	mockBin := filepath.Join(workDir, "bin")
+	err := os.MkdirAll(mockBin, 0o755)
+	if err != nil {
+		t.Fatalf("failed to create mock bin: %v", err)
+	}
+
+	ghLogPath := filepath.Join(workDir, "gh.log")
+	writeReleasePRCheckMockGH(t, filepath.Join(mockBin, "gh"))
+
+	t.Setenv("PATH", mockBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GITHUB_REPOSITORY", "owner/repository")
+	t.Setenv("TARGET_BRANCH", "v3-beta")
+	t.Setenv("RELEASE_PR_CHECK_LOOKUP_ATTEMPTS", "1")
+	t.Setenv("RELEASE_PR_CHECK_LOOKUP_INTERVAL_SECONDS", "1")
+	t.Setenv("RELEASE_PR_CHECK_WATCH_INTERVAL_SECONDS", "1")
+	t.Setenv("GH_PR_LIST_JSON", testCase.prListJSON)
+	t.Setenv("GH_RUN_LIST_JSON", testCase.runListJSON)
+	t.Setenv("GH_RUN_WATCH_STATUS", testCase.runWatchStatus)
+	t.Setenv("GH_LOG", ghLogPath)
+
+	originalNow := releasePRCheckNow
+	originalSleep := releasePRCheckSleep
+	sleeps := []time.Duration{}
+	releasePRCheckNow = func() time.Time {
+		return time.Date(2026, 5, 30, 1, 0, 0, 0, time.UTC)
+	}
+	releasePRCheckSleep = func(duration time.Duration) {
+		sleeps = append(sleeps, duration)
+	}
+	t.Cleanup(func() {
+		releasePRCheckNow = originalNow
+		releasePRCheckSleep = originalSleep
+	})
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	exitCode := RunReleasePleasePRChecks(context.Background(), &stdout, &stderr)
+	ghLogBytes, err := os.ReadFile(ghLogPath)
+	if err != nil {
+		t.Fatalf("failed to read gh log: %v", err)
+	}
+
+	return releasePRCheckRunResult{
+		exitCode: exitCode,
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+		ghLog:    string(ghLogBytes),
+		sleeps:   sleeps,
+	}
+}
+
+func writeReleasePRCheckMockGH(t *testing.T, path string) {
+	t.Helper()
+
+	content := `#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$GH_LOG"
+
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '%s\n' "$GH_PR_LIST_JSON"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "ready" ]; then
+  exit 0
+fi
+
+if [ "$1" = "workflow" ] && [ "$2" = "run" ]; then
+  exit 0
+fi
+
+if [ "$1" = "run" ] && [ "$2" = "list" ]; then
+  printf '%s\n' "$GH_RUN_LIST_JSON"
+  exit 0
+fi
+
+if [ "$1" = "run" ] && [ "$2" = "watch" ]; then
+  exit "$GH_RUN_WATCH_STATUS"
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 1
+`
+	err := os.WriteFile(path, []byte(content), 0o755)
+	if err != nil {
+		t.Fatalf("failed to write mock gh command: %v", err)
+	}
+}
+
+func assertReleasePRCheckLogContains(t *testing.T, actual string, expected string) {
+	t.Helper()
+	if !strings.Contains(actual, expected) {
+		t.Fatalf("expected log to contain %q, got:\n%s", expected, actual)
+	}
+}
+
+func assertReleasePRCheckLogDoesNotContain(t *testing.T, actual string, unexpected string) {
+	t.Helper()
+	if strings.Contains(actual, unexpected) {
+		t.Fatalf("expected log not to contain %q, got:\n%s", unexpected, actual)
+	}
+}
+
+func assertReleasePRCheckLogContainsLine(t *testing.T, actual string, expected string) {
+	t.Helper()
+	for _, line := range strings.Split(actual, "\n") {
+		if line == expected {
+			return
+		}
+	}
+	t.Fatalf("expected log to contain line %q, got:\n%s", expected, actual)
+}
+
+func assertReleasePRCheckLogDoesNotContainLine(t *testing.T, actual string, unexpected string) {
+	t.Helper()
+	for _, line := range strings.Split(actual, "\n") {
+		if line == unexpected {
+			t.Fatalf("expected log not to contain line %q, got:\n%s", unexpected, actual)
+		}
+	}
+}

--- a/scripts/sync-release-please-go-cli-dist.sh
+++ b/scripts/sync-release-please-go-cli-dist.sh
@@ -49,6 +49,8 @@ RELEASE_PR_HEAD_REF=$(printf '%s' "$MATCHING_RELEASE_PRS" | jq -r '.[0].headRefN
 RELEASE_PR_URL=$(printf '%s' "$MATCHING_RELEASE_PRS" | jq -r '.[0].url')
 
 echo "Syncing native CLI dist files for release PR #$RELEASE_PR_NUMBER: $RELEASE_PR_URL"
+echo "Marking release PR #$RELEASE_PR_NUMBER as draft while generated files are synced."
+gh pr ready "$RELEASE_PR_NUMBER" --repo "$REPO_FULL_NAME" --undo
 
 git fetch origin "$RELEASE_PR_HEAD_REF"
 git checkout -B "$RELEASE_PR_HEAD_REF" FETCH_HEAD

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -51,6 +51,26 @@ assert_file_contains() {
   fi
 }
 
+line_number() {
+  path=$1
+  text=$2
+
+  grep -nF -- "$text" "$path" | head -n 1 | cut -d: -f 1
+}
+
+assert_file_order() {
+  path=$1
+  earlier=$2
+  later=$3
+
+  earlier_line=$(line_number "$path" "$earlier")
+  later_line=$(line_number "$path" "$later")
+  if [ -z "$earlier_line" ] || [ -z "$later_line" ] || [ "$earlier_line" -ge "$later_line" ]; then
+    echo "Expected '$earlier' to appear before '$later' in $path." >&2
+    exit 1
+  fi
+}
+
 assert_package_path_exists() {
   package_path=$1
   path=$2
@@ -89,6 +109,14 @@ assert_json_value '.packages["Packages/src/Cli~"].["extra-files"][1].path' 'cont
 
 assert_file_contains "$RELEASE_WORKFLOW" 'id: package_release_sync'
 assert_file_contains "$RELEASE_WORKFLOW" "steps.package_release_sync.outputs.ready != 'false'"
+assert_file_contains "$RELEASE_WORKFLOW" '  actions: write'
+assert_file_contains "$RELEASE_WORKFLOW" '  checks: read'
+assert_file_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation'
+assert_file_contains "$RELEASE_WORKFLOW" '      - name: Dispatch release PR checks'
+assert_file_contains "$RELEASE_WORKFLOW" '        working-directory: Packages/src/Cli~'
+assert_file_contains "$RELEASE_WORKFLOW" '        run: go run ./cmd/dispatch-release-please-pr-checks'
+assert_file_order "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' '      - name: Dispatch release PR checks'
+assert_file_order "$RELEASE_WORKFLOW" '      - name: Sync native CLI binaries into release PR' '      - name: Dispatch release PR checks'
 
 assert_manifest_semver '.["."]'
 assert_manifest_semver '.["Packages/src/Cli~"]'

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -77,7 +77,12 @@ assert_step_contains() {
   expected=$3
 
   step_line=$(line_number "$path" "$step")
-  if [ -z "$step_line" ] || ! tail -n +"$step_line" "$path" | sed -n '1,8p' | grep -F -- "$expected" >/dev/null; then
+  if [ -z "$step_line" ] || ! awk -v start="$step_line" '
+    NR < start { next }
+    NR == start { in_step = 1 }
+    in_step && NR > start && /^      - name: / { exit }
+    in_step { print }
+  ' "$path" | grep -F -- "$expected" >/dev/null; then
     echo "Expected step '$step' to contain: $expected" >&2
     exit 1
   fi

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -71,6 +71,18 @@ assert_file_order() {
   fi
 }
 
+assert_step_contains() {
+  path=$1
+  step=$2
+  expected=$3
+
+  step_line=$(line_number "$path" "$step")
+  if [ -z "$step_line" ] || ! tail -n +"$step_line" "$path" | sed -n '1,8p' | grep -F -- "$expected" >/dev/null; then
+    echo "Expected step '$step' to contain: $expected" >&2
+    exit 1
+  fi
+}
+
 assert_package_path_exists() {
   package_path=$1
   path=$2
@@ -115,6 +127,8 @@ assert_file_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR 
 assert_file_contains "$RELEASE_WORKFLOW" '      - name: Dispatch release PR checks'
 assert_file_contains "$RELEASE_WORKFLOW" '        working-directory: Packages/src/Cli~'
 assert_file_contains "$RELEASE_WORKFLOW" '        run: go run ./cmd/dispatch-release-please-pr-checks'
+assert_step_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' "        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'"
+assert_step_contains "$RELEASE_WORKFLOW" '      - name: Dispatch release PR checks' "        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'"
 assert_file_order "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' '      - name: Dispatch release PR checks'
 assert_file_order "$RELEASE_WORKFLOW" '      - name: Sync native CLI binaries into release PR' '      - name: Dispatch release PR checks'
 

--- a/scripts/test-sync-release-please-go-cli-dist.sh
+++ b/scripts/test-sync-release-please-go-cli-dist.sh
@@ -26,6 +26,11 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
   exit 0
 fi
 
+if [ "$1" = "pr" ] && [ "$2" = "ready" ]; then
+  printf '%s\n' "$*" >> "$GH_LOG"
+  exit 0
+fi
+
 echo "unexpected gh command: $*" >&2
 exit 1
 MOCK_GH
@@ -105,12 +110,13 @@ run_case() {
   work_dir="$TMP_DIR/$name"
   mkdir -p "$work_dir"
   write_mock_commands "$work_dir"
-  touch "$work_dir/git.log" "$work_dir/script.log"
+  touch "$work_dir/gh.log" "$work_dir/git.log" "$work_dir/script.log"
 
   (
     cd "$work_dir"
     PATH="$work_dir/bin:$ORIGINAL_PATH" \
       GH_PR_LIST_JSON="$pr_json" \
+      GH_LOG="$work_dir/gh.log" \
       GIT_LOG="$work_dir/git.log" \
       SCRIPT_LOG="$work_dir/script.log" \
       DIST_DIRTY="$dist_dirty" \
@@ -154,6 +160,7 @@ test_current_dist_checks_without_commit() {
 
   assert_contains "$TMP_DIR/current-dist/script.log" "build"
   assert_contains "$TMP_DIR/current-dist/script.log" "check"
+  assert_contains "$TMP_DIR/current-dist/gh.log" "pr ready 1043 --repo hatayama/unity-cli-loop --undo"
   assert_contains "$TMP_DIR/current-dist/git.log" "fetch origin release-please--branches--v3-beta"
   assert_contains "$TMP_DIR/current-dist/git.log" "checkout -B release-please--branches--v3-beta FETCH_HEAD"
   assert_not_contains "$TMP_DIR/current-dist/git.log" "commit -m"
@@ -182,6 +189,7 @@ test_stale_dist_commits_and_pushes() {
 
   assert_contains "$TMP_DIR/stale-dist/script.log" "build"
   assert_contains "$TMP_DIR/stale-dist/script.log" "check"
+  assert_contains "$TMP_DIR/stale-dist/gh.log" "pr ready 1043 --repo hatayama/unity-cli-loop --undo"
   assert_contains "$TMP_DIR/stale-dist/git.log" "add Packages/src/Cli~/dist"
   assert_contains "$TMP_DIR/stale-dist/git.log" "commit -m chore(v3-beta): update native CLI binaries"
   assert_contains "$TMP_DIR/stale-dist/git.log" "push origin HEAD:release-please--branches--v3-beta"


### PR DESCRIPTION
## Summary
- Release PRs now stay in draft while generated native CLI updates are followed by the same build-and-test workflow used for normal PRs.
- Release automation now refuses to mark a release PR ready if its head commit changed while checks were running.

## User Impact
- Maintainers can add more release contents over time without merging a release PR that only passed checks before generated files changed.
- Failed or stale generated release updates are caught before the release PR becomes ready to merge.

## Changes
- Add Go-based release PR check dispatch automation for the v3-beta release workflow.
- Draft release PRs during native CLI dist sync and check dispatch, then mark them ready only after the matching workflow run succeeds.
- Guard same-second GitHub workflow timestamps and head-SHA changes before marking the PR ready.
- Document Go as the preferred language for non-trivial CI automation.

## Verification
- `go -C Packages/src/Cli~ test ./internal/automation`
- `go -C Packages/src/Cli~ test ./...`
- `scripts/test-release-please-config.sh`
- `scripts/test-sync-release-please-go-cli-dist.sh`
- `scripts/check-go-cli.sh`
- `codex-review v3-beta`