### PR TITLE
fix: Compile waits longer before reporting indeterminate results

### DIFF
--- a/Assets/Tests/Editor/CompileLifecycleWatchdogTests.cs
+++ b/Assets/Tests/Editor/CompileLifecycleWatchdogTests.cs
@@ -69,6 +69,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task WatchAsync_WhenRequestCompletesAfterOldFinishGrace_StopsWithoutRecovery()
+        {
+            // Verifies delayed finish callbacks are still accepted after the old 500ms grace window.
+            SequenceCompilationState compilationState = new SequenceCompilationState(
+                new bool[] { false, true, false, false, false, false, false, false, false });
+            int waitCount = 0;
+            int missedCallbackCount = 0;
+            int startTimeoutCount = 0;
+            CompileLifecycleWatchdog watchdog = new CompileLifecycleWatchdog(
+                compilationState.IsCompiling,
+                () => waitCount >= 7,
+                () =>
+                {
+                    waitCount++;
+                    return Task.CompletedTask;
+                },
+                _ => { },
+                _ => startTimeoutCount++,
+                _ => missedCallbackCount++,
+                _ => { });
+
+            await watchdog.WatchAsync(CancellationToken.None);
+
+            Assert.That(waitCount * UnityCliLoopConstants.COMPILE_START_POLL_INTERVAL_MS, Is.GreaterThan(500));
+            Assert.That(missedCallbackCount, Is.EqualTo(0));
+            Assert.That(startTimeoutCount, Is.EqualTo(0));
+        }
+
+        [Test]
         public async Task WatchAsync_WhenCompileNeverStarts_RequestsStartTimeout()
         {
             // Verifies the watchdog keeps the existing start-timeout recovery path.

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -95,7 +95,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
 
         public const int COMPILE_START_TIMEOUT_MS = 5000;
         public const int COMPILE_START_POLL_INTERVAL_MS = 100;
-        public const int COMPILE_FINISH_MISSED_CALLBACK_GRACE_MS = 500;
+        public const int COMPILE_FINISH_MISSED_CALLBACK_GRACE_MS = 2000;
         
         public const int MAX_SETTINGS_SIZE_BYTES = 1024 * 16;
         public const string SECURITY_LOG_PREFIX = "[UnityCliLoop Security]";


### PR DESCRIPTION
## Summary
- Compile now waits longer before treating a stopped compiler state as a missing finish callback.
- Delayed normal completion callbacks no longer produce premature indeterminate results.

## User Impact
- Before, compile could return `Success: null` after Unity reported it was no longer compiling if the finish callback arrived later than 500ms.
- After, compile allows a 2 second window before falling back to missed-callback recovery, reducing false indeterminate results while still recovering from real misses.

## Changes
- Extended the compile finish missed-callback grace window from 500ms to 2000ms.
- Added watchdog coverage for requests that complete after the previous 500ms window.
- Kept the existing missed-callback recovery path for real callback misses.

## Verification
- `cli/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`
- `cli/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value "CompileLifecycleWatchdogTests"`
- `git diff --check`

Closes #1273