### PR TITLE
chore: Unblock the v3-beta release: align the next CLI release with the stamped version and stop release PRs failing the CLI version check

### DIFF
--- a/cli/internal/architecture/comment_cli_minimum_version_warning_test.go
+++ b/cli/internal/architecture/comment_cli_minimum_version_warning_test.go
@@ -26,6 +26,7 @@ type commentScriptOptions struct {
 	Mutation          string
 	BaseRef           string
 	HeadRef           string
+	HeadBranch        string
 	IncludePRNumber   bool
 	FailOnWarning     bool
 	ExpectFailure     bool
@@ -134,6 +135,21 @@ func TestCommentCliMinimumVersionWarningIgnoresUnrelatedChanges(t *testing.T) {
 	assertNotContains(t, result.GitHubLog, "PATCH")
 }
 
+// Verifies that release-please release PRs skip check mode even with Go CLI changes.
+func TestCommentCliMinimumVersionWarningSkipsReleasePleaseBranch(t *testing.T) {
+	result := runCommentScriptCase(t, commentScriptOptions{
+		Mutation:        "go-cli",
+		BaseRef:         "HEAD^",
+		HeadBranch:      "release-please--branches--v3-beta",
+		IncludePRNumber: true,
+		FailOnWarning:   true,
+	})
+
+	assertContains(t, result.Output, "release-please release PR")
+	assertNotContains(t, result.GitHubLog, "POST")
+	assertNotContains(t, result.GitHubLog, "PATCH")
+}
+
 // Verifies that non-PR runs stop before calling GitHub issue APIs.
 func TestCommentCliMinimumVersionWarningSkipsNonPullRequestRuns(t *testing.T) {
 	result := runCommentScriptCase(t, commentScriptOptions{
@@ -190,6 +206,8 @@ func runCommentScript(
 
 	command := exec.Command(filepath.Join(repositoryRoot(t), commentScriptPath))
 	command.Dir = repositoryPath
+	// GITHUB_HEAD_REF is always set explicitly because CI inherits the real PR head
+	// branch into the test process, which would trigger the release-please skip path.
 	command.Env = append(os.Environ(),
 		"PATH="+mockBinPath+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"GH_LOG="+gitHubLogPath,
@@ -197,6 +215,7 @@ func runCommentScript(
 		"GH_EXISTING_COMMENT_ID="+options.ExistingCommentID,
 		"ULOOP_REPOSITORY_ROOT="+repositoryPath,
 		"GITHUB_REPOSITORY=hatayama/unity-cli-loop",
+		"GITHUB_HEAD_REF="+options.HeadBranch,
 	)
 	if options.IncludePRNumber {
 		command.Env = append(command.Env, "PR_NUMBER=123")

--- a/cli/internal/automation/minimum_version_warning.go
+++ b/cli/internal/automation/minimum_version_warning.go
@@ -25,6 +25,8 @@ Please confirm whether the Unity package can still accept older CLI versions. If
 Resolved: this PR no longer has Go CLI changes without a ` + "`MINIMUM_REQUIRED_CLI_VERSION`" + ` update.
 `
 	goCliPackageRoot = "cli/"
+	// release-please names its release branches "release-please--branches--<target>".
+	releasePleaseBranchPrefix = "release-please--"
 )
 
 var minimumVersionWarningValuePattern = regexp.MustCompile(`MINIMUM_REQUIRED_CLI_VERSION\s*=\s*"([^"]+)"`)
@@ -35,6 +37,7 @@ type minimumVersionWarningConfig struct {
 	repository     string
 	baseRef        string
 	headRef        string
+	headBranch     string
 	failOnWarning  bool
 }
 
@@ -46,6 +49,13 @@ func RunMinimumVersionWarning(ctx context.Context, stdout io.Writer, stderr io.W
 	}
 	if config.pullRequest == "" && !config.failOnWarning {
 		writeMinimumVersionWarningLine(stdout, "Skipping CLI minimum version comment because no PR number was provided.")
+		return 0
+	}
+
+	// Release PRs only contain release-please version stamps (cli/contract.json and
+	// internal/tools/default-tools.json); the reminder targets human-authored CLI changes.
+	if strings.HasPrefix(config.headBranch, releasePleaseBranchPrefix) {
+		writeMinimumVersionWarningLine(stdout, "Skipping CLI minimum version check because this is a release-please release PR.")
 		return 0
 	}
 
@@ -127,6 +137,7 @@ func minimumVersionWarningConfigFromEnvironment() (minimumVersionWarningConfig, 
 		repository:     os.Getenv("GITHUB_REPOSITORY"),
 		baseRef:        baseRef,
 		headRef:        headRef,
+		headBranch:     os.Getenv("GITHUB_HEAD_REF"),
 		failOnWarning:  os.Getenv("CLI_MINIMUM_VERSION_FAIL_ON_WARNING") == "true",
 	}, nil
 }

--- a/cli/internal/automation/minimum_version_warning_test.go
+++ b/cli/internal/automation/minimum_version_warning_test.go
@@ -64,6 +64,33 @@ func TestMinimumVersionWarningSkipsMissingBaseRefBeforeRepositoryResolution(t *t
 	}
 }
 
+// Verifies that release-please release PRs skip the check before any git diff runs.
+func TestMinimumVersionWarningSkipsReleasePleaseHeadBranch(t *testing.T) {
+	t.Setenv("ULOOP_REPOSITORY_ROOT", t.TempDir())
+	t.Setenv("PR_NUMBER", "123")
+	t.Setenv("GITHUB_REPOSITORY", "owner/repository")
+	t.Setenv("GITHUB_BASE_REF", "v3-beta")
+	t.Setenv("GITHUB_HEAD_REF", "release-please--branches--v3-beta")
+	t.Setenv("CLI_MINIMUM_VERSION_BASE_REF", "")
+	t.Setenv("CLI_MINIMUM_VERSION_HEAD_REF", "")
+	t.Setenv("CLI_MINIMUM_VERSION_FAIL_ON_WARNING", "true")
+	t.Setenv("PATH", t.TempDir())
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	exitCode := RunMinimumVersionWarning(context.Background(), &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected release-please head branch to skip with exit code 0, got %d\n%s", exitCode, stderr.String())
+	}
+	if stdout.String() != "Skipping CLI minimum version check because this is a release-please release PR.\n" {
+		t.Fatalf("expected release-please skip message, got %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("expected no stderr on release-please skip, got %q", stderr.String())
+	}
+}
+
 // Verifies that Go CLI source changes require a minimum-version warning.
 func TestMinimumVersionWarningRequiresCommentForGoCliSourceChanges(t *testing.T) {
 	testCases := []struct {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,6 +21,7 @@
     },
     "cli": {
       "component": "cli",
+      "release-as": "3.0.0-beta.31",
       "release-type": "go",
       "versioning": "prerelease",
       "prerelease": true,


### PR DESCRIPTION
## Summary
- The release-please PR (#1278) no longer fails the `build-cli` check: release PRs are now exempt from the CLI minimum version reminder, which is meant for human-authored CLI changes.
- The next CLI release is pinned to `3.0.0-beta.31` so it matches the version already stamped in `cli/contract.json` and required by the Unity package.

## User Impact
- Before: the pending release would have published the CLI as `cli-v3.0.0-beta.25` while the Unity package rejects any CLI older than `3.0.0-beta.31` and tells users to update to a version that does not exist. The `build-cli` check on the release PR also failed, blocking the release.
- After: the release ships the CLI as `cli-v3.0.0-beta.31`, matching what the package requires, and release PRs pass the `build-cli` check.

## Background
Since `cli-v3.0.0-beta.24`, seven merged PRs each manually bumped `cliVersion` in `cli/contract.json` (now `3.0.0-beta.31`) together with `MINIMUM_REQUIRED_CLI_VERSION`, but release-please still computes the next CLI version as `3.0.0-beta.25` from its manifest. The release PR therefore tried to downgrade the stamped versions, which both tripped the minimum-version check and would have produced a broken release.

## Changes
- `cli/internal/automation/minimum_version_warning.go`: skip the check when `GITHUB_HEAD_REF` starts with `release-please--`, since release PRs only contain release-please version stamps.
- Architecture test harness now always sets `GITHUB_HEAD_REF` explicitly so CI-inherited values cannot leak into the script under test; added unit and end-to-end tests for the skip.
- `release-please-config.json`: one-shot `"release-as": "3.0.0-beta.31"` for the `cli` component. **Remove it right after `cli-v3.0.0-beta.31` is published**, otherwise the next release reuses the same version.

## Verification
- `scripts/check-go-cli.sh` (fmt, vet, lint, full test suite): all green
- `scripts/test-release-please-config.sh`, `scripts/test-cli-minimum-version-warning-workflow.sh`, `scripts/test-comment-cli-minimum-version-warning.sh`: all green

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

