### PR TITLE
fix: Prevent interrupted test runs from changing Play Mode settings

### DIFF
--- a/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
+++ b/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
@@ -19,6 +19,7 @@ namespace io.github.hatayama.uLoopMCP
             _originalOptions = EditorSettings.enterPlayModeOptions;
             _originalSettings = McpEditorSettings.GetSettings();
 
+            DomainReloadDisableScope.ResetActiveScopeCountForTests();
             DomainReloadDisableScopeRecovery.ClearPendingRestore();
         }
 
@@ -27,6 +28,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             EditorSettings.enterPlayModeOptionsEnabled = _originalEnabled;
             EditorSettings.enterPlayModeOptions = _originalOptions;
+            DomainReloadDisableScope.ResetActiveScopeCountForTests();
             McpEditorSettings.SaveSettings(_originalSettings);
         }
 
@@ -41,6 +43,27 @@ namespace io.github.hatayama.uLoopMCP
                 Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
                 Assert.That(McpEditorSettings.GetSettings().domainReloadDisableScopeRestorePending, Is.True);
             }
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(McpEditorSettings.GetSettings().domainReloadDisableScopeRestorePending, Is.False);
+        }
+
+        [Test]
+        public void Dispose_KeepsDomainReloadDisabled_UntilLastNestedScopeDisposes()
+        {
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+
+            DomainReloadDisableScope outerScope = new DomainReloadDisableScope();
+            DomainReloadDisableScope innerScope = new DomainReloadDisableScope();
+
+            innerScope.Dispose();
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.True);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
+            Assert.That(McpEditorSettings.GetSettings().domainReloadDisableScopeRestorePending, Is.True);
+
+            outerScope.Dispose();
 
             Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
             Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
@@ -71,6 +94,7 @@ namespace io.github.hatayama.uLoopMCP
 
             DomainReloadDisableScope abandonedScope = new DomainReloadDisableScope();
             Assert.That(McpEditorSettings.GetSettings().domainReloadDisableScopeRestorePending, Is.True);
+            DomainReloadDisableScope.ResetActiveScopeCountForTests();
 
             DomainReloadDisableScope nextScope = new DomainReloadDisableScope();
             McpEditorSettingsData settings = McpEditorSettings.GetSettings();

--- a/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
+++ b/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
@@ -1,0 +1,95 @@
+using NUnit.Framework;
+using UnityEditor;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Tests for restoring Enter Play Mode settings changed by DomainReloadDisableScope.
+    /// </summary>
+    public class DomainReloadDisableScopeTests
+    {
+        private bool _originalEnabled;
+        private EnterPlayModeOptions _originalOptions;
+        private McpEditorSettingsData _originalSettings;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _originalEnabled = EditorSettings.enterPlayModeOptionsEnabled;
+            _originalOptions = EditorSettings.enterPlayModeOptions;
+            _originalSettings = McpEditorSettings.GetSettings();
+
+            DomainReloadDisableScopeRecovery.ClearPendingRestore();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            EditorSettings.enterPlayModeOptionsEnabled = _originalEnabled;
+            EditorSettings.enterPlayModeOptions = _originalOptions;
+            McpEditorSettings.SaveSettings(_originalSettings);
+        }
+
+        [Test]
+        public void Dispose_RestoresOriginalSettingsAndClearsPendingRestore()
+        {
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+
+            using (DomainReloadDisableScope scope = new DomainReloadDisableScope())
+            {
+                Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.True);
+                Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
+                Assert.That(McpEditorSettings.GetSettings().domainReloadDisableScopeRestorePending, Is.True);
+            }
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(McpEditorSettings.GetSettings().domainReloadDisableScopeRestorePending, Is.False);
+        }
+
+        [Test]
+        public void RestoreIfPending_RestoresOriginalSettings_WhenScopeWasAbandoned()
+        {
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+
+            DomainReloadDisableScope scope = new DomainReloadDisableScope();
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.True);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
+
+            DomainReloadDisableScopeRecovery.RestoreIfPending();
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(McpEditorSettings.GetSettings().domainReloadDisableScopeRestorePending, Is.False);
+            System.GC.KeepAlive(scope);
+        }
+
+        [Test]
+        public void Constructor_RestoresPendingOriginalSettings_BeforeSavingNewRun()
+        {
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+
+            DomainReloadDisableScope abandonedScope = new DomainReloadDisableScope();
+            Assert.That(McpEditorSettings.GetSettings().domainReloadDisableScopeRestorePending, Is.True);
+
+            DomainReloadDisableScope nextScope = new DomainReloadDisableScope();
+            McpEditorSettingsData settings = McpEditorSettings.GetSettings();
+
+            Assert.That(settings.domainReloadDisableScopeOriginalOptionsEnabled, Is.False);
+            Assert.That(settings.domainReloadDisableScopeOriginalOptions, Is.EqualTo((int)EnterPlayModeOptions.None));
+
+            nextScope.Dispose();
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(McpEditorSettings.GetSettings().domainReloadDisableScopeRestorePending, Is.False);
+            System.GC.KeepAlive(abandonedScope);
+        }
+
+        private static void SetEnterPlayModeSettings(bool enabled, EnterPlayModeOptions options)
+        {
+            EditorSettings.enterPlayModeOptionsEnabled = enabled;
+            EditorSettings.enterPlayModeOptions = options;
+        }
+    }
+}

--- a/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs.meta
+++ b/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3271770aac19470ea8253e5d22ff6824
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -51,6 +51,9 @@ namespace io.github.hatayama.uLoopMCP
         public bool isReconnecting = false;
         public bool showReconnectingUI = false;
         public bool showPostCompileReconnectingUI = false;
+        public bool domainReloadDisableScopeRestorePending = false;
+        public bool domainReloadDisableScopeOriginalOptionsEnabled = false;
+        public int domainReloadDisableScopeOriginalOptions = (int)EnterPlayModeOptions.None;
         public int selectedEditorType = (int)McpEditorType.Cursor;
         public int connectionMode = (int)ConnectionMode.CLI;
         public float communicationLogHeight = McpUIConstants.DEFAULT_COMMUNICATION_LOG_HEIGHT;

--- a/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScope.cs
+++ b/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScope.cs
@@ -3,24 +3,23 @@ using UnityEditor;
 
 namespace io.github.hatayama.uLoopMCP
 {
+    /// <summary>
+    /// Temporarily disables domain reload while preserving the user's Enter Play Mode settings.
+    /// </summary>
     public class DomainReloadDisableScope : IDisposable
     {
-        private readonly bool _originalEnabled;
-        private readonly EnterPlayModeOptions _originalOptions;
-        
         public DomainReloadDisableScope()
         {
-            _originalEnabled = EditorSettings.enterPlayModeOptionsEnabled;
-            _originalOptions = EditorSettings.enterPlayModeOptions;
-            
+            DomainReloadDisableScopeRecovery.RestoreIfPending();
+            DomainReloadDisableScopeRecovery.SaveCurrentSettingsIfNeeded();
+
             EditorSettings.enterPlayModeOptionsEnabled = true;
             EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableDomainReload;
         }
         
         public void Dispose()
         {
-            EditorSettings.enterPlayModeOptionsEnabled = _originalEnabled;
-            EditorSettings.enterPlayModeOptions = _originalOptions;
+            DomainReloadDisableScopeRecovery.RestoreIfPending();
         }
     }
 }

--- a/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScope.cs
+++ b/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScope.cs
@@ -8,10 +8,18 @@ namespace io.github.hatayama.uLoopMCP
     /// </summary>
     public class DomainReloadDisableScope : IDisposable
     {
+        private static int _activeScopeCount;
+        private bool _disposed;
+
         public DomainReloadDisableScope()
         {
-            DomainReloadDisableScopeRecovery.RestoreIfPending();
-            DomainReloadDisableScopeRecovery.SaveCurrentSettingsIfNeeded();
+            if (_activeScopeCount == 0)
+            {
+                DomainReloadDisableScopeRecovery.RestoreIfPending();
+                DomainReloadDisableScopeRecovery.SaveCurrentSettingsIfNeeded();
+            }
+
+            _activeScopeCount++;
 
             EditorSettings.enterPlayModeOptionsEnabled = true;
             EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableDomainReload;
@@ -19,7 +27,24 @@ namespace io.github.hatayama.uLoopMCP
         
         public void Dispose()
         {
-            DomainReloadDisableScopeRecovery.RestoreIfPending();
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            System.Diagnostics.Debug.Assert(_activeScopeCount > 0, "active scope count must be positive before dispose");
+            _activeScopeCount--;
+
+            if (_activeScopeCount == 0)
+            {
+                DomainReloadDisableScopeRecovery.RestoreIfPending();
+            }
+        }
+
+        internal static void ResetActiveScopeCountForTests()
+        {
+            _activeScopeCount = 0;
         }
     }
 }

--- a/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScopeRecovery.cs
+++ b/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScopeRecovery.cs
@@ -1,0 +1,69 @@
+using UnityEditor;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Restores Enter Play Mode settings when DomainReloadDisableScope was interrupted.
+    /// </summary>
+    internal static class DomainReloadDisableScopeRecovery
+    {
+        [InitializeOnLoadMethod]
+        private static void RestorePendingSettingsOnEditorLoad()
+        {
+            if (AssetDatabase.IsAssetImportWorkerProcess())
+            {
+                return;
+            }
+
+            RestoreIfPending();
+        }
+
+        /// <summary>
+        /// Saves the current Enter Play Mode settings before DomainReloadDisableScope changes them.
+        /// </summary>
+        internal static void SaveCurrentSettingsIfNeeded()
+        {
+            McpEditorSettingsData settings = McpEditorSettings.GetSettings();
+            if (settings.domainReloadDisableScopeRestorePending)
+            {
+                return;
+            }
+
+            McpEditorSettings.UpdateSettings(current => current with
+            {
+                domainReloadDisableScopeRestorePending = true,
+                domainReloadDisableScopeOriginalOptionsEnabled = EditorSettings.enterPlayModeOptionsEnabled,
+                domainReloadDisableScopeOriginalOptions = (int)EditorSettings.enterPlayModeOptions
+            });
+        }
+
+        /// <summary>
+        /// Restores Enter Play Mode settings saved before DomainReloadDisableScope changed them.
+        /// </summary>
+        internal static void RestoreIfPending()
+        {
+            McpEditorSettingsData settings = McpEditorSettings.GetSettings();
+            if (!settings.domainReloadDisableScopeRestorePending)
+            {
+                return;
+            }
+
+            EditorSettings.enterPlayModeOptionsEnabled = settings.domainReloadDisableScopeOriginalOptionsEnabled;
+            EditorSettings.enterPlayModeOptions = (EnterPlayModeOptions)settings.domainReloadDisableScopeOriginalOptions;
+            ClearPendingRestore();
+        }
+
+        /// <summary>
+        /// Clears any saved Enter Play Mode settings pending restore.
+        /// </summary>
+        internal static void ClearPendingRestore()
+        {
+            McpEditorSettings.UpdateSettings(settings => settings with
+            {
+                domainReloadDisableScopeRestorePending = false,
+                domainReloadDisableScopeOriginalOptionsEnabled = false,
+                domainReloadDisableScopeOriginalOptions = (int)EnterPlayModeOptions.None
+            });
+        }
+    }
+}

--- a/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScopeRecovery.cs.meta
+++ b/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScopeRecovery.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 824972efbb024a6db39f172abd8781ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Play Mode test runs now restore Unity Enter Play Mode settings even when the run is interrupted before cleanup finishes.
- Nested test runs keep domain reload disabled until the last active run exits, avoiding premature restoration.

## User Impact
- Before this change, an interrupted PlayMode test run could leave Disable Domain Reload enabled in ProjectSettings/EditorSettings.asset and create a tracked settings diff.
- After this change, local recovery state restores the original settings on the next editor load or next scoped test run, keeping project settings clean.

## Changes
- Persist a local recovery marker in UserSettings/UnityMcpSettings.json instead of UnityEditor.SessionState so recovery survives editor restarts or killed processes.
- Restore pending Enter Play Mode settings during editor load and before a new scoped test run saves its original state.
- Track active nested scopes so settings restore only after the final scope is disposed.
- Add focused EditMode tests for normal cleanup, abandoned scopes, new-run recovery, and nested scope disposal.

## Verification
- node Packages/src/Cli~/dist/cli.bundle.cjs compile --force-recompile true --wait-for-domain-reload true --project-path <PROJECT_ROOT>
- node Packages/src/Cli~/dist/cli.bundle.cjs run-tests --test-mode EditMode --filter-type regex --filter-value io.github.hatayama.uLoopMCP.DomainReloadDisableScope --save-before-run false --project-path <PROJECT_ROOT>
- git diff --check origin/main...HEAD
- Confirmed ProjectSettings/EditorSettings.asset has no tracked diff.

Fixes #1243