### PR TITLE
fix: Test runs no longer race Play Mode cleanup

### DIFF
--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -22,7 +22,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RunTestsUseCase useCase = new(
                 new TestFilterCreationService(),
                 executionService,
-                validationService
+                validationService,
+                NoCleanupWait
             );
             UnityCliLoopTestExecutionRequest parameters = new()
             {
@@ -56,7 +57,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RunTestsUseCase useCase = new(
                 new TestFilterCreationService(),
                 executionService,
-                validationService
+                validationService,
+                NoCleanupWait
             );
             UnityCliLoopTestExecutionRequest parameters = new()
             {
@@ -80,7 +82,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RunTestsUseCase useCase = new(
                 new TestFilterCreationService(),
                 executionService,
-                validationService
+                validationService,
+                NoCleanupWait
             );
             UnityCliLoopTestExecutionRequest parameters = new();
 
@@ -103,7 +106,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RunTestsUseCase useCase = new(
                 new TestFilterCreationService(),
                 executionService,
-                validationService
+                validationService,
+                NoCleanupWait
             );
             UnityCliLoopTestExecutionRequest parameters = new()
             {
@@ -150,7 +154,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RunTestsUseCase useCase = new(
                 new TestFilterCreationService(),
                 executionService,
-                validationService
+                validationService,
+                NoCleanupWait
             );
             UnityCliLoopTestExecutionRequest parameters = new()
             {
@@ -169,6 +174,94 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
             Assert.That(response.TestCount, Is.EqualTo(0));
             Assert.That(response.FailedCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_AfterTestExecution_ShouldWaitForCleanup()
+        {
+            // Verifies run-tests waits for Unity Test Runner cleanup before responding.
+            int cleanupWaitCount = 0;
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                ct =>
+                {
+                    ct.ThrowIfCancellationRequested();
+                    cleanupWaitCount++;
+                    return Task.CompletedTask;
+                }
+            );
+            UnityCliLoopTestExecutionRequest parameters = new();
+
+            await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(cleanupWaitCount, Is.EqualTo(1));
+            Assert.That(executionService.WasCalled, Is.True);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenValidationFails_ShouldNotWaitForCleanup()
+        {
+            // Verifies fail-fast validation errors do not wait for cleanup that was never scheduled.
+            int cleanupWaitCount = 0;
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(
+                ValidationResult.Failure("EditMode tests cannot run during play mode"));
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                ct =>
+                {
+                    ct.ThrowIfCancellationRequested();
+                    cleanupWaitCount++;
+                    return Task.CompletedTask;
+                }
+            );
+            UnityCliLoopTestExecutionRequest parameters = new();
+
+            await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(cleanupWaitCount, Is.EqualTo(0));
+            Assert.That(executionService.WasCalled, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenTestFrameworkUnavailable_ShouldNotWaitForCleanup()
+        {
+            // Verifies missing Test Framework returns before any Test Runner cleanup wait.
+            int cleanupWaitCount = 0;
+            StubTestExecutionService executionService = new()
+            {
+                TestFrameworkAvailable = false
+            };
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                ct =>
+                {
+                    ct.ThrowIfCancellationRequested();
+                    cleanupWaitCount++;
+                    return Task.CompletedTask;
+                }
+            );
+            UnityCliLoopTestExecutionRequest parameters = new();
+
+            await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(cleanupWaitCount, Is.EqualTo(0));
+            Assert.That(executionService.WasCalled, Is.False);
+        }
+
+        private static Task NoCleanupWait(CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -18,6 +18,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly TestExecutionService _executionService;
         private readonly TestExecutionStateValidationService _validationService;
         private readonly RunTestsNoTestsDiagnosticService _noTestsDiagnosticService;
+        private readonly Func<CancellationToken, Task> _waitForTestRunnerCleanupAsync;
+        private const int TestRunnerCleanupFallbackDelayMilliseconds = 3000;
 
         public RunTestsUseCase()
             : this(
@@ -30,7 +32,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public RunTestsUseCase(
             TestFilterCreationService filterService,
             TestExecutionService executionService,
-            TestExecutionStateValidationService validationService)
+            TestExecutionStateValidationService validationService,
+            Func<CancellationToken, Task> waitForTestRunnerCleanupAsync = null)
         {
             Debug.Assert(filterService != null, "filterService must not be null");
             Debug.Assert(executionService != null, "executionService must not be null");
@@ -39,6 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _executionService = executionService;
             _validationService = validationService;
             _noTestsDiagnosticService = new RunTestsNoTestsDiagnosticService();
+            _waitForTestRunnerCleanupAsync = waitForTestRunnerCleanupAsync ?? WaitForTestRunnerCleanupAsync;
         }
 
         /// <summary>
@@ -106,6 +110,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Create a minimal error result
                 throw new System.InvalidOperationException("Test execution failed. Please check the logs for details.", ex);
             }
+
+            await _waitForTestRunnerCleanupAsync(ct);
             
             // 3. Response creation
             UnityCliLoopTestExecutionResult response = new UnityCliLoopTestExecutionResult
@@ -166,6 +172,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 SkippedCount = 0,
                 XmlPath = null
             };
+        }
+
+        private static async Task WaitForTestRunnerCleanupAsync(CancellationToken ct)
+        {
+            // Why: Unity Test Framework exposes the real active-run signal only through internal API,
+            // while the public RunFinished callback fires before cleanup tasks such as RestoreSceneSetupTask.
+            await TimerDelay.Wait(TestRunnerCleanupFallbackDelayMilliseconds, ct);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Test runs now give Unity Test Runner cleanup a short window before returning control to the next command.
- Immediate Play Mode entry after a test run no longer trips delayed Test Runner cleanup work.

## User Impact
- Before this change, running tests and immediately starting Play Mode could leave Unity busy or surface delayed Test Runner cleanup errors.
- After this change, command chains such as run-tests followed by Play Mode are more stable.

## Changes
- Wait briefly after successful Unity Test Runner execution before building the run-tests response.
- Keep fail-fast paths unchanged so validation errors and missing Test Framework responses do not wait.
- Add focused coverage for cleanup wait and skip paths.

## Verification
- cli\dist\windows-amd64\uloop.exe compile
- cli\dist\windows-amd64\uloop.exe run-tests --test-mode EditMode --filter-type regex --filter-value 'io.github.hatayama.UnityCliLoop.Tests.Editor.RunTestsUseCaseTests'
- cli\dist\windows-amd64\uloop.exe run-tests --test-mode EditMode --filter-type exact --filter-value 'io.github.hatayama.UnityCliLoop.Tests.Editor.CliPathSetupProfileResolverTests.ResolvePlan_WhenBashProfileExistsUsesExistingProfile' && cli\dist\windows-amd64\uloop.exe control-play-mode --action Play && cli\dist\windows-amd64\uloop.exe get-logs --include-stack-trace
- codex review --commit HEAD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

