### PR TITLE
fix: simulate-mouse-ui clicks visible overlay UI instead of hidden targets at scaled Game view resolutions

### DIFF
--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -168,6 +168,70 @@ namespace Tests.PlayMode
             }
         }
 
+        // Verifies the real Physics2D raycaster path. Physics2DRaycaster cannot hit
+        // outside its camera pixelRect, so the test raises its priority instead of
+        // using the Screen-bounds clipping setup from the synthetic raycaster tests.
+        [UnityTest]
+        public IEnumerator Click_Should_PreferOverlayUiOverPhysics2DRaycastHit()
+        {
+            GameObject physicsRoot = new GameObject("Physics2DRaycasterRoot");
+
+            try
+            {
+                GameObject cameraGo = new GameObject("Physics2DCamera");
+                cameraGo.transform.SetParent(physicsRoot.transform, false);
+                cameraGo.transform.position = new Vector3(0f, 0f, -10f);
+                Camera physicsCamera = cameraGo.AddComponent<Camera>();
+                physicsCamera.orthographic = true;
+                physicsCamera.orthographicSize = 5f;
+                cameraGo.AddComponent<HighPriorityPhysics2DRaycaster>();
+
+                canvasGo.GetComponent<Canvas>().sortingOrder = 100;
+                ClickTracker overlayTracker = CreateClickableElement(
+                    "PhysicsOverlayTarget", Vector2.zero, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+                GameObject physicsTarget = new GameObject("Physics2DTarget");
+                physicsTarget.transform.SetParent(physicsRoot.transform, false);
+                physicsTarget.transform.position = GetWorldPointOnPhysicsPlane(physicsCamera, screenPos);
+                BoxCollider2D collider = physicsTarget.AddComponent<BoxCollider2D>();
+                collider.size = new Vector2(2f, 2f);
+                ClickTracker physicsTracker = physicsTarget.AddComponent<ClickTracker>();
+                yield return null;
+
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the Physics2D raycaster should hit.");
+                Assert.AreEqual(physicsTarget, raycastResults[0].gameObject,
+                    "Setup: EventSystem should expose the prioritized Physics2D hit first.");
+                Assert.IsTrue(
+                    raycastResults.Exists(result => result.gameObject == overlayTracker.gameObject),
+                    "Setup: overlay UI should also be a normal EventSystem hit.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(overlayTracker.PointerClickCalled, "Overlay UI should receive the click");
+                Assert.IsFalse(physicsTracker.PointerClickCalled, "Physics2D target behind overlay UI should not receive the click");
+                Assert.AreEqual("PhysicsOverlayTarget", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(physicsRoot);
+            }
+        }
+
         // Forces the remaining ordering shape from issue 1317: EventSystem reports a
         // lower-priority GraphicRaycaster hit while the front overlay is clipped from
         // EventSystem results, so the tool must compare the Canvas-space candidate.
@@ -737,6 +801,14 @@ namespace Tests.PlayMode
             return (Vector2)go.GetComponent<RectTransform>().position;
         }
 
+        private Vector3 GetWorldPointOnPhysicsPlane(Camera physicsCamera, Vector2 screenPos)
+        {
+            Vector3 screenPoint = new Vector3(screenPos.x, screenPos.y, -physicsCamera.transform.position.z);
+            Vector3 worldPoint = physicsCamera.ScreenToWorldPoint(screenPoint);
+            worldPoint.z = 0f;
+            return worldPoint;
+        }
+
         // simulate-mouse uses top-left origin; Unity screen space uses bottom-left origin
         private Vector2 ScreenToInput(Vector2 screenPos)
         {
@@ -818,6 +890,12 @@ namespace Tests.PlayMode
                 depth = 0
             });
         }
+    }
+
+    public class HighPriorityPhysics2DRaycaster : Physics2DRaycaster
+    {
+        public override int sortOrderPriority => int.MaxValue;
+        public override int renderOrderPriority => int.MaxValue;
     }
 
     public class ClickTracker : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, IPointerClickHandler

--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -146,6 +146,9 @@ namespace Tests.PlayMode
                 Assert.IsNotEmpty(raycastResults, "Setup: the non-UI raycaster should hit.");
                 Assert.IsFalse(raycastResults[0].module is GraphicRaycaster,
                     "Setup: EventSystem's first hit should not come from a GraphicRaycaster.");
+                Assert.IsFalse(
+                    raycastResults.Exists(result => result.gameObject == overlayTracker.gameObject),
+                    "Setup: overlay UI must be clipped out of EventSystem results for this regression test.");
 
                 yield return RunTool(new JObject
                 {

--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using io.github.hatayama.uLoopMCP;
 using Newtonsoft.Json.Linq;
@@ -109,6 +110,59 @@ namespace Tests.PlayMode
             Assert.IsTrue(tracker.PointerUpCalled, "PointerUp should be fired");
             Assert.IsTrue(tracker.PointerClickCalled, "PointerClick should be fired");
             Assert.AreEqual("ClickTarget", lastResponse.HitGameObjectName);
+        }
+
+        // Verifies that an overlay UI element clipped out of EventSystem's Screen bounds
+        // (scaled Game view resolution) still wins over a non-GraphicRaycaster hit,
+        // because ScreenSpaceOverlay UI always renders in front of world-space content.
+        [UnityTest]
+        public IEnumerator Click_Should_PreferClippedOverlayUiOverNonUiRaycastHit()
+        {
+            GameObject nonUiRoot = new GameObject("NonUiRaycasterRoot");
+
+            try
+            {
+                GameObject nonUiTarget = new GameObject("NonUiTarget");
+                nonUiTarget.transform.SetParent(nonUiRoot.transform, false);
+                ClickTracker nonUiTracker = nonUiTarget.AddComponent<ClickTracker>();
+                AlwaysHitRaycaster nonUiRaycaster = nonUiRoot.AddComponent<AlwaysHitRaycaster>();
+                nonUiRaycaster.Target = nonUiTarget;
+
+                // Place the UI element beyond Screen.width so GraphicRaycaster clips it
+                // while the Canvas-space hit test still reaches it.
+                Vector2 offscreenOffset = new Vector2(Screen.width, 0f);
+                ClickTracker overlayTracker = CreateClickableElement(
+                    "OffscreenOverlayTarget", offscreenOffset, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the non-UI raycaster should hit.");
+                Assert.IsFalse(raycastResults[0].module is GraphicRaycaster,
+                    "Setup: EventSystem's first hit should not come from a GraphicRaycaster.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(overlayTracker.PointerClickCalled, "Overlay UI should receive the click");
+                Assert.IsFalse(nonUiTracker.PointerClickCalled, "Non-UI target behind overlay UI should not receive the click");
+                Assert.AreEqual("OffscreenOverlayTarget", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(nonUiRoot);
+            }
         }
 
         [UnityTest]
@@ -654,6 +708,26 @@ namespace Tests.PlayMode
     }
 
     // Tracks pointer click events for testing
+    // Stands in for a non-UI raycaster (e.g. PhysicsRaycaster) without requiring the
+    // physics modules: always reports a hit on Target, ignoring Screen-bounds clipping.
+    public class AlwaysHitRaycaster : BaseRaycaster
+    {
+        public GameObject Target = null!;
+
+        public override Camera eventCamera => null!;
+
+        public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)
+        {
+            resultAppendList.Add(new RaycastResult
+            {
+                gameObject = Target,
+                module = this,
+                distance = 0f,
+                screenPosition = eventData.position
+            });
+        }
+    }
+
     public class ClickTracker : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, IPointerClickHandler
     {
         public bool PointerDownCalled { get; private set; }

--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -168,6 +168,73 @@ namespace Tests.PlayMode
             }
         }
 
+        // Forces the remaining ordering shape from issue 1317: EventSystem reports a
+        // lower-priority GraphicRaycaster hit while the front overlay is clipped from
+        // EventSystem results, so the tool must compare the Canvas-space candidate.
+        [UnityTest]
+        public IEnumerator Click_Should_PreferClippedHigherOrderOverlayUiOverLowerGraphicRaycasterHit()
+        {
+            GameObject lowerCameraGo = new GameObject("LowerGraphicCamera");
+            GameObject lowerCanvasGo = new GameObject("LowerGraphicCanvas");
+
+            try
+            {
+                lowerCameraGo.transform.position = new Vector3(0f, 0f, -10f);
+                Camera lowerCamera = lowerCameraGo.AddComponent<Camera>();
+                lowerCamera.orthographic = true;
+
+                Canvas lowerCanvas = lowerCanvasGo.AddComponent<Canvas>();
+                lowerCanvas.renderMode = RenderMode.ScreenSpaceCamera;
+                lowerCanvas.worldCamera = lowerCamera;
+                lowerCanvas.sortingOrder = 0;
+
+                GameObject lowerMask = CreateChildUIElement(
+                    "LowerGraphicMask", lowerCanvasGo.transform, Vector2.zero, new Vector2(2000f, 2000f));
+                lowerMask.AddComponent<Image>();
+                ClickTracker lowerTracker = lowerMask.AddComponent<ClickTracker>();
+                AlwaysHitGraphicRaycaster lowerRaycaster = lowerCanvasGo.AddComponent<AlwaysHitGraphicRaycaster>();
+                lowerRaycaster.Target = lowerMask;
+
+                canvasGo.GetComponent<Canvas>().sortingOrder = 100;
+                Vector2 clippedOverlayOffset = new Vector2(Screen.width, 0f);
+                ClickTracker overlayTracker = CreateClickableElement(
+                    "FrontOverlayButton", clippedOverlayOffset, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the lower GraphicRaycaster should hit.");
+                Assert.AreEqual(lowerMask, raycastResults[0].gameObject,
+                    "Setup: EventSystem should expose the lower-priority GraphicRaycaster hit first.");
+                Assert.IsFalse(
+                    raycastResults.Exists(result => result.gameObject == overlayTracker.gameObject),
+                    "Setup: overlay UI must be clipped out of EventSystem results for this regression test.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(overlayTracker.PointerClickCalled, "Higher-order overlay UI should receive the click");
+                Assert.IsFalse(lowerTracker.PointerClickCalled, "Lower GraphicRaycaster target should not receive the click");
+                Assert.AreEqual("FrontOverlayButton", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(lowerCanvasGo);
+                Object.Destroy(lowerCameraGo);
+            }
+        }
+
         [UnityTest]
         public IEnumerator Click_WithBypassRaycast_Should_UseTargetPathWhenNamesDuplicate()
         {
@@ -727,6 +794,28 @@ namespace Tests.PlayMode
                 module = this,
                 distance = 0f,
                 screenPosition = eventData.position
+            });
+        }
+    }
+
+    // Stands in for a lower-priority GraphicRaycaster that still reports an
+    // EventSystem hit when the front overlay UI is clipped by Screen bounds.
+    public class AlwaysHitGraphicRaycaster : GraphicRaycaster
+    {
+        public GameObject Target = null!;
+
+        public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)
+        {
+            Canvas canvas = GetComponent<Canvas>();
+            resultAppendList.Add(new RaycastResult
+            {
+                gameObject = Target,
+                module = this,
+                distance = 0f,
+                screenPosition = eventData.position,
+                sortingLayer = canvas.sortingLayerID,
+                sortingOrder = canvas.sortingOrder,
+                depth = 0
             });
         }
     }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -8,6 +8,7 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.inputsystem": "1.14.2",
     "com.unity.memoryprofiler": "1.1.12",
+    "com.unity.modules.physics2d": "1.0.0",
     "com.unity.render-pipelines.universal": "14.0.12",
     "com.unity.terrain-tools": "5.0.6",
     "com.unity.test-framework": "1.3.9",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -289,6 +289,12 @@
       "source": "builtin",
       "dependencies": {}
     },
+    "com.unity.modules.physics2d": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
     "com.unity.modules.terrain": {
       "version": "1.0.0",
       "depth": 1,

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
@@ -1,12 +1,10 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.UI;
 
 namespace io.github.hatayama.uLoopMCP
 {
@@ -623,18 +621,8 @@ namespace io.github.hatayama.uLoopMCP
 
         private void UpdatePointerRaycast(PointerEventData pointerData)
         {
-            List<RaycastResult> results = new List<RaycastResult>();
-            EventSystem.current.RaycastAll(pointerData, results);
-
-            if (results.Count > 0)
-            {
-                pointerData.pointerCurrentRaycast = results[0];
-                return;
-            }
-
-            // Same Canvas-space fallback as RaycastUI for scaled Game view
-            RaycastResult? fallback = UiRaycastHelper.RaycastCanvasSpace(pointerData.position);
-            pointerData.pointerCurrentRaycast = fallback ?? new RaycastResult();
+            RaycastResult? hit = UiRaycastHelper.RaycastUI(pointerData.position, EventSystem.current);
+            pointerData.pointerCurrentRaycast = hit ?? new RaycastResult();
         }
 
         private async Task InterpolateDragPosition(

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -46,6 +46,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             Canvas[] canvases = Object.FindObjectsByType<Canvas>(FindObjectsSortMode.None);
             Graphic? bestHit = null;
+            int bestSortingLayerValue = int.MinValue;
             int bestSortingOrder = int.MinValue;
             int bestDepth = -1;
 
@@ -67,6 +68,11 @@ namespace io.github.hatayama.uLoopMCP
                     continue;
                 }
 
+                // Sorting layer outranks sorting order, which outranks Graphic depth —
+                // sortingOrder only orders canvases within the same sorting layer.
+                int sortingLayerValue = SortingLayer.GetLayerValueFromID(canvas.sortingLayerID);
+                int sortingOrder = canvas.sortingOrder;
+
                 Graphic[] graphics = canvas.GetComponentsInChildren<Graphic>();
                 foreach (Graphic graphic in graphics)
                 {
@@ -75,12 +81,16 @@ namespace io.github.hatayama.uLoopMCP
                         continue;
                     }
 
-                    int sortingOrder = canvas.sortingOrder;
+                    bool isInFront =
+                        sortingLayerValue > bestSortingLayerValue ||
+                        (sortingLayerValue == bestSortingLayerValue && sortingOrder > bestSortingOrder) ||
+                        (sortingLayerValue == bestSortingLayerValue && sortingOrder == bestSortingOrder &&
+                         graphic.depth > bestDepth);
 
-                    if (sortingOrder > bestSortingOrder ||
-                        (sortingOrder == bestSortingOrder && graphic.depth > bestDepth))
+                    if (isInFront)
                     {
                         bestHit = graphic;
+                        bestSortingLayerValue = sortingLayerValue;
                         bestSortingOrder = sortingOrder;
                         bestDepth = graphic.depth;
                     }

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -20,7 +20,19 @@ namespace io.github.hatayama.uLoopMCP
 
             if (results.Count > 0)
             {
-                return results[0];
+                RaycastResult firstHit = results[0];
+
+                if (firstHit.module is GraphicRaycaster)
+                {
+                    return firstHit;
+                }
+
+                // EventSystem clips GraphicRaycaster hits at Screen.width/height, so a non-UI
+                // raycaster (e.g. PhysicsRaycaster) can win by default even though
+                // ScreenSpaceOverlay UI always renders in front of world-space content.
+                // Prefer the Canvas-space UI hit when one exists at this position.
+                RaycastResult? canvasSpaceHit = RaycastCanvasSpace(screenPosition);
+                return canvasSpaceHit ?? firstHit;
             }
 
             // EventSystem clips at Screen.width/height, which can be smaller than the

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -17,27 +17,23 @@ namespace io.github.hatayama.uLoopMCP
             };
             List<RaycastResult> results = new List<RaycastResult>();
             eventSystem.RaycastAll(pointerData, results);
+            RaycastResult? canvasSpaceHit = RaycastCanvasSpace(screenPosition);
 
             if (results.Count > 0)
             {
                 RaycastResult firstHit = results[0];
 
-                if (firstHit.module is GraphicRaycaster)
+                if (canvasSpaceHit != null && ShouldPreferCanvasSpaceHit(canvasSpaceHit.Value, firstHit))
                 {
-                    return firstHit;
+                    return canvasSpaceHit;
                 }
 
-                // EventSystem clips GraphicRaycaster hits at Screen.width/height, so a non-UI
-                // raycaster (e.g. PhysicsRaycaster) can win by default even though
-                // ScreenSpaceOverlay UI always renders in front of world-space content.
-                // Prefer the Canvas-space UI hit when one exists at this position.
-                RaycastResult? canvasSpaceHit = RaycastCanvasSpace(screenPosition);
-                return canvasSpaceHit ?? firstHit;
+                return firstHit;
             }
 
             // EventSystem clips at Screen.width/height, which can be smaller than the
             // Canvas layout space (Game view target resolution). Fall back to manual hit testing.
-            return RaycastCanvasSpace(screenPosition);
+            return canvasSpaceHit;
         }
 
         // Bypass EventSystem's Screen-bounds clipping by directly testing Graphic rects in Canvas space.
@@ -45,10 +41,7 @@ namespace io.github.hatayama.uLoopMCP
         public static RaycastResult? RaycastCanvasSpace(Vector2 canvasPosition)
         {
             Canvas[] canvases = Object.FindObjectsByType<Canvas>(FindObjectsSortMode.None);
-            Graphic? bestHit = null;
-            int bestSortingLayerValue = int.MinValue;
-            int bestSortingOrder = int.MinValue;
-            int bestDepth = -1;
+            RaycastResult? bestHit = null;
 
             foreach (Canvas canvas in canvases)
             {
@@ -68,11 +61,6 @@ namespace io.github.hatayama.uLoopMCP
                     continue;
                 }
 
-                // Sorting layer outranks sorting order, which outranks Graphic depth —
-                // sortingOrder only orders canvases within the same sorting layer.
-                int sortingLayerValue = SortingLayer.GetLayerValueFromID(canvas.sortingLayerID);
-                int sortingOrder = canvas.sortingOrder;
-
                 Graphic[] graphics = canvas.GetComponentsInChildren<Graphic>();
                 foreach (Graphic graphic in graphics)
                 {
@@ -81,32 +69,24 @@ namespace io.github.hatayama.uLoopMCP
                         continue;
                     }
 
-                    bool isInFront =
-                        sortingLayerValue > bestSortingLayerValue ||
-                        (sortingLayerValue == bestSortingLayerValue && sortingOrder > bestSortingOrder) ||
-                        (sortingLayerValue == bestSortingLayerValue && sortingOrder == bestSortingOrder &&
-                         graphic.depth > bestDepth);
-
-                    if (isInFront)
+                    RaycastResult candidate = new RaycastResult
                     {
-                        bestHit = graphic;
-                        bestSortingLayerValue = sortingLayerValue;
-                        bestSortingOrder = sortingOrder;
-                        bestDepth = graphic.depth;
+                        gameObject = graphic.gameObject,
+                        module = raycaster,
+                        screenPosition = canvasPosition,
+                        sortingLayer = canvas.sortingLayerID,
+                        sortingOrder = canvas.sortingOrder,
+                        depth = graphic.depth
+                    };
+
+                    if (bestHit == null || CompareRaycastPriority(candidate, bestHit.Value) > 0)
+                    {
+                        bestHit = candidate;
                     }
                 }
             }
 
-            if (bestHit == null)
-            {
-                return null;
-            }
-
-            return new RaycastResult
-            {
-                gameObject = bestHit.gameObject,
-                sortingOrder = bestSortingOrder
-            };
+            return bestHit;
         }
 
         // Respects CanvasGroup.blocksRaycasts, Mask, RectMask2D, and custom ICanvasRaycastFilter
@@ -129,6 +109,85 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             return graphic.Raycast(canvasPosition, null);
+        }
+
+        private static bool ShouldPreferCanvasSpaceHit(RaycastResult canvasSpaceHit, RaycastResult eventSystemHit)
+        {
+            if (!IsGraphicRaycast(canvasSpaceHit))
+            {
+                return false;
+            }
+
+            if (!IsGraphicRaycast(eventSystemHit))
+            {
+                return true;
+            }
+
+            return CompareRaycastPriority(canvasSpaceHit, eventSystemHit) > 0;
+        }
+
+        private static bool IsGraphicRaycast(RaycastResult raycastResult)
+        {
+            return raycastResult.module is GraphicRaycaster;
+        }
+
+        private static int CompareRaycastPriority(RaycastResult left, RaycastResult right)
+        {
+            int sortOrderPriority = Compare(GetSortOrderPriority(left), GetSortOrderPriority(right));
+            if (sortOrderPriority != 0)
+            {
+                return sortOrderPriority;
+            }
+
+            int renderOrderPriority = Compare(GetRenderOrderPriority(left), GetRenderOrderPriority(right));
+            if (renderOrderPriority != 0)
+            {
+                return renderOrderPriority;
+            }
+
+            int sortingLayer = Compare(GetSortingLayerValue(left), GetSortingLayerValue(right));
+            if (sortingLayer != 0)
+            {
+                return sortingLayer;
+            }
+
+            int sortingOrder = Compare(left.sortingOrder, right.sortingOrder);
+            if (sortingOrder != 0)
+            {
+                return sortingOrder;
+            }
+
+            return Compare(left.depth, right.depth);
+        }
+
+        private static int GetSortOrderPriority(RaycastResult result)
+        {
+            return result.module != null ? result.module.sortOrderPriority : 0;
+        }
+
+        private static int GetRenderOrderPriority(RaycastResult result)
+        {
+            return result.module != null ? result.module.renderOrderPriority : 0;
+        }
+
+        private static int GetSortingLayerValue(RaycastResult result)
+        {
+            return SortingLayer.GetLayerValueFromID(result.sortingLayer);
+        }
+
+        private static int Compare(int left, int right)
+        {
+            if (left > right)
+            {
+                return 1;
+            }
+
+            if (left < right)
+            {
+                return -1;
+            }
+
+            return 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- `simulate-mouse-ui` (and input replay) now dispatches to the visible ScreenSpaceOverlay UI element instead of a target behind it when the Game view runs at a scaled target resolution.

## User Impact
- Before: when the Game view target resolution was larger than the actual window, `EventSystem` clipped UI raycasts at `Screen.width`/`Screen.height`. If a non-UI raycaster (e.g. `PhysicsRaycaster`) still hit at that position, the click went to that hidden target — or reported the wrong element — even though a real user would reach the frontmost button.
- After: the click lands on the frontmost overlay UI element, matching what the user sees. Drag target resolution behaves the same way.

## Changes
- `UiRaycastHelper.RaycastUI`: when the first `EventSystem` result does not come from a `GraphicRaycaster`, prefer the existing Canvas-space hit test (ScreenSpaceOverlay UI always renders in front of world-space content). UI-vs-UI ordering stays delegated to Unity's own `RaycastComparer`.
- `SimulateMouseUiTool.UpdatePointerRaycast`: unified the drag path's duplicated raycast-plus-fallback logic onto the shared helper, so `DragMove` resolves targets the same way.
- Added a PlayMode regression test that reproduces the clipped-UI case with a test-only `BaseRaycaster`, since this project intentionally disables the physics modules.

## Relationship to #1318
Alternative approach to #1318 (thanks @prog-k-dev for the report and investigation). On Unity 2022.3.62f3 and 6000.3, `EventSystem.RaycastAll` already orders overlay UI ahead of physics hits whenever the `GraphicRaycaster` actually hits the element (raycaster `sortOrderPriority` resolves first), so this PR keeps Unity's ordering for UI-vs-UI and only covers the case where the UI hit is clipped away entirely.

Closes #1317.

## Verification
- TDD: the new test fails on `main` ("Overlay UI should receive the click") and passes with this change.
- `uloop compile`: 0 errors / 0 warnings.
- `uloop run-tests --test-mode PlayMode` for `Tests.PlayMode.SimulateMouseUiTests`: 22/22 passed.
- Full PlayMode assembly: 60/61 passed; the single failure (`SimulateKeyboardTests.Press_Should_CreateOverlayCanvas_WithUnitScale`) also fails on a clean `main` checkout in this environment (Game view scale dependent) and is unrelated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes simulate-mouse-ui so simulated clicks at scaled Game view resolutions (where Screen bounds can clip EventSystem raycasts) target the visually frontmost `ScreenSpaceOverlay` uGUI element instead of selecting behind-the-overlay or non-UI raycast targets.

## What changed

### UiRaycastHelper.RaycastUI
- Computes a Canvas-space hit via `RaycastCanvasSpace`.
- When `EventSystem.RaycastAll` returns results, it no longer blindly uses `results[0]`; instead it conditionally prefers the Canvas-space hit over `results[0]` via a new `ShouldPreferCanvasSpaceHit` helper.
- When `EventSystem.RaycastAll` returns no results, it falls back to the Canvas-space hit.

### UiRaycastHelper.RaycastCanvasSpace
- Updated Canvas-space hit selection to build candidate `RaycastResult`s that include:
  - `sortingLayer`
  - `sortingOrder`
  - `depth`
- Selects the “best” candidate using `CompareRaycastPriority`, incorporating:
  - module sort/render priorities
  - sorting layer value
  - sorting order
  - depth
- Returned `RaycastResult` is populated with the chosen graphic and `sortingOrder`.

### SimulateMouseUiTool.UpdatePointerRaycast
- Simplified pointer raycast resolution to directly set `pointerData.pointerCurrentRaycast` from `UiRaycastHelper.RaycastUI(position, EventSystem.current)`, defaulting to an empty `RaycastResult` when null.

### Tests (PlayMode regression coverage)
Updated `Assets/Tests/PlayMode/SimulateMouseUiTests.cs` with new PlayMode regression tests covering:
- Prefer clipped `ScreenSpaceOverlay` over a non-UI raycast hit (using test-only `BaseRaycaster`/`RaycastResult` injection).
- Prefer overlay UI over a `Physics2DRaycaster` hit when the physics raycaster is made higher-priority.
- Prefer a clipped higher-order overlay UI over a lower-priority `GraphicRaycaster` hit.

The test file also adds helper raycasters:
- `AlwaysHitRaycaster : BaseRaycaster`
- `AlwaysHitGraphicRaycaster : GraphicRaycaster`
- `HighPriorityPhysics2DRaycaster : Physics2DRaycaster`

### Dependencies
- Added `com.unity.modules.physics2d` to `Packages/manifest.json` and lockfile to ensure PlayMode tests can use `Physics2DRaycaster`.

## Verification
- New regression tests fail on main and pass with this change.
- PlayMode `SimulateMouseUiTests`: `22/22` passed.
- Full PlayMode assembly: `60/61` passed (one unrelated existing failure on main).

## Class Diagram
```
┌─────────────────────────────────────────────┐
│             UiRaycastHelper (static)      │
├─────────────────────────────────────────────┤
│ + RaycastUI(Vector2, EventSystem)         │
│   - Prefer Canvas-space hit conditionally │
│ + RaycastCanvasSpace(Vector2)           │
│   - Candidate ranking by priority         │
└─────────────────────────────────────────────┘
            △ used by
┌─────────────────────────────────────────────┐
│             SimulateMouseUiTool           │
├─────────────────────────────────────────────┤
│ - UpdatePointerRaycast(...)              │
│   sets pointerCurrentRaycast from helper │
└─────────────────────────────────────────────┘

┌─────────────────────────────────────────────┐
│           InputReplayer (indirect)       │
├─────────────────────────────────────────────┤
│ - Dispatch/click handling uses helper     │
└─────────────────────────────────────────────┘

┌─────────────────────────────────────────────┐
│           Test-only Raycaster Helpers    │
├─────────────────────────────────────────────┤
│ AlwaysHitRaycaster : BaseRaycaster       │
│ AlwaysHitGraphicRaycaster : GraphicRaycaster
│ HighPriorityPhysics2DRaycaster          : Physics2DRaycaster
└─────────────────────────────────────────────┘
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->