### PR TITLE
chore: Stabilize package release sync after native CLI publishing

### DIFF
--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -21,6 +21,7 @@ on:
         default: false
 
 permissions:
+  actions: write
   contents: write
   id-token: write
   attestations: write
@@ -258,6 +259,14 @@ jobs:
               gh release edit "${RELEASE_TAG}" --draft=false
               ;;
           esac
+
+      - name: Dispatch release-please after native CLI publish
+        if: github.event_name == 'push' && steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: ${{ github.ref_name }}
+        run: |
+          gh workflow run release-please.yml --ref "${TARGET_BRANCH}" -f branch="${TARGET_BRANCH}"
 
       - name: Sync release-please package releases
         id: package_release_sync

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -334,7 +334,7 @@ wait_for_cli_release_ready() {
     sleep_seconds=$delay_seconds
     if [ "$delay_seconds" -le 0 ]; then
       delay_seconds=1
-      sleep_seconds=0
+      sleep_seconds=1
     fi
     if [ "$delay_seconds" -gt "$remaining_seconds" ]; then
       delay_seconds=$remaining_seconds

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -229,14 +229,49 @@ create_package_release() {
     exit 1
   fi
 
+  create_error_file="$TMP_DIR/create-release-error.txt"
+  set +e
   gh release create "$release_tag" \
     --repo "$REPO_FULL_NAME" \
     --title "$release_tag" \
     --notes-file "$notes_file" \
     --target "$target_sha" \
-    $prerelease_flag
+    $prerelease_flag 2>"$create_error_file"
 
-  echo "Created release-please package release $release_tag at $target_sha."
+  release_created=$?
+  set -e
+  if [ "$release_created" -eq 0 ]; then
+    rm -f "$create_error_file"
+    echo "Created release-please package release $release_tag at $target_sha."
+    return
+  fi
+
+  create_error=$(cat "$create_error_file")
+  rm -f "$create_error_file"
+
+  set +e
+  release_data=$(release_json "$release_tag")
+  release_status=$?
+  set -e
+
+  case "$release_status" in
+    0)
+      ensure_release_points_to_commit "$release_tag" "$target_sha" "$release_data"
+      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
+      if [ "$is_draft" != "false" ]; then
+        publish_existing_draft_release "$release_tag" "$version"
+      else
+        echo "Release $release_tag was created by another workflow."
+      fi
+      ;;
+    1)
+      printf '%s\n' "$create_error" >&2
+      exit 1
+      ;;
+    *)
+      exit "$release_status"
+      ;;
+  esac
 }
 
 release_has_all_cli_assets() {

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -276,6 +276,44 @@ cli_release_is_ready() {
   esac
 }
 
+wait_for_cli_release_ready() {
+  release_tag=$1
+  timeout_seconds=${CLI_RELEASE_WAIT_TIMEOUT_SECONDS:-600}
+  interval_seconds=${CLI_RELEASE_WAIT_INTERVAL_SECONDS:-30}
+  elapsed_seconds=0
+
+  while :; do
+    if cli_release_is_ready "$release_tag"; then
+      if [ "$elapsed_seconds" -gt 0 ]; then
+        echo "CLI release $release_tag is now published with complete assets."
+      fi
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      return 1
+    fi
+
+    remaining_seconds=$((timeout_seconds - elapsed_seconds))
+    delay_seconds=$interval_seconds
+    sleep_seconds=$delay_seconds
+    if [ "$delay_seconds" -le 0 ]; then
+      delay_seconds=1
+      sleep_seconds=0
+    fi
+    if [ "$delay_seconds" -gt "$remaining_seconds" ]; then
+      delay_seconds=$remaining_seconds
+      sleep_seconds=$delay_seconds
+    fi
+
+    echo "CLI release $release_tag is not published with complete assets yet; waiting ${delay_seconds}s before retry."
+    if [ "$sleep_seconds" -gt 0 ]; then
+      sleep "$sleep_seconds"
+    fi
+    elapsed_seconds=$((elapsed_seconds + delay_seconds))
+  done
+}
+
 release_tag_from_config() {
   package_path=$1
   version=$2
@@ -306,7 +344,7 @@ fetch_release_refs
 cli_version=$(jq -r --arg package_path "$CLI_PACKAGE_PATH" '.[$package_path] // empty' "$MANIFEST")
 if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packages[$package_path] != null' "$CONFIG" >/dev/null; then
   cli_release_tag=$(release_tag_from_config "$CLI_PACKAGE_PATH" "$cli_version")
-  if ! cli_release_is_ready "$cli_release_tag"; then
+  if ! wait_for_cli_release_ready "$cli_release_tag"; then
     mark_package_release_sync_ready false
     echo "CLI release $cli_release_tag is not published with complete assets; package release sync will wait."
     exit 0

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -32,6 +32,7 @@ assert_before() {
 }
 
 test_attestation_permissions() {
+  assert_contains "$WORKFLOW" "  actions: write"
   assert_contains "$WORKFLOW" "  id-token: write"
   assert_contains "$WORKFLOW" "  attestations: write"
   assert_contains "$WORKFLOW" "  artifact-metadata: write"
@@ -65,7 +66,17 @@ test_release_tagged_installer_scripts_are_verified() {
   assert_before "$WORKFLOW" "      - name: Verify release-tagged installer scripts" "      - name: Upload native CLI assets"
 }
 
+test_release_please_is_dispatched_after_publish() {
+  assert_contains "$WORKFLOW" "      - name: Dispatch release-please after native CLI publish"
+  assert_contains "$WORKFLOW" "        if: github.event_name == 'push' && steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'"
+  assert_contains "$WORKFLOW" '          TARGET_BRANCH: ${{ github.ref_name }}'
+  assert_contains "$WORKFLOW" '          gh workflow run release-please.yml --ref "${TARGET_BRANCH}" -f branch="${TARGET_BRANCH}"'
+  assert_before "$WORKFLOW" "      - name: Publish draft release" "      - name: Dispatch release-please after native CLI publish"
+  assert_before "$WORKFLOW" "      - name: Dispatch release-please after native CLI publish" "      - name: Sync release-please package releases"
+}
+
 test_attestation_permissions
 test_release_assets_are_attested
 test_release_asset_attestations_are_verified
 test_release_tagged_installer_scripts_are_verified
+test_release_please_is_dispatched_after_publish

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -78,11 +78,26 @@ if [ "$1" = "release" ] && [ "$2" = "view" ]; then
     exit 0
   fi
 
+  if [ -n "${CREATE_RELEASE_RACE_TAG:-}" ] && [ "$tag" = "$CREATE_RELEASE_RACE_TAG" ]; then
+    race_file="$GH_LOG.release-created-by-other-workflow"
+    if [ -f "$race_file" ]; then
+      printf '{"isDraft":false,"targetCommitish":"%s","assets":[]}\n' "$CREATE_RELEASE_RACE_TARGET"
+      exit 0
+    fi
+  fi
+
   echo "release not found" >&2
   exit 1
 fi
 
 if [ "$1" = "release" ] && [ "$2" = "create" ]; then
+  tag=$3
+  if [ -n "${CREATE_RELEASE_RACE_TAG:-}" ] && [ "$tag" = "$CREATE_RELEASE_RACE_TAG" ]; then
+    touch "$GH_LOG.release-created-by-other-workflow"
+    echo "release already exists" >&2
+    exit 1
+  fi
+
   exit 0
 fi
 
@@ -257,6 +272,8 @@ run_sync() {
     CLI_RELEASE_WAIT_TIMEOUT_SECONDS="$cli_release_wait_timeout" \
     CLI_RELEASE_WAIT_INTERVAL_SECONDS="$cli_release_wait_interval" \
     CLI_RELEASE_READY_AFTER_ATTEMPTS="$cli_release_ready_after_attempts" \
+    CREATE_RELEASE_RACE_TAG="${CREATE_RELEASE_RACE_TAG:-}" \
+    CREATE_RELEASE_RACE_TARGET="${CREATE_RELEASE_RACE_TARGET:-}" \
     GITHUB_OUTPUT="$work_dir/github-output.txt" \
     GITHUB_REPOSITORY=hatayama/unity-cli-loop \
     ULOOP_REPO_ROOT="$work_dir" \
@@ -346,6 +363,19 @@ test_retries_until_cli_assets_are_ready() {
   assert_contains "$work_dir/github-output.txt" "ready=true"
 }
 
+# Verifies a root package release created by another workflow during creation is reused.
+test_concurrent_root_release_creation_is_reused() {
+  work_dir=$(create_release_repo concurrent-root-create)
+  release_sha=$(cat "$work_dir/release-sha.txt")
+
+  CREATE_RELEASE_RACE_TAG=v3.0.0-beta.6 CREATE_RELEASE_RACE_TARGET="$release_sha" run_sync "$work_dir" "" false ""
+
+  assert_contains "$work_dir/output.txt" "Release v3.0.0-beta.6 was created by another workflow."
+  assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
+  assert_not_contains "$work_dir/stderr.txt" "release already exists"
+  assert_contains "$work_dir/github-output.txt" "ready=true"
+}
+
 test_creates_missing_root_release_from_release_commit
 test_existing_root_release_is_reused
 test_existing_root_release_target_branch_resolves_via_origin
@@ -353,3 +383,4 @@ test_existing_draft_root_release_is_published
 test_waits_for_cli_release_before_creating_root_release
 test_waits_for_cli_assets_before_creating_root_release
 test_retries_until_cli_assets_are_ready
+test_concurrent_root_release_creation_is_reused

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -40,6 +40,19 @@ asset_json() {
 if [ "$1" = "release" ] && [ "$2" = "view" ]; then
   tag=$3
   if [ "$tag" = "cli-v3.0.0-beta.6" ]; then
+    if [ -n "${CLI_RELEASE_READY_AFTER_ATTEMPTS:-}" ]; then
+      attempt_file="$GH_LOG.cli-release-attempts"
+      attempt=1
+      if [ -f "$attempt_file" ]; then
+        attempt=$(($(cat "$attempt_file") + 1))
+      fi
+      printf '%s\n' "$attempt" > "$attempt_file"
+      if [ "$attempt" -lt "$CLI_RELEASE_READY_AFTER_ATTEMPTS" ]; then
+        echo "release not found" >&2
+        exit 1
+      fi
+    fi
+
     case "${CLI_RELEASE_STATE:-published}" in
       published)
         printf '{"isDraft":false,"targetCommitish":"%s","assets":' "${CLI_RELEASE_TARGET:-cli-release-sha}"
@@ -226,6 +239,9 @@ run_sync() {
   existing_target=$4
   cli_release_state=${5:-published}
   cli_release_assets=${6:-complete}
+  cli_release_wait_timeout=${7:-0}
+  cli_release_wait_interval=${8:-0}
+  cli_release_ready_after_attempts=${9:-}
 
   touch "$work_dir/gh.log"
   touch "$work_dir/github-output.txt"
@@ -238,6 +254,9 @@ run_sync() {
     EXISTING_RELEASE_TARGET="$existing_target" \
     CLI_RELEASE_STATE="$cli_release_state" \
     CLI_RELEASE_ASSETS="$cli_release_assets" \
+    CLI_RELEASE_WAIT_TIMEOUT_SECONDS="$cli_release_wait_timeout" \
+    CLI_RELEASE_WAIT_INTERVAL_SECONDS="$cli_release_wait_interval" \
+    CLI_RELEASE_READY_AFTER_ATTEMPTS="$cli_release_ready_after_attempts" \
     GITHUB_OUTPUT="$work_dir/github-output.txt" \
     GITHUB_REPOSITORY=hatayama/unity-cli-loop \
     ULOOP_REPO_ROOT="$work_dir" \
@@ -313,9 +332,24 @@ test_waits_for_cli_assets_before_creating_root_release() {
   assert_contains "$work_dir/github-output.txt" "ready=false"
 }
 
+# Verifies the release sync waits for a concurrently publishing CLI release before creating package releases.
+test_retries_until_cli_assets_are_ready() {
+  work_dir=$(create_release_repo retries-until-cli-ready)
+  release_sha=$(cat "$work_dir/release-sha.txt")
+
+  run_sync "$work_dir" "" false "" published complete 3 0 3
+
+  assert_contains "$work_dir/output.txt" "CLI release cli-v3.0.0-beta.6 is not published with complete assets yet; waiting 1s before retry."
+  assert_contains "$work_dir/output.txt" "CLI release cli-v3.0.0-beta.6 is now published with complete assets."
+  assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
+  assert_contains "$work_dir/gh.log" "--target $release_sha --prerelease"
+  assert_contains "$work_dir/github-output.txt" "ready=true"
+}
+
 test_creates_missing_root_release_from_release_commit
 test_existing_root_release_is_reused
 test_existing_root_release_target_branch_resolves_via_origin
 test_existing_draft_root_release_is_published
 test_waits_for_cli_release_before_creating_root_release
 test_waits_for_cli_assets_before_creating_root_release
+test_retries_until_cli_assets_are_ready

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -110,6 +110,15 @@ exit 1
 MOCK_GH
 
   chmod +x "$mock_bin/gh"
+
+  cat > "$mock_bin/sleep" <<'MOCK_SLEEP'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$SLEEP_LOG"
+MOCK_SLEEP
+
+  chmod +x "$mock_bin/sleep"
 }
 
 write_release_files() {
@@ -260,10 +269,12 @@ run_sync() {
 
   touch "$work_dir/gh.log"
   touch "$work_dir/github-output.txt"
+  touch "$work_dir/sleep.log"
   write_mock_commands "$work_dir"
 
   PATH="$work_dir/bin:$ORIGINAL_PATH" \
     GH_LOG="$work_dir/gh.log" \
+    SLEEP_LOG="$work_dir/sleep.log" \
     EXISTING_RELEASE_TAG="$existing_tag" \
     EXISTING_RELEASE_DRAFT="$existing_draft" \
     EXISTING_RELEASE_TARGET="$existing_target" \
@@ -357,6 +368,7 @@ test_retries_until_cli_assets_are_ready() {
   run_sync "$work_dir" "" false "" published complete 3 0 3
 
   assert_contains "$work_dir/output.txt" "CLI release cli-v3.0.0-beta.6 is not published with complete assets yet; waiting 1s before retry."
+  assert_contains "$work_dir/sleep.log" "1"
   assert_contains "$work_dir/output.txt" "CLI release cli-v3.0.0-beta.6 is now published with complete assets."
   assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
   assert_contains "$work_dir/gh.log" "--target $release_sha --prerelease"


### PR DESCRIPTION
## Summary
- Package release automation now waits for the matching native CLI release assets before continuing.
- Native CLI publishing now retriggers release-please once the CLI release is ready, so the package release PR can be opened without manual reruns.

## User Impact
- Maintainers no longer have to manually rerun release-please when it starts before native CLI assets finish publishing.
- Concurrent release workflow runs now reuse an already-created package release instead of failing nondeterministically.

## Changes
- Add a readiness wait for the matching CLI release before syncing package releases.
- Dispatch release-please after native CLI publishing completes on push events.
- Make package release creation safe when another workflow creates the same release first.
- Extend release automation tests to cover readiness retries, workflow dispatch, and concurrent package release creation.

## Verification
- scripts/test-release-please-config.sh
- scripts/test-native-cli-publish-workflow.sh
- scripts/test-sync-release-please-package-releases.sh
- git diff --check
- ~/.codex/skills/codex-review/scripts/codex-review --parallel-tests "scripts/test-release-please-config.sh && scripts/test-native-cli-publish-workflow.sh && scripts/test-sync-release-please-package-releases.sh && git diff --check" v3-beta
