### PR TITLE
fix: Windows CLI accepts WSL and Git Bash project paths

### DIFF
--- a/cli/internal/cli/launch.go
+++ b/cli/internal/cli/launch.go
@@ -343,14 +343,7 @@ func unityLockfilePath(projectRoot string) string {
 
 func resolveLaunchProjectRoot(startPath string, options launchOptions) (string, error) {
 	if options.projectPath != "" {
-		projectRoot, err := filepath.Abs(options.projectPath)
-		if err != nil {
-			return "", err
-		}
-		if !project.IsUnityProject(projectRoot) {
-			return "", fmt.Errorf("not a Unity project: %s", projectRoot)
-		}
-		return projectRoot, nil
+		return project.ResolveExplicitProjectRoot(options.projectPath)
 	}
 	return project.FindUnityProjectRootWithin(startPath, options.maxDepth)
 }

--- a/cli/internal/cli/run.go
+++ b/cli/internal/cli/run.go
@@ -133,6 +133,17 @@ func RunProjectLocal(ctx context.Context, args []string, stdout io.Writer, stder
 			})
 			return 1
 		}
+		if nestedProjectPath != "" {
+			nestedConnection, err := project.ResolveConnection(startPath, nestedProjectPath)
+			if err != nil {
+				writeClassifiedError(stderr, err, errorContext{
+					projectRoot: connection.ProjectRoot,
+					command:     command,
+				})
+				return 1
+			}
+			nestedProjectPath = nestedConnection.ProjectRoot
+		}
 		if nestedProjectPath != "" && nestedProjectPath != connection.ProjectRoot {
 			writeErrorEnvelope(stderr, (&argumentError{
 				message:      "--project-path must target the same Unity project for this command",

--- a/cli/internal/cli/skills.go
+++ b/cli/internal/cli/skills.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -204,14 +203,7 @@ func unknownSkillsSubcommandError(subcommand string, context errorContext) cliEr
 
 func resolveSkillsProjectRoot(startPath string, explicitProjectPath string, global bool) (string, error) {
 	if explicitProjectPath != "" {
-		projectRoot, err := filepath.Abs(explicitProjectPath)
-		if err != nil {
-			return "", err
-		}
-		if !project.IsUnityProject(projectRoot) {
-			return "", fmt.Errorf("not a Unity project: %s", projectRoot)
-		}
-		return projectRoot, nil
+		return project.ResolveExplicitProjectRoot(explicitProjectPath)
 	}
 	if global {
 		projectRoot, err := project.FindUnityProjectRoot(startPath)

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -223,6 +223,9 @@ func windowsPosixProjectPathCandidate(projectPath string) (string, bool) {
 	if projectPath == "" {
 		return "", false
 	}
+	if projectPath[0] != '/' {
+		return "", false
+	}
 
 	slashPath := strings.ReplaceAll(projectPath, `\`, "/")
 	if len(slashPath) >= 2 && slashPath[0] == '/' && isASCIIAlpha(slashPath[1]) {

--- a/cli/internal/project/project.go
+++ b/cli/internal/project/project.go
@@ -175,15 +175,106 @@ func resolveProjectRoot(startPath string, explicitProjectPath string) (string, e
 		return FindProjectRoot(startPath)
 	}
 
-	projectRoot, err := filepath.Abs(explicitProjectPath)
+	return ResolveExplicitProjectRoot(explicitProjectPath)
+}
+
+// ResolveExplicitProjectRoot resolves a user-supplied Unity project path for the current platform.
+func ResolveExplicitProjectRoot(explicitProjectPath string) (string, error) {
+	resolution := normalizeExplicitProjectPathForOS(explicitProjectPath, runtime.GOOS, exists)
+	projectRoot, err := filepath.Abs(resolution.path)
 	if err != nil {
 		return "", err
 	}
 	if !IsUnityProject(projectRoot) {
-		return "", fmt.Errorf("not a Unity project: %s", projectRoot)
+		return "", notUnityProjectError(projectRoot, resolution.suggestion)
 	}
 
 	return projectRoot, nil
+}
+
+type explicitProjectPathResolution struct {
+	path       string
+	suggestion string
+}
+
+func normalizeExplicitProjectPathForOS(
+	explicitProjectPath string,
+	goos string,
+	pathExists func(string) bool,
+) explicitProjectPathResolution {
+	if goos != "windows" {
+		return explicitProjectPathResolution{path: explicitProjectPath}
+	}
+
+	candidate, ok := windowsPosixProjectPathCandidate(explicitProjectPath)
+	if !ok {
+		return explicitProjectPathResolution{path: explicitProjectPath}
+	}
+	if pathExists(candidate) {
+		return explicitProjectPathResolution{path: candidate}
+	}
+	return explicitProjectPathResolution{
+		path:       explicitProjectPath,
+		suggestion: candidate,
+	}
+}
+
+func windowsPosixProjectPathCandidate(projectPath string) (string, bool) {
+	if projectPath == "" {
+		return "", false
+	}
+
+	slashPath := strings.ReplaceAll(projectPath, `\`, "/")
+	if len(slashPath) >= 2 && slashPath[0] == '/' && isASCIIAlpha(slashPath[1]) {
+		if len(slashPath) == 2 {
+			return windowsDrivePath(slashPath[1], ""), true
+		}
+		if slashPath[2] == '/' {
+			return windowsDrivePath(slashPath[1], slashPath[3:]), true
+		}
+	}
+
+	if len(slashPath) >= 6 &&
+		strings.EqualFold(slashPath[:5], "/mnt/") &&
+		isASCIIAlpha(slashPath[5]) {
+		if len(slashPath) == 6 {
+			return windowsDrivePath(slashPath[5], ""), true
+		}
+		if slashPath[6] == '/' {
+			return windowsDrivePath(slashPath[5], slashPath[7:]), true
+		}
+	}
+
+	return "", false
+}
+
+func windowsDrivePath(driveLetter byte, rest string) string {
+	drive := string(toUpperASCIILetter(driveLetter)) + `:\`
+	if rest == "" {
+		return drive
+	}
+	return drive + strings.ReplaceAll(rest, "/", `\`)
+}
+
+func notUnityProjectError(projectRoot string, suggestion string) error {
+	if suggestion == "" {
+		return fmt.Errorf("not a Unity project: %s", projectRoot)
+	}
+	return fmt.Errorf(
+		"not a Unity project: %s. This looks like a WSL or Git Bash path. Did you mean: %s",
+		projectRoot,
+		suggestion)
+}
+
+func isASCIIAlpha(value byte) bool {
+	return (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z')
+}
+
+func toUpperASCIILetter(value byte) byte {
+	if value >= 'a' && value <= 'z' {
+		return value - ('a' - 'A')
+	}
+	return value
 }
 
 func createEndpointName(canonicalProjectRoot string) string {

--- a/cli/internal/project/project_test.go
+++ b/cli/internal/project/project_test.go
@@ -128,6 +128,142 @@ func TestResolveConnection_WhenSettingsFileContainsStaleRuntimeState_ShouldIgnor
 	assertProjectConnection(t, connection, projectRoot)
 }
 
+func TestResolveExplicitProjectRoot_WhenWindowsWslPathTargetsExistingProject_ShouldResolveProject(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows WSL path conversion is platform-specific")
+	}
+
+	// Verifies the Windows CLI accepts a WSL /mnt/<drive> path for an existing Unity project.
+	projectRoot := t.TempDir()
+	createUnityProject(t, projectRoot)
+	wslPath := windowsPathToWslMountPath(t, projectRoot)
+
+	resolved, err := ResolveExplicitProjectRoot(wslPath)
+	if err != nil {
+		t.Fatalf("ResolveExplicitProjectRoot failed: %v", err)
+	}
+
+	if resolved != projectRoot {
+		t.Fatalf("project root mismatch: %s", resolved)
+	}
+}
+
+func TestResolveExplicitProjectRoot_WhenWindowsGitBashPathTargetsExistingProject_ShouldResolveProject(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows Git Bash path conversion is platform-specific")
+	}
+
+	// Verifies the Windows CLI accepts a Git Bash /<drive> path for an existing Unity project.
+	projectRoot := t.TempDir()
+	createUnityProject(t, projectRoot)
+	gitBashPath := windowsPathToGitBashPath(t, projectRoot)
+
+	resolved, err := ResolveExplicitProjectRoot(gitBashPath)
+	if err != nil {
+		t.Fatalf("ResolveExplicitProjectRoot failed: %v", err)
+	}
+
+	if resolved != projectRoot {
+		t.Fatalf("project root mismatch: %s", resolved)
+	}
+}
+
+func TestNormalizeExplicitProjectPathForOS_WhenWindowsWslPathExists_ShouldUseWin32Path(t *testing.T) {
+	// Verifies that WSL /mnt/<drive> project paths become Win32 paths before Windows file APIs see them.
+	result := normalizeExplicitProjectPathForOS(
+		"/mnt/c/Users/ExampleUser/Game",
+		"windows",
+		existsOnly(`C:\Users\ExampleUser\Game`),
+	)
+
+	if result.path != `C:\Users\ExampleUser\Game` {
+		t.Fatalf("path mismatch: %s", result.path)
+	}
+	if result.suggestion != "" {
+		t.Fatalf("suggestion should be empty for an accepted conversion: %s", result.suggestion)
+	}
+}
+
+func TestNormalizeExplicitProjectPathForOS_WhenWindowsGitBashPathExists_ShouldUseWin32Path(t *testing.T) {
+	// Verifies that Git Bash /<drive> project paths become Win32 paths before Windows file APIs see them.
+	result := normalizeExplicitProjectPathForOS(
+		"/d/Projects/My Game",
+		"windows",
+		existsOnly(`D:\Projects\My Game`),
+	)
+
+	if result.path != `D:\Projects\My Game` {
+		t.Fatalf("path mismatch: %s", result.path)
+	}
+}
+
+func TestNormalizeExplicitProjectPathForOS_WhenConvertedWindowsPathIsMissing_ShouldKeepOriginalWithSuggestion(t *testing.T) {
+	// Verifies missing converted paths are not silently adopted, but still produce a diagnostic suggestion.
+	result := normalizeExplicitProjectPathForOS(
+		"/mnt/c/Users/ExampleUser/MissingGame",
+		"windows",
+		existsOnly(),
+	)
+
+	if result.path != "/mnt/c/Users/ExampleUser/MissingGame" {
+		t.Fatalf("original path should be preserved: %s", result.path)
+	}
+	if result.suggestion != `C:\Users\ExampleUser\MissingGame` {
+		t.Fatalf("suggestion mismatch: %s", result.suggestion)
+	}
+}
+
+func TestNormalizeExplicitProjectPathForOS_WhenWindowsPathIsNotPosixDrive_ShouldKeepOriginal(t *testing.T) {
+	// Verifies non-drive POSIX paths are not guessed as Windows project paths.
+	for _, input := range []string{
+		"/home/example/Game",
+		"/help",
+		"relative/Game",
+		`C:\Users\ExampleUser\Game`,
+		`\\server\share\Game`,
+	} {
+		result := normalizeExplicitProjectPathForOS(input, "windows", existsOnly())
+		if result.path != input {
+			t.Fatalf("path %q should be unchanged, got %q", input, result.path)
+		}
+		if result.suggestion != "" {
+			t.Fatalf("path %q should not have suggestion %q", input, result.suggestion)
+		}
+	}
+}
+
+func TestNormalizeExplicitProjectPathForOS_WhenNotWindows_ShouldKeepPosixPath(t *testing.T) {
+	// Verifies POSIX platforms do not reinterpret WSL-looking paths.
+	result := normalizeExplicitProjectPathForOS(
+		"/mnt/c/Users/ExampleUser/Game",
+		"linux",
+		existsOnly(`C:\Users\ExampleUser\Game`),
+	)
+
+	if result.path != "/mnt/c/Users/ExampleUser/Game" {
+		t.Fatalf("non-Windows path should be unchanged: %s", result.path)
+	}
+	if result.suggestion != "" {
+		t.Fatalf("non-Windows path should not have suggestion: %s", result.suggestion)
+	}
+}
+
+func TestNotUnityProjectError_WhenSuggestionExists_ShouldIncludeConvertedPath(t *testing.T) {
+	// Verifies path diagnostics show the safer Win32 candidate when WSL or Git Bash conversion was not adopted.
+	err := notUnityProjectError(`C:\mnt\c\Users\ExampleUser\Game`, `C:\Users\ExampleUser\Game`)
+
+	message := err.Error()
+	for _, expected := range []string{
+		`not a Unity project: C:\mnt\c\Users\ExampleUser\Game`,
+		"This looks like a WSL or Git Bash path",
+		`Did you mean: C:\Users\ExampleUser\Game`,
+	} {
+		if !strings.Contains(message, expected) {
+			t.Fatalf("message %q should contain %q", message, expected)
+		}
+	}
+}
+
 func createUnityProject(t *testing.T, projectRoot string) {
 	t.Helper()
 
@@ -137,6 +273,42 @@ func createUnityProject(t *testing.T, projectRoot string) {
 	if err := os.MkdirAll(filepath.Join(projectRoot, "ProjectSettings"), 0o755); err != nil {
 		t.Fatalf("failed to create ProjectSettings: %v", err)
 	}
+}
+
+func existsOnly(paths ...string) func(string) bool {
+	accepted := map[string]bool{}
+	for _, path := range paths {
+		accepted[path] = true
+	}
+	return func(path string) bool {
+		return accepted[path]
+	}
+}
+
+func windowsPathToWslMountPath(t *testing.T, path string) string {
+	t.Helper()
+
+	driveLetter, rest := splitWindowsDrivePath(t, path)
+	return "/mnt/" + strings.ToLower(driveLetter) + "/" + rest
+}
+
+func windowsPathToGitBashPath(t *testing.T, path string) string {
+	t.Helper()
+
+	driveLetter, rest := splitWindowsDrivePath(t, path)
+	return "/" + strings.ToLower(driveLetter) + "/" + rest
+}
+
+func splitWindowsDrivePath(t *testing.T, path string) (string, string) {
+	t.Helper()
+
+	volumeName := filepath.VolumeName(path)
+	if len(volumeName) != 2 || volumeName[1] != ':' {
+		t.Fatalf("expected drive-qualified Windows path, got %q", path)
+	}
+	rest := strings.TrimLeft(strings.TrimPrefix(path, volumeName), `\/`)
+	rest = strings.ReplaceAll(rest, `\`, "/")
+	return volumeName[:1], rest
 }
 
 func assertProjectConnection(t *testing.T, connection unityipc.Connection, projectRoot string) {

--- a/cli/internal/project/project_test.go
+++ b/cli/internal/project/project_test.go
@@ -220,9 +220,10 @@ func TestNormalizeExplicitProjectPathForOS_WhenWindowsPathIsNotPosixDrive_Should
 		"/help",
 		"relative/Game",
 		`C:\Users\ExampleUser\Game`,
+		`\c\Game`,
 		`\\server\share\Game`,
 	} {
-		result := normalizeExplicitProjectPathForOS(input, "windows", existsOnly())
+		result := normalizeExplicitProjectPathForOS(input, "windows", existsOnly(`C:\Game`))
 		if result.path != input {
 			t.Fatalf("path %q should be unchanged, got %q", input, result.path)
 		}


### PR DESCRIPTION
## Summary
- Windows CLI commands now accept WSL and Git Bash style project paths when they point to an existing Unity project.
- Missing converted paths keep the original input but show a Win32 path suggestion.

## User Impact
- Users running uloop on Windows from WSL or Git Bash can pass `--project-path /mnt/c/...` or `--project-path /c/...` without manually rewriting it to `C:\...`.
- PowerShell, cmd, UNC, relative, and non-drive POSIX paths are left unchanged unless the Windows conversion points to an existing path.

## Changes
- Normalize explicit project paths through the shared project resolution used by regular commands, `launch`, `skills`, and nested tool `--project-path` checks.
- Add Windows-specific integration coverage and platform-independent normalization and diagnostic tests.

## Verification
- `go test ./internal/project ./internal/cli`
- `scripts/check-go-cli.sh`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

