### PR TITLE
fix: run-tests now identifies zero-test runs

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -12,7 +12,7 @@ Before running `uloop run-tests`, run `uloop compile` for the same Unity project
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
-When an unfiltered `--filter-type all` run returns `TestCount: 0` and `Message` says no tests were found, read the `Message` for asmdef hints. `run-tests` only appends those hints when it detects likely test assembly configuration issues; exact, regex, and assembly filter misses keep the plain no-tests message.
+When a run returns `Status: "NoTestsFound"` or `NoTestsFound: true`, no matching tests were discovered. This is not the same as a failed test case: `HasFailures` remains `false`, `FailedCount` remains `0`, and `NoTestsFoundExplanation` explains the zero-discovery state for agents. When an unfiltered `--filter-type all` run also has `Message` set to the no-tests message, read the `Message` for asmdef hints. `run-tests` only appends those hints when it detects likely test assembly configuration issues; exact, regex, and assembly filter misses keep the plain no-tests message.
 
 ## Usage
 
@@ -58,7 +58,11 @@ uloop run-tests --filter-type regex --filter-value ".*Integration.*"
 
 Returns JSON with:
 - `Success` (boolean): Whether all tests passed
+- `Status` (string): Machine-readable execution status such as `Passed`, `Failed`, `NoTestsFound`, or `ExecutionFailed`
+- `HasFailures` (boolean): Whether any discovered test failed
 - `Message` (string): Summary message
+- `NoTestsFound` (boolean): Whether Unity Test Runner discovered zero matching tests
+- `NoTestsFoundExplanation` (string): Agent-facing explanation when `NoTestsFound` is true; empty otherwise
 - `CompletedAt` (string): ISO timestamp when the run finished
 - `TestCount` (number): Total tests executed
 - `PassedCount` (number): Passed tests

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -12,7 +12,7 @@ Before running `uloop run-tests`, run `uloop compile` for the same Unity project
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
-When an unfiltered `--filter-type all` run returns `TestCount: 0` and `Message` says no tests were found, read the `Message` for asmdef hints. `run-tests` only appends those hints when it detects likely test assembly configuration issues; exact, regex, and assembly filter misses keep the plain no-tests message.
+When a run returns `Status: "NoTestsFound"` or `NoTestsFound: true`, no matching tests were discovered. This is not the same as a failed test case: `HasFailures` remains `false`, `FailedCount` remains `0`, and `NoTestsFoundExplanation` explains the zero-discovery state for agents. When an unfiltered `--filter-type all` run also has `Message` set to the no-tests message, read the `Message` for asmdef hints. `run-tests` only appends those hints when it detects likely test assembly configuration issues; exact, regex, and assembly filter misses keep the plain no-tests message.
 
 ## Usage
 
@@ -58,7 +58,11 @@ uloop run-tests --filter-type regex --filter-value ".*Integration.*"
 
 Returns JSON with:
 - `Success` (boolean): Whether all tests passed
+- `Status` (string): Machine-readable execution status such as `Passed`, `Failed`, `NoTestsFound`, or `ExecutionFailed`
+- `HasFailures` (boolean): Whether any discovered test failed
 - `Message` (string): Summary message
+- `NoTestsFound` (boolean): Whether Unity Test Runner discovered zero matching tests
+- `NoTestsFoundExplanation` (string): Agent-facing explanation when `NoTestsFound` is true; empty otherwise
 - `CompletedAt` (string): ISO timestamp when the run finished
 - `TestCount` (number): Total tests executed
 - `PassedCount` (number): Passed tests

--- a/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
@@ -125,12 +125,62 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             SerializableTestResult result = SerializableTestResultConverter.FromTestResult(null);
 
             Assert.That(result.success, Is.False);
+            Assert.That(result.status, Is.EqualTo(RunTestsExecutionStatus.ExecutionFailed));
+            Assert.That(result.hasFailures, Is.False);
+            Assert.That(result.noTestsFound, Is.False);
+            Assert.That(result.noTestsFoundExplanation, Is.Empty);
             Assert.That(result.message, Is.EqualTo("Test execution failed: no test result was produced"));
             Assert.That(result.testCount, Is.EqualTo(0));
             Assert.That(result.passedCount, Is.EqualTo(0));
             Assert.That(result.failedCount, Is.EqualTo(0));
             Assert.That(result.skippedCount, Is.EqualTo(0));
             Assert.That(result.xmlPath, Is.Null);
+        }
+
+        [Test]
+        public void FromTestResult_WhenNoTestsWereDiscovered_ReturnsNoTestsFoundState()
+        {
+            // Verifies that zero discovered tests are reported separately from failed tests.
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Passed,
+                0.1,
+                new List<ITestResultAdaptor>());
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.success, Is.False);
+            Assert.That(result.status, Is.EqualTo(RunTestsExecutionStatus.NoTestsFound));
+            Assert.That(result.hasFailures, Is.False);
+            Assert.That(result.noTestsFound, Is.True);
+            Assert.That(result.noTestsFoundExplanation, Does.Contain("not a test failure"));
+            Assert.That(result.message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+            Assert.That(result.testCount, Is.EqualTo(0));
+            Assert.That(result.failedCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void FromTestResult_WhenAChildTestFails_ReturnsFailureState()
+        {
+            // Verifies that real failed tests are marked independently from command success.
+            ITestResultAdaptor resultAdaptor = CreateTestSuite(
+                "RootSuite",
+                TestResultStatus.Failed,
+                0.1,
+                new List<ITestResultAdaptor>
+                {
+                    CreateTestCase("FailingTest", TestResultStatus.Failed, 0.1)
+                });
+
+            SerializableTestResult result = SerializableTestResultConverter.FromTestResult(resultAdaptor);
+
+            Assert.That(result.success, Is.False);
+            Assert.That(result.status, Is.EqualTo(RunTestsExecutionStatus.Failed));
+            Assert.That(result.hasFailures, Is.True);
+            Assert.That(result.noTestsFound, Is.False);
+            Assert.That(result.noTestsFoundExplanation, Is.Empty);
+            Assert.That(result.testCount, Is.EqualTo(1));
+            Assert.That(result.failedCount, Is.EqualTo(1));
         }
 
         [Test]

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -102,5 +102,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.SkippedCount, Is.EqualTo(0));
             Assert.That(response.XmlPath, Is.Null);
         }
+
+        [Test]
+        public void Constructor_WhenLegacySuccessfulCallerOmitsStatus_ShouldDerivePassedStatus()
+        {
+            // Verifies source-compatible constructor calls cannot report success as execution failure.
+            RunTestsResponse response = new(
+                success: true,
+                message: "Test execution completed with status: Passed",
+                completedAt: "2026-01-01T00:00:00.0000000Z",
+                testCount: 1,
+                passedCount: 1,
+                failedCount: 0,
+                skippedCount: 0);
+
+            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.Passed));
+            Assert.That(response.HasFailures, Is.False);
+            Assert.That(response.NoTestsFound, Is.False);
+            Assert.That(response.NoTestsFoundExplanation, Is.Empty);
+        }
+
+        [Test]
+        public void Constructor_WhenLegacyNoTestsCallerOmitsStatus_ShouldDeriveNoTestsFoundStatus()
+        {
+            // Verifies source-compatible zero-discovery responses remain distinct from execution failures.
+            RunTestsResponse response = new(
+                success: false,
+                message: RunTestsResponse.NoTestsFoundMessage,
+                completedAt: "2026-01-01T00:00:00.0000000Z",
+                testCount: 0,
+                passedCount: 0,
+                failedCount: 0,
+                skippedCount: 0);
+
+            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.NoTestsFound));
+            Assert.That(response.HasFailures, Is.False);
+            Assert.That(response.NoTestsFound, Is.True);
+            Assert.That(response.NoTestsFoundExplanation, Does.Contain("not a test failure"));
+        }
     }
 } 

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -90,6 +90,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RunTestsResponse response = RunTestsResponse.CreateTestFrameworkUnavailable();
 
             Assert.That(response.Success, Is.False);
+            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.ExecutionFailed));
+            Assert.That(response.HasFailures, Is.False);
+            Assert.That(response.NoTestsFound, Is.False);
+            Assert.That(response.NoTestsFoundExplanation, Is.Empty);
             Assert.That(response.Message, Does.Contain(UnityCliLoopConstants.PACKAGE_NAME_TEST_FRAMEWORK));
             Assert.That(response.CompletedAt, Is.Not.Empty);
             Assert.That(response.TestCount, Is.EqualTo(0));

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -15,6 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public async Task ExecuteAsync_WithInvalidExecutionState_ShouldFailFastWithoutRunningTests()
         {
+            // Verifies validation failures remain command failures without pretending tests failed.
             StubTestExecutionService executionService = new();
             StubTestExecutionStateValidationService validationService = new(
                 ValidationResult.Failure("EditMode tests cannot run during play mode"));
@@ -32,6 +33,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopTestExecutionResult response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.Success, Is.False);
+            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.ExecutionFailed));
+            Assert.That(response.HasFailures, Is.False);
+            Assert.That(response.NoTestsFound, Is.False);
+            Assert.That(response.NoTestsFoundExplanation, Is.Empty);
             Assert.That(response.Message, Is.EqualTo("EditMode tests cannot run during play mode"));
             Assert.That(response.CompletedAt, Is.Not.Empty);
             Assert.That(response.TestCount, Is.EqualTo(0));
@@ -89,6 +94,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public async Task ExecuteAsync_WhenTestFrameworkUnavailable_ShouldFailFastWithoutValidation()
         {
+            // Verifies missing Unity Test Framework is distinct from a failed test suite.
             StubTestExecutionService executionService = new()
             {
                 TestFrameworkAvailable = false
@@ -108,10 +114,61 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopTestExecutionResult response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.Success, Is.False);
+            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.ExecutionFailed));
+            Assert.That(response.HasFailures, Is.False);
+            Assert.That(response.NoTestsFound, Is.False);
+            Assert.That(response.NoTestsFoundExplanation, Is.Empty);
             Assert.That(response.Message, Is.EqualTo(RunTestsResponse.TestFrameworkUnavailableMessage));
             Assert.That(response.TestCount, Is.EqualTo(0));
             Assert.That(executionService.WasCalled, Is.False);
             Assert.That(validationService.WasCalled, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenNoTestsWereFound_ShouldExposeNoTestsFoundState()
+        {
+            // Verifies UseCase responses expose zero-discovery as its own machine-readable state.
+            StubTestExecutionService executionService = new()
+            {
+                NextResult = new SerializableTestResult
+                {
+                    success = false,
+                    status = RunTestsExecutionStatus.NoTestsFound,
+                    hasFailures = false,
+                    noTestsFound = true,
+                    noTestsFoundExplanation = RunTestsResponse.NoTestsFoundExplanationText,
+                    message = RunTestsResponse.NoTestsFoundMessage,
+                    completedAt = "2026-01-01T00:00:00.0000000Z",
+                    testCount = 0,
+                    passedCount = 0,
+                    failedCount = 0,
+                    skippedCount = 0,
+                    xmlPath = null
+                }
+            };
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService
+            );
+            UnityCliLoopTestExecutionRequest parameters = new()
+            {
+                TestMode = UnityCliLoopTestMode.PlayMode,
+                FilterType = TestFilterType.exact,
+                FilterValue = "MissingTest"
+            };
+
+            UnityCliLoopTestExecutionResult response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.NoTestsFound));
+            Assert.That(response.HasFailures, Is.False);
+            Assert.That(response.NoTestsFound, Is.True);
+            Assert.That(response.NoTestsFoundExplanation, Does.Contain("not a test failure"));
+            Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
+            Assert.That(response.TestCount, Is.EqualTo(0));
+            Assert.That(response.FailedCount, Is.EqualTo(0));
         }
 
         /// <summary>
@@ -144,6 +201,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             public bool TestFrameworkAvailable { get; set; } = true;
             public bool WasCalled { get; private set; }
+            public SerializableTestResult NextResult { get; set; } = new();
 
             public override bool IsTestFrameworkAvailable => TestFrameworkAvailable;
 
@@ -151,14 +209,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 ct.ThrowIfCancellationRequested();
                 WasCalled = true;
-                return Task.FromResult(new SerializableTestResult());
+                return Task.FromResult(NextResult);
             }
 
             public override Task<SerializableTestResult> ExecuteEditModeTestAsync(TestExecutionFilter filter, CancellationToken ct)
             {
                 ct.ThrowIfCancellationRequested();
                 WasCalled = true;
-                return Task.FromResult(new SerializableTestResult());
+                return Task.FromResult(NextResult);
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -11,6 +11,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class RunTestsResponse : UnityCliLoopToolResponse
     {
         internal const string NoTestsFoundMessage = "No tests found matching the specified filter criteria";
+        internal const string NoTestsFoundExplanationText =
+            "No tests were discovered for this run. This is not a test failure; check TestMode, FilterType, FilterValue, or test assembly configuration.";
 
         public static readonly string TestFrameworkUnavailableMessage =
             $"run-tests requires the Unity Test Framework package ({UnityCliLoopConstants.PACKAGE_NAME_TEST_FRAMEWORK}). Install it via Package Manager to use test execution.";
@@ -19,6 +21,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Whether test execution was successful
         /// </summary>
         public bool Success { get; set; }
+
+        /// <summary>
+        /// Machine-readable execution status
+        /// </summary>
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Whether any discovered test failed
+        /// </summary>
+        public bool HasFailures { get; set; }
+
+        /// <summary>
+        /// Whether Unity Test Runner discovered zero tests
+        /// </summary>
+        public bool NoTestsFound { get; set; }
+
+        /// <summary>
+        /// Explanation for agents when zero tests are discovered
+        /// </summary>
+        public string NoTestsFoundExplanation { get; set; }
 
         /// <summary>
         /// Test execution message
@@ -59,9 +81,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Create a new RunTestsResponse
         /// </summary>
         public RunTestsResponse(bool success, string message, string completedAt, int testCount, 
-                               int passedCount, int failedCount, int skippedCount, string xmlPath = null)
+                               int passedCount, int failedCount, int skippedCount, string xmlPath = null,
+                               string status = RunTestsExecutionStatus.ExecutionFailed,
+                               bool hasFailures = false,
+                               bool noTestsFound = false,
+                               string noTestsFoundExplanation = "")
         {
             Success = success;
+            Status = status;
+            HasFailures = hasFailures;
+            NoTestsFound = noTestsFound;
+            NoTestsFoundExplanation = noTestsFoundExplanation;
             Message = message;
             CompletedAt = completedAt;
             TestCount = testCount;
@@ -77,6 +107,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public RunTestsResponse()
         {
             Message = string.Empty;
+            Status = string.Empty;
+            NoTestsFoundExplanation = string.Empty;
             CompletedAt = string.Empty;
             XmlPath = string.Empty;
         }
@@ -91,7 +123,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 passedCount: 0,
                 failedCount: 0,
                 skippedCount: 0,
-                xmlPath: null);
+                xmlPath: null,
+                status: RunTestsExecutionStatus.ExecutionFailed,
+                hasFailures: false,
+                noTestsFound: false,
+                noTestsFoundExplanation: string.Empty);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -82,16 +82,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public RunTestsResponse(bool success, string message, string completedAt, int testCount, 
                                int passedCount, int failedCount, int skippedCount, string xmlPath = null,
-                               string status = RunTestsExecutionStatus.ExecutionFailed,
-                               bool hasFailures = false,
-                               bool noTestsFound = false,
-                               string noTestsFoundExplanation = "")
+                               string status = null,
+                               bool? hasFailures = null,
+                               bool? noTestsFound = null,
+                               string noTestsFoundExplanation = null)
         {
             Success = success;
-            Status = status;
-            HasFailures = hasFailures;
-            NoTestsFound = noTestsFound;
-            NoTestsFoundExplanation = noTestsFoundExplanation;
             Message = message;
             CompletedAt = completedAt;
             TestCount = testCount;
@@ -99,6 +95,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             FailedCount = failedCount;
             SkippedCount = skippedCount;
             XmlPath = xmlPath;
+            HasFailures = hasFailures ?? failedCount > 0;
+            NoTestsFound = noTestsFound ?? IsNoTestsFound(success, message, testCount, failedCount);
+            Status = string.IsNullOrEmpty(status)
+                ? DeriveStatus(success, testCount, FailedCount, NoTestsFound)
+                : status;
+            NoTestsFoundExplanation = noTestsFoundExplanation ?? DeriveNoTestsFoundExplanation(NoTestsFound);
         }
 
         /// <summary>
@@ -128,6 +130,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 hasFailures: false,
                 noTestsFound: false,
                 noTestsFoundExplanation: string.Empty);
+        }
+
+        private static bool IsNoTestsFound(bool success, string message, int testCount, int failedCount)
+        {
+            return !success
+                   && testCount == 0
+                   && failedCount == 0
+                   && string.Equals(message, NoTestsFoundMessage, StringComparison.Ordinal);
+        }
+
+        private static string DeriveStatus(bool success, int testCount, int failedCount, bool noTestsFound)
+        {
+            if (noTestsFound)
+            {
+                return RunTestsExecutionStatus.NoTestsFound;
+            }
+
+            if (failedCount > 0)
+            {
+                return RunTestsExecutionStatus.Failed;
+            }
+
+            if (success && testCount > 0)
+            {
+                return RunTestsExecutionStatus.Passed;
+            }
+
+            return RunTestsExecutionStatus.ExecutionFailed;
+        }
+
+        private static string DeriveNoTestsFoundExplanation(bool noTestsFound)
+        {
+            return noTestsFound ? NoTestsFoundExplanationText : string.Empty;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTool.cs
@@ -51,7 +51,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 passedCount: result.PassedCount,
                 failedCount: result.FailedCount,
                 skippedCount: result.SkippedCount,
-                xmlPath: result.XmlPath);
+                xmlPath: result.XmlPath,
+                status: result.Status,
+                hasFailures: result.HasFailures,
+                noTestsFound: result.NoTestsFound,
+                noTestsFoundExplanation: result.NoTestsFoundExplanation);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -111,6 +111,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityCliLoopTestExecutionResult response = new UnityCliLoopTestExecutionResult
             {
                 Success = result.success,
+                Status = result.status,
+                HasFailures = result.hasFailures,
+                NoTestsFound = result.noTestsFound,
+                NoTestsFoundExplanation = result.noTestsFoundExplanation,
                 Message = result.message,
                 CompletedAt = result.completedAt,
                 TestCount = result.testCount,
@@ -150,6 +154,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new UnityCliLoopTestExecutionResult
             {
                 Success = false,
+                Status = RunTestsExecutionStatus.ExecutionFailed,
+                HasFailures = false,
+                NoTestsFound = false,
+                NoTestsFoundExplanation = string.Empty,
                 Message = message,
                 CompletedAt = DateTime.UtcNow.ToString("o"),
                 TestCount = 0,

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -12,7 +12,7 @@ Before running `uloop run-tests`, run `uloop compile` for the same Unity project
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
-When an unfiltered `--filter-type all` run returns `TestCount: 0` and `Message` says no tests were found, read the `Message` for asmdef hints. `run-tests` only appends those hints when it detects likely test assembly configuration issues; exact, regex, and assembly filter misses keep the plain no-tests message.
+When a run returns `Status: "NoTestsFound"` or `NoTestsFound: true`, no matching tests were discovered. This is not the same as a failed test case: `HasFailures` remains `false`, `FailedCount` remains `0`, and `NoTestsFoundExplanation` explains the zero-discovery state for agents. When an unfiltered `--filter-type all` run also has `Message` set to the no-tests message, read the `Message` for asmdef hints. `run-tests` only appends those hints when it detects likely test assembly configuration issues; exact, regex, and assembly filter misses keep the plain no-tests message.
 
 ## Usage
 
@@ -58,7 +58,11 @@ uloop run-tests --filter-type regex --filter-value ".*Integration.*"
 
 Returns JSON with:
 - `Success` (boolean): Whether all tests passed
+- `Status` (string): Machine-readable execution status such as `Passed`, `Failed`, `NoTestsFound`, or `ExecutionFailed`
+- `HasFailures` (boolean): Whether any discovered test failed
 - `Message` (string): Summary message
+- `NoTestsFound` (boolean): Whether Unity Test Runner discovered zero matching tests
+- `NoTestsFoundExplanation` (string): Agent-facing explanation when `NoTestsFound` is true; empty otherwise
 - `CompletedAt` (string): ISO timestamp when the run finished
 - `TestCount` (number): Total tests executed
 - `PassedCount` (number): Passed tests

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/SerializableTestResultConverter.cs
@@ -17,6 +17,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return new SerializableTestResult
                 {
                     success = false,
+                    status = RunTestsExecutionStatus.ExecutionFailed,
+                    hasFailures = false,
+                    noTestsFound = false,
+                    noTestsFoundExplanation = string.Empty,
                     message = "Test execution failed: no test result was produced",
                     completedAt = DateTime.UtcNow.ToString("o"),
                     testCount = 0,
@@ -31,12 +35,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int passedTests = CountPassedTests(result);
             int failedTests = CountFailedTests(result);
             int skippedTests = CountSkippedTests(result);
+            bool noTestsFound = totalTests == 0;
+            bool hasFailures = failedTests > 0;
             bool success = totalTests > 0 && result.TestStatus == TestStatus.Passed;
             string message = CreateMessage(result, totalTests);
+            string status = CreateStatus(result, noTestsFound, hasFailures);
+            string noTestsFoundExplanation = noTestsFound
+                ? RunTestsResponse.NoTestsFoundExplanationText
+                : string.Empty;
 
             return new SerializableTestResult
             {
                 success = success,
+                status = status,
+                hasFailures = hasFailures,
+                noTestsFound = noTestsFound,
+                noTestsFoundExplanation = noTestsFoundExplanation,
                 message = message,
                 completedAt = DateTime.UtcNow.ToString("o"),
                 testCount = totalTests,
@@ -45,6 +59,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 skippedCount = skippedTests,
                 xmlPath = null
             };
+        }
+
+        private static string CreateStatus(ITestResultAdaptor result, bool noTestsFound, bool hasFailures)
+        {
+            if (noTestsFound)
+            {
+                return RunTestsExecutionStatus.NoTestsFound;
+            }
+
+            if (hasFailures)
+            {
+                return RunTestsExecutionStatus.Failed;
+            }
+
+            if (result.TestStatus == TestStatus.Passed)
+            {
+                return RunTestsExecutionStatus.Passed;
+            }
+
+            return result.TestStatus.ToString();
         }
 
         private static string CreateMessage(ITestResultAdaptor result, int totalTests)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/SerializableTestResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestRunner/SerializableTestResult.cs
@@ -10,6 +10,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class SerializableTestResult
     {
         [SerializeField] public bool success;
+        [SerializeField] public string status;
+        [SerializeField] public bool hasFailures;
+        [SerializeField] public bool noTestsFound;
+        [SerializeField] public string noTestsFoundExplanation;
         [SerializeField] public string message;
         [SerializeField] public string completedAt;
         [SerializeField] public int testCount;
@@ -23,6 +27,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new SerializableTestResult
             {
                 success = false,
+                status = RunTestsExecutionStatus.ExecutionFailed,
+                hasFailures = false,
+                noTestsFound = false,
+                noTestsFoundExplanation = string.Empty,
                 message = RunTestsResponse.TestFrameworkUnavailableMessage,
                 completedAt = DateTime.UtcNow.ToString("o"),
                 testCount = 0,

--- a/Packages/src/Editor/FirstPartyTools/RunTests/UnityCliLoopTestExecutionTypes.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/UnityCliLoopTestExecutionTypes.cs
@@ -26,6 +26,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
+    /// Defines machine-readable run-tests result states returned to CLI callers.
+    /// </summary>
+    internal static class RunTestsExecutionStatus
+    {
+        public const string Passed = "Passed";
+        public const string Failed = "Failed";
+        public const string NoTestsFound = "NoTestsFound";
+        public const string ExecutionFailed = "ExecutionFailed";
+    }
+
+    /// <summary>
     /// Carries the request data needed for Unity CLI Loop Test Execution behavior.
     /// </summary>
     public sealed class UnityCliLoopTestExecutionRequest
@@ -42,6 +53,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public sealed class UnityCliLoopTestExecutionResult
     {
         public bool Success { get; set; }
+        public string Status { get; set; } = "";
+        public bool HasFailures { get; set; }
+        public bool NoTestsFound { get; set; }
+        public string NoTestsFoundExplanation { get; set; } = "";
         public string Message { get; set; } = "";
         public string CompletedAt { get; set; } = "";
         public int TestCount { get; set; }


### PR DESCRIPTION
## Summary
- `run-tests` now reports zero discovered tests as an explicit `NoTestsFound` status.
- The response separates test failures from zero-test discovery with `HasFailures`, `TestCount`, and `NoTestsFound` fields.

## User Impact
- Agents no longer need to infer whether `Success: false` means failed tests or no matching tests were discovered.
- A zero-test run now returns `HasFailures: false`, `TestCount: 0`, `NoTestsFound: true`, and an explanation that it is not a test failure.

## Changes
- Added machine-readable run-tests status fields to the response path.
- Classified Unity Test Runner zero-discovery results as `NoTestsFound`.
- Updated run-tests skill guidance and focused coverage for zero-test, failed-test, and execution-failure cases.

## Verification
- `./cli/dist/windows-amd64/uloop.exe compile --project-path <PROJECT_ROOT>`
- `./cli/dist/windows-amd64/uloop.exe run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value .*RunTests.*`
- `./cli/dist/windows-amd64/uloop.exe run-tests --project-path <PROJECT_ROOT> --test-mode PlayMode --filter-type exact --filter-value __NoSuchRunTestsNoTestsFoundProbe__`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

