### PR TITLE
fix: Input simulation overlays stay usable without shipping runtime DLLs

### DIFF
--- a/Assets/Tests/Demo/uLoopMCP.Tests.Demo.asmdef
+++ b/Assets/Tests/Demo/uLoopMCP.Tests.Demo.asmdef
@@ -6,15 +6,15 @@
         "GUID:c956a21f824994ef087b6de566690b3d",
         "GUID:4307f53044263cf4b835bd812fc161a4"
     ],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.inputsystem",

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -1,0 +1,103 @@
+#nullable enable
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Verifies that the shared input visualization prefab keeps attachable overlay components.
+    /// </summary>
+    public sealed class InputVisualizationCanvasPrefabTests
+    {
+        private const string PrefabPath =
+            "Packages/io.github.hatayama.uloopmcp/Runtime/Common/InputVisualizationCanvas.prefab";
+        private const string RuntimeAssemblyDefinitionPath =
+            "Packages/src/Runtime/uLoopMCP.Runtime.asmdef";
+        private const string SimulateMouseInputOverlayPrefabPath =
+            "Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.prefab";
+        private const string DemoMouseInputOverlayTesterMetaPath =
+            "Assets/Tests/Demo/DemoMouseInputOverlayTester.cs.meta";
+
+        [Test]
+        public void RuntimeAssemblyDefinition_WhenScanned_IsPrefabAttachableAndNotAutoReferenced()
+        {
+            // The runtime assembly must stay attachable for prefab scripts while avoiding implicit user assembly references.
+            JObject asmdef = JObject.Parse(ReadProjectText(RuntimeAssemblyDefinitionPath));
+            JToken? includePlatformsToken = asmdef["includePlatforms"];
+
+            Assert.That(includePlatformsToken, Is.Not.Null);
+            Assert.That(includePlatformsToken!.Type, Is.EqualTo(JTokenType.Array));
+            Assert.That(includePlatformsToken.HasValues, Is.False);
+            Assert.That(asmdef["autoReferenced"]?.Value<bool>(), Is.False);
+        }
+
+        [Test]
+        public void InputVisualizationCanvasPrefab_WhenInstantiated_HasOverlayReferences()
+        {
+            // Instantiation proves Unity can resolve the prefab scripts after import, not only in raw YAML.
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PrefabPath);
+
+            Assert.That(prefab, Is.Not.Null);
+
+            UnityEngine.Object instantiatedObject = PrefabUtility.InstantiatePrefab(prefab);
+            Assert.That(instantiatedObject, Is.TypeOf<GameObject>());
+
+            GameObject instance = (GameObject)instantiatedObject;
+            try
+            {
+                InputVisualizationCanvas canvas = instance.GetComponent<InputVisualizationCanvas>();
+
+                Assert.That(canvas, Is.Not.Null);
+                Assert.That(canvas.KeyboardOverlay, Is.Not.Null);
+                Assert.That(canvas.MouseUiOverlay, Is.Not.Null);
+                Assert.That(canvas.MouseInputOverlay, Is.Not.Null);
+                Assert.That(canvas.RecordInputOverlayPresenter, Is.Not.Null);
+                Assert.That(canvas.ReplayInputOverlay, Is.Not.Null);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(instance);
+            }
+        }
+
+        [Test]
+        public void SimulateMouseInputOverlayPrefab_WhenSerialized_DoesNotReferenceDemoTester()
+        {
+            // Package prefabs cannot reference demo/test scripts because consumers import only Packages/src.
+            string prefabText = ReadProjectText(SimulateMouseInputOverlayPrefabPath);
+            string demoTesterGuid = ReadMetaGuid(DemoMouseInputOverlayTesterMetaPath);
+
+            Assert.That(prefabText, Does.Not.Contain(demoTesterGuid));
+        }
+
+        private static string ReadProjectText(string relativePath)
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string absolutePath = Path.Combine(projectRoot, relativePath);
+
+            return File.ReadAllText(absolutePath);
+        }
+
+        private static string ReadMetaGuid(string relativePath)
+        {
+            string[] lines = ReadProjectText(relativePath).Split('\n');
+            const string Prefix = "guid: ";
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i].Trim();
+                if (line.StartsWith(Prefix, StringComparison.Ordinal))
+                {
+                    return line.Substring(Prefix.Length).Trim();
+                }
+            }
+
+            Assert.Fail("Meta file must contain a guid line");
+            return string.Empty;
+        }
+    }
+}

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs.meta
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eff3e2ca33fd44eaa80d8954b7cec566
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/RuntimeAssemblyBuildFilterTests.cs
+++ b/Assets/Tests/Editor/RuntimeAssemblyBuildFilterTests.cs
@@ -27,5 +27,21 @@ namespace io.github.hatayama.uLoopMCP
                 "/build/Managed/UnityEngine.CoreModule.dll"
             }));
         }
+
+        [Test]
+        public void OnFilterAssemblies_WhenTestAssembliesAreIncluded_KeepsRuntimeAssembly()
+        {
+            RuntimeAssemblyBuildFilter filter = new RuntimeAssemblyBuildFilter();
+            string[] assemblies =
+            {
+                "/build/Managed/Assembly-CSharp.dll",
+                "/build/Managed/uLoopMCP.Runtime.dll",
+                "/build/Managed/uLoopMCP.Tests.PlayMode.dll"
+            };
+
+            string[] filteredAssemblies = filter.OnFilterAssemblies(BuildOptions.IncludeTestAssemblies, assemblies);
+
+            Assert.That(filteredAssemblies, Is.EqualTo(assemblies));
+        }
     }
 }

--- a/Assets/Tests/Editor/RuntimeAssemblyBuildFilterTests.cs
+++ b/Assets/Tests/Editor/RuntimeAssemblyBuildFilterTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using UnityEditor;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Verifies that the Player build callback removes only the prefab-only runtime assembly.
+    /// </summary>
+    public sealed class RuntimeAssemblyBuildFilterTests
+    {
+        [Test]
+        public void OnFilterAssemblies_WhenRuntimeAssemblyIsPresent_RemovesOnlyRuntimeAssembly()
+        {
+            RuntimeAssemblyBuildFilter filter = new RuntimeAssemblyBuildFilter();
+            string[] assemblies =
+            {
+                "/build/Managed/Assembly-CSharp.dll",
+                "/build/Managed/uLoopMCP.Runtime.dll",
+                "/build/Managed/UnityEngine.CoreModule.dll"
+            };
+
+            string[] filteredAssemblies = filter.OnFilterAssemblies(BuildOptions.None, assemblies);
+
+            Assert.That(filteredAssemblies, Is.EqualTo(new[]
+            {
+                "/build/Managed/Assembly-CSharp.dll",
+                "/build/Managed/UnityEngine.CoreModule.dll"
+            }));
+        }
+    }
+}

--- a/Assets/Tests/Editor/RuntimeAssemblyBuildFilterTests.cs.meta
+++ b/Assets/Tests/Editor/RuntimeAssemblyBuildFilterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25812280c766b4d0f8aa505c53df1439
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/uLoopMCP.Tests.Editor.asmdef
+++ b/Assets/Tests/Editor/uLoopMCP.Tests.Editor.asmdef
@@ -7,6 +7,7 @@
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:332048ead1ebf4658b9961338e5d68c3",
         "GUID:290394860909340b7835eb7cc215ee75",
+        "GUID:c956a21f824994ef087b6de566690b3d",
         "uLoopMCP.Editor.MetadataValidation"
     ],
     "includePlatforms": [

--- a/Assets/Tests/PlayMode/InputReplayerCompletionTests.cs
+++ b/Assets/Tests/PlayMode/InputReplayerCompletionTests.cs
@@ -1,0 +1,269 @@
+#if ULOOPMCP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Collections;
+using System.Collections.Generic;
+using io.github.hatayama.uLoopMCP;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.UI;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace Tests.PlayMode
+{
+    /// <summary>
+    /// Verifies that replay completion waits for UI modules to consume the final injected input frame.
+    /// </summary>
+    public sealed class InputReplayerCompletionTests
+    {
+        private const float ReplayTimeoutSeconds = 5f;
+        private const float ButtonWidth = 240f;
+        private const float ButtonHeight = 120f;
+
+        private GameObject _canvasGo = null!;
+        private GameObject _eventSystemGo = null!;
+        private GameObject _buttonGo = null!;
+        private Mouse? _createdMouse;
+        private bool _replayCompleted;
+        private int _clickCount;
+        private int _clickCountAtCompletion;
+        private bool _observedLoopFrameBeyondTotal;
+        private bool _observedLoopReset;
+        private int _loopObservationTicks;
+        private PointerLifecycleTracker _pointerLifecycleTracker = null!;
+
+        [UnitySetUp]
+        public IEnumerator SetUp()
+        {
+            _replayCompleted = false;
+            _clickCount = 0;
+            _clickCountAtCompletion = 0;
+            _observedLoopFrameBeyondTotal = false;
+            _observedLoopReset = false;
+            _loopObservationTicks = 0;
+
+            EnsureMouseDeviceExists();
+            CreateScene();
+
+            yield return null;
+        }
+
+        [UnityTearDown]
+        public IEnumerator TearDown()
+        {
+            InputReplayer.ReplayCompleted -= OnReplayCompleted;
+            InputSystem.onAfterUpdate -= ObserveLoopReplayCadence;
+
+            if (InputReplayer.IsReplaying)
+            {
+                InputReplayer.StopReplay();
+            }
+
+            if (_createdMouse != null)
+            {
+                InputSystem.RemoveDevice(_createdMouse);
+                _createdMouse = null;
+            }
+
+            Object.Destroy(_buttonGo);
+            Object.Destroy(_eventSystemGo);
+            Object.Destroy(_canvasGo);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ReplayCompleted_WhenInputSystemUiConsumesTerminalRelease_FiresAfterClick()
+        {
+            Vector2 screenPosition = RectTransformUtility.WorldToScreenPoint(null, _buttonGo.transform.position);
+            InputRecordingData recording = CreateTerminalClickRecording(screenPosition);
+
+            InputReplayer.ReplayCompleted += OnReplayCompleted;
+            InputReplayer.StartReplay(recording, loop: false, showOverlay: false);
+
+            float timeoutAt = Time.realtimeSinceStartup + ReplayTimeoutSeconds;
+            yield return new WaitUntil(() =>
+                _replayCompleted || Time.realtimeSinceStartup >= timeoutAt);
+
+            Assert.IsTrue(_replayCompleted, $"Replay did not complete within {ReplayTimeoutSeconds}s");
+            Assert.AreEqual(1, _clickCountAtCompletion,
+                "ReplayCompleted must fire after InputSystemUIInputModule processes the terminal release");
+            Assert.AreEqual(1, _clickCount, "Button click must be processed exactly once");
+        }
+
+        [UnityTest]
+        public IEnumerator LoopReplay_WhenInputSystemUiConsumesTerminalRelease_DoesNotInsertEmptyFrame()
+        {
+            Vector2 screenPosition = RectTransformUtility.WorldToScreenPoint(null, _buttonGo.transform.position);
+            InputRecordingData recording = CreateTerminalClickRecording(screenPosition);
+
+            InputReplayer.StartReplay(recording, loop: true, showOverlay: false);
+            InputSystem.onAfterUpdate += ObserveLoopReplayCadence;
+
+            float timeoutAt = Time.realtimeSinceStartup + ReplayTimeoutSeconds;
+            yield return new WaitUntil(() =>
+                _observedLoopReset || Time.realtimeSinceStartup >= timeoutAt);
+
+            Assert.IsTrue(_observedLoopReset, $"Looped replay did not reset within {ReplayTimeoutSeconds}s");
+            Assert.IsFalse(
+                _observedLoopFrameBeyondTotal,
+                "Looped replay must reset on the terminal release without exposing an unrecorded empty frame");
+        }
+
+        [UnityTest]
+        public IEnumerator Replay_WhenInputSystemUiModuleIsSelectedAfterManualPress_FiresMatchingPointerUp()
+        {
+            RecreateEventSystemWithoutSelectedInputModule();
+            EventSystem? eventSystem = EventSystem.current;
+            Assert.IsNotNull(eventSystem, "EventSystem.current must be assigned");
+            Assert.IsNull(eventSystem!.currentInputModule, "Fresh EventSystem should not select an input module until update");
+
+            Vector2 screenPosition = RectTransformUtility.WorldToScreenPoint(null, _buttonGo.transform.position);
+            InputRecordingData recording = CreateTerminalClickRecording(screenPosition);
+
+            InputReplayer.ReplayCompleted += OnReplayCompleted;
+            InputReplayer.StartReplay(recording, loop: false, showOverlay: false);
+
+            float timeoutAt = Time.realtimeSinceStartup + ReplayTimeoutSeconds;
+            yield return new WaitUntil(() =>
+                _replayCompleted || Time.realtimeSinceStartup >= timeoutAt);
+
+            Assert.IsTrue(_replayCompleted, $"Replay did not complete within {ReplayTimeoutSeconds}s");
+            Assert.Greater(_pointerLifecycleTracker.PointerDownCount, 0,
+                "The replay should dispatch at least one pointer down to the target");
+            Assert.AreEqual(_pointerLifecycleTracker.PointerDownCount, _pointerLifecycleTracker.PointerUpCount,
+                "Every pointer down must receive a matching pointer up even if the input module is selected later");
+        }
+
+        private void OnReplayCompleted()
+        {
+            _clickCountAtCompletion = _clickCount;
+            _replayCompleted = true;
+        }
+
+        private void ObserveLoopReplayCadence()
+        {
+            if (!InputReplayer.IsReplaying)
+            {
+                return;
+            }
+
+            if (InputReplayer.CurrentFrame > InputReplayer.TotalFrames)
+            {
+                _observedLoopFrameBeyondTotal = true;
+            }
+
+            if (_loopObservationTicks > 0 && InputReplayer.CurrentFrame == 0)
+            {
+                _observedLoopReset = true;
+            }
+
+            _loopObservationTicks++;
+        }
+
+        private void OnButtonClicked()
+        {
+            _clickCount++;
+        }
+
+        private void EnsureMouseDeviceExists()
+        {
+            if (Mouse.current != null)
+            {
+                return;
+            }
+
+            _createdMouse = InputSystem.AddDevice<Mouse>();
+        }
+
+        private void CreateScene()
+        {
+            _canvasGo = new GameObject("InputReplayerCompletionCanvas");
+            Canvas canvas = _canvasGo.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            _canvasGo.AddComponent<GraphicRaycaster>();
+
+            _eventSystemGo = new GameObject("InputReplayerCompletionEventSystem");
+            _eventSystemGo.AddComponent<EventSystem>();
+            _eventSystemGo.AddComponent<InputSystemUIInputModule>();
+
+            _buttonGo = new GameObject("TerminalReleaseButton");
+            _buttonGo.transform.SetParent(_canvasGo.transform, false);
+            RectTransform buttonRect = _buttonGo.AddComponent<RectTransform>();
+            buttonRect.sizeDelta = new Vector2(ButtonWidth, ButtonHeight);
+            Image buttonImage = _buttonGo.AddComponent<Image>();
+            Button button = _buttonGo.AddComponent<Button>();
+            button.targetGraphic = buttonImage;
+            button.onClick.AddListener(OnButtonClicked);
+            _pointerLifecycleTracker = _buttonGo.AddComponent<PointerLifecycleTracker>();
+        }
+
+        private void RecreateEventSystemWithoutSelectedInputModule()
+        {
+            Object.DestroyImmediate(_eventSystemGo);
+
+            _eventSystemGo = new GameObject("LateSelectedInputSystemEventSystem");
+            EventSystem eventSystem = _eventSystemGo.AddComponent<EventSystem>();
+            _eventSystemGo.AddComponent<InputSystemUIInputModule>();
+            EventSystem.current = eventSystem;
+        }
+
+        private static InputRecordingData CreateTerminalClickRecording(Vector2 screenPosition)
+        {
+            string positionData = $"{Mathf.RoundToInt(screenPosition.x)},{Mathf.RoundToInt(screenPosition.y)}";
+
+            return new InputRecordingData
+            {
+                Metadata = new InputRecordingMetadata
+                {
+                    RecordedAt = "test",
+                    TotalFrames = 1,
+                    DurationSeconds = 0.02f
+                },
+                Frames = new List<InputFrameEvents>
+                {
+                    new InputFrameEvents
+                    {
+                        Frame = 0,
+                        Events = new List<RecordedInputEvent>
+                        {
+                            new RecordedInputEvent { Type = InputEventTypes.MOUSE_POSITION, Data = positionData },
+                            new RecordedInputEvent { Type = InputEventTypes.MOUSE_CLICK, Data = "Left" }
+                        }
+                    },
+                    new InputFrameEvents
+                    {
+                        Frame = 1,
+                        Events = new List<RecordedInputEvent>
+                        {
+                            new RecordedInputEvent { Type = InputEventTypes.MOUSE_POSITION, Data = positionData },
+                            new RecordedInputEvent { Type = InputEventTypes.MOUSE_RELEASE, Data = "Left" }
+                        }
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Counts pointer lifecycle events sent to the replay target.
+        /// </summary>
+        private sealed class PointerLifecycleTracker : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
+        {
+            public int PointerDownCount { get; private set; }
+            public int PointerUpCount { get; private set; }
+
+            public void OnPointerDown(PointerEventData eventData)
+            {
+                PointerDownCount++;
+            }
+
+            public void OnPointerUp(PointerEventData eventData)
+            {
+                PointerUpCount++;
+            }
+        }
+    }
+}
+#endif

--- a/Assets/Tests/PlayMode/InputReplayerCompletionTests.cs.meta
+++ b/Assets/Tests/PlayMode/InputReplayerCompletionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66c1cddd1fab484e9843d0c28489bbc7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/PlayMode/SimulateMouseDemoE2ETests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseDemoE2ETests.cs
@@ -22,6 +22,7 @@ namespace Tests.PlayMode
         private const string FULL_HD_LABEL = "uLoop E2E Full HD";
 
         private bool _replayCompleted;
+        private int _previousGameViewSizeIndex = -1;
 
         [UnitySetUp]
         public IEnumerator SetUp()
@@ -63,6 +64,8 @@ namespace Tests.PlayMode
             CleanupLogFile(Path.Combine(
                 ReplayVerificationControllerBase.LOG_OUTPUT_DIR,
                 ReplayVerificationControllerBase.REPLAY_LOG_FILE));
+
+            RestoreGameViewResolution();
 
             yield return null;
         }
@@ -113,12 +116,12 @@ namespace Tests.PlayMode
             _replayCompleted = true;
         }
 
-        private static void SetGameViewResolution()
+        private void SetGameViewResolution()
         {
-            System.Type gameViewType = typeof(Editor).Assembly.GetType("UnityEditor.GameView");
-            Debug.Assert(gameViewType != null, "GameView type must exist");
-
+            System.Type gameViewType = GetGameViewType();
             EditorWindow gameView = EditorWindow.GetWindow(gameViewType);
+            _previousGameViewSizeIndex = GetSelectedGameViewSizeIndex(gameViewType, gameView);
+
             MethodInfo setCustomResolution = gameViewType.GetMethod(
                 "SetCustomResolution",
                 BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
@@ -129,6 +132,65 @@ namespace Tests.PlayMode
             setCustomResolution.Invoke(
                 gameView,
                 new object[] { new Vector2(FULL_HD_WIDTH, FULL_HD_HEIGHT), FULL_HD_LABEL });
+        }
+
+        private void RestoreGameViewResolution()
+        {
+            if (_previousGameViewSizeIndex < 0)
+            {
+                return;
+            }
+
+            System.Type gameViewType = GetGameViewType();
+            EditorWindow gameView = EditorWindow.GetWindow(gameViewType);
+            SetSelectedGameViewSizeIndex(gameViewType, gameView, _previousGameViewSizeIndex);
+            UpdateGameViewZoom(gameViewType, gameView);
+            gameView.Repaint();
+            SceneView.RepaintAll();
+            _previousGameViewSizeIndex = -1;
+        }
+
+        private static System.Type GetGameViewType()
+        {
+            System.Type gameViewType = typeof(Editor).Assembly.GetType("UnityEditor.GameView");
+            Debug.Assert(gameViewType != null, "GameView type must exist");
+            return gameViewType;
+        }
+
+        private static int GetSelectedGameViewSizeIndex(System.Type gameViewType, EditorWindow gameView)
+        {
+            MethodInfo getSelectedSizeIndex = gameViewType.GetMethod(
+                "get_selectedSizeIndex",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            Debug.Assert(getSelectedSizeIndex != null, "GameView.get_selectedSizeIndex must exist");
+
+            object selectedSizeIndex = getSelectedSizeIndex.Invoke(gameView, null);
+            Debug.Assert(selectedSizeIndex is int, "GameView selected size index must be an int");
+            return (int)selectedSizeIndex;
+        }
+
+        private static void SetSelectedGameViewSizeIndex(
+            System.Type gameViewType,
+            EditorWindow gameView,
+            int selectedSizeIndex)
+        {
+            MethodInfo setSelectedSizeIndex = gameViewType.GetMethod(
+                "set_selectedSizeIndex",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            Debug.Assert(setSelectedSizeIndex != null, "GameView.set_selectedSizeIndex must exist");
+
+            // Game View size is editor-persistent; restore it so this fixed-resolution E2E test stays isolated.
+            setSelectedSizeIndex.Invoke(gameView, new object[] { selectedSizeIndex });
+        }
+
+        private static void UpdateGameViewZoom(System.Type gameViewType, EditorWindow gameView)
+        {
+            MethodInfo updateZoomArea = gameViewType.GetMethod(
+                "UpdateZoomAreaAndParent",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            Debug.Assert(updateZoomArea != null, "GameView.UpdateZoomAreaAndParent must exist");
+
+            updateZoomArea.Invoke(gameView, null);
         }
 
         private static void AssertGameViewResolution()

--- a/Assets/Tests/PlayMode/SimulateMouseDemoE2ETests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseDemoE2ETests.cs
@@ -1,8 +1,10 @@
 #if ULOOPMCP_HAS_INPUT_SYSTEM
 using System.Collections;
 using System.IO;
+using System.Reflection;
 using io.github.hatayama.uLoopMCP;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -15,6 +17,9 @@ namespace Tests.PlayMode
         private const string SCENE_PATH = "Assets/Scenes/SimulateMouseDemoScene.unity";
         private const string FIXTURE_DIR = "Assets/Tests/PlayMode/Fixtures/SimulateMouseDemoScene";
         private const float REPLAY_TIMEOUT_SECONDS = 30f;
+        private const int FULL_HD_WIDTH = 1920;
+        private const int FULL_HD_HEIGHT = 1080;
+        private const string FULL_HD_LABEL = "uLoop E2E Full HD";
 
         private bool _replayCompleted;
 
@@ -23,6 +28,7 @@ namespace Tests.PlayMode
         {
             _replayCompleted = false;
             InputReplayer.ReplayCompleted += OnReplayCompleted;
+            SetGameViewResolution();
 
             AsyncOperation loadOp = EditorSceneManager.LoadSceneAsyncInPlayMode(
                 SCENE_PATH,
@@ -32,6 +38,8 @@ namespace Tests.PlayMode
             {
                 yield return null;
             }
+
+            AssertGameViewResolution();
 
             // EditorBridge [InitializeOnLoad] subscribes on the first frame after load;
             // second yield ensures its event hooks are active before replay starts.
@@ -80,7 +88,7 @@ namespace Tests.PlayMode
             InputRecordingData recordingData = InputRecordingFileHelper.Load(fixtureRecordingJson);
             Debug.Assert(recordingData != null, $"Failed to load fixture: {fixtureRecordingJson}");
 
-            InputReplayer.StartReplay(recordingData, loop: false, showOverlay: false);
+            InputReplayer.StartReplay(recordingData, loop: false, showOverlay: true);
 
             float timeoutAt = Time.realtimeSinceStartup + REPLAY_TIMEOUT_SECONDS;
             yield return new WaitUntil(() =>
@@ -103,6 +111,31 @@ namespace Tests.PlayMode
         private void OnReplayCompleted()
         {
             _replayCompleted = true;
+        }
+
+        private static void SetGameViewResolution()
+        {
+            System.Type gameViewType = typeof(Editor).Assembly.GetType("UnityEditor.GameView");
+            Debug.Assert(gameViewType != null, "GameView type must exist");
+
+            EditorWindow gameView = EditorWindow.GetWindow(gameViewType);
+            MethodInfo setCustomResolution = gameViewType.GetMethod(
+                "SetCustomResolution",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            Debug.Assert(setCustomResolution != null, "GameView.SetCustomResolution must exist");
+
+            // Unity exposes no public API for Game View target resolution, but this E2E
+            // fixture must replay against the same pixel size as the recorded mouse positions.
+            setCustomResolution.Invoke(
+                gameView,
+                new object[] { new Vector2(FULL_HD_WIDTH, FULL_HD_HEIGHT), FULL_HD_LABEL });
+        }
+
+        private static void AssertGameViewResolution()
+        {
+            Vector2 size = Handles.GetMainGameViewSize();
+            Assert.AreEqual(FULL_HD_WIDTH, Mathf.RoundToInt(size.x), "Game View width must match fixture recording");
+            Assert.AreEqual(FULL_HD_HEIGHT, Mathf.RoundToInt(size.y), "Game View height must match fixture recording");
         }
 
         private static void CleanupLogFile(string path)

--- a/Packages/src/Editor/Api/McpTools/ReplayInput/InputReplayer.cs
+++ b/Packages/src/Editor/Api/McpTools/ReplayInput/InputReplayer.cs
@@ -9,6 +9,7 @@ using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.UI;
 
 namespace io.github.hatayama.uLoopMCP
 {
@@ -36,8 +37,8 @@ namespace io.github.hatayama.uLoopMCP
         private static readonly HashSet<MouseButton> _replayHeldButtons = new();
         private static Vector2? _replayMousePosition;
 
-        // InputModule (StandaloneInputModule / InputSystemUIInputModule) ignores injected
-        // Mouse.current state, so UI interactions must go through ExecuteEvents directly.
+        // Some UI modules do not consume injected Mouse.current state, so replay keeps
+        // manual ExecuteEvents support for those modules.
         private static bool _hasMousePosition;
         private static bool _prevLeftButtonHeld;
         private static Vector2? _previousReplayMousePosition;
@@ -86,10 +87,8 @@ namespace io.github.hatayama.uLoopMCP
             _replayHeldButtons.Clear();
             _hasMousePosition = DetectMousePositionEvents(data!);
             ResetUiReplayState();
-            if (_hasMousePosition)
-            {
-                SimulateMouseInputOverlayState.Clear();
-            }
+            EnsureOverlayForReplay(showOverlay);
+            ClearOverlayState();
             _isReplaying = true;
 
             InputSystem.onAfterUpdate -= OnAfterUpdate;
@@ -117,11 +116,7 @@ namespace io.github.hatayama.uLoopMCP
             _replayHeldButtons.Clear();
             ResetUiReplayState();
 
-            ReplayInputOverlayState.Clear();
-            if (_hasMousePosition)
-            {
-                SimulateMouseUiOverlayState.Clear();
-            }
+            ClearOverlayState();
         }
 
         private static void OnAfterUpdate()
@@ -245,7 +240,10 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             _replayHeldKeys.Add(key);
-            SimulateKeyboardOverlayState.AddHeldKey(keyName);
+            if (_showOverlay)
+            {
+                SimulateKeyboardOverlayState.AddHeldKey(keyName);
+            }
         }
 
         private static void ProcessKeyUp(string keyName)
@@ -256,7 +254,10 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             _replayHeldKeys.Remove(key);
-            SimulateKeyboardOverlayState.RemoveHeldKey(keyName);
+            if (_showOverlay)
+            {
+                SimulateKeyboardOverlayState.RemoveHeldKey(keyName);
+            }
         }
 
         private static void ProcessMouseClick(string buttonName)
@@ -267,7 +268,7 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             _replayHeldButtons.Add(button);
-            if (!_hasMousePosition)
+            if (_showOverlay && !_hasMousePosition)
             {
                 SimulateMouseInputOverlayState.SetButtonHeld(button, true);
             }
@@ -281,7 +282,7 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             _replayHeldButtons.Remove(button);
-            if (!_hasMousePosition)
+            if (_showOverlay && !_hasMousePosition)
             {
                 SimulateMouseInputOverlayState.SetButtonHeld(button, false);
             }
@@ -290,7 +291,7 @@ namespace io.github.hatayama.uLoopMCP
         private static void ProcessMouseDelta(string data, ref Vector2 frameDelta)
         {
             frameDelta = InputRecorder.ParseVector2(data);
-            if (!_hasMousePosition)
+            if (_showOverlay && !_hasMousePosition)
             {
                 SimulateMouseInputOverlayState.SetMoveDelta(frameDelta);
             }
@@ -309,7 +310,7 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             frameScroll = new Vector2(0f, scrollY);
-            if (!_hasMousePosition)
+            if (_showOverlay && !_hasMousePosition)
             {
                 int direction = scrollY > 0f ? 1 : scrollY < 0f ? -1 : 0;
                 SimulateMouseInputOverlayState.SetScrollDirection(direction);
@@ -389,18 +390,21 @@ namespace io.github.hatayama.uLoopMCP
                 ApplyMouseSnapshot(mouse, _emptyButtons, Vector2.zero, Vector2.zero, null);
             }
 
-            foreach (Key key in _replayHeldKeys)
+            if (_showOverlay)
             {
-                SimulateKeyboardOverlayState.RemoveHeldKey(key.ToString());
-            }
+                foreach (Key key in _replayHeldKeys)
+                {
+                    SimulateKeyboardOverlayState.RemoveHeldKey(key.ToString());
+                }
 
-            foreach (MouseButton button in _replayHeldButtons)
-            {
-                SimulateMouseInputOverlayState.SetButtonHeld(button, false);
-            }
+                foreach (MouseButton button in _replayHeldButtons)
+                {
+                    SimulateMouseInputOverlayState.SetButtonHeld(button, false);
+                }
 
-            SimulateMouseInputOverlayState.SetMoveDelta(Vector2.zero);
-            SimulateMouseInputOverlayState.SetScrollDirection(0);
+                SimulateMouseInputOverlayState.SetMoveDelta(Vector2.zero);
+                SimulateMouseInputOverlayState.SetScrollDirection(0);
+            }
             _replayHeldKeys.Clear();
             _replayHeldButtons.Clear();
         }
@@ -466,30 +470,49 @@ namespace io.github.hatayama.uLoopMCP
 
             Vector2 gameViewSize = Handles.GetMainGameViewSize();
             Vector2 inputPos = new Vector2(screenPos.x, gameViewSize.y - screenPos.y);
+            bool dispatchUiEventsManually = ShouldDispatchUiEventsManually(eventSystem);
 
             if (justPressed)
             {
                 _suppressIdleUiOverlay = false;
                 _pressTime = Time.realtimeSinceStartup;
-                OnUiPointerDown(screenPos, eventSystem);
-                SimulateMouseUiOverlayState.Update(
-                    MouseAction.Click, inputPos, null, _currentPressTarget?.name, gameViewSize);
-                SimulateMouseUiOverlayState.RequestExpandAnimation();
+                _pressScreenPosition = screenPos;
+                _isDragging = false;
+                if (dispatchUiEventsManually)
+                {
+                    OnUiPointerDown(screenPos, eventSystem);
+                }
+                if (_showOverlay)
+                {
+                    SimulateMouseUiOverlayState.Update(
+                        MouseAction.Click, inputPos, null, _currentPressTarget?.name, gameViewSize);
+                    SimulateMouseUiOverlayState.RequestExpandAnimation();
+                }
             }
-            else if (leftHeld && (_currentPressTarget != null || _currentDragTarget != null))
+            else if (leftHeld && ShouldTrackHeldPointer(dispatchUiEventsManually))
             {
-                OnUiDrag(screenPos);
+                if (dispatchUiEventsManually)
+                {
+                    OnUiDrag(screenPos);
+                }
+                else
+                {
+                    UpdateOverlayDragState(screenPos, eventSystem);
+                }
 
                 if (_isDragging)
                 {
-                    Vector2 pressInputPos = new Vector2(_pressScreenPosition.x, gameViewSize.y - _pressScreenPosition.y);
-                    SimulateMouseUiOverlayState.Update(
-                        MouseAction.Drag, inputPos, pressInputPos, null, gameViewSize);
+                    if (_showOverlay)
+                    {
+                        Vector2 pressInputPos = new Vector2(_pressScreenPosition.x, gameViewSize.y - _pressScreenPosition.y);
+                        SimulateMouseUiOverlayState.Update(
+                            MouseAction.Drag, inputPos, pressInputPos, null, gameViewSize);
+                    }
                 }
                 else
                 {
                     float elapsed = Time.realtimeSinceStartup - _pressTime;
-                    if (elapsed >= 0.5f)
+                    if (_showOverlay && elapsed >= 0.5f)
                     {
                         SimulateMouseUiOverlayState.Update(
                             MouseAction.LongPress, inputPos, null, _currentPressTarget?.name, gameViewSize);
@@ -502,16 +525,78 @@ namespace io.github.hatayama.uLoopMCP
                 // Keeping the overlay hidden until the pointer actually moves prevents release fade-out
                 // from being cancelled by the next idle frame at the same position.
                 _suppressIdleUiOverlay = false;
-                SimulateMouseUiOverlayState.Update(
-                    MouseAction.Click, inputPos, null, null, gameViewSize);
+                if (_showOverlay)
+                {
+                    SimulateMouseUiOverlayState.Update(
+                        MouseAction.Click, inputPos, null, null, gameViewSize);
+                }
             }
 
             if (justReleased)
             {
-                OnUiPointerUp(screenPos, eventSystem);
+                if (dispatchUiEventsManually)
+                {
+                    OnUiPointerUp(screenPos, eventSystem);
+                }
+                else
+                {
+                    ClearPointerState();
+                }
                 _suppressIdleUiOverlay = true;
-                SimulateMouseUiOverlayState.RequestDissipateAnimation();
-                SimulateMouseUiOverlayState.Clear();
+                if (_showOverlay)
+                {
+                    SimulateMouseUiOverlayState.RequestDissipateAnimation();
+                    SimulateMouseUiOverlayState.Clear();
+                }
+            }
+        }
+
+        private static void EnsureOverlayForReplay(bool showOverlay)
+        {
+            if (!showOverlay)
+            {
+                return;
+            }
+
+            OverlayCanvasFactory.EnsureExists();
+            RecordReplayOverlayFactory.EnsureReplayOverlay();
+        }
+
+        private static void ClearOverlayState()
+        {
+            ReplayInputOverlayState.Clear();
+            SimulateMouseUiOverlayState.Clear();
+            SimulateMouseInputOverlayState.Clear();
+            SimulateKeyboardOverlayState.Clear();
+        }
+
+        private static bool ShouldDispatchUiEventsManually(EventSystem eventSystem)
+        {
+            BaseInputModule? inputModule = eventSystem.currentInputModule;
+            return !(inputModule is InputSystemUIInputModule);
+        }
+
+        private static bool ShouldTrackHeldPointer(bool dispatchUiEventsManually)
+        {
+            if (!dispatchUiEventsManually)
+            {
+                return true;
+            }
+
+            return _currentPressTarget != null || _currentDragTarget != null;
+        }
+
+        private static void UpdateOverlayDragState(Vector2 screenPos, EventSystem eventSystem)
+        {
+            if (_isDragging)
+            {
+                return;
+            }
+
+            float distance = (screenPos - _pressScreenPosition).magnitude;
+            if (distance > eventSystem.pixelDragThreshold)
+            {
+                _isDragging = true;
             }
         }
 
@@ -631,6 +716,11 @@ namespace io.github.hatayama.uLoopMCP
                 }
             }
 
+            ClearPointerState();
+        }
+
+        private static void ClearPointerState()
+        {
             _currentPressTarget = null;
             _currentDragTarget = null;
             _isDragging = false;

--- a/Packages/src/Editor/Api/McpTools/ReplayInput/InputReplayer.cs
+++ b/Packages/src/Editor/Api/McpTools/ReplayInput/InputReplayer.cs
@@ -49,6 +49,9 @@ namespace io.github.hatayama.uLoopMCP
         private static bool _isDragging;
         private static Vector2 _pressScreenPosition;
         private static float _pressTime;
+        private static bool _delayCompletionForUiModule;
+        private static bool _hasActivePressDispatchMode;
+        private static bool _activePressDispatchesUiEventsManually;
 
         public static event Action? ReplayStarted;
         public static event Action? ReplayCompleted;
@@ -153,6 +156,12 @@ namespace io.github.hatayama.uLoopMCP
 
             if (_eventIndex >= _data.Frames.Count && _currentFrame > _data.Metadata.TotalFrames)
             {
+                if (_delayCompletionForUiModule)
+                {
+                    _delayCompletionForUiModule = false;
+                    return;
+                }
+
                 if (_loop)
                 {
                     ReleaseAllHeldInputs();
@@ -470,10 +479,13 @@ namespace io.github.hatayama.uLoopMCP
 
             Vector2 gameViewSize = Handles.GetMainGameViewSize();
             Vector2 inputPos = new Vector2(screenPos.x, gameViewSize.y - screenPos.y);
-            bool dispatchUiEventsManually = ShouldDispatchUiEventsManually(eventSystem);
+            bool currentDispatchUiEventsManually = ShouldDispatchUiEventsManually(eventSystem);
+            bool dispatchUiEventsManually = GetPointerDispatchMode(currentDispatchUiEventsManually);
 
             if (justPressed)
             {
+                StorePointerDispatchMode(currentDispatchUiEventsManually);
+                dispatchUiEventsManually = GetPointerDispatchMode(currentDispatchUiEventsManually);
                 _suppressIdleUiOverlay = false;
                 _pressTime = Time.realtimeSinceStartup;
                 _pressScreenPosition = screenPos;
@@ -540,6 +552,7 @@ namespace io.github.hatayama.uLoopMCP
                 }
                 else
                 {
+                    RequestCompletionDelayForInputSystemUiModule();
                     ClearPointerState();
                 }
                 _suppressIdleUiOverlay = true;
@@ -574,6 +587,48 @@ namespace io.github.hatayama.uLoopMCP
         {
             BaseInputModule? inputModule = eventSystem.currentInputModule;
             return !(inputModule is InputSystemUIInputModule);
+        }
+
+        private static bool GetPointerDispatchMode(bool currentDispatchUiEventsManually)
+        {
+            if (_hasActivePressDispatchMode)
+            {
+                return _activePressDispatchesUiEventsManually;
+            }
+
+            return currentDispatchUiEventsManually;
+        }
+
+        private static void StorePointerDispatchMode(bool dispatchUiEventsManually)
+        {
+            // EventSystem may select its currentInputModule after the press frame, so release must reuse the press path.
+            _hasActivePressDispatchMode = true;
+            _activePressDispatchesUiEventsManually = dispatchUiEventsManually;
+        }
+
+        private static void RequestCompletionDelayForInputSystemUiModule()
+        {
+            if (_loop)
+            {
+                // Looping replays do not invoke ReplayCompleted, so delaying would add an unrecorded gap before reset.
+                return;
+            }
+
+            if (!IsFinalRecordedFrame())
+            {
+                return;
+            }
+
+            // InputSystemUIInputModule consumes this release in EventSystem.Update after input update,
+            // while ReplayCompleted handlers read UI verification state synchronously.
+            _delayCompletionForUiModule = true;
+        }
+
+        private static bool IsFinalRecordedFrame()
+        {
+            Debug.Assert(_data != null, "_data must not be null while replaying");
+
+            return _eventIndex >= _data!.Frames.Count && _currentFrame >= _data.Metadata.TotalFrames;
         }
 
         private static bool ShouldTrackHeldPointer(bool dispatchUiEventsManually)
@@ -725,6 +780,8 @@ namespace io.github.hatayama.uLoopMCP
             _currentDragTarget = null;
             _isDragging = false;
             _pointerData = null;
+            _hasActivePressDispatchMode = false;
+            _activePressDispatchesUiEventsManually = false;
         }
 
         private static bool DetectMousePositionEvents(InputRecordingData data)
@@ -754,6 +811,9 @@ namespace io.github.hatayama.uLoopMCP
             _currentDragTarget = null;
             _isDragging = false;
             _pressTime = 0f;
+            _delayCompletionForUiModule = false;
+            _hasActivePressDispatchMode = false;
+            _activePressDispatchesUiEventsManually = false;
         }
 
         private static void OnPlayModeStateChanged(PlayModeStateChange state)

--- a/Packages/src/Editor/Api/McpTools/ReplayInput/ReplayInputTool.cs
+++ b/Packages/src/Editor/Api/McpTools/ReplayInput/ReplayInputTool.cs
@@ -157,8 +157,6 @@ namespace io.github.hatayama.uLoopMCP
                 };
             }
 
-            OverlayCanvasFactory.EnsureExists();
-            RecordReplayOverlayFactory.EnsureReplayOverlay();
             InputReplayer.StartReplay(data, parameters.Loop, parameters.ShowOverlay);
 
             int eventCount = data.GetTotalEventCount();

--- a/Packages/src/Editor/Build/RuntimeAssemblyBuildFilter.cs
+++ b/Packages/src/Editor/Build/RuntimeAssemblyBuildFilter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEngine;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    // Removes uLoop's prefab-only runtime assembly from Player builds after Editor compilation keeps prefab scripts resolvable.
+    internal sealed class RuntimeAssemblyBuildFilter : IFilterBuildAssemblies
+    {
+        public int callbackOrder => 0;
+
+        public string[] OnFilterAssemblies(BuildOptions buildOptions, string[] assemblies)
+        {
+            Debug.Assert(assemblies != null, "assemblies must be provided by Unity build pipeline");
+
+            List<string> filteredAssemblies = new List<string>(assemblies.Length);
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                string assemblyPath = assemblies[i];
+                if (IsRuntimeAssembly(assemblyPath))
+                {
+                    continue;
+                }
+
+                filteredAssemblies.Add(assemblyPath);
+            }
+
+            return filteredAssemblies.ToArray();
+        }
+
+        private static bool IsRuntimeAssembly(string assemblyPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyPath), "assemblyPath must be provided by Unity build pipeline");
+
+            string fileName = Path.GetFileName(assemblyPath);
+            return string.Equals(fileName, McpConstants.RUNTIME_ASSEMBLY_FILE_NAME, StringComparison.Ordinal);
+        }
+    }
+}

--- a/Packages/src/Editor/Build/RuntimeAssemblyBuildFilter.cs
+++ b/Packages/src/Editor/Build/RuntimeAssemblyBuildFilter.cs
@@ -16,6 +16,12 @@ namespace io.github.hatayama.uLoopMCP
         {
             Debug.Assert(assemblies != null, "assemblies must be provided by Unity build pipeline");
 
+            if ((buildOptions & BuildOptions.IncludeTestAssemblies) == BuildOptions.IncludeTestAssemblies)
+            {
+                // Player test builds need runtime references from test assemblies, so filtering here breaks PlayMode test players.
+                return assemblies;
+            }
+
             List<string> filteredAssemblies = new List<string>(assemblies.Length);
             for (int i = 0; i < assemblies.Length; i++)
             {

--- a/Packages/src/Editor/Build/RuntimeAssemblyBuildFilter.cs.meta
+++ b/Packages/src/Editor/Build/RuntimeAssemblyBuildFilter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 042727ba0224740ea88a475b774caf52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Shared/Config/McpConstants.cs
+++ b/Packages/src/Editor/Shared/Config/McpConstants.cs
@@ -129,6 +129,7 @@ namespace io.github.hatayama.uLoopMCP
         public const string ULOOPMCP_DIR = "uLoopMCP";
         public const string COMPILE_RESULTS_DIR = "compile-results";
         public const string JSON_FILE_EXTENSION = ".json";
+        public const string RUNTIME_ASSEMBLY_FILE_NAME = "uLoopMCP.Runtime.dll";
         
         // .uloop directory
         public const string ULOOP_DIR = ".uloop";

--- a/Packages/src/Runtime/Common/InputVisualizationCanvas.cs
+++ b/Packages/src/Runtime/Common/InputVisualizationCanvas.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEngine;
 
 namespace io.github.hatayama.uLoopMCP
@@ -27,3 +28,4 @@ namespace io.github.hatayama.uLoopMCP
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/Common/InputVisualizationCanvas.prefab
+++ b/Packages/src/Runtime/Common/InputVisualizationCanvas.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5473869302179759802}
   m_Layer: 0
   m_Name: InputVisualizationCanvas
-  m_TagString: Untagged
+  m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -127,9 +127,17 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 855430283409054088}
     m_Modifications:
+    - target: {fileID: 22181428640489494, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 5910659660082971454, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
       propertyPath: m_Name
       value: RecordInputOverlay
+      objectReference: {fileID: 0}
+    - target: {fileID: 5910659660082971454, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
       objectReference: {fileID: 0}
     - target: {fileID: 6520280533638980191, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
       propertyPath: m_Pivot.x
@@ -211,6 +219,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7302841544564334857, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 7304014939787943379, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
       propertyPath: _view
       value: 
@@ -239,6 +251,18 @@ PrefabInstance:
       propertyPath: _recordingGroup
       value: 
       objectReference: {fileID: 156814871501579555}
+    - target: {fileID: 8311708416284801602, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 8406836639261979753, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 8747864644649913744, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -327,6 +351,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 855430283409054088}
     m_Modifications:
+    - target: {fileID: 3579496036604184255, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 3645456351603840414, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 4096853404940709834, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 5435175328419204271, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -407,6 +443,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6086391879608123167, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
       propertyPath: _crosshairH
       value: 
@@ -439,9 +479,21 @@ PrefabInstance:
       propertyPath: _dragStartMarker
       value: 
       objectReference: {fileID: 1578214708066381370}
+    - target: {fileID: 7486829258772114075, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 8398465818153543159, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 9106729417482781781, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
       propertyPath: m_Name
       value: SimulateMouseUiOverlay
+      objectReference: {fileID: 0}
+    - target: {fileID: 9106729417482781781, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -537,9 +589,29 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 855430283409054088}
     m_Modifications:
+    - target: {fileID: 253023116830826680, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 641186257110384445, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 1893870842996581666, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 2122203629555508201, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
       propertyPath: m_Name
       value: SimulateMouseInputOverlay
+      objectReference: {fileID: 0}
+    - target: {fileID: 2122203629555508201, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 2131268326784498726, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
       objectReference: {fileID: 0}
     - target: {fileID: 5622481146988834445, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
       propertyPath: m_LocalRotation.x
@@ -552,6 +624,26 @@ PrefabInstance:
     - target: {fileID: 5622481146988834445, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6254897849895741874, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 7009724595179871094, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345968847908351245, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 7553317276571807195, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009591172217868134, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
       objectReference: {fileID: 0}
     - target: {fileID: 8124307820913732345, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
       propertyPath: m_Pivot.x
@@ -632,6 +724,18 @@ PrefabInstance:
     - target: {fileID: 8124307820913732345, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8293422726571725699, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 8702196187181304333, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 8719267255120921363, guid: 242afb3abe6ac48f99512e35951c9978, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -754,9 +858,17 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3143306149169442488, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 4291754732258876827, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
       propertyPath: m_Name
       value: ReplayInputOverlay
+      objectReference: {fileID: 0}
+    - target: {fileID: 4291754732258876827, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
       objectReference: {fileID: 0}
     - target: {fileID: 4495645932648773490, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
       propertyPath: m_SizeDelta.y
@@ -769,6 +881,14 @@ PrefabInstance:
     - target: {fileID: 5842103157894414940, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5842103157894414940, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320914726685114482, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -821,6 +941,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 855430283409054088}
     m_Modifications:
+    - target: {fileID: 1163102534174049270, guid: 13a5dea128bba49df91807161c323487, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 1254632121800322779, guid: 13a5dea128bba49df91807161c323487, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -949,6 +1073,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3492586335444099666, guid: 13a5dea128bba49df91807161c323487, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 5371017374443542522, guid: 13a5dea128bba49df91807161c323487, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -981,6 +1109,10 @@ PrefabInstance:
       propertyPath: _containerImage
       value: 
       objectReference: {fileID: 1286791144272469249}
+    - target: {fileID: 6281231881990964606, guid: 13a5dea128bba49df91807161c323487, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
+      objectReference: {fileID: 0}
     - target: {fileID: 8394911915651975566, guid: 13a5dea128bba49df91807161c323487, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
@@ -996,6 +1128,10 @@ PrefabInstance:
     - target: {fileID: 9003946234088771061, guid: 13a5dea128bba49df91807161c323487, type: 3}
       propertyPath: m_Name
       value: SimulateKeyboardOverlay
+      objectReference: {fileID: 0}
+    - target: {fileID: 9003946234088771061, guid: 13a5dea128bba49df91807161c323487, type: 3}
+      propertyPath: m_TagString
+      value: EditorOnly
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Packages/src/Runtime/Common/InputVisualizationCanvas.prefab
+++ b/Packages/src/Runtime/Common/InputVisualizationCanvas.prefab
@@ -211,11 +211,71 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7304014939787943379, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: _view
+      value: 
+      objectReference: {fileID: 7500804184470111482}
+    - target: {fileID: 7672979299455549903, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: _recDotText
+      value: 
+      objectReference: {fileID: 8650917651823086408}
+    - target: {fileID: 7672979299455549903, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: _statusText
+      value: 
+      objectReference: {fileID: 799087218663616109}
+    - target: {fileID: 7672979299455549903, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: _canvasGroup
+      value: 
+      objectReference: {fileID: 1512996111237769590}
+    - target: {fileID: 7672979299455549903, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: _countdownText
+      value: 
+      objectReference: {fileID: 5622076999123470954}
+    - target: {fileID: 7672979299455549903, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: _countdownGroup
+      value: 
+      objectReference: {fileID: 8864626840232069285}
+    - target: {fileID: 7672979299455549903, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+      propertyPath: _recordingGroup
+      value: 
+      objectReference: {fileID: 156814871501579555}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+--- !u!1 &156814871501579555 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 22181428640489494, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+  m_PrefabInstance: {fileID: 172213960314160437}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &799087218663616109 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 681519330149296984, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+  m_PrefabInstance: {fileID: 172213960314160437}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!225 &1512996111237769590 stripped
+CanvasGroup:
+  m_CorrespondingSourceObject: {fileID: 1629439249830669379, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+  m_PrefabInstance: {fileID: 172213960314160437}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5622076999123470954 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5505213563100565343, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+  m_PrefabInstance: {fileID: 172213960314160437}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &6349903084446132074 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6520280533638980191, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
@@ -232,6 +292,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 55b9e485125e14c979260f3aa7816f9c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &7500804184470111482 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7672979299455549903, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+  m_PrefabInstance: {fileID: 172213960314160437}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 626f611c789dd4febbff8920eeb25837, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8650917651823086408 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8821962787790114429, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+  m_PrefabInstance: {fileID: 172213960314160437}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8864626840232069285 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8747864644649913744, guid: 62ec688be40ba465a8653a8437b9a739, type: 3}
+  m_PrefabInstance: {fileID: 172213960314160437}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &828123329405598390
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -320,6 +407,38 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: _crosshairH
+      value: 
+      objectReference: {fileID: 3067451695685099051}
+    - target: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: _crosshairV
+      value: 
+      objectReference: {fileID: 2321804306982394422}
+    - target: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: _canvasGroup
+      value: 
+      objectReference: {fileID: 6408876800999454565}
+    - target: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: _circleImage
+      value: 
+      objectReference: {fileID: 2042927172406633204}
+    - target: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: _cursorGroup
+      value: 
+      objectReference: {fileID: 1411858458224765341}
+    - target: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: _circleSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 0294a084c436048db9ed81eac798a709, type: 3}
+    - target: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: _longPressText
+      value: 
+      objectReference: {fileID: 7219080529419826848}
+    - target: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+      propertyPath: _dragStartMarker
+      value: 
+      objectReference: {fileID: 1578214708066381370}
     - target: {fileID: 9106729417482781781, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
       propertyPath: m_Name
       value: SimulateMouseUiOverlay
@@ -329,11 +448,76 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+--- !u!224 &1411858458224765341 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1795238667056386859, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+  m_PrefabInstance: {fileID: 828123329405598390}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1578214708066381370 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2204762901719864460, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+  m_PrefabInstance: {fileID: 828123329405598390}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2042927172406633204 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1668577853838809154, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+  m_PrefabInstance: {fileID: 828123329405598390}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2321804306982394422 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3118357298515763328, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+  m_PrefabInstance: {fileID: 828123329405598390}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3067451695685099051 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2445404945182483613, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+  m_PrefabInstance: {fileID: 828123329405598390}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &4617186797138212377 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5435175328419204271, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
   m_PrefabInstance: {fileID: 828123329405598390}
   m_PrefabAsset: {fileID: 0}
+--- !u!225 &6408876800999454565 stripped
+CanvasGroup:
+  m_CorrespondingSourceObject: {fileID: 6021016629897285075, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+  m_PrefabInstance: {fileID: 828123329405598390}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7219080529419826848 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8021270174096083990, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
+  m_PrefabInstance: {fileID: 828123329405598390}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &8059412677754260861 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7252727134433425355, guid: f47ccc1f9351044799d3c9da246db73a, type: 3}
@@ -478,6 +662,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 855430283409054088}
     m_Modifications:
+    - target: {fileID: 750881311793061267, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
+      propertyPath: _statusText
+      value: 
+      objectReference: {fileID: 2893399217642933393}
+    - target: {fileID: 750881311793061267, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
+      propertyPath: _progressBarFill
+      value: 
+      objectReference: {fileID: 2064571181623911462}
     - target: {fileID: 1866048660558847936, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -583,6 +775,28 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
+--- !u!114 &2064571181623911462 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5900655728717313438, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
+  m_PrefabInstance: {fileID: 5568001178914132408}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2893399217642933393 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7305657527396605225, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
+  m_PrefabInstance: {fileID: 5568001178914132408}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &5129082111969823787 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 750881311793061267, guid: 6ddbcdb56af1c46719cf4fa1b302f1b4, type: 3}
@@ -759,6 +973,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6082752830946661477, guid: 13a5dea128bba49df91807161c323487, type: 3}
+      propertyPath: _container
+      value: 
+      objectReference: {fileID: 6364288575518178073}
+    - target: {fileID: 6082752830946661477, guid: 13a5dea128bba49df91807161c323487, type: 3}
+      propertyPath: _containerImage
+      value: 
+      objectReference: {fileID: 1286791144272469249}
     - target: {fileID: 8394911915651975566, guid: 13a5dea128bba49df91807161c323487, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
@@ -780,6 +1002,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13a5dea128bba49df91807161c323487, type: 3}
+--- !u!114 &1286791144272469249 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8787032785713595466, guid: 13a5dea128bba49df91807161c323487, type: 3}
+  m_PrefabInstance: {fileID: 7505906806931134795}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6364288575518178073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &4341488740020178222 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6082752830946661477, guid: 13a5dea128bba49df91807161c323487, type: 3}
@@ -791,6 +1024,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 22d59970393a54b4cb41f956e0eb3f41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &6364288575518178073 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3492586335444099666, guid: 13a5dea128bba49df91807161c323487, type: 3}
+  m_PrefabInstance: {fileID: 7505906806931134795}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &8952917233715870054 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1447186769560363053, guid: 13a5dea128bba49df91807161c323487, type: 3}

--- a/Packages/src/Runtime/RecordInput/RecordInputOverlayPresenter.cs
+++ b/Packages/src/Runtime/RecordInput/RecordInputOverlayPresenter.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System.Globalization;
 using UnityEngine;
 
@@ -87,3 +88,4 @@ namespace io.github.hatayama.uLoopMCP
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/RecordInput/RecordInputOverlayView.cs
+++ b/Packages/src/Runtime/RecordInput/RecordInputOverlayView.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -71,3 +72,4 @@ namespace io.github.hatayama.uLoopMCP
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/ReplayInput/ReplayInputOverlay.cs
+++ b/Packages/src/Runtime/ReplayInput/ReplayInputOverlay.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using UnityEngine;
 using UnityEngine.UI;
@@ -105,3 +106,4 @@ namespace io.github.hatayama.uLoopMCP
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.cs
+++ b/Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using System.Collections.Generic;
 using UnityEngine;
@@ -200,3 +201,4 @@ namespace io.github.hatayama.uLoopMCP
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs
+++ b/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using UnityEngine;
 using UnityEngine.UI;
@@ -145,3 +146,4 @@ namespace io.github.hatayama.uLoopMCP
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.prefab
+++ b/Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.prefab
@@ -257,7 +257,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8124307820913732345}
   - component: {fileID: 8863844378423265032}
-  - component: {fileID: 5623037964506870047}
   - component: {fileID: 8237013949146870878}
   m_Layer: 0
   m_Name: SimulateMouseInputOverlay
@@ -304,18 +303,6 @@ MonoBehaviour:
   _scrollArrowTop: {fileID: 4893873975114215188}
   _scrollArrowBottom: {fileID: 6545894353452666225}
   _moveDirectionGroup: {fileID: 5622481146988834445}
---- !u!114 &5623037964506870047
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2122203629555508201}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3661bc54aaacf4bc09ae641533d2a78e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!225 &8237013949146870878
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.cs
+++ b/Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #nullable enable
 using System.Collections.Generic;
 using UnityEngine;
@@ -314,3 +315,4 @@ namespace io.github.hatayama.uLoopMCP
         }
     }
 }
+#endif

--- a/Packages/src/Runtime/uLoopMCP.Runtime.asmdef
+++ b/Packages/src/Runtime/uLoopMCP.Runtime.asmdef
@@ -2,14 +2,12 @@
     "name": "uLoopMCP.Runtime",
     "rootNamespace": "",
     "references": [],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/Packages/src/TypeScriptServer~/package-lock.json
+++ b/Packages/src/TypeScriptServer~/package-lock.json
@@ -5052,9 +5052,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/Packages/src/TypeScriptServer~/package.json
+++ b/Packages/src/TypeScriptServer~/package.json
@@ -92,7 +92,7 @@
   },
   "overrides": {
     "@hono/node-server": "1.19.13",
-    "hono": "4.12.18",
+    "hono": "4.12.23",
     "minimatch": "10.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- Input simulation overlays remain usable in the Editor without missing prefab components.
- Player builds no longer include the prefab-only uLoop runtime DLL when the overlay objects are excluded from the build.

## User Impact
- Mouse, keyboard, and input replay simulation tools can show their overlay UI in Play Mode again after the overlay prefab script resolution regression.
- Apps built from projects that install the package avoid carrying the small prefab-only runtime assembly in Player builds.

## Changes
- Keep the overlay runtime asmdef player-compatible for Editor prefab script resolution while disabling automatic references.
- Mark the shared overlay prefab hierarchy as EditorOnly and add build-time filtering for the prefab-only runtime DLL.
- Stabilize replay/mouse simulation coverage so overlay UI and mouse replay behavior are verified consistently.

## Verification
- `uloop compile --wait-for-domain-reload true`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value io.github.hatayama.uLoopMCP.InputVisualizationCanvasPrefabTests`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value io.github.hatayama.uLoopMCP.(RuntimeAssemblyBuildFilterTests|InputVisualizationCanvasPrefabTests)`
- Verified mouse, mouse UI, and keyboard simulation overlays in the validation project.
- Built the validation project with Mono and managed stripping disabled; the build succeeded and `uLoopMCP.Runtime.dll` was absent from the Player managed assemblies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a regression where input simulation overlay prefab script references were not resolving in the Editor and prevents the prefab-only runtime DLL from being included in Player builds when overlay objects are excluded. Overlays show UI again in Editor Play Mode while Player builds no longer include the small prefab-only runtime assembly when overlays are excluded.

## Changes Summary

- Make the overlay runtime asmdef player-compatible so Editor prefab script resolution works, but disable auto-references to avoid forcing inclusion in Player builds.
- Mark the shared input visualization prefab hierarchy as EditorOnly and add build-time filtering to exclude the prefab-only runtime assembly (uLoopMCP.Runtime.dll) from Player managed assemblies.
- Wrap overlay runtime types in editor-only compilation guards (`#if` UNITY_EDITOR) to exclude overlay classes from non-editor compilation:
  - Packages/src/Runtime/Common/InputVisualizationCanvas.cs
  - Packages/src/Runtime/RecordInput/RecordInputOverlayPresenter.cs
  - Packages/src/Runtime/RecordInput/RecordInputOverlayView.cs
  - Packages/src/Runtime/ReplayInput/ReplayInputOverlay.cs
  - Packages/src/Runtime/SimulateKeyboard/SimulateKeyboardOverlay.cs
  - Packages/src/Runtime/SimulateMouseInput/SimulateMouseInputOverlay.cs
  - Packages/src/Runtime/SimulateMouseUi/SimulateMouseUiOverlay.cs
- Add a build-time filter:
  - Packages/src/Editor/Build/RuntimeAssemblyBuildFilter.cs implements IFilterBuildAssemblies and removes uLoopMCP.Runtime.dll from Player builds (skips filtering when BuildOptions.IncludeTestAssemblies is set).
  - Packages/src/Editor/Shared/Config/McpConstants.cs: new constant RUNTIME_ASSEMBLY_FILE_NAME = "uLoopMCP.Runtime.dll".
- Stabilize replay and mouse simulation coverage and adjust replay timing so the InputSystem UI input module can consume terminal releases without producing spurious frames:
  - Packages/src/Editor/Api/McpTools/ReplayInput/InputReplayer.cs: refactor to manage overlay lifecycle (EnsureOverlayForReplay, ClearOverlayState), gate overlay updates on _showOverlay, separate UI dispatch modes, add ClearPointerState and replay completion/delay handling.
  - Packages/src/Editor/Api/McpTools/ReplayInput/ReplayInputTool.cs: simplify start logic to rely on InputReplayer for overlay setup.

## Tests & Verification

- EditMode tests:
  - Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs: validates runtime asmdef includePlatforms/autoReferenced contract, instantiates InputVisualizationCanvas.prefab and asserts overlay component references (keyboard, mouse UI, mouse input, record presenter, replay), and checks SimulateMouseInputOverlay.prefab does not reference a demo/test GUID.
  - Assets/Tests/Editor/RuntimeAssemblyBuildFilterTests.cs: verifies RuntimeAssemblyBuildFilter removes only uLoopMCP.Runtime.dll for normal builds and preserves it when test assemblies are included.
- PlayMode / E2E:
  - Assets/Tests/PlayMode/SimulateMouseDemoE2ETests.cs: enforces Full HD Game View resolution for reproducible replay tests and shows overlay during replay.
  - Assets/Tests/PlayMode/InputReplayerCompletionTests.cs: validates replay completion behavior relative to Unity UI consumption of terminal releases (firing after UI consumes release, looped replay not inserting empty frames, and matching pointer-up dispatch).
- Manual validation:
  - Mouse/mouse UI/keyboard overlays validated in the Editor.
  - Player build (Mono, managed stripping disabled) verified uLoopMCP.Runtime.dll absent from managed assemblies when overlays are excluded.

## Architecture

```mermaid
classDiagram
    class RuntimeAssemblyBuildFilter {
        -callbackOrder: int
        +OnFilterAssemblies(BuildOptions, string[]) string[]
        -IsRuntimeAssembly(string) bool
    }
    
    class InputReplayer {
        -_showOverlay: bool
        +EnsureOverlayForReplay()
        +ClearOverlayState()
        -ClearPointerState()
        `#ApplyUiEvents`()
    }
    
    class McpConstants {
        +RUNTIME_ASSEMBLY_FILE_NAME: string
    }
    
    RuntimeAssemblyBuildFilter --|> IFilterBuildAssemblies
    RuntimeAssemblyBuildFilter --> McpConstants
    InputReplayer -.-> ReplayInputOverlay
```

## User Impact

- Editor Play Mode: Mouse, keyboard, and input replay overlays display UI correctly again.
- Player Builds: Projects that install the package no longer include the prefab-only uLoopMCP.Runtime.dll when overlays are excluded, reducing build footprint.
- Tests: New EditMode and PlayMode tests cover prefab contracts, build filtering, and replay completion behavior.

## Commit Notes

- Timing fix for replay completion: delay non-loop replay completion so InputSystemUIInputModule can consume terminal release without producing spurious frames; preserve loop cadence and pointer dispatch mode.
- Keep runtime assembly in player test builds so PlayMode test players can resolve package test references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->