### PR TITLE
fix: Update pause point skill description

### DIFF
--- a/.agents/skills/uloop-wait-for-pause-point/SKILL.md
+++ b/.agents/skills/uloop-wait-for-pause-point/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-wait-for-pause-point
-description: "An alternative to IDE breakpoints. Temporarily pauses Unity and then inspects a specific frozen frame. Use this during bug investigations or PlayMode/E2E testing to examine variable states at specific frames or verify whether particular code has been executed."
+description: "Pauses Unity's playback and allows you to inspect specific frames. Use this for bug investigation or PlayMode/E2E testing. It's the most convenient yet rigorous method for verifying variable states at specific frames or confirming whether particular code has been executed."
 ---
 
 ## Quick Check Template

--- a/.claude/skills/uloop-wait-for-pause-point/SKILL.md
+++ b/.claude/skills/uloop-wait-for-pause-point/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-wait-for-pause-point
-description: "An alternative to IDE breakpoints. Temporarily pauses Unity and then inspects a specific frozen frame. Use this during bug investigations or PlayMode/E2E testing to examine variable states at specific frames or verify whether particular code has been executed."
+description: "Pauses Unity's playback and allows you to inspect specific frames. Use this for bug investigation or PlayMode/E2E testing. It's the most convenient yet rigorous method for verifying variable states at specific frames or confirming whether particular code has been executed."
 ---
 
 ## Quick Check Template

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uloop-wait-for-pause-point
-description: "An alternative to IDE breakpoints. Temporarily pauses Unity and then inspects a specific frozen frame. Use this during bug investigations or PlayMode/E2E testing to examine variable states at specific frames or verify whether particular code has been executed."
+description: "Pauses Unity's playback and allows you to inspect specific frames. Use this for bug investigation or PlayMode/E2E testing. It's the most convenient yet rigorous method for verifying variable states at specific frames or confirming whether particular code has been executed."
 ---
 
 ## Quick Check Template


### PR DESCRIPTION
Align the source skill and generated copies with the refined trigger text so agents understand the playback pause workflow consistently.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

