### PR TITLE
fix: Multiline dynamic code snippets work reliably on Windows

### DIFF
--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-execute-dynamic-code
-description: "Execute C# code dynamically in Unity Editor. Use find-game-objects first for basic selected GameObject discovery or property inspection. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) Execute Unity Editor menu commands through EditorApplication.ExecuteMenuItem, (5) PlayMode automation (click buttons, invoke methods, tweak runtime state), (6) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (7) PlayMode inspection that requires custom Unity API code beyond existing tools. NOT for file I/O or script authoring."
+description: "Execute C# with Unity APIs when existing uloop tools cannot inspect or edit enough. Use for scene, prefab, SerializedObject, AssetDatabase refresh/.meta generation, menu, or PlayMode automation."
 context: fork
 ---
 
@@ -14,14 +14,16 @@ For basic selected GameObject discovery or property inspection, use `find-game-o
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute via Bash: `uloop execute-dynamic-code --code '<code>'`
-4. If execution fails, adjust code and retry
-5. Report the execution result
+3. For multiline snippets, write the C# statements to a temporary `.csx` file and execute `uloop execute-dynamic-code --code-file <path>`
+4. Use `uloop execute-dynamic-code --code '<code>'` only for short one-line snippets
+5. If execution fails, adjust code and retry
+6. Report the execution result
 
 ## Parameters
 
-- `--code '<code>'` (required): Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`).
+- `--code '<code>'`: Inline C# statements to execute. Use this for one-line snippets only.
+- `--code-file <path>`: Read C# statements from a UTF-8 file. Prefer this for multiline snippets, especially on PowerShell, because Windows `.cmd` shims can lose lines from multiline inline arguments before `uloop` receives them.
+- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell single-quoted strings can contain normal double quotes, for example `uloop execute-dynamic-code --code 'Debug.Log("Hello!");'`.
 - `--parameters {}` (advanced, optional): Pass an object when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets, and pass an object instead of a JSON string.
 - `--compile-only true` (optional): Compile the snippet without executing it. Use this when you want Roslyn diagnostics before running new code.
 
@@ -42,7 +44,7 @@ return x;
 Returns JSON:
 - `Success`: boolean — overall execution success
 - `Result`: string — value of the snippet's `return` statement (empty when omitted)
-- `Logs`: string[] — `Debug.Log` / `Debug.LogWarning` / `Debug.LogError` messages emitted during the run
+- `Logs`: string[] — execution diagnostics from the dynamic-code runner, not Unity Console entries
 - `CompilationErrors`: object[] — Roslyn diagnostics with `Message`, `Line`, `Column`, `ErrorCode`, optional `Hint` and `Suggestions`
 - `ErrorMessage`: string — top-level failure summary (empty on success)
 - `Error`: string — alias of `ErrorMessage`
@@ -51,7 +53,7 @@ Returns JSON:
 - `DiagnosticsSummary`: string|null — compact summary when diagnostics are available
 - `Diagnostics`: object[] — structured diagnostics; same shape as `CompilationErrors`, usually populated together with it
 
-On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, security violation, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.
+Use `uloop get-logs` to retrieve `Debug.Log`, `Debug.LogWarning`, and `Debug.LogError` messages emitted by the snippet. On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, security violation, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.
 
 ## Code Examples by Category
 

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-execute-dynamic-code
-description: "Execute C# code dynamically in Unity Editor. Use find-game-objects first for basic selected GameObject discovery or property inspection. Use when you need to: (1) Wire prefab/material references and AddComponent operations, (2) Edit SerializedObject properties and reference wiring, (3) Perform scene/hierarchy edits and batch operations, (4) Execute Unity Editor menu commands through EditorApplication.ExecuteMenuItem, (5) PlayMode automation (click buttons, invoke methods, tweak runtime state), (6) PlayMode UI controls (InputField, Slider, Toggle, Dropdown), (7) PlayMode inspection that requires custom Unity API code beyond existing tools. NOT for file I/O or script authoring."
+description: "Execute C# with Unity APIs when existing uloop tools cannot inspect or edit enough. Use for scene, prefab, SerializedObject, AssetDatabase refresh/.meta generation, menu, or PlayMode automation."
 context: fork
 ---
 
@@ -14,14 +14,16 @@ For basic selected GameObject discovery or property inspection, use `find-game-o
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute via Bash: `uloop execute-dynamic-code --code '<code>'`
-4. If execution fails, adjust code and retry
-5. Report the execution result
+3. For multiline snippets, write the C# statements to a temporary `.csx` file and execute `uloop execute-dynamic-code --code-file <path>`
+4. Use `uloop execute-dynamic-code --code '<code>'` only for short one-line snippets
+5. If execution fails, adjust code and retry
+6. Report the execution result
 
 ## Parameters
 
-- `--code '<code>'` (required): Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`).
+- `--code '<code>'`: Inline C# statements to execute. Use this for one-line snippets only.
+- `--code-file <path>`: Read C# statements from a UTF-8 file. Prefer this for multiline snippets, especially on PowerShell, because Windows `.cmd` shims can lose lines from multiline inline arguments before `uloop` receives them.
+- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell single-quoted strings can contain normal double quotes, for example `uloop execute-dynamic-code --code 'Debug.Log("Hello!");'`.
 - `--parameters {}` (advanced, optional): Pass an object when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets, and pass an object instead of a JSON string.
 - `--compile-only true` (optional): Compile the snippet without executing it. Use this when you want Roslyn diagnostics before running new code.
 
@@ -42,7 +44,7 @@ return x;
 Returns JSON:
 - `Success`: boolean — overall execution success
 - `Result`: string — value of the snippet's `return` statement (empty when omitted)
-- `Logs`: string[] — `Debug.Log` / `Debug.LogWarning` / `Debug.LogError` messages emitted during the run
+- `Logs`: string[] — execution diagnostics from the dynamic-code runner, not Unity Console entries
 - `CompilationErrors`: object[] — Roslyn diagnostics with `Message`, `Line`, `Column`, `ErrorCode`, optional `Hint` and `Suggestions`
 - `ErrorMessage`: string — top-level failure summary (empty on success)
 - `Error`: string — alias of `ErrorMessage`
@@ -51,7 +53,7 @@ Returns JSON:
 - `DiagnosticsSummary`: string|null — compact summary when diagnostics are available
 - `Diagnostics`: object[] — structured diagnostics; same shape as `CompilationErrors`, usually populated together with it
 
-On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, security violation, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.
+Use `uloop get-logs` to retrieve `Debug.Log`, `Debug.LogWarning`, and `Debug.LogError` messages emitted by the snippet. On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, security violation, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.
 
 ## Code Examples by Category
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,6 +54,10 @@ jobs:
       working-directory: Packages/src/Cli~
       run: npx knip
 
+    - name: Run CLI unit tests
+      working-directory: Packages/src/Cli~
+      run: npm run test:unit
+
     - name: Build TypeScript Server
       working-directory: Packages/src/TypeScriptServer~
       env:

--- a/Packages/src/Cli~/jest.config.cjs
+++ b/Packages/src/Cli~/jest.config.cjs
@@ -6,8 +6,11 @@ module.exports = {
   testMatch: ['**/__tests__/**/*.test.ts'],
   transform: {
     '^.+\\.ts$': 'ts-jest',
+    // commander v15 is ESM-only; transpile it to CJS so Jest's CJS runtime can load it
+    '^.+\\.js$': ['ts-jest', { tsconfig: { allowJs: true } }],
     '^.+\\.md$': '<rootDir>/md-transformer.cjs',
   },
+  transformIgnorePatterns: ['[\\\\/]node_modules[\\\\/](?!commander[\\\\/])'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },

--- a/Packages/src/Cli~/package.json
+++ b/Packages/src/Cli~/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write src/**/*.ts",
     "format:check": "prettier --check src/**/*.ts",
     "knip": "knip",
-    "test:cli": "jest src/__tests__ --testTimeout=60000 --runInBand"
+    "test:cli": "jest src/__tests__ --testTimeout=60000 --runInBand",
+    "test:unit": "jest src/__tests__ --testPathIgnorePatterns cli-e2e --testTimeout=60000"
   },
   "keywords": [
     "cli",

--- a/Packages/src/Cli~/src/__tests__/cli-fast-path.test.ts
+++ b/Packages/src/Cli~/src/__tests__/cli-fast-path.test.ts
@@ -61,6 +61,16 @@ describe('tryParseFastExecuteDynamicCodeCommand', () => {
     });
   });
 
+  it('falls back when --code-file is requested', () => {
+    const command = tryParseFastExecuteDynamicCodeCommand([
+      'execute-dynamic-code',
+      '--code-file',
+      'snippet.csx',
+    ]);
+
+    expect(command).toBeNull();
+  });
+
   it('falls back when help is requested', () => {
     const command = tryParseFastExecuteDynamicCodeCommand(['execute-dynamic-code', '--help']);
 

--- a/Packages/src/Cli~/src/__tests__/execute-tool.test.ts
+++ b/Packages/src/Cli~/src/__tests__/execute-tool.test.ts
@@ -19,8 +19,9 @@ import {
   UnityServerNotRunningError,
 } from '../port-resolver.js';
 import { ProjectMismatchError } from '../project-validator.js';
-import type { Stats } from 'fs';
-import { resolve as resolvePath } from 'path';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, type Stats } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 function createStatResult(mtimeMs: number): Stats {
   return { mtimeMs } as unknown as Stats;
@@ -833,8 +834,23 @@ describe('isSettingsReadError', () => {
 });
 
 describe('resolveUnityConnectionWithStartupDiagnosis', () => {
+  // validateProjectPath reads the real filesystem, so a temp Unity project keeps
+  // these tests independent from the state of the machine running them
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'uloop-startup-test-'));
+    mkdirSync(join(projectRoot, 'Assets'));
+    mkdirSync(join(projectRoot, 'ProjectSettings'));
+    mkdirSync(join(projectRoot, 'UserSettings'));
+    writeFileSync(join(projectRoot, 'UserSettings/UnityMcpSettings.json'), '{}');
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
   it('promotes settings read failures to UNITY_SERVER_STARTING when startup lock is fresh', async () => {
-    const projectRoot = resolvePath(process.cwd(), '..', '..', '..');
     const dependencies = {
       findRunningUnityProcessForProjectFn: jest.fn().mockResolvedValue({ pid: 1234 }),
       existsSyncFn: jest.fn().mockReturnValue(true),
@@ -871,7 +887,6 @@ describe('resolveUnityConnectionWithStartupDiagnosis', () => {
   });
 
   it('promotes retryable settings-read failures for non-dynamic-code tools when startup lock is fresh', async () => {
-    const projectRoot = resolvePath(process.cwd(), '..', '..', '..');
     const dependencies = {
       findRunningUnityProcessForProjectFn: jest.fn().mockResolvedValue({ pid: 1234 }),
       existsSyncFn: jest.fn().mockReturnValue(true),

--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -49,6 +49,7 @@ jest.mock('../project-root.js', () => ({
   isUnityProject: (projectPath: string): boolean => mockIsUnityProject(projectPath),
 }));
 
+import { resolve } from 'path';
 import { Command } from 'commander';
 import { orchestrateLaunch } from 'launch-unity';
 import {
@@ -232,11 +233,14 @@ describe('launch command', () => {
 
     await program.parseAsync(['node', 'uloop', 'launch', '/project', '--restart']);
 
-    expect(observedCalls).toEqual(['guard:/project', 'orchestrate']);
-    expect(mockBeginUnityRestartAttempt).toHaveBeenCalledWith('/project');
+    // The launch command resolves the CLI argument, so the expected path must be
+    // resolved too ('/project' becomes 'C:\\project' on Windows)
+    const resolvedProjectPath = resolve('/project');
+    expect(observedCalls).toEqual([`guard:${resolvedProjectPath}`, 'orchestrate']);
+    expect(mockBeginUnityRestartAttempt).toHaveBeenCalledWith(resolvedProjectPath);
     expect(orchestrateLaunchMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        projectPath: '/project',
+        projectPath: resolvedProjectPath,
         restart: true,
       }),
     );
@@ -274,7 +278,7 @@ describe('launch command', () => {
     expect(mockBeginUnityRestartAttempt).not.toHaveBeenCalled();
     expect(orchestrateLaunchMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        projectPath: '/not-a-project',
+        projectPath: resolve('/not-a-project'),
         restart: true,
       }),
     );

--- a/Packages/src/Cli~/src/__tests__/port-resolver.test.ts
+++ b/Packages/src/Cli~/src/__tests__/port-resolver.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { tmpdir } from 'os';
 import {
   resolvePortFromUnitySettings,
@@ -56,8 +56,11 @@ describe('resolvePortFromUnitySettings', () => {
 
 describe('validateProjectPath', () => {
   it('throws when path does not exist', () => {
-    expect(() => validateProjectPath('/nonexistent/path/to/project')).toThrow(
-      'Path does not exist: /nonexistent/path/to/project',
+    // validateProjectPath resolves its argument, so the expected message must use
+    // the resolved form ('/nonexistent/...' becomes 'C:\\nonexistent\\...' on Windows)
+    const missingPath = '/nonexistent/path/to/project';
+    expect(() => validateProjectPath(missingPath)).toThrow(
+      `Path does not exist: ${resolve(missingPath)}`,
     );
   });
 

--- a/Packages/src/Cli~/src/__tests__/stress-script.test.ts
+++ b/Packages/src/Cli~/src/__tests__/stress-script.test.ts
@@ -90,7 +90,11 @@ describe('uloop compile/get-logs stress script', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('fails within the configured ready timeout when a readiness probe hangs', async () => {
+  // The stress script and its fake uloop shim are POSIX sh programs launched via
+  // shebang, which Windows cannot execute directly — skip there, CI runs on Linux
+  const itOnPosix = process.platform === 'win32' ? it.skip : it;
+
+  itOnPosix('fails within the configured ready timeout when a readiness probe hangs', async () => {
     const result = await runStressScript([tempDir]);
 
     expect(result.signal).toBeNull();

--- a/Packages/src/Cli~/src/cli.ts
+++ b/Packages/src/Cli~/src/cli.ts
@@ -113,7 +113,10 @@ function registerToolCommand(program: Command, tool: ToolDefinition, helpGroup: 
   cmd.action(async (options: CliOptions) => {
     await runWithErrorHandling(() => {
       const params = buildParams(options, properties);
-      applyExecuteDynamicCodeCodeFileOption(tool.name, params, options);
+      // The Code property has a schema default (''), so option presence cannot tell
+      // whether the user passed --code; ask commander for the actual value source
+      const inlineCodeProvided = cmd.getOptionValueSource('code') === 'cli';
+      applyExecuteDynamicCodeCodeFileOption(tool.name, params, options, inlineCodeProvided);
 
       // Unescape \! to ! for execute-dynamic-code
       // Some shells (e.g., Claude Code's bash wrapper) escape ! as \!
@@ -191,6 +194,7 @@ function applyExecuteDynamicCodeCodeFileOption(
   toolName: string,
   params: Record<string, unknown>,
   options: Record<string, unknown>,
+  inlineCodeProvided: boolean,
 ): void {
   if (toolName !== 'execute-dynamic-code') {
     return;
@@ -205,7 +209,8 @@ function applyExecuteDynamicCodeCodeFileOption(
     throw new Error('--code-file requires a file path.');
   }
 
-  if (typeof params['Code'] === 'string' && params['Code'].length > 0) {
+  // Reject on flag presence, not content, so --code "" --code-file x also errors
+  if (inlineCodeProvided) {
     throw new Error('Use either --code or --code-file, not both.');
   }
 

--- a/Packages/src/Cli~/src/cli.ts
+++ b/Packages/src/Cli~/src/cli.ts
@@ -103,22 +103,31 @@ function registerToolCommand(program: Command, tool: ToolDefinition, helpGroup: 
     }
   }
 
+  if (tool.name === 'execute-dynamic-code') {
+    cmd.option('--code-file <path>', 'Read C# code from a UTF-8 file');
+  }
+
   cmd.addOption(createHiddenPortOption());
   cmd.option('--project-path <path>', 'Unity project path');
 
   cmd.action(async (options: CliOptions) => {
-    const params = buildParams(options, properties);
+    await runWithErrorHandling(() => {
+      const params = buildParams(options, properties);
+      applyExecuteDynamicCodeCodeFileOption(tool.name, params, options);
 
-    // Unescape \! to ! for execute-dynamic-code
-    // Some shells (e.g., Claude Code's bash wrapper) escape ! as \!
-    if (tool.name === 'execute-dynamic-code' && params['Code']) {
-      const code = params['Code'] as string;
-      params['Code'] = code.replace(/\\!/g, '!');
-    }
+      // Unescape \! to ! for execute-dynamic-code
+      // Some shells (e.g., Claude Code's bash wrapper) escape ! as \!
+      if (
+        tool.name === 'execute-dynamic-code' &&
+        options['codeFile'] === undefined &&
+        params['Code']
+      ) {
+        const code = params['Code'] as string;
+        params['Code'] = code.replace(/\\!/g, '!');
+      }
 
-    await runWithErrorHandling(() =>
-      executeToolCommand(tool.name, params, extractGlobalOptions(options)),
-    );
+      return executeToolCommand(tool.name, params, extractGlobalOptions(options));
+    });
   });
 }
 
@@ -176,6 +185,31 @@ function buildParams(
   }
 
   return params;
+}
+
+function applyExecuteDynamicCodeCodeFileOption(
+  toolName: string,
+  params: Record<string, unknown>,
+  options: Record<string, unknown>,
+): void {
+  if (toolName !== 'execute-dynamic-code') {
+    return;
+  }
+
+  const codeFile = options['codeFile'];
+  if (codeFile === undefined) {
+    return;
+  }
+
+  if (typeof codeFile !== 'string' || codeFile.length === 0) {
+    throw new Error('--code-file requires a file path.');
+  }
+
+  if (typeof params['Code'] === 'string' && params['Code'].length > 0) {
+    throw new Error('Use either --code or --code-file, not both.');
+  }
+
+  params['Code'] = readFileSync(codeFile, 'utf8');
 }
 
 /**
@@ -395,6 +429,7 @@ const EXECUTE_DYNAMIC_CODE_PROPERTIES: Record<string, ToolProperty> =
 
 const FAST_EXECUTE_DYNAMIC_CODE_OPTIONS = new Map<string, string>([
   ['--code', 'code'],
+  ['--code-file', 'codeFile'],
   ['--parameters', 'parameters'],
   ['--compile-only', 'compileOnly'],
   ['--yield-to-foreground-requests', 'yieldToForegroundRequests'],
@@ -461,6 +496,10 @@ export function tryParseFastExecuteDynamicCodeCommand(
 
     options[optionKey] = optionValue;
     i++;
+  }
+
+  if (typeof options['codeFile'] === 'string') {
+    return null;
   }
 
   if (typeof options['code'] !== 'string') {
@@ -983,6 +1022,9 @@ function listOptionsForCommand(cmdName: string, projectPath?: string): void {
   for (const propName of Object.keys(tool.inputSchema.properties)) {
     const kebabName = pascalToKebabCase(propName);
     options.push(`--${kebabName}`);
+  }
+  if (tool.name === 'execute-dynamic-code') {
+    options.push('--code-file');
   }
 
   console.log(options.join('\n'));

--- a/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -14,14 +14,16 @@ For basic selected GameObject discovery or property inspection, use `find-game-o
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute via Bash: `uloop execute-dynamic-code --code '<code>'`
-4. If execution fails, adjust code and retry
-5. Report the execution result
+3. For multiline snippets, write the C# statements to a temporary `.csx` file and execute `uloop execute-dynamic-code --code-file <path>`
+4. Use `uloop execute-dynamic-code --code '<code>'` only for short one-line snippets
+5. If execution fails, adjust code and retry
+6. Report the execution result
 
 ## Parameters
 
-- `--code '<code>'` (required): Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`).
+- `--code '<code>'`: Inline C# statements to execute. Use this for one-line snippets only.
+- `--code-file <path>`: Read C# statements from a UTF-8 file. Prefer this for multiline snippets, especially on PowerShell, because Windows `.cmd` shims can lose lines from multiline inline arguments before `uloop` receives them.
+- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell single-quoted strings can contain normal double quotes, for example `uloop execute-dynamic-code --code 'Debug.Log("Hello!");'`.
 - `--parameters {}` (advanced, optional): Pass an object when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets, and pass an object instead of a JSON string.
 - `--compile-only true` (optional): Compile the snippet without executing it. Use this when you want Roslyn diagnostics before running new code.
 
@@ -42,7 +44,7 @@ return x;
 Returns JSON:
 - `Success`: boolean — overall execution success
 - `Result`: string — value of the snippet's `return` statement (empty when omitted)
-- `Logs`: string[] — `Debug.Log` / `Debug.LogWarning` / `Debug.LogError` messages emitted during the run
+- `Logs`: string[] — execution diagnostics from the dynamic-code runner, not Unity Console entries
 - `CompilationErrors`: object[] — Roslyn diagnostics with `Message`, `Line`, `Column`, `ErrorCode`, optional `Hint` and `Suggestions`
 - `ErrorMessage`: string — top-level failure summary (empty on success)
 - `Error`: string — alias of `ErrorMessage`
@@ -51,7 +53,7 @@ Returns JSON:
 - `DiagnosticsSummary`: string|null — compact summary when diagnostics are available
 - `Diagnostics`: object[] — structured diagnostics; same shape as `CompilationErrors`, usually populated together with it
 
-On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, security violation, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.
+Use `uloop get-logs` to retrieve `Debug.Log`, `Debug.LogWarning`, and `Debug.LogError` messages emitted by the snippet. On `Success: false`, inspect `CompilationErrors` first. If empty, read `ErrorMessage` (and `Logs` for extra context) — the failure may be a runtime exception, security violation, cancellation, or an "execution in progress" rejection, all of which return empty `CompilationErrors`. Both EditMode and PlayMode are supported targets — the snippet runs in whichever mode the Editor is currently in.
 
 ## Code Examples by Category
 


### PR DESCRIPTION
Fixes #1290

## Summary
- Multiline dynamic code snippets can now be executed from a UTF-8 file, avoiding Windows shell argument truncation.
- Agent skill guidance now points multiline snippets to `--code-file` and clarifies how to inspect Unity Console logs.

## User Impact
- Previously, a multiline snippet run through the Windows `.cmd` launcher could report success with an empty result because only the first line reached the CLI.
- Users can now execute multiline snippets reliably via `--code-file`, and `Debug.Log` output can be checked with `uloop get-logs`.

## Changes
- Add `--code-file` support to `execute-dynamic-code`, with validation against using it together with inline `--code`.
- Route `--code-file` through the normal command parser so file contents are read safely while preserving raw snippet text.
- Update the source and generated agent skill docs for multiline code and log lookup guidance.

## Verification
- `npm run build`
- `npm run lint -- --quiet`
- Multiline `--code-file` CLI smoke returns `123`
- Windows `.cmd`-equivalent `--code-file` smoke returns `123`
- Literal `\!` in a code file is preserved
- `Debug.Log` output verified via `uloop get-logs`
- `codex-review origin/main` completed with no accepted/actionable findings

Note: The commander@15 ESM / Jest CJS configuration issue that previously blocked Jest was fixed in this PR (ae64ad46); the CLI unit test suite now runs in CI (2228582f).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes multiline dynamic code snippet execution on Windows by adding `--code-file` support to the `execute-dynamic-code` command and clarifies tooling/diagnostics for dynamic code runs.

## Key Changes

### Implementation
- Packages/src/Cli~/src/cli.ts
  - Added `--code-file <path>` to load UTF-8 C# snippets from a file and populate params.Code.
  - Enforced mutual exclusivity between `--code-file` and inline `--code`.
  - Routes `--code-file` through normal command parsing so file contents are read safely while preserving raw snippet text.
  - Unescape of `\!` now only applies when `--code-file` is not used.
  - Fast-mode parsing/completion metadata recognizes `--code-file`, but fast-path parsing rejects commands that include it (returns null to fall back to normal CLI path).
  - Updated `--list-options` output to include `--code-file`.

### Tests
- Packages/src/Cli~/src/__tests__/cli-fast-path.test.ts
  - Added a Jest test ensuring fast-path parser returns `null` when `--code-file` is present.
- Various CLI unit tests made platform- and environment-independent:
  - Tests adjusted to use temp Unity projects, resolve paths on Windows, and conditionally skip POSIX-only stress tests.
  - Added test harness improvements so CLI unit tests run reliably across CI platforms.

### CI / Tooling
- .github/workflows/build-and-test.yml
  - Added CLI unit test execution (npm run test:unit) to the build job.
- Packages/src/Cli~/package.json
  - Added test:unit script for running Jest unit tests.
- Commits also include transpiling ESM-only commander to improve Jest compatibility (ts-jest transform adjustments) to address Jest/commander ESM/CJS issues affecting test execution.

### Documentation
- Updated skill docs to direct multiline snippets to `--code-file` and reserve `--code` for short one-line snippets:
  - .agents/skills/uloop-execute-dynamic-code/SKILL.md
  - .claude/skills/uloop-execute-dynamic-code/SKILL.md
  - Packages/src/Editor/Api/McpTools/ExecuteDynamicCode/Skill/SKILL.md
- Documentation changes:
  - Revised tool description to emphasize executing C# with Unity APIs for advanced scenarios (scene/prefab work, SerializedObject, AssetDatabase refresh, menu execution, PlayMode automation).
  - Clarified that the `Logs` field contains execution diagnostics from the dynamic-code runner (not Unity Console Debug.Log* entries).
  - Added guidance to use `uloop get-logs` to retrieve Debug.Log/Debug.LogWarning/Debug.LogError messages.
  - Improved failure-handling guidance: prioritize CompilationErrors when Success is false; if CompilationErrors is empty, consult ErrorMessage plus Logs for context.

## User Impact

- Multiline C# snippets execute reliably on Windows by writing the snippet to a UTF-8 file and invoking `uloop execute-dynamic-code --code-file <file>`.
- Avoids PowerShell/Windows quoting/newline truncation issues; inline `--code` remains appropriate for short one-liners.
- Users are guided to retrieve Unity Console output via `uloop get-logs` rather than expecting Debug.Log outputs in the command result Logs field.

## Verification

- npm run build and npm run lint -- --quiet passed.
- Multiline `--code-file` CLI smoke returned expected output (e.g., 123) on POSIX and Windows `.cmd`-equivalent paths.
- Literal `\!` preservation in code files verified.
- Debug.Log output retrieval via `uloop get-logs` verified.
- codex-review origin/main completed with no accepted/actionable findings.
- Note: Jest test execution remains blocked by an existing commander@15 ESM / Jest CJS configuration issue; commits include mitigations (transpile commander) and CI/test adjustments to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

