### PR TITLE
fix: Setup now installs CLI releases that match the required protocol

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -39,6 +39,6 @@ reviews:
 
         The compatibility gate is an exact protocol match, not a release-semver range. If a change makes a CLI/package from the previous protocol generation unable to interoperate, require both `cli/contract.json` `protocolVersion` and `CliConstants.REQUIRED_CLI_PROTOCOL_VERSION` to be incremented in the same PR.
 
-        Do not request a protocol bump for ordinary CLI features, bug fixes, UI changes, documentation, or additive wire-format changes that older counterparts can safely ignore. `cliVersion`, `default-tools.json` `version`, and `CliConstants.MINIMUM_REQUIRED_CLI_VERSION` are release/install concerns and must not be hand-edited to keep up with feature PRs.
+        Do not request a protocol bump for ordinary CLI features, bug fixes, UI changes, documentation, or additive wire-format changes that older counterparts can safely ignore. `cliVersion` and `default-tools.json` `version` are release-please managed release metadata. If a PR bumps `CliConstants.REQUIRED_CLI_PROTOCOL_VERSION`, require a matching update to `CliConstants.MINIMUM_REQUIRED_CLI_VERSION` after the corresponding published CLI release tag is available, because setup must install a CLI release that advertises the required protocol.
 chat:
   auto_reply: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,6 +36,7 @@ jobs:
           scripts/test-resolve-native-cli-release-target.sh
           scripts/test-is-release-please-release-commit.sh
           scripts/test-release-please-config.sh
+          scripts/test-protocol-minimum-version-workflow.sh
           scripts/test-mark-release-pr-tagged.sh
           scripts/test-sync-published-release-pr-labels.sh
           scripts/test-sync-release-please-package-releases.sh
@@ -47,6 +48,11 @@ jobs:
         if: github.event_name == 'pull_request'
         working-directory: cli
         run: go run ./cmd/check-ipc-protocol-reminder --base "origin/${{ github.base_ref }}" --head HEAD
+
+      - name: Check protocol minimum version bump
+        if: github.event_name == 'pull_request'
+        working-directory: cli
+        run: go run ./cmd/check-protocol-minimum-version --base "origin/${{ github.base_ref }}" --head HEAD
 
       - name: Install golangci-lint
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Check protocol minimum version bump
         if: github.event_name == 'pull_request'
         working-directory: cli
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: go run ./cmd/check-protocol-minimum-version --base "origin/${{ github.base_ref }}" --head HEAD
 
       - name: Install golangci-lint

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -72,7 +72,7 @@ jobs:
           scripts/resolve-native-cli-release-target.sh >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        if: steps.release.outputs.publish == 'true'
+        if: steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: cli/.go-version

--- a/.github/workflows/protocol-minimum-version-warning.yml
+++ b/.github/workflows/protocol-minimum-version-warning.yml
@@ -1,0 +1,39 @@
+name: Protocol Minimum Version Warning
+
+on:
+  pull_request_target:
+    branches: [main, v3-beta]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: cli/.go-version
+          cache: false
+
+      - name: Fetch pull request head
+        run: git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:protocol-minimum-version-pr-head"
+
+      - name: Comment on protocol minimum version guard
+        working-directory: cli
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PROTOCOL_MINIMUM_VERSION_BASE_REF: origin/${{ github.base_ref }}
+          PROTOCOL_MINIMUM_VERSION_HEAD_REF: protocol-minimum-version-pr-head
+        run: go run ./cmd/comment-protocol-minimum-version

--- a/.github/workflows/protocol-minimum-version-warning.yml
+++ b/.github/workflows/protocol-minimum-version-warning.yml
@@ -25,8 +25,8 @@ jobs:
           go-version-file: cli/.go-version
           cache: false
 
-      - name: Fetch pull request head
-        run: git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:protocol-minimum-version-pr-head"
+      - name: Fetch pull request merge
+        run: git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/merge:protocol-minimum-version-pr-merge"
 
       - name: Comment on protocol minimum version guard
         working-directory: cli
@@ -35,5 +35,5 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PROTOCOL_MINIMUM_VERSION_BASE_REF: origin/${{ github.base_ref }}
-          PROTOCOL_MINIMUM_VERSION_HEAD_REF: protocol-minimum-version-pr-head
+          PROTOCOL_MINIMUM_VERSION_HEAD_REF: protocol-minimum-version-pr-merge
         run: go run ./cmd/comment-protocol-minimum-version

--- a/.github/workflows/protocol-minimum-version-warning.yml
+++ b/.github/workflows/protocol-minimum-version-warning.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,6 +71,12 @@ jobs:
         run: |
           test -f Packages/src/package.json && echo "✅ Unity package.json OK"
 
+      - name: Setup Go for package release sync
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: cli/.go-version
+          cache-dependency-path: cli/**/go.sum
+
       - name: 🏷️ Sync release-please package releases
         id: package_release_sync
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,13 @@ Do not touch the protocol version to "keep up with releases":
 - `cli/contract.json` `cliVersion` and `cli/internal/tools/default-tools.json` `version` are
   stamped by release-please only. Never edit them by hand in a feature PR.
 - `CliConstants.MINIMUM_REQUIRED_CLI_VERSION` is the release that setup installs. It must always
-  point at a published CLI release, so it advances after a release, never inside a feature PR.
-- Runtime protocol mismatch guidance must not pin updates to `MINIMUM_REQUIRED_CLI_VERSION`; that
-  value may be older than the protocol the package now requires. Use the unpinned CLI update path
-  for older clients and tell newer clients to align the package and CLI releases.
+  point at a published CLI release.
+- When a protocol bump changes `CliConstants.REQUIRED_CLI_PROTOCOL_VERSION`, prepare the matching
+  CLI release tag first, then update `CliConstants.MINIMUM_REQUIRED_CLI_VERSION` in the same PR.
+  PR CI fails, and the PR warning comment stays open, until the minimum CLI release advances to a
+  published CLI release that advertises the required protocol.
+- Runtime protocol mismatch guidance must use the unpinned CLI update path for older clients and
+  tell newer clients to align the package and CLI releases.
 
 ## Generated Skill Files
 

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -12,7 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const int REQUIRED_CLI_PROTOCOL_VERSION = 2;
         // Why: setup installs this pinned release; it must always point at a published CLI
         // release, so it advances after releases, never inside feature PRs.
-        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.32";
+        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.33";
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         public const string VERSION_FLAG = "--version";
         public const string SHORT_VERSION_FLAG = "-v";

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -10,8 +10,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         // Bump it together with cli/contract.json protocolVersion only when this package can
         // no longer interoperate with a different CLI protocol generation.
         public const int REQUIRED_CLI_PROTOCOL_VERSION = 2;
-        // Why: setup installs this pinned release; it must always point at a published CLI
-        // release, so it advances after releases, never inside feature PRs.
+        // Why: setup installs this pinned release; protocol bump PRs can advance it only after
+        // the matching CLI tag is published.
         public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.33";
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         public const string VERSION_FLAG = "--version";

--- a/cli/cmd/check-protocol-minimum-version/main.go
+++ b/cli/cmd/check-protocol-minimum-version/main.go
@@ -11,14 +11,16 @@ import (
 func main() {
 	baseRef := flag.String("base", "", "base git ref to compare from")
 	headRef := flag.String("head", "HEAD", "head git ref to compare to")
-	verifyRelease := flag.Bool("verify-release", false, "verify the minimum CLI release tag advertises the required protocol")
+	verifyRelease := flag.Bool("verify-release", false, "verify the minimum CLI release is published and advertises the required protocol")
+	verifyReleaseRef := flag.String("ref", "", "git ref to read the minimum CLI release requirement from when --verify-release is set")
 	flag.Parse()
 
 	if *verifyRelease {
 		os.Exit(automation.RunMinimumCliReleaseProtocolCheck(
 			context.Background(),
 			os.Stdout,
-			os.Stderr))
+			os.Stderr,
+			*verifyReleaseRef))
 	}
 
 	os.Exit(automation.RunProtocolMinimumVersionGuard(

--- a/cli/cmd/check-protocol-minimum-version/main.go
+++ b/cli/cmd/check-protocol-minimum-version/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/cli/internal/automation"
+)
+
+func main() {
+	baseRef := flag.String("base", "", "base git ref to compare from")
+	headRef := flag.String("head", "HEAD", "head git ref to compare to")
+	verifyRelease := flag.Bool("verify-release", false, "verify the minimum CLI release tag advertises the required protocol")
+	flag.Parse()
+
+	if *verifyRelease {
+		os.Exit(automation.RunMinimumCliReleaseProtocolCheck(
+			context.Background(),
+			os.Stdout,
+			os.Stderr))
+	}
+
+	os.Exit(automation.RunProtocolMinimumVersionGuard(
+		context.Background(),
+		os.Stdout,
+		os.Stderr,
+		automation.ProtocolMinimumVersionGuardConfig{
+			BaseRef: *baseRef,
+			HeadRef: *headRef,
+		}))
+}

--- a/cli/cmd/comment-protocol-minimum-version/main.go
+++ b/cli/cmd/comment-protocol-minimum-version/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/cli/internal/automation"
+)
+
+func main() {
+	os.Exit(automation.RunProtocolMinimumVersionComment(
+		context.Background(),
+		os.Stdout,
+		os.Stderr))
+}

--- a/cli/internal/automation/protocol_minimum_version_comment.go
+++ b/cli/internal/automation/protocol_minimum_version_comment.go
@@ -1,0 +1,236 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+type protocolMinimumVersionCommentConfig struct {
+	repositoryRoot string
+	pullRequest    string
+	repository     string
+	baseRef        string
+	headRef        string
+}
+
+func RunProtocolMinimumVersionComment(ctx context.Context, stdout io.Writer, stderr io.Writer) int {
+	config, err := protocolMinimumVersionCommentConfigFromEnvironment()
+	if err != nil {
+		writeProtocolMinimumVersionLine(stderr, err)
+		return 1
+	}
+	if config.pullRequest == "" {
+		writeProtocolMinimumVersionLine(stdout, "Skipping protocol minimum version comment because no PR number was provided.")
+		return 0
+	}
+	if config.baseRef == "" {
+		writeProtocolMinimumVersionLine(stdout, "Skipping protocol minimum version comment because no base ref was provided.")
+		return 0
+	}
+
+	result, err := AnalyzeProtocolMinimumVersionGuardForRefs(ctx, ProtocolMinimumVersionGuardConfig{
+		BaseRef: config.baseRef,
+		HeadRef: config.headRef,
+	})
+	if err != nil {
+		writeProtocolMinimumVersionLine(stderr, err)
+		return 1
+	}
+
+	repository, err := resolveProtocolMinimumVersionRepository(ctx, config)
+	if err != nil {
+		writeProtocolMinimumVersionLine(stderr, err)
+		return 1
+	}
+	config.repository = repository
+
+	if result.NeedsMinimumVersionUpdate {
+		message, err := upsertProtocolMinimumVersionComment(ctx, config, FormatProtocolMinimumVersionWarning(result))
+		if err != nil {
+			writeProtocolMinimumVersionLine(stderr, err)
+			return 1
+		}
+		writeProtocolMinimumVersionLine(stdout, message)
+		return 0
+	}
+
+	deleted, err := deleteProtocolMinimumVersionComment(ctx, config)
+	if err != nil {
+		writeProtocolMinimumVersionLine(stderr, err)
+		return 1
+	}
+	if deleted {
+		writeProtocolMinimumVersionLine(stdout, "Deleted resolved protocol minimum version comment.")
+	}
+	return 0
+}
+
+func protocolMinimumVersionCommentConfigFromEnvironment() (protocolMinimumVersionCommentConfig, error) {
+	repositoryRoot := os.Getenv("ULOOP_REPOSITORY_ROOT")
+	if repositoryRoot == "" {
+		workingDirectory, err := os.Getwd()
+		if err != nil {
+			return protocolMinimumVersionCommentConfig{}, fmt.Errorf("failed to resolve repository root: %w", err)
+		}
+		repositoryRoot = workingDirectory
+	}
+
+	baseRef := os.Getenv("PROTOCOL_MINIMUM_VERSION_BASE_REF")
+	if baseRef == "" && os.Getenv("GITHUB_BASE_REF") != "" {
+		baseRef = "origin/" + os.Getenv("GITHUB_BASE_REF")
+	}
+
+	headRef := os.Getenv("PROTOCOL_MINIMUM_VERSION_HEAD_REF")
+	if headRef == "" {
+		headRef = "HEAD"
+	}
+
+	return protocolMinimumVersionCommentConfig{
+		repositoryRoot: repositoryRoot,
+		pullRequest:    os.Getenv("PR_NUMBER"),
+		repository:     os.Getenv("GITHUB_REPOSITORY"),
+		baseRef:        baseRef,
+		headRef:        headRef,
+	}, nil
+}
+
+func resolveProtocolMinimumVersionRepository(
+	ctx context.Context,
+	config protocolMinimumVersionCommentConfig,
+) (string, error) {
+	if config.repository != "" {
+		return config.repository, nil
+	}
+	output, err := runProtocolMinimumVersionOutput(
+		ctx,
+		config.repositoryRoot,
+		"gh",
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"--jq",
+		".nameWithOwner")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+func upsertProtocolMinimumVersionComment(
+	ctx context.Context,
+	config protocolMinimumVersionCommentConfig,
+	body string,
+) (string, error) {
+	commentID, err := existingProtocolMinimumVersionComment(ctx, config)
+	if err != nil {
+		return "", err
+	}
+
+	bodyFile, cleanup, err := writeProtocolMinimumVersionBodyFile(body)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	if commentID != "" {
+		_, err = runProtocolMinimumVersionOutput(
+			ctx,
+			config.repositoryRoot,
+			"gh",
+			"api",
+			"--method",
+			"PATCH",
+			"repos/"+config.repository+"/issues/comments/"+commentID,
+			"--input",
+			bodyFile)
+		return "Updated protocol minimum version comment.", err
+	}
+
+	_, err = runProtocolMinimumVersionOutput(
+		ctx,
+		config.repositoryRoot,
+		"gh",
+		"api",
+		"--method",
+		"POST",
+		"repos/"+config.repository+"/issues/"+config.pullRequest+"/comments",
+		"--input",
+		bodyFile)
+	return "Posted protocol minimum version comment.", err
+}
+
+func deleteProtocolMinimumVersionComment(
+	ctx context.Context,
+	config protocolMinimumVersionCommentConfig,
+) (bool, error) {
+	commentID, err := existingProtocolMinimumVersionComment(ctx, config)
+	if err != nil {
+		return false, err
+	}
+	if commentID == "" {
+		return false, nil
+	}
+
+	_, err = runProtocolMinimumVersionOutput(
+		ctx,
+		config.repositoryRoot,
+		"gh",
+		"api",
+		"--method",
+		"DELETE",
+		"repos/"+config.repository+"/issues/comments/"+commentID)
+	return err == nil, err
+}
+
+func existingProtocolMinimumVersionComment(
+	ctx context.Context,
+	config protocolMinimumVersionCommentConfig,
+) (string, error) {
+	output, err := runProtocolMinimumVersionOutput(
+		ctx,
+		config.repositoryRoot,
+		"gh",
+		"api",
+		"--paginate",
+		"repos/"+config.repository+"/issues/"+config.pullRequest+"/comments",
+		"--jq",
+		".[] | select(.body | contains(\""+protocolMinimumVersionMarker+"\")) | .id")
+	if err != nil {
+		return "", err
+	}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for index := len(lines) - 1; index >= 0; index-- {
+		line := strings.TrimSpace(lines[index])
+		if line != "" {
+			return line, nil
+		}
+	}
+	return "", nil
+}
+
+func writeProtocolMinimumVersionBodyFile(body string) (string, func(), error) {
+	bodyFile, err := os.CreateTemp("", "uloop-protocol-minimum-version-warning-*.json")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("failed to create comment body file: %w", err)
+	}
+	cleanup := func() { _ = os.Remove(bodyFile.Name()) }
+
+	err = json.NewEncoder(bodyFile).Encode(struct {
+		Body string `json:"body"`
+	}{Body: body})
+	closeErr := bodyFile.Close()
+	if err != nil || closeErr != nil {
+		cleanup()
+		if err != nil {
+			return "", func() {}, fmt.Errorf("failed to encode comment body: %w", err)
+		}
+		return "", func() {}, fmt.Errorf("failed to close comment body file: %w", closeErr)
+	}
+	return bodyFile.Name(), cleanup, nil
+}

--- a/cli/internal/automation/protocol_minimum_version_comment.go
+++ b/cli/internal/automation/protocol_minimum_version_comment.go
@@ -9,12 +9,15 @@ import (
 	"strings"
 )
 
+const protocolMinimumVersionCommentAuthor = "github-actions[bot]"
+
 type protocolMinimumVersionCommentConfig struct {
 	repositoryRoot string
 	pullRequest    string
 	repository     string
 	baseRef        string
 	headRef        string
+	commentAuthor  string
 }
 
 func RunProtocolMinimumVersionComment(ctx context.Context, stdout io.Writer, stderr io.Writer) int {
@@ -89,12 +92,18 @@ func protocolMinimumVersionCommentConfigFromEnvironment() (protocolMinimumVersio
 		headRef = "HEAD"
 	}
 
+	commentAuthor := os.Getenv("PROTOCOL_MINIMUM_VERSION_COMMENT_AUTHOR")
+	if commentAuthor == "" {
+		commentAuthor = protocolMinimumVersionCommentAuthor
+	}
+
 	return protocolMinimumVersionCommentConfig{
 		repositoryRoot: repositoryRoot,
 		pullRequest:    os.Getenv("PR_NUMBER"),
 		repository:     os.Getenv("GITHUB_REPOSITORY"),
 		baseRef:        baseRef,
 		headRef:        headRef,
+		commentAuthor:  commentAuthor,
 	}, nil
 }
 
@@ -191,6 +200,12 @@ func existingProtocolMinimumVersionComment(
 	ctx context.Context,
 	config protocolMinimumVersionCommentConfig,
 ) (string, error) {
+	jqFilter := ".[] | select(.user.login == " +
+		protocolMinimumVersionJQString(config.commentAuthor) +
+		" and (.body | contains(" +
+		protocolMinimumVersionJQString(protocolMinimumVersionMarker) +
+		"))) | .id"
+
 	output, err := runProtocolMinimumVersionOutput(
 		ctx,
 		config.repositoryRoot,
@@ -199,7 +214,7 @@ func existingProtocolMinimumVersionComment(
 		"--paginate",
 		"repos/"+config.repository+"/issues/"+config.pullRequest+"/comments",
 		"--jq",
-		".[] | select(.body | contains(\""+protocolMinimumVersionMarker+"\")) | .id")
+		jqFilter)
 	if err != nil {
 		return "", err
 	}
@@ -212,6 +227,11 @@ func existingProtocolMinimumVersionComment(
 		}
 	}
 	return "", nil
+}
+
+func protocolMinimumVersionJQString(value string) string {
+	encodedValue, _ := json.Marshal(value)
+	return string(encodedValue)
 }
 
 func writeProtocolMinimumVersionBodyFile(body string) (string, func(), error) {

--- a/cli/internal/automation/protocol_minimum_version_comment.go
+++ b/cli/internal/automation/protocol_minimum_version_comment.go
@@ -48,7 +48,7 @@ func RunProtocolMinimumVersionComment(ctx context.Context, stdout io.Writer, std
 	}
 	config.repository = repository
 
-	if result.NeedsMinimumVersionUpdate {
+	if protocolMinimumVersionGuardNeedsAction(result) {
 		message, err := upsertProtocolMinimumVersionComment(ctx, config, FormatProtocolMinimumVersionWarning(result))
 		if err != nil {
 			writeProtocolMinimumVersionLine(stderr, err)

--- a/cli/internal/automation/protocol_minimum_version_guard.go
+++ b/cli/internal/automation/protocol_minimum_version_guard.go
@@ -21,8 +21,18 @@ const (
 )
 
 var (
-	requiredProtocolVersionPattern = regexp.MustCompile(`REQUIRED_CLI_PROTOCOL_VERSION\s*=\s*(\d+)`)
-	minimumCliVersionPattern       = regexp.MustCompile(`MINIMUM_REQUIRED_CLI_VERSION\s*=\s*"([^"]+)"`)
+	requiredProtocolVersionPattern  = regexp.MustCompile(`REQUIRED_CLI_PROTOCOL_VERSION\s*=\s*(\d+)`)
+	minimumCliVersionPattern        = regexp.MustCompile(`MINIMUM_REQUIRED_CLI_VERSION\s*=\s*"([^"]+)"`)
+	requiredMinimumCliReleaseAssets = []string{
+		"install.sh",
+		"install.ps1",
+		"uloop-darwin-amd64.tar.gz",
+		"uloop-darwin-amd64.tar.gz.sha256",
+		"uloop-darwin-arm64.tar.gz",
+		"uloop-darwin-arm64.tar.gz.sha256",
+		"uloop-windows-amd64.zip",
+		"uloop-windows-amd64.zip.sha256",
+	}
 )
 
 type ProtocolMinimumVersionGuardConfig struct {
@@ -50,6 +60,16 @@ type minimumCliReleaseContract struct {
 	CliVersion      string `json:"cliVersion"`
 }
 
+type minimumCliReleaseView struct {
+	IsDraft bool                     `json:"isDraft"`
+	Assets  []minimumCliReleaseAsset `json:"assets"`
+}
+
+type minimumCliReleaseAsset struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
 func RunProtocolMinimumVersionGuard(
 	ctx context.Context,
 	stdout io.Writer,
@@ -70,14 +90,14 @@ func RunProtocolMinimumVersionGuard(
 	return 0
 }
 
-func RunMinimumCliReleaseProtocolCheck(ctx context.Context, stdout io.Writer, stderr io.Writer) int {
+func RunMinimumCliReleaseProtocolCheck(ctx context.Context, stdout io.Writer, stderr io.Writer, ref string) int {
 	repoRoot, err := gitRepoRoot(ctx)
 	if err != nil {
 		writeProtocolMinimumVersionLine(stderr, fmt.Sprintf("failed to resolve git repository root: %v", err))
 		return 1
 	}
 
-	content, err := os.ReadFile(filepath.Join(repoRoot, protocolMinimumVersionFile))
+	content, err := minimumCliReleaseProtocolFile(ctx, repoRoot, ref)
 	if err != nil {
 		writeProtocolMinimumVersionLine(stderr, fmt.Sprintf("failed to read %s: %v", protocolMinimumVersionFile, err))
 		return 1
@@ -218,7 +238,65 @@ func verifyMinimumCliReleaseProtocolAtRef(
 	if err != nil {
 		return fmt.Errorf("CLI release %s does not provide cli/contract.json", releaseTag)
 	}
-	return VerifyMinimumCliReleaseProtocol(values, []byte(contractContent))
+	if err := VerifyMinimumCliReleaseProtocol(values, []byte(contractContent)); err != nil {
+		return err
+	}
+	return verifyMinimumCliReleaseIsPublished(ctx, repoRoot, releaseTag)
+}
+
+func minimumCliReleaseProtocolFile(ctx context.Context, repoRoot string, ref string) ([]byte, error) {
+	if ref == "" {
+		return os.ReadFile(filepath.Join(repoRoot, protocolMinimumVersionFile))
+	}
+
+	content, err := protocolMinimumVersionFileAtRef(ctx, repoRoot, ref, protocolMinimumVersionFile)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(content), nil
+}
+
+func verifyMinimumCliReleaseIsPublished(ctx context.Context, repoRoot string, releaseTag string) error {
+	output, err := runProtocolMinimumVersionOutput(
+		ctx,
+		repoRoot,
+		"gh",
+		"release",
+		"view",
+		releaseTag,
+		"--json",
+		"isDraft,assets")
+	if err != nil {
+		return fmt.Errorf("CLI release %s is not published with complete native assets: %w", releaseTag, err)
+	}
+
+	releaseView := minimumCliReleaseView{}
+	if err := json.Unmarshal([]byte(output), &releaseView); err != nil {
+		return fmt.Errorf("CLI release %s metadata is invalid JSON: %w", releaseTag, err)
+	}
+	if releaseView.IsDraft {
+		return fmt.Errorf("CLI release %s is still draft", releaseTag)
+	}
+	if missingAsset := missingMinimumCliReleaseAsset(releaseView.Assets); missingAsset != "" {
+		return fmt.Errorf("CLI release %s is missing release asset %s", releaseTag, missingAsset)
+	}
+	return nil
+}
+
+func missingMinimumCliReleaseAsset(assets []minimumCliReleaseAsset) string {
+	availableAssets := map[string]bool{}
+	for _, asset := range assets {
+		if asset.Size > 0 {
+			availableAssets[asset.Name] = true
+		}
+	}
+
+	for _, assetName := range requiredMinimumCliReleaseAssets {
+		if !availableAssets[assetName] {
+			return assetName
+		}
+	}
+	return ""
 }
 
 func FormatProtocolMinimumVersionWarning(result ProtocolMinimumVersionGuardResult) string {

--- a/cli/internal/automation/protocol_minimum_version_guard.go
+++ b/cli/internal/automation/protocol_minimum_version_guard.go
@@ -56,8 +56,8 @@ type ProtocolMinimumVersionGuardResult struct {
 }
 
 type minimumCliReleaseContract struct {
-	ProtocolVersion *int   `json:"protocolVersion"`
-	CliVersion      string `json:"cliVersion"`
+	ProtocolVersion *json.RawMessage `json:"protocolVersion"`
+	CliVersion      string           `json:"cliVersion"`
 }
 
 type minimumCliReleaseView struct {
@@ -211,21 +211,34 @@ func VerifyMinimumCliReleaseProtocol(values ProtocolMinimumVersionValues, contra
 	if err != nil {
 		return fmt.Errorf("CLI release contract is invalid JSON: %w", err)
 	}
-	if contract.ProtocolVersion == nil {
+	protocolVersion, hasProtocolVersion := minimumCliReleaseProtocolVersion(contract.ProtocolVersion)
+	if !hasProtocolVersion {
 		return fmt.Errorf(
 			"CLI release %s%s does not define protocolVersion",
 			cliReleaseTagPrefix,
 			values.MinimumCliVersion)
 	}
-	if *contract.ProtocolVersion != values.RequiredProtocolVersion {
+	if protocolVersion != values.RequiredProtocolVersion {
 		return fmt.Errorf(
 			"unity package requires protocol %d, but CLI release %s%s advertises protocol %d",
 			values.RequiredProtocolVersion,
 			cliReleaseTagPrefix,
 			values.MinimumCliVersion,
-			*contract.ProtocolVersion)
+			protocolVersion)
 	}
 	return nil
+}
+
+func minimumCliReleaseProtocolVersion(value *json.RawMessage) (int, bool) {
+	if value == nil {
+		return 0, false
+	}
+
+	protocolVersion, err := strconv.Atoi(strings.TrimSpace(string(*value)))
+	if err != nil {
+		return 0, false
+	}
+	return protocolVersion, true
 }
 
 func verifyMinimumCliReleaseProtocolAtRef(

--- a/cli/internal/automation/protocol_minimum_version_guard.go
+++ b/cli/internal/automation/protocol_minimum_version_guard.go
@@ -1,0 +1,286 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	protocolMinimumVersionFile   = "Packages/src/Editor/Domain/CliConstants.cs"
+	protocolMinimumVersionMarker = "<!-- uloop-protocol-minimum-version-warning -->"
+	cliReleaseTagPrefix          = "cli-v"
+)
+
+var (
+	requiredProtocolVersionPattern = regexp.MustCompile(`REQUIRED_CLI_PROTOCOL_VERSION\s*=\s*(\d+)`)
+	minimumCliVersionPattern       = regexp.MustCompile(`MINIMUM_REQUIRED_CLI_VERSION\s*=\s*"([^"]+)"`)
+)
+
+type ProtocolMinimumVersionGuardConfig struct {
+	BaseRef string
+	HeadRef string
+}
+
+type ProtocolMinimumVersionValues struct {
+	RequiredProtocolVersion int
+	HasRequiredProtocol     bool
+	MinimumCliVersion       string
+}
+
+type ProtocolMinimumVersionGuardResult struct {
+	Base                      ProtocolMinimumVersionValues
+	Head                      ProtocolMinimumVersionValues
+	RequiredProtocolChanged   bool
+	MinimumCliVersionChanged  bool
+	NeedsMinimumVersionUpdate bool
+}
+
+type minimumCliReleaseContract struct {
+	ProtocolVersion *int   `json:"protocolVersion"`
+	CliVersion      string `json:"cliVersion"`
+}
+
+func RunProtocolMinimumVersionGuard(
+	ctx context.Context,
+	stdout io.Writer,
+	stderr io.Writer,
+	config ProtocolMinimumVersionGuardConfig,
+) int {
+	result, err := AnalyzeProtocolMinimumVersionGuardForRefs(ctx, config)
+	if err != nil {
+		writeProtocolMinimumVersionLine(stderr, err)
+		return 1
+	}
+	if result.NeedsMinimumVersionUpdate {
+		writeProtocolMinimumVersionLine(stderr, FormatProtocolMinimumVersionWarning(result))
+		return 1
+	}
+
+	writeProtocolMinimumVersionLine(stdout, "Protocol minimum version guard passed.")
+	return 0
+}
+
+func RunMinimumCliReleaseProtocolCheck(ctx context.Context, stdout io.Writer, stderr io.Writer) int {
+	repoRoot, err := gitRepoRoot(ctx)
+	if err != nil {
+		writeProtocolMinimumVersionLine(stderr, fmt.Sprintf("failed to resolve git repository root: %v", err))
+		return 1
+	}
+
+	content, err := os.ReadFile(filepath.Join(repoRoot, protocolMinimumVersionFile))
+	if err != nil {
+		writeProtocolMinimumVersionLine(stderr, fmt.Sprintf("failed to read %s: %v", protocolMinimumVersionFile, err))
+		return 1
+	}
+	values, err := ParseProtocolMinimumVersionValues(content)
+	if err != nil {
+		writeProtocolMinimumVersionLine(stderr, err)
+		return 1
+	}
+	if !values.HasRequiredProtocol {
+		writeProtocolMinimumVersionLine(stderr, protocolMinimumVersionFile+" does not define REQUIRED_CLI_PROTOCOL_VERSION")
+		return 1
+	}
+
+	releaseTag := cliReleaseTagPrefix + values.MinimumCliVersion
+	contractContent, err := protocolMinimumVersionFileAtRef(ctx, repoRoot, releaseTag, "cli/contract.json")
+	if err != nil {
+		writeProtocolMinimumVersionLine(
+			stderr,
+			fmt.Sprintf("failed to read cli/contract.json from %s: %v", releaseTag, err))
+		return 1
+	}
+	err = VerifyMinimumCliReleaseProtocol(values, []byte(contractContent))
+	if err != nil {
+		writeProtocolMinimumVersionLine(stderr, err)
+		return 1
+	}
+
+	writeProtocolMinimumVersionLine(
+		stdout,
+		fmt.Sprintf(
+			"Minimum CLI release %s advertises protocol %d.",
+			releaseTag,
+			values.RequiredProtocolVersion))
+	return 0
+}
+
+func AnalyzeProtocolMinimumVersionGuardForRefs(
+	ctx context.Context,
+	config ProtocolMinimumVersionGuardConfig,
+) (ProtocolMinimumVersionGuardResult, error) {
+	if config.BaseRef == "" {
+		return ProtocolMinimumVersionGuardResult{}, fmt.Errorf("--base is required")
+	}
+	if config.HeadRef == "" {
+		config.HeadRef = "HEAD"
+	}
+
+	repoRoot, err := gitRepoRoot(ctx)
+	if err != nil {
+		return ProtocolMinimumVersionGuardResult{}, fmt.Errorf("failed to resolve git repository root: %w", err)
+	}
+
+	baseValues, err := protocolMinimumVersionValuesAtRef(ctx, repoRoot, config.BaseRef)
+	if err != nil {
+		return ProtocolMinimumVersionGuardResult{}, err
+	}
+	headValues, err := protocolMinimumVersionValuesAtRef(ctx, repoRoot, config.HeadRef)
+	if err != nil {
+		return ProtocolMinimumVersionGuardResult{}, err
+	}
+
+	return AnalyzeProtocolMinimumVersionGuard(baseValues, headValues), nil
+}
+
+func AnalyzeProtocolMinimumVersionGuard(
+	base ProtocolMinimumVersionValues,
+	head ProtocolMinimumVersionValues,
+) ProtocolMinimumVersionGuardResult {
+	requiredProtocolChanged := base.HasRequiredProtocol != head.HasRequiredProtocol ||
+		base.RequiredProtocolVersion != head.RequiredProtocolVersion
+	minimumCliVersionChanged := base.MinimumCliVersion != head.MinimumCliVersion
+
+	return ProtocolMinimumVersionGuardResult{
+		Base:                      base,
+		Head:                      head,
+		RequiredProtocolChanged:   requiredProtocolChanged,
+		MinimumCliVersionChanged:  minimumCliVersionChanged,
+		NeedsMinimumVersionUpdate: requiredProtocolChanged && !minimumCliVersionChanged,
+	}
+}
+
+func ParseProtocolMinimumVersionValues(content []byte) (ProtocolMinimumVersionValues, error) {
+	text := string(content)
+	values := ProtocolMinimumVersionValues{}
+
+	requiredMatches := requiredProtocolVersionPattern.FindStringSubmatch(text)
+	if len(requiredMatches) == 2 {
+		requiredProtocolVersion, err := strconv.Atoi(requiredMatches[1])
+		if err != nil {
+			return ProtocolMinimumVersionValues{}, fmt.Errorf("REQUIRED_CLI_PROTOCOL_VERSION is not an integer: %w", err)
+		}
+		values.RequiredProtocolVersion = requiredProtocolVersion
+		values.HasRequiredProtocol = true
+	}
+
+	minimumMatches := minimumCliVersionPattern.FindStringSubmatch(text)
+	if len(minimumMatches) != 2 {
+		return ProtocolMinimumVersionValues{}, fmt.Errorf("%s does not define MINIMUM_REQUIRED_CLI_VERSION", protocolMinimumVersionFile)
+	}
+	values.MinimumCliVersion = minimumMatches[1]
+	return values, nil
+}
+
+func VerifyMinimumCliReleaseProtocol(values ProtocolMinimumVersionValues, contractContent []byte) error {
+	if !values.HasRequiredProtocol {
+		return fmt.Errorf("%s does not define REQUIRED_CLI_PROTOCOL_VERSION", protocolMinimumVersionFile)
+	}
+
+	contract := minimumCliReleaseContract{}
+	err := json.Unmarshal(contractContent, &contract)
+	if err != nil {
+		return fmt.Errorf("CLI release contract is invalid JSON: %w", err)
+	}
+	if contract.ProtocolVersion == nil {
+		return fmt.Errorf(
+			"CLI release %s%s does not define protocolVersion",
+			cliReleaseTagPrefix,
+			values.MinimumCliVersion)
+	}
+	if *contract.ProtocolVersion != values.RequiredProtocolVersion {
+		return fmt.Errorf(
+			"unity package requires protocol %d, but CLI release %s%s advertises protocol %d",
+			values.RequiredProtocolVersion,
+			cliReleaseTagPrefix,
+			values.MinimumCliVersion,
+			*contract.ProtocolVersion)
+	}
+	return nil
+}
+
+func FormatProtocolMinimumVersionWarning(result ProtocolMinimumVersionGuardResult) string {
+	builder := strings.Builder{}
+	builder.WriteString(protocolMinimumVersionMarker)
+	builder.WriteString("\n")
+	builder.WriteString("Protocol version changed, but `MINIMUM_REQUIRED_CLI_VERSION` did not.\n\n")
+	builder.WriteString("- Base required protocol: ")
+	builder.WriteString(protocolMinimumVersionValueLabel(result.Base))
+	builder.WriteString("\n")
+	builder.WriteString("- Head required protocol: ")
+	builder.WriteString(protocolMinimumVersionValueLabel(result.Head))
+	builder.WriteString("\n")
+	builder.WriteString("- Current minimum CLI: `")
+	builder.WriteString(result.Head.MinimumCliVersion)
+	builder.WriteString("`\n\n")
+	builder.WriteString("Update `MINIMUM_REQUIRED_CLI_VERSION` to a published CLI release that advertises the new protocol before releasing the Unity package.")
+	return builder.String()
+}
+
+func protocolMinimumVersionValueLabel(values ProtocolMinimumVersionValues) string {
+	if !values.HasRequiredProtocol {
+		return "`<missing>`"
+	}
+	return "`" + strconv.Itoa(values.RequiredProtocolVersion) + "`"
+}
+
+func protocolMinimumVersionValuesAtRef(
+	ctx context.Context,
+	repoRoot string,
+	ref string,
+) (ProtocolMinimumVersionValues, error) {
+	content, err := protocolMinimumVersionFileAtRef(ctx, repoRoot, ref, protocolMinimumVersionFile)
+	if err != nil {
+		return ProtocolMinimumVersionValues{}, err
+	}
+	return ParseProtocolMinimumVersionValues([]byte(content))
+}
+
+func protocolMinimumVersionFileAtRef(
+	ctx context.Context,
+	repoRoot string,
+	ref string,
+	file string,
+) (string, error) {
+	return runProtocolMinimumVersionOutput(
+		ctx,
+		repoRoot,
+		"git",
+		"-C",
+		repoRoot,
+		"show",
+		ref+":"+file)
+}
+
+func runProtocolMinimumVersionOutput(
+	ctx context.Context,
+	workDir string,
+	name string,
+	args ...string,
+) (string, error) {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Dir = filepath.Clean(workDir)
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	if err != nil {
+		return "", fmt.Errorf("%s %s failed: %w\n%s%s", name, strings.Join(args, " "), err, stderr.String(), stdout.String())
+	}
+	return stdout.String(), nil
+}
+
+func writeProtocolMinimumVersionLine(writer io.Writer, values ...any) {
+	// CI status output failures cannot be recovered after the command outcome is known.
+	_, _ = fmt.Fprintln(writer, values...)
+}

--- a/cli/internal/automation/protocol_minimum_version_guard.go
+++ b/cli/internal/automation/protocol_minimum_version_guard.go
@@ -37,11 +37,12 @@ type ProtocolMinimumVersionValues struct {
 }
 
 type ProtocolMinimumVersionGuardResult struct {
-	Base                      ProtocolMinimumVersionValues
-	Head                      ProtocolMinimumVersionValues
-	RequiredProtocolChanged   bool
-	MinimumCliVersionChanged  bool
-	NeedsMinimumVersionUpdate bool
+	Base                           ProtocolMinimumVersionValues
+	Head                           ProtocolMinimumVersionValues
+	RequiredProtocolChanged        bool
+	MinimumCliVersionChanged       bool
+	NeedsMinimumVersionUpdate      bool
+	MinimumCliReleaseProtocolError string
 }
 
 type minimumCliReleaseContract struct {
@@ -60,7 +61,7 @@ func RunProtocolMinimumVersionGuard(
 		writeProtocolMinimumVersionLine(stderr, err)
 		return 1
 	}
-	if result.NeedsMinimumVersionUpdate {
+	if protocolMinimumVersionGuardNeedsAction(result) {
 		writeProtocolMinimumVersionLine(stderr, FormatProtocolMinimumVersionWarning(result))
 		return 1
 	}
@@ -91,16 +92,7 @@ func RunMinimumCliReleaseProtocolCheck(ctx context.Context, stdout io.Writer, st
 		return 1
 	}
 
-	releaseTag := cliReleaseTagPrefix + values.MinimumCliVersion
-	contractContent, err := protocolMinimumVersionFileAtRef(ctx, repoRoot, releaseTag, "cli/contract.json")
-	if err != nil {
-		writeProtocolMinimumVersionLine(
-			stderr,
-			fmt.Sprintf("failed to read cli/contract.json from %s: %v", releaseTag, err))
-		return 1
-	}
-	err = VerifyMinimumCliReleaseProtocol(values, []byte(contractContent))
-	if err != nil {
+	if err := verifyMinimumCliReleaseProtocolAtRef(ctx, repoRoot, values); err != nil {
 		writeProtocolMinimumVersionLine(stderr, err)
 		return 1
 	}
@@ -108,8 +100,9 @@ func RunMinimumCliReleaseProtocolCheck(ctx context.Context, stdout io.Writer, st
 	writeProtocolMinimumVersionLine(
 		stdout,
 		fmt.Sprintf(
-			"Minimum CLI release %s advertises protocol %d.",
-			releaseTag,
+			"Minimum CLI release %s%s advertises protocol %d.",
+			cliReleaseTagPrefix,
+			values.MinimumCliVersion,
 			values.RequiredProtocolVersion))
 	return 0
 }
@@ -139,7 +132,14 @@ func AnalyzeProtocolMinimumVersionGuardForRefs(
 		return ProtocolMinimumVersionGuardResult{}, err
 	}
 
-	return AnalyzeProtocolMinimumVersionGuard(baseValues, headValues), nil
+	result := AnalyzeProtocolMinimumVersionGuard(baseValues, headValues)
+	if result.RequiredProtocolChanged && !result.NeedsMinimumVersionUpdate {
+		err = verifyMinimumCliReleaseProtocolAtRef(ctx, repoRoot, result.Head)
+		if err != nil {
+			result.MinimumCliReleaseProtocolError = err.Error()
+		}
+	}
+	return result, nil
 }
 
 func AnalyzeProtocolMinimumVersionGuard(
@@ -208,11 +208,28 @@ func VerifyMinimumCliReleaseProtocol(values ProtocolMinimumVersionValues, contra
 	return nil
 }
 
+func verifyMinimumCliReleaseProtocolAtRef(
+	ctx context.Context,
+	repoRoot string,
+	values ProtocolMinimumVersionValues,
+) error {
+	releaseTag := cliReleaseTagPrefix + values.MinimumCliVersion
+	contractContent, err := protocolMinimumVersionFileAtRef(ctx, repoRoot, releaseTag, "cli/contract.json")
+	if err != nil {
+		return fmt.Errorf("CLI release %s does not provide cli/contract.json", releaseTag)
+	}
+	return VerifyMinimumCliReleaseProtocol(values, []byte(contractContent))
+}
+
 func FormatProtocolMinimumVersionWarning(result ProtocolMinimumVersionGuardResult) string {
 	builder := strings.Builder{}
 	builder.WriteString(protocolMinimumVersionMarker)
 	builder.WriteString("\n")
-	builder.WriteString("Protocol version changed, but `MINIMUM_REQUIRED_CLI_VERSION` did not.\n\n")
+	if result.NeedsMinimumVersionUpdate {
+		builder.WriteString("Protocol version changed, but `MINIMUM_REQUIRED_CLI_VERSION` did not.\n\n")
+	} else {
+		builder.WriteString("Protocol version changed, but `MINIMUM_REQUIRED_CLI_VERSION` does not point to a published CLI release that advertises the required protocol.\n\n")
+	}
 	builder.WriteString("- Base required protocol: ")
 	builder.WriteString(protocolMinimumVersionValueLabel(result.Base))
 	builder.WriteString("\n")
@@ -221,9 +238,19 @@ func FormatProtocolMinimumVersionWarning(result ProtocolMinimumVersionGuardResul
 	builder.WriteString("\n")
 	builder.WriteString("- Current minimum CLI: `")
 	builder.WriteString(result.Head.MinimumCliVersion)
-	builder.WriteString("`\n\n")
+	builder.WriteString("`\n")
+	if result.MinimumCliReleaseProtocolError != "" {
+		builder.WriteString("- Release check: ")
+		builder.WriteString(protocolMinimumVersionErrorLabel(result.MinimumCliReleaseProtocolError))
+		builder.WriteString("\n")
+	}
+	builder.WriteString("\n")
 	builder.WriteString("Update `MINIMUM_REQUIRED_CLI_VERSION` to a published CLI release that advertises the new protocol before releasing the Unity package.")
 	return builder.String()
+}
+
+func protocolMinimumVersionGuardNeedsAction(result ProtocolMinimumVersionGuardResult) bool {
+	return result.NeedsMinimumVersionUpdate || result.MinimumCliReleaseProtocolError != ""
 }
 
 func protocolMinimumVersionValueLabel(values ProtocolMinimumVersionValues) string {
@@ -231,6 +258,12 @@ func protocolMinimumVersionValueLabel(values ProtocolMinimumVersionValues) strin
 		return "`<missing>`"
 	}
 	return "`" + strconv.Itoa(values.RequiredProtocolVersion) + "`"
+}
+
+func protocolMinimumVersionErrorLabel(value string) string {
+	trimmedValue := strings.TrimSpace(value)
+	singleLineValue := strings.ReplaceAll(trimmedValue, "\n", " ")
+	return "`" + singleLineValue + "`"
 }
 
 func protocolMinimumVersionValuesAtRef(

--- a/cli/internal/automation/protocol_minimum_version_guard.go
+++ b/cli/internal/automation/protocol_minimum_version_guard.go
@@ -133,7 +133,7 @@ func AnalyzeProtocolMinimumVersionGuardForRefs(
 	}
 
 	result := AnalyzeProtocolMinimumVersionGuard(baseValues, headValues)
-	if result.RequiredProtocolChanged && !result.NeedsMinimumVersionUpdate {
+	if protocolMinimumVersionGuardNeedsReleaseCheck(result) {
 		err = verifyMinimumCliReleaseProtocolAtRef(ctx, repoRoot, result.Head)
 		if err != nil {
 			result.MinimumCliReleaseProtocolError = err.Error()
@@ -227,8 +227,10 @@ func FormatProtocolMinimumVersionWarning(result ProtocolMinimumVersionGuardResul
 	builder.WriteString("\n")
 	if result.NeedsMinimumVersionUpdate {
 		builder.WriteString("Protocol version changed, but `MINIMUM_REQUIRED_CLI_VERSION` did not.\n\n")
-	} else {
+	} else if result.RequiredProtocolChanged {
 		builder.WriteString("Protocol version changed, but `MINIMUM_REQUIRED_CLI_VERSION` does not point to a published CLI release that advertises the required protocol.\n\n")
+	} else {
+		builder.WriteString("`MINIMUM_REQUIRED_CLI_VERSION` changed, but it does not point to a published CLI release that advertises the required protocol.\n\n")
 	}
 	builder.WriteString("- Base required protocol: ")
 	builder.WriteString(protocolMinimumVersionValueLabel(result.Base))
@@ -251,6 +253,13 @@ func FormatProtocolMinimumVersionWarning(result ProtocolMinimumVersionGuardResul
 
 func protocolMinimumVersionGuardNeedsAction(result ProtocolMinimumVersionGuardResult) bool {
 	return result.NeedsMinimumVersionUpdate || result.MinimumCliReleaseProtocolError != ""
+}
+
+func protocolMinimumVersionGuardNeedsReleaseCheck(result ProtocolMinimumVersionGuardResult) bool {
+	if result.NeedsMinimumVersionUpdate {
+		return false
+	}
+	return result.RequiredProtocolChanged || result.MinimumCliVersionChanged
 }
 
 func protocolMinimumVersionValueLabel(values ProtocolMinimumVersionValues) string {

--- a/cli/internal/automation/protocol_minimum_version_guard_test.go
+++ b/cli/internal/automation/protocol_minimum_version_guard_test.go
@@ -30,7 +30,7 @@ func TestAnalyzeProtocolMinimumVersionGuard_WhenProtocolChangesWithoutMinimumVer
 }
 
 func TestAnalyzeProtocolMinimumVersionGuard_WhenProtocolAndMinimumVersionChange_DoesNotWarn(t *testing.T) {
-	// Verifies paired protocol and installer target updates pass the PR guard.
+	// Verifies paired protocol and installer target updates clear the update-omission warning.
 	result := AnalyzeProtocolMinimumVersionGuard(
 		ProtocolMinimumVersionValues{
 			RequiredProtocolVersion: 1,
@@ -65,6 +65,36 @@ func TestAnalyzeProtocolMinimumVersionGuard_WhenProtocolDoesNotChange_DoesNotWar
 	if result.NeedsMinimumVersionUpdate {
 		t.Fatalf("unexpected warning: %#v", result)
 	}
+}
+
+func TestRunProtocolMinimumVersionGuard_WhenMinimumReleaseMatches_Passes(t *testing.T) {
+	// Verifies protocol bump PRs pass only after the selected CLI release advertises the new protocol.
+	result := runProtocolMinimumVersionGuardCase(t, protocolMinimumVersionRefCase{
+		baseContent:    buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
+		headContent:    buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
+		releaseContent: `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.33"}`,
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertProtocolMinimumVersionLogContains(t, result.stdout, "Protocol minimum version guard passed.")
+	assertProtocolMinimumVersionLogContains(t, result.gitLog, "cli-v3.0.0-beta.33:cli/contract.json")
+}
+
+func TestRunProtocolMinimumVersionGuard_WhenMinimumReleaseProtocolDiffers_Fails(t *testing.T) {
+	// Verifies changing the minimum version text is not enough when the release uses the old protocol.
+	result := runProtocolMinimumVersionGuardCase(t, protocolMinimumVersionRefCase{
+		baseContent:    buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
+		headContent:    buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
+		releaseContent: `{"schemaVersion":1,"protocolVersion":1,"cliVersion":"3.0.0-beta.33"}`,
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\nstdout: %s", result.exitCode, result.stdout)
+	}
+	assertProtocolMinimumVersionLogContains(t, result.stderr, "does not point to a published CLI release")
+	assertProtocolMinimumVersionLogContains(t, result.stderr, "advertises protocol 1")
 }
 
 func TestVerifyMinimumCliReleaseProtocol_WhenTagProtocolMatches_Passes(t *testing.T) {
@@ -129,9 +159,10 @@ func TestRunProtocolMinimumVersionComment_WhenWarningExists_UpsertsComment(t *te
 func TestRunProtocolMinimumVersionComment_WhenWarningIsResolved_DeletesComment(t *testing.T) {
 	// Verifies stale protocol minimum comments are removed after the PR is fixed.
 	result := runProtocolMinimumVersionCommentCase(t, protocolMinimumVersionCommentCase{
-		baseContent: buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
-		headContent: buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
-		commentIDs:  "123",
+		baseContent:    buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
+		headContent:    buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
+		releaseContent: `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.33"}`,
+		commentIDs:     "123",
 	})
 
 	if result.exitCode != 0 {
@@ -141,10 +172,77 @@ func TestRunProtocolMinimumVersionComment_WhenWarningIsResolved_DeletesComment(t
 	assertProtocolMinimumVersionLogContains(t, result.ghLog, "api --method DELETE repos/owner/repository/issues/comments/123")
 }
 
+func TestRunProtocolMinimumVersionComment_WhenMinimumReleaseProtocolDiffers_UpsertsComment(t *testing.T) {
+	// Verifies stale protocol minimum comments stay open until the selected release protocol matches.
+	result := runProtocolMinimumVersionCommentCase(t, protocolMinimumVersionCommentCase{
+		baseContent:    buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
+		headContent:    buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
+		releaseContent: `{"schemaVersion":1,"protocolVersion":1,"cliVersion":"3.0.0-beta.33"}`,
+		commentIDs:     "123",
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertProtocolMinimumVersionLogContains(t, result.stdout, "Updated protocol minimum version comment.")
+	assertProtocolMinimumVersionLogContains(t, result.ghLog, "api --method PATCH repos/owner/repository/issues/comments/123 --input")
+}
+
+type protocolMinimumVersionRefCase struct {
+	baseContent    string
+	headContent    string
+	releaseContent string
+}
+
+type protocolMinimumVersionGuardRunResult struct {
+	exitCode int
+	stdout   string
+	stderr   string
+	gitLog   string
+}
+
+func runProtocolMinimumVersionGuardCase(t *testing.T, testCase protocolMinimumVersionRefCase) protocolMinimumVersionGuardRunResult {
+	t.Helper()
+
+	workDir := t.TempDir()
+	mockBin := filepath.Join(workDir, "bin")
+	err := os.MkdirAll(mockBin, 0o755)
+	if err != nil {
+		t.Fatalf("failed to create mock bin: %v", err)
+	}
+
+	gitLogPath := filepath.Join(workDir, "git.log")
+	writeProtocolMinimumVersionMockGit(t, filepath.Join(mockBin, "git"))
+	prepareProtocolMinimumVersionGitContents(t, workDir, testCase)
+
+	t.Setenv("PATH", mockBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ULOOP_REPOSITORY_ROOT", workDir)
+	t.Setenv("GIT_LOG", gitLogPath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	exitCode := RunProtocolMinimumVersionGuard(
+		context.Background(),
+		&stdout,
+		&stderr,
+		ProtocolMinimumVersionGuardConfig{
+			BaseRef: "origin/v3-beta",
+			HeadRef: "protocol-pr-head",
+		})
+
+	return protocolMinimumVersionGuardRunResult{
+		exitCode: exitCode,
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+		gitLog:   readFile(t, gitLogPath),
+	}
+}
+
 type protocolMinimumVersionCommentCase struct {
-	baseContent string
-	headContent string
-	commentIDs  string
+	baseContent    string
+	headContent    string
+	releaseContent string
+	commentIDs     string
 }
 
 type protocolMinimumVersionCommentResult struct {
@@ -166,12 +264,13 @@ func runProtocolMinimumVersionCommentCase(t *testing.T, testCase protocolMinimum
 
 	gitLogPath := filepath.Join(workDir, "git.log")
 	ghLogPath := filepath.Join(workDir, "gh.log")
-	baseContentPath := filepath.Join(workDir, "base.cs")
-	headContentPath := filepath.Join(workDir, "head.cs")
 	writeProtocolMinimumVersionMockGit(t, filepath.Join(mockBin, "git"))
 	writeProtocolMinimumVersionMockGH(t, filepath.Join(mockBin, "gh"))
-	writeFile(t, baseContentPath, testCase.baseContent)
-	writeFile(t, headContentPath, testCase.headContent)
+	prepareProtocolMinimumVersionGitContents(t, workDir, protocolMinimumVersionRefCase{
+		baseContent:    testCase.baseContent,
+		headContent:    testCase.headContent,
+		releaseContent: testCase.releaseContent,
+	})
 
 	t.Setenv("PATH", mockBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("ULOOP_REPOSITORY_ROOT", workDir)
@@ -180,8 +279,6 @@ func runProtocolMinimumVersionCommentCase(t *testing.T, testCase protocolMinimum
 	t.Setenv("GITHUB_BASE_REF", "v3-beta")
 	t.Setenv("PROTOCOL_MINIMUM_VERSION_HEAD_REF", "protocol-pr-head")
 	t.Setenv("GIT_LOG", gitLogPath)
-	t.Setenv("GIT_BASE_CONTENT", baseContentPath)
-	t.Setenv("GIT_HEAD_CONTENT", headContentPath)
 	t.Setenv("GH_LOG", ghLogPath)
 	t.Setenv("GH_COMMENT_IDS", testCase.commentIDs)
 
@@ -196,6 +293,22 @@ func runProtocolMinimumVersionCommentCase(t *testing.T, testCase protocolMinimum
 		stderr:   stderr.String(),
 		ghLog:    ghLog,
 	}
+}
+
+func prepareProtocolMinimumVersionGitContents(t *testing.T, workDir string, testCase protocolMinimumVersionRefCase) {
+	t.Helper()
+
+	baseContentPath := filepath.Join(workDir, "base.cs")
+	headContentPath := filepath.Join(workDir, "head.cs")
+	releaseContentPath := filepath.Join(workDir, "release-contract.json")
+	writeFile(t, baseContentPath, testCase.baseContent)
+	writeFile(t, headContentPath, testCase.headContent)
+	if testCase.releaseContent != "" {
+		writeFile(t, releaseContentPath, testCase.releaseContent)
+		t.Setenv("GIT_RELEASE_CONTENT", releaseContentPath)
+	}
+	t.Setenv("GIT_BASE_CONTENT", baseContentPath)
+	t.Setenv("GIT_HEAD_CONTENT", headContentPath)
 }
 
 func buildProtocolMinimumVersionConstants(requiredProtocolVersion int, minimumCliVersion string) string {
@@ -230,6 +343,14 @@ if [ "$1" = "show" ]; then
   case "$2" in
     origin/v3-beta:*) cat "$GIT_BASE_CONTENT" ;;
     protocol-pr-head:*) cat "$GIT_HEAD_CONTENT" ;;
+    cli-v*:cli/contract.json)
+      if [ -n "${GIT_RELEASE_CONTENT:-}" ]; then
+        cat "$GIT_RELEASE_CONTENT"
+      else
+        echo "release not found" >&2
+        exit 1
+      fi
+      ;;
     *) echo "unexpected git show ref: $2" >&2; exit 1 ;;
   esac
   exit 0

--- a/cli/internal/automation/protocol_minimum_version_guard_test.go
+++ b/cli/internal/automation/protocol_minimum_version_guard_test.go
@@ -97,6 +97,38 @@ func TestRunProtocolMinimumVersionGuard_WhenMinimumReleaseProtocolDiffers_Fails(
 	assertProtocolMinimumVersionLogContains(t, result.stderr, "advertises protocol 1")
 }
 
+func TestRunProtocolMinimumVersionGuard_WhenMinimumReleaseIsDraft_Fails(t *testing.T) {
+	// Verifies protocol bump PRs wait for a published CLI release, not only a git tag.
+	result := runProtocolMinimumVersionGuardCase(t, protocolMinimumVersionRefCase{
+		baseContent:    buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
+		headContent:    buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
+		releaseContent: `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.33"}`,
+		releaseView:    `{"isDraft":true,"assets":[]}`,
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\nstdout: %s", result.exitCode, result.stdout)
+	}
+	assertProtocolMinimumVersionLogContains(t, result.stderr, "does not point to a published CLI release")
+	assertProtocolMinimumVersionLogContains(t, result.stderr, "is still draft")
+}
+
+func TestRunProtocolMinimumVersionGuard_WhenMinimumReleaseAssetsAreMissing_Fails(t *testing.T) {
+	// Verifies protocol bump PRs wait for installable native CLI release assets.
+	result := runProtocolMinimumVersionGuardCase(t, protocolMinimumVersionRefCase{
+		baseContent:    buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
+		headContent:    buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
+		releaseContent: `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.33"}`,
+		releaseView:    `{"isDraft":false,"assets":[]}`,
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\nstdout: %s", result.exitCode, result.stdout)
+	}
+	assertProtocolMinimumVersionLogContains(t, result.stderr, "does not point to a published CLI release")
+	assertProtocolMinimumVersionLogContains(t, result.stderr, "is missing release asset")
+}
+
 func TestRunProtocolMinimumVersionGuard_WhenOnlyMinimumReleaseProtocolDiffers_Fails(t *testing.T) {
 	// Verifies installer target changes are validated even without a protocol declaration bump.
 	result := runProtocolMinimumVersionGuardCase(t, protocolMinimumVersionRefCase{
@@ -156,6 +188,46 @@ func TestVerifyMinimumCliReleaseProtocol_WhenTagProtocolDiffers_Fails(t *testing
 	}
 }
 
+func TestRunMinimumCliReleaseProtocolCheck_WhenRefIsProvided_ReadsValuesAtRef(t *testing.T) {
+	// Verifies release backfill checks validate the release commit instead of the current checkout.
+	workDir := t.TempDir()
+	mockBin := filepath.Join(workDir, "bin")
+	err := os.MkdirAll(mockBin, 0o755)
+	if err != nil {
+		t.Fatalf("failed to create mock bin: %v", err)
+	}
+
+	gitLogPath := filepath.Join(workDir, "git.log")
+	ghLogPath := filepath.Join(workDir, "gh.log")
+	writeProtocolMinimumVersionMockGit(t, filepath.Join(mockBin, "git"))
+	writeProtocolMinimumVersionMockGH(t, filepath.Join(mockBin, "gh"))
+	prepareProtocolMinimumVersionGitContents(t, workDir, protocolMinimumVersionRefCase{
+		baseContent:    buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
+		headContent:    buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
+		releaseContent: `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.33"}`,
+	})
+
+	t.Setenv("PATH", mockBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ULOOP_REPOSITORY_ROOT", workDir)
+	t.Setenv("GIT_LOG", gitLogPath)
+	t.Setenv("GH_LOG", ghLogPath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	exitCode := RunMinimumCliReleaseProtocolCheck(
+		context.Background(),
+		&stdout,
+		&stderr,
+		"protocol-release")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", exitCode, stderr.String())
+	}
+	assertProtocolMinimumVersionLogContains(t, stdout.String(), "Minimum CLI release cli-v3.0.0-beta.33 advertises protocol 2.")
+	assertProtocolMinimumVersionLogContains(t, readFile(t, gitLogPath), "protocol-release:"+protocolMinimumVersionFile)
+	assertProtocolMinimumVersionLogContains(t, readFile(t, ghLogPath), "release view cli-v3.0.0-beta.33")
+}
+
 func TestRunProtocolMinimumVersionComment_WhenWarningExists_UpsertsComment(t *testing.T) {
 	// Verifies PR comments explain protocol bump installer target omissions.
 	result := runProtocolMinimumVersionCommentCase(t, protocolMinimumVersionCommentCase{
@@ -207,6 +279,7 @@ type protocolMinimumVersionRefCase struct {
 	baseContent    string
 	headContent    string
 	releaseContent string
+	releaseView    string
 }
 
 type protocolMinimumVersionGuardRunResult struct {
@@ -227,12 +300,18 @@ func runProtocolMinimumVersionGuardCase(t *testing.T, testCase protocolMinimumVe
 	}
 
 	gitLogPath := filepath.Join(workDir, "git.log")
+	ghLogPath := filepath.Join(workDir, "gh.log")
 	writeProtocolMinimumVersionMockGit(t, filepath.Join(mockBin, "git"))
+	writeProtocolMinimumVersionMockGH(t, filepath.Join(mockBin, "gh"))
 	prepareProtocolMinimumVersionGitContents(t, workDir, testCase)
 
 	t.Setenv("PATH", mockBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("ULOOP_REPOSITORY_ROOT", workDir)
 	t.Setenv("GIT_LOG", gitLogPath)
+	t.Setenv("GH_LOG", ghLogPath)
+	if testCase.releaseView != "" {
+		t.Setenv("GH_RELEASE_VIEW", testCase.releaseView)
+	}
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
@@ -358,6 +437,7 @@ if [ "$1" = "show" ]; then
   case "$2" in
     origin/v3-beta:*) cat "$GIT_BASE_CONTENT" ;;
     protocol-pr-head:*) cat "$GIT_HEAD_CONTENT" ;;
+    protocol-release:*) cat "$GIT_HEAD_CONTENT" ;;
     cli-v*:cli/contract.json)
       if [ -n "${GIT_RELEASE_CONTENT:-}" ]; then
         cat "$GIT_RELEASE_CONTENT"
@@ -388,6 +468,15 @@ func writeProtocolMinimumVersionMockGH(t *testing.T, path string) {
 set -eu
 
 printf '%s\n' "$*" >> "$GH_LOG"
+
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  if [ -n "${GH_RELEASE_VIEW:-}" ]; then
+    printf '%s\n' "$GH_RELEASE_VIEW"
+  else
+    printf '%s\n' '{"isDraft":false,"assets":[{"name":"install.sh","size":1},{"name":"install.ps1","size":1},{"name":"uloop-darwin-amd64.tar.gz","size":1},{"name":"uloop-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-darwin-arm64.tar.gz","size":1},{"name":"uloop-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-windows-amd64.zip","size":1},{"name":"uloop-windows-amd64.zip.sha256","size":1}]}'
+  fi
+  exit 0
+fi
 
 if [ "$1" = "api" ] && [ "$2" = "--paginate" ]; then
   if [ -n "$GH_COMMENT_IDS" ]; then

--- a/cli/internal/automation/protocol_minimum_version_guard_test.go
+++ b/cli/internal/automation/protocol_minimum_version_guard_test.go
@@ -97,6 +97,21 @@ func TestRunProtocolMinimumVersionGuard_WhenMinimumReleaseProtocolDiffers_Fails(
 	assertProtocolMinimumVersionLogContains(t, result.stderr, "advertises protocol 1")
 }
 
+func TestRunProtocolMinimumVersionGuard_WhenOnlyMinimumReleaseProtocolDiffers_Fails(t *testing.T) {
+	// Verifies installer target changes are validated even without a protocol declaration bump.
+	result := runProtocolMinimumVersionGuardCase(t, protocolMinimumVersionRefCase{
+		baseContent:    buildProtocolMinimumVersionConstants(2, "3.0.0-beta.32"),
+		headContent:    buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
+		releaseContent: `{"schemaVersion":1,"protocolVersion":1,"cliVersion":"3.0.0-beta.33"}`,
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\nstdout: %s", result.exitCode, result.stdout)
+	}
+	assertProtocolMinimumVersionLogContains(t, result.stderr, "`MINIMUM_REQUIRED_CLI_VERSION` changed")
+	assertProtocolMinimumVersionLogContains(t, result.stderr, "advertises protocol 1")
+}
+
 func TestVerifyMinimumCliReleaseProtocol_WhenTagProtocolMatches_Passes(t *testing.T) {
 	// Verifies release validation accepts a CLI tag that advertises the required protocol.
 	err := VerifyMinimumCliReleaseProtocol(ProtocolMinimumVersionValues{

--- a/cli/internal/automation/protocol_minimum_version_guard_test.go
+++ b/cli/internal/automation/protocol_minimum_version_guard_test.go
@@ -1,0 +1,299 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeProtocolMinimumVersionGuard_WhenProtocolChangesWithoutMinimumVersionChange_Warns(t *testing.T) {
+	// Verifies protocol bumps cannot leave the installer target on the old CLI release.
+	result := AnalyzeProtocolMinimumVersionGuard(
+		ProtocolMinimumVersionValues{
+			RequiredProtocolVersion: 1,
+			HasRequiredProtocol:     true,
+			MinimumCliVersion:       "3.0.0-beta.32",
+		},
+		ProtocolMinimumVersionValues{
+			RequiredProtocolVersion: 2,
+			HasRequiredProtocol:     true,
+			MinimumCliVersion:       "3.0.0-beta.32",
+		})
+
+	if !result.NeedsMinimumVersionUpdate {
+		t.Fatalf("expected warning: %#v", result)
+	}
+}
+
+func TestAnalyzeProtocolMinimumVersionGuard_WhenProtocolAndMinimumVersionChange_DoesNotWarn(t *testing.T) {
+	// Verifies paired protocol and installer target updates pass the PR guard.
+	result := AnalyzeProtocolMinimumVersionGuard(
+		ProtocolMinimumVersionValues{
+			RequiredProtocolVersion: 1,
+			HasRequiredProtocol:     true,
+			MinimumCliVersion:       "3.0.0-beta.32",
+		},
+		ProtocolMinimumVersionValues{
+			RequiredProtocolVersion: 2,
+			HasRequiredProtocol:     true,
+			MinimumCliVersion:       "3.0.0-beta.33",
+		})
+
+	if result.NeedsMinimumVersionUpdate {
+		t.Fatalf("unexpected warning: %#v", result)
+	}
+}
+
+func TestAnalyzeProtocolMinimumVersionGuard_WhenProtocolDoesNotChange_DoesNotWarn(t *testing.T) {
+	// Verifies ordinary package edits do not force a CLI installer target bump.
+	result := AnalyzeProtocolMinimumVersionGuard(
+		ProtocolMinimumVersionValues{
+			RequiredProtocolVersion: 2,
+			HasRequiredProtocol:     true,
+			MinimumCliVersion:       "3.0.0-beta.32",
+		},
+		ProtocolMinimumVersionValues{
+			RequiredProtocolVersion: 2,
+			HasRequiredProtocol:     true,
+			MinimumCliVersion:       "3.0.0-beta.32",
+		})
+
+	if result.NeedsMinimumVersionUpdate {
+		t.Fatalf("unexpected warning: %#v", result)
+	}
+}
+
+func TestVerifyMinimumCliReleaseProtocol_WhenTagProtocolMatches_Passes(t *testing.T) {
+	// Verifies release validation accepts a CLI tag that advertises the required protocol.
+	err := VerifyMinimumCliReleaseProtocol(ProtocolMinimumVersionValues{
+		RequiredProtocolVersion: 2,
+		HasRequiredProtocol:     true,
+		MinimumCliVersion:       "3.0.0-beta.33",
+	}, []byte(`{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.33"}`))
+	if err != nil {
+		t.Fatalf("expected matching release protocol, got %v", err)
+	}
+}
+
+func TestVerifyMinimumCliReleaseProtocol_WhenTagProtocolIsMissing_Fails(t *testing.T) {
+	// Verifies release validation rejects CLI tags that predate protocol metadata.
+	err := VerifyMinimumCliReleaseProtocol(ProtocolMinimumVersionValues{
+		RequiredProtocolVersion: 2,
+		HasRequiredProtocol:     true,
+		MinimumCliVersion:       "3.0.0-beta.32",
+	}, []byte(`{"schemaVersion":1,"cliVersion":"3.0.0-beta.32"}`))
+
+	if err == nil {
+		t.Fatal("expected missing protocolVersion to fail")
+	}
+	if !strings.Contains(err.Error(), "protocolVersion") {
+		t.Fatalf("expected protocolVersion error, got %v", err)
+	}
+}
+
+func TestVerifyMinimumCliReleaseProtocol_WhenTagProtocolDiffers_Fails(t *testing.T) {
+	// Verifies release validation rejects published CLIs from a different protocol generation.
+	err := VerifyMinimumCliReleaseProtocol(ProtocolMinimumVersionValues{
+		RequiredProtocolVersion: 3,
+		HasRequiredProtocol:     true,
+		MinimumCliVersion:       "3.0.0-beta.33",
+	}, []byte(`{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.33"}`))
+
+	if err == nil {
+		t.Fatal("expected mismatched protocolVersion to fail")
+	}
+	if !strings.Contains(err.Error(), "requires protocol 3") {
+		t.Fatalf("expected mismatch error, got %v", err)
+	}
+}
+
+func TestRunProtocolMinimumVersionComment_WhenWarningExists_UpsertsComment(t *testing.T) {
+	// Verifies PR comments explain protocol bump installer target omissions.
+	result := runProtocolMinimumVersionCommentCase(t, protocolMinimumVersionCommentCase{
+		baseContent: buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
+		headContent: buildProtocolMinimumVersionConstants(2, "3.0.0-beta.32"),
+		commentIDs:  "123",
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertProtocolMinimumVersionLogContains(t, result.stdout, "Updated protocol minimum version comment.")
+	assertProtocolMinimumVersionLogContains(t, result.ghLog, "api --method PATCH repos/owner/repository/issues/comments/123 --input")
+}
+
+func TestRunProtocolMinimumVersionComment_WhenWarningIsResolved_DeletesComment(t *testing.T) {
+	// Verifies stale protocol minimum comments are removed after the PR is fixed.
+	result := runProtocolMinimumVersionCommentCase(t, protocolMinimumVersionCommentCase{
+		baseContent: buildProtocolMinimumVersionConstants(1, "3.0.0-beta.32"),
+		headContent: buildProtocolMinimumVersionConstants(2, "3.0.0-beta.33"),
+		commentIDs:  "123",
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertProtocolMinimumVersionLogContains(t, result.stdout, "Deleted resolved protocol minimum version comment.")
+	assertProtocolMinimumVersionLogContains(t, result.ghLog, "api --method DELETE repos/owner/repository/issues/comments/123")
+}
+
+type protocolMinimumVersionCommentCase struct {
+	baseContent string
+	headContent string
+	commentIDs  string
+}
+
+type protocolMinimumVersionCommentResult struct {
+	exitCode int
+	stdout   string
+	stderr   string
+	ghLog    string
+}
+
+func runProtocolMinimumVersionCommentCase(t *testing.T, testCase protocolMinimumVersionCommentCase) protocolMinimumVersionCommentResult {
+	t.Helper()
+
+	workDir := t.TempDir()
+	mockBin := filepath.Join(workDir, "bin")
+	err := os.MkdirAll(mockBin, 0o755)
+	if err != nil {
+		t.Fatalf("failed to create mock bin: %v", err)
+	}
+
+	gitLogPath := filepath.Join(workDir, "git.log")
+	ghLogPath := filepath.Join(workDir, "gh.log")
+	baseContentPath := filepath.Join(workDir, "base.cs")
+	headContentPath := filepath.Join(workDir, "head.cs")
+	writeProtocolMinimumVersionMockGit(t, filepath.Join(mockBin, "git"))
+	writeProtocolMinimumVersionMockGH(t, filepath.Join(mockBin, "gh"))
+	writeFile(t, baseContentPath, testCase.baseContent)
+	writeFile(t, headContentPath, testCase.headContent)
+
+	t.Setenv("PATH", mockBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ULOOP_REPOSITORY_ROOT", workDir)
+	t.Setenv("PR_NUMBER", "456")
+	t.Setenv("GITHUB_REPOSITORY", "owner/repository")
+	t.Setenv("GITHUB_BASE_REF", "v3-beta")
+	t.Setenv("PROTOCOL_MINIMUM_VERSION_HEAD_REF", "protocol-pr-head")
+	t.Setenv("GIT_LOG", gitLogPath)
+	t.Setenv("GIT_BASE_CONTENT", baseContentPath)
+	t.Setenv("GIT_HEAD_CONTENT", headContentPath)
+	t.Setenv("GH_LOG", ghLogPath)
+	t.Setenv("GH_COMMENT_IDS", testCase.commentIDs)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	exitCode := RunProtocolMinimumVersionComment(context.Background(), &stdout, &stderr)
+	ghLog := readFile(t, ghLogPath)
+
+	return protocolMinimumVersionCommentResult{
+		exitCode: exitCode,
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+		ghLog:    ghLog,
+	}
+}
+
+func buildProtocolMinimumVersionConstants(requiredProtocolVersion int, minimumCliVersion string) string {
+	return `namespace Tests {
+public static class CliConstants {
+public const int REQUIRED_CLI_PROTOCOL_VERSION = ` +
+		strconv.Itoa(requiredProtocolVersion) +
+		`;
+public const string MINIMUM_REQUIRED_CLI_VERSION = "` + minimumCliVersion + `";
+}
+}`
+}
+
+func writeProtocolMinimumVersionMockGit(t *testing.T, path string) {
+	t.Helper()
+
+	content := `#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$GIT_LOG"
+
+if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then
+  printf '%s\n' "$ULOOP_REPOSITORY_ROOT"
+  exit 0
+fi
+
+if [ "$1" = "-C" ]; then
+  shift 2
+fi
+
+if [ "$1" = "show" ]; then
+  case "$2" in
+    origin/v3-beta:*) cat "$GIT_BASE_CONTENT" ;;
+    protocol-pr-head:*) cat "$GIT_HEAD_CONTENT" ;;
+    *) echo "unexpected git show ref: $2" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+echo "unexpected git command: $*" >&2
+exit 1
+`
+	writeFile(t, path, content)
+	err := os.Chmod(path, 0o755)
+	if err != nil {
+		t.Fatalf("failed to chmod mock git: %v", err)
+	}
+}
+
+func writeProtocolMinimumVersionMockGH(t *testing.T, path string) {
+	t.Helper()
+
+	content := `#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$GH_LOG"
+
+if [ "$1" = "api" ] && [ "$2" = "--paginate" ]; then
+  if [ -n "$GH_COMMENT_IDS" ]; then
+    printf '%s\n' "$GH_COMMENT_IDS"
+  fi
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "--method" ]; then
+  exit 0
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 1
+`
+	writeFile(t, path, content)
+	err := os.Chmod(path, 0o755)
+	if err != nil {
+		t.Fatalf("failed to chmod mock gh: %v", err)
+	}
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	err := os.WriteFile(path, []byte(content), 0o755)
+	if err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(content)
+}
+
+func assertProtocolMinimumVersionLogContains(t *testing.T, actual string, expected string) {
+	t.Helper()
+	if !strings.Contains(actual, expected) {
+		t.Fatalf("expected log to contain %q, got:\n%s", expected, actual)
+	}
+}

--- a/cli/internal/automation/protocol_minimum_version_guard_test.go
+++ b/cli/internal/automation/protocol_minimum_version_guard_test.go
@@ -172,6 +172,25 @@ func TestVerifyMinimumCliReleaseProtocol_WhenTagProtocolIsMissing_Fails(t *testi
 	}
 }
 
+func TestVerifyMinimumCliReleaseProtocol_WhenProtocolVersionIsOutOfRange_FailsAsMissingMetadata(t *testing.T) {
+	// Verifies malformed protocol metadata is reported consistently with missing metadata.
+	err := VerifyMinimumCliReleaseProtocol(ProtocolMinimumVersionValues{
+		RequiredProtocolVersion: 2,
+		HasRequiredProtocol:     true,
+		MinimumCliVersion:       "3.0.0-beta.33",
+	}, []byte(`{"schemaVersion":1,"protocolVersion":999999999999999999999999999999,"cliVersion":"3.0.0-beta.33"}`))
+
+	if err == nil {
+		t.Fatal("expected out-of-range protocolVersion to fail")
+	}
+	if !strings.Contains(err.Error(), "does not define protocolVersion") {
+		t.Fatalf("expected missing protocolVersion error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "invalid JSON") {
+		t.Fatalf("expected metadata error instead of invalid JSON, got %v", err)
+	}
+}
+
 func TestVerifyMinimumCliReleaseProtocol_WhenTagProtocolDiffers_Fails(t *testing.T) {
 	// Verifies release validation rejects published CLIs from a different protocol generation.
 	err := VerifyMinimumCliReleaseProtocol(ProtocolMinimumVersionValues{
@@ -241,6 +260,7 @@ func TestRunProtocolMinimumVersionComment_WhenWarningExists_UpsertsComment(t *te
 	}
 	assertProtocolMinimumVersionLogContains(t, result.stdout, "Updated protocol minimum version comment.")
 	assertProtocolMinimumVersionLogContains(t, result.ghLog, "api --method PATCH repos/owner/repository/issues/comments/123 --input")
+	assertProtocolMinimumVersionLogContains(t, result.ghLog, ".user.login == \"github-actions[bot]\"")
 }
 
 func TestRunProtocolMinimumVersionComment_WhenWarningIsResolved_DeletesComment(t *testing.T) {

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -129,6 +129,14 @@ fetch_release_refs() {
   fi
 }
 
+fetch_cli_release_tag() {
+  release_tag=$1
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    git fetch --force origin "refs/tags/$release_tag:refs/tags/$release_tag" >/dev/null
+  fi
+}
+
 resolve_release_target_commit() {
   release_target=$1
 
@@ -391,6 +399,7 @@ if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packa
     echo "CLI release $cli_release_tag is not published with complete assets; package release sync will wait."
     exit 0
   fi
+  fetch_cli_release_tag "$cli_release_tag"
   verify_minimum_cli_release_protocol
 fi
 

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -358,9 +358,11 @@ wait_for_cli_release_ready() {
 }
 
 verify_minimum_cli_release_protocol() {
+  release_ref=$1
+
   (
     cd "$ROOT_DIR/cli"
-    go run ./cmd/check-protocol-minimum-version --verify-release
+    go run ./cmd/check-protocol-minimum-version --verify-release --ref "$release_ref"
   )
 }
 
@@ -400,7 +402,6 @@ if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packa
     exit 0
   fi
   fetch_cli_release_tag "$cli_release_tag"
-  verify_minimum_cli_release_protocol
 fi
 
 jq -r --arg skip "$CLI_PACKAGE_PATH" '
@@ -453,6 +454,9 @@ while IFS='	' read -r package_path changelog_config_path component include_compo
 
       is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
       if [ "$is_draft" != "false" ]; then
+        if [ -n "$release_commit_sha" ]; then
+          verify_minimum_cli_release_protocol "$release_commit_sha"
+        fi
         publish_existing_draft_release "$release_tag" "$version"
       else
         echo "Release $release_tag already exists."
@@ -465,6 +469,7 @@ while IFS='	' read -r package_path changelog_config_path component include_compo
         exit 1
       fi
 
+      verify_minimum_cli_release_protocol "$release_commit_sha"
       notes_file="$TMP_DIR/$release_tag.md"
       write_release_notes "$changelog_path" "$version" "$notes_file"
       create_package_release "$release_tag" "$version" "$release_commit_sha" "$notes_file"

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -454,9 +454,11 @@ while IFS='	' read -r package_path changelog_config_path component include_compo
 
       is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
       if [ "$is_draft" != "false" ]; then
-        if [ -n "$release_commit_sha" ]; then
-          verify_minimum_cli_release_protocol "$release_commit_sha"
+        if [ -z "$release_commit_sha" ]; then
+          echo "Draft release $release_tag cannot be protocol-verified because no release-please commit for $package_path version $version was found." >&2
+          exit 1
         fi
+        verify_minimum_cli_release_protocol "$release_commit_sha"
         publish_existing_draft_release "$release_tag" "$version"
       else
         echo "Release $release_tag already exists."

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -349,6 +349,13 @@ wait_for_cli_release_ready() {
   done
 }
 
+verify_minimum_cli_release_protocol() {
+  (
+    cd "$ROOT_DIR/cli"
+    go run ./cmd/check-protocol-minimum-version --verify-release
+  )
+}
+
 release_tag_from_config() {
   package_path=$1
   version=$2
@@ -384,6 +391,7 @@ if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packa
     echo "CLI release $cli_release_tag is not published with complete assets; package release sync will wait."
     exit 0
   fi
+  verify_minimum_cli_release_protocol
 fi
 
 jq -r --arg skip "$CLI_PACKAGE_PATH" '

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -38,6 +38,12 @@ test_attestation_permissions() {
   assert_contains "$WORKFLOW" "  artifact-metadata: write"
 }
 
+test_go_is_available_for_package_release_sync() {
+  assert_contains "$WORKFLOW" "      - name: Setup Go"
+  assert_contains "$WORKFLOW" "        if: steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true'"
+  assert_before "$WORKFLOW" "      - name: Setup Go" "      - name: Sync release-please package releases"
+}
+
 test_release_assets_are_attested() {
   assert_contains "$WORKFLOW" "      - name: Attest native CLI release assets"
   assert_contains "$WORKFLOW" "        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'"
@@ -76,6 +82,7 @@ test_release_please_is_dispatched_after_publish() {
 }
 
 test_attestation_permissions
+test_go_is_available_for_package_release_sync
 test_release_assets_are_attested
 test_release_asset_attestations_are_verified
 test_release_tagged_installer_scripts_are_verified

--- a/scripts/test-protocol-minimum-version-workflow.sh
+++ b/scripts/test-protocol-minimum-version-workflow.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+BUILD_WORKFLOW="$ROOT_DIR/.github/workflows/build-and-test.yml"
+COMMENT_WORKFLOW="$ROOT_DIR/.github/workflows/protocol-minimum-version-warning.yml"
+
+assert_contains() {
+  file=$1
+  expected=$2
+  if ! grep -F -- "$expected" "$file" >/dev/null 2>&1; then
+    echo "Expected $file to contain: $expected" >&2
+    exit 1
+  fi
+}
+
+assert_file_exists() {
+  file=$1
+  if [ ! -f "$file" ]; then
+    echo "Expected file to exist: $file" >&2
+    exit 1
+  fi
+}
+
+test_pull_request_guard_fails_on_minimum_version_omission() {
+  assert_contains "$BUILD_WORKFLOW" "      - name: Check protocol minimum version bump"
+  assert_contains "$BUILD_WORKFLOW" "        if: github.event_name == 'pull_request'"
+  assert_contains "$BUILD_WORKFLOW" '        run: go run ./cmd/check-protocol-minimum-version --base "origin/${{ github.base_ref }}" --head HEAD'
+}
+
+test_pull_request_target_comment_workflow_is_trusted() {
+  assert_file_exists "$COMMENT_WORKFLOW"
+  assert_contains "$COMMENT_WORKFLOW" "name: Protocol Minimum Version Warning"
+  assert_contains "$COMMENT_WORKFLOW" "  pull_request_target:"
+  assert_contains "$COMMENT_WORKFLOW" "  contents: read"
+  assert_contains "$COMMENT_WORKFLOW" "  issues: write"
+  assert_contains "$COMMENT_WORKFLOW" "  pull-requests: read"
+  assert_contains "$COMMENT_WORKFLOW" "      - name: Checkout base repository"
+  assert_contains "$COMMENT_WORKFLOW" "      - name: Fetch pull request head"
+  assert_contains "$COMMENT_WORKFLOW" '        run: git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:protocol-minimum-version-pr-head"'
+  assert_contains "$COMMENT_WORKFLOW" "      - name: Comment on protocol minimum version guard"
+  assert_contains "$COMMENT_WORKFLOW" "          PROTOCOL_MINIMUM_VERSION_HEAD_REF: protocol-minimum-version-pr-head"
+  assert_contains "$COMMENT_WORKFLOW" "        run: go run ./cmd/comment-protocol-minimum-version"
+}
+
+test_pull_request_guard_fails_on_minimum_version_omission
+test_pull_request_target_comment_workflow_is_trusted

--- a/scripts/test-protocol-minimum-version-workflow.sh
+++ b/scripts/test-protocol-minimum-version-workflow.sh
@@ -36,10 +36,10 @@ test_pull_request_target_comment_workflow_is_trusted() {
   assert_contains "$COMMENT_WORKFLOW" "  issues: write"
   assert_contains "$COMMENT_WORKFLOW" "  pull-requests: read"
   assert_contains "$COMMENT_WORKFLOW" "      - name: Checkout base repository"
-  assert_contains "$COMMENT_WORKFLOW" "      - name: Fetch pull request head"
-  assert_contains "$COMMENT_WORKFLOW" '        run: git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:protocol-minimum-version-pr-head"'
+  assert_contains "$COMMENT_WORKFLOW" "      - name: Fetch pull request merge"
+  assert_contains "$COMMENT_WORKFLOW" '        run: git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/merge:protocol-minimum-version-pr-merge"'
   assert_contains "$COMMENT_WORKFLOW" "      - name: Comment on protocol minimum version guard"
-  assert_contains "$COMMENT_WORKFLOW" "          PROTOCOL_MINIMUM_VERSION_HEAD_REF: protocol-minimum-version-pr-head"
+  assert_contains "$COMMENT_WORKFLOW" "          PROTOCOL_MINIMUM_VERSION_HEAD_REF: protocol-minimum-version-pr-merge"
   assert_contains "$COMMENT_WORKFLOW" "        run: go run ./cmd/comment-protocol-minimum-version"
 }
 

--- a/scripts/test-protocol-minimum-version-workflow.sh
+++ b/scripts/test-protocol-minimum-version-workflow.sh
@@ -37,6 +37,7 @@ test_pull_request_target_comment_workflow_is_trusted() {
   assert_contains "$COMMENT_WORKFLOW" "  issues: write"
   assert_contains "$COMMENT_WORKFLOW" "  pull-requests: read"
   assert_contains "$COMMENT_WORKFLOW" "      - name: Checkout base repository"
+  assert_contains "$COMMENT_WORKFLOW" "          persist-credentials: false"
   assert_contains "$COMMENT_WORKFLOW" "      - name: Fetch pull request merge"
   assert_contains "$COMMENT_WORKFLOW" '        run: git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/merge:protocol-minimum-version-pr-merge"'
   assert_contains "$COMMENT_WORKFLOW" "      - name: Comment on protocol minimum version guard"

--- a/scripts/test-protocol-minimum-version-workflow.sh
+++ b/scripts/test-protocol-minimum-version-workflow.sh
@@ -25,6 +25,7 @@ assert_file_exists() {
 test_pull_request_guard_fails_on_minimum_version_omission() {
   assert_contains "$BUILD_WORKFLOW" "      - name: Check protocol minimum version bump"
   assert_contains "$BUILD_WORKFLOW" "        if: github.event_name == 'pull_request'"
+  assert_contains "$BUILD_WORKFLOW" "          GH_TOKEN: \${{ github.token }}"
   assert_contains "$BUILD_WORKFLOW" '        run: go run ./cmd/check-protocol-minimum-version --base "origin/${{ github.base_ref }}" --head HEAD'
 }
 

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -128,12 +128,14 @@ assert_file_contains "$RELEASE_WORKFLOW" 'id: package_release_sync'
 assert_file_contains "$RELEASE_WORKFLOW" "steps.package_release_sync.outputs.ready != 'false'"
 assert_file_contains "$RELEASE_WORKFLOW" '  actions: write'
 assert_file_contains "$RELEASE_WORKFLOW" '  checks: read'
+assert_file_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for package release sync'
 assert_file_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation'
 assert_file_contains "$RELEASE_WORKFLOW" '      - name: Dispatch release PR checks'
 assert_file_contains "$RELEASE_WORKFLOW" '        working-directory: cli'
 assert_file_contains "$RELEASE_WORKFLOW" '        run: go run ./cmd/dispatch-release-please-pr-checks'
 assert_step_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' "        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'"
 assert_step_contains "$RELEASE_WORKFLOW" '      - name: Dispatch release PR checks' "        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'"
+assert_file_order "$RELEASE_WORKFLOW" '      - name: Setup Go for package release sync' '      - name: 🏷️ Sync release-please package releases'
 assert_file_order "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' '      - name: Dispatch release PR checks'
 
 assert_manifest_semver '.["."]'

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -39,7 +39,7 @@ asset_json() {
 
 if [ "$1" = "release" ] && [ "$2" = "view" ]; then
   tag=$3
-  if [ "$tag" = "cli-v3.0.0-beta.6" ]; then
+  if [ "$tag" = "${CLI_RELEASE_TAG:-cli-v3.0.0-beta.6}" ]; then
     if [ -n "${CLI_RELEASE_READY_AFTER_ATTEMPTS:-}" ]; then
       attempt_file="$GH_LOG.cli-release-attempts"
       attempt=1
@@ -294,6 +294,7 @@ run_sync() {
     EXISTING_RELEASE_TARGET="$existing_target" \
     CLI_RELEASE_STATE="$cli_release_state" \
     CLI_RELEASE_ASSETS="$cli_release_assets" \
+    CLI_RELEASE_TAG="${CLI_RELEASE_TAG:-cli-v3.0.0-beta.6}" \
     CLI_RELEASE_WAIT_TIMEOUT_SECONDS="$cli_release_wait_timeout" \
     CLI_RELEASE_WAIT_INTERVAL_SECONDS="$cli_release_wait_interval" \
     CLI_RELEASE_READY_AFTER_ATTEMPTS="$cli_release_ready_after_attempts" \
@@ -353,6 +354,24 @@ test_existing_draft_root_release_is_published() {
   assert_contains "$work_dir/gh.log" "release edit v3.0.0-beta.6 --repo hatayama/unity-cli-loop --draft=false --prerelease"
 }
 
+# Verifies draft package releases are not published when their release commit cannot be checked.
+test_existing_draft_root_release_without_release_commit_fails() {
+  work_dir=$(create_release_repo draft-root-missing-release-commit)
+
+  (
+    cd "$work_dir"
+    write_release_files 3.0.0-beta.7
+  )
+
+  if CLI_RELEASE_TAG=cli-v3.0.0-beta.7 run_sync "$work_dir" v3.0.0-beta.7 true "manual-release-target"; then
+    echo "Expected draft release without a release commit to fail." >&2
+    exit 1
+  fi
+
+  assert_contains "$work_dir/stderr.txt" "Draft release v3.0.0-beta.7 cannot be protocol-verified"
+  assert_not_contains "$work_dir/gh.log" "release edit v3.0.0-beta.7"
+}
+
 # Verifies package releases wait until the matching CLI release is public.
 test_waits_for_cli_release_before_creating_root_release() {
   work_dir=$(create_release_repo waits-for-cli)
@@ -408,6 +427,7 @@ test_creates_missing_root_release_from_release_commit
 test_existing_root_release_is_reused
 test_existing_root_release_target_branch_resolves_via_origin
 test_existing_draft_root_release_is_published
+test_existing_draft_root_release_without_release_commit_fails
 test_waits_for_cli_release_before_creating_root_release
 test_waits_for_cli_assets_before_creating_root_release
 test_retries_until_cli_assets_are_ready

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -220,6 +220,7 @@ create_release_repo() {
     write_release_files 3.0.0-beta.6
     git add .
     git commit -q -m "chore: release v3-beta"
+    git tag cli-v3.0.0-beta.6
     git rev-parse HEAD > "$work_dir/release-sha.txt"
 
     printf '%s\n' "follow-up" > follow-up.txt
@@ -240,7 +241,7 @@ prepare_origin_branch() {
   (
     cd "$work_dir"
     git remote add origin "$remote_dir"
-    git push -q origin "$commit_sha:refs/heads/$branch_name"
+    git push -q origin "$commit_sha:refs/heads/$branch_name" refs/tags/cli-v3.0.0-beta.6
   )
 }
 
@@ -402,6 +403,7 @@ test_concurrent_root_release_creation_is_reused() {
   assert_contains "$work_dir/github-output.txt" "ready=true"
 }
 
+assert_contains "$SCRIPT" 'fetch_cli_release_tag "$cli_release_tag"'
 test_creates_missing_root_release_from_release_commit
 test_existing_root_release_is_reused
 test_existing_root_release_target_branch_resolves_via_origin

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -316,7 +316,7 @@ test_creates_missing_root_release_from_release_commit() {
   assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
   assert_contains "$work_dir/gh.log" "--target $release_sha --prerelease"
   assert_contains "$work_dir/gh.log" "release view cli-v3.0.0-beta.6 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish,assets"
-  assert_contains "$work_dir/go.log" "run ./cmd/check-protocol-minimum-version --verify-release"
+  assert_contains "$work_dir/go.log" "run ./cmd/check-protocol-minimum-version --verify-release --ref $release_sha"
   assert_contains "$work_dir/github-output.txt" "ready=true"
 }
 

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -111,6 +111,16 @@ MOCK_GH
 
   chmod +x "$mock_bin/gh"
 
+  cat > "$mock_bin/go" <<'MOCK_GO'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$GO_LOG"
+exit "${PROTOCOL_CHECK_STATUS:-0}"
+MOCK_GO
+
+  chmod +x "$mock_bin/go"
+
   cat > "$mock_bin/sleep" <<'MOCK_SLEEP'
 #!/bin/sh
 set -eu
@@ -268,12 +278,15 @@ run_sync() {
   cli_release_ready_after_attempts=${9:-}
 
   touch "$work_dir/gh.log"
+  touch "$work_dir/go.log"
   touch "$work_dir/github-output.txt"
   touch "$work_dir/sleep.log"
   write_mock_commands "$work_dir"
 
   PATH="$work_dir/bin:$ORIGINAL_PATH" \
     GH_LOG="$work_dir/gh.log" \
+    GO_LOG="$work_dir/go.log" \
+    PROTOCOL_CHECK_STATUS="${PROTOCOL_CHECK_STATUS:-0}" \
     SLEEP_LOG="$work_dir/sleep.log" \
     EXISTING_RELEASE_TAG="$existing_tag" \
     EXISTING_RELEASE_DRAFT="$existing_draft" \
@@ -302,6 +315,7 @@ test_creates_missing_root_release_from_release_commit() {
   assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
   assert_contains "$work_dir/gh.log" "--target $release_sha --prerelease"
   assert_contains "$work_dir/gh.log" "release view cli-v3.0.0-beta.6 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish,assets"
+  assert_contains "$work_dir/go.log" "run ./cmd/check-protocol-minimum-version --verify-release"
   assert_contains "$work_dir/github-output.txt" "ready=true"
 }
 


### PR DESCRIPTION
## Summary
- Setup now points at a published CLI release that advertises the protocol required by the Unity package.
- Protocol bump PRs now fail and receive a PR comment until the selected minimum CLI release is published and installable.

## User Impact
- Older package builds could require a newer protocol while Setup still installed an older CLI release, causing CLI/Unity protocol mismatches.
- Future protocol bumps should be caught during PR review before users receive a package that installs an incompatible CLI.

## Changes
- Bump the package minimum CLI release to `3.0.0-beta.33`.
- Add a protocol minimum-version guard and PR comment workflow.
- Verify selected CLI releases against published GitHub Release assets and release-tagged protocol metadata.
- Validate release backfills against the resolved release commit instead of the current checkout.
- Update release automation and policy docs to match the new protocol bump process.

## Verification
- `scripts/check-go-cli.sh`
- `cd cli && go test ./internal/automation ./cmd/check-protocol-minimum-version ./cmd/comment-protocol-minimum-version`
- `sh scripts/test-protocol-minimum-version-workflow.sh && sh scripts/test-sync-release-please-package-releases.sh && sh scripts/test-native-cli-publish-workflow.sh && sh scripts/test-release-please-config.sh`
- `cd cli && go run ./cmd/check-protocol-minimum-version --base origin/v3-beta --head HEAD`
- `cd cli && go run ./cmd/check-protocol-minimum-version --verify-release`
- Unity compile completed with 0 errors and 0 warnings
- `$codex-review v3-beta --parallel-tests "scripts/check-go-cli.sh"`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

