### PR TITLE
fix: Setup no longer opens after upgrades with no CLI or skill updates

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -137,6 +137,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(hasSkillUpdate, Is.False);
         }
 
+        [Test]
+        public void HasSkillUpdateForSetupWizard_WhenTargetHasDifferentLayoutSkills_ReturnsTrue()
+        {
+            // Verifies that existing skills in the old layout request the upgrade-time wizard.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateSkillTarget(
+                    hasSkillsDirectory: true,
+                    installState: SkillInstallState.Missing,
+                    hasDifferentLayoutSkills: true)
+            };
+
+            bool hasSkillUpdate = SetupWizardWindow.HasSkillUpdateForSetupWizard(targets);
+
+            Assert.That(hasSkillUpdate, Is.True);
+        }
+
         [TestCase("2.1.1", "3.0.0-beta.7", true)]
         [TestCase("1.9.0", "3.0.0", true)]
         [TestCase("", "3.0.0-beta.7", false)]
@@ -778,7 +795,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private static SkillSetupTargetInfo CreateSkillTarget(
             bool hasSkillsDirectory,
-            SkillInstallState installState)
+            SkillInstallState installState,
+            bool hasDifferentLayoutSkills = false)
         {
             return new SkillSetupTargetInfo(
                 "Claude Code",
@@ -786,7 +804,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "--claude",
                 hasSkillsDirectory,
                 hasExistingSkills: hasSkillsDirectory,
-                hasDifferentLayoutSkills: false,
+                hasDifferentLayoutSkills,
                 installState);
         }
 

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -58,25 +58,83 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _originalSessionState.Restore(_sessionStateService);
         }
 
-        [TestCase("", "1.7.3", false, true)]
-        [TestCase("1.7.2", "1.7.3", false, true)]
-        [TestCase("1.7.4", "1.7.3", false, true)]
-        [TestCase("1.7.3", "1.7.3", false, false)]
-        [TestCase("", "1.7.3", true, false)]
-        [TestCase("1.7.2", "1.7.3", true, false)]
+        [TestCase("", "1.7.3", false, false, false, true)]
+        [TestCase("1.7.2", "1.7.3", false, false, false, false)]
+        [TestCase("1.7.2", "1.7.3", false, true, false, true)]
+        [TestCase("1.7.2", "1.7.3", false, false, true, true)]
+        [TestCase("1.7.4", "1.7.3", false, false, true, true)]
+        [TestCase("1.7.3", "1.7.3", false, true, true, false)]
+        [TestCase("", "1.7.3", true, true, true, false)]
+        [TestCase("1.7.2", "1.7.3", true, true, true, false)]
         public void ShouldAutoShowForVersion_ReturnsExpectedValue(
             string lastSeenVersion,
             string currentVersion,
             bool suppressAutoShow,
+            bool needsCliUpdate,
+            bool hasSkillUpdate,
             bool expected)
         {
+            // Verifies that package upgrades auto-show only for first install or actionable updates.
             bool shouldAutoShow =
                 SetupWizardWindow.ShouldAutoShowForVersion(
                     currentVersion,
                     lastSeenVersion,
-                    suppressAutoShow);
+                    suppressAutoShow,
+                    needsCliUpdate,
+                    hasSkillUpdate);
 
             Assert.That(shouldAutoShow, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void HasSkillUpdateForSetupWizard_WhenOutdatedTargetHasSkillsDirectory_ReturnsTrue()
+        {
+            // Verifies that outdated installed skills request the upgrade-time wizard.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateSkillTarget(
+                    hasSkillsDirectory: true,
+                    installState: SkillInstallState.Outdated)
+            };
+
+            bool hasSkillUpdate = SetupWizardWindow.HasSkillUpdateForSetupWizard(targets);
+
+            Assert.That(hasSkillUpdate, Is.True);
+        }
+
+        [TestCase(SkillInstallState.Installed)]
+        [TestCase(SkillInstallState.Missing)]
+        [TestCase(SkillInstallState.Checking)]
+        public void HasSkillUpdateForSetupWizard_WhenTargetIsNotOutdated_ReturnsFalse(
+            SkillInstallState installState)
+        {
+            // Verifies that non-outdated skill states do not request the upgrade-time wizard.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateSkillTarget(
+                    hasSkillsDirectory: true,
+                    installState)
+            };
+
+            bool hasSkillUpdate = SetupWizardWindow.HasSkillUpdateForSetupWizard(targets);
+
+            Assert.That(hasSkillUpdate, Is.False);
+        }
+
+        [Test]
+        public void HasSkillUpdateForSetupWizard_WhenOutdatedTargetHasNoSkillsDirectory_ReturnsFalse()
+        {
+            // Verifies that missing opt-in skills directories are not treated as skill updates.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateSkillTarget(
+                    hasSkillsDirectory: false,
+                    installState: SkillInstallState.Outdated)
+            };
+
+            bool hasSkillUpdate = SetupWizardWindow.HasSkillUpdateForSetupWizard(targets);
+
+            Assert.That(hasSkillUpdate, Is.False);
         }
 
         [TestCase("2.1.1", "3.0.0-beta.7", true)]
@@ -716,6 +774,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool hasFiniteSize = SetupWizardWindow.HasFiniteSize(new Vector2(240f, 120f));
 
             Assert.That(hasFiniteSize, Is.True);
+        }
+
+        private static SkillSetupTargetInfo CreateSkillTarget(
+            bool hasSkillsDirectory,
+            SkillInstallState installState)
+        {
+            return new SkillSetupTargetInfo(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory,
+                hasExistingSkills: hasSkillsDirectory,
+                hasDifferentLayoutSkills: false,
+                installState);
         }
 
         private static void RestoreFile(string path, bool existed, string content)

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -722,7 +722,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(targets != null, "targets must not be null");
             return targets.Any(
                 target => target.HasSkillsDirectory
-                    && target.InstallState == SkillInstallState.Outdated);
+                    && (target.InstallState == SkillInstallState.Outdated
+                        || target.HasDifferentLayoutSkills));
         }
 
         internal static bool ShouldUseFirstInstallSkillsUi(string lastSeenSetupWizardVersion)

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -65,12 +65,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool ShouldAutoShowForVersion(
             string currentVersion,
             string lastSeenVersion,
-            bool suppressAutoShow)
+            bool suppressAutoShow,
+            bool needsCliUpdate,
+            bool hasSkillUpdate)
         {
             bool versionChanged = !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
             if (!versionChanged) return false;
+            if (suppressAutoShow) return false;
 
-            return !suppressAutoShow;
+            return string.IsNullOrEmpty(lastSeenVersion)
+                || needsCliUpdate
+                || hasSkillUpdate;
         }
 
         internal static bool ShouldAutoScanThirdPartyToolMigration(string currentVersion, string lastSeenVersion)
@@ -124,7 +129,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             EvaluateVersionChange(CancellationToken.None);
         }
 
-        private static void EvaluateVersionChange(CancellationToken ct)
+        private static async void EvaluateVersionChange(CancellationToken ct)
         {
             string currentVersion = UnityCliLoopConstants.PackageInfo.version;
             UnityCliLoopEditorSettingsService editorSettingsService = GetEditorSettingsService();
@@ -140,18 +145,80 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 lastSeenVersion);
             MaybeScheduleThirdPartyToolMigrationAutoScan(shouldAutoScanThirdPartyToolMigration);
 
-            bool shouldAutoShow = ShouldAutoShowForVersion(
+            bool versionChanged = !string.Equals(
                 currentVersion,
                 lastSeenVersion,
-                suppressAutoShow);
-
-            if (!shouldAutoShow)
+                System.StringComparison.Ordinal);
+            if (!versionChanged || suppressAutoShow)
             {
                 MaybeRecordSuppressedVersion(suppressAutoShow, currentVersion);
                 return;
             }
 
+            bool needsCliUpdate = false;
+            bool hasSkillUpdate = false;
+            if (!string.IsNullOrEmpty(lastSeenVersion))
+            {
+                needsCliUpdate = await NeedsCliUpdateForSetupWizardAsync(ct);
+                if (ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                if (!needsCliUpdate)
+                {
+                    hasSkillUpdate = await HasSkillUpdateForSetupWizardAsync(ct);
+                    if (ct.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                }
+            }
+
+            bool shouldAutoShow = ShouldAutoShowForVersion(
+                currentVersion,
+                lastSeenVersion,
+                suppressAutoShow,
+                needsCliUpdate,
+                hasSkillUpdate);
+
+            if (!shouldAutoShow)
+            {
+                MaybeRecordLastSeenVersion(true, currentVersion);
+                return;
+            }
+
             EditorApplication.delayCall += ShowWindowOnVersionChange;
+        }
+
+        private static async Task<bool> NeedsCliUpdateForSetupWizardAsync(CancellationToken ct)
+        {
+            await CliSetupApplicationFacade.ForceRefreshCliVersionAsync(ct);
+            string cliVersion = CliSetupApplicationFacade.GetCachedCliVersion();
+            if (string.IsNullOrEmpty(cliVersion))
+            {
+                return false;
+            }
+
+            string requiredCliVersion = GetMinimumRequiredCliVersion();
+            return !IsCliVersionSatisfied(cliVersion, requiredCliVersion);
+        }
+
+        private static async Task<bool> HasSkillUpdateForSetupWizardAsync(CancellationToken ct)
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            SkillSetupUseCase skillSetupUseCase = SkillSetupUseCaseRegistry.GetRegisteredUseCase();
+            List<SkillSetupTargetInfo> targets = await Task.Run(
+                () => skillSetupUseCase.DetectSkillTargetsForLayoutAtProjectRoot(
+                    projectRoot,
+                    !ForceFlatSkillInstall),
+                ct);
+            if (ct.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            return HasSkillUpdateForSetupWizard(targets);
         }
 
         private static void ShowWindowOnVersionChange()
@@ -647,6 +714,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return targets
                 .Where(target => target.HasSkillsDirectory)
                 .ToList();
+        }
+
+        internal static bool HasSkillUpdateForSetupWizard(
+            IEnumerable<SkillSetupTargetInfo> targets)
+        {
+            Debug.Assert(targets != null, "targets must not be null");
+            return targets.Any(
+                target => target.HasSkillsDirectory
+                    && target.InstallState == SkillInstallState.Outdated);
         }
 
         internal static bool ShouldUseFirstInstallSkillsUi(string lastSeenSetupWizardVersion)


### PR DESCRIPTION
## Summary
- Setup no longer opens automatically after every package upgrade when the installed CLI and skills are already current.
- Existing skills in older folder layouts still reopen Setup so users can migrate or update them.

## User Impact
- Returning users are not interrupted by Setup on version bumps that do not require any CLI or skill update.
- Users with outdated skills or older skill folder layouts still see Setup when an upgrade leaves skill work to do.

## Changes
- Gate upgrade-time Setup auto-show on first install, required CLI updates, outdated skills, or older skill folder layout migration.
- Record the package version as seen when no actionable CLI or skill update exists.
- Add focused Setup Wizard tests for update, missing, outdated, and different-layout skill states.

## Verification
- `cli/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `cli/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "SetupWizardWindowTests|SetupWizardStartup_WhenLoaded_SchedulesVersionCheckInsteadOfReadingSettingsSynchronously"`
- `~/.codex/skills/codex-review/scripts/codex-review v3-beta --parallel-tests ...`