### PR TITLE
chore: Remove the one-shot CLI release version override now that 3.0.0-beta.31 shipped

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,7 +21,6 @@
     },
     "cli": {
       "component": "cli",
-      "release-as": "3.0.0-beta.31",
       "release-type": "go",
       "versioning": "prerelease",
       "prerelease": true,


### PR DESCRIPTION
## Summary
- Removes the temporary `"release-as": "3.0.0-beta.31"` from the `cli` package in `release-please-config.json`, as planned in #1325.

## User Impact
- None at runtime. Without this cleanup, every future CLI release would be pinned to `3.0.0-beta.31`; the next CLI release now computes normally from the manifest (`3.0.0-beta.32` and onward).

## Verification
- `scripts/test-release-please-config.sh`: green

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

