### PR TITLE
fix: Make Unity readiness and PlayMode stop results clearer

### DIFF
--- a/.agents/skills/uloop-control-play-mode/SKILL.md
+++ b/.agents/skills/uloop-control-play-mode/SKILL.md
@@ -48,12 +48,14 @@ uloop control-play-mode --action Pause
 Returns JSON with the current play mode state:
 - `IsPlaying`: Whether Unity is currently in play mode
 - `IsPaused`: Whether play mode is paused
+- `Changed`: Whether the requested action changed the current play mode state
+- `WasAlreadyStopped`: Whether `Stop` was requested while Play Mode was already stopped
 - `Message`: Description of the action performed
 
 ## Notes
 
 - Play action starts the game in the Unity Editor (also resumes from pause)
-- Stop action exits play mode and returns to edit mode
+- Stop action exits play mode and returns to edit mode. If Play Mode was already stopped, `Changed` is `false`, `WasAlreadyStopped` is `true`, and `Message` is `Play mode was already stopped`.
 - Pause action pauses the game while remaining in play mode
 - Useful for automated testing workflows
 - The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.

--- a/.agents/skills/uloop-launch/SKILL.md
+++ b/.agents/skills/uloop-launch/SKILL.md
@@ -50,4 +50,11 @@ uloop launch --quit
 - Prints detected Unity version
 - Prints project path
 - If Unity is already running, focuses the existing window
+- If launching, prints when it is waiting for Unity CLI Loop server readiness
 - If launching, waits until Unity finishes startup and the CLI can connect to the project
+- When launch readiness completes, returns JSON with:
+  - `Success`: whether launch readiness completed
+  - `Ready`: whether Unity CLI Loop is ready for commands
+  - `ServerReady`: whether the Unity CLI Loop server accepted requests
+  - `ProjectIpcReady`: whether the project IPC path accepted tool requests
+  - `Message`: readiness summary

--- a/.claude/skills/uloop-control-play-mode/SKILL.md
+++ b/.claude/skills/uloop-control-play-mode/SKILL.md
@@ -48,12 +48,14 @@ uloop control-play-mode --action Pause
 Returns JSON with the current play mode state:
 - `IsPlaying`: Whether Unity is currently in play mode
 - `IsPaused`: Whether play mode is paused
+- `Changed`: Whether the requested action changed the current play mode state
+- `WasAlreadyStopped`: Whether `Stop` was requested while Play Mode was already stopped
 - `Message`: Description of the action performed
 
 ## Notes
 
 - Play action starts the game in the Unity Editor (also resumes from pause)
-- Stop action exits play mode and returns to edit mode
+- Stop action exits play mode and returns to edit mode. If Play Mode was already stopped, `Changed` is `false`, `WasAlreadyStopped` is `true`, and `Message` is `Play mode was already stopped`.
 - Pause action pauses the game while remaining in play mode
 - Useful for automated testing workflows
 - The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.

--- a/.claude/skills/uloop-launch/SKILL.md
+++ b/.claude/skills/uloop-launch/SKILL.md
@@ -50,4 +50,11 @@ uloop launch --quit
 - Prints detected Unity version
 - Prints project path
 - If Unity is already running, focuses the existing window
+- If launching, prints when it is waiting for Unity CLI Loop server readiness
 - If launching, waits until Unity finishes startup and the CLI can connect to the project
+- When launch readiness completes, returns JSON with:
+  - `Success`: whether launch readiness completed
+  - `Ready`: whether Unity CLI Loop is ready for commands
+  - `ServerReady`: whether the Unity CLI Loop server accepted requests
+  - `ProjectIpcReady`: whether the project IPC path accepted tool requests
+  - `Message`: readiness summary

--- a/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
+++ b/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
@@ -31,25 +31,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void GetMinimumRequiredCliVersion_RequiresDebugBreakCliRelease()
+        public void GetMinimumRequiredCliVersion_UsesCliContractVersion()
         {
-            // Verifies this package release requires the CLI with debug-break native commands.
+            // Verifies setup reports the minimum CLI contract required by the package.
             CliSetupApplicationService service = new(
                 new FakeCliInstallationDetector(new string[] { null }),
                 new FakeNativeCliInstaller());
 
-            Assert.That(service.GetMinimumRequiredCliVersion(), Is.EqualTo("3.0.0-beta.26"));
+            Assert.That(service.GetMinimumRequiredCliVersion(), Is.EqualTo(CliConstants.MINIMUM_REQUIRED_CLI_VERSION));
         }
 
         [Test]
-        public void GetMinimumRequiredCliReleaseTag_UsesCliGitHubReleaseTag()
+        public void GetMinimumRequiredCliReleaseTag_UsesCliContractReleaseTag()
         {
-            // Verifies installers target the prefixed CLI GitHub Release tag.
+            // Verifies setup reports the prefixed release tag for the required CLI contract.
             CliSetupApplicationService service = new(
                 new FakeCliInstallationDetector(new string[] { null }),
                 new FakeNativeCliInstaller());
 
-            Assert.That(service.GetMinimumRequiredCliReleaseTag(), Is.EqualTo("cli-v3.0.0-beta.26"));
+            Assert.That(service.GetMinimumRequiredCliReleaseTag(), Is.EqualTo(CliConstants.MINIMUM_REQUIRED_CLI_RELEASE_TAG));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UnityEditor;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
@@ -33,6 +34,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
 
             Assert.That(response.Message, Is.EqualTo("Play mode status"));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenStopAlreadyStopped_ReturnsNoOpState()
+        {
+            // Verifies Stop distinguishes a no-op from a state-changing PlayMode exit.
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase();
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Stop,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.Message, Is.EqualTo("Play mode was already stopped"));
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.WasAlreadyStopped, Is.True);
         }
     }
 }

--- a/Packages/src/Editor/CliOnlyTools~/Launch/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/Launch/Skill/SKILL.md
@@ -50,4 +50,11 @@ uloop launch --quit
 - Prints detected Unity version
 - Prints project path
 - If Unity is already running, focuses the existing window
+- If launching, prints when it is waiting for Unity CLI Loop server readiness
 - If launching, waits until Unity finishes startup and the CLI can connect to the project
+- When launch readiness completes, returns JSON with:
+  - `Success`: whether launch readiness completed
+  - `Ready`: whether Unity CLI Loop is ready for commands
+  - `ServerReady`: whether the Unity CLI Loop server accepted requests
+  - `ProjectIpcReady`: whether the project IPC path accepted tool requests
+  - `Message`: readiness summary

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -6,7 +6,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     public static class CliConstants
     {
         public const string EXECUTABLE_NAME = "uloop";
-        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.26";
+        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.27";
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         public const string VERSION_FLAG = "--version";
         public const string SHORT_VERSION_FLAG = "-v";

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
@@ -9,7 +9,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public bool IsPlaying { get; set; }
         public bool IsPaused { get; set; }
+        public bool Changed { get; set; }
+        public bool WasAlreadyStopped { get; set; }
         public string Message { get; set; }
     }
 }
-

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -22,11 +22,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (parameters.StatusOnly)
             {
-                return Task.FromResult(CreateResponse("Play mode status"));
+                return Task.FromResult(CreateResponse("Play mode status", false, false));
             }
 
             string message;
             bool wasPaused = EditorApplication.isPaused;
+            bool wasPlaying = EditorApplication.isPlaying;
+            bool changed = false;
+            bool wasAlreadyStopped = false;
 
             switch (parameters.Action)
             {
@@ -39,10 +42,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     {
                         EditorApplication.isPlaying = true;
                     }
+                    changed = wasPaused || !wasPlaying;
                     message = wasPaused ? "Play mode resumed" : "Play mode started";
                     break;
 
                 case PlayModeAction.Stop:
+                    wasAlreadyStopped = !wasPlaying;
                     if (wasPaused)
                     {
                         EditorApplication.isPaused = false;
@@ -51,11 +56,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     {
                         EditorApplication.isPlaying = false;
                     }
-                    message = "Play mode stopped";
+                    changed = wasPaused || wasPlaying;
+                    message = wasAlreadyStopped ? "Play mode was already stopped" : "Play mode stopped";
                     break;
 
                 case PlayModeAction.Pause:
                     EditorApplication.isPaused = true;
+                    changed = !wasPaused;
                     message = "Play mode paused";
                     break;
 
@@ -64,15 +71,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     break;
             }
 
-            return Task.FromResult(CreateResponse(message));
+            return Task.FromResult(CreateResponse(message, changed, wasAlreadyStopped));
         }
 
-        private static ControlPlayModeResponse CreateResponse(string message)
+        private static ControlPlayModeResponse CreateResponse(string message, bool changed, bool wasAlreadyStopped)
         {
             ControlPlayModeResponse response = new()
             {
                 IsPlaying = EditorApplication.isPlaying,
                 IsPaused = EditorApplication.isPaused,
+                Changed = changed,
+                WasAlreadyStopped = wasAlreadyStopped,
                 Message = message
             };
 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/Skill/SKILL.md
@@ -48,12 +48,14 @@ uloop control-play-mode --action Pause
 Returns JSON with the current play mode state:
 - `IsPlaying`: Whether Unity is currently in play mode
 - `IsPaused`: Whether play mode is paused
+- `Changed`: Whether the requested action changed the current play mode state
+- `WasAlreadyStopped`: Whether `Stop` was requested while Play Mode was already stopped
 - `Message`: Description of the action performed
 
 ## Notes
 
 - Play action starts the game in the Unity Editor (also resumes from pause)
-- Stop action exits play mode and returns to edit mode
+- Stop action exits play mode and returns to edit mode. If Play Mode was already stopped, `Changed` is `false`, `WasAlreadyStopped` is `true`, and `Message` is `Play mode was already stopped`.
 - Pause action pauses the game while remaining in play mode
 - Useful for automated testing workflows
 - The command waits for the requested state before returning. Increase `--timeout-seconds` for projects with slow PlayMode entry.

--- a/cli/contract.json
+++ b/cli/contract.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "cliVersion": "3.0.0-beta.26"
+  "cliVersion": "3.0.0-beta.27"
 }

--- a/cli/internal/cli/control_play_mode_wait.go
+++ b/cli/internal/cli/control_play_mode_wait.go
@@ -23,9 +23,11 @@ const (
 var controlPlayModeStatePoll = 50 * time.Millisecond
 
 type controlPlayModeResponse struct {
-	IsPlaying bool   `json:"IsPlaying"`
-	IsPaused  bool   `json:"IsPaused"`
-	Message   string `json:"Message"`
+	IsPlaying         bool   `json:"IsPlaying"`
+	IsPaused          bool   `json:"IsPaused"`
+	Changed           bool   `json:"Changed"`
+	WasAlreadyStopped bool   `json:"WasAlreadyStopped"`
+	Message           string `json:"Message"`
 }
 
 func shouldWaitForControlPlayModeState(command string, params map[string]any) bool {
@@ -105,6 +107,10 @@ func runControlPlayModeWithStateWait(
 	}
 
 	response.Message = completedControlPlayModeMessage(action, initialResponse, hasInitialResponse)
+	if hasInitialResponse {
+		response.Changed = initialResponse.Changed
+		response.WasAlreadyStopped = initialResponse.WasAlreadyStopped
+	}
 	result, marshalErr := json.Marshal(response)
 	if marshalErr != nil {
 		writeClassifiedError(stderr, marshalErr, errorContext{

--- a/cli/internal/cli/control_play_mode_wait_test.go
+++ b/cli/internal/cli/control_play_mode_wait_test.go
@@ -91,6 +91,77 @@ func TestRunControlPlayModeWithStateWaitPollsStatusAfterStaleInitialResponse(t *
 	}
 }
 
+// Verifies that state polling preserves the action result fields from the initial command response.
+func TestRunControlPlayModeWithStateWaitPreservesStopChangeFields(t *testing.T) {
+	originalPoll := controlPlayModeStatePoll
+	controlPlayModeStatePoll = time.Millisecond
+	t.Cleanup(func() {
+		controlPlayModeStatePoll = originalPoll
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	serverErr := make(chan error, 1)
+	go serveControlPlayModeResponses(
+		listener,
+		make(chan map[string]any, 2),
+		serverErr,
+		[]string{
+			`{"IsPlaying":true,"IsPaused":false,"Changed":true,"WasAlreadyStopped":false,"Message":"Play mode stopped"}`,
+			`{"IsPlaying":false,"IsPaused":false,"Message":"Play mode status"}`,
+		})
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: "tcp",
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runControlPlayModeWithStateWait(
+		context.Background(),
+		connection,
+		map[string]any{
+			controlPlayModeActionParam:  "Stop",
+			controlPlayModeTimeoutParam: 1,
+		},
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("runControlPlayModeWithStateWait failed with %d: %s", code, stderr.String())
+	}
+
+	response := controlPlayModeResponse{}
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode stdout: %v\n%s", err, stdout.String())
+	}
+	if !response.Changed {
+		t.Fatalf("response should preserve Changed=true: %#v", response)
+	}
+	if response.WasAlreadyStopped {
+		t.Fatalf("response should preserve WasAlreadyStopped=false: %#v", response)
+	}
+	if response.Message != "Play mode stopped" {
+		t.Fatalf("response message mismatch: %s", response.Message)
+	}
+
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
 // Verifies that dispatched PlayMode disconnects are treated as post-reload waits.
 func TestShouldWaitForControlPlayModeDisconnectWaitsAfterDispatchedTransportLoss(t *testing.T) {
 	outcome := unityipc.UnitySendOutcome{RequestDispatched: true}

--- a/cli/internal/cli/launch.go
+++ b/cli/internal/cli/launch.go
@@ -272,8 +272,7 @@ func runLaunch(ctx context.Context, options launchOptions, startPath string, std
 		return 1
 	}
 	spinner.Stop()
-	writeLaunchReadyResponse(stdout)
-	return 0
+	return writeLaunchReadyResponse(stdout, stderr, projectRoot)
 }
 
 func newUnityLaunchCommand(unityPath string, launchArgs []string) *exec.Cmd {

--- a/cli/internal/cli/launch.go
+++ b/cli/internal/cli/launch.go
@@ -27,8 +27,11 @@ const (
 )
 
 var (
-	findRunningUnityProcessForLaunch = findRunningUnityProcess
-	focusUnityProcessForLaunch       = focusUnityProcess
+	findRunningUnityProcessForLaunch    = findRunningUnityProcess
+	focusUnityProcessForLaunch          = focusUnityProcess
+	resolveUnityExecutablePathForLaunch = resolveUnityExecutablePath
+	waitForUnityLockfileForLaunch       = waitForUnityLockfile
+	waitForToolReadinessForLaunch       = waitForToolReadiness
 )
 
 var editorVersionPattern = regexp.MustCompile(`(?m)^m_EditorVersion:\s*(.+)$`)
@@ -231,7 +234,7 @@ func runLaunch(ctx context.Context, options launchOptions, startPath string, std
 		writeLine(stdout, "")
 	}
 
-	unityPath, err := resolveUnityExecutablePath(projectRoot)
+	unityPath, err := resolveUnityExecutablePathForLaunch(projectRoot)
 	if err != nil {
 		writeClassifiedError(stderr, err, errorContext{projectRoot: projectRoot, command: launchCommandName})
 		return 1
@@ -259,14 +262,17 @@ func runLaunch(ctx context.Context, options launchOptions, startPath string, std
 		writeClassifiedError(stderr, err, errorContext{projectRoot: projectRoot, command: launchCommandName})
 		return 1
 	}
-	if err := waitForUnityLockfile(ctx, unityLockfilePath(projectRoot), launchLockfilePoll, launchLockfileTimeout); err != nil {
+	if err := waitForUnityLockfileForLaunch(ctx, unityLockfilePath(projectRoot), launchLockfilePoll, launchLockfileTimeout); err != nil {
 		writeClassifiedError(stderr, err, errorContext{projectRoot: projectRoot, command: launchCommandName})
 		return 1
 	}
-	if err := waitForToolReadiness(ctx, projectRoot); err != nil {
+	writeLaunchReadinessWait(stdout, spinner)
+	if err := waitForToolReadinessForLaunch(ctx, projectRoot); err != nil {
 		writeClassifiedError(stderr, err, errorContext{projectRoot: projectRoot, command: launchCommandName})
 		return 1
 	}
+	spinner.Stop()
+	writeLaunchReadyResponse(stdout)
 	return 0
 }
 

--- a/cli/internal/cli/launch_ready.go
+++ b/cli/internal/cli/launch_ready.go
@@ -25,7 +25,7 @@ func writeLaunchReadinessWait(stdout io.Writer, spinner *terminalSpinner) {
 	}
 }
 
-func writeLaunchReadyResponse(stdout io.Writer) {
+func writeLaunchReadyResponse(stdout io.Writer, stderr io.Writer, projectRoot string) int {
 	response := launchReadyResponse{
 		Success:         true,
 		Ready:           true,
@@ -35,7 +35,9 @@ func writeLaunchReadyResponse(stdout io.Writer) {
 	}
 	payload, err := json.Marshal(response)
 	if err != nil {
-		panic(err)
+		writeClassifiedError(stderr, err, errorContext{projectRoot: projectRoot, command: launchCommandName})
+		return 1
 	}
 	writeJSON(stdout, payload)
+	return 0
 }

--- a/cli/internal/cli/launch_ready.go
+++ b/cli/internal/cli/launch_ready.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+)
+
+const (
+	launchReadinessMessage = "Waiting for Unity CLI Loop server readiness..."
+	launchReadyMessage     = "Unity CLI Loop is ready."
+)
+
+type launchReadyResponse struct {
+	Success         bool   `json:"Success"`
+	Ready           bool   `json:"Ready"`
+	ServerReady     bool   `json:"ServerReady"`
+	ProjectIpcReady bool   `json:"ProjectIpcReady"`
+	Message         string `json:"Message"`
+}
+
+func writeLaunchReadinessWait(stdout io.Writer, spinner *terminalSpinner) {
+	spinner.Update(launchReadinessMessage)
+	if !spinner.enabled {
+		writeLine(stdout, launchReadinessMessage)
+	}
+}
+
+func writeLaunchReadyResponse(stdout io.Writer) {
+	response := launchReadyResponse{
+		Success:         true,
+		Ready:           true,
+		ServerReady:     true,
+		ProjectIpcReady: true,
+		Message:         launchReadyMessage,
+	}
+	payload, err := json.Marshal(response)
+	if err != nil {
+		panic(err)
+	}
+	writeJSON(stdout, payload)
+}

--- a/cli/internal/cli/launch_test.go
+++ b/cli/internal/cli/launch_test.go
@@ -112,6 +112,61 @@ func TestRunLaunchQuitDoesNotLaunchWhenUnityIsNotRunning(t *testing.T) {
 	}
 }
 
+func TestRunLaunchWritesReadyResponseAfterToolReadiness(t *testing.T) {
+	// Verifies launch reports an explicit ready payload after Unity accepts tool requests.
+	originalFinder := findRunningUnityProcessForLaunch
+	originalResolver := resolveUnityExecutablePathForLaunch
+	originalLockfileWait := waitForUnityLockfileForLaunch
+	originalReadinessWait := waitForToolReadinessForLaunch
+	findRunningUnityProcessForLaunch = func(context.Context, string) (*unityProcess, error) {
+		return nil, nil
+	}
+	resolveUnityExecutablePathForLaunch = func(string) (string, error) {
+		return "/usr/bin/true", nil
+	}
+	waitForUnityLockfileForLaunch = func(context.Context, string, time.Duration, time.Duration) error {
+		return nil
+	}
+	waitForToolReadinessForLaunch = func(context.Context, string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		findRunningUnityProcessForLaunch = originalFinder
+		resolveUnityExecutablePathForLaunch = originalResolver
+		waitForUnityLockfileForLaunch = originalLockfileWait
+		waitForToolReadinessForLaunch = originalReadinessWait
+	})
+
+	projectRoot := createLaunchTestProject(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runLaunch(
+		context.Background(),
+		launchOptions{projectPath: projectRoot},
+		projectRoot,
+		&stdout,
+		&stderr,
+	)
+
+	if code != 0 {
+		t.Fatalf("exit code mismatch: %d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, expected := range []string{
+		"Waiting for Unity CLI Loop server readiness...",
+		`"Success": true`,
+		`"Ready": true`,
+		`"ServerReady": true`,
+		`"ProjectIpcReady": true`,
+		`"Message": "Unity CLI Loop is ready."`,
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("launch output missing %q:\n%s", expected, output)
+		}
+	}
+}
+
 // Verifies launch logs when it focuses an already-running Unity process.
 func TestRunLaunchWritesExistingFocusSuccessVibeLog(t *testing.T) {
 	enableCliVibeLog(t)

--- a/cli/internal/tools/default-tools.json
+++ b/cli/internal/tools/default-tools.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-beta.26",
+  "version": "3.0.0-beta.27",
   "tools": [
     {
       "name": "compile",


### PR DESCRIPTION
## Summary
- Launch now shows when it is waiting for Unity CLI Loop server readiness and prints a final ready JSON payload after the project IPC path is usable.
- Stopping Play Mode now distinguishes a real state change from a no-op when Play Mode was already stopped.

## User Impact
- Agents and scripts no longer have to infer whether `uloop launch -r` finished at Unity startup or at CLI readiness.
- `control-play-mode --action Stop` now reports `Changed` and `WasAlreadyStopped`, so cleanup commands can tell whether they actually stopped Play Mode.

## Changes
- Added a launch readiness response and tests around the launch wait flow.
- Added Control Play Mode response fields and preserved them through CLI state polling.
- Updated source and generated skill docs for the new output contract.

## Verification
- `go test ./internal/cli -run "TestRunLaunchWritesReadyResponseAfterToolReadiness|TestRunControlPlayModeWithStateWaitPreservesStopChangeFields"`
- `scripts/check-go-cli.sh`
- `cli/dist/darwin-arm64/uloop launch -r --project-path "$(git rev-parse --show-toplevel)"`
- `cli/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `cli/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ControlPlayModeUseCaseTests"`
- `cli/dist/darwin-arm64/uloop control-play-mode --project-path "$(git rev-parse --show-toplevel)" --action Stop`
- `git diff --check`