### PR TITLE
fix: Setup updates outdated CLI before offering PATH repair

### DIFF
--- a/.agents/skills/uloop-control-play-mode/SKILL.md
+++ b/.agents/skills/uloop-control-play-mode/SKILL.md
@@ -19,6 +19,7 @@ uloop control-play-mode [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--action` | string | `Play` | Action to perform: `Play`, `Stop`, `Pause` |
+| `--timeout-seconds` | integer | `180` | Maximum seconds to wait for the requested play mode state |
 
 ## Global Options
 
@@ -31,6 +32,9 @@ uloop control-play-mode [options]
 ```bash
 # Start play mode
 uloop control-play-mode --action Play
+
+# Start play mode with a longer wait budget
+uloop control-play-mode --action Play --timeout-seconds 600
 
 # Stop play mode
 uloop control-play-mode --action Stop
@@ -52,5 +56,4 @@ Returns JSON with the current play mode state:
 - Stop action exits play mode and returns to edit mode
 - Pause action pauses the game while remaining in play mode
 - Useful for automated testing workflows
-
-- PlayMode entry may complete on the next editor frame. If a PlayMode-dependent command reports "PlayMode is not active" immediately after `--action Play`, wait briefly and retry.
+- The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.

--- a/.claude/skills/uloop-control-play-mode/SKILL.md
+++ b/.claude/skills/uloop-control-play-mode/SKILL.md
@@ -19,6 +19,7 @@ uloop control-play-mode [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--action` | string | `Play` | Action to perform: `Play`, `Stop`, `Pause` |
+| `--timeout-seconds` | integer | `180` | Maximum seconds to wait for the requested play mode state |
 
 ## Global Options
 
@@ -31,6 +32,9 @@ uloop control-play-mode [options]
 ```bash
 # Start play mode
 uloop control-play-mode --action Play
+
+# Start play mode with a longer wait budget
+uloop control-play-mode --action Play --timeout-seconds 600
 
 # Stop play mode
 uloop control-play-mode --action Stop
@@ -52,5 +56,4 @@ Returns JSON with the current play mode state:
 - Stop action exits play mode and returns to edit mode
 - Pause action pauses the game while remaining in play mode
 - Useful for automated testing workflows
-
-- PlayMode entry may complete on the next editor frame. If a PlayMode-dependent command reports "PlayMode is not active" immediately after `--action Play`, wait briefly and retry.
+- The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.

--- a/Assets/Tests/Editor/CliSetupSectionTests.cs
+++ b/Assets/Tests/Editor/CliSetupSectionTests.cs
@@ -19,6 +19,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(true, false, false, false, false, false, false, "3.0.0", "3.0.0", "Install CLI")]
         [TestCase(true, false, false, false, false, true, true, "3.0.0", "3.0.0", "Fix PATH")]
         [TestCase(true, false, false, true, false, true, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, false, true, true, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
         [TestCase(true, false, false, false, true, true, false, "3.1.0", "3.0.0", "Downgrade CLI (v3.1.0 \u2192 v3.0.0)")]
         [TestCase(true, true, false, false, false, true, false, "3.0.0", "3.0.0", "Uninstalling...")]
         [TestCase(true, true, false, false, false, true, true, "3.0.0", "3.0.0", "Fixing PATH...")]

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -404,6 +404,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(true, false, false, false, false, "3.0.0", "3.0.0", "Installed")]
         [TestCase(true, false, false, false, true, "3.0.0", "3.0.0", "Fix PATH")]
         [TestCase(true, false, false, true, false, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
+        [TestCase(true, false, false, true, true, "2.9.0", "3.0.0", "Update CLI (v2.9.0 \u2192 v3.0.0)")]
         [TestCase(true, true, false, false, false, "3.0.0", "3.0.0", "Installing...")]
         [TestCase(true, true, false, false, true, "3.0.0", "3.0.0", "Fixing PATH...")]
         [TestCase(false, false, true, false, false, null, "3.0.0", "Checking...")]
@@ -453,14 +454,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(enabled, Is.EqualTo(expectedEnabled));
         }
 
-        [TestCase(false, false)]
-        [TestCase(true, true)]
+        [TestCase(false, false, false)]
+        [TestCase(true, false, true)]
+        [TestCase(true, true, false)]
         public void ShouldRepairCliPathFromPrimaryButton_ReturnsExpectedAction(
             bool needsCliPathSetup,
+            bool needsUpdate,
             bool expected)
         {
-            // Verifies that setup wizard chooses PATH repair for installed terminal-invisible CLIs.
-            bool result = SetupWizardWindow.ShouldRepairCliPathFromPrimaryButton(needsCliPathSetup);
+            // Verifies that setup wizard chooses PATH repair only after the CLI version is already usable.
+            bool result = SetupWizardWindow.ShouldRepairCliPathFromPrimaryButton(
+                needsCliPathSetup,
+                needsUpdate);
 
             Assert.That(result, Is.EqualTo(expected));
         }

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -30,19 +30,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result, Is.EqualTo(expected));
         }
 
-        [TestCase(false, false)]
-        [TestCase(true, true)]
+        [TestCase(false, false, false)]
+        [TestCase(true, false, true)]
+        [TestCase(true, true, false)]
         public void ShouldRepairCliPathFromPrimaryButton_ReturnsExpectedAction(
             bool needsCliPathSetup,
+            bool needsUpdate,
             bool expected)
         {
-            // Verifies that stale terminal PATH state routes the primary button to repair before uninstall.
-            bool result = UnityCliLoopSettingsWindow.ShouldRepairCliPathFromPrimaryButton(needsCliPathSetup);
+            // Verifies that stale terminal PATH state routes to repair only when install/update is not needed.
+            bool result = UnityCliLoopSettingsWindow.ShouldRepairCliPathFromPrimaryButton(
+                needsCliPathSetup,
+                needsUpdate);
 
             Assert.That(result, Is.EqualTo(expected));
         }
 
         [TestCase(true, "3.0.0", "3.0.0", true, "RepairPath")]
+        [TestCase(true, "2.9.0", "3.0.0", true, "InstallOrUpdate")]
         [TestCase(false, "3.0.0", "3.0.0", true, "Uninstall")]
         [TestCase(false, "2.9.0", "3.0.0", true, "InstallOrUpdate")]
         [TestCase(false, null, "3.0.0", true, "InstallOrUpdate")]

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -781,24 +781,29 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "Checking...";
             }
 
-            if (needsCliPathSetup)
-            {
-                return isInstallingCli ? "Fixing PATH..." : "Fix PATH";
-            }
-
             if (isInstallingCli)
             {
-                return "Installing...";
-            }
+                if (needsCliPathSetup && !needsUpdate)
+                {
+                    return "Fixing PATH...";
+                }
 
-            if (!cliInstalled)
-            {
-                return "Install CLI";
+                return "Installing...";
             }
 
             if (needsUpdate)
             {
                 return $"Update CLI (v{cliVersion} \u2192 v{requiredCliVersion})";
+            }
+
+            if (needsCliPathSetup)
+            {
+                return "Fix PATH";
+            }
+
+            if (!cliInstalled)
+            {
+                return "Install CLI";
             }
 
             return "Installed";
@@ -1053,7 +1058,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             await RefreshCliPrimaryActionStateAsync(CancellationToken.None);
 
-            if (ShouldRepairCliPathFromPrimaryButton(_needsCliPathSetup))
+            string cliVersion = CliSetupApplicationFacade.GetCachedCliVersion();
+            string requiredCliVersion = GetMinimumRequiredCliVersion();
+            bool cliInstalled = IsCliInstalled(cliVersion);
+            bool cliVersionMatched = IsCliVersionSatisfied(cliVersion, requiredCliVersion) && cliInstalled;
+            bool needsUpdate = cliInstalled && !cliVersionMatched;
+            if (ShouldRepairCliPathFromPrimaryButton(_needsCliPathSetup, needsUpdate))
             {
                 await HandleRepairCliPathSetup();
                 return;
@@ -1121,9 +1131,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             UpdateCliStep(cliInstalled, cliVersion, requiredCliVersion, cliVersionMatched);
         }
 
-        internal static bool ShouldRepairCliPathFromPrimaryButton(bool needsCliPathSetup)
+        internal static bool ShouldRepairCliPathFromPrimaryButton(
+            bool needsCliPathSetup,
+            bool needsUpdate)
         {
-            return needsCliPathSetup;
+            return needsCliPathSetup && !needsUpdate;
         }
 
         private async Task HandleRepairCliPathSetup()

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/CliSetupSection.cs
@@ -219,20 +219,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "Checking...";
             }
 
-            if (needsCliPathSetup)
-            {
-                return isInstallingCli ? "Fixing PATH..." : "Fix PATH";
-            }
-
             bool isUninstallAction = IsUninstallCliAction(isCliInstalled, needsUpdate, needsDowngrade, canUninstallCli);
             if (isInstallingCli)
             {
-                return isUninstallAction ? "Uninstalling..." : "Installing...";
-            }
+                if (needsCliPathSetup && !needsUpdate && !needsDowngrade)
+                {
+                    return "Fixing PATH...";
+                }
 
-            if (!isCliInstalled)
-            {
-                return "Install CLI";
+                return isUninstallAction ? "Uninstalling..." : "Installing...";
             }
 
             if (needsUpdate)
@@ -243,6 +238,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             if (needsDowngrade)
             {
                 return $"Downgrade CLI (v{cliVersion} \u2192 v{requiredCliVersion})";
+            }
+
+            if (needsCliPathSetup)
+            {
+                return "Fix PATH";
+            }
+
+            if (!isCliInstalled)
+            {
+                return "Install CLI";
             }
 
             return canUninstallCli ? "Uninstall CLI" : "Install CLI";

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -872,7 +872,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string requiredCliVersion,
             bool canUninstallCli)
         {
-            if (ShouldRepairCliPathFromPrimaryButton(needsCliPathSetup))
+            bool needsUpdate = IsCliUpdateNeeded(cliVersion, requiredCliVersion);
+            if (ShouldRepairCliPathFromPrimaryButton(
+                    needsCliPathSetup,
+                    needsUpdate))
             {
                 return CliPrimaryButtonAction.RepairPath;
             }
@@ -903,9 +906,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return CliPrimaryButtonAction.None;
         }
 
-        internal static bool ShouldRepairCliPathFromPrimaryButton(bool needsCliPathSetup)
+        internal static bool ShouldRepairCliPathFromPrimaryButton(
+            bool needsCliPathSetup,
+            bool needsUpdate)
         {
-            return needsCliPathSetup;
+            return needsCliPathSetup && !needsUpdate;
         }
 
         private async Task RefreshCliPrimaryActionStateAsync(CancellationToken ct)


### PR DESCRIPTION
## Summary
- Setup and Settings now update an outdated terminal-visible CLI before offering PATH repair.
- The control-play-mode skill docs now describe the timeout option and the wait behavior.

## User Impact
- Before this change, users could see Fix PATH while their terminal still resolved an older CLI version. Pressing that button did not satisfy the package requirement.
- After this change, the primary action updates the CLI first when the visible command is too old. Fix PATH remains available for the case where a usable package-owned CLI is installed but not visible from a fresh shell.

## Changes
- Reordered Setup Wizard and Settings button label/action selection so CLI update wins over PATH repair when both are needed.
- Added regression coverage for the outdated CLI plus PATH repair overlap.
- Updated generated control-play-mode skill docs for timeout guidance.

## Verification
- cli/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT> succeeded with 0 errors and 0 warnings.
- cli/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value .*(CliSetupSectionTests|SetupWizardWindowTests|UnityCliLoopSettingsWindowCliActionTests).* passed 151 tests.