### PR TITLE
fix: Windows dynamic code snippets are easier to pass safely

### DIFF
--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -17,15 +17,15 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute via Bash: `uloop execute-dynamic-code --code '<code>'`
+3. Execute inline code: `uloop execute-dynamic-code --code '<code>'`
 4. If execution fails, adjust code and retry
 5. Report the execution result
 
 ## Parameters
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
-- `--code-file <path>`: Read the C# statements from a file instead of `--code`. Prefer this for long or multi-line snippets because it removes shell quoting entirely. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`). With `--code-file` no quoting is needed.
+- `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
+- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted strings. Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands; escape C# double quotes as `\"` there, or use `--code-file` when the snippet has many strings.
 - `--parameters {}` (advanced, optional): Pass an object when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets, and pass an object instead of a JSON string.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 
@@ -46,7 +46,7 @@ return x;
 Returns JSON:
 - `Success`: boolean — overall execution success
 - `Result`: string — value of the snippet's `return` statement (empty when omitted)
-- `Logs`: string[] — `Debug.Log` / `Debug.LogWarning` / `Debug.LogError` messages emitted during the run
+- `Logs`: string[] — execution messages from the dynamic-code tool; read Unity Console `Debug.Log` output with `get-logs`
 - `CompilationErrors`: object[] — Roslyn diagnostics with `Message`, `Line`, `Column`, `ErrorCode`, optional `Hint` and `Suggestions`
 - `ErrorMessage`: string — top-level failure summary (empty on success)
 - `Error`: string — alias of `ErrorMessage`

--- a/.agents/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.agents/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -26,12 +26,28 @@ Use `execute-dynamic-code` for direct automation and diagnostics, and switch to 
 
 Use these patterns when you need shell-safe inline code:
 
+### Native launcher check
+
+Multi-line `--code` expects PowerShell to call the native `uloop.exe` launcher directly.
+If `Get-Command uloop` resolves to an old npm `.cmd` shim, run `uloop install` and open a new terminal before relying on multi-line inline snippets.
+
+```powershell
+(Get-Command uloop).Source
+```
+
 ### Double quotes inside C# strings
 
-Single-quote the whole snippet and keep C# string literals unchanged.
+PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
 
 ```powershell
 uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
+```
+
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
+Escape C# double quotes as `\"` when using inline `--code` from Windows PowerShell 5.1.
+
+```powershell
+uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
 ```
 
 ### Single quotes inside inline C# code
@@ -52,7 +68,7 @@ uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{
 
 ### Multi-line C# snippets
 
-Use a here-string when the snippet spans multiple lines.
+Use a here-string when the snippet spans multiple lines in PowerShell 7 (`pwsh`).
 
 ```powershell
 $code = @'
@@ -60,6 +76,21 @@ using UnityEngine;
 
 GameObject obj = GameObject.Find("Player");
 if (obj == null) return "Player not found";
+
+return obj.name;
+'@
+
+uloop execute-dynamic-code --code $code
+```
+
+When using Windows PowerShell 5.1, escape C# double quotes inside the here-string before passing it to native `uloop.exe`.
+
+```powershell
+$code = @'
+using UnityEngine;
+
+GameObject obj = GameObject.Find(\"Player\");
+if (obj == null) return \"Player not found\";
 
 return obj.name;
 '@

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -17,15 +17,15 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute via Bash: `uloop execute-dynamic-code --code '<code>'`
+3. Execute inline code: `uloop execute-dynamic-code --code '<code>'`
 4. If execution fails, adjust code and retry
 5. Report the execution result
 
 ## Parameters
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
-- `--code-file <path>`: Read the C# statements from a file instead of `--code`. Prefer this for long or multi-line snippets because it removes shell quoting entirely. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`). With `--code-file` no quoting is needed.
+- `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
+- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted strings. Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands; escape C# double quotes as `\"` there, or use `--code-file` when the snippet has many strings.
 - `--parameters {}` (advanced, optional): Pass an object when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets, and pass an object instead of a JSON string.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 
@@ -46,7 +46,7 @@ return x;
 Returns JSON:
 - `Success`: boolean — overall execution success
 - `Result`: string — value of the snippet's `return` statement (empty when omitted)
-- `Logs`: string[] — `Debug.Log` / `Debug.LogWarning` / `Debug.LogError` messages emitted during the run
+- `Logs`: string[] — execution messages from the dynamic-code tool; read Unity Console `Debug.Log` output with `get-logs`
 - `CompilationErrors`: object[] — Roslyn diagnostics with `Message`, `Line`, `Column`, `ErrorCode`, optional `Hint` and `Suggestions`
 - `ErrorMessage`: string — top-level failure summary (empty on success)
 - `Error`: string — alias of `ErrorMessage`

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -26,12 +26,28 @@ Use `execute-dynamic-code` for direct automation and diagnostics, and switch to 
 
 Use these patterns when you need shell-safe inline code:
 
+### Native launcher check
+
+Multi-line `--code` expects PowerShell to call the native `uloop.exe` launcher directly.
+If `Get-Command uloop` resolves to an old npm `.cmd` shim, run `uloop install` and open a new terminal before relying on multi-line inline snippets.
+
+```powershell
+(Get-Command uloop).Source
+```
+
 ### Double quotes inside C# strings
 
-Single-quote the whole snippet and keep C# string literals unchanged.
+PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
 
 ```powershell
 uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
+```
+
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
+Escape C# double quotes as `\"` when using inline `--code` from Windows PowerShell 5.1.
+
+```powershell
+uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
 ```
 
 ### Single quotes inside inline C# code
@@ -52,7 +68,7 @@ uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{
 
 ### Multi-line C# snippets
 
-Use a here-string when the snippet spans multiple lines.
+Use a here-string when the snippet spans multiple lines in PowerShell 7 (`pwsh`).
 
 ```powershell
 $code = @'
@@ -60,6 +76,21 @@ using UnityEngine;
 
 GameObject obj = GameObject.Find("Player");
 if (obj == null) return "Player not found";
+
+return obj.name;
+'@
+
+uloop execute-dynamic-code --code $code
+```
+
+When using Windows PowerShell 5.1, escape C# double quotes inside the here-string before passing it to native `uloop.exe`.
+
+```powershell
+$code = @'
+using UnityEngine;
+
+GameObject obj = GameObject.Find(\"Player\");
+if (obj == null) return \"Player not found\";
 
 return obj.name;
 '@

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -17,15 +17,15 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute via Bash: `uloop execute-dynamic-code --code '<code>'`
+3. Execute inline code: `uloop execute-dynamic-code --code '<code>'`
 4. If execution fails, adjust code and retry
 5. Report the execution result
 
 ## Parameters
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
-- `--code-file <path>`: Read the C# statements from a file instead of `--code`. Prefer this for long or multi-line snippets because it removes shell quoting entirely. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell doubles inner quotes (`'Debug.Log(""Hello!"");'`). With `--code-file` no quoting is needed.
+- `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
+- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted strings. Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands; escape C# double quotes as `\"` there, or use `--code-file` when the snippet has many strings.
 - `--parameters {}` (advanced, optional): Pass an object when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets, and pass an object instead of a JSON string.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 
@@ -46,7 +46,7 @@ return x;
 Returns JSON:
 - `Success`: boolean — overall execution success
 - `Result`: string — value of the snippet's `return` statement (empty when omitted)
-- `Logs`: string[] — `Debug.Log` / `Debug.LogWarning` / `Debug.LogError` messages emitted during the run
+- `Logs`: string[] — execution messages from the dynamic-code tool; read Unity Console `Debug.Log` output with `get-logs`
 - `CompilationErrors`: object[] — Roslyn diagnostics with `Message`, `Line`, `Column`, `ErrorCode`, optional `Hint` and `Suggestions`
 - `ErrorMessage`: string — top-level failure summary (empty on success)
 - `Error`: string — alias of `ErrorMessage`

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -26,12 +26,28 @@ Use `execute-dynamic-code` for direct automation and diagnostics, and switch to 
 
 Use these patterns when you need shell-safe inline code:
 
+### Native launcher check
+
+Multi-line `--code` expects PowerShell to call the native `uloop.exe` launcher directly.
+If `Get-Command uloop` resolves to an old npm `.cmd` shim, run `uloop install` and open a new terminal before relying on multi-line inline snippets.
+
+```powershell
+(Get-Command uloop).Source
+```
+
 ### Double quotes inside C# strings
 
-Single-quote the whole snippet and keep C# string literals unchanged.
+PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
 
 ```powershell
 uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
+```
+
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
+Escape C# double quotes as `\"` when using inline `--code` from Windows PowerShell 5.1.
+
+```powershell
+uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
 ```
 
 ### Single quotes inside inline C# code
@@ -52,7 +68,7 @@ uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{
 
 ### Multi-line C# snippets
 
-Use a here-string when the snippet spans multiple lines.
+Use a here-string when the snippet spans multiple lines in PowerShell 7 (`pwsh`).
 
 ```powershell
 $code = @'
@@ -60,6 +76,21 @@ using UnityEngine;
 
 GameObject obj = GameObject.Find("Player");
 if (obj == null) return "Player not found";
+
+return obj.name;
+'@
+
+uloop execute-dynamic-code --code $code
+```
+
+When using Windows PowerShell 5.1, escape C# double quotes inside the here-string before passing it to native `uloop.exe`.
+
+```powershell
+$code = @'
+using UnityEngine;
+
+GameObject obj = GameObject.Find(\"Player\");
+if (obj == null) return \"Player not found\";
 
 return obj.name;
 '@

--- a/cli/internal/cli/command_help.go
+++ b/cli/internal/cli/command_help.go
@@ -118,6 +118,7 @@ func visibleOptionHelpEntriesForTool(tool toolDefinition) []optionHelpEntry {
 		})
 	}
 
+	entries = appendDynamicCodeFileOptionHelpEntry(tool, entries)
 	sort.Slice(entries, func(i int, j int) bool {
 		return entries[i].name < entries[j].name
 	})

--- a/cli/internal/cli/completion_test.go
+++ b/cli/internal/cli/completion_test.go
@@ -122,6 +122,9 @@ func TestCompletionListOptionsUsesExecuteDynamicCodeWaitFlag(t *testing.T) {
 	if !strings.Contains(output, "--wait-for-domain-reload") {
 		t.Fatalf("execute-dynamic-code wait option was not listed: %s", output)
 	}
+	if !strings.Contains(output, "--code-file") {
+		t.Fatalf("execute-dynamic-code code-file option was not listed: %s", output)
+	}
 	if strings.Contains(output, "--no-wait-for-domain-reload") {
 		t.Fatalf("execute-dynamic-code no-wait option should not be listed: %s", output)
 	}

--- a/cli/internal/cli/dynamic_code_file.go
+++ b/cli/internal/cli/dynamic_code_file.go
@@ -8,8 +8,12 @@ import (
 
 const (
 	dynamicCodeFileFlagName     = "code-file"
+	dynamicCodeFileOptionName   = "--" + dynamicCodeFileFlagName
+	dynamicCodeFileOptionUsage  = dynamicCodeFileOptionName + " <path>"
 	dynamicCodeCodePropertyName = "Code"
 )
+
+const dynamicCodeFileOptionDescription = "Read C# code from a file instead of --code when shell quoting would alter multiline code"
 
 // extractDynamicCodeFileFlag pulls --code-file out of execute-dynamic-code args before
 // generic tool parsing, because the flag is CLI-side sugar and not part of the Unity schema.
@@ -67,4 +71,32 @@ func applyDynamicCodeFileParam(params map[string]any, path string) error {
 
 	params[dynamicCodeCodePropertyName] = string(content)
 	return nil
+}
+
+func appendDynamicCodeFileOptionName(tool toolDefinition, options []string) []string {
+	if tool.Name != executeDynamicCodeCommandName {
+		return options
+	}
+	for _, option := range options {
+		if option == dynamicCodeFileOptionName {
+			return options
+		}
+	}
+	return append(options, dynamicCodeFileOptionName)
+}
+
+func appendDynamicCodeFileOptionHelpEntry(tool toolDefinition, entries []optionHelpEntry) []optionHelpEntry {
+	if tool.Name != executeDynamicCodeCommandName {
+		return entries
+	}
+	for _, entry := range entries {
+		if entry.name == dynamicCodeFileOptionName {
+			return entries
+		}
+	}
+	return append(entries, optionHelpEntry{
+		name:        dynamicCodeFileOptionName,
+		usage:       dynamicCodeFileOptionUsage,
+		description: dynamicCodeFileOptionDescription,
+	})
 }

--- a/cli/internal/cli/help_test.go
+++ b/cli/internal/cli/help_test.go
@@ -279,6 +279,35 @@ func TestRunProjectLocalCompileHelpDoesNotRequireUnityProject(t *testing.T) {
 	}
 }
 
+// Tests that execute-dynamic-code help includes CLI-side code-file support without resolving a Unity project.
+func TestRunProjectLocalExecuteDynamicCodeHelpDoesNotRequireUnityProject(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := RunProjectLocal(context.Background(), []string{executeDynamicCodeCommandName, "--help"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("execute-dynamic-code help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, expected := range []string{
+		"Usage:",
+		"uloop execute-dynamic-code",
+		"--code <value>",
+		dynamicCodeFileOptionUsage,
+		"--wait-for-domain-reload",
+		"Read C# code from a file",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("execute-dynamic-code help missing %q:\n%s", expected, output)
+		}
+	}
+	if strings.Contains(output, "--compile-only") {
+		t.Fatalf("execute-dynamic-code help exposed internal compile-only flag:\n%s", output)
+	}
+}
+
 // Tests that command help wins even after other tool options.
 func TestRunProjectLocalCompileHelpWinsAfterOtherOptions(t *testing.T) {
 	t.Chdir(t.TempDir())

--- a/cli/internal/cli/tools.go
+++ b/cli/internal/cli/tools.go
@@ -334,6 +334,7 @@ func visibleOptionNamesForTool(tool toolDefinition) []string {
 		}
 		options = append(options, "--"+optionNameForProperty(tool.Name, propertyName, property))
 	}
+	options = appendDynamicCodeFileOptionName(tool, options)
 	sort.Strings(options)
 	return options
 }

--- a/cli/internal/cli/tools_test.go
+++ b/cli/internal/cli/tools_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +83,28 @@ func TestBuildToolParamsConvertsExecuteDynamicCodeWaitFlag(t *testing.T) {
 
 	if params[compileWaitParam] != true {
 		t.Fatalf("WaitForDomainReload mismatch: %#v", params[compileWaitParam])
+	}
+}
+
+// Tests that execute-dynamic-code preserves multiline inline code as one argument.
+func TestBuildToolParamsPreservesExecuteDynamicCodeMultilineCode(t *testing.T) {
+	tool, ok := findTool(loadDefaultTools(), executeDynamicCodeCommandName)
+	if !ok {
+		t.Fatal("execute-dynamic-code was not found in default tools")
+	}
+	source := "using UnityEngine;\nGameObject obj = GameObject.Find(\"Player\");\nif (obj == null) return \"Player not found\";\nreturn obj.name;"
+
+	params, _, err := buildToolParams([]string{"--code", source}, tool)
+	if err != nil {
+		t.Fatalf("buildToolParams failed: %v", err)
+	}
+
+	code, ok := params[dynamicCodeCodePropertyName].(string)
+	if !ok {
+		t.Fatalf("Code param type mismatch: %#v", params[dynamicCodeCodePropertyName])
+	}
+	if code != source {
+		t.Fatalf("Code param was not preserved:\nexpected: %q\nactual:   %q", source, code)
 	}
 }
 
@@ -220,6 +243,53 @@ func TestBuildToolParamsAcceptsHiddenExecuteDynamicCodeCompileOnlyFlag(t *testin
 
 	if params[dynamicCodeCompileOnlyParam] != true {
 		t.Fatalf("CompileOnly mismatch: %#v", params[dynamicCodeCompileOnlyParam])
+	}
+}
+
+// Tests that execute-dynamic-code lists CLI-side file input without exposing internal flags.
+func TestVisibleOptionNamesIncludesExecuteDynamicCodeCodeFile(t *testing.T) {
+	tool, ok := findTool(loadDefaultTools(), executeDynamicCodeCommandName)
+	if !ok {
+		t.Fatal("execute-dynamic-code was not found in default tools")
+	}
+
+	options := visibleOptionNamesForTool(tool)
+
+	if !containsString(options, "--code") {
+		t.Fatalf("execute-dynamic-code code option was not listed: %#v", options)
+	}
+	if !containsString(options, dynamicCodeFileOptionName) {
+		t.Fatalf("execute-dynamic-code code-file option was not listed: %#v", options)
+	}
+	if containsString(options, "--compile-only") {
+		t.Fatalf("execute-dynamic-code internal compile-only option should stay hidden: %#v", options)
+	}
+}
+
+// Tests that execute-dynamic-code help describes CLI-side file input.
+func TestVisibleOptionHelpEntriesIncludesExecuteDynamicCodeCodeFile(t *testing.T) {
+	tool, ok := findTool(loadDefaultTools(), executeDynamicCodeCommandName)
+	if !ok {
+		t.Fatal("execute-dynamic-code was not found in default tools")
+	}
+
+	entries := visibleOptionHelpEntriesForTool(tool)
+
+	found := false
+	for _, entry := range entries {
+		if entry.name != dynamicCodeFileOptionName {
+			continue
+		}
+		found = true
+		if entry.usage != dynamicCodeFileOptionUsage {
+			t.Fatalf("code-file usage mismatch: %#v", entry)
+		}
+		if !strings.Contains(entry.description, "Read C# code from a file") {
+			t.Fatalf("code-file description mismatch: %#v", entry)
+		}
+	}
+	if !found {
+		t.Fatalf("execute-dynamic-code code-file help was not listed: %#v", entries)
 	}
 }
 

--- a/cli/internal/install/command.go
+++ b/cli/internal/install/command.go
@@ -119,10 +119,13 @@ function Test-LegacyNpmUloopPath {
     $CommandContent = Get-Content -Path $CommandPath -Raw
     return $CommandContent.Contains('node_modules/uloop-cli') -or $CommandContent.Contains('node_modules\uloop-cli')
 }
+function Write-LegacyNpmMultilineArgumentWarning {
+    Write-Host 'Legacy npm shims can alter multiline PowerShell arguments before the native CLI receives them.'
+}
 function Write-LegacyNpmManualRemoval {
     param([string]$LegacyUloopPath, [string]$LegacyPrefix)
     Write-Host 'Could not remove the legacy npm package automatically.'
-    Write-Host 'Legacy npm shims can alter multiline PowerShell arguments before the native CLI receives them.'
+    Write-LegacyNpmMultilineArgumentWarning
     if ($LegacyUloopPath) {
         Write-Host "Legacy uloop command: $LegacyUloopPath"
     }
@@ -325,7 +328,9 @@ function Report-PathShadowing {
     }
     Write-Host "Installed uloop to $ExpectedUloopPath, but PATH resolves uloop to:"
     Write-Host "  $($ResolvedCommand.Source)"
-    Write-Host 'Legacy npm shims can alter multiline PowerShell arguments before the native CLI receives them.'
+    if (Test-LegacyNpmUloopPath -CommandPath $ResolvedCommand.Source) {
+        Write-LegacyNpmMultilineArgumentWarning
+    }
     Write-Host "Move $InstallDir earlier in PATH, or remove the legacy installation if it owns that command."
 }
 Set-UserPathWithInstallDirectoryFirst -Directory $InstallDir

--- a/cli/internal/install/command.go
+++ b/cli/internal/install/command.go
@@ -122,6 +122,7 @@ function Test-LegacyNpmUloopPath {
 function Write-LegacyNpmManualRemoval {
     param([string]$LegacyUloopPath, [string]$LegacyPrefix)
     Write-Host 'Could not remove the legacy npm package automatically.'
+    Write-Host 'Legacy npm shims can alter multiline PowerShell arguments before the native CLI receives them.'
     if ($LegacyUloopPath) {
         Write-Host "Legacy uloop command: $LegacyUloopPath"
     }
@@ -324,6 +325,7 @@ function Report-PathShadowing {
     }
     Write-Host "Installed uloop to $ExpectedUloopPath, but PATH resolves uloop to:"
     Write-Host "  $($ResolvedCommand.Source)"
+    Write-Host 'Legacy npm shims can alter multiline PowerShell arguments before the native CLI receives them.'
     Write-Host "Move $InstallDir earlier in PATH, or remove the legacy installation if it owns that command."
 }
 Set-UserPathWithInstallDirectoryFirst -Directory $InstallDir

--- a/cli/internal/install/command_test.go
+++ b/cli/internal/install/command_test.go
@@ -36,6 +36,8 @@ func TestCommandForWindowsConfiguresUserPathAndLegacyCleanup(t *testing.T) {
 		"npm uninstall -g --prefix",
 		"npm uninstall -g uloop-cli",
 		"Report-PathShadowing",
+		"function Write-LegacyNpmMultilineArgumentWarning",
+		"if (Test-LegacyNpmUloopPath -CommandPath $ResolvedCommand.Source) {\n        Write-LegacyNpmMultilineArgumentWarning\n    }",
 		"foreach ($ShimName in @('uloop.exe', 'uloop.cmd', 'uloop.ps1', 'uloop'))",
 		"Legacy npm shims can alter multiline PowerShell arguments before the native CLI receives them.",
 	} {
@@ -54,6 +56,12 @@ func TestCommandForWindowsConfiguresUserPathAndLegacyCleanup(t *testing.T) {
 	}
 	if strings.Contains(setupScript, "foreach ($ShimName in @('uloop', 'uloop.cmd', 'uloop.ps1', 'uloop.exe'))") {
 		t.Fatal("legacy npm shim detection should not content-scan native exe files")
+	}
+	if count := strings.Count(setupScript, "Legacy npm shims can alter multiline PowerShell arguments before the native CLI receives them."); count != 1 {
+		t.Fatalf("legacy npm multiline warning should have one message definition, got %d", count)
+	}
+	if count := strings.Count(setupScript, "Write-LegacyNpmMultilineArgumentWarning"); count != 3 {
+		t.Fatalf("legacy npm multiline warning should be centralized and called from two sites, got %d occurrences", count)
 	}
 }
 

--- a/cli/internal/install/command_test.go
+++ b/cli/internal/install/command_test.go
@@ -36,6 +36,8 @@ func TestCommandForWindowsConfiguresUserPathAndLegacyCleanup(t *testing.T) {
 		"npm uninstall -g --prefix",
 		"npm uninstall -g uloop-cli",
 		"Report-PathShadowing",
+		"foreach ($ShimName in @('uloop.exe', 'uloop.cmd', 'uloop.ps1', 'uloop'))",
+		"Legacy npm shims can alter multiline PowerShell arguments before the native CLI receives them.",
 	} {
 		if !strings.Contains(setupScript, expected) {
 			t.Fatalf("expected %s in setup script: %s", expected, setupScript)


### PR DESCRIPTION
## Summary
- Windows users can now discover the file-based fallback for dynamic code snippets directly from CLI help and completion.
- PowerShell guidance now distinguishes PowerShell 7 from Windows PowerShell 5.1 so inline snippets with C# strings are not accidentally corrupted.

## User Impact
- Previously, Windows users could be told to pass inline C# strings in a way that Windows PowerShell 5.1 could alter before `uloop` received them.
- The CLI now surfaces `--code-file`, and the skill guidance explains when inline `--code` is safe, when escaping is required, and when a legacy npm shim can still interfere.

## Changes
- Show `--code-file` in `execute-dynamic-code --help` and shell completion option lists.
- Add regression coverage for preserving multiline inline `--code` arguments and for listing the CLI-side file option.
- Update generated agent skill docs from the source skill guidance.
- Improve Windows install diagnostics when legacy npm shims may shadow the native launcher.

## Verification
- `bash -lc 'cd /mnt/c/Users/booql/oss/unity-cli-loop2 && scripts/check-go-cli.sh'`
- `go test ./...`
- Windows PowerShell 5.1 argv smoke for escaped C# double quotes
- `go run ./cmd/uloop execute-dynamic-code --help`
- `go run ./cmd/uloop --list-options execute-dynamic-code`
- `codex-review v3-beta`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

