### PR TITLE
fix: Other local users can no longer connect to the Unity Editor's uloop channel on Windows

### DIFF
--- a/Assets/Tests/Editor/WindowsOwnerOnlyNamedPipeFactoryTests.cs
+++ b/Assets/Tests/Editor/WindowsOwnerOnlyNamedPipeFactoryTests.cs
@@ -1,0 +1,65 @@
+using System.IO.Pipes;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the owner-only named pipe factory on the Windows editor.
+    /// </summary>
+    public class WindowsOwnerOnlyNamedPipeFactoryTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            if (UnityEngine.Application.platform != UnityEngine.RuntimePlatform.WindowsEditor)
+            {
+                Assert.Ignore("Windows named pipe factory tests only run on the Windows editor.");
+            }
+        }
+
+        [Test]
+        public void BuildCurrentUserOnlySddl_ReturnsProtectedDaclWithSingleUserAce()
+        {
+            // Tests that the SDDL grants FullControl to exactly one SID and marks the DACL
+            // protected, because any extra ACE would widen access beyond the Editor owner.
+            string sddl = WindowsOwnerOnlyNamedPipeFactory.BuildCurrentUserOnlySddl();
+
+            StringAssert.StartsWith("D:P(A;;FA;;;S-1-5-", sddl);
+            StringAssert.EndsWith(")", sddl);
+            Assert.That(sddl.Split('(').Length - 1, Is.EqualTo(1), "SDDL must contain exactly one ACE");
+        }
+
+        [Test]
+        public void CreateServer_ReturnsUsableServerStream()
+        {
+            // Tests that the native pipe creation and managed handle wrap succeed on this
+            // runtime, because the Mono PipeSecurity overload silently ignores ACLs and the
+            // factory is the only path that actually applies the descriptor.
+            string sddl = WindowsOwnerOnlyNamedPipeFactory.BuildCurrentUserOnlySddl();
+            string pipeName = "uloop-factory-test-" + System.Guid.NewGuid().ToString("N").Substring(0, 8);
+
+            using NamedPipeServerStream server = WindowsOwnerOnlyNamedPipeFactory.CreateServer(pipeName, sddl);
+
+            Assert.That(server, Is.Not.Null);
+            Assert.That(server.SafePipeHandle.IsInvalid, Is.False);
+        }
+
+        [Test]
+        public void CreateServer_AllowsMultipleConcurrentInstancesOfSamePipe()
+        {
+            // Tests that a second server instance of the same pipe name can be created while
+            // the first is still open, because the accept loop creates a new instance per
+            // client and the ACL must not break PIPE_UNLIMITED_INSTANCES.
+            string sddl = WindowsOwnerOnlyNamedPipeFactory.BuildCurrentUserOnlySddl();
+            string pipeName = "uloop-factory-test-" + System.Guid.NewGuid().ToString("N").Substring(0, 8);
+
+            using NamedPipeServerStream first = WindowsOwnerOnlyNamedPipeFactory.CreateServer(pipeName, sddl);
+            using NamedPipeServerStream second = WindowsOwnerOnlyNamedPipeFactory.CreateServer(pipeName, sddl);
+
+            Assert.That(first.SafePipeHandle.IsInvalid, Is.False);
+            Assert.That(second.SafePipeHandle.IsInvalid, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/WindowsOwnerOnlyNamedPipeFactoryTests.cs.meta
+++ b/Assets/Tests/Editor/WindowsOwnerOnlyNamedPipeFactoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60404027f69f8ea4397b03b33da41022
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/BridgeTransportListener.cs
+++ b/Packages/src/Editor/Infrastructure/BridgeTransportListener.cs
@@ -2,8 +2,6 @@ using System;
 using System.IO;
 using System.IO.Pipes;
 using System.Net.Sockets;
-using System.Security.AccessControl;
-using System.Security.Principal;
 using System.Threading;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
@@ -180,11 +178,17 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     internal sealed class WindowsNamedPipeBridgeTransportListener : IBridgeTransportListener
     {
+        // Why: closing a non-overlapped pipe handle does not cancel a synchronous
+        // ConnectNamedPipe wait, so Stop must wake a pending accept with a loopback
+        // connection; the short timeout covers the case where no accept is pending.
+        private const int WAKE_PENDING_ACCEPT_CONNECT_TIMEOUT_MS = 250;
+
         private NamedPipeServerStream _activePipe;
         private long _nextClientId;
         // Why: without a stopped state, an accept racing with Stop could create a fresh
         // pipe that nobody can wake, leaving the accept loop blocked forever.
         private volatile bool _stopped;
+        private string _ownerOnlySddl;
 
         public BridgeTransportEndpoint Endpoint { get; }
 
@@ -195,21 +199,24 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         public void Start()
         {
+            // Why: unit tests construct this listener on macOS/Linux where the Windows
+            // token APIs do not exist; production only accepts on the Windows editor.
+            if (UnityEngine.Application.platform != UnityEngine.RuntimePlatform.WindowsEditor)
+            {
+                return;
+            }
+
+            // Resolving the SID here makes a broken security setup fail the bind itself
+            // instead of throwing inside the accept loop on every iteration.
+            _ownerOnlySddl = WindowsOwnerOnlyNamedPipeFactory.BuildCurrentUserOnlySddl();
         }
 
         public BridgeClientConnection AcceptClient(CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
             ThrowIfStopped();
-            NamedPipeServerStream pipe = new(
-                Endpoint.PipeName,
-                PipeDirection.InOut,
-                NamedPipeServerStream.MaxAllowedServerInstances,
-                PipeTransmissionMode.Byte,
-                PipeOptions.Asynchronous,
-                inBufferSize: 0,
-                outBufferSize: 0,
-                CreateCurrentUserPipeSecurity());
+            System.Diagnostics.Debug.Assert(_ownerOnlySddl != null, "Start must resolve the owner-only SDDL before accepting");
+            NamedPipeServerStream pipe = WindowsOwnerOnlyNamedPipeFactory.CreateServer(Endpoint.PipeName, _ownerOnlySddl);
             _activePipe = pipe;
             // Why: Stop may have run between the stopped check and the assignment above;
             // re-checking after publishing the pipe guarantees one side disposes it.
@@ -236,6 +243,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     throw new OperationCanceledException(ct);
                 }
 
+                // Why: Stop wakes a pending accept with a loopback connection, so a wait that
+                // returned after cancellation or stop holds a wake client, not a real CLI session.
+                if (ct.IsCancellationRequested)
+                {
+                    throw new OperationCanceledException(ct);
+                }
+
+                ThrowIfStopped();
+
                 connected = true;
                 string clientEndpoint = $"{Endpoint.Path}#{Interlocked.Increment(ref _nextClientId)}";
                 return new BridgeClientConnection(clientEndpoint, pipe, () => pipe.IsConnected);
@@ -258,7 +274,35 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             // hands the pipe to exactly one caller so Dispose runs once.
             _stopped = true;
             NamedPipeServerStream pipe = Interlocked.Exchange(ref _activePipe, null);
-            pipe?.Dispose();
+            if (pipe == null)
+            {
+                return;
+            }
+
+            // Wake before Dispose: a disposed instance can no longer be connected to,
+            // which would leave a blocked synchronous WaitForConnection stuck forever.
+            WakePendingAccept();
+            pipe.Dispose();
+        }
+
+        // Why: closing the pipe handle does not cancel a pending synchronous ConnectNamedPipe
+        // wait, so the only reliable release is a loopback connection. The accept loop discards
+        // the wake connection through its stopped/cancellation checks. A connect failure means
+        // no accept was pending, which leaves nothing to wake or clean up.
+        private void WakePendingAccept()
+        {
+            try
+            {
+                using NamedPipeClientStream wakeClient = new(
+                    ".",
+                    Endpoint.PipeName,
+                    PipeDirection.InOut,
+                    PipeOptions.None);
+                wakeClient.Connect(WAKE_PENDING_ACCEPT_CONNECT_TIMEOUT_MS);
+            }
+            catch (Exception)
+            {
+            }
         }
 
         public void Dispose()
@@ -276,22 +320,5 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        // Why: a named pipe created without an explicit ACL inherits a default security descriptor
-        // that lets any local user open the pipe. Because any connected client can invoke
-        // execute-dynamic-code (arbitrary C# inside this Editor process), the pipe must be reachable
-        // only by the user who owns this Editor. Granting FullControl to the current user's SID alone
-        // denies every other local principal, including other interactive/RDP users on a shared host.
-        private static PipeSecurity CreateCurrentUserPipeSecurity()
-        {
-            SecurityIdentifier currentUser = WindowsIdentity.GetCurrent().User;
-            System.Diagnostics.Debug.Assert(currentUser != null, "current Windows user SID must be resolvable");
-
-            PipeSecurity pipeSecurity = new();
-            pipeSecurity.AddAccessRule(new PipeAccessRule(
-                currentUser,
-                PipeAccessRights.FullControl,
-                AccessControlType.Allow));
-            return pipeSecurity;
-        }
     }
 }

--- a/Packages/src/Editor/Infrastructure/BridgeTransportListener.cs
+++ b/Packages/src/Editor/Infrastructure/BridgeTransportListener.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.IO.Pipes;
 using System.Net.Sockets;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Threading;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
@@ -204,7 +206,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 PipeDirection.InOut,
                 NamedPipeServerStream.MaxAllowedServerInstances,
                 PipeTransmissionMode.Byte,
-                PipeOptions.Asynchronous);
+                PipeOptions.Asynchronous,
+                inBufferSize: 0,
+                outBufferSize: 0,
+                CreateCurrentUserPipeSecurity());
             _activePipe = pipe;
             // Why: Stop may have run between the stopped check and the assignment above;
             // re-checking after publishing the pipe guarantees one side disposes it.
@@ -269,6 +274,24 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 // recovery instead of re-listening on a stopped listener.
                 throw new ObjectDisposedException(nameof(WindowsNamedPipeBridgeTransportListener));
             }
+        }
+
+        // Why: a named pipe created without an explicit ACL inherits a default security descriptor
+        // that lets any local user open the pipe. Because any connected client can invoke
+        // execute-dynamic-code (arbitrary C# inside this Editor process), the pipe must be reachable
+        // only by the user who owns this Editor. Granting FullControl to the current user's SID alone
+        // denies every other local principal, including other interactive/RDP users on a shared host.
+        private static PipeSecurity CreateCurrentUserPipeSecurity()
+        {
+            SecurityIdentifier currentUser = WindowsIdentity.GetCurrent().User;
+            System.Diagnostics.Debug.Assert(currentUser != null, "current Windows user SID must be resolvable");
+
+            PipeSecurity pipeSecurity = new();
+            pipeSecurity.AddAccessRule(new PipeAccessRule(
+                currentUser,
+                PipeAccessRights.FullControl,
+                AccessControlType.Allow));
+            return pipeSecurity;
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/BridgeTransportListener.cs
+++ b/Packages/src/Editor/Infrastructure/BridgeTransportListener.cs
@@ -4,6 +4,8 @@ using System.IO.Pipes;
 using System.Net.Sockets;
 using System.Threading;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
     /// <summary>
@@ -300,8 +302,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     PipeOptions.None);
                 wakeClient.Connect(WAKE_PENDING_ACCEPT_CONNECT_TIMEOUT_MS);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                // A connect failure when no accept was pending is the expected, harmless case,
+                // so this stays at debug level. But it is also the only signal that the single
+                // unblock path failed, so record it: if a stuck accept ever causes a shutdown
+                // hang, this is the breadcrumb that points here.
+                VibeLogger.LogDebug(
+                    "wake_pending_accept_failed",
+                    ex.Message,
+                    new { exceptionType = ex.GetType().Name });
             }
         }
 

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -496,6 +496,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     if (failedAttemptCount >= UnityCliLoopServerConfig.RECOVERY_RETRY_DELAYS_MS.Length)
                     {
                         string message = $"Unity CLI Loop server recovery failed before the bridge became ready. {ex.GetBaseException().Message}";
+                        // Why: the thrown exception ends in an unobserved task and VibeLogger is
+                        // compiled out without ULOOP_DEBUG, so without this console entry an
+                        // unrecoverable server (uloop unreachable) would be completely silent.
+                        Debug.LogError($"[{UnityCliLoopConstants.PROJECT_NAME}] {message}");
                         VibeLogger.LogError(
                             "server_recovery_failed",
                             message);

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
@@ -119,11 +119,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public bool IsRunning => _isRunning;
         
         public string Endpoint => _transportListener?.Endpoint.DisplayName() ?? string.Empty;
-        
-        /// <summary>
-        /// Event on error.
-        /// </summary>
-        public event Action<string> OnError;
 
         public void StartServer()
         {
@@ -164,15 +159,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressAlreadyInUse)
             {
                 _isRunning = false;
-                string errorMessage = $"Project IPC endpoint is already in use: {endpoint.DisplayName()}";
-                OnError?.Invoke(errorMessage);
-                throw new InvalidOperationException(errorMessage, ex);
+                throw new InvalidOperationException(
+                    $"Project IPC endpoint is already in use: {endpoint.DisplayName()}", ex);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 _isRunning = false;
-                string errorMessage = $"Failed to start Unity CLI bridge: {ex.Message}";
-                OnError?.Invoke(errorMessage);
                 throw;
             }
         }
@@ -291,7 +283,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
                 catch (Exception ex)
                 {
-                    OnError?.Invoke($"Error disconnecting client {client.Key}: {ex.Message}");
+                    VibeLogger.LogWarning(
+                        "client_disconnect_failed",
+                        $"Error disconnecting client {client.Key}: {ex.Message}");
                     clientsToRemove.Add(client.Key); // Remove even if disconnect failed
                 }
             }
@@ -369,17 +363,31 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         // Log and re-throw ThreadAbortException
                         if (!DomainReloadStateRegistry.IsDomainReloadInProgress())
                         {
-                            OnError?.Invoke($"Unexpected thread abort: {ex.Message}");
+                            VibeLogger.LogWarning(
+                                "server_loop_thread_abort",
+                                $"Unexpected thread abort: {ex.Message}");
                         }
                         throw;
                     }
                     catch (Exception ex)
                     {
-                        if (!cancellationToken.IsCancellationRequested)
+                        if (cancellationToken.IsCancellationRequested)
                         {
-                            string errorMessage = $"Server loop error: {ex.Message}";
-                            OnError?.Invoke(errorMessage);
+                            break;
                         }
+
+                        // Why: continuing here would retry a failing accept in a tight loop
+                        // (silently pinning a CPU core, as the Mono PipeSecurity regression showed).
+                        // Exiting the loop hands the failure to the recovery path, which retries
+                        // with bounded backoff. Debug.LogError is required for visibility because
+                        // VibeLogger is compiled out unless ULOOP_DEBUG is defined.
+                        Debug.LogError(
+                            $"[{UnityCliLoopConstants.PROJECT_NAME}] Server accept loop failed; restarting the IPC server. {ex}");
+                        VibeLogger.LogError(
+                            "server_accept_loop_failed",
+                            ex.Message,
+                            new { exceptionType = ex.GetType().Name });
+                        break;
                     }
                 }
             }
@@ -413,7 +421,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     _clientTasks.TryRemove(taskId, out _);
                     if (task.IsFaulted && task.Exception != null)
                     {
-                        OnError?.Invoke(task.Exception.GetBaseException().Message);
+                        // HandleClientAsync catches expected failures itself, so a faulted task is
+                        // an anomaly worth surfacing in the console for non-debug installs.
+                        Debug.LogError(
+                            $"[{UnityCliLoopConstants.PROJECT_NAME}] Client handler task faulted: {task.Exception.GetBaseException()}");
                     }
                 },
                 CancellationToken.None,
@@ -437,7 +448,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 // Log and re-throw ThreadAbortException
                 if (!DomainReloadStateRegistry.IsDomainReloadInProgress())
                 {
-                    OnError?.Invoke($"Unexpected thread abort: {ex.Message}");
+                    VibeLogger.LogWarning(
+                        "accept_thread_abort",
+                        $"Unexpected thread abort: {ex.Message}");
                 }
                 throw;
             }
@@ -536,7 +549,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
             catch (Exception ex)
             {
-                OnError?.Invoke(ex.Message);
+                // Expected failures (cancellation, reload aborts, normal disconnects) are filtered
+                // above, so anything reaching here means a CLI session died abnormally and the
+                // console must say so even on installs where VibeLogger is compiled out.
+                Debug.LogError(
+                    $"[{UnityCliLoopConstants.PROJECT_NAME}] Client session for {clientKey} failed: {ex}");
             }
             finally
             {
@@ -548,7 +565,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
                 catch (Exception ex)
                 {
-                    OnError?.Invoke($"Error during client disposal: {ex.Message}");
+                    VibeLogger.LogWarning(
+                        "client_dispose_failed",
+                        $"Error during client disposal: {ex.Message}");
                 }
                 
                 _clientStreams.TryRemove(clientKey, out _);

--- a/Packages/src/Editor/Infrastructure/WindowsOwnerOnlyNamedPipeFactory.cs
+++ b/Packages/src/Editor/Infrastructure/WindowsOwnerOnlyNamedPipeFactory.cs
@@ -24,6 +24,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const int SDDL_REVISION_1 = 1;
         private const uint PIPE_ACCESS_DUPLEX = 0x00000003;
         private const uint PIPE_TYPE_BYTE_READMODE_BYTE_WAIT = 0x00000000;
+        // Why: defense in depth alongside the owner-only DACL — reject clients connecting over the
+        // network so the execute-code channel never accepts a remote principal. The managed
+        // NamedPipeServerStream sets this by default; the native CreateNamedPipeW path does not.
+        private const uint PIPE_REJECT_REMOTE_CLIENTS = 0x00000008;
         private const uint PIPE_UNLIMITED_INSTANCES = 255;
 
         /// <summary>
@@ -65,7 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 IntPtr handle = CreateNamedPipeW(
                     @"\\.\pipe\" + pipeName,
                     PIPE_ACCESS_DUPLEX,
-                    PIPE_TYPE_BYTE_READMODE_BYTE_WAIT,
+                    PIPE_TYPE_BYTE_READMODE_BYTE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
                     PIPE_UNLIMITED_INSTANCES,
                     0,
                     0,

--- a/Packages/src/Editor/Infrastructure/WindowsOwnerOnlyNamedPipeFactory.cs
+++ b/Packages/src/Editor/Infrastructure/WindowsOwnerOnlyNamedPipeFactory.cs
@@ -1,0 +1,167 @@
+using System;
+using System.ComponentModel;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using Microsoft.Win32.SafeHandles;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Creates Windows named pipe server streams whose DACL grants access to the owning user only.
+    /// </summary>
+    // Why: on Unity's Mono runtime the managed security APIs are unusable for this:
+    // WindowsIdentity.GetCurrent().User throws NotImplementedException, the
+    // NamedPipeServerStream(..., PipeSecurity) overload silently ignores the supplied ACL
+    // (the pipe keeps the default DACL that any local user can open), and
+    // PipeStream.GetAccessControl crashes the editor natively. The only reliable way to
+    // restrict the pipe is to create it through CreateNamedPipeW with an explicit security
+    // descriptor and wrap the native handle in a managed stream.
+    internal static class WindowsOwnerOnlyNamedPipeFactory
+    {
+        private const int TOKEN_QUERY = 0x0008;
+        private const int TOKEN_INFORMATION_CLASS_TOKEN_USER = 1;
+        private const int SDDL_REVISION_1 = 1;
+        private const uint PIPE_ACCESS_DUPLEX = 0x00000003;
+        private const uint PIPE_TYPE_BYTE_READMODE_BYTE_WAIT = 0x00000000;
+        private const uint PIPE_UNLIMITED_INSTANCES = 255;
+
+        /// <summary>
+        /// Builds an SDDL descriptor that grants FullControl to the current user's SID only.
+        /// </summary>
+        // Why: "P" marks the DACL protected and the single ACE covers exactly the owning user,
+        // so every other local principal (other interactive/RDP users on a shared host) is
+        // denied at the transport boundary.
+        internal static string BuildCurrentUserOnlySddl()
+        {
+            SecurityIdentifier currentUser = GetCurrentUserSid();
+            return $"D:P(A;;FA;;;{currentUser.Value})";
+        }
+
+        /// <summary>
+        /// Creates a byte-mode duplex named pipe server instance protected by the given SDDL descriptor.
+        /// </summary>
+        // Why: the handle is created without FILE_FLAG_OVERLAPPED and wrapped with isAsync: false
+        // because Mono's managed wrap of an overlapped pipe handle hangs in WaitForConnection.
+        // The synchronous wait matches how the accept loop already runs (a dedicated Task.Run thread).
+        internal static NamedPipeServerStream CreateServer(string pipeName, string sddl)
+        {
+            System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(pipeName), "pipeName must not be empty");
+            System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sddl), "sddl must not be empty");
+
+            if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl, SDDL_REVISION_1, out IntPtr descriptor, out _))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "Security descriptor conversion failed for the named pipe DACL.");
+            }
+
+            try
+            {
+                SECURITY_ATTRIBUTES attributes = new SECURITY_ATTRIBUTES
+                {
+                    nLength = Marshal.SizeOf<SECURITY_ATTRIBUTES>(),
+                    lpSecurityDescriptor = descriptor,
+                    bInheritHandle = false,
+                };
+                IntPtr handle = CreateNamedPipeW(
+                    @"\\.\pipe\" + pipeName,
+                    PIPE_ACCESS_DUPLEX,
+                    PIPE_TYPE_BYTE_READMODE_BYTE_WAIT,
+                    PIPE_UNLIMITED_INSTANCES,
+                    0,
+                    0,
+                    0,
+                    ref attributes);
+                if (handle == new IntPtr(-1))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), $"CreateNamedPipeW failed for pipe '{pipeName}'.");
+                }
+
+                SafePipeHandle safeHandle = new SafePipeHandle(handle, ownsHandle: true);
+                return new NamedPipeServerStream(PipeDirection.InOut, isAsync: false, isConnected: false, safePipeHandle: safeHandle);
+            }
+            finally
+            {
+                LocalFree(descriptor);
+            }
+        }
+
+        private static SecurityIdentifier GetCurrentUserSid()
+        {
+            if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, out IntPtr token))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "OpenProcessToken failed while resolving the current user SID.");
+            }
+
+            try
+            {
+                GetTokenInformation(token, TOKEN_INFORMATION_CLASS_TOKEN_USER, IntPtr.Zero, 0, out int requiredLength);
+                IntPtr buffer = Marshal.AllocHGlobal(requiredLength);
+                try
+                {
+                    if (!GetTokenInformation(token, TOKEN_INFORMATION_CLASS_TOKEN_USER, buffer, requiredLength, out _))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error(), "GetTokenInformation failed while resolving the current user SID.");
+                    }
+
+                    // TOKEN_USER begins with a SID_AND_ATTRIBUTES whose first field is the PSID.
+                    IntPtr sidPointer = Marshal.ReadIntPtr(buffer);
+                    return new SecurityIdentifier(sidPointer);
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(buffer);
+                }
+            }
+            finally
+            {
+                CloseHandle(token);
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SECURITY_ATTRIBUTES
+        {
+            public int nLength;
+            public IntPtr lpSecurityDescriptor;
+            [MarshalAs(UnmanagedType.Bool)] public bool bInheritHandle;
+        }
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GetCurrentProcess();
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        private static extern bool OpenProcessToken(IntPtr processHandle, int desiredAccess, out IntPtr tokenHandle);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        private static extern bool GetTokenInformation(
+            IntPtr tokenHandle,
+            int tokenInformationClass,
+            IntPtr tokenInformation,
+            int tokenInformationLength,
+            out int returnLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool CloseHandle(IntPtr handle);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            string sddl,
+            int revision,
+            out IntPtr descriptor,
+            out int descriptorSize);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateNamedPipeW(
+            string name,
+            uint openMode,
+            uint pipeMode,
+            uint maxInstances,
+            uint outBufferSize,
+            uint inBufferSize,
+            uint defaultTimeout,
+            ref SECURITY_ATTRIBUTES securityAttributes);
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr LocalFree(IntPtr memory);
+    }
+}

--- a/Packages/src/Editor/Infrastructure/WindowsOwnerOnlyNamedPipeFactory.cs.meta
+++ b/Packages/src/Editor/Infrastructure/WindowsOwnerOnlyNamedPipeFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 333b7c53b9052a44f89eeefe0231b61b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- On Windows, the uloop IPC named pipe is now restricted to the user who owns the Unity Editor. Other local accounts on a shared machine or RDP host can no longer open it.
- The first attempt at this restriction (managed `PipeSecurity`) turned out to be silently broken on Unity's Mono runtime; this PR replaces it with an implementation that verifiably applies the ACL on a real Windows editor.
- IPC server failures are now visible in the Unity console instead of disappearing silently, so a broken server can no longer hang every `uloop` command without leaving a trace.

## User Impact
- Before: any local user on the same machine could open the pipe (its name is derivable from the project path) and reach `execute-dynamic-code`, i.e. run arbitrary C# with the Editor owner's privileges.
- Also before this PR (with only the first commit): on a real Windows editor the server failed to create the pipe at all — every `uloop` command hung and the Editor burned a full CPU core — with no log output whatsoever, because all server errors were raised through an event nobody subscribes to.
- After: `uloop` works normally for the Editor's owner, the pipe's DACL contains exactly one ACE granting access to that user only, and if the server ever fails to accept connections the Unity console says so and the server restarts itself with bounded backoff.

## Changes
- Create the pipe natively (`CreateNamedPipeW`) with an explicit owner-only security descriptor and wrap the handle in a managed stream, because Unity's Mono ignores the `PipeSecurity` ctor argument and `WindowsIdentity.GetCurrent().User` throws `NotImplementedException`.
- Resolve the current user's SID from the process token (`OpenProcessToken` / `GetTokenInformation`).
- Use a non-overlapped handle: Mono hangs `WaitForConnection` on a wrapped overlapped handle. Since closing a non-overlapped handle does not cancel a pending synchronous wait, `Stop()` now wakes a pending accept with a loopback connection before disposing, and the accept loop discards that wake connection.
- Remove the dead `OnError` event (zero subscribers) and log each former call site directly. Genuine failures (accept loop, client session crashes, terminal recovery failure) go to the Unity console — `VibeLogger` alone compiles out of end-user installs (`[Conditional(ULOOP_DEBUG)]`). Teardown noise stays at debug-only warning level.
- Accept-loop failures exit the loop and hand off to the existing bounded-backoff recovery instead of retrying in a tight loop.
- Unit tests for the SDDL shape, pipe creation, and multi-instance support.

## Verification
- `uloop compile` (0 errors / 0 warnings), `uloop get-logs`, and repeated sequential commands against a live Windows 11 / Unity 2022.3.62f3 editor, including recovery across domain reloads.
- Live pipe DACL inspected from an external process via `GetSecurityInfo`: `O:<owner> D:P(A;;FA;;;<owner SID>)` — no Everyone/Anonymous/Administrators/SYSTEM ACEs.
- `uloop run-tests` (EditMode): server-related suites 13 passed / 0 failed (new factory tests + listener contract + server shutdown + heartbeat tests).
- Note: a direct connect attempt from a second local account was not possible on the verification machine (no admin rights / no second-account credentials); rejection is established by the inspected DACL. The note's PowerShell snippet can be used from another account for a direct check if desired.