### PR TITLE
fix: Interrupted PlayMode tests no longer leave domain reload disabled

### DIFF
--- a/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
+++ b/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
@@ -1,0 +1,166 @@
+using System.IO;
+
+using NUnit.Framework;
+using UnityEditor;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Test fixture that verifies Enter Play Mode settings recovery for DomainReloadDisableScope.
+    /// </summary>
+    public sealed class DomainReloadDisableScopeTests
+    {
+        private static readonly string MarkerFilePath = DomainReloadDisableScopeRecovery.MarkerFilePathForTests;
+        private static readonly string TempFilePath = DomainReloadDisableScopeRecovery.TempFilePathForTests;
+
+        private bool _originalEnabled;
+        private EnterPlayModeOptions _originalOptions;
+        private bool _markerFileExisted;
+        private string _markerFileContent;
+        private bool _tempFileExisted;
+        private string _tempFileContent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _originalEnabled = EditorSettings.enterPlayModeOptionsEnabled;
+            _originalOptions = EditorSettings.enterPlayModeOptions;
+            _markerFileExisted = File.Exists(MarkerFilePath);
+            _markerFileContent = _markerFileExisted ? File.ReadAllText(MarkerFilePath) : string.Empty;
+            _tempFileExisted = File.Exists(TempFilePath);
+            _tempFileContent = _tempFileExisted ? File.ReadAllText(TempFilePath) : string.Empty;
+
+            DomainReloadDisableScope.ResetActiveScopeCountForTests();
+            DomainReloadDisableScopeRecovery.ClearPendingRestoreForTests();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            EditorSettings.enterPlayModeOptionsEnabled = _originalEnabled;
+            EditorSettings.enterPlayModeOptions = _originalOptions;
+            DomainReloadDisableScope.ResetActiveScopeCountForTests();
+            DomainReloadDisableScopeRecovery.ClearPendingRestoreForTests();
+            RestoreFile(MarkerFilePath, _markerFileExisted, _markerFileContent);
+            RestoreFile(TempFilePath, _tempFileExisted, _tempFileContent);
+        }
+
+        [Test]
+        public void Dispose_RestoresOriginalSettingsAndDeletesMarkerFile()
+        {
+            // Verifies that a completed scope restores settings and removes its recovery marker.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+
+            using (DomainReloadDisableScope scope = new DomainReloadDisableScope())
+            {
+                Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.True);
+                Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
+                Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.True);
+            }
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+        }
+
+        [Test]
+        public void Dispose_KeepsDomainReloadDisabled_UntilLastNestedScopeDisposes()
+        {
+            // Verifies that nested scopes restore settings only after the final scope exits.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+
+            DomainReloadDisableScope outerScope = new DomainReloadDisableScope();
+            DomainReloadDisableScope innerScope = new DomainReloadDisableScope();
+
+            innerScope.Dispose();
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.True);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.True);
+
+            outerScope.Dispose();
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+        }
+
+        [Test]
+        public void RestoreIfPending_RestoresOriginalSettings_WhenScopeWasAbandoned()
+        {
+            // Verifies that a marker left by an abandoned scope can restore the original settings.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+
+            DomainReloadDisableScope scope = new DomainReloadDisableScope();
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.True);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
+
+            DomainReloadDisableScopeRecovery.RestoreIfPending();
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+            System.GC.KeepAlive(scope);
+        }
+
+        [Test]
+        public void Constructor_RestoresStaleMarker_BeforeSavingNewRunMarker()
+        {
+            // Verifies that stale recovery state is consumed before the next run records its baseline.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+
+            DomainReloadDisableScope abandonedScope = new DomainReloadDisableScope();
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.True);
+            DomainReloadDisableScope.ResetActiveScopeCountForTests();
+
+            DomainReloadDisableScope nextScope = new DomainReloadDisableScope();
+            DomainReloadDisableScopeRecoveryData markerData = DomainReloadDisableScopeRecovery.ReadMarkerDataForTests();
+
+            Assert.That(markerData.originalOptionsEnabled, Is.False);
+            Assert.That(markerData.originalOptions, Is.EqualTo((int)EnterPlayModeOptions.None));
+
+            nextScope.Dispose();
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+            System.GC.KeepAlive(abandonedScope);
+        }
+
+        [Test]
+        public void RestoreIfPending_LeavesNoMarkerFile_AfterSuccessfulRestore()
+        {
+            // Verifies that successful recovery deletes the marker instead of saving a cleared state.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+            DomainReloadDisableScope scope = new DomainReloadDisableScope();
+
+            DomainReloadDisableScopeRecovery.RestoreIfPending();
+
+            Assert.That(File.Exists(MarkerFilePath), Is.False);
+            Assert.That(File.Exists(TempFilePath), Is.False);
+            System.GC.KeepAlive(scope);
+        }
+
+        private static void SetEnterPlayModeSettings(bool enabled, EnterPlayModeOptions options)
+        {
+            EditorSettings.enterPlayModeOptionsEnabled = enabled;
+            EditorSettings.enterPlayModeOptions = options;
+        }
+
+        private static void RestoreFile(string filePath, bool fileExisted, string fileContent)
+        {
+            if (!fileExisted)
+            {
+                return;
+            }
+
+            string directoryPath = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(filePath, fileContent);
+        }
+    }
+}

--- a/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
+++ b/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
@@ -128,6 +128,29 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public void Constructor_RestoresStaleMarker_WhenPreviousScopeWasAbandonedInSameEditorSession()
+        {
+            // Verifies same-session recovery after the abandoned scope is no longer alive.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+
+            System.WeakReference abandonedScopeReference = CreateAbandonedScopeReference();
+            CollectGarbage();
+            Assert.That(abandonedScopeReference.IsAlive, Is.False);
+
+            DomainReloadDisableScope nextScope = new DomainReloadDisableScope();
+            DomainReloadDisableScopeRecoveryData markerData = DomainReloadDisableScopeRecovery.ReadMarkerDataForTests();
+
+            Assert.That(markerData.originalOptionsEnabled, Is.False);
+            Assert.That(markerData.originalOptions, Is.EqualTo((int)EnterPlayModeOptions.None));
+
+            nextScope.Dispose();
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+        }
+
+        [Test]
         public void RestoreIfPending_LeavesNoMarkerFile_AfterSuccessfulRestore()
         {
             // Verifies that successful recovery deletes the marker instead of saving a cleared state.
@@ -145,6 +168,22 @@ namespace io.github.hatayama.uLoopMCP
         {
             EditorSettings.enterPlayModeOptionsEnabled = enabled;
             EditorSettings.enterPlayModeOptions = options;
+        }
+
+        private static System.WeakReference CreateAbandonedScopeReference()
+        {
+            DomainReloadDisableScope scope = new DomainReloadDisableScope();
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.True);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.True);
+            return new System.WeakReference(scope);
+        }
+
+        private static void CollectGarbage()
+        {
+            System.GC.Collect();
+            System.GC.WaitForPendingFinalizers();
+            System.GC.Collect();
         }
 
         private static void RestoreFile(string filePath, bool fileExisted, string fileContent)

--- a/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs.meta
+++ b/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 252ce50bd4844006a19e039419a86783
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScope.cs
+++ b/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScope.cs
@@ -1,26 +1,51 @@
 using System;
 using UnityEditor;
+using UnityEngine;
 
 namespace io.github.hatayama.uLoopMCP
 {
+    /// <summary>
+    /// Temporarily disables domain reload while preserving the user's Enter Play Mode settings.
+    /// </summary>
     public class DomainReloadDisableScope : IDisposable
     {
-        private readonly bool _originalEnabled;
-        private readonly EnterPlayModeOptions _originalOptions;
-        
+        private static int _activeScopeCount;
+        private bool _disposed;
+
         public DomainReloadDisableScope()
         {
-            _originalEnabled = EditorSettings.enterPlayModeOptionsEnabled;
-            _originalOptions = EditorSettings.enterPlayModeOptions;
-            
+            if (_activeScopeCount == 0)
+            {
+                DomainReloadDisableScopeRecovery.RestoreIfPending();
+                DomainReloadDisableScopeRecovery.SaveCurrentSettings();
+            }
+
+            _activeScopeCount++;
+
             EditorSettings.enterPlayModeOptionsEnabled = true;
             EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableDomainReload;
         }
         
         public void Dispose()
         {
-            EditorSettings.enterPlayModeOptionsEnabled = _originalEnabled;
-            EditorSettings.enterPlayModeOptions = _originalOptions;
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            Debug.Assert(_activeScopeCount > 0, "active scope count must be positive before dispose");
+            _activeScopeCount--;
+
+            if (_activeScopeCount == 0)
+            {
+                DomainReloadDisableScopeRecovery.RestoreIfPending();
+            }
+        }
+
+        internal static void ResetActiveScopeCountForTests()
+        {
+            _activeScopeCount = 0;
         }
     }
 }

--- a/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScope.cs
+++ b/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScope.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -9,18 +10,19 @@ namespace io.github.hatayama.uLoopMCP
     /// </summary>
     public class DomainReloadDisableScope : IDisposable
     {
-        private static int _activeScopeCount;
+        private static readonly List<WeakReference> ActiveScopeReferences = new List<WeakReference>();
         private bool _disposed;
 
         public DomainReloadDisableScope()
         {
-            if (_activeScopeCount == 0)
+            PruneInactiveScopeReferences();
+            if (ActiveScopeReferences.Count == 0)
             {
                 DomainReloadDisableScopeRecovery.RestoreIfPending();
                 DomainReloadDisableScopeRecovery.SaveCurrentSettings();
             }
 
-            _activeScopeCount++;
+            ActiveScopeReferences.Add(new WeakReference(this));
 
             EditorSettings.enterPlayModeOptionsEnabled = true;
             EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableDomainReload;
@@ -34,10 +36,10 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             _disposed = true;
-            Debug.Assert(_activeScopeCount > 0, "active scope count must be positive before dispose");
-            _activeScopeCount--;
+            bool removed = RemoveScopeReference(this);
+            Debug.Assert(removed, "active scope reference must exist before dispose");
 
-            if (_activeScopeCount == 0)
+            if (ActiveScopeReferences.Count == 0)
             {
                 DomainReloadDisableScopeRecovery.RestoreIfPending();
             }
@@ -45,7 +47,41 @@ namespace io.github.hatayama.uLoopMCP
 
         internal static void ResetActiveScopeCountForTests()
         {
-            _activeScopeCount = 0;
+            ActiveScopeReferences.Clear();
+        }
+
+        private static void PruneInactiveScopeReferences()
+        {
+            for (int index = ActiveScopeReferences.Count - 1; index >= 0; index--)
+            {
+                DomainReloadDisableScope activeScope =
+                    ActiveScopeReferences[index].Target as DomainReloadDisableScope;
+                if (activeScope == null || activeScope._disposed)
+                {
+                    ActiveScopeReferences.RemoveAt(index);
+                }
+            }
+        }
+
+        private static bool RemoveScopeReference(DomainReloadDisableScope scope)
+        {
+            bool removed = false;
+            for (int index = ActiveScopeReferences.Count - 1; index >= 0; index--)
+            {
+                DomainReloadDisableScope activeScope =
+                    ActiveScopeReferences[index].Target as DomainReloadDisableScope;
+                if (activeScope == null || activeScope._disposed || ReferenceEquals(activeScope, scope))
+                {
+                    ActiveScopeReferences.RemoveAt(index);
+                }
+
+                if (ReferenceEquals(activeScope, scope))
+                {
+                    removed = true;
+                }
+            }
+
+            return removed;
         }
     }
 }

--- a/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScopeRecovery.cs
+++ b/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScopeRecovery.cs
@@ -1,0 +1,156 @@
+using System;
+using System.IO;
+
+using UnityEditor;
+using UnityEngine;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Restores Enter Play Mode settings when DomainReloadDisableScope was interrupted.
+    /// </summary>
+    internal static class DomainReloadDisableScopeRecovery
+    {
+        internal static string MarkerFilePathForTests => DomainReloadDisableScopeRecoveryConstants.MarkerFilePath;
+        internal static string TempFilePathForTests => DomainReloadDisableScopeRecoveryConstants.TempFilePath;
+
+        [InitializeOnLoadMethod]
+        private static void RestorePendingSettingsOnEditorLoad()
+        {
+            if (AssetDatabase.IsAssetImportWorkerProcess())
+            {
+                return;
+            }
+
+            RestoreIfPending();
+        }
+
+        /// <summary>
+        /// Saves the current Enter Play Mode settings before DomainReloadDisableScope changes them.
+        /// </summary>
+        internal static void SaveCurrentSettings()
+        {
+            Debug.Assert(
+                !File.Exists(DomainReloadDisableScopeRecoveryConstants.MarkerFilePath),
+                "recovery marker must be restored before saving a new marker");
+
+            DomainReloadDisableScopeRecoveryData markerData = new DomainReloadDisableScopeRecoveryData
+            {
+                originalOptionsEnabled = EditorSettings.enterPlayModeOptionsEnabled,
+                originalOptions = (int)EditorSettings.enterPlayModeOptions
+            };
+
+            SaveMarkerData(markerData);
+        }
+
+        /// <summary>
+        /// Restores Enter Play Mode settings saved before DomainReloadDisableScope changed them.
+        /// </summary>
+        internal static void RestoreIfPending()
+        {
+            DeleteTempFileIfExists();
+            if (!File.Exists(DomainReloadDisableScopeRecoveryConstants.MarkerFilePath))
+            {
+                return;
+            }
+
+            DomainReloadDisableScopeRecoveryData markerData = ReadMarkerData();
+            EditorSettings.enterPlayModeOptionsEnabled = markerData.originalOptionsEnabled;
+            EditorSettings.enterPlayModeOptions = (EnterPlayModeOptions)markerData.originalOptions;
+            DeleteMarkerFileIfExists();
+        }
+
+        /// <summary>
+        /// Deletes any saved Enter Play Mode settings pending restore.
+        /// </summary>
+        internal static void ClearPendingRestoreForTests()
+        {
+            DeleteTempFileIfExists();
+            DeleteMarkerFileIfExists();
+        }
+
+        internal static bool HasPendingRestoreForTests()
+        {
+            return File.Exists(DomainReloadDisableScopeRecoveryConstants.MarkerFilePath);
+        }
+
+        internal static DomainReloadDisableScopeRecoveryData ReadMarkerDataForTests()
+        {
+            return ReadMarkerData();
+        }
+
+        private static void SaveMarkerData(DomainReloadDisableScopeRecoveryData markerData)
+        {
+            Debug.Assert(markerData != null, "markerData must not be null");
+
+            string directoryPath = DomainReloadDisableScopeRecoveryConstants.DirectoryPath;
+            if (!Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            DeleteTempFileIfExists();
+            string json = JsonUtility.ToJson(markerData, true);
+            File.WriteAllText(DomainReloadDisableScopeRecoveryConstants.TempFilePath, json);
+            DeleteMarkerFileIfExists();
+            File.Move(
+                DomainReloadDisableScopeRecoveryConstants.TempFilePath,
+                DomainReloadDisableScopeRecoveryConstants.MarkerFilePath);
+
+            Debug.Assert(
+                File.Exists(DomainReloadDisableScopeRecoveryConstants.MarkerFilePath),
+                "marker file must exist after save");
+        }
+
+        private static DomainReloadDisableScopeRecoveryData ReadMarkerData()
+        {
+            string json = File.ReadAllText(DomainReloadDisableScopeRecoveryConstants.MarkerFilePath);
+            DomainReloadDisableScopeRecoveryData markerData =
+                JsonUtility.FromJson<DomainReloadDisableScopeRecoveryData>(json);
+            if (markerData == null)
+            {
+                throw new InvalidOperationException("Domain reload recovery marker must contain valid JSON.");
+            }
+
+            return markerData;
+        }
+
+        private static void DeleteMarkerFileIfExists()
+        {
+            if (File.Exists(DomainReloadDisableScopeRecoveryConstants.MarkerFilePath))
+            {
+                File.Delete(DomainReloadDisableScopeRecoveryConstants.MarkerFilePath);
+            }
+        }
+
+        private static void DeleteTempFileIfExists()
+        {
+            if (File.Exists(DomainReloadDisableScopeRecoveryConstants.TempFilePath))
+            {
+                File.Delete(DomainReloadDisableScopeRecoveryConstants.TempFilePath);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stores the original Enter Play Mode settings needed for interrupted scope recovery.
+    /// </summary>
+    [Serializable]
+    internal sealed class DomainReloadDisableScopeRecoveryData
+    {
+        public bool originalOptionsEnabled;
+        public int originalOptions;
+    }
+
+    /// <summary>
+    /// Centralizes DomainReloadDisableScope recovery marker paths.
+    /// </summary>
+    internal static class DomainReloadDisableScopeRecoveryConstants
+    {
+        internal const string DirectoryPath = "UserSettings";
+        internal const string MarkerFileName = "uloop-domain-reload-recovery.json";
+        internal const string TempFileName = MarkerFileName + ".tmp";
+        internal static readonly string MarkerFilePath = Path.Combine(DirectoryPath, MarkerFileName);
+        internal static readonly string TempFilePath = Path.Combine(DirectoryPath, TempFileName);
+    }
+}

--- a/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScopeRecovery.cs.meta
+++ b/Packages/src/Editor/Core/CoreTools/Util/DomainReloadDisableScopeRecovery.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6416a4617c74fb39f47434ba6714d14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Interrupted PlayMode test runs now restore the user's Enter Play Mode settings even if the disable scope is abandoned.
- Recovery state is stored in a dedicated UserSettings marker file, not SessionState or UnityMcpSettings.json, so it survives editor reloads while staying separate from editor session config.

## User Impact
- Before this change, an interrupted PlayMode test run could leave domain reload disabled in Unity.
- After this change, Unity restores the original Enter Play Mode settings on editor load, before the next run, or when the final active scope exits.

## Changes
- Persist the original Enter Play Mode settings to `UserSettings/uloop-domain-reload-recovery.json` through a temporary sidecar file.
- Restore and delete pending recovery markers on editor load and before starting a new disable scope.
- Track nested disable scopes so settings are restored only after the last active scope exits.
- Add focused EditMode coverage for normal disposal, nested scopes, abandoned scopes, stale markers, and marker cleanup.

## Verification
- `node Packages/src/Cli~/dist/cli.bundle.cjs compile --force-recompile true --wait-for-domain-reload true --project-path <PROJECT_ROOT>` -> ErrorCount 0, WarningCount 0
- `node Packages/src/Cli~/dist/cli.bundle.cjs run-tests --test-mode EditMode --filter-type regex --filter-value io.github.hatayama.uLoopMCP.DomainReloadDisableScope --save-before-run false --project-path <PROJECT_ROOT>` -> 5 passed
- `~/.codex/skills/codex-review/scripts/codex-review --parallel-tests "node Packages/src/Cli~/dist/cli.bundle.cjs run-tests --test-mode EditMode --filter-type regex --filter-value io.github.hatayama.uLoopMCP.DomainReloadDisableScope --save-before-run false --project-path <PROJECT_ROOT>" main` -> no accepted/actionable findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Fix: Interrupted PlayMode Tests No Longer Leave Domain Reload Disabled

## Overview
This PR resolves an issue where interrupted PlayMode test runs could leave domain reload disabled in Unity. The fix introduces a static reference-counted scope model with persistent recovery state, allowing the editor to restore the user's original `Enter Play Mode` settings even if a `DomainReloadDisableScope` is abandoned or the editor is reloaded.

## Architecture

### Key Components

```mermaid
classDiagram
    class DomainReloadDisableScope {
        -_activeScopeCount: static int
        -_disposed: bool
        +DomainReloadDisableScope()
        +Dispose() void
        +ResetActiveScopeCountForTests() internal static void
    }
    
    class DomainReloadDisableScopeRecovery {
        +SaveCurrentSettings() internal static void
        +RestoreIfPending() internal static void
        +ClearPendingRestoreForTests() internal static void
        +HasPendingRestoreForTests() internal static bool
        +ReadMarkerDataForTests() internal static DomainReloadDisableScopeRecoveryData
        -RestorePendingSettingsOnEditorLoad() private static void
    }
    
    class DomainReloadDisableScopeRecoveryData {
        +originalOptionsEnabled: bool
        +originalOptions: int
    }
    
    class DomainReloadDisableScopeRecoveryConstants {
        +DirectoryPath: const string
        +MarkerFileName: const string
        +TempFileName: const string
        +MarkerFilePath: readonly string
        +TempFilePath: readonly string
    }
    
    DomainReloadDisableScope --> DomainReloadDisableScopeRecovery
    DomainReloadDisableScopeRecovery --> DomainReloadDisableScopeRecoveryData
    DomainReloadDisableScopeRecovery --> DomainReloadDisableScopeRecoveryConstants
```

## Changes Summary

### 1. **DomainReloadDisableScope.cs** (Refactored)
- **Static Reference Tracking**: Replaced per-instance captured original-settings with a static collection of active scope instances (via weak references) to track nested scopes and abandoned scopes.
- **Pruning/Recovery**: Constructor prunes inactive/abandoned weak references, and on first active scope creation it calls `RestoreIfPending()` and `SaveCurrentSettings()` before forcing disable-domain-reload EditorSettings.
- **Disposal Idempotency**: `Dispose()` is idempotent per instance (guarded by a `_disposed` flag), removes the instance from the static collection, and only when the last active scope is removed does it call `RestoreIfPending()`.
- **Test Support**: Added `ResetActiveScopeCountForTests()` internal helper to clear static tracking for tests.

### 2. **DomainReloadDisableScopeRecovery.cs** (New)
- **Automatic Recovery**: Registers an `[InitializeOnLoadMethod]` to restore pending settings on editor load (skips Asset Import worker processes).
- **Persistence Strategy**:
  - Saves original `EditorSettings.enterPlayModeOptionsEnabled` and `EditorSettings.enterPlayModeOptions` to `UserSettings/uloop-domain-reload-recovery.json` with an atomic temp-file-then-rename strategy.
  - Restores settings and deletes both marker and temp files after successful restoration.
  - Uses a dedicated UserSettings marker file so recovery survives editor reloads and remains separate from session config.
- **Test Helpers**:
  - `HasPendingRestoreForTests()`, `ReadMarkerDataForTests()`, `ClearPendingRestoreForTests()`, and test path properties for inspecting and cleaning marker/temp files.

### 3. **DomainReloadDisableScopeRecoveryData.cs** (New)
- Serializable data class storing original Enter Play Mode settings persisted as JSON in the recovery marker file.

### 4. **DomainReloadDisableScopeRecoveryConstants.cs** (New)
- Centralizes file paths: `UserSettings/uloop-domain-reload-recovery.json` and `.tmp` variant.

### 5. **DomainReloadDisableScopeTests.cs** (New Test Suite)
Comprehensive test coverage with lifecycle handling and recovery verification:

- SetUp/TearDown snapshot and restore EditorSettings and existing marker/temp files.
- Tests verify:
  - Normal disposal restores original settings and removes recovery marker.
  - Nested scopes keep domain reload disabled until the last nested scope disposes, then restore settings and clear pending state.
  - `RestoreIfPending()` restores original settings when a scope is abandoned and clears pending state.
  - Constructor consumes stale markers from previous runs before saving a new baseline (including when a previous scope was GC-collected in the same session).
  - Successful `RestoreIfPending()` removes both marker and temp files (no residual state).

## Recovery Flow

```
Editor Load
    ↓
[InitializeOnLoadMethod] triggers
    ↓
RestoreIfPending() checks for marker file
    ├─ If found: Read JSON → Restore settings → Delete marker/temp files
    └─ If not found: No-op

User Creates DomainReloadDisableScope
    ↓
First scope activation:
    ├─ Call RestoreIfPending() (handles stale markers)
    ├─ Call SaveCurrentSettings() (write to marker file)
    └─ Force DisableDomainReload settings
    ↓
Nested scopes: Register themselves in static collection only

Scope Disposal
    ├─ Last active scope exits → Call RestoreIfPending()
    └─ Settings restored, marker deleted
```

## User Impact

- **Before**: Interrupted PlayMode test runs could leave `EditorSettings.enterPlayModeOptions` set to disable domain reload, affecting subsequent runs.
- **After**:
  - Recovery marker persisted on first scope activation.
  - Editor automatically restores original settings on load.
  - Settings restored when scope exits normally, when final nested scope exits, or when a stale marker is encountered.
  - Recovery state survives editor reload and is isolated from session configuration.

## Verification
- Compilation: ErrorCount 0, WarningCount 0
- EditMode tests for DomainReloadDisableScope: 5 passed
- Parallel test review: no accepted/actionable findings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->