### PR TITLE
chore: Release PR checks no longer fail on an environment-dependent unit test

### DIFF
--- a/cli/internal/automation/minimum_version_warning_test.go
+++ b/cli/internal/automation/minimum_version_warning_test.go
@@ -45,6 +45,9 @@ func TestMinimumVersionWarningSkipsMissingBaseRefBeforeRepositoryResolution(t *t
 	t.Setenv("PR_NUMBER", "123")
 	t.Setenv("GITHUB_REPOSITORY", "")
 	t.Setenv("GITHUB_BASE_REF", "")
+	// CI sets the real PR head branch for every step; clear it so the
+	// release-please skip cannot fire before the base-ref skip under test.
+	t.Setenv("GITHUB_HEAD_REF", "")
 	t.Setenv("CLI_MINIMUM_VERSION_BASE_REF", "")
 	t.Setenv("CLI_MINIMUM_VERSION_HEAD_REF", "")
 	t.Setenv("PATH", t.TempDir())


### PR DESCRIPTION
## Summary
- Fixes the `build-cli` failure that reappeared on the regenerated release PR (#1278) after #1325.

## User Impact
- Before: `TestMinimumVersionWarningSkipsMissingBaseRefBeforeRepositoryResolution` failed when the test suite ran on the release PR's own CI, keeping the release blocked.
- After: the test passes regardless of the CI environment, so the release PR can go green.

## Changes
- GitHub Actions sets `GITHUB_HEAD_REF` for every step of `pull_request` runs. On the release PR that value is `release-please--branches--v3-beta`, so the release-please skip introduced in #1325 fired before the base-ref skip the test asserts. The test now clears `GITHUB_HEAD_REF` explicitly, the same way the architecture test harness already controls it.

## Verification
- `GITHUB_HEAD_REF=release-please--branches--v3-beta GITHUB_BASE_REF=v3-beta go test ./... -count=1` reproduced the CI failure before the fix and passes after it
- `scripts/check-go-cli.sh`: all green

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

