### PR TITLE
fix: Compile handles externally changed open Scenes without blocking

### DIFF
--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -11,7 +11,7 @@ Execute Unity project compilation.
 ## Usage
 
 ```bash
-uloop compile [--force-recompile] [--no-wait-for-domain-reload]
+uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-external-scene-changes]
 ```
 
 ## Parameters
@@ -20,6 +20,7 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 |-----------|------|---------|-------------|
 | `--force-recompile` | flag | - | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
 | `--no-wait-for-domain-reload` | flag | - | Return before Domain Reload completion |
+| `--stop-on-external-scene-changes` | flag | - | Stop before compilation if open Scene files changed externally instead of auto-reloading them |
 
 ## Global Options
 
@@ -35,6 +36,9 @@ uloop compile
 
 # Start compilation without waiting for Domain Reload completion
 uloop compile --no-wait-for-domain-reload
+
+# Stop instead of auto-reloading externally changed open Scene files
+uloop compile --stop-on-external-scene-changes
 ```
 
 ## Output

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -11,7 +11,7 @@ Execute Unity project compilation.
 ## Usage
 
 ```bash
-uloop compile [--force-recompile] [--no-wait-for-domain-reload]
+uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-external-scene-changes]
 ```
 
 ## Parameters
@@ -20,6 +20,7 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 |-----------|------|---------|-------------|
 | `--force-recompile` | flag | - | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
 | `--no-wait-for-domain-reload` | flag | - | Return before Domain Reload completion |
+| `--stop-on-external-scene-changes` | flag | - | Stop before compilation if open Scene files changed externally instead of auto-reloading them |
 
 ## Global Options
 
@@ -35,6 +36,9 @@ uloop compile
 
 # Start compilation without waiting for Domain Reload completion
 uloop compile --no-wait-for-domain-reload
+
+# Stop instead of auto-reloading externally changed open Scene files
+uloop compile --stop-on-external-scene-changes
 ```
 
 ## Output

--- a/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
+++ b/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
@@ -31,14 +31,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void GetMinimumRequiredCliVersion_RequiresCompileRecoveryCliRelease()
+        public void GetMinimumRequiredCliVersion_RequiresExternalSceneChangeFlagCliRelease()
         {
-            // Verifies this package release requires the CLI that polls stored compile status.
+            // Verifies this package release requires the CLI with external Scene change options.
             CliSetupApplicationService service = new(
                 new FakeCliInstallationDetector(new string[] { null }),
                 new FakeNativeCliInstaller());
 
-            Assert.That(service.GetMinimumRequiredCliVersion(), Is.EqualTo("3.0.0-beta.23"));
+            Assert.That(service.GetMinimumRequiredCliVersion(), Is.EqualTo("3.0.0-beta.24"));
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new FakeCliInstallationDetector(new string[] { null }),
                 new FakeNativeCliInstaller());
 
-            Assert.That(service.GetMinimumRequiredCliReleaseTag(), Is.EqualTo("cli-v3.0.0-beta.23"));
+            Assert.That(service.GetMinimumRequiredCliReleaseTag(), Is.EqualTo("cli-v3.0.0-beta.24"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
+++ b/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
@@ -106,5 +106,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Warnings, Is.Null);
             Assert.That(response.Message, Is.Null);
         }
+
+        [Test]
+        public void CreateCompileResult_WhenForceCompileHasPreservedFailure_MapsDetailedIssues()
+        {
+            // Verifies preflight failures keep actionable details even during force compile.
+            CompilerMessage error = new CompilerMessage
+            {
+                type = CompilerMessageType.Error,
+                message = "external Scene changed",
+                file = "Assets/Scenes/SampleScene.unity",
+                line = 0
+            };
+            CompileResult result = new CompileResult(
+                success: false,
+                errorCount: 1,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: new[] { error },
+                errors: new[] { error },
+                warnings: Array.Empty<CompilerMessage>(),
+                message: "Compilation stopped because open Scene files changed externally.",
+                preserveDetailsWhenForceRecompile: true);
+
+            UnityCliLoopCompileResult response =
+                CompileSessionResultService.CreateCompileResult(result, forceRecompile: true);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.ErrorCount, Is.EqualTo(1));
+            Assert.That(response.Errors, Has.Length.EqualTo(1));
+            Assert.That(response.Errors[0].File, Is.EqualTo("Assets/Scenes/SampleScene.unity"));
+            Assert.That(response.Message, Does.Contain("externally"));
+        }
     }
 }

--- a/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs
+++ b/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests external Scene change resolution without invoking Unity's real Scene loading APIs.
+    /// </summary>
+    public sealed class ExternalSceneChangeResolverTests
+    {
+        private const string ScenePath = "Assets/Scenes/SampleScene.unity";
+        private static readonly DateTime SavedTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime ChangedTime = new DateTime(2026, 1, 1, 0, 1, 0, DateTimeKind.Utc);
+
+        [Test]
+        public void ResolveExternalSceneChanges_WhenCleanSceneChangedAndReloadEnabled_ReloadsSceneSetup()
+        {
+            // Verifies default compile behavior reloads clean externally changed Scenes.
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
+            bool saveWasCalled = false;
+            bool reloadWasCalled = false;
+            ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
+                snapshots,
+                () => new[] { (AssetPath: ScenePath, IsDirty: false) },
+                _ => (true, ChangedTime, 20),
+                _ =>
+                {
+                    saveWasCalled = true;
+                    return true;
+                },
+                () =>
+                {
+                    reloadWasCalled = true;
+                    return true;
+                });
+
+            (bool CanProceed, string Message, string[] ScenePaths) result = resolver.ResolveExternalSceneChanges(
+                reloadExternalSceneChanges: true);
+
+            Assert.That(result.CanProceed, Is.True);
+            Assert.That(saveWasCalled, Is.False);
+            Assert.That(reloadWasCalled, Is.True);
+        }
+
+        [Test]
+        public void ResolveExternalSceneChanges_WhenDirtySceneChangedAndReloadEnabled_SavesScene()
+        {
+            // Verifies default compile behavior saves dirty externally changed Scenes before continuing.
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
+            bool saveWasCalled = false;
+            bool reloadWasCalled = false;
+            ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
+                snapshots,
+                () => new[] { (AssetPath: ScenePath, IsDirty: true) },
+                _ => (true, ChangedTime, 20),
+                _ =>
+                {
+                    saveWasCalled = true;
+                    return true;
+                },
+                () =>
+                {
+                    reloadWasCalled = true;
+                    return true;
+                });
+
+            (bool CanProceed, string Message, string[] ScenePaths) result = resolver.ResolveExternalSceneChanges(
+                reloadExternalSceneChanges: true);
+
+            Assert.That(result.CanProceed, Is.True);
+            Assert.That(saveWasCalled, Is.True);
+            Assert.That(reloadWasCalled, Is.False);
+        }
+
+        [Test]
+        public void ResolveExternalSceneChanges_WhenStopPolicyIsEnabled_ReturnsFailureWithoutMutation()
+        {
+            // Verifies stop-on-external-scene-changes prevents automatic save or reload.
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
+            bool saveWasCalled = false;
+            bool reloadWasCalled = false;
+            ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
+                snapshots,
+                () => new[] { (AssetPath: ScenePath, IsDirty: true) },
+                _ => (true, ChangedTime, 20),
+                _ =>
+                {
+                    saveWasCalled = true;
+                    return true;
+                },
+                () =>
+                {
+                    reloadWasCalled = true;
+                    return true;
+                });
+
+            (bool CanProceed, string Message, string[] ScenePaths) result = resolver.ResolveExternalSceneChanges(
+                reloadExternalSceneChanges: false);
+
+            Assert.That(result.CanProceed, Is.False);
+            Assert.That(result.Message, Does.Contain("--stop-on-external-scene-changes"));
+            Assert.That(result.ScenePaths, Is.EqualTo(new[] { ScenePath }));
+            Assert.That(saveWasCalled, Is.False);
+            Assert.That(reloadWasCalled, Is.False);
+        }
+
+        [Test]
+        public void ResolveExternalSceneChanges_WhenDirtySaveFails_ReturnsFailure()
+        {
+            // Verifies compile stops when a dirty externally changed Scene cannot be saved.
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
+            ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
+                snapshots,
+                () => new[] { (AssetPath: ScenePath, IsDirty: true) },
+                _ => (true, ChangedTime, 20),
+                _ => false,
+                () => true);
+
+            (bool CanProceed, string Message, string[] ScenePaths) result = resolver.ResolveExternalSceneChanges(
+                reloadExternalSceneChanges: true);
+
+            Assert.That(result.CanProceed, Is.False);
+            Assert.That(result.Message, Does.Contain("could not be saved or reloaded"));
+            Assert.That(result.ScenePaths, Is.EqualTo(new[] { ScenePath }));
+        }
+
+        [Test]
+        public void ResolveExternalSceneChanges_WhenSceneUnchanged_DoesNotSaveOrReload()
+        {
+            // Verifies unchanged Scene fingerprints do not trigger compile preflight work.
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
+            bool saveWasCalled = false;
+            bool reloadWasCalled = false;
+            ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
+                snapshots,
+                () => new[] { (AssetPath: ScenePath, IsDirty: true) },
+                _ => (true, SavedTime, 10),
+                _ =>
+                {
+                    saveWasCalled = true;
+                    return true;
+                },
+                () =>
+                {
+                    reloadWasCalled = true;
+                    return true;
+                });
+
+            (bool CanProceed, string Message, string[] ScenePaths) result = resolver.ResolveExternalSceneChanges(
+                reloadExternalSceneChanges: true);
+
+            Assert.That(result.CanProceed, Is.True);
+            Assert.That(saveWasCalled, Is.False);
+            Assert.That(reloadWasCalled, Is.False);
+        }
+
+        private static Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> CreateSnapshots()
+        {
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots =
+                new Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)>(StringComparer.Ordinal);
+            snapshots[ScenePath] = (true, SavedTime, 10);
+            return snapshots;
+        }
+    }
+}

--- a/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs
+++ b/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs
@@ -20,17 +20,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies default compile behavior reloads clean externally changed Scenes.
             Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
-            bool saveWasCalled = false;
             bool reloadWasCalled = false;
             ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
                 snapshots,
                 () => new[] { (AssetPath: ScenePath, IsDirty: false) },
                 _ => (true, ChangedTime, 20),
-                _ =>
-                {
-                    saveWasCalled = true;
-                    return true;
-                },
+                () => Array.Empty<string>(),
                 () =>
                 {
                     reloadWasCalled = true;
@@ -41,25 +36,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 reloadExternalSceneChanges: true);
 
             Assert.That(result.CanProceed, Is.True);
-            Assert.That(saveWasCalled, Is.False);
             Assert.That(reloadWasCalled, Is.True);
         }
 
         [Test]
-        public void ResolveExternalSceneChanges_WhenDirtySceneChangedAndReloadEnabled_SavesScene()
+        public void ResolveExternalSceneChanges_WhenDirtySceneChangedAndReloadEnabled_ReturnsFailureWithoutMutation()
         {
-            // Verifies default compile behavior saves dirty externally changed Scenes before continuing.
+            // Verifies dirty externally changed Scenes are not overwritten by automatic compile preflight.
             Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
-            bool saveWasCalled = false;
+            bool saveDirtyOpenScenesWasCalled = false;
             bool reloadWasCalled = false;
             ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
                 snapshots,
                 () => new[] { (AssetPath: ScenePath, IsDirty: true) },
                 _ => (true, ChangedTime, 20),
-                _ =>
+                () =>
                 {
-                    saveWasCalled = true;
-                    return true;
+                    saveDirtyOpenScenesWasCalled = true;
+                    return Array.Empty<string>();
                 },
                 () =>
                 {
@@ -70,8 +64,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             (bool CanProceed, string Message, string[] ScenePaths) result = resolver.ResolveExternalSceneChanges(
                 reloadExternalSceneChanges: true);
 
-            Assert.That(result.CanProceed, Is.True);
-            Assert.That(saveWasCalled, Is.True);
+            Assert.That(result.CanProceed, Is.False);
+            Assert.That(result.Message, Does.Contain("not overwritten automatically"));
+            Assert.That(result.ScenePaths, Is.EqualTo(new[] { ScenePath }));
+            Assert.That(saveDirtyOpenScenesWasCalled, Is.False);
             Assert.That(reloadWasCalled, Is.False);
         }
 
@@ -80,16 +76,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies stop-on-external-scene-changes prevents automatic save or reload.
             Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
-            bool saveWasCalled = false;
+            bool saveDirtyOpenScenesWasCalled = false;
             bool reloadWasCalled = false;
             ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
                 snapshots,
                 () => new[] { (AssetPath: ScenePath, IsDirty: true) },
                 _ => (true, ChangedTime, 20),
-                _ =>
+                () =>
                 {
-                    saveWasCalled = true;
-                    return true;
+                    saveDirtyOpenScenesWasCalled = true;
+                    return Array.Empty<string>();
                 },
                 () =>
                 {
@@ -103,45 +99,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.CanProceed, Is.False);
             Assert.That(result.Message, Does.Contain("--stop-on-external-scene-changes"));
             Assert.That(result.ScenePaths, Is.EqualTo(new[] { ScenePath }));
-            Assert.That(saveWasCalled, Is.False);
+            Assert.That(saveDirtyOpenScenesWasCalled, Is.False);
             Assert.That(reloadWasCalled, Is.False);
         }
 
         [Test]
-        public void ResolveExternalSceneChanges_WhenDirtySaveFails_ReturnsFailure()
+        public void ResolveExternalSceneChanges_WhenCleanSceneChangedAndReloadEnabled_SavesDirtyScenesBeforeReload()
         {
-            // Verifies compile stops when a dirty externally changed Scene cannot be saved.
+            // Verifies reload preflight saves other dirty open Scenes before restoring Scene setup.
             Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
-            ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
-                snapshots,
-                () => new[] { (AssetPath: ScenePath, IsDirty: true) },
-                _ => (true, ChangedTime, 20),
-                _ => false,
-                () => true);
-
-            (bool CanProceed, string Message, string[] ScenePaths) result = resolver.ResolveExternalSceneChanges(
-                reloadExternalSceneChanges: true);
-
-            Assert.That(result.CanProceed, Is.False);
-            Assert.That(result.Message, Does.Contain("could not be saved or reloaded"));
-            Assert.That(result.ScenePaths, Is.EqualTo(new[] { ScenePath }));
-        }
-
-        [Test]
-        public void ResolveExternalSceneChanges_WhenSceneUnchanged_DoesNotSaveOrReload()
-        {
-            // Verifies unchanged Scene fingerprints do not trigger compile preflight work.
-            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
-            bool saveWasCalled = false;
+            bool saveDirtyOpenScenesWasCalled = false;
             bool reloadWasCalled = false;
             ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
                 snapshots,
-                () => new[] { (AssetPath: ScenePath, IsDirty: true) },
-                _ => (true, SavedTime, 10),
-                _ =>
+                () => new[] { (AssetPath: ScenePath, IsDirty: false) },
+                _ => (true, ChangedTime, 20),
+                () =>
                 {
-                    saveWasCalled = true;
-                    return true;
+                    saveDirtyOpenScenesWasCalled = true;
+                    return Array.Empty<string>();
                 },
                 () =>
                 {
@@ -153,7 +129,64 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 reloadExternalSceneChanges: true);
 
             Assert.That(result.CanProceed, Is.True);
-            Assert.That(saveWasCalled, Is.False);
+            Assert.That(saveDirtyOpenScenesWasCalled, Is.True);
+            Assert.That(reloadWasCalled, Is.True);
+        }
+
+        [Test]
+        public void ResolveExternalSceneChanges_WhenDirtyScenesBeforeReloadCannotBeSaved_ReturnsFailure()
+        {
+            // Verifies reload does not proceed when any dirty open Scene cannot be saved first.
+            const string DirtyScenePath = "Assets/Scenes/DirtyScene.unity";
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
+            bool reloadWasCalled = false;
+            ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
+                snapshots,
+                () => new[] { (AssetPath: ScenePath, IsDirty: false) },
+                _ => (true, ChangedTime, 20),
+                () => new[] { DirtyScenePath },
+                () =>
+                {
+                    reloadWasCalled = true;
+                    return true;
+                });
+
+            (bool CanProceed, string Message, string[] ScenePaths) result = resolver.ResolveExternalSceneChanges(
+                reloadExternalSceneChanges: true);
+
+            Assert.That(result.CanProceed, Is.False);
+            Assert.That(result.Message, Does.Contain("cannot save dirty Scene files"));
+            Assert.That(result.ScenePaths, Is.EqualTo(new[] { DirtyScenePath }));
+            Assert.That(reloadWasCalled, Is.False);
+        }
+
+        [Test]
+        public void ResolveExternalSceneChanges_WhenSceneUnchanged_DoesNotSaveOrReload()
+        {
+            // Verifies unchanged Scene fingerprints do not trigger compile preflight work.
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots = CreateSnapshots();
+            bool saveDirtyOpenScenesWasCalled = false;
+            bool reloadWasCalled = false;
+            ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
+                snapshots,
+                () => new[] { (AssetPath: ScenePath, IsDirty: true) },
+                _ => (true, SavedTime, 10),
+                () =>
+                {
+                    saveDirtyOpenScenesWasCalled = true;
+                    return Array.Empty<string>();
+                },
+                () =>
+                {
+                    reloadWasCalled = true;
+                    return true;
+                });
+
+            (bool CanProceed, string Message, string[] ScenePaths) result = resolver.ResolveExternalSceneChanges(
+                reloadExternalSceneChanges: true);
+
+            Assert.That(result.CanProceed, Is.True);
+            Assert.That(saveDirtyOpenScenesWasCalled, Is.False);
             Assert.That(reloadWasCalled, Is.False);
         }
 

--- a/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs.meta
+++ b/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs.meta
+++ b/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0b638aca4fe778f0006af8499fadd2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -6,7 +6,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     public static class CliConstants
     {
         public const string EXECUTABLE_NAME = "uloop";
-        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.23";
+        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.24";
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         public const string VERSION_FLAG = "--version";
         public const string SHORT_VERSION_FLAG = "-v";

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
@@ -24,6 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             using CompileController compileController = new();
             compileController.SetResultRecordingContext(CompileResultRecordingContext.Create(request));
+            compileController.SetExternalSceneChangePolicy(request.ReloadExternalSceneChanges);
             return await compileController.TryCompileAsync(request.ForceRecompile, ct);
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -22,6 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private List<CompilerMessage> _compileMessages = new();
         private TaskCompletionSource<CompileResult> _currentCompileTask;
         private bool _isForceCompile = false;
+        private bool _reloadExternalSceneChanges = true;
         private CompileResultRecordingContext _resultRecordingContext = CompileResultRecordingContext.Disabled();
 
         /// <summary>
@@ -55,6 +56,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal void SetResultRecordingContext(CompileResultRecordingContext resultRecordingContext)
         {
             _resultRecordingContext = resultRecordingContext;
+        }
+
+        /// <summary>
+        /// Sets how compile handles open Scene files changed outside Unity before asset refresh.
+        /// </summary>
+        internal void SetExternalSceneChangePolicy(bool reloadExternalSceneChanges)
+        {
+            _reloadExternalSceneChanges = reloadExternalSceneChanges;
         }
 
         /// <summary>
@@ -106,6 +115,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     isIndeterminate: true,
                     message: validation.ErrorMessage
                 );
+            }
+
+            (bool CanProceed, string Message, string[] ScenePaths) sceneChangeResult =
+                ExternalSceneChangeTracker.ResolveForCompile(_reloadExternalSceneChanges);
+            if (!sceneChangeResult.CanProceed)
+            {
+                VibeLogger.LogWarning(
+                    "compile_external_scene_change_resolution_failed",
+                    sceneChangeResult.Message,
+                    new
+                    {
+                        reload_external_scene_changes = _reloadExternalSceneChanges,
+                        scene_paths = sceneChangeResult.ScenePaths
+                    });
+                return CreateExternalSceneChangeFailureResult(sceneChangeResult);
             }
 
             _isCompiling = true;
@@ -270,7 +294,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ["editor_compiling"] = EditorApplication.isCompiling,
                 ["editor_updating"] = EditorApplication.isUpdating,
                 ["editor_playing"] = EditorApplication.isPlaying,
-                ["editor_paused"] = EditorApplication.isPaused
+                ["editor_paused"] = EditorApplication.isPaused,
+                ["reload_external_scene_changes"] = _reloadExternalSceneChanges
             };
             if (extraContext == null)
             {
@@ -644,6 +669,51 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
+        /// Creates a failed compile result for external Scene changes that cannot be auto-resolved.
+        /// </summary>
+        private static CompileResult CreateExternalSceneChangeFailureResult(
+            (bool CanProceed, string Message, string[] ScenePaths) sceneChangeResult)
+        {
+            UnityEngine.Debug.Assert(!sceneChangeResult.CanProceed, "sceneChangeResult must be a failure");
+
+            CompilerMessage[] errors = CreateExternalSceneChangeCompilerMessages(sceneChangeResult);
+            return new CompileResult(
+                success: false,
+                errorCount: errors.Length,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: errors,
+                errors: errors,
+                warnings: Array.Empty<CompilerMessage>(),
+                message: sceneChangeResult.Message
+            );
+        }
+
+        /// <summary>
+        /// Converts unresolved external Scene changes into compiler-shaped errors for compile responses.
+        /// </summary>
+        private static CompilerMessage[] CreateExternalSceneChangeCompilerMessages(
+            (bool CanProceed, string Message, string[] ScenePaths) sceneChangeResult)
+        {
+            UnityEngine.Debug.Assert(sceneChangeResult.ScenePaths != null, "scene paths must not be null");
+            UnityEngine.Debug.Assert(sceneChangeResult.ScenePaths.Length > 0, "scene paths must not be empty");
+
+            CompilerMessage[] errors = new CompilerMessage[sceneChangeResult.ScenePaths.Length];
+            for (int i = 0; i < sceneChangeResult.ScenePaths.Length; i++)
+            {
+                errors[i] = new CompilerMessage
+                {
+                    type = CompilerMessageType.Error,
+                    message = sceneChangeResult.Message,
+                    file = sceneChangeResult.ScenePaths[i],
+                    line = 0
+                };
+            }
+
+            return errors;
+        }
+
+        /// <summary>
         /// Converts Assembly Definition and Assembly Reference Console errors into compiler messages.
         /// </summary>
         private static CompilerMessage[] CreateAssemblyDefinitionCompilerMessages(
@@ -682,6 +752,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             _isCompiling = false;
             _isForceCompile = false;
+            _reloadExternalSceneChanges = true;
             _resultRecordingContext = CompileResultRecordingContext.Disabled();
         }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -685,7 +685,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 messages: errors,
                 errors: errors,
                 warnings: Array.Empty<CompilerMessage>(),
-                message: sceneChangeResult.Message
+                message: sceneChangeResult.Message,
+                preserveDetailsWhenForceRecompile: true
             );
         }
 
@@ -824,6 +825,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string Message { get; }
 
         /// <summary>
+        /// Whether force-compile response shaping must keep detailed non-compiler preflight errors.
+        /// </summary>
+        internal bool PreserveDetailsWhenForceRecompile { get; }
+
+        /// <summary>
         /// Alias for error messages (for backward compatibility).
         /// </summary>
         public CompilerMessage[] error => Errors;
@@ -853,7 +859,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CompilerMessage[] errors,
             CompilerMessage[] warnings,
             bool isIndeterminate = false,
-            string message = null
+            string message = null,
+            bool preserveDetailsWhenForceRecompile = false
         )
         {
             Success = success;
@@ -865,6 +872,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Warnings = warnings;
             IsIndeterminate = isIndeterminate;
             Message = message;
+            PreserveDetailsWhenForceRecompile = preserveDetailsWhenForceRecompile;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSchema.cs
@@ -21,6 +21,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool WaitForDomainReload { get; set; } = true;
 
         /// <summary>
+        /// Whether to reload or save externally changed open Scene files before compilation refresh.
+        /// </summary>
+        [Description("Automatically reload or save open Scene files changed outside Unity before compiling")]
+        public bool ReloadExternalSceneChanges { get; set; } = true;
+
+        /// <summary>
         /// Internal request identifier used for delayed result recovery across domain reload.
         /// </summary>
         [Browsable(false)]

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSchema.cs
@@ -23,7 +23,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// Whether to reload or save externally changed open Scene files before compilation refresh.
         /// </summary>
-        [Description("Automatically reload or save open Scene files changed outside Unity before compiling")]
         public bool ReloadExternalSceneChanges { get; set; } = true;
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(result != null, "result must not be null");
 
-            if (forceRecompile)
+            if (forceRecompile && !result.PreserveDetailsWhenForceRecompile)
             {
                 return CreateForceCompileResult(result);
             }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileTool.cs
@@ -33,6 +33,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 ForceRecompile = parameters.ForceRecompile,
                 WaitForDomainReload = parameters.WaitForDomainReload,
+                ReloadExternalSceneChanges = parameters.ReloadExternalSceneChanges,
                 RequestId = parameters.RequestId,
             };
         }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -271,7 +271,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 request_id = request.RequestId,
                 force_recompile = request.ForceRecompile,
-                wait_for_domain_reload = request.WaitForDomainReload
+                wait_for_domain_reload = request.WaitForDomainReload,
+                reload_external_scene_changes = request.ReloadExternalSceneChanges
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeResolver.cs
@@ -44,7 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Snapshots,
                 GetOpenSceneStates,
                 ReadSceneFileFingerprint,
-                SaveSceneByPath,
+                SaveDirtyOpenScenesBeforeReload,
                 ReloadOpenSceneSetup);
             return resolver.ResolveExternalSceneChanges(reloadExternalSceneChanges);
         }
@@ -130,17 +130,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return (true, fileInfo.LastWriteTimeUtc, fileInfo.Length);
         }
 
-        private static bool SaveSceneByPath(string assetPath)
+        private static string[] SaveDirtyOpenScenesBeforeReload()
         {
-            Debug.Assert(!string.IsNullOrEmpty(assetPath), "assetPath must not be empty");
-
-            Scene scene = SceneManager.GetSceneByPath(assetPath);
-            if (!scene.IsValid() || !scene.isLoaded)
+            List<string> failedScenePaths = new List<string>();
+            for (int i = 0; i < SceneManager.sceneCount; i++)
             {
-                return false;
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(scene.path) || !EditorSceneManager.SaveScene(scene))
+                {
+                    failedScenePaths.Add(GetSceneDisplayPath(scene));
+                    continue;
+                }
+
+                RecordSceneSnapshot(scene);
             }
 
-            return EditorSceneManager.SaveScene(scene);
+            return failedScenePaths.ToArray();
         }
 
         private static bool ReloadOpenSceneSetup()
@@ -161,6 +171,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(!string.IsNullOrEmpty(assetPath), "assetPath must not be empty");
             return assetPath.Replace('\\', '/');
         }
+
+        private static string GetSceneDisplayPath(Scene scene)
+        {
+            if (!string.IsNullOrEmpty(scene.path))
+            {
+                return NormalizeAssetPath(scene.path);
+            }
+
+            if (!string.IsNullOrEmpty(scene.name))
+            {
+                return scene.name;
+            }
+
+            return "Untitled scene";
+        }
     }
 
     /// <summary>
@@ -172,26 +197,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> _snapshots;
         private readonly Func<(string AssetPath, bool IsDirty)[]> _getOpenScenes;
         private readonly Func<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> _readFileFingerprint;
-        private readonly Func<string, bool> _saveScene;
+        private readonly Func<string[]> _saveDirtyOpenScenesBeforeReload;
         private readonly Func<bool> _reloadOpenSceneSetup;
 
         public ExternalSceneChangeResolver(
             Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots,
             Func<(string AssetPath, bool IsDirty)[]> getOpenScenes,
             Func<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> readFileFingerprint,
-            Func<string, bool> saveScene,
+            Func<string[]> saveDirtyOpenScenesBeforeReload,
             Func<bool> reloadOpenSceneSetup)
         {
             Debug.Assert(snapshots != null, "snapshots must not be null");
             Debug.Assert(getOpenScenes != null, "getOpenScenes must not be null");
             Debug.Assert(readFileFingerprint != null, "readFileFingerprint must not be null");
-            Debug.Assert(saveScene != null, "saveScene must not be null");
+            Debug.Assert(saveDirtyOpenScenesBeforeReload != null, "saveDirtyOpenScenesBeforeReload must not be null");
             Debug.Assert(reloadOpenSceneSetup != null, "reloadOpenSceneSetup must not be null");
 
             _snapshots = snapshots ?? throw new ArgumentNullException(nameof(snapshots));
             _getOpenScenes = getOpenScenes ?? throw new ArgumentNullException(nameof(getOpenScenes));
             _readFileFingerprint = readFileFingerprint ?? throw new ArgumentNullException(nameof(readFileFingerprint));
-            _saveScene = saveScene ?? throw new ArgumentNullException(nameof(saveScene));
+            _saveDirtyOpenScenesBeforeReload = saveDirtyOpenScenesBeforeReload ??
+                                               throw new ArgumentNullException(nameof(saveDirtyOpenScenesBeforeReload));
             _reloadOpenSceneSetup = reloadOpenSceneSetup ?? throw new ArgumentNullException(nameof(reloadOpenSceneSetup));
         }
 
@@ -233,13 +259,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 if (scene.IsDirty)
                 {
-                    if (!_saveScene(scene.AssetPath))
-                    {
-                        unresolvedScenePaths.Add(scene.AssetPath);
-                        continue;
-                    }
-
-                    _snapshots[scene.AssetPath] = _readFileFingerprint(scene.AssetPath);
+                    unresolvedScenePaths.Add(scene.AssetPath);
                     continue;
                 }
 
@@ -254,6 +274,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (unresolvedScenePaths.Count > 0)
             {
                 return (false, CreateUnresolvedMessage(unresolvedScenePaths.ToArray()), unresolvedScenePaths.ToArray());
+            }
+
+            if (shouldReloadSceneSetup)
+            {
+                string[] dirtySceneSaveFailures = _saveDirtyOpenScenesBeforeReload();
+                Debug.Assert(dirtySceneSaveFailures != null, "dirty Scene save failures must not be null");
+                if (dirtySceneSaveFailures.Length > 0)
+                {
+                    return (false, CreateDirtySaveBeforeReloadFailureMessage(dirtySceneSaveFailures), dirtySceneSaveFailures);
+                }
             }
 
             if (shouldReloadSceneSetup && !_reloadOpenSceneSetup())
@@ -284,15 +314,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static string CreateUnresolvedMessage(string[] scenePaths)
         {
             return "Compilation cannot resolve externally changed Scene files before compile. " +
-                   "Scenes that could not be saved or reloaded: " +
+                   "Scenes that could not be safely saved or reloaded: " +
                    FormatScenePaths(scenePaths) +
-                   ".";
+                   ". Dirty Scenes changed externally are not overwritten automatically.";
         }
 
         private static string CreateReloadFailureMessage(string[] scenePaths)
         {
             return "Compilation cannot reload externally changed Scene files before compile. " +
                    "Scenes that could not be reloaded: " +
+                   FormatScenePaths(scenePaths) +
+                   ".";
+        }
+
+        private static string CreateDirtySaveBeforeReloadFailureMessage(string[] scenePaths)
+        {
+            return "Compilation cannot save dirty Scene files before reloading externally changed Scene files. " +
+                   "Dirty Scenes that could not be saved: " +
                    FormatScenePaths(scenePaths) +
                    ".";
         }

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeResolver.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Tracks open Scene file snapshots so compile can resolve external disk changes before asset refresh.
+    /// </summary>
+    internal static class ExternalSceneChangeTracker
+    {
+        private static readonly Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> Snapshots =
+            new Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)>(StringComparer.Ordinal);
+        private static bool _initialized;
+
+        public static void Initialize()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+            EditorSceneManager.sceneOpened -= HandleSceneOpened;
+            EditorSceneManager.sceneOpened += HandleSceneOpened;
+            EditorSceneManager.sceneSaved -= HandleSceneSaved;
+            EditorSceneManager.sceneSaved += HandleSceneSaved;
+            EditorSceneManager.sceneClosed -= HandleSceneClosed;
+            EditorSceneManager.sceneClosed += HandleSceneClosed;
+            RecordOpenSceneSnapshots();
+        }
+
+        public static (bool CanProceed, string Message, string[] ScenePaths) ResolveForCompile(
+            bool reloadExternalSceneChanges)
+        {
+            Initialize();
+            ExternalSceneChangeResolver resolver = new ExternalSceneChangeResolver(
+                Snapshots,
+                GetOpenSceneStates,
+                ReadSceneFileFingerprint,
+                SaveSceneByPath,
+                ReloadOpenSceneSetup);
+            return resolver.ResolveExternalSceneChanges(reloadExternalSceneChanges);
+        }
+
+        private static void HandleSceneOpened(Scene scene, OpenSceneMode mode)
+        {
+            RecordSceneSnapshot(scene);
+        }
+
+        private static void HandleSceneSaved(Scene scene)
+        {
+            RecordSceneSnapshot(scene);
+        }
+
+        private static void HandleSceneClosed(Scene scene)
+        {
+            if (!IsTrackableScene(scene))
+            {
+                return;
+            }
+
+            Snapshots.Remove(NormalizeAssetPath(scene.path));
+        }
+
+        private static void RecordOpenSceneSnapshots()
+        {
+            (string AssetPath, bool IsDirty)[] scenes = GetOpenSceneStates();
+            for (int i = 0; i < scenes.Length; i++)
+            {
+                Snapshots[scenes[i].AssetPath] = ReadSceneFileFingerprint(scenes[i].AssetPath);
+            }
+        }
+
+        private static void RecordSceneSnapshot(Scene scene)
+        {
+            if (!IsTrackableScene(scene))
+            {
+                return;
+            }
+
+            string assetPath = NormalizeAssetPath(scene.path);
+            Snapshots[assetPath] = ReadSceneFileFingerprint(assetPath);
+        }
+
+        private static (string AssetPath, bool IsDirty)[] GetOpenSceneStates()
+        {
+            List<(string AssetPath, bool IsDirty)> scenes = new List<(string AssetPath, bool IsDirty)>();
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!IsTrackableScene(scene))
+                {
+                    continue;
+                }
+
+                scenes.Add((NormalizeAssetPath(scene.path), scene.isDirty));
+            }
+
+            return scenes.ToArray();
+        }
+
+        private static bool IsTrackableScene(Scene scene)
+        {
+            return scene.IsValid() &&
+                   scene.isLoaded &&
+                   !string.IsNullOrEmpty(scene.path) &&
+                   scene.path.EndsWith(".unity", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static (bool Exists, DateTime LastWriteTimeUtc, long Length) ReadSceneFileFingerprint(
+            string assetPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assetPath), "assetPath must not be empty");
+
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string fullPath = Path.GetFullPath(Path.Combine(projectRoot, assetPath));
+            FileInfo fileInfo = new FileInfo(fullPath);
+            if (!fileInfo.Exists)
+            {
+                return (false, DateTime.MinValue, 0);
+            }
+
+            return (true, fileInfo.LastWriteTimeUtc, fileInfo.Length);
+        }
+
+        private static bool SaveSceneByPath(string assetPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assetPath), "assetPath must not be empty");
+
+            Scene scene = SceneManager.GetSceneByPath(assetPath);
+            if (!scene.IsValid() || !scene.isLoaded)
+            {
+                return false;
+            }
+
+            return EditorSceneManager.SaveScene(scene);
+        }
+
+        private static bool ReloadOpenSceneSetup()
+        {
+            SceneSetup[] sceneSetup = EditorSceneManager.GetSceneManagerSetup();
+            if (sceneSetup == null || sceneSetup.Length == 0)
+            {
+                return true;
+            }
+
+            EditorSceneManager.RestoreSceneManagerSetup(sceneSetup);
+            RecordOpenSceneSnapshots();
+            return true;
+        }
+
+        private static string NormalizeAssetPath(string assetPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assetPath), "assetPath must not be empty");
+            return assetPath.Replace('\\', '/');
+        }
+    }
+
+    /// <summary>
+    /// Resolves external Scene file changes according to the compile request policy.
+    /// </summary>
+    internal sealed class ExternalSceneChangeResolver
+    {
+        private const string StopOnExternalSceneChangesOption = "--stop-on-external-scene-changes";
+        private readonly Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> _snapshots;
+        private readonly Func<(string AssetPath, bool IsDirty)[]> _getOpenScenes;
+        private readonly Func<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> _readFileFingerprint;
+        private readonly Func<string, bool> _saveScene;
+        private readonly Func<bool> _reloadOpenSceneSetup;
+
+        public ExternalSceneChangeResolver(
+            Dictionary<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> snapshots,
+            Func<(string AssetPath, bool IsDirty)[]> getOpenScenes,
+            Func<string, (bool Exists, DateTime LastWriteTimeUtc, long Length)> readFileFingerprint,
+            Func<string, bool> saveScene,
+            Func<bool> reloadOpenSceneSetup)
+        {
+            Debug.Assert(snapshots != null, "snapshots must not be null");
+            Debug.Assert(getOpenScenes != null, "getOpenScenes must not be null");
+            Debug.Assert(readFileFingerprint != null, "readFileFingerprint must not be null");
+            Debug.Assert(saveScene != null, "saveScene must not be null");
+            Debug.Assert(reloadOpenSceneSetup != null, "reloadOpenSceneSetup must not be null");
+
+            _snapshots = snapshots ?? throw new ArgumentNullException(nameof(snapshots));
+            _getOpenScenes = getOpenScenes ?? throw new ArgumentNullException(nameof(getOpenScenes));
+            _readFileFingerprint = readFileFingerprint ?? throw new ArgumentNullException(nameof(readFileFingerprint));
+            _saveScene = saveScene ?? throw new ArgumentNullException(nameof(saveScene));
+            _reloadOpenSceneSetup = reloadOpenSceneSetup ?? throw new ArgumentNullException(nameof(reloadOpenSceneSetup));
+        }
+
+        public (bool CanProceed, string Message, string[] ScenePaths) ResolveExternalSceneChanges(
+            bool reloadExternalSceneChanges)
+        {
+            (string AssetPath, bool IsDirty)[] openScenes = _getOpenScenes();
+            List<string> changedScenePaths = new List<string>();
+            List<string> unresolvedScenePaths = new List<string>();
+            bool shouldReloadSceneSetup = false;
+
+            for (int i = 0; i < openScenes.Length; i++)
+            {
+                (string AssetPath, bool IsDirty) scene = openScenes[i];
+                (bool Exists, DateTime LastWriteTimeUtc, long Length) currentFingerprint =
+                    _readFileFingerprint(scene.AssetPath);
+                if (!_snapshots.ContainsKey(scene.AssetPath))
+                {
+                    _snapshots[scene.AssetPath] = currentFingerprint;
+                    continue;
+                }
+
+                if (HasSameFileState(_snapshots[scene.AssetPath], currentFingerprint))
+                {
+                    continue;
+                }
+
+                changedScenePaths.Add(scene.AssetPath);
+                if (!reloadExternalSceneChanges)
+                {
+                    continue;
+                }
+
+                if (!currentFingerprint.Exists)
+                {
+                    unresolvedScenePaths.Add(scene.AssetPath);
+                    continue;
+                }
+
+                if (scene.IsDirty)
+                {
+                    if (!_saveScene(scene.AssetPath))
+                    {
+                        unresolvedScenePaths.Add(scene.AssetPath);
+                        continue;
+                    }
+
+                    _snapshots[scene.AssetPath] = _readFileFingerprint(scene.AssetPath);
+                    continue;
+                }
+
+                shouldReloadSceneSetup = true;
+            }
+
+            if (changedScenePaths.Count > 0 && !reloadExternalSceneChanges)
+            {
+                return (false, CreateStoppedMessage(changedScenePaths.ToArray()), changedScenePaths.ToArray());
+            }
+
+            if (unresolvedScenePaths.Count > 0)
+            {
+                return (false, CreateUnresolvedMessage(unresolvedScenePaths.ToArray()), unresolvedScenePaths.ToArray());
+            }
+
+            if (shouldReloadSceneSetup && !_reloadOpenSceneSetup())
+            {
+                return (false, CreateReloadFailureMessage(changedScenePaths.ToArray()), changedScenePaths.ToArray());
+            }
+
+            return (true, null, Array.Empty<string>());
+        }
+
+        private static bool HasSameFileState(
+            (bool Exists, DateTime LastWriteTimeUtc, long Length) previousFingerprint,
+            (bool Exists, DateTime LastWriteTimeUtc, long Length) currentFingerprint)
+        {
+            return previousFingerprint.Exists == currentFingerprint.Exists &&
+                   previousFingerprint.LastWriteTimeUtc == currentFingerprint.LastWriteTimeUtc &&
+                   previousFingerprint.Length == currentFingerprint.Length;
+        }
+
+        private static string CreateStoppedMessage(string[] scenePaths)
+        {
+            return "Compilation stopped because open Scene files changed externally. " +
+                   "External Scene changes: " +
+                   FormatScenePaths(scenePaths) +
+                   $". Rerun without {StopOnExternalSceneChangesOption} to reload or save them automatically.";
+        }
+
+        private static string CreateUnresolvedMessage(string[] scenePaths)
+        {
+            return "Compilation cannot resolve externally changed Scene files before compile. " +
+                   "Scenes that could not be saved or reloaded: " +
+                   FormatScenePaths(scenePaths) +
+                   ".";
+        }
+
+        private static string CreateReloadFailureMessage(string[] scenePaths)
+        {
+            return "Compilation cannot reload externally changed Scene files before compile. " +
+                   "Scenes that could not be reloaded: " +
+                   FormatScenePaths(scenePaths) +
+                   ".";
+        }
+
+        private static string FormatScenePaths(string[] scenePaths)
+        {
+            Debug.Assert(scenePaths != null, "scenePaths must not be null");
+            Debug.Assert(scenePaths.Length > 0, "scenePaths must not be empty");
+
+            string[] displayPaths = new string[scenePaths.Length];
+            for (int i = 0; i < scenePaths.Length; i++)
+            {
+                displayPaths[i] = "Scene: " + scenePaths[i];
+            }
+
+            return string.Join(", ", displayPaths);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeResolver.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcf0f6dd6c867336dc66beacabb5ae40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
@@ -11,7 +11,7 @@ Execute Unity project compilation.
 ## Usage
 
 ```bash
-uloop compile [--force-recompile] [--no-wait-for-domain-reload]
+uloop compile [--force-recompile] [--no-wait-for-domain-reload] [--stop-on-external-scene-changes]
 ```
 
 ## Parameters
@@ -20,6 +20,7 @@ uloop compile [--force-recompile] [--no-wait-for-domain-reload]
 |-----------|------|---------|-------------|
 | `--force-recompile` | flag | - | Use for broader validation, including warnings hidden by other asmdefs; much slower than normal compile |
 | `--no-wait-for-domain-reload` | flag | - | Return before Domain Reload completion |
+| `--stop-on-external-scene-changes` | flag | - | Stop before compilation if open Scene files changed externally instead of auto-reloading them |
 
 ## Global Options
 
@@ -35,6 +36,9 @@ uloop compile
 
 # Start compilation without waiting for Domain Reload completion
 uloop compile --no-wait-for-domain-reload
+
+# Stop instead of auto-reloading externally changed open Scene files
+uloop compile --stop-on-external-scene-changes
 ```
 
 ## Output

--- a/Packages/src/Editor/FirstPartyTools/Compile/UnityCliLoopCompileTypes.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/UnityCliLoopCompileTypes.cs
@@ -18,6 +18,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public bool ForceRecompile { get; set; }
         public bool WaitForDomainReload { get; set; }
+        public bool ReloadExternalSceneChanges { get; set; } = true;
         public string RequestId { get; set; } = "";
     }
 

--- a/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
@@ -8,6 +8,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public static void Initialize()
         {
+            ExternalSceneChangeTracker.Initialize();
             ExecuteDynamicCodeEditorStartup.Initialize();
             GetLogsEditorStartup.Initialize();
 #if ULOOP_HAS_TEST_FRAMEWORK

--- a/cli/contract.json
+++ b/cli/contract.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "cliVersion": "3.0.0-beta.23"
+  "cliVersion": "3.0.0-beta.24"
 }

--- a/cli/internal/cli/command_help.go
+++ b/cli/internal/cli/command_help.go
@@ -150,6 +150,9 @@ func optionDescription(toolName string, propertyName string, property toolProper
 	if isRunTestsSaveBeforeRunOption(toolName, propertyName, property) {
 		return optionSummary(toolName, propertyName, property) + "; default: auto-save enabled"
 	}
+	if isCompileReloadExternalSceneChangesOption(toolName, propertyName, property) {
+		return optionSummary(toolName, propertyName, property) + "; default: auto-reload enabled"
+	}
 
 	parts := []string{}
 	if description := optionSummary(toolName, propertyName, property); description != "" {
@@ -168,6 +171,9 @@ func optionSummary(toolName string, propertyName string, property toolProperty) 
 	if isNegatedBooleanProperty(property) {
 		if isRunTestsSaveBeforeRunOption(toolName, propertyName, property) {
 			return "Fail before execution if unsaved editor changes remain instead of auto-saving them"
+		}
+		if isCompileReloadExternalSceneChangesOption(toolName, propertyName, property) {
+			return "Stop before execution if open Scene files changed externally instead of auto-reloading them"
 		}
 		summary := firstHelpLine(property.Description)
 		normalizedSummary := strings.ToLower(summary)

--- a/cli/internal/cli/completion_test.go
+++ b/cli/internal/cli/completion_test.go
@@ -50,7 +50,7 @@ func TestCompletionListOptionsUsesToolSchema(t *testing.T) {
 	}
 
 	output := stdout.String()
-	for _, option := range []string{"--force-recompile", "--no-wait-for-domain-reload"} {
+	for _, option := range []string{"--force-recompile", "--no-wait-for-domain-reload", "--stop-on-external-scene-changes"} {
 		if !strings.Contains(output, option) {
 			t.Fatalf("option %s was not listed: %s", option, output)
 		}
@@ -92,6 +92,9 @@ func TestCompletionListOptionsUsesEmbeddedFirstPartyToolSchema(t *testing.T) {
 	output := stdout.String()
 	if !strings.Contains(output, "--no-wait-for-domain-reload") {
 		t.Fatalf("embedded compile options were not used: %s", output)
+	}
+	if !strings.Contains(output, "--stop-on-external-scene-changes") {
+		t.Fatalf("embedded compile external Scene option was not used: %s", output)
 	}
 	if strings.Contains(output, "--wait-for-domain-reload") {
 		t.Fatalf("stale wait option should not be listed: %s", output)

--- a/cli/internal/cli/help_test.go
+++ b/cli/internal/cli/help_test.go
@@ -243,6 +243,9 @@ func TestRunProjectLocalCompileHelpDoesNotRequireUnityProject(t *testing.T) {
 		"uloop compile",
 		"--force-recompile",
 		"--no-wait-for-domain-reload",
+		"--stop-on-external-scene-changes",
+		"Stop before execution if open Scene files changed externally instead of auto-reloading them",
+		"default: auto-reload enabled",
 	} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("compile help missing %q:\n%s", expected, output)

--- a/cli/internal/cli/tools.go
+++ b/cli/internal/cli/tools.go
@@ -13,10 +13,11 @@ import (
 var version = clicontract.Current.CliVersion
 
 const (
-	cacheDirectoryName  = tools.CacheDirectoryName
-	cacheFileName       = tools.CacheFileName
-	projectPathFlagName = "project-path"
-	runTestsCommandName = "run-tests"
+	cacheDirectoryName                     = tools.CacheDirectoryName
+	cacheFileName                          = tools.CacheFileName
+	projectPathFlagName                    = "project-path"
+	runTestsCommandName                    = "run-tests"
+	reloadExternalSceneChangesPropertyName = "ReloadExternalSceneChanges"
 )
 
 type (
@@ -301,6 +302,9 @@ func optionNameForProperty(toolName string, propertyName string, property toolPr
 		if isRunTestsSaveBeforeRunOption(toolName, propertyName, property) {
 			return "fail-on-unsaved-changes"
 		}
+		if isCompileReloadExternalSceneChangesOption(toolName, propertyName, property) {
+			return "stop-on-external-scene-changes"
+		}
 		return "no-" + kebabName
 	}
 	return kebabName
@@ -309,6 +313,12 @@ func optionNameForProperty(toolName string, propertyName string, property toolPr
 func isRunTestsSaveBeforeRunOption(toolName string, propertyName string, property toolProperty) bool {
 	return toolName == runTestsCommandName &&
 		propertyName == "SaveBeforeRun" &&
+		isNegatedBooleanProperty(property)
+}
+
+func isCompileReloadExternalSceneChangesOption(toolName string, propertyName string, property toolProperty) bool {
+	return toolName == compileCommandName &&
+		propertyName == reloadExternalSceneChangesPropertyName &&
 		isNegatedBooleanProperty(property)
 }
 

--- a/cli/internal/cli/tools_test.go
+++ b/cli/internal/cli/tools_test.go
@@ -102,6 +102,23 @@ func TestBuildToolParamsConvertsRunTestsFailOnUnsavedChangesFlag(t *testing.T) {
 	}
 }
 
+// Tests that compile accepts --stop-on-external-scene-changes from embedded tools.
+func TestBuildToolParamsConvertsCompileStopOnExternalSceneChangesFlag(t *testing.T) {
+	tool, ok := findTool(loadDefaultTools(), compileCommandName)
+	if !ok {
+		t.Fatal("compile was not found in default tools")
+	}
+
+	params, _, err := buildToolParams([]string{"--stop-on-external-scene-changes"}, tool)
+	if err != nil {
+		t.Fatalf("buildToolParams failed: %v", err)
+	}
+
+	if params[reloadExternalSceneChangesPropertyName] != false {
+		t.Fatalf("ReloadExternalSceneChanges mismatch: %#v", params[reloadExternalSceneChangesPropertyName])
+	}
+}
+
 // Tests that run-tests-specific aliases do not leak into unrelated tool schemas.
 func TestBuildToolParamsKeepsGenericSaveBeforeRunFlagForOtherTools(t *testing.T) {
 	tool := toolDefinition{
@@ -124,6 +141,31 @@ func TestBuildToolParamsKeepsGenericSaveBeforeRunFlagForOtherTools(t *testing.T)
 	_, _, err = buildToolParams([]string{"--fail-on-unsaved-changes"}, tool)
 	if err == nil {
 		t.Fatal("expected run-tests-specific flag to be rejected")
+	}
+}
+
+// Tests that compile-specific aliases do not leak into unrelated tool schemas.
+func TestBuildToolParamsKeepsGenericReloadExternalSceneChangesFlagForOtherTools(t *testing.T) {
+	tool := toolDefinition{
+		Name: "sample-tool",
+		InputSchema: inputSchema{
+			Properties: map[string]toolProperty{
+				reloadExternalSceneChangesPropertyName: {Type: "boolean", Default: true},
+			},
+		},
+	}
+
+	params, _, err := buildToolParams([]string{"--no-reload-external-scene-changes"}, tool)
+	if err != nil {
+		t.Fatalf("buildToolParams failed: %v", err)
+	}
+	if params[reloadExternalSceneChangesPropertyName] != false {
+		t.Fatalf("ReloadExternalSceneChanges mismatch: %#v", params[reloadExternalSceneChangesPropertyName])
+	}
+
+	_, _, err = buildToolParams([]string{"--stop-on-external-scene-changes"}, tool)
+	if err == nil {
+		t.Fatal("expected compile-specific flag to be rejected")
 	}
 }
 

--- a/cli/internal/tools/default-tools.json
+++ b/cli/internal/tools/default-tools.json
@@ -15,6 +15,11 @@
             "type": "boolean",
             "description": "Wait for domain reload completion before returning",
             "default": true
+          },
+          "ReloadExternalSceneChanges": {
+            "type": "boolean",
+            "description": "Automatically reload or save open Scene files changed outside Unity before compiling",
+            "default": true
           }
         }
       }

--- a/cli/internal/tools/default-tools.json
+++ b/cli/internal/tools/default-tools.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-beta.23",
+  "version": "3.0.0-beta.24",
   "tools": [
     {
       "name": "compile",


### PR DESCRIPTION
## Summary
- Compile now resolves clean externally changed open Scenes before Unity refreshes assets, avoiding the modal dialog that can block autonomous CLI runs.
- Callers can use `--stop-on-external-scene-changes` to fail fast instead of automatic reload, while dirty external conflicts now stop with clear diagnostics instead of overwriting files.

## User Impact
- Before this change, a compile request could hang behind the Unity external Scene change dialog after a Scene file changed on disk.
- After this change, default compile runs continue automatically for clean external Scene changes, and unsafe dirty conflicts return actionable errors.

## Changes
- Track open Scene file fingerprints and resolve external changes before compile refresh.
- Add CLI parsing/help/completion support for `--stop-on-external-scene-changes`.
- Preserve external Scene preflight details during force compile and bump the native CLI contract/minimum version.

## Verification
- `git diff --check origin/v3-beta`
- `cli/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `cli/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "ExternalSceneChangeResolverTests|CompileSessionResultServiceTests|FirstPartySchemaProperties_WhenLoaded_ShouldNotExposeDescriptionAttributes|CliSetupApplicationServiceTests"`
- `scripts/check-go-cli.sh`
- `~/.codex/skills/codex-review/scripts/codex-review v3-beta`
