### PR TITLE
chore: Stabilize timing-sensitive Go CLI tests that intermittently fail in CI

### DIFF
--- a/cli/internal/cli/connection_retry_test.go
+++ b/cli/internal/cli/connection_retry_test.go
@@ -236,7 +236,10 @@ func TestSendWithTransientConnectionRetryDoesNotCancelAcceptedRequestAtRetryTime
 	}
 
 	originalTimeout := serverConnectionRetryTimeout
-	serverConnectionRetryTimeout = 20 * time.Millisecond
+	// The retry window must be wide enough that the dial plus accepted ack always
+	// completes inside it even on a loaded CI machine, while the server delay stays
+	// well past the window so the timeout reliably fires mid-request.
+	serverConnectionRetryTimeout = 200 * time.Millisecond
 	t.Cleanup(func() {
 		serverConnectionRetryTimeout = originalTimeout
 	})
@@ -271,7 +274,7 @@ func TestSendWithTransientConnectionRetryDoesNotCancelAcceptedRequestAtRetryTime
 			return
 		}
 
-		time.Sleep(60 * time.Millisecond)
+		time.Sleep(600 * time.Millisecond)
 
 		final := []byte(`{"jsonrpc":"2.0","result":{"ok":true},"id":1}`)
 		if err := unityipc.Write(conn, final); err != nil {
@@ -315,7 +318,10 @@ func TestSendWithTransientConnectionRetryKeepsRetryTimeoutBeforeAcceptedAck(t *t
 	}
 
 	originalTimeout := serverConnectionRetryTimeout
-	serverConnectionRetryTimeout = 20 * time.Millisecond
+	// The retry window must be wide enough that the dial and request write always
+	// complete inside it even on a loaded CI machine, while the server delay stays
+	// well past the window so the pre-accept timeout reliably fires first.
+	serverConnectionRetryTimeout = 200 * time.Millisecond
 	t.Cleanup(func() {
 		serverConnectionRetryTimeout = originalTimeout
 	})
@@ -344,7 +350,7 @@ func TestSendWithTransientConnectionRetryKeepsRetryTimeoutBeforeAcceptedAck(t *t
 			return
 		}
 
-		time.Sleep(60 * time.Millisecond)
+		time.Sleep(600 * time.Millisecond)
 
 		final := []byte(`{"jsonrpc":"2.0","result":{"ok":true},"id":1}`)
 		if err := unityipc.Write(conn, final); err != nil {
@@ -446,11 +452,26 @@ func TestSendWithTransientConnectionRetryReturnsBusyAfterRetryWindow(t *testing.
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
 	}
 
+	originalFinder := findRunningUnityProcessForConnectionRetry
 	originalTimeout := serverConnectionRetryTimeout
 	originalPoll := serverConnectionRetryPoll
-	serverConnectionRetryTimeout = 30 * time.Millisecond
+	// The busy assertion only holds once at least one busy response lands inside the
+	// retry window. A narrow window can expire before the first dial completes on a
+	// loaded CI machine, surfacing a dial timeout instead of the busy RPC error.
+	serverConnectionRetryTimeout = 500 * time.Millisecond
 	serverConnectionRetryPoll = 5 * time.Millisecond
+	// A dial cut short by the expiring window probes for a running Unity process.
+	// The dial deadline is a separate timer that can fire microseconds before
+	// retryContext reports expiry, so an instant probe would reach the busy-masking
+	// guard while retryContext.Err() is still nil and surface the dial error instead.
+	// Block until the context is done, like a real OS process scan that always
+	// outlasts those microseconds, so the busy guard sees the expired context.
+	findRunningUnityProcessForConnectionRetry = func(ctx context.Context, projectRoot string) (*unityProcess, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	t.Cleanup(func() {
+		findRunningUnityProcessForConnectionRetry = originalFinder
 		serverConnectionRetryTimeout = originalTimeout
 		serverConnectionRetryPoll = originalPoll
 	})

--- a/cli/internal/unityipc/client_test.go
+++ b/cli/internal/unityipc/client_test.go
@@ -219,7 +219,7 @@ func TestSendWithProgressOutcomeWaitsForFinalResponseAfterDispatchAckWithoutAcce
 			return
 		}
 
-		time.Sleep(150 * time.Millisecond)
+		time.Sleep(750 * time.Millisecond)
 
 		final := []byte(`{"jsonrpc":"2.0","result":{"ok":true},"id":1}`)
 		if err := Write(conn, final); err != nil {
@@ -236,7 +236,10 @@ func TestSendWithProgressOutcomeWaitsForFinalResponseAfterDispatchAckWithoutAcce
 		ProjectRoot: "/tmp/MyProject",
 	}
 	client := NewClient(connection, "3.0.0-beta.6")
-	client.acceptTimeout = 50 * time.Millisecond
+	// The accept timeout must be wide enough that the accepted ack always arrives
+	// inside it even on a loaded CI machine, while the server delays the final
+	// response well past it to prove accepted requests outlive the accept timeout.
+	client.acceptTimeout = 250 * time.Millisecond
 
 	outcome, err := client.SendWithProgressOutcome(context.Background(), "execute-dynamic-code", map[string]any{}, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Go CLI test runs no longer fail intermittently on loaded CI machines due to overly tight real-time test margins.

## User Impact
- Before: the build-cli CI job could fail randomly even when no Go code changed (most recently on PR #1310, where a busy-retry test surfaced a dial i/o timeout instead of the expected busy error), forcing re-runs and blocking unrelated PRs.
- After: the four timing-sensitive tests use margins wide enough to be deterministic under CI load, so a red build-cli job means a real regression again.

## Changes
- Connection retry busy test: widened the retry window from 30ms to 500ms so at least one busy response always lands inside the window, and stubbed the Unity process probe to block until the context is done — the dial deadline is a separate timer that can fire microseconds before the retry context reports expiry, so an instant probe skipped the busy-masking guard (this exact failure was reproduced locally before the fix).
- Accepted-ack retry tests: widened from a 20ms window vs 60ms server delay to 200ms vs 600ms, keeping the 3x ratio that defines their semantics.
- IPC client accept-timeout test: widened from 50ms vs 150ms to 250ms vs 750ms for the same reason.
- Test-only changes; no production code paths are modified.

## Verification
- go test ./internal/cli/ -run 'TestSendWithTransientConnectionRetry' -count=30 -race (30/30 pass)
- go test ./internal/unityipc/ -run 'TestSendWithProgressOutcome' -count=30 -race (30/30 pass)
- scripts/check-go-cli.sh (full pass, exit 0)