### PR TITLE
fix: Compile reports assembly definition errors instead of unknown status

### DIFF
--- a/Assets/Tests/Editor/CompileLifecycleWatchdogTests.cs
+++ b/Assets/Tests/Editor/CompileLifecycleWatchdogTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UnityEditor.Compilation;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -133,6 +134,63 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 staleCompileTask);
 
             Assert.That(isCurrentCompileRequest, Is.False);
+        }
+
+        [Test]
+        public void CreateStoppedWithoutFinishResult_WhenAsmdefErrorsExist_ReturnsFailureWithAsmdefErrors()
+        {
+            // Verifies missed callback recovery reports actionable asmdef import errors instead of unknown status.
+            const string asmdefPath = "Assets/Tests/EditMode/BlockKuzushi.EditMode.Tests.asmdef";
+            AssemblyDefinitionConsoleError[] assemblyDefinitionErrors =
+            {
+                new(
+                    $"Assembly has duplicate references: UnityEngine.TestRunner,UnityEditor.TestRunner ({asmdefPath})",
+                    asmdefPath,
+                    0)
+            };
+            AssemblyDefinitionConsoleErrorResult assemblyDefinitionResult = new(assemblyDefinitionErrors);
+            CompilerMessage[] compilerMessages = new CompilerMessage[0];
+
+            CompileResult result = CompileController.CreateStoppedWithoutFinishResult(
+                assemblyDefinitionResult,
+                compilerMessages,
+                false,
+                "Compilation stopped before the finish callback.");
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.IsIndeterminate, Is.False);
+            Assert.That(result.ErrorCount, Is.EqualTo(1));
+            Assert.That(result.Errors[0].file, Is.EqualTo(asmdefPath));
+            Assert.That(result.Errors[0].message, Does.Contain("duplicate references"));
+        }
+
+        [Test]
+        public void CreateStoppedWithoutFinishResult_WhenNoAsmdefErrorsExist_ReturnsIndeterminateMessages()
+        {
+            // Verifies missed callback recovery keeps unknown status when no known importer error explains the gap.
+            AssemblyDefinitionConsoleErrorResult assemblyDefinitionResult =
+                new(new AssemblyDefinitionConsoleError[0]);
+            CompilerMessage[] compilerMessages =
+            {
+                new()
+                {
+                    type = CompilerMessageType.Error,
+                    message = "CS0000: sample compile error",
+                    file = "Assets/Scripts/Sample.cs",
+                    line = 7
+                }
+            };
+
+            CompileResult result = CompileController.CreateStoppedWithoutFinishResult(
+                assemblyDefinitionResult,
+                compilerMessages,
+                false,
+                "Compilation stopped before the finish callback.");
+
+            Assert.That(result.Success, Is.Null);
+            Assert.That(result.IsIndeterminate, Is.True);
+            Assert.That(result.ErrorCount, Is.EqualTo(1));
+            Assert.That(result.Errors[0].message, Is.EqualTo("CS0000: sample compile error"));
         }
 
         private sealed class SequenceCompilationState

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -335,20 +335,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string message =
                 "Unity stopped compiling before Unity CLI Loop received the compilationFinished callback. " +
                 "The compile result is indeterminate; use get-logs to inspect the compiler output.";
+            AssemblyDefinitionConsoleErrorValidationService assemblyDefinitionValidationService = new();
+            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors =
+                assemblyDefinitionValidationService.FindCurrentErrors();
+            CompileResult result = CreateStoppedWithoutFinishResult(
+                assemblyDefinitionErrors,
+                _compileMessages.ToArray(),
+                _isForceCompile,
+                message);
             VibeLogger.LogWarning(
                 "compile_finish_callback_missing",
-                message,
+                result.Message ?? message,
                 new
                 {
                     force_recompile = _isForceCompile,
                     stopped_ms = stoppedMs,
                     message_count = _compileMessages.Count,
+                    assembly_definition_error_count = assemblyDefinitionErrors.Errors.Length,
                     editor_compiling = EditorApplication.isCompiling,
                     editor_updating = EditorApplication.isUpdating,
                     editor_playing = EditorApplication.isPlaying,
                     editor_paused = EditorApplication.isPaused
                 });
-            AbortCompileWithResult(CreateIndeterminateCompileResult(message));
+            AbortCompileWithResult(result);
         }
 
         /// <summary>
@@ -567,13 +576,41 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             );
         }
 
-        private CompileResult CreateIndeterminateCompileResult(string message)
+        /// <summary>
+        /// Creates the result used when Unity stops compiling before the finish callback is received.
+        /// </summary>
+        internal static CompileResult CreateStoppedWithoutFinishResult(
+            AssemblyDefinitionConsoleErrorResult assemblyDefinitionErrors,
+            CompilerMessage[] compileMessages,
+            bool isForceCompile,
+            string message)
         {
-            CompilerMessage[] errors = _compileMessages.Where(m => m.type == CompilerMessageType.Error).ToArray();
-            CompilerMessage[] warnings = _compileMessages.Where(m => m.type == CompilerMessageType.Warning).ToArray();
-            CompilerMessage[] messages = _isForceCompile ? Array.Empty<CompilerMessage>() : _compileMessages.ToArray();
-            CompilerMessage[] resultErrors = _isForceCompile ? Array.Empty<CompilerMessage>() : errors;
-            CompilerMessage[] resultWarnings = _isForceCompile ? Array.Empty<CompilerMessage>() : warnings;
+            UnityEngine.Debug.Assert(assemblyDefinitionErrors != null, "assemblyDefinitionErrors must not be null");
+            UnityEngine.Debug.Assert(compileMessages != null, "compileMessages must not be null");
+
+            if (assemblyDefinitionErrors.HasErrors)
+            {
+                return CreateAssemblyDefinitionFailureResult(assemblyDefinitionErrors);
+            }
+
+            return CreateIndeterminateCompileResultFromMessages(compileMessages, isForceCompile, message);
+        }
+
+        /// <summary>
+        /// Creates an unknown compile result from the compiler messages already observed by this request.
+        /// </summary>
+        private static CompileResult CreateIndeterminateCompileResultFromMessages(
+            CompilerMessage[] compileMessages,
+            bool isForceCompile,
+            string message)
+        {
+            UnityEngine.Debug.Assert(compileMessages != null, "compileMessages must not be null");
+
+            CompilerMessage[] errors = compileMessages.Where(m => m.type == CompilerMessageType.Error).ToArray();
+            CompilerMessage[] warnings = compileMessages.Where(m => m.type == CompilerMessageType.Warning).ToArray();
+            CompilerMessage[] messages = isForceCompile ? Array.Empty<CompilerMessage>() : compileMessages;
+            CompilerMessage[] resultErrors = isForceCompile ? Array.Empty<CompilerMessage>() : errors;
+            CompilerMessage[] resultWarnings = isForceCompile ? Array.Empty<CompilerMessage>() : warnings;
             return new CompileResult(
                 success: null,
                 errorCount: errors.Length,


### PR DESCRIPTION
## Summary
- Compile now reports current assembly definition import errors when Unity stops compiling before the finish callback.
- The existing compile status polling flow remains unchanged, but known assembly definition failures are returned as actionable compile errors.

## User Impact
- Before, compile could return an indeterminate result and ask users to inspect logs even when Unity already had a concrete assembly definition error.
- Now those known assembly definition errors are surfaced directly in the compile response, making the next fix step clear without an extra log lookup.

## Changes
- Re-check current assembly definition Console errors in the missed finish-callback recovery path.
- Preserve the previous unknown-result behavior when no known assembly definition error explains the callback gap.
- Add focused EditMode coverage for both the actionable-error path and the remaining indeterminate path.

## Verification
- cli/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>
- cli/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value ".*CompileLifecycleWatchdogTests.*"
- codex-review v3-beta --parallel-tests "cli/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value '.*CompileLifecycleWatchdogTests.*'"