### PR TITLE
fix: No-test runs now explain likely test assembly setup issues

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -12,6 +12,8 @@ Before running `uloop run-tests`, run `uloop compile` for the same Unity project
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
+When an unfiltered `--filter-type all` run returns `TestCount: 0` and `Message` says no tests were found, read the `Message` for asmdef hints. `run-tests` only appends those hints when it detects likely test assembly configuration issues; exact, regex, and assembly filter misses keep the plain no-tests message.
+
 ## Usage
 
 ```bash

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -12,6 +12,8 @@ Before running `uloop run-tests`, run `uloop compile` for the same Unity project
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
+When an unfiltered `--filter-type all` run returns `TestCount: 0` and `Message` says no tests were found, read the `Message` for asmdef hints. `run-tests` only appends those hints when it detects likely test assembly configuration issues; exact, regex, and assembly filter misses keep the plain no-tests message.
+
 ## Usage
 
 ```bash

--- a/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs
+++ b/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs
@@ -61,6 +61,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void AppendDiagnosticsOrOriginalMessage_WhenDiagnosticsThrow_ReturnsOriginalMessage()
+        {
+            // Verifies optional no-test diagnostics cannot replace the original run-tests result with an exception.
+            string message = RunTestsNoTestsDiagnosticService.AppendDiagnosticsOrOriginalMessage(
+                RunTestsResponse.NoTestsFoundMessage,
+                () => throw new InvalidOperationException("diagnostic failure"));
+
+            Assert.That(message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+        }
+
+        [Test]
         public void ShouldAppendDiagnostics_WhenFilterIsAllAndNoTestsWereFound_ReturnsTrue()
         {
             // Verifies that unfiltered no-discovery results can receive asmdef diagnostics.

--- a/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs
+++ b/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
 
@@ -61,14 +62,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void AppendDiagnosticsOrOriginalMessage_WhenDiagnosticsThrow_ReturnsOriginalMessage()
+        public void AppendDiagnosticsOrOriginalMessage_WhenInspectionReadFails_ReturnsOriginalMessage()
         {
-            // Verifies optional no-test diagnostics cannot replace the original run-tests result with an exception.
+            // Verifies optional no-test diagnostics cannot replace the original run-tests result with an I/O failure.
             string message = RunTestsNoTestsDiagnosticService.AppendDiagnosticsOrOriginalMessage(
                 RunTestsResponse.NoTestsFoundMessage,
-                () => throw new InvalidOperationException("diagnostic failure"));
+                () => throw new IOException("diagnostic failure"));
 
             Assert.That(message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+        }
+
+        [Test]
+        public void AppendDiagnosticsOrOriginalMessage_WhenDiagnosticsHaveLogicFailure_Throws()
+        {
+            // Verifies no-test diagnostics do not hide programmer errors behind the original run-tests message.
+            Assert.Throws<InvalidOperationException>(() =>
+                RunTestsNoTestsDiagnosticService.AppendDiagnosticsOrOriginalMessage(
+                    RunTestsResponse.NoTestsFoundMessage,
+                    () => throw new InvalidOperationException("diagnostic failure")));
         }
 
         [Test]

--- a/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs
+++ b/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies run-tests no-discovery asmdef diagnostics.
+    /// </summary>
+    public sealed class RunTestsNoTestsDiagnosticServiceTests
+    {
+        [Test]
+        public void AppendFindingsIfEligible_WhenRunWasSuccessful_DoesNotAppendFindings()
+        {
+            // Verifies that a normal successful result cannot receive no-test asmdef hints.
+            RunTestsAsmdefDiagnosticFinding[] findings =
+            {
+                new RunTestsAsmdefDiagnosticFinding("Assets/Tests/EditMode/Sample.Tests.asmdef", "sample finding")
+            };
+
+            string message = RunTestsNoTestsDiagnosticService.AppendFindingsIfEligible(
+                RunTestsResponse.NoTestsFoundMessage,
+                success: true,
+                testCount: 1,
+                findings);
+
+            Assert.That(message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+        }
+
+        [Test]
+        public void AppendFindingsIfEligible_WhenNoFindingsExist_DoesNotAppendGenericHint()
+        {
+            // Verifies that filter-only no-discovery results stay unchanged when asmdefs look healthy.
+            string message = RunTestsNoTestsDiagnosticService.AppendFindingsIfEligible(
+                RunTestsResponse.NoTestsFoundMessage,
+                success: false,
+                testCount: 0,
+                Array.Empty<RunTestsAsmdefDiagnosticFinding>());
+
+            Assert.That(message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+        }
+
+        [Test]
+        public void AppendFindingsIfEligible_WhenMessageIsNull_DoesNotAppendFindings()
+        {
+            // Verifies unset result messages are ignored by no-test diagnostics.
+            RunTestsAsmdefDiagnosticFinding[] findings =
+            {
+                new RunTestsAsmdefDiagnosticFinding("Assets/Tests/EditMode/Sample.Tests.asmdef", "sample finding")
+            };
+
+            string message = RunTestsNoTestsDiagnosticService.AppendFindingsIfEligible(
+                null,
+                success: false,
+                testCount: 0,
+                findings);
+
+            Assert.That(message, Is.Null);
+        }
+
+        [Test]
+        public void ShouldAppendDiagnostics_WhenFilterIsAllAndNoTestsWereFound_ReturnsTrue()
+        {
+            // Verifies that unfiltered no-discovery results can receive asmdef diagnostics.
+            bool shouldAppend = RunTestsNoTestsDiagnosticService.ShouldAppendDiagnostics(
+                RunTestsResponse.NoTestsFoundMessage,
+                success: false,
+                testCount: 0,
+                TestFilterType.all);
+
+            Assert.That(shouldAppend, Is.True);
+        }
+
+        [Test]
+        public void ShouldAppendDiagnostics_WhenFilterIsExact_ReturnsFalse()
+        {
+            // Verifies that narrow filter misses cannot receive asmdef diagnostics.
+            bool shouldAppend = RunTestsNoTestsDiagnosticService.ShouldAppendDiagnostics(
+                RunTestsResponse.NoTestsFoundMessage,
+                success: false,
+                testCount: 0,
+                TestFilterType.exact);
+
+            Assert.That(shouldAppend, Is.False);
+        }
+
+        [Test]
+        public void Analyze_WhenTestNamedAsmdefIsNotMarkedAsTestAssembly_ReturnsMarkerFinding()
+        {
+            // Verifies that a test-named asmdef without any test assembly marker is diagnosed.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/EditMode/Sample.EditMode.Tests.asmdef",
+                "Sample.EditMode.Tests");
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "not marked as a test assembly"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenTestsEditorNamedAsmdefIsNotMarkedAsTestAssembly_ReturnsMarkerFinding()
+        {
+            // Verifies that the common Tests.Editor asmdef naming convention is diagnosed.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/Editor/Sample.Tests.Editor.asmdef",
+                "Sample.Tests.Editor");
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "not marked as a test assembly"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenNestedTestsEditModeAsmdefIsNotMarkedAsTestAssembly_ReturnsMarkerFinding()
+        {
+            // Verifies that nested feature test asmdefs using Tests.EditMode naming are diagnosed.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/Gameplay/Editor/Gameplay.Tests.EditMode.asmdef",
+                "Gameplay.Tests.EditMode");
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "not marked as a test assembly"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenNestedTestsFeatureEditorAsmdefIsNotMarkedAsTestAssembly_ReturnsMarkerFinding()
+        {
+            // Verifies that nested feature test asmdefs using Tests.Feature.Editor naming are diagnosed.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/Gameplay/Editor/Gameplay.Tests.Rendering.Editor.asmdef",
+                "Gameplay.Tests.Rendering.Editor");
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "not marked as a test assembly"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenEditorFolderAsmdefIsNotMarkedAsTestAssembly_ReturnsMarkerFinding()
+        {
+            // Verifies that asmdefs under Assets/Tests/Editor are diagnosed even without a test-like name.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/Editor/Sample.asmdef",
+                "Sample.EditorChecks");
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "not marked as a test assembly"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenPlayModeIsRequested_IgnoresEditorAsmdef()
+        {
+            // Verifies that PlayMode no-discovery diagnostics do not point at EditMode asmdefs.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/Editor/Sample.asmdef",
+                "Sample.EditorChecks");
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.PlayMode);
+
+            Assert.That(findings, Is.Empty);
+        }
+
+        [Test]
+        public void Analyze_WhenEditModeIsRequested_IgnoresPlayModeAsmdef()
+        {
+            // Verifies that EditMode no-discovery diagnostics do not point at PlayMode asmdefs.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/PlayMode/Sample.Tests.PlayMode.asmdef",
+                "Sample.Tests.PlayMode",
+                includePlatforms: new[] { "Editor" });
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(findings, Is.Empty);
+        }
+
+        [Test]
+        public void Analyze_WhenPlayModeAsmdefIsNotMarkedAsTestAssembly_ReturnsMarkerFinding()
+        {
+            // Verifies that PlayMode-relevant asmdefs still receive missing-marker diagnostics.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/PlayMode/Sample.Tests.PlayMode.asmdef",
+                "Sample.Tests.PlayMode");
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.PlayMode);
+
+            Assert.That(HasFinding(findings, "not marked as a test assembly"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenPlayModeAsmdefTargetsEditor_ReturnsPlayModePlatformFinding()
+        {
+            // Verifies that PlayMode asmdefs restricted to Editor are diagnosed instead of being filtered out.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/PlayMode/Sample.Tests.PlayMode.asmdef",
+                "Sample.Tests.PlayMode",
+                optionalUnityReferences: new[] { "TestAssemblies" },
+                includePlatforms: new[] { "Editor" });
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.PlayMode);
+
+            Assert.That(HasFinding(findings, "PlayMode test asmdef but targets Editor only"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenTestNamedAsmdefHasDirectTestRunnerReference_DoesNotReportMissingMarker()
+        {
+            // Verifies that legacy direct TestRunner references are not treated as missing markers by themselves.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/EditMode/Sample.EditMode.Tests.asmdef",
+                "Sample.EditMode.Tests",
+                references: new[] { "UnityEngine.TestRunner" });
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "not marked as a test assembly"), Is.False);
+        }
+
+        [Test]
+        public void Analyze_WhenTestAssemblyAlsoReferencesNamedTestRunner_ReturnsDuplicateFinding()
+        {
+            // Verifies that TestAssemblies plus direct named TestRunner references are treated as duplicate-risk configuration.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/EditMode/Sample.EditMode.Tests.asmdef",
+                "Sample.EditMode.Tests",
+                references: new[] { "UnityEngine.TestRunner", "UnityEditor.TestRunner" },
+                optionalUnityReferences: new[] { "TestAssemblies" },
+                includePlatforms: new[] { "Editor" });
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "duplicate references"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenTestAssemblyAlsoReferencesGuidTestRunner_ReturnsDuplicateFinding()
+        {
+            // Verifies that TestAssemblies plus GUID TestRunner references are treated as duplicate-risk configuration.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/EditMode/Sample.EditMode.Tests.asmdef",
+                "Sample.EditMode.Tests",
+                references: new[] { "GUID:27619889b8ba8c24980f49ee34dbb44a" },
+                optionalUnityReferences: new[] { "TestAssemblies" },
+                includePlatforms: new[] { "Editor" });
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "duplicate references"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenEditModeAsmdefDoesNotTargetEditor_ReturnsEditorPlatformFinding()
+        {
+            // Verifies that EditMode test asmdefs without the Editor platform receive a targeted hint.
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/EditMode/Sample.EditMode.Tests.asmdef",
+                "Sample.EditMode.Tests",
+                optionalUnityReferences: new[] { "TestAssemblies" });
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "includePlatforms"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenRuntimeReferenceExists_DoesNotReturnRuntimeReferenceFinding()
+        {
+            // Verifies that test asmdefs referencing runtime code do not receive the runtime-reference hint.
+            RunTestsAsmdefInfo runtimeAsmdef = CreateAsmdef(
+                "Assets/Scripts/Sample.Runtime.asmdef",
+                "Sample.Runtime");
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/EditMode/Sample.EditMode.Tests.asmdef",
+                "Sample.EditMode.Tests",
+                references: new[] { "Sample.Runtime" },
+                optionalUnityReferences: new[] { "TestAssemblies" },
+                includePlatforms: new[] { "Editor" });
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { runtimeAsmdef, testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "runtime asmdef"), Is.False);
+        }
+
+        [Test]
+        public void Analyze_WhenRuntimeReferenceIsMissing_ReturnsRuntimeReferenceFinding()
+        {
+            // Verifies that a test asmdef without runtime references receives a weak runtime-code hint.
+            RunTestsAsmdefInfo runtimeAsmdef = CreateAsmdef(
+                "Assets/Scripts/Sample.Runtime.asmdef",
+                "Sample.Runtime");
+            RunTestsAsmdefInfo testAsmdef = CreateAsmdef(
+                "Assets/Tests/EditMode/Sample.EditMode.Tests.asmdef",
+                "Sample.EditMode.Tests",
+                optionalUnityReferences: new[] { "TestAssemblies" },
+                includePlatforms: new[] { "Editor" });
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { runtimeAsmdef, testAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "runtime asmdef"), Is.True);
+        }
+
+        [Test]
+        public void Analyze_WhenOtherModeTestAsmdefExists_DoesNotTreatItAsRuntime()
+        {
+            // Verifies that PlayMode test asmdefs do not create runtime-reference hints for EditMode tests.
+            RunTestsAsmdefInfo playModeAsmdef = CreateAsmdef(
+                "Assets/Tests/PlayMode/Gameplay.asmdef",
+                "Gameplay");
+            RunTestsAsmdefInfo editModeAsmdef = CreateAsmdef(
+                "Assets/Tests/EditMode/Sample.EditMode.Tests.asmdef",
+                "Sample.EditMode.Tests",
+                optionalUnityReferences: new[] { "TestAssemblies" },
+                includePlatforms: new[] { "Editor" });
+
+            RunTestsAsmdefDiagnosticFinding[] findings = RunTestsNoTestsDiagnosticService.Analyze(
+                new[] { playModeAsmdef, editModeAsmdef },
+                UnityCliLoopTestMode.EditMode);
+
+            Assert.That(HasFinding(findings, "runtime asmdef"), Is.False);
+        }
+
+        private static bool HasFinding(RunTestsAsmdefDiagnosticFinding[] findings, string expectedText)
+        {
+            return findings.Any(finding => finding.Message.Contains(expectedText, StringComparison.Ordinal));
+        }
+
+        private static RunTestsAsmdefInfo CreateAsmdef(
+            string assetPath,
+            string name,
+            string[] references = null,
+            string[] optionalUnityReferences = null,
+            string[] includePlatforms = null,
+            bool testAssemblies = false)
+        {
+            return new RunTestsAsmdefInfo(
+                assetPath,
+                string.Empty,
+                name,
+                references ?? Array.Empty<string>(),
+                optionalUnityReferences ?? Array.Empty<string>(),
+                includePlatforms ?? Array.Empty<string>(),
+                testAssemblies);
+        }
+    }
+}

--- a/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs.meta
+++ b/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6b27797724704b0baf1c67fa8bb320a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
@@ -1,0 +1,414 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Adds asmdef configuration hints when Unity Test Runner reports that no tests were discovered.
+    /// </summary>
+    internal sealed class RunTestsNoTestsDiagnosticService
+    {
+        private const string HintPrefix = " Possible asmdef issues:";
+        private const string TestAssembliesReference = "TestAssemblies";
+        private const string UnityEngineTestRunnerReference = "UnityEngine.TestRunner";
+        private const string UnityEditorTestRunnerReference = "UnityEditor.TestRunner";
+        private const string UnityEngineTestRunnerGuidReference = "GUID:27619889b8ba8c24980f49ee34dbb44a";
+        private const string UnityEditorTestRunnerGuidReference = "GUID:0acc523941302664db1f4e527237feb3";
+        private const int MaxFindings = 4;
+
+        public string AppendDiagnosticsIfNeeded(
+            string message,
+            bool success,
+            int testCount,
+            UnityCliLoopTestMode testMode,
+            TestFilterType filterType)
+        {
+            if (!ShouldAppendDiagnostics(message, success, testCount, filterType))
+            {
+                return message;
+            }
+
+            RunTestsAsmdefInfo[] asmdefs = LoadProjectAsmdefs();
+            RunTestsAsmdefDiagnosticFinding[] findings = Analyze(asmdefs, testMode);
+            return AppendFindingsIfEligible(message, success, testCount, findings);
+        }
+
+        internal static string AppendFindingsIfEligible(
+            string message,
+            bool success,
+            int testCount,
+            IReadOnlyList<RunTestsAsmdefDiagnosticFinding> findings)
+        {
+            Debug.Assert(findings != null, "findings must not be null");
+
+            if (!ShouldInspect(message, success, testCount) || findings.Count == 0)
+            {
+                return message;
+            }
+
+            string[] findingMessages = findings
+                .Take(MaxFindings)
+                .Select(finding => $"{finding.AssetPath}: {finding.Message}")
+                .ToArray();
+            string suffix = string.Join(" ", findingMessages);
+            if (findings.Count > MaxFindings)
+            {
+                suffix += $" Additional asmdef issues omitted: {findings.Count - MaxFindings}.";
+            }
+
+            return message + HintPrefix + " " + suffix;
+        }
+
+        internal static RunTestsAsmdefDiagnosticFinding[] Analyze(
+            IReadOnlyList<RunTestsAsmdefInfo> asmdefs,
+            UnityCliLoopTestMode testMode)
+        {
+            Debug.Assert(asmdefs != null, "asmdefs must not be null");
+
+            RunTestsAsmdefInfo[] allTestAsmdefs = asmdefs
+                .Where(IsTestAsmdefCandidate)
+                .ToArray();
+            RunTestsAsmdefInfo[] testAsmdefs = allTestAsmdefs
+                .Where(asmdef => IsRelevantToTestMode(asmdef, testMode))
+                .ToArray();
+            RunTestsAsmdefInfo[] runtimeAsmdefs = asmdefs
+                .Where(asmdef => IsRuntimeAsmdef(asmdef, allTestAsmdefs))
+                .ToArray();
+            List<RunTestsAsmdefDiagnosticFinding> findings = new();
+
+            foreach (RunTestsAsmdefInfo testAsmdef in testAsmdefs)
+            {
+                bool hasTestAssemblyMarker = HasTestAssemblyMarker(testAsmdef);
+                bool hasAnyDirectTestRunnerReference = HasAnyDirectTestRunnerReference(testAsmdef);
+
+                if (!hasTestAssemblyMarker && !hasAnyDirectTestRunnerReference)
+                {
+                    findings.Add(new RunTestsAsmdefDiagnosticFinding(
+                        testAsmdef.AssetPath,
+                        "looks like a test asmdef but is not marked as a test assembly. Add optionalUnityReferences: [\"TestAssemblies\"] or enable testAssemblies."));
+                }
+
+                if (hasTestAssemblyMarker && hasAnyDirectTestRunnerReference)
+                {
+                    findings.Add(new RunTestsAsmdefDiagnosticFinding(
+                        testAsmdef.AssetPath,
+                        "test assembly marker is combined with direct UnityEngine.TestRunner or UnityEditor.TestRunner references. Remove direct TestRunner references to avoid duplicate references."));
+                }
+
+                if (testMode == UnityCliLoopTestMode.EditMode && LooksLikeEditModeAsmdef(testAsmdef) && !IncludesEditorPlatform(testAsmdef))
+                {
+                    findings.Add(new RunTestsAsmdefDiagnosticFinding(
+                        testAsmdef.AssetPath,
+                        "looks like an EditMode test asmdef but does not target Editor. Add includePlatforms: [\"Editor\"]."));
+                }
+
+                if (testMode == UnityCliLoopTestMode.PlayMode && LooksLikePlayModeAsmdef(testAsmdef) && IncludesEditorPlatform(testAsmdef))
+                {
+                    findings.Add(new RunTestsAsmdefDiagnosticFinding(
+                        testAsmdef.AssetPath,
+                        "looks like a PlayMode test asmdef but targets Editor only. Remove Editor-only includePlatforms for PlayMode tests."));
+                }
+
+                if (runtimeAsmdefs.Length > 0 && !ReferencesAnyRuntimeAsmdef(testAsmdef, runtimeAsmdefs))
+                {
+                    findings.Add(new RunTestsAsmdefDiagnosticFinding(
+                        testAsmdef.AssetPath,
+                        "does not reference a runtime asmdef. If these tests target runtime code, reference the runtime asmdef under test."));
+                }
+            }
+
+            return findings.ToArray();
+        }
+
+        internal static bool ShouldAppendDiagnostics(
+            string message,
+            bool success,
+            int testCount,
+            TestFilterType filterType)
+        {
+            return filterType == TestFilterType.all && ShouldInspect(message, success, testCount);
+        }
+
+        internal static bool ShouldInspect(string message, bool success, int testCount)
+        {
+            return !success
+                   && testCount == 0
+                   && string.Equals(message, RunTestsResponse.NoTestsFoundMessage, StringComparison.Ordinal);
+        }
+
+        private static RunTestsAsmdefInfo[] LoadProjectAsmdefs()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string[] asmdefGuids = AssetDatabase.FindAssets("t:AssemblyDefinitionAsset");
+            List<RunTestsAsmdefInfo> asmdefs = new();
+
+            foreach (string guid in asmdefGuids)
+            {
+                string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                if (!IsInspectableProjectAsmdef(assetPath))
+                {
+                    continue;
+                }
+
+                string absolutePath = Path.Combine(projectRoot, assetPath);
+                if (!File.Exists(absolutePath))
+                {
+                    continue;
+                }
+
+                AsmdefJson json = JsonUtility.FromJson<AsmdefJson>(File.ReadAllText(absolutePath));
+                if (json == null)
+                {
+                    continue;
+                }
+
+                string name = string.IsNullOrEmpty(json.name)
+                    ? Path.GetFileNameWithoutExtension(assetPath)
+                    : json.name;
+                asmdefs.Add(new RunTestsAsmdefInfo(
+                    assetPath,
+                    guid,
+                    name,
+                    json.references ?? Array.Empty<string>(),
+                    json.optionalUnityReferences ?? Array.Empty<string>(),
+                    json.includePlatforms ?? Array.Empty<string>(),
+                    json.testAssemblies));
+            }
+
+            return asmdefs
+                .OrderBy(asmdef => asmdef.AssetPath, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static bool IsInspectableProjectAsmdef(string assetPath)
+        {
+            return !string.IsNullOrEmpty(assetPath)
+                   && assetPath.StartsWith("Assets/", StringComparison.Ordinal);
+        }
+
+        private static bool IsTestAsmdefCandidate(RunTestsAsmdefInfo asmdef)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            return HasTestAssemblyMarker(asmdef)
+                   || HasAnyDirectTestRunnerReference(asmdef)
+                   || LooksLikeNamedTestAsmdef(asmdef);
+        }
+
+        private static bool IsRelevantToTestMode(RunTestsAsmdefInfo asmdef, UnityCliLoopTestMode testMode)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            bool looksLikeEditModeAsmdef = LooksLikeEditModeNameOrPath(asmdef);
+            bool looksLikePlayModeAsmdef = LooksLikePlayModeAsmdef(asmdef);
+            if (testMode == UnityCliLoopTestMode.EditMode)
+            {
+                return looksLikeEditModeAsmdef
+                       || (!looksLikePlayModeAsmdef && IncludesEditorPlatform(asmdef));
+            }
+
+            return looksLikePlayModeAsmdef
+                   || (!looksLikeEditModeAsmdef && !IncludesEditorPlatform(asmdef));
+        }
+
+        private static bool LooksLikeNamedTestAsmdef(RunTestsAsmdefInfo asmdef)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            string fileName = Path.GetFileNameWithoutExtension(asmdef.AssetPath);
+            return ContainsModeTestName(asmdef.Name)
+                   || ContainsModeTestName(fileName)
+                   || IsUnderCommonTestFolder(asmdef.AssetPath);
+        }
+
+        private static bool ContainsModeTestName(string value)
+        {
+            Debug.Assert(value != null, "value must not be null");
+
+            return value.Contains("EditMode.Tests", StringComparison.OrdinalIgnoreCase)
+                   || value.Contains("PlayMode.Tests", StringComparison.OrdinalIgnoreCase)
+                   || value.EndsWith(".Tests.Editor", StringComparison.OrdinalIgnoreCase)
+                   || ContainsNestedTestsModeName(value)
+                   || value.EndsWith(".Tests.PlayMode", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool ContainsNestedTestsModeName(string value)
+        {
+            Debug.Assert(value != null, "value must not be null");
+
+            return value.Contains(".Tests.", StringComparison.OrdinalIgnoreCase)
+                   && (value.EndsWith(".Editor", StringComparison.OrdinalIgnoreCase)
+                       || value.EndsWith(".EditMode", StringComparison.OrdinalIgnoreCase)
+                       || value.EndsWith(".PlayMode", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool IsUnderCommonTestFolder(string assetPath)
+        {
+            Debug.Assert(assetPath != null, "assetPath must not be null");
+
+            return assetPath.StartsWith("Assets/Tests/Editor/", StringComparison.Ordinal)
+                   || assetPath.StartsWith("Assets/Tests/EditMode/", StringComparison.Ordinal)
+                   || assetPath.StartsWith("Assets/Tests/PlayMode/", StringComparison.Ordinal);
+        }
+
+        private static bool IsRuntimeAsmdef(RunTestsAsmdefInfo asmdef, IReadOnlyList<RunTestsAsmdefInfo> testAsmdefs)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+            Debug.Assert(testAsmdefs != null, "testAsmdefs must not be null");
+
+            return !testAsmdefs.Contains(asmdef)
+                   && !LooksLikeEditModeAsmdef(asmdef)
+                   && !asmdef.Name.Contains("Test", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool HasTestAssemblyMarker(RunTestsAsmdefInfo asmdef)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            return asmdef.TestAssemblies
+                   || asmdef.OptionalUnityReferences.Contains(TestAssembliesReference);
+        }
+
+        private static bool HasNamedDirectTestRunnerReference(RunTestsAsmdefInfo asmdef)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            return asmdef.References.Contains(UnityEngineTestRunnerReference)
+                   || asmdef.References.Contains(UnityEditorTestRunnerReference);
+        }
+
+        private static bool HasAnyDirectTestRunnerReference(RunTestsAsmdefInfo asmdef)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            return HasNamedDirectTestRunnerReference(asmdef)
+                   || asmdef.References.Contains(UnityEngineTestRunnerGuidReference)
+                   || asmdef.References.Contains(UnityEditorTestRunnerGuidReference);
+        }
+
+        private static bool IncludesEditorPlatform(RunTestsAsmdefInfo asmdef)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            return asmdef.IncludePlatforms.Contains("Editor");
+        }
+
+        private static bool LooksLikeEditModeAsmdef(RunTestsAsmdefInfo asmdef)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            return LooksLikeEditModeNameOrPath(asmdef) || IncludesEditorPlatform(asmdef);
+        }
+
+        private static bool LooksLikeEditModeNameOrPath(RunTestsAsmdefInfo asmdef)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            return asmdef.AssetPath.Contains("/Editor/", StringComparison.Ordinal)
+                   || asmdef.AssetPath.Contains("/EditMode/", StringComparison.Ordinal)
+                   || asmdef.Name.EndsWith(".Editor", StringComparison.Ordinal)
+                   || asmdef.Name.Contains("EditMode", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool LooksLikePlayModeAsmdef(RunTestsAsmdefInfo asmdef)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+
+            return asmdef.AssetPath.Contains("/PlayMode/", StringComparison.Ordinal)
+                   || asmdef.Name.EndsWith(".PlayMode", StringComparison.Ordinal)
+                   || asmdef.Name.Contains("PlayMode", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool ReferencesAnyRuntimeAsmdef(
+            RunTestsAsmdefInfo testAsmdef,
+            IReadOnlyList<RunTestsAsmdefInfo> runtimeAsmdefs)
+        {
+            Debug.Assert(testAsmdef != null, "testAsmdef must not be null");
+            Debug.Assert(runtimeAsmdefs != null, "runtimeAsmdefs must not be null");
+
+            foreach (RunTestsAsmdefInfo runtimeAsmdef in runtimeAsmdefs)
+            {
+                if (testAsmdef.References.Contains(runtimeAsmdef.Name) ||
+                    testAsmdef.References.Contains("GUID:" + runtimeAsmdef.Guid))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [Serializable]
+        private sealed class AsmdefJson
+        {
+            public string name = string.Empty;
+            public string[] references = Array.Empty<string>();
+            public string[] optionalUnityReferences = Array.Empty<string>();
+            public string[] includePlatforms = Array.Empty<string>();
+            public bool testAssemblies = false;
+        }
+    }
+
+    /// <summary>
+    /// Carries the asmdef fields needed for run-tests no-discovery diagnostics.
+    /// </summary>
+    internal sealed class RunTestsAsmdefInfo
+    {
+        public RunTestsAsmdefInfo(
+            string assetPath,
+            string guid,
+            string name,
+            string[] references,
+            string[] optionalUnityReferences,
+            string[] includePlatforms,
+            bool testAssemblies)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assetPath), "assetPath must not be null or empty");
+            Debug.Assert(guid != null, "guid must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(name), "name must not be null or empty");
+            Debug.Assert(references != null, "references must not be null");
+            Debug.Assert(optionalUnityReferences != null, "optionalUnityReferences must not be null");
+            Debug.Assert(includePlatforms != null, "includePlatforms must not be null");
+
+            AssetPath = assetPath;
+            Guid = guid;
+            Name = name;
+            References = references;
+            OptionalUnityReferences = optionalUnityReferences;
+            IncludePlatforms = includePlatforms;
+            TestAssemblies = testAssemblies;
+        }
+
+        public string AssetPath { get; }
+        public string Guid { get; }
+        public string Name { get; }
+        public string[] References { get; }
+        public string[] OptionalUnityReferences { get; }
+        public string[] IncludePlatforms { get; }
+        public bool TestAssemblies { get; }
+    }
+
+    /// <summary>
+    /// Carries one asmdef hint that can be appended to a no-tests run-tests response.
+    /// </summary>
+    internal sealed class RunTestsAsmdefDiagnosticFinding
+    {
+        public RunTestsAsmdefDiagnosticFinding(string assetPath, string message)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assetPath), "assetPath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(message), "message must not be null or empty");
+
+            AssetPath = assetPath;
+            Message = message;
+        }
+
+        public string AssetPath { get; }
+        public string Message { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
@@ -39,6 +39,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return AppendFindingsIfEligible(message, success, testCount, findings);
         }
 
+        internal static string AppendDiagnosticsOrOriginalMessage(string message, Func<string> appendDiagnostics)
+        {
+            Debug.Assert(appendDiagnostics != null, "appendDiagnostics must not be null");
+
+            try
+            {
+                return appendDiagnostics();
+            }
+            catch (Exception exception)
+            {
+                Debug.LogWarning($"Failed to build no-tests diagnostics: {exception}");
+                return message;
+            }
+        }
+
         internal static string AppendFindingsIfEligible(
             string message,
             bool success,

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
@@ -47,11 +47,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return appendDiagnostics();
             }
-            catch (Exception exception)
+            catch (Exception exception) when (IsRecoverableAsmdefInspectionException(exception))
             {
                 Debug.LogWarning($"Failed to build no-tests diagnostics: {exception}");
                 return message;
             }
+        }
+
+        private static bool IsRecoverableAsmdefInspectionException(Exception exception)
+        {
+            Debug.Assert(exception != null, "exception must not be null");
+
+            return exception is IOException ||
+                   exception is UnauthorizedAccessException;
         }
 
         internal static string AppendFindingsIfEligible(

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bada1df639f064070a050344d4e9dd58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -10,6 +10,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class RunTestsResponse : UnityCliLoopToolResponse
     {
+        internal const string NoTestsFoundMessage = "No tests found matching the specified filter criteria";
+
         public static readonly string TestFrameworkUnavailableMessage =
             $"run-tests requires the Unity Test Framework package ({UnityCliLoopConstants.PACKAGE_NAME_TEST_FRAMEWORK}). Install it via Package Manager to use test execution.";
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -119,12 +119,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SkippedCount = result.skippedCount,
                 XmlPath = result.xmlPath
             };
-            response.Message = _noTestsDiagnosticService.AppendDiagnosticsIfNeeded(
+            response.Message = RunTestsNoTestsDiagnosticService.AppendDiagnosticsOrOriginalMessage(
                 response.Message,
-                response.Success,
-                response.TestCount,
-                parameters.TestMode,
-                parameters.FilterType);
+                () => _noTestsDiagnosticService.AppendDiagnosticsIfNeeded(
+                    response.Message,
+                    response.Success,
+                    response.TestCount,
+                    parameters.TestMode,
+                    parameters.FilterType));
             return response;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -17,6 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly TestFilterCreationService _filterService;
         private readonly TestExecutionService _executionService;
         private readonly TestExecutionStateValidationService _validationService;
+        private readonly RunTestsNoTestsDiagnosticService _noTestsDiagnosticService;
 
         public RunTestsUseCase()
             : this(
@@ -37,6 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _filterService = filterService;
             _executionService = executionService;
             _validationService = validationService;
+            _noTestsDiagnosticService = new RunTestsNoTestsDiagnosticService();
         }
 
         /// <summary>
@@ -106,7 +108,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             
             // 3. Response creation
-            return new UnityCliLoopTestExecutionResult
+            UnityCliLoopTestExecutionResult response = new UnityCliLoopTestExecutionResult
             {
                 Success = result.success,
                 Message = result.message,
@@ -117,6 +119,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SkippedCount = result.skippedCount,
                 XmlPath = result.xmlPath
             };
+            response.Message = _noTestsDiagnosticService.AppendDiagnosticsIfNeeded(
+                response.Message,
+                response.Success,
+                response.TestCount,
+                parameters.TestMode,
+                parameters.FilterType);
+            return response;
         }
 
         public Task<UnityCliLoopTestExecutionResult> RunTestsAsync(UnityCliLoopTestExecutionRequest request, CancellationToken ct)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -12,6 +12,8 @@ Before running `uloop run-tests`, run `uloop compile` for the same Unity project
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
+When an unfiltered `--filter-type all` run returns `TestCount: 0` and `Message` says no tests were found, read the `Message` for asmdef hints. `run-tests` only appends those hints when it detects likely test assembly configuration issues; exact, regex, and assembly filter misses keep the plain no-tests message.
+
 ## Usage
 
 ```bash

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs
@@ -51,7 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (totalTests == 0)
             {
-                return "No tests found matching the specified filter criteria";
+                return RunTestsResponse.NoTestsFoundMessage;
             }
 
             return $"Test execution completed with status: {result.TestStatus}";


### PR DESCRIPTION
## Summary
- `uloop run-tests` now gives actionable asmdef hints when an unfiltered run discovers zero tests.
- Narrow filter misses still keep the plain no-tests message, so normal exact, regex, and assembly misses are not over-diagnosed.

## User Impact
- Before this change, Unity Test Runner could report `No tests found matching the specified filter criteria` with no clue that the project asmdef setup was likely wrong.
- After this change, agents and developers get targeted hints for likely missing test assembly markers, duplicate TestRunner references, wrong EditMode or PlayMode platform targeting, and missing runtime asmdef references.

## Changes
- Adds no-test diagnostics that run only for unfiltered zero-discovery results.
- Detects common test asmdef layouts, including nested feature test assemblies.
- Keeps the run-tests response schema unchanged and updates generated run-tests skill docs.
- Adds focused EditMode coverage for the diagnostic and false-positive guard cases.

## Verification
- `git diff --check`
- `dotnet build UnityCLILoop.FirstPartyTools.RunTests.Editor.csproj /v:minimal /p:RunAnalyzers=false`
- `cli/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`
- `cli/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value RunTestsNoTestsDiagnosticServiceTests`
- `cli/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type exact --filter-value Does.Not.Exist`
- `codex-review v3-beta`
