### PR TITLE
chore: Report the Compile Check status on every main PR

### DIFF
--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -1,15 +1,14 @@
 name: Unity Compile Check
 
+# This job is a required status check, so it must report exactly one
+# "Compile Check (Linux)" result on every PR. A workflow-level paths filter
+# would skip the job for PRs that touch no C# files, leaving the required
+# check unreported and blocking the PR forever. Instead the workflow always
+# runs and a change-detection step decides whether to do the real Unity work
+# or report success immediately.
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'Packages/src/Editor/**/*.cs'
-      - 'Packages/src/Runtime/**/*.cs'
-      - 'Assets/**/*.cs'
-      - 'tests/**/*.cs'
-      - 'tests/**/*.csproj'
-      - '.github/workflows/unity-compile-check-and-test-runner.yml'
   workflow_dispatch:
 
 permissions:
@@ -27,14 +26,45 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # Full history is required so the change-detection step can diff the
+          # PR head against its base.
+          fetch-depth: 0
           lfs: true
 
+      - name: Detect C# changes
+        id: changes
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          # workflow_dispatch has no PR context, so run the full check.
+          if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+            echo "csharp=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "=== Changed files ==="
+          echo "$CHANGED"
+
+          if echo "$CHANGED" | grep -qE '^(Packages/src/Editor/.*\.cs|Packages/src/Runtime/.*\.cs|Assets/.*\.cs|tests/.*\.cs|tests/.*\.csproj|Packages/.*\.asmdef|Assets/.*\.asmdef|Packages/manifest\.json|Packages/packages-lock\.json|\.github/workflows/unity-compile-check-and-test-runner\.yml)$'; then
+            echo "csharp=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "csharp=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip notice
+        if: steps.changes.outputs.csharp != 'true'
+        run: echo "No C# changes detected; compile check is satisfied without running Unity."
+
       - name: Setup .NET
+        if: steps.changes.outputs.csharp == 'true'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
       - name: Run concurrency unit tests
+        if: steps.changes.outputs.csharp == 'true'
         run: dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
 
       - name: Cache Library folder
@@ -47,7 +77,7 @@ jobs:
             Library-2022.3.62f1-
 
       - name: Compile Unity project
-        if: env.HAS_UNITY_LICENSE == 'true'
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'
         id: compile
         uses: game-ci/unity-builder@v5
         timeout-minutes: 30
@@ -63,7 +93,7 @@ jobs:
         continue-on-error: true
 
       - name: Check for compile errors and warnings
-        if: env.HAS_UNITY_LICENSE == 'true'
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'
         run: |
           LOG_FILE=$(find . -name "*.log" -path "*/build/*" -o -name "Editor.log" 2>/dev/null | head -1)
 


### PR DESCRIPTION
## Summary
- Lets `Compile Check (Linux)` work as a required merge gate on main without blocking PRs that do not touch C# code.

## User Impact
- The branch ruleset requires `Compile Check (Linux)` before merging into main. The workflow previously only ran when C# files changed, so a PR touching no C# files never reported the check and the required gate left it stuck on "Expected — waiting for status to be reported", blocking the merge.
- After this change, every PR to main reports exactly one `Compile Check (Linux)` result — either the real Unity compile (when C# / asmdef / package metadata changed) or an instant success (otherwise) — so the required check is always satisfiable.

## Changes
- Remove the workflow-level `paths` filter; the job now always runs on PRs to main.
- Add an in-job change-detection step that diffs the PR head against its base and gates the .NET tests and Unity compile on whether compile-affecting files changed.
- Treat `.asmdef` and `Packages/manifest.json` / `Packages/packages-lock.json` as compile-affecting, consistent with the Library cache key.

## Notes
- This mirrors the same fix already merged on v3-beta. Existing action version pins (`@v6`/`@v5`) are kept unchanged to match main's conventions.

## Verification
- Validated the workflow YAML parses successfully.
- Verified the change-detection regex against sample paths (C# under each root, `.asmdef`, manifest, lock) and confirmed unrelated files resolve to `csharp=false`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

