### PR TITLE
chore: Release PRs return to review after generated checks pass

### DIFF
--- a/Packages/src/Cli~/internal/automation/release_pr_checks.go
+++ b/Packages/src/Cli~/internal/automation/release_pr_checks.go
@@ -80,20 +80,20 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 		return 1
 	}
 
-	runID, err := findDispatchedReleasePRCheckRun(ctx, config, releasePR, dispatchedAt)
+	run, err := findDispatchedReleasePRCheckRun(ctx, config, releasePR, dispatchedAt)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
 	}
 
-	writeReleasePRCheckLine(stdout, fmt.Sprintf("Watching %s run %d for release PR #%d.", config.workflow, runID, releasePR.Number))
-	err = watchReleasePRCheckRun(ctx, config, runID)
+	writeReleasePRCheckLine(stdout, fmt.Sprintf("Watching %s run %d for release PR #%d.", config.workflow, run.DatabaseID, releasePR.Number))
+	err = watchReleasePRCheckRun(ctx, config, run.DatabaseID)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
 	}
 
-	err = verifyReleasePRCheckHeadUnchanged(ctx, config, releasePR)
+	err = verifyReleasePRCheckHeadMatchesRun(ctx, config, releasePR, run.HeadSHA)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
@@ -242,23 +242,33 @@ func dispatchReleasePRCheckWorkflow(ctx context.Context, config releasePRCheckCo
 	return err
 }
 
-func findDispatchedReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest, dispatchedAt time.Time) (int64, error) {
+func findDispatchedReleasePRCheckRun(
+	ctx context.Context,
+	config releasePRCheckConfig,
+	releasePR releasePullRequest,
+	dispatchedAt time.Time,
+) (releaseWorkflowRun, error) {
 	for attempt := 0; attempt < config.lookupAttempts; attempt++ {
-		runID, found, err := latestReleasePRCheckRun(ctx, config, releasePR, dispatchedAt)
+		run, found, err := latestReleasePRCheckRun(ctx, config, releasePR, dispatchedAt)
 		if err != nil {
-			return 0, err
+			return releaseWorkflowRun{}, err
 		}
 		if found {
-			return runID, nil
+			return run, nil
 		}
 		if attempt+1 < config.lookupAttempts {
 			releasePRCheckSleep(time.Duration(config.lookupIntervalSeconds) * time.Second)
 		}
 	}
-	return 0, fmt.Errorf("could not find dispatched %s workflow run for %s", config.workflow, releasePR.HeadRefOID)
+	return releaseWorkflowRun{}, fmt.Errorf("could not find dispatched %s workflow run for %s", config.workflow, releasePR.HeadRefOID)
 }
 
-func latestReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest, dispatchedAt time.Time) (int64, bool, error) {
+func latestReleasePRCheckRun(
+	ctx context.Context,
+	config releasePRCheckConfig,
+	releasePR releasePullRequest,
+	dispatchedAt time.Time,
+) (releaseWorkflowRun, bool, error) {
 	output, err := runReleasePRCheckOutput(
 		ctx,
 		"gh",
@@ -278,25 +288,22 @@ func latestReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, r
 		"20",
 	)
 	if err != nil {
-		return 0, false, err
+		return releaseWorkflowRun{}, false, err
 	}
 
 	runs := []releaseWorkflowRun{}
 	err = json.Unmarshal([]byte(output), &runs)
 	if err != nil {
-		return 0, false, fmt.Errorf("failed to parse workflow runs: %w", err)
+		return releaseWorkflowRun{}, false, fmt.Errorf("failed to parse workflow runs: %w", err)
 	}
 
 	var latestRun releaseWorkflowRun
 	var latestCreatedAt time.Time
 	found := false
 	for _, run := range runs {
-		if run.HeadSHA != releasePR.HeadRefOID {
-			continue
-		}
 		createdAt, err := time.Parse(time.RFC3339, run.CreatedAt)
 		if err != nil {
-			return 0, false, fmt.Errorf("failed to parse workflow run createdAt %q: %w", run.CreatedAt, err)
+			return releaseWorkflowRun{}, false, fmt.Errorf("failed to parse workflow run createdAt %q: %w", run.CreatedAt, err)
 		}
 		if createdAt.Before(dispatchedAt) {
 			continue
@@ -308,9 +315,9 @@ func latestReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, r
 		}
 	}
 	if !found {
-		return 0, false, nil
+		return releaseWorkflowRun{}, false, nil
 	}
-	return latestRun.DatabaseID, true, nil
+	return latestRun, true, nil
 }
 
 func watchReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, runID int64) error {
@@ -330,7 +337,12 @@ func watchReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, ru
 	return err
 }
 
-func verifyReleasePRCheckHeadUnchanged(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) error {
+func verifyReleasePRCheckHeadMatchesRun(
+	ctx context.Context,
+	config releasePRCheckConfig,
+	releasePR releasePullRequest,
+	checkedHeadSHA string,
+) error {
 	currentReleasePR, found, err := findReleasePRCheckPullRequest(ctx, config)
 	if err != nil {
 		return err
@@ -341,8 +353,8 @@ func verifyReleasePRCheckHeadUnchanged(ctx context.Context, config releasePRChec
 	if currentReleasePR.Number != releasePR.Number {
 		return fmt.Errorf("pending release PR changed from #%d to #%d before marking ready", releasePR.Number, currentReleasePR.Number)
 	}
-	if currentReleasePR.HeadRefOID != releasePR.HeadRefOID {
-		return fmt.Errorf("release PR #%d head changed from %s to %s before marking ready", releasePR.Number, releasePR.HeadRefOID, currentReleasePR.HeadRefOID)
+	if currentReleasePR.HeadRefOID != checkedHeadSHA {
+		return fmt.Errorf("release PR #%d head changed from %s to %s before marking ready", releasePR.Number, checkedHeadSHA, currentReleasePR.HeadRefOID)
 	}
 	return nil
 }

--- a/Packages/src/Cli~/internal/automation/release_pr_checks_test.go
+++ b/Packages/src/Cli~/internal/automation/release_pr_checks_test.go
@@ -74,6 +74,22 @@ func TestReleasePRChecksAcceptSameSecondRunAfterDispatch(t *testing.T) {
 	assertReleasePRCheckLogContainsLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
 }
 
+// Verifies that a stale PR head SHA before dispatch does not hide successful checks for the updated branch head.
+func TestReleasePRChecksUseDispatchedRunHeadWhenPRListReturnsStaleHead(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:           `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"release123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		prListJSONAfterWatch: `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"dist456","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		runListJSON:          `[{"databaseId":4242,"headSha":"dist456","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
+		runWatchStatus:       "0",
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertReleasePRCheckLogContains(t, result.stdout, "Watching build-and-test.yml run 4242 for release PR #1043.")
+	assertReleasePRCheckLogContainsLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
+}
+
 // Verifies that release-looking PRs are ignored without a release-please branch.
 func TestReleasePRChecksIgnoreManualReleasePR(t *testing.T) {
 	result := runReleasePRCheckCase(t, releasePRCheckCase{


### PR DESCRIPTION
## Summary
- Release PRs no longer stay in draft when generated native CLI checks are dispatched for the updated branch head.
- Draft protection is still kept while checks run, and stale checked results still block the PR from becoming ready.

## User Impact
- Before this change, a release PR could remain draft even after its generated check workflow passed, because the automation was still looking for an older head SHA.
- After this change, release PRs return to review once the dispatched check run succeeds for the current branch head.

## Changes
- Track the head SHA from the dispatched workflow run instead of trusting the first PR list response.
- Verify the current release PR head against the successful workflow run head before marking it ready.
- Add a regression test for stale PR head data after generated release commits.

## Verification
- `go -C Packages/src/Cli~ test ./internal/automation -run TestReleasePRChecksUseDispatchedRunHeadWhenPRListReturnsStaleHead -count=1`
- `go -C Packages/src/Cli~ test ./internal/automation -run 'TestReleasePRChecks(UseDispatchedRunHeadWhenPRListReturnsStaleHead|FailWhenHeadChangesBeforeReady|DispatchAndMarkReady)' -count=1`
- `go -C Packages/src/Cli~ test ./internal/automation ./internal/architecture -count=1`
- `scripts/test-release-please-config.sh && scripts/test-sync-release-please-go-cli-dist.sh`
- `scripts/check-go-cli.sh`