### PR TITLE
Respect UI raycast priority in simulate-mouse-ui

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -85,7 +85,7 @@ jobs:
         echo "Note: node_modules will be automatically cleaned up when GitHub Actions environment is destroyed"
         
     - name: Commit built files (if changed)
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
@@ -122,6 +122,20 @@ jobs:
           git commit -m "chore: rebuild server bundle [skip ci]"
           git push origin "$BRANCH_NAME"
           echo "Built files committed successfully"
+        fi
+
+    - name: Verify built files are committed for fork PRs
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+      run: |
+        echo "Fork PR detected; skipping automatic bundle commit."
+        echo "Verifying built server bundle matches committed files..."
+        if git diff --quiet -- Packages/src/TypeScriptServer~/dist/server.bundle.js Packages/src/TypeScriptServer~/dist/server.bundle.js.map; then
+          echo "Built server bundle is already committed."
+        else
+          echo "Built server bundle differs from committed files."
+          echo "Please commit Packages/src/TypeScriptServer~/dist/server.bundle.js and server.bundle.js.map."
+          git diff --stat -- Packages/src/TypeScriptServer~/dist/server.bundle.js Packages/src/TypeScriptServer~/dist/server.bundle.js.map
+          exit 1
         fi
         
   test-unity-package:

--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using io.github.hatayama.uLoopMCP;
 using Newtonsoft.Json.Linq;
@@ -109,6 +110,54 @@ namespace Tests.PlayMode
             Assert.IsTrue(tracker.PointerUpCalled, "PointerUp should be fired");
             Assert.IsTrue(tracker.PointerClickCalled, "PointerClick should be fired");
             Assert.AreEqual("ClickTarget", lastResponse.HitGameObjectName);
+        }
+
+        [UnityTest]
+        public IEnumerator Click_Should_PreferScreenSpaceOverlayUiOverPhysics2DHit()
+        {
+            GameObject testRoot = new GameObject("Physics2DOverlayPriorityTest");
+
+            GameObject cameraGo = new GameObject("PhysicsRaycastCamera");
+            cameraGo.transform.SetParent(testRoot.transform, false);
+            cameraGo.transform.position = new Vector3(0f, 0f, -10f);
+            Camera camera = cameraGo.AddComponent<Camera>();
+            camera.orthographic = true;
+            cameraGo.AddComponent<Physics2DRaycaster>();
+
+            GameObject physicsTarget = new GameObject("PhysicsTarget");
+            physicsTarget.transform.SetParent(testRoot.transform, false);
+            physicsTarget.AddComponent<BoxCollider2D>().size = new Vector2(100f, 100f);
+            physicsTarget.AddComponent<SpriteRenderer>().sortingOrder = 32000;
+            ClickTracker physicsTracker = physicsTarget.AddComponent<ClickTracker>();
+
+            canvasGo.GetComponent<Canvas>().sortingOrder = 100;
+            ClickTracker overlayTracker = CreateClickableElement("OverlayTarget", Vector2.zero, new Vector2(200f, 100f));
+            yield return null;
+
+            Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+            PointerEventData pointerData = new PointerEventData(EventSystem.current)
+            {
+                position = screenPos
+            };
+            List<RaycastResult> raycastResults = new List<RaycastResult>();
+            EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+            Assert.IsNotEmpty(raycastResults);
+            Assert.AreEqual("PhysicsTarget", raycastResults[0].gameObject.name, "Test setup should reproduce Physics2D first-hit ordering.");
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = MouseAction.Click.ToString(),
+                ["x"] = screenPos.x,
+                ["y"] = screenPos.y
+            });
+
+            Assert.IsTrue(lastResponse.Success);
+            Assert.IsTrue(overlayTracker.PointerClickCalled, "Overlay UI should receive the click");
+            Assert.IsFalse(physicsTracker.PointerClickCalled, "Physics2D target behind overlay UI should not receive the click");
+            Assert.AreEqual("OverlayTarget", lastResponse.HitGameObjectName);
+
+            Object.Destroy(testRoot);
         }
 
         [UnityTest]

--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -117,47 +117,52 @@ namespace Tests.PlayMode
         {
             GameObject testRoot = new GameObject("Physics2DOverlayPriorityTest");
 
-            GameObject cameraGo = new GameObject("PhysicsRaycastCamera");
-            cameraGo.transform.SetParent(testRoot.transform, false);
-            cameraGo.transform.position = new Vector3(0f, 0f, -10f);
-            Camera camera = cameraGo.AddComponent<Camera>();
-            camera.orthographic = true;
-            cameraGo.AddComponent<Physics2DRaycaster>();
-
-            GameObject physicsTarget = new GameObject("PhysicsTarget");
-            physicsTarget.transform.SetParent(testRoot.transform, false);
-            physicsTarget.AddComponent<BoxCollider2D>().size = new Vector2(100f, 100f);
-            physicsTarget.AddComponent<SpriteRenderer>().sortingOrder = 32000;
-            ClickTracker physicsTracker = physicsTarget.AddComponent<ClickTracker>();
-
-            canvasGo.GetComponent<Canvas>().sortingOrder = 100;
-            ClickTracker overlayTracker = CreateClickableElement("OverlayTarget", Vector2.zero, new Vector2(200f, 100f));
-            yield return null;
-
-            Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
-            PointerEventData pointerData = new PointerEventData(EventSystem.current)
+            try
             {
-                position = screenPos
-            };
-            List<RaycastResult> raycastResults = new List<RaycastResult>();
-            EventSystem.current.RaycastAll(pointerData, raycastResults);
+                GameObject cameraGo = new GameObject("PhysicsRaycastCamera");
+                cameraGo.transform.SetParent(testRoot.transform, false);
+                cameraGo.transform.position = new Vector3(0f, 0f, -10f);
+                Camera camera = cameraGo.AddComponent<Camera>();
+                camera.orthographic = true;
+                cameraGo.AddComponent<Physics2DRaycaster>();
 
-            Assert.IsNotEmpty(raycastResults);
-            Assert.AreEqual("PhysicsTarget", raycastResults[0].gameObject.name, "Test setup should reproduce Physics2D first-hit ordering.");
+                GameObject physicsTarget = new GameObject("PhysicsTarget");
+                physicsTarget.transform.SetParent(testRoot.transform, false);
+                physicsTarget.AddComponent<BoxCollider2D>().size = new Vector2(100f, 100f);
+                physicsTarget.AddComponent<SpriteRenderer>().sortingOrder = 32000;
+                ClickTracker physicsTracker = physicsTarget.AddComponent<ClickTracker>();
 
-            yield return RunTool(new JObject
+                canvasGo.GetComponent<Canvas>().sortingOrder = 100;
+                ClickTracker overlayTracker = CreateClickableElement("OverlayTarget", Vector2.zero, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults);
+                Assert.AreEqual("PhysicsTarget", raycastResults[0].gameObject.name, "Test setup should reproduce Physics2D first-hit ordering.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(overlayTracker.PointerClickCalled, "Overlay UI should receive the click");
+                Assert.IsFalse(physicsTracker.PointerClickCalled, "Physics2D target behind overlay UI should not receive the click");
+                Assert.AreEqual("OverlayTarget", lastResponse.HitGameObjectName);
+            }
+            finally
             {
-                ["action"] = MouseAction.Click.ToString(),
-                ["x"] = screenPos.x,
-                ["y"] = screenPos.y
-            });
-
-            Assert.IsTrue(lastResponse.Success);
-            Assert.IsTrue(overlayTracker.PointerClickCalled, "Overlay UI should receive the click");
-            Assert.IsFalse(physicsTracker.PointerClickCalled, "Physics2D target behind overlay UI should not receive the click");
-            Assert.AreEqual("OverlayTarget", lastResponse.HitGameObjectName);
-
-            Object.Destroy(testRoot);
+                Object.Destroy(testRoot);
+            }
         }
 
         [UnityTest]

--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -166,6 +166,49 @@ namespace Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator Click_Should_PreferHigherSortingOrderOverlayCanvasOverLowerOrderMask()
+        {
+            canvasGo.GetComponent<Canvas>().sortingOrder = 0;
+            GameObject mask = CreateUIElement("StencilMaskedLayer", Vector2.zero, new Vector2(2000f, 2000f));
+            mask.AddComponent<Image>();
+            ClickTracker maskTracker = mask.AddComponent<ClickTracker>();
+
+            GameObject modalCanvasGo = new GameObject("ModalCanvas");
+
+            try
+            {
+                Canvas modalCanvas = modalCanvasGo.AddComponent<Canvas>();
+                modalCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+                modalCanvas.overrideSorting = true;
+                modalCanvas.sortingOrder = 100;
+                modalCanvasGo.AddComponent<CanvasScaler>();
+                modalCanvasGo.AddComponent<GraphicRaycaster>();
+
+                ClickTracker modalTracker = CreateChildClickableElement(
+                    "GoldButton", modalCanvasGo.transform, Vector2.zero, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(modalTracker.gameObject);
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(modalTracker.PointerClickCalled, "Higher sorting-order modal UI should receive the click");
+                Assert.IsFalse(maskTracker.PointerClickCalled, "Lower sorting-order mask should not receive the click");
+                Assert.AreEqual("GoldButton", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(modalCanvasGo);
+            }
+        }
+
+        [UnityTest]
         public IEnumerator Click_WithBypassRaycast_Should_UseTargetPathWhenNamesDuplicate()
         {
             GameObject firstPanel = CreateUIElement("FirstPanel", new Vector2(-120f, 0f), new Vector2(240f, 160f));

--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -112,28 +112,27 @@ namespace Tests.PlayMode
             Assert.AreEqual("ClickTarget", lastResponse.HitGameObjectName);
         }
 
+        // Verifies that an overlay UI element clipped out of EventSystem's Screen bounds
+        // (scaled Game view resolution) still wins over a non-GraphicRaycaster hit,
+        // because ScreenSpaceOverlay UI always renders in front of world-space content.
         [UnityTest]
-        public IEnumerator Click_Should_PreferScreenSpaceOverlayUiOverPhysics2DHit()
+        public IEnumerator Click_Should_PreferClippedOverlayUiOverNonUiRaycastHit()
         {
-            GameObject testRoot = new GameObject("Physics2DOverlayPriorityTest");
+            GameObject nonUiRoot = new GameObject("NonUiRaycasterRoot");
 
             try
             {
-                GameObject cameraGo = new GameObject("PhysicsRaycastCamera");
-                cameraGo.transform.SetParent(testRoot.transform, false);
-                cameraGo.transform.position = new Vector3(0f, 0f, -10f);
-                Camera camera = cameraGo.AddComponent<Camera>();
-                camera.orthographic = true;
-                cameraGo.AddComponent<Physics2DRaycaster>();
+                GameObject nonUiTarget = new GameObject("NonUiTarget");
+                nonUiTarget.transform.SetParent(nonUiRoot.transform, false);
+                ClickTracker nonUiTracker = nonUiTarget.AddComponent<ClickTracker>();
+                AlwaysHitRaycaster nonUiRaycaster = nonUiRoot.AddComponent<AlwaysHitRaycaster>();
+                nonUiRaycaster.Target = nonUiTarget;
 
-                GameObject physicsTarget = new GameObject("PhysicsTarget");
-                physicsTarget.transform.SetParent(testRoot.transform, false);
-                physicsTarget.AddComponent<BoxCollider2D>().size = new Vector2(100f, 100f);
-                physicsTarget.AddComponent<SpriteRenderer>().sortingOrder = 32000;
-                ClickTracker physicsTracker = physicsTarget.AddComponent<ClickTracker>();
-
-                canvasGo.GetComponent<Canvas>().sortingOrder = 100;
-                ClickTracker overlayTracker = CreateClickableElement("OverlayTarget", Vector2.zero, new Vector2(200f, 100f));
+                // Place the UI element beyond Screen.width so GraphicRaycaster clips it
+                // while the Canvas-space hit test still reaches it.
+                Vector2 offscreenOffset = new Vector2(Screen.width, 0f);
+                ClickTracker overlayTracker = CreateClickableElement(
+                    "OffscreenOverlayTarget", offscreenOffset, new Vector2(200f, 100f));
                 yield return null;
 
                 Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
@@ -144,8 +143,76 @@ namespace Tests.PlayMode
                 List<RaycastResult> raycastResults = new List<RaycastResult>();
                 EventSystem.current.RaycastAll(pointerData, raycastResults);
 
-                Assert.IsNotEmpty(raycastResults);
-                Assert.AreEqual("PhysicsTarget", raycastResults[0].gameObject.name, "Test setup should reproduce Physics2D first-hit ordering.");
+                Assert.IsNotEmpty(raycastResults, "Setup: the non-UI raycaster should hit.");
+                Assert.IsFalse(raycastResults[0].module is GraphicRaycaster,
+                    "Setup: EventSystem's first hit should not come from a GraphicRaycaster.");
+                Assert.IsFalse(
+                    raycastResults.Exists(result => result.gameObject == overlayTracker.gameObject),
+                    "Setup: overlay UI must be clipped out of EventSystem results for this regression test.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(overlayTracker.PointerClickCalled, "Overlay UI should receive the click");
+                Assert.IsFalse(nonUiTracker.PointerClickCalled, "Non-UI target behind overlay UI should not receive the click");
+                Assert.AreEqual("OffscreenOverlayTarget", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(nonUiRoot);
+            }
+        }
+
+        // Verifies the real Physics2D raycaster path. Physics2DRaycaster cannot hit
+        // outside its camera pixelRect, so the test raises its priority instead of
+        // using the Screen-bounds clipping setup from the synthetic raycaster tests.
+        [UnityTest]
+        public IEnumerator Click_Should_PreferOverlayUiOverPhysics2DRaycastHit()
+        {
+            GameObject physicsRoot = new GameObject("Physics2DRaycasterRoot");
+
+            try
+            {
+                GameObject cameraGo = new GameObject("Physics2DCamera");
+                cameraGo.transform.SetParent(physicsRoot.transform, false);
+                cameraGo.transform.position = new Vector3(0f, 0f, -10f);
+                Camera physicsCamera = cameraGo.AddComponent<Camera>();
+                physicsCamera.orthographic = true;
+                physicsCamera.orthographicSize = 5f;
+                cameraGo.AddComponent<HighPriorityPhysics2DRaycaster>();
+
+                canvasGo.GetComponent<Canvas>().sortingOrder = 100;
+                ClickTracker overlayTracker = CreateClickableElement(
+                    "PhysicsOverlayTarget", Vector2.zero, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+                GameObject physicsTarget = new GameObject("Physics2DTarget");
+                physicsTarget.transform.SetParent(physicsRoot.transform, false);
+                physicsTarget.transform.position = GetWorldPointOnPhysicsPlane(physicsCamera, screenPos);
+                BoxCollider2D collider = physicsTarget.AddComponent<BoxCollider2D>();
+                collider.size = new Vector2(2f, 2f);
+                ClickTracker physicsTracker = physicsTarget.AddComponent<ClickTracker>();
+                yield return null;
+
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the Physics2D raycaster should hit.");
+                Assert.AreEqual(physicsTarget, raycastResults[0].gameObject,
+                    "Setup: EventSystem should expose the prioritized Physics2D hit first.");
+                Assert.IsTrue(
+                    raycastResults.Exists(result => result.gameObject == overlayTracker.gameObject),
+                    "Setup: overlay UI should also be a normal EventSystem hit.");
 
                 yield return RunTool(new JObject
                 {
@@ -157,38 +224,61 @@ namespace Tests.PlayMode
                 Assert.IsTrue(lastResponse.Success);
                 Assert.IsTrue(overlayTracker.PointerClickCalled, "Overlay UI should receive the click");
                 Assert.IsFalse(physicsTracker.PointerClickCalled, "Physics2D target behind overlay UI should not receive the click");
-                Assert.AreEqual("OverlayTarget", lastResponse.HitGameObjectName);
+                Assert.AreEqual("PhysicsOverlayTarget", lastResponse.HitGameObjectName);
             }
             finally
             {
-                Object.Destroy(testRoot);
+                Object.Destroy(physicsRoot);
             }
         }
 
+        // Forces the remaining ordering shape from issue 1317: EventSystem reports a
+        // lower-priority GraphicRaycaster hit while the front overlay is clipped from
+        // EventSystem results, so the tool must compare the Canvas-space candidate.
         [UnityTest]
-        public IEnumerator Click_Should_PreferHigherSortingOrderOverlayCanvasOverLowerOrderMask()
+        public IEnumerator Click_Should_PreferClippedHigherOrderOverlayUiOverLowerGraphicRaycasterHit()
         {
-            canvasGo.GetComponent<Canvas>().sortingOrder = 0;
-            GameObject mask = CreateUIElement("StencilMaskedLayer", Vector2.zero, new Vector2(2000f, 2000f));
-            mask.AddComponent<Image>();
-            ClickTracker maskTracker = mask.AddComponent<ClickTracker>();
-
-            GameObject modalCanvasGo = new GameObject("ModalCanvas");
+            GameObject lowerCameraGo = new GameObject("LowerGraphicCamera");
+            GameObject lowerCanvasGo = new GameObject("LowerGraphicCanvas");
 
             try
             {
-                Canvas modalCanvas = modalCanvasGo.AddComponent<Canvas>();
-                modalCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
-                modalCanvas.overrideSorting = true;
-                modalCanvas.sortingOrder = 100;
-                modalCanvasGo.AddComponent<CanvasScaler>();
-                modalCanvasGo.AddComponent<GraphicRaycaster>();
+                lowerCameraGo.transform.position = new Vector3(0f, 0f, -10f);
+                Camera lowerCamera = lowerCameraGo.AddComponent<Camera>();
+                lowerCamera.orthographic = true;
 
-                ClickTracker modalTracker = CreateChildClickableElement(
-                    "GoldButton", modalCanvasGo.transform, Vector2.zero, new Vector2(200f, 100f));
+                Canvas lowerCanvas = lowerCanvasGo.AddComponent<Canvas>();
+                lowerCanvas.renderMode = RenderMode.ScreenSpaceCamera;
+                lowerCanvas.worldCamera = lowerCamera;
+                lowerCanvas.sortingOrder = 0;
+
+                GameObject lowerMask = CreateChildUIElement(
+                    "LowerGraphicMask", lowerCanvasGo.transform, Vector2.zero, new Vector2(2000f, 2000f));
+                lowerMask.AddComponent<Image>();
+                ClickTracker lowerTracker = lowerMask.AddComponent<ClickTracker>();
+                AlwaysHitGraphicRaycaster lowerRaycaster = lowerCanvasGo.AddComponent<AlwaysHitGraphicRaycaster>();
+                lowerRaycaster.Target = lowerMask;
+
+                canvasGo.GetComponent<Canvas>().sortingOrder = 100;
+                Vector2 clippedOverlayOffset = new Vector2(Screen.width, 0f);
+                ClickTracker overlayTracker = CreateClickableElement(
+                    "FrontOverlayButton", clippedOverlayOffset, new Vector2(200f, 100f));
                 yield return null;
 
-                Vector2 screenPos = GetScreenPosition(modalTracker.gameObject);
+                Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the lower GraphicRaycaster should hit.");
+                Assert.AreEqual(lowerMask, raycastResults[0].gameObject,
+                    "Setup: EventSystem should expose the lower-priority GraphicRaycaster hit first.");
+                Assert.IsFalse(
+                    raycastResults.Exists(result => result.gameObject == overlayTracker.gameObject),
+                    "Setup: overlay UI must be clipped out of EventSystem results for this regression test.");
 
                 yield return RunTool(new JObject
                 {
@@ -198,13 +288,14 @@ namespace Tests.PlayMode
                 });
 
                 Assert.IsTrue(lastResponse.Success);
-                Assert.IsTrue(modalTracker.PointerClickCalled, "Higher sorting-order modal UI should receive the click");
-                Assert.IsFalse(maskTracker.PointerClickCalled, "Lower sorting-order mask should not receive the click");
-                Assert.AreEqual("GoldButton", lastResponse.HitGameObjectName);
+                Assert.IsTrue(overlayTracker.PointerClickCalled, "Higher-order overlay UI should receive the click");
+                Assert.IsFalse(lowerTracker.PointerClickCalled, "Lower GraphicRaycaster target should not receive the click");
+                Assert.AreEqual("FrontOverlayButton", lastResponse.HitGameObjectName);
             }
             finally
             {
-                Object.Destroy(modalCanvasGo);
+                Object.Destroy(lowerCanvasGo);
+                Object.Destroy(lowerCameraGo);
             }
         }
 
@@ -710,6 +801,14 @@ namespace Tests.PlayMode
             return (Vector2)go.GetComponent<RectTransform>().position;
         }
 
+        private Vector3 GetWorldPointOnPhysicsPlane(Camera physicsCamera, Vector2 screenPos)
+        {
+            Vector3 screenPoint = new Vector3(screenPos.x, screenPos.y, -physicsCamera.transform.position.z);
+            Vector3 worldPoint = physicsCamera.ScreenToWorldPoint(screenPoint);
+            worldPoint.z = 0f;
+            return worldPoint;
+        }
+
         // simulate-mouse uses top-left origin; Unity screen space uses bottom-left origin
         private Vector2 ScreenToInput(Vector2 screenPos)
         {
@@ -751,6 +850,54 @@ namespace Tests.PlayMode
     }
 
     // Tracks pointer click events for testing
+    // Stands in for a non-UI raycaster (e.g. PhysicsRaycaster) without requiring the
+    // physics modules: always reports a hit on Target, ignoring Screen-bounds clipping.
+    public class AlwaysHitRaycaster : BaseRaycaster
+    {
+        public GameObject Target = null!;
+
+        public override Camera eventCamera => null!;
+
+        public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)
+        {
+            resultAppendList.Add(new RaycastResult
+            {
+                gameObject = Target,
+                module = this,
+                distance = 0f,
+                screenPosition = eventData.position
+            });
+        }
+    }
+
+    // Stands in for a lower-priority GraphicRaycaster that still reports an
+    // EventSystem hit when the front overlay UI is clipped by Screen bounds.
+    public class AlwaysHitGraphicRaycaster : GraphicRaycaster
+    {
+        public GameObject Target = null!;
+
+        public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)
+        {
+            Canvas canvas = GetComponent<Canvas>();
+            resultAppendList.Add(new RaycastResult
+            {
+                gameObject = Target,
+                module = this,
+                distance = 0f,
+                screenPosition = eventData.position,
+                sortingLayer = canvas.sortingLayerID,
+                sortingOrder = canvas.sortingOrder,
+                depth = 0
+            });
+        }
+    }
+
+    public class HighPriorityPhysics2DRaycaster : Physics2DRaycaster
+    {
+        public override int sortOrderPriority => int.MaxValue;
+        public override int renderOrderPriority => int.MaxValue;
+    }
+
     public class ClickTracker : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, IPointerClickHandler
     {
         public bool PointerDownCalled { get; private set; }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -8,6 +8,7 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.inputsystem": "1.14.2",
     "com.unity.memoryprofiler": "1.1.12",
+    "com.unity.modules.physics2d": "1.0.0",
     "com.unity.render-pipelines.universal": "14.0.12",
     "com.unity.terrain-tools": "5.0.6",
     "com.unity.test-framework": "1.3.9",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -289,6 +289,12 @@
       "source": "builtin",
       "dependencies": {}
     },
+    "com.unity.modules.physics2d": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
     "com.unity.modules.terrain": {
       "version": "1.0.0",
       "depth": 1,

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
@@ -623,18 +623,8 @@ namespace io.github.hatayama.uLoopMCP
 
         private void UpdatePointerRaycast(PointerEventData pointerData)
         {
-            List<RaycastResult> results = new List<RaycastResult>();
-            EventSystem.current.RaycastAll(pointerData, results);
-
-            if (results.Count > 0)
-            {
-                pointerData.pointerCurrentRaycast = results[0];
-                return;
-            }
-
-            // Same Canvas-space fallback as RaycastUI for scaled Game view
-            RaycastResult? fallback = UiRaycastHelper.RaycastCanvasSpace(pointerData.position);
-            pointerData.pointerCurrentRaycast = fallback ?? new RaycastResult();
+            RaycastResult? hit = UiRaycastHelper.RaycastUI(pointerData.position, EventSystem.current);
+            pointerData.pointerCurrentRaycast = hit ?? new RaycastResult();
         }
 
         private async Task InterpolateDragPosition(

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
@@ -1,12 +1,10 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.UI;
 
 namespace io.github.hatayama.uLoopMCP
 {

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -73,6 +73,7 @@ namespace io.github.hatayama.uLoopMCP
                     {
                         gameObject = graphic.gameObject,
                         module = raycaster,
+                        screenPosition = canvasPosition,
                         sortingLayer = canvas.sortingLayerID,
                         sortingOrder = canvas.sortingOrder,
                         depth = graphic.depth
@@ -110,11 +111,6 @@ namespace io.github.hatayama.uLoopMCP
             return graphic.Raycast(canvasPosition, null);
         }
 
-        private static bool IsGraphicRaycast(RaycastResult raycastResult)
-        {
-            return raycastResult.module is GraphicRaycaster;
-        }
-
         private static bool ShouldPreferCanvasSpaceHit(RaycastResult canvasSpaceHit, RaycastResult eventSystemHit)
         {
             if (!IsGraphicRaycast(canvasSpaceHit))
@@ -130,27 +126,26 @@ namespace io.github.hatayama.uLoopMCP
             return CompareRaycastPriority(canvasSpaceHit, eventSystemHit) > 0;
         }
 
+        private static bool IsGraphicRaycast(RaycastResult raycastResult)
+        {
+            return raycastResult.module is GraphicRaycaster;
+        }
+
         private static int CompareRaycastPriority(RaycastResult left, RaycastResult right)
         {
-            int sortOrderPriority = Compare(
-                GetSortOrderPriority(left),
-                GetSortOrderPriority(right));
+            int sortOrderPriority = Compare(GetSortOrderPriority(left), GetSortOrderPriority(right));
             if (sortOrderPriority != 0)
             {
                 return sortOrderPriority;
             }
 
-            int renderOrderPriority = Compare(
-                GetRenderOrderPriority(left),
-                GetRenderOrderPriority(right));
+            int renderOrderPriority = Compare(GetRenderOrderPriority(left), GetRenderOrderPriority(right));
             if (renderOrderPriority != 0)
             {
                 return renderOrderPriority;
             }
 
-            int sortingLayer = Compare(
-                GetSortingLayerValue(left),
-                GetSortingLayerValue(right));
+            int sortingLayer = Compare(GetSortingLayerValue(left), GetSortingLayerValue(right));
             if (sortingLayer != 0)
             {
                 return sortingLayer;

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -18,14 +18,22 @@ namespace io.github.hatayama.uLoopMCP
             List<RaycastResult> results = new List<RaycastResult>();
             eventSystem.RaycastAll(pointerData, results);
 
+            RaycastResult? overlayHit = RaycastCanvasSpace(screenPosition);
+
             if (results.Count > 0)
             {
-                return results[0];
+                RaycastResult firstHit = results[0];
+                if (overlayHit != null && !IsGraphicRaycast(firstHit))
+                {
+                    return overlayHit;
+                }
+
+                return firstHit;
             }
 
             // EventSystem clips at Screen.width/height, which can be smaller than the
             // Canvas layout space (Game view target resolution). Fall back to manual hit testing.
-            return RaycastCanvasSpace(screenPosition);
+            return overlayHit;
         }
 
         // Bypass EventSystem's Screen-bounds clipping by directly testing Graphic rects in Canvas space.
@@ -107,6 +115,11 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             return graphic.Raycast(canvasPosition, null);
+        }
+
+        private static bool IsGraphicRaycast(RaycastResult raycastResult)
+        {
+            return raycastResult.module is GraphicRaycaster;
         }
     }
 }

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -18,14 +18,16 @@ namespace io.github.hatayama.uLoopMCP
             List<RaycastResult> results = new List<RaycastResult>();
             eventSystem.RaycastAll(pointerData, results);
 
-            RaycastResult? overlayHit = RaycastCanvasSpace(screenPosition);
-
             if (results.Count > 0)
             {
                 RaycastResult firstHit = results[0];
-                if (overlayHit != null && !IsGraphicRaycast(firstHit))
+                if (!IsGraphicRaycast(firstHit))
                 {
-                    return overlayHit;
+                    RaycastResult? overlayHit = RaycastCanvasSpace(screenPosition);
+                    if (overlayHit != null)
+                    {
+                        return overlayHit;
+                    }
                 }
 
                 return firstHit;
@@ -33,7 +35,7 @@ namespace io.github.hatayama.uLoopMCP
 
             // EventSystem clips at Screen.width/height, which can be smaller than the
             // Canvas layout space (Game view target resolution). Fall back to manual hit testing.
-            return overlayHit;
+            return RaycastCanvasSpace(screenPosition);
         }
 
         // Bypass EventSystem's Screen-bounds clipping by directly testing Graphic rects in Canvas space.

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -17,17 +17,15 @@ namespace io.github.hatayama.uLoopMCP
             };
             List<RaycastResult> results = new List<RaycastResult>();
             eventSystem.RaycastAll(pointerData, results);
+            RaycastResult? canvasSpaceHit = RaycastCanvasSpace(screenPosition);
 
             if (results.Count > 0)
             {
                 RaycastResult firstHit = results[0];
-                if (!IsGraphicRaycast(firstHit))
+
+                if (canvasSpaceHit != null && ShouldPreferCanvasSpaceHit(canvasSpaceHit.Value, firstHit))
                 {
-                    RaycastResult? overlayHit = RaycastCanvasSpace(screenPosition);
-                    if (overlayHit != null)
-                    {
-                        return overlayHit;
-                    }
+                    return canvasSpaceHit;
                 }
 
                 return firstHit;
@@ -35,7 +33,7 @@ namespace io.github.hatayama.uLoopMCP
 
             // EventSystem clips at Screen.width/height, which can be smaller than the
             // Canvas layout space (Game view target resolution). Fall back to manual hit testing.
-            return RaycastCanvasSpace(screenPosition);
+            return canvasSpaceHit;
         }
 
         // Bypass EventSystem's Screen-bounds clipping by directly testing Graphic rects in Canvas space.
@@ -43,9 +41,7 @@ namespace io.github.hatayama.uLoopMCP
         public static RaycastResult? RaycastCanvasSpace(Vector2 canvasPosition)
         {
             Canvas[] canvases = Object.FindObjectsByType<Canvas>(FindObjectsSortMode.None);
-            Graphic? bestHit = null;
-            int bestSortingOrder = int.MinValue;
-            int bestDepth = -1;
+            RaycastResult? bestHit = null;
 
             foreach (Canvas canvas in canvases)
             {
@@ -73,28 +69,23 @@ namespace io.github.hatayama.uLoopMCP
                         continue;
                     }
 
-                    int sortingOrder = canvas.sortingOrder;
-
-                    if (sortingOrder > bestSortingOrder ||
-                        (sortingOrder == bestSortingOrder && graphic.depth > bestDepth))
+                    RaycastResult candidate = new RaycastResult
                     {
-                        bestHit = graphic;
-                        bestSortingOrder = sortingOrder;
-                        bestDepth = graphic.depth;
+                        gameObject = graphic.gameObject,
+                        module = raycaster,
+                        sortingLayer = canvas.sortingLayerID,
+                        sortingOrder = canvas.sortingOrder,
+                        depth = graphic.depth
+                    };
+
+                    if (bestHit == null || CompareRaycastPriority(candidate, bestHit.Value) > 0)
+                    {
+                        bestHit = candidate;
                     }
                 }
             }
 
-            if (bestHit == null)
-            {
-                return null;
-            }
-
-            return new RaycastResult
-            {
-                gameObject = bestHit.gameObject,
-                sortingOrder = bestSortingOrder
-            };
+            return bestHit;
         }
 
         // Respects CanvasGroup.blocksRaycasts, Mask, RectMask2D, and custom ICanvasRaycastFilter
@@ -122,6 +113,86 @@ namespace io.github.hatayama.uLoopMCP
         private static bool IsGraphicRaycast(RaycastResult raycastResult)
         {
             return raycastResult.module is GraphicRaycaster;
+        }
+
+        private static bool ShouldPreferCanvasSpaceHit(RaycastResult canvasSpaceHit, RaycastResult eventSystemHit)
+        {
+            if (!IsGraphicRaycast(canvasSpaceHit))
+            {
+                return false;
+            }
+
+            if (!IsGraphicRaycast(eventSystemHit))
+            {
+                return true;
+            }
+
+            return CompareRaycastPriority(canvasSpaceHit, eventSystemHit) > 0;
+        }
+
+        private static int CompareRaycastPriority(RaycastResult left, RaycastResult right)
+        {
+            int sortOrderPriority = Compare(
+                GetSortOrderPriority(left),
+                GetSortOrderPriority(right));
+            if (sortOrderPriority != 0)
+            {
+                return sortOrderPriority;
+            }
+
+            int renderOrderPriority = Compare(
+                GetRenderOrderPriority(left),
+                GetRenderOrderPriority(right));
+            if (renderOrderPriority != 0)
+            {
+                return renderOrderPriority;
+            }
+
+            int sortingLayer = Compare(
+                GetSortingLayerValue(left),
+                GetSortingLayerValue(right));
+            if (sortingLayer != 0)
+            {
+                return sortingLayer;
+            }
+
+            int sortingOrder = Compare(left.sortingOrder, right.sortingOrder);
+            if (sortingOrder != 0)
+            {
+                return sortingOrder;
+            }
+
+            return Compare(left.depth, right.depth);
+        }
+
+        private static int GetSortOrderPriority(RaycastResult result)
+        {
+            return result.module != null ? result.module.sortOrderPriority : 0;
+        }
+
+        private static int GetRenderOrderPriority(RaycastResult result)
+        {
+            return result.module != null ? result.module.renderOrderPriority : 0;
+        }
+
+        private static int GetSortingLayerValue(RaycastResult result)
+        {
+            return SortingLayer.GetLayerValueFromID(result.sortingLayer);
+        }
+
+        private static int Compare(int left, int right)
+        {
+            if (left > right)
+            {
+                return 1;
+            }
+
+            if (left < right)
+            {
+                return -1;
+            }
+
+            return 0;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1317.

This updates `simulate-mouse-ui` raycast selection so it better matches real user input priority when mixed raycasters or multiple ScreenSpace-Overlay canvases overlap at the same screen position.

Previously, `simulate-mouse-ui` used the first `EventSystem.RaycastAll` result directly. In some scenes that result can be a lower-priority target, such as:

- a Physics2D collider behind a visible overlay UI button
- a lower-sorting-order full-screen uGUI mask in front of gameplay but behind a higher-sorting-order modal button

That could cause `simulate-mouse-ui` to dispatch to the wrong target or report that no clickable UI handler was hit even though manual user input reaches the frontmost button.

## Changes

- Reuse the ScreenSpace-Overlay canvas-space hit test before returning the first `EventSystem.RaycastAll` result.
- Prefer the overlay Graphic hit when the first EventSystem hit is not from a `GraphicRaycaster`.
- When both candidates are UI hits, compare raycaster/canvas priority before selecting the target.
- Populate canvas-space `RaycastResult` candidates with module, sorting layer/order, and depth.
- Use the shared helper while updating drag pointer raycasts.
- Add PlayMode regression tests for:
  - Physics2D first-hit behind an overlay UI target
  - lower-order full-screen UI mask behind a higher-order modal Canvas target

## Testing

- Verified compilation in a Unity 6000.1 project that consumes the package.
- Manually validated a runtime setup where `EventSystem.RaycastAll` first returned a Physics2D collider, while `simulate-mouse-ui` clicked the visible ScreenSpace-Overlay button.
- Manually validated a layered modal setup where a lower-order full-screen uGUI mask previously intercepted the simulated click; after this change, `simulate-mouse-ui` clicked the higher-order modal button and the flow completed.
- Added PlayMode regression tests in this repository.
- The repository PlayMode test suite was not run locally because Unity 2022.3.62f3 is not installed in this environment.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Summary

## Problem
The `simulate-mouse-ui` tool was selecting raycast targets based on the first result from `EventSystem.RaycastAll()`, which doesn't accurately reflect UI visual priority when multiple raycasters overlap. This caused clicks to be dispatched to lower-priority targets such as Physics2D colliders behind visible overlay UI buttons, or lower-sorting-order full-screen UI masks positioned between gameplay and higher-priority modal buttons.

## Solution
Implemented priority-aware raycast selection that compares candidate hits using UI priority factors (raycaster module priority, canvas sorting layer/order, and graphic depth) before selecting the target. The fix reuses canvas-space hit testing and prefers GraphicRaycaster-based UI results over non-UI raycaster results.

## Changes

### Core Logic (`UiRaycastHelper.cs`)
- Enhanced `RaycastUI()` to compute canvas-space hits before EventSystem results and apply intelligent preference logic via `ShouldPreferCanvasSpaceHit()`
- Expanded `RaycastCanvasSpace()` to build fully populated `RaycastResult` candidates with complete metadata (module, sorting layer/order, graphic depth) instead of partial hits
- Added comprehensive priority-ranking system (`CompareRaycastPriority`) that orders hits by:
  1. Raycaster module sort order priority
  2. Raycaster module render order priority  
  3. Canvas sorting layer value
  4. Canvas sorting order
  5. Graphic depth

### Integration (`SimulateMouseUiTool.cs`)
- Updated `UpdatePointerRaycast()` to delegate raycast selection to `UiRaycastHelper.RaycastUI()` instead of directly using EventSystem results, removing prior first-result selection logic

### Test Coverage (`SimulateMouseUiTests.cs`)
- Added three regression tests validating correct target selection:
  - `Click_Should_PreferClippedOverlayUiOverNonUiRaycastHit()`: Clipped ScreenSpace-Overlay UI preferred over non-UI raycaster hit
  - `Click_Should_PreferOverlayUiOverPhysics2DRaycastHit()`: Overlay UI correctly selected even when Physics2D collider appears first in raycast ordering
  - `Click_Should_PreferClippedHigherOrderOverlayUiOverLowerGraphicRaycasterHit()`: Higher-order overlay UI preferred over lower-priority GraphicRaycaster hit
- Introduced deterministic test-only raycaster types:
  - `AlwaysHitRaycaster`: Simulates non-UI raycaster (e.g., PhysicsRaycaster) without requiring physics modules
  - `AlwaysHitGraphicRaycaster`: Lower-priority GraphicRaycaster for testing canvas-order scenarios
  - `HighPriorityPhysics2DRaycaster`: Physics2D raycaster with maximum sort/render priority for testing priority comparison

### Dependencies (`Packages/manifest.json`)
- Added `com.unity.modules.physics2d` (1.0.0) to support Physics2D test scenarios

### CI/CD (`build-and-test.yml`)
- Added fork PR validation: Verifies built artifacts (`dist/server.bundle.js`) are committed by fork contributors, preventing workflow failures on missing builds
- Simplified main repository PR builds with conditional commit guard

## Verification
The fix has been validated against both original failure scenarios described in issue `#1317`:
- Physics2D collider behind overlay UI button: Click now correctly dispatches to the visible button instead of the hidden collider
- Lower-sorting-order full-screen UI mask behind modal button: Click now reaches the frontmost modal button instead of being intercepted by the lower-priority mask

Backward compatibility maintained by limiting Physics2D module dependency to test project only, not the main package manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->