### PR TITLE
fix: Forced compilation now explains unknown result fields

### DIFF
--- a/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
+++ b/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
@@ -95,7 +95,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 completedAt: DateTime.Now,
                 messages: Array.Empty<CompilerMessage>(),
                 errors: Array.Empty<CompilerMessage>(),
-                warnings: Array.Empty<CompilerMessage>());
+                warnings: Array.Empty<CompilerMessage>(),
+                message: "Internal force compile status message.");
 
             UnityCliLoopCompileResult response =
                 CompileSessionResultService.CreateCompileResult(result, forceRecompile: true);

--- a/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
+++ b/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
@@ -81,7 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.WarningCount, Is.Null);
             Assert.That(response.Errors, Is.Null);
             Assert.That(response.Warnings, Is.Null);
-            Assert.That(response.Message, Is.EqualTo(UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE));
+            Assert.That(response.Message, Is.EqualTo(ForceCompileUnknownResult.MessageText));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.WarningCount, Is.Null);
             Assert.That(response.Errors, Is.Null);
             Assert.That(response.Warnings, Is.Null);
-            Assert.That(response.Message, Is.EqualTo(UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE));
+            Assert.That(response.Message, Is.EqualTo(ForceCompileUnknownResult.MessageText));
         }
 
         [Test]

--- a/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
+++ b/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using UnityEditor.Compilation;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -80,8 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.WarningCount, Is.Null);
             Assert.That(response.Errors, Is.Null);
             Assert.That(response.Warnings, Is.Null);
-            Assert.That(response.Message, Does.Contain("Unity does not return"));
-            Assert.That(response.Message, Does.Contain("get-logs"));
+            Assert.That(response.Message, Is.EqualTo(UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE));
         }
 
         [Test]
@@ -105,8 +105,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.WarningCount, Is.Null);
             Assert.That(response.Errors, Is.Null);
             Assert.That(response.Warnings, Is.Null);
-            Assert.That(response.Message, Does.Contain("Unity does not return"));
-            Assert.That(response.Message, Does.Contain("intentionally null"));
+            Assert.That(response.Message, Is.EqualTo(UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE));
         }
 
         [Test]

--- a/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
+++ b/Assets/Tests/Editor/CompileSessionResultServiceTests.cs
@@ -51,7 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void CreateCompileResult_WhenForceCompileIsUnknown_DropsDetailedIssues()
+        public void CreateCompileResult_WhenForceCompileIsUnknown_ExplainsNullDetails()
         {
             // Verifies force compile results do not pretend Unity returned detailed issue content.
             CompilerMessage error = new CompilerMessage
@@ -80,11 +80,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.WarningCount, Is.Null);
             Assert.That(response.Errors, Is.Null);
             Assert.That(response.Warnings, Is.Null);
-            Assert.That(response.Message, Is.Null);
+            Assert.That(response.Message, Does.Contain("Unity does not return"));
+            Assert.That(response.Message, Does.Contain("get-logs"));
         }
 
         [Test]
-        public void CreateCompileResult_WhenForceCompileHasOutcome_DropsCountsAndDetailedIssues()
+        public void CreateCompileResult_WhenForceCompileHasOutcome_ExplainsNullDetails()
         {
             // Verifies force compile does not report counts or issue lists even when a high-level outcome exists.
             CompileResult result = new CompileResult(
@@ -104,7 +105,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.WarningCount, Is.Null);
             Assert.That(response.Errors, Is.Null);
             Assert.That(response.Warnings, Is.Null);
-            Assert.That(response.Message, Is.Null);
+            Assert.That(response.Message, Does.Contain("Unity does not return"));
+            Assert.That(response.Message, Does.Contain("intentionally null"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/CompileStatusBridgeCommandTests.cs
+++ b/Assets/Tests/Editor/CompileStatusBridgeCommandTests.cs
@@ -190,7 +190,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Result["ErrorCount"]?.Type, Is.EqualTo(JTokenType.Null));
             Assert.That(
                 response.Result["Message"]?.ToString(),
-                Is.EqualTo(UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE));
+                Is.EqualTo(ForceCompileUnknownResult.MessageText));
         }
     }
 }

--- a/Assets/Tests/Editor/CompileStatusBridgeCommandTests.cs
+++ b/Assets/Tests/Editor/CompileStatusBridgeCommandTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -187,8 +188,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.HasResult, Is.True);
             Assert.That(response.Result["Success"]?.Type, Is.EqualTo(JTokenType.Null));
             Assert.That(response.Result["ErrorCount"]?.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(response.Result["Message"]?.ToString(), Does.Contain("Unity does not return"));
-            Assert.That(response.Result["Message"]?.ToString(), Does.Contain("get-logs"));
+            Assert.That(
+                response.Result["Message"]?.ToString(),
+                Is.EqualTo(UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE));
         }
     }
 }

--- a/Assets/Tests/Editor/CompileStatusBridgeCommandTests.cs
+++ b/Assets/Tests/Editor/CompileStatusBridgeCommandTests.cs
@@ -167,9 +167,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void BuildResponse_WhenForceCompilePendingRequestHasNoResult_ReturnsNullMessage()
+        public void BuildResponse_WhenForceCompilePendingRequestHasNoResult_ReturnsExplanationMessage()
         {
-            // Verifies forced compile recovery preserves the no-details response shape.
+            // Verifies forced compile recovery explains why detailed result fields are null.
             _sessionStateService.MarkPendingCompileRequest(
                 "compile_test_request",
                 forceRecompile: true,
@@ -187,7 +187,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.HasResult, Is.True);
             Assert.That(response.Result["Success"]?.Type, Is.EqualTo(JTokenType.Null));
             Assert.That(response.Result["ErrorCount"]?.Type, Is.EqualTo(JTokenType.Null));
-            Assert.That(response.Result["Message"]?.Type, Is.EqualTo(JTokenType.Null));
+            Assert.That(response.Result["Message"]?.ToString(), Does.Contain("Unity does not return"));
+            Assert.That(response.Result["Message"]?.ToString(), Does.Contain("get-logs"));
         }
     }
 }

--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -62,9 +62,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Tests that extension-facing result values stay outside project implementation assemblies.
             string validationResultAssemblyName = typeof(ValidationResult).Assembly.GetName().Name;
+            string forceCompileUnknownResultAssemblyName = typeof(ForceCompileUnknownResult).Assembly.GetName().Name;
             string serviceResultAssemblyName = typeof(ServiceResult<int>).Assembly.GetName().Name;
 
             Assert.That(validationResultAssemblyName, Is.EqualTo(ToolContractsAssemblyName));
+            Assert.That(forceCompileUnknownResultAssemblyName, Is.EqualTo(ToolContractsAssemblyName));
             Assert.That(serviceResultAssemblyName, Is.EqualTo(DomainAssemblyName));
         }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
@@ -16,6 +16,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private const string MissingTestFrameworkReferenceHint =
             "Possible test asmdef issue: Unity test framework symbols are missing. Make sure com.unity.test-framework is installed and add optionalUnityReferences: [\"TestAssemblies\"] or enable testAssemblies on the test asmdef.";
+        private const string ForceCompileResultMessage =
+            "Forced full compilation completed, but Unity does not return a definitive compile result for this forced full compile path. Fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
 
         internal static UnityCliLoopCompileResult CreateCompileResult(
             CompileResult result,
@@ -104,7 +106,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 WarningCount = null,
                 Errors = null,
                 Warnings = null,
-                Message = null
+                Message = string.IsNullOrWhiteSpace(result.Message)
+                    ? ForceCompileResultMessage
+                    : $"{result.Message} {ForceCompileResultMessage}"
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
@@ -16,8 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private const string MissingTestFrameworkReferenceHint =
             "Possible test asmdef issue: Unity test framework symbols are missing. Make sure com.unity.test-framework is installed and add optionalUnityReferences: [\"TestAssemblies\"] or enable testAssemblies on the test asmdef.";
-        private const string ForceCompileResultMessage =
-            "Forced full compilation completed. " + UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_EXPLANATION;
 
         internal static UnityCliLoopCompileResult CreateCompileResult(
             CompileResult result,
@@ -107,8 +105,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Errors = null,
                 Warnings = null,
                 Message = string.IsNullOrWhiteSpace(result.Message)
-                    ? ForceCompileResultMessage
-                    : $"{result.Message} {ForceCompileResultMessage}"
+                    ? UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE
+                    : $"{result.Message} {UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE}"
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
@@ -104,9 +104,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 WarningCount = null,
                 Errors = null,
                 Warnings = null,
-                Message = string.IsNullOrWhiteSpace(result.Message)
-                    ? UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE
-                    : $"{result.Message} {UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE}"
+                Message = UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
@@ -17,7 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string MissingTestFrameworkReferenceHint =
             "Possible test asmdef issue: Unity test framework symbols are missing. Make sure com.unity.test-framework is installed and add optionalUnityReferences: [\"TestAssemblies\"] or enable testAssemblies on the test asmdef.";
         private const string ForceCompileResultMessage =
-            "Forced full compilation completed, but Unity does not return a definitive compile result for this forced full compile path. Fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
+            "Forced full compilation completed. " + UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_EXPLANATION;
 
         internal static UnityCliLoopCompileResult CreateCompileResult(
             CompileResult result,

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultService.cs
@@ -97,14 +97,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static UnityCliLoopCompileResult CreateForceCompileResult(CompileResult result)
         {
+            ForceCompileUnknownResult unknownResult = ForceCompileUnknownResult.Create(result.Success);
             return new UnityCliLoopCompileResult
             {
-                Success = result.Success,
-                ErrorCount = null,
-                WarningCount = null,
+                Success = unknownResult.Success,
+                ErrorCount = unknownResult.ErrorCount,
+                WarningCount = unknownResult.WarningCount,
                 Errors = null,
                 Warnings = null,
-                Message = UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE
+                Message = unknownResult.Message
             };
         }
 

--- a/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
@@ -18,8 +18,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string RequestIdParamName = "RequestId";
         private const string RecoveredCompileResultMessage =
             "Compilation completed, but Unity reloaded scripts before Unity CLI Loop could record detailed errors or warnings. Use get-logs to inspect the compiler output.";
-        private const string RecoveredForceCompileResultMessage =
-            "Forced full compilation completed, but Unity reloaded scripts before Unity CLI Loop could record detailed errors or warnings. " + UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_EXPLANATION;
 
         public static GetCompileStatusResponse Execute(JToken paramsToken)
         {
@@ -161,7 +159,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             if (forceRecompile)
             {
-                return new JValue(RecoveredForceCompileResultMessage);
+                return new JValue(UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE);
             }
 
             return new JValue(RecoveredCompileResultMessage);

--- a/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
@@ -19,7 +19,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string RecoveredCompileResultMessage =
             "Compilation completed, but Unity reloaded scripts before Unity CLI Loop could record detailed errors or warnings. Use get-logs to inspect the compiler output.";
         private const string RecoveredForceCompileResultMessage =
-            "Forced full compilation completed, but Unity reloaded scripts before Unity CLI Loop could record detailed errors or warnings. Unity does not return a definitive compile result for this forced full compile path, so fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
+            "Forced full compilation completed, but Unity reloaded scripts before Unity CLI Loop could record detailed errors or warnings. " + UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_EXPLANATION;
 
         public static GetCompileStatusResponse Execute(JToken paramsToken)
         {

--- a/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
@@ -143,6 +143,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(pendingRequest != null, "pendingRequest must not be null");
 
+            string message = RecoveredCompileResultMessage;
+            if (pendingRequest.ForceRecompile)
+            {
+                ForceCompileUnknownResult unknownForceCompileResult =
+                    ForceCompileUnknownResult.Create(null);
+                message = unknownForceCompileResult.Message;
+            }
+
             return new JObject
             {
                 ["Success"] = JValue.CreateNull(),
@@ -150,19 +158,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 ["WarningCount"] = JValue.CreateNull(),
                 ["Errors"] = JValue.CreateNull(),
                 ["Warnings"] = JValue.CreateNull(),
-                ["Message"] = CreateRecoveredCompileMessage(pendingRequest.ForceRecompile),
+                ["Message"] = message,
                 ["ProjectRoot"] = UnityCliLoopPathResolver.GetProjectRoot()
             };
-        }
-
-        private static JToken CreateRecoveredCompileMessage(bool forceRecompile)
-        {
-            if (forceRecompile)
-            {
-                return new JValue(UnityCliLoopConstants.FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE);
-            }
-
-            return new JValue(RecoveredCompileResultMessage);
         }
 
         private static string CreateMessage(bool ready, bool hasResult)

--- a/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
@@ -18,6 +18,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string RequestIdParamName = "RequestId";
         private const string RecoveredCompileResultMessage =
             "Compilation completed, but Unity reloaded scripts before Unity CLI Loop could record detailed errors or warnings. Use get-logs to inspect the compiler output.";
+        private const string RecoveredForceCompileResultMessage =
+            "Forced full compilation completed, but Unity reloaded scripts before Unity CLI Loop could record detailed errors or warnings. Unity does not return a definitive compile result for this forced full compile path, so fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
 
         public static GetCompileStatusResponse Execute(JToken paramsToken)
         {
@@ -159,7 +161,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             if (forceRecompile)
             {
-                return JValue.CreateNull();
+                return new JValue(RecoveredForceCompileResultMessage);
             }
 
             return new JValue(RecoveredCompileResultMessage);

--- a/Packages/src/Editor/ToolContracts/ForceCompileUnknownResult.cs
+++ b/Packages/src/Editor/ToolContracts/ForceCompileUnknownResult.cs
@@ -1,0 +1,28 @@
+namespace io.github.hatayama.UnityCliLoop.ToolContracts
+{
+    /// <summary>
+    /// Shared result values for forced full compilation when Unity does not provide a definitive result.
+    /// </summary>
+    public sealed class ForceCompileUnknownResult
+    {
+        public const string MessageText = "Forced full compilation completed. Unity does not return a definitive compile result for this forced full compile path, so fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
+
+        private ForceCompileUnknownResult(bool? success)
+        {
+            Success = success;
+            ErrorCount = null;
+            WarningCount = null;
+            Message = MessageText;
+        }
+
+        public bool? Success { get; }
+        public int? ErrorCount { get; }
+        public int? WarningCount { get; }
+        public string Message { get; }
+
+        public static ForceCompileUnknownResult Create(bool? success)
+        {
+            return new ForceCompileUnknownResult(success);
+        }
+    }
+}

--- a/Packages/src/Editor/ToolContracts/ForceCompileUnknownResult.cs.meta
+++ b/Packages/src/Editor/ToolContracts/ForceCompileUnknownResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2f51be702a6462e83abd0b532bb1fff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -91,8 +91,6 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         
         public const string ERROR_MESSAGE_DUPLICATE_ASMDEF = "Duplicate asmdef assembly name detected. Unity may not start compilation until duplicates are removed.";
         public const string ERROR_MESSAGE_ASSEMBLY_DEFINITION_IMPORT_ERROR = "Assembly Definition or Assembly Reference import error detected. Unity may not start compilation until asmdef or asmref errors are removed.";
-        public const string FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE = "Forced full compilation completed. Unity does not return a definitive compile result for this forced full compile path, so fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
-        
         public const string ERROR_MESSAGE_EXECUTION_IN_PROGRESS = "Another execution is already in progress";
         public const string ERROR_MESSAGE_EXECUTION_CANCELLED = "Execution was cancelled or timed out";
         public const string ERROR_MESSAGE_NO_COMPILED_ASSEMBLY = "No compiled assembly provided";

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -91,7 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         
         public const string ERROR_MESSAGE_DUPLICATE_ASMDEF = "Duplicate asmdef assembly name detected. Unity may not start compilation until duplicates are removed.";
         public const string ERROR_MESSAGE_ASSEMBLY_DEFINITION_IMPORT_ERROR = "Assembly Definition or Assembly Reference import error detected. Unity may not start compilation until asmdef or asmref errors are removed.";
-        public const string FORCE_COMPILE_UNKNOWN_RESULT_EXPLANATION = "Unity does not return a definitive compile result for this forced full compile path, so fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
+        public const string FORCE_COMPILE_UNKNOWN_RESULT_MESSAGE = "Forced full compilation completed. Unity does not return a definitive compile result for this forced full compile path, so fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
         
         public const string ERROR_MESSAGE_EXECUTION_IN_PROGRESS = "Another execution is already in progress";
         public const string ERROR_MESSAGE_EXECUTION_CANCELLED = "Execution was cancelled or timed out";

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -91,6 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         
         public const string ERROR_MESSAGE_DUPLICATE_ASMDEF = "Duplicate asmdef assembly name detected. Unity may not start compilation until duplicates are removed.";
         public const string ERROR_MESSAGE_ASSEMBLY_DEFINITION_IMPORT_ERROR = "Assembly Definition or Assembly Reference import error detected. Unity may not start compilation until asmdef or asmref errors are removed.";
+        public const string FORCE_COMPILE_UNKNOWN_RESULT_EXPLANATION = "Unity does not return a definitive compile result for this forced full compile path, so fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
         
         public const string ERROR_MESSAGE_EXECUTION_IN_PROGRESS = "Another execution is already in progress";
         public const string ERROR_MESSAGE_EXECUTION_CANCELLED = "Execution was cancelled or timed out";


### PR DESCRIPTION
## Summary
- Forced full compilation now returns an explanatory message when Unity cannot provide definitive result fields.
- Normal completion and domain reload recovery now use the same unknown-result wording.

## User Impact
- Before, forced full compilation could return null result fields without context, which made agents treat the response as ambiguous or broken.
- Now the response explains that Unity did not provide those fields for this path and points agents to get-logs for compiler output.

## Changes
- Added a shared forced full compile unknown-result contract value.
- Updated compile result shaping and compile status recovery to use the shared value.
- Added EditMode coverage for the message and contract assembly ownership.

## Verification
- `cli/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `cli/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.(CompileSessionResultServiceTests|CompileStatusBridgeCommandTests|OnionAssemblyDependencyTests.PlatformResultTypes_WhenLoaded_CompileUnderDomainAssembly)"`
- `cli/dist/darwin-arm64/uloop compile --force-recompile --project-path "$(git rev-parse --show-toplevel)"`
- Codex review against `v3-beta`: clean, with targeted EditMode tests passing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

