### PR TITLE
fix: PlayMode start reports compiler errors instead of timing out

### DIFF
--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -2,6 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using UnityEditor;
+using UnityEditor.Compilation;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
@@ -69,6 +70,165 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Message, Is.EqualTo("Play mode was already stopped"));
             Assert.That(response.Changed, Is.False);
             Assert.That(response.WasAlreadyStopped, Is.True);
+        }
+
+        [Test]
+        public void CompilationFailureService_WhenCompilationFails_StoresCompilerErrors()
+        {
+            // Verifies saved PlayMode diagnostics come from the compiler failure snapshot.
+            ControlPlayModeCompilationFailureService service = new ControlPlayModeCompilationFailureService();
+            CompilerMessage error = new CompilerMessage
+            {
+                type = CompilerMessageType.Error,
+                message = "CS1002: ; expected",
+                file = "Assets/Scripts/Sample.cs",
+                line = 12
+            };
+            CompilerMessage warning = new CompilerMessage
+            {
+                type = CompilerMessageType.Warning,
+                message = "CS0168: variable declared but never used",
+                file = "Assets/Scripts/Sample.cs",
+                line = 8
+            };
+
+            service.HandleCompilationStarted(null);
+            service.HandleAssemblyCompilationFinished("Assembly-CSharp.dll", new[] { error, warning });
+            service.HandleCompilationFinished(null);
+
+            ControlPlayModeCompileError[] errors = service.GetLastFailedErrors();
+            Assert.That(errors.Length, Is.EqualTo(1));
+            Assert.That(errors[0].Message, Is.EqualTo("CS1002: ; expected"));
+            Assert.That(errors[0].File, Is.EqualTo("Assets/Scripts/Sample.cs"));
+            Assert.That(errors[0].Line, Is.EqualTo(12));
+        }
+
+        [Test]
+        public void CompilationFailureService_WhenNextCompilationStarts_ClearsPreviousErrors()
+        {
+            // Verifies stale compiler diagnostics are discarded as soon as Unity starts compiling again.
+            ControlPlayModeCompilationFailureService service = new ControlPlayModeCompilationFailureService();
+            CompilerMessage error = new CompilerMessage
+            {
+                type = CompilerMessageType.Error,
+                message = "CS0103: name does not exist",
+                file = "Assets/Scripts/Sample.cs",
+                line = 3
+            };
+
+            service.HandleCompilationStarted(null);
+            service.HandleAssemblyCompilationFinished("Assembly-CSharp.dll", new[] { error });
+            service.HandleCompilationFinished(null);
+            service.HandleCompilationStarted(null);
+
+            ControlPlayModeCompileError[] errors = service.GetLastFailedErrors();
+            Assert.That(errors, Is.Empty);
+        }
+
+        [Test]
+        public void CompilationFailureService_WhenCompilationSucceeds_ClearsPreviousErrors()
+        {
+            // Verifies successful compilation removes the previous failure snapshot.
+            ControlPlayModeCompilationFailureService service = new ControlPlayModeCompilationFailureService();
+            CompilerMessage error = new CompilerMessage
+            {
+                type = CompilerMessageType.Error,
+                message = "CS0246: type not found",
+                file = "Assets/Scripts/Sample.cs",
+                line = 5
+            };
+
+            service.HandleCompilationStarted(null);
+            service.HandleAssemblyCompilationFinished("Assembly-CSharp.dll", new[] { error });
+            service.HandleCompilationFinished(null);
+            service.HandleCompilationStarted(null);
+            service.HandleAssemblyCompilationFinished("Assembly-CSharp.dll", System.Array.Empty<CompilerMessage>());
+            service.HandleCompilationFinished(null);
+
+            ControlPlayModeCompileError[] errors = service.GetLastFailedErrors();
+            Assert.That(errors, Is.Empty);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenPlayBlockedByCompileErrors_ReturnsSavedDiagnostics()
+        {
+            // Verifies Play returns compiler diagnostics immediately instead of waiting for a state timeout.
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            ControlPlayModeCompileError[] compileErrors =
+            {
+                new ControlPlayModeCompileError
+                {
+                    Message = "CS1002: ; expected",
+                    File = "Assets/Scripts/Sample.cs",
+                    Line = 12
+                }
+            };
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(compileErrors),
+                new StubCompilationFailureGate(true));
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.BlockedByCompileErrors, Is.True);
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.IsPlaying, Is.False);
+            Assert.That(response.CompileErrorCount, Is.EqualTo(1));
+            Assert.That(response.CompileErrors[0].Message, Is.EqualTo("CS1002: ; expected"));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenPlayBlockedWithoutSavedErrors_ReturnsEmptyDiagnostics()
+        {
+            // Verifies Play still fails fast when Unity reports compilation failure but no snapshot is available.
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(true));
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.BlockedByCompileErrors, Is.True);
+            Assert.That(response.CompileErrorCount, Is.EqualTo(0));
+            Assert.That(response.CompileErrors, Is.Empty);
+            Assert.That(response.Message, Does.Contain("no saved compiler diagnostics"));
+        }
+
+        private sealed class StubCompilationFailureProvider : IControlPlayModeCompilationFailureProvider
+        {
+            private readonly ControlPlayModeCompileError[] _errors;
+
+            public StubCompilationFailureProvider(ControlPlayModeCompileError[] errors)
+            {
+                _errors = errors;
+            }
+
+            public ControlPlayModeCompileError[] GetLastFailedErrors()
+            {
+                return _errors;
+            }
+        }
+
+        private sealed class StubCompilationFailureGate : IControlPlayModeCompilationFailureGate
+        {
+            private readonly bool _hasScriptCompilationFailed;
+
+            public StubCompilationFailureGate(bool hasScriptCompilationFailed)
+            {
+                _hasScriptCompilationFailed = hasScriptCompilationFailed;
+            }
+
+            public bool HasScriptCompilationFailed()
+            {
+                return _hasScriptCompilationFailed;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -38,6 +38,65 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task ExecuteAsync_WhenStatusOnlyPlayBlockedByCompileErrors_ReturnsSavedDiagnostics()
+        {
+            // Verifies polling can report compiler diagnostics when PlayMode becomes blocked after the first request.
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            ControlPlayModeCompileError[] compileErrors =
+            {
+                new ControlPlayModeCompileError
+                {
+                    Message = "CS1525: invalid expression",
+                    File = "Assets/Scripts/Sample.cs",
+                    Line = 3
+                }
+            };
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(compileErrors),
+                new StubCompilationFailureGate(true));
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+                StatusOnly = true,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.BlockedByCompileErrors, Is.True);
+            Assert.That(response.CompileErrorCount, Is.EqualTo(1));
+            Assert.That(response.CompileErrors[0].Message, Is.EqualTo("CS1525: invalid expression"));
+            Assert.That(response.Message, Is.EqualTo("Play mode could not start because Unity has compiler errors."));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenStatusOnlyStopAndCompileFailed_ReturnsCurrentPlayModeState()
+        {
+            // Verifies compiler errors are only treated as a status polling blocker for Play requests.
+            ControlPlayModeCompileError[] compileErrors =
+            {
+                new ControlPlayModeCompileError
+                {
+                    Message = "CS1525: invalid expression",
+                    File = "Assets/Scripts/Sample.cs",
+                    Line = 3
+                }
+            };
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(compileErrors),
+                new StubCompilationFailureGate(true));
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Stop,
+                StatusOnly = true,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(response.BlockedByCompileErrors, Is.False);
+            Assert.That(response.Message, Is.EqualTo("Play mode status"));
+        }
+
+        [Test]
         public async Task ExecuteAsync_WhenStepOutsidePlayMode_ReturnsNoOpWithGuidance()
         {
             // Verifies Step refuses to run outside PlayMode instead of silently queuing a frame step.

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/AssemblyInfo.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5260eeff74344d889809afe46ca8680
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeCompilationFailureService.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeCompilationFailureService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor.Compilation;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Provides saved compiler diagnostics for PlayMode entry checks.
+    /// </summary>
+    public interface IControlPlayModeCompilationFailureProvider
+    {
+        ControlPlayModeCompileError[] GetLastFailedErrors();
+    }
+
+    /// <summary>
+    /// Provides the current Unity compiler-failure gate used before PlayMode entry.
+    /// </summary>
+    public interface IControlPlayModeCompilationFailureGate
+    {
+        bool HasScriptCompilationFailed();
+    }
+
+    /// <summary>
+    /// Records compiler errors from the current Editor domain so PlayMode failure responses are not inferred from stale Console logs.
+    /// </summary>
+    internal sealed class ControlPlayModeCompilationFailureService : IControlPlayModeCompilationFailureProvider
+    {
+        private readonly List<ControlPlayModeCompileError> _currentErrors = new();
+        private ControlPlayModeCompileError[] _lastFailedErrors = Array.Empty<ControlPlayModeCompileError>();
+
+        internal void InitializeForEditorStartup()
+        {
+            CompilationPipeline.compilationStarted -= HandleCompilationStarted;
+            CompilationPipeline.assemblyCompilationFinished -= HandleAssemblyCompilationFinished;
+            CompilationPipeline.compilationFinished -= HandleCompilationFinished;
+
+            CompilationPipeline.compilationStarted += HandleCompilationStarted;
+            CompilationPipeline.assemblyCompilationFinished += HandleAssemblyCompilationFinished;
+            CompilationPipeline.compilationFinished += HandleCompilationFinished;
+        }
+
+        internal void HandleCompilationStarted(object context)
+        {
+            _currentErrors.Clear();
+            _lastFailedErrors = Array.Empty<ControlPlayModeCompileError>();
+        }
+
+        internal void HandleAssemblyCompilationFinished(string assemblyPath, CompilerMessage[] compilerMessages)
+        {
+            if (compilerMessages == null)
+            {
+                return;
+            }
+
+            foreach (CompilerMessage compilerMessage in compilerMessages)
+            {
+                if (compilerMessage.type != CompilerMessageType.Error)
+                {
+                    continue;
+                }
+
+                _currentErrors.Add(ControlPlayModeCompileError.FromCompilerMessage(compilerMessage));
+            }
+        }
+
+        internal void HandleCompilationFinished(object context)
+        {
+            if (_currentErrors.Count == 0)
+            {
+                _lastFailedErrors = Array.Empty<ControlPlayModeCompileError>();
+                return;
+            }
+
+            _lastFailedErrors = _currentErrors.ToArray();
+            _currentErrors.Clear();
+        }
+
+        public ControlPlayModeCompileError[] GetLastFailedErrors()
+        {
+            ControlPlayModeCompileError[] errors = new ControlPlayModeCompileError[_lastFailedErrors.Length];
+            Array.Copy(_lastFailedErrors, errors, _lastFailedErrors.Length);
+            return errors;
+        }
+    }
+
+    /// <summary>
+    /// Reads Unity's current script-compilation failure flag for PlayMode entry gating.
+    /// </summary>
+    internal sealed class ControlPlayModeCompilationFailureGate : IControlPlayModeCompilationFailureGate
+    {
+        public bool HasScriptCompilationFailed()
+        {
+            return UnityEditor.EditorUtility.scriptCompilationFailed;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeCompilationFailureService.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeCompilationFailureService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bf3693a9865449099f62f5886dd1781
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeCompileError.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeCompileError.cs
@@ -1,0 +1,26 @@
+using UnityEditor.Compilation;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Carries a compiler error that blocked PlayMode entry.
+    /// </summary>
+    public sealed class ControlPlayModeCompileError
+    {
+        public string Message { get; set; }
+        public string File { get; set; }
+        public int Line { get; set; }
+
+        internal static ControlPlayModeCompileError FromCompilerMessage(CompilerMessage compilerMessage)
+        {
+            UnityEngine.Debug.Assert(compilerMessage.type == CompilerMessageType.Error, "compilerMessage must be an error");
+
+            return new ControlPlayModeCompileError
+            {
+                Message = compilerMessage.message ?? string.Empty,
+                File = compilerMessage.file ?? string.Empty,
+                Line = compilerMessage.line
+            };
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeCompileError.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeCompileError.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98ccd0c0d07e413c8c02745c0b169b63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeEditorStartup.cs
@@ -1,0 +1,13 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Initializes Control Play Mode editor-domain services.
+    /// </summary>
+    internal static class ControlPlayModeEditorStartup
+    {
+        internal static void Initialize()
+        {
+            ControlPlayModeServices.InitializeForEditorStartup();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeEditorStartup.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeEditorStartup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6814a45f469c4de4922a37ee5a7cdf5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeResponse.cs
@@ -11,6 +11,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool IsPaused { get; set; }
         public bool Changed { get; set; }
         public bool WasAlreadyStopped { get; set; }
+        public bool BlockedByCompileErrors { get; set; }
+        public int CompileErrorCount { get; set; }
+        public ControlPlayModeCompileError[] CompileErrors { get; set; }
         public string Message { get; set; }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs
@@ -1,0 +1,35 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Owns Control Play Mode services for one Editor domain.
+    /// </summary>
+    internal sealed class ControlPlayModeServicesRegistry
+    {
+        internal ControlPlayModeCompilationFailureService CompilationFailureService { get; } = new();
+        internal ControlPlayModeCompilationFailureGate CompilationFailureGate { get; } = new();
+
+        internal void InitializeForEditorStartup()
+        {
+            CompilationFailureService.InitializeForEditorStartup();
+        }
+    }
+
+    /// <summary>
+    /// Exposes the Control Play Mode service registry to parameterless tool construction.
+    /// </summary>
+    internal static class ControlPlayModeServices
+    {
+        private static readonly ControlPlayModeServicesRegistry RegistryValue = new();
+
+        internal static IControlPlayModeCompilationFailureProvider CompilationFailureProvider =>
+            RegistryValue.CompilationFailureService;
+
+        internal static IControlPlayModeCompilationFailureGate CompilationFailureGate =>
+            RegistryValue.CompilationFailureGate;
+
+        internal static void InitializeForEditorStartup()
+        {
+            RegistryValue.InitializeForEditorStartup();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1217442b8293492baad45e0ea988ebb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -36,6 +36,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (parameters.StatusOnly)
             {
+                if (parameters.Action == PlayModeAction.Play &&
+                    !EditorApplication.isPlaying &&
+                    _compilationFailureGate.HasScriptCompilationFailed())
+                {
+                    ControlPlayModeCompileError[] compileErrors =
+                        _compilationFailureProvider.GetLastFailedErrors();
+                    return Task.FromResult(CreateCompileErrorBlockedResponse(compileErrors));
+                }
+
                 return Task.FromResult(CreateResponse("Play mode status", false, false));
             }
 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -10,6 +11,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class ControlPlayModeUseCase
     {
         public const int DefaultTimeoutSeconds = 180;
+
+        private readonly IControlPlayModeCompilationFailureProvider _compilationFailureProvider;
+        private readonly IControlPlayModeCompilationFailureGate _compilationFailureGate;
+
+        public ControlPlayModeUseCase(
+            IControlPlayModeCompilationFailureProvider compilationFailureProvider = null,
+            IControlPlayModeCompilationFailureGate compilationFailureGate = null)
+        {
+            _compilationFailureProvider =
+                compilationFailureProvider ?? ControlPlayModeServices.CompilationFailureProvider;
+            _compilationFailureGate =
+                compilationFailureGate ?? ControlPlayModeServices.CompilationFailureGate;
+        }
 
         public Task<ControlPlayModeResponse> ExecuteAsync(ControlPlayModeSchema parameters, CancellationToken ct)
         {
@@ -34,6 +48,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             switch (parameters.Action)
             {
                 case PlayModeAction.Play:
+                    if (!wasPlaying && _compilationFailureGate.HasScriptCompilationFailed())
+                    {
+                        ControlPlayModeCompileError[] compileErrors =
+                            _compilationFailureProvider.GetLastFailedErrors();
+                        return Task.FromResult(CreateCompileErrorBlockedResponse(compileErrors));
+                    }
+
                     if (wasPaused)
                     {
                         EditorApplication.isPaused = false;
@@ -95,9 +116,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 IsPaused = EditorApplication.isPaused,
                 Changed = changed,
                 WasAlreadyStopped = wasAlreadyStopped,
+                CompileErrors = Array.Empty<ControlPlayModeCompileError>(),
                 Message = message
             };
 
+            return response;
+        }
+
+        private static ControlPlayModeResponse CreateCompileErrorBlockedResponse(
+            ControlPlayModeCompileError[] compileErrors)
+        {
+            ControlPlayModeCompileError[] errors = compileErrors ?? Array.Empty<ControlPlayModeCompileError>();
+            string message = errors.Length == 0
+                ? "Play mode could not start because Unity reports script compilation failed, but no saved compiler diagnostics are available. Run `uloop compile` or `uloop get-logs` for details."
+                : "Play mode could not start because Unity has compiler errors.";
+
+            ControlPlayModeResponse response = CreateResponse(message, false, false);
+            response.BlockedByCompileErrors = true;
+            response.CompileErrors = errors;
+            response.CompileErrorCount = errors.Length;
             return response;
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
+++ b/Packages/src/Editor/FirstPartyTools/FirstPartyToolsEditorStartup.cs
@@ -9,6 +9,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static void Initialize()
         {
             ExternalSceneChangeTracker.Initialize();
+            ControlPlayModeEditorStartup.Initialize();
             ExecuteDynamicCodeEditorStartup.Initialize();
             GetLogsEditorStartup.Initialize();
 #if ULOOP_HAS_TEST_FRAMEWORK

--- a/cli/internal/cli/control_play_mode_wait.go
+++ b/cli/internal/cli/control_play_mode_wait.go
@@ -114,6 +114,12 @@ func runControlPlayModeWithStateWait(
 	}
 
 	if !completed {
+		if response.BlockedByCompileErrors {
+			writeDebugTiming(stderr, controlPlayModeCommandName, time.Since(startedAt), outcome)
+			writeErrorEnvelope(stderr, controlPlayModeCompileErrorsError(connection.ProjectRoot, action, response))
+			return 1
+		}
+
 		writeDebugTiming(stderr, controlPlayModeCommandName, time.Since(startedAt), outcome)
 		writeErrorEnvelope(stderr, controlPlayModeWaitTimeoutError(connection.ProjectRoot, action, timeoutSeconds, response))
 		return 1
@@ -152,10 +158,13 @@ func waitForControlPlayModeState(
 	ticker := time.NewTicker(controlPlayModeStatePoll)
 	defer ticker.Stop()
 	for {
-		response, err := requestControlPlayModeStatus(waitContext, connection)
+		response, err := requestControlPlayModeStatus(waitContext, connection, action)
 		if err == nil {
 			lastResponse = response
 			hasResponse = true
+			if strings.EqualFold(action, "Play") && response.BlockedByCompileErrors {
+				return response, false, nil
+			}
 			if controlPlayModeStateMatches(action, response) {
 				return response, true, nil
 			}
@@ -180,14 +189,21 @@ func waitForControlPlayModeState(
 	}
 }
 
-func requestControlPlayModeStatus(ctx context.Context, connection unityipc.Connection) (controlPlayModeResponse, error) {
+func requestControlPlayModeStatus(
+	ctx context.Context,
+	connection unityipc.Connection,
+	action string,
+) (controlPlayModeResponse, error) {
 	probeContext, cancel := context.WithTimeout(ctx, controlPlayModeStatusTimeout)
 	defer cancel()
 
 	result, err := unityipc.NewClient(connection, version).Send(
 		probeContext,
 		controlPlayModeCommandName,
-		map[string]any{controlPlayModeStatusOnlyParam: true},
+		map[string]any{
+			controlPlayModeActionParam:     action,
+			controlPlayModeStatusOnlyParam: true,
+		},
 	)
 	if err != nil {
 		return controlPlayModeResponse{}, err

--- a/cli/internal/cli/control_play_mode_wait.go
+++ b/cli/internal/cli/control_play_mode_wait.go
@@ -23,11 +23,20 @@ const (
 var controlPlayModeStatePoll = 50 * time.Millisecond
 
 type controlPlayModeResponse struct {
-	IsPlaying         bool   `json:"IsPlaying"`
-	IsPaused          bool   `json:"IsPaused"`
-	Changed           bool   `json:"Changed"`
-	WasAlreadyStopped bool   `json:"WasAlreadyStopped"`
-	Message           string `json:"Message"`
+	IsPlaying              bool                          `json:"IsPlaying"`
+	IsPaused               bool                          `json:"IsPaused"`
+	Changed                bool                          `json:"Changed"`
+	WasAlreadyStopped      bool                          `json:"WasAlreadyStopped"`
+	BlockedByCompileErrors bool                          `json:"BlockedByCompileErrors"`
+	CompileErrorCount      int                           `json:"CompileErrorCount"`
+	CompileErrors          []controlPlayModeCompileError `json:"CompileErrors"`
+	Message                string                        `json:"Message"`
+}
+
+type controlPlayModeCompileError struct {
+	Message string `json:"Message"`
+	File    string `json:"File"`
+	Line    int    `json:"Line"`
 }
 
 func shouldWaitForControlPlayModeState(command string, params map[string]any) bool {
@@ -70,6 +79,12 @@ func runControlPlayModeWithStateWait(
 			return 1
 		}
 		hasInitialResponse = true
+		if initialResponse.BlockedByCompileErrors {
+			spinner.Stop()
+			writeDebugTiming(stderr, controlPlayModeCommandName, time.Since(startedAt), outcome)
+			writeErrorEnvelope(stderr, controlPlayModeCompileErrorsError(connection.ProjectRoot, action, initialResponse))
+			return 1
+		}
 		if controlPlayModeStateMatches(action, initialResponse) {
 			spinner.Stop()
 			writeJSON(stdout, outcome.Result)
@@ -304,6 +319,37 @@ func controlPlayModeWaitTimeoutError(
 			"isPlaying":       response.IsPlaying,
 			"isPaused":        response.IsPaused,
 			"timeoutSeconds":  timeoutSeconds,
+		},
+	}
+}
+
+func controlPlayModeCompileErrorsError(
+	projectRoot string,
+	action string,
+	response controlPlayModeResponse,
+) cliError {
+	compileErrorCount := response.CompileErrorCount
+	if compileErrorCount == 0 && len(response.CompileErrors) > 0 {
+		compileErrorCount = len(response.CompileErrors)
+	}
+
+	return cliError{
+		ErrorCode:   errorCodeControlPlayModeCompileErrors,
+		Phase:       errorPhaseExecution,
+		Message:     "Play mode start was blocked because Unity has compiler errors.",
+		Retryable:   false,
+		SafeToRetry: true,
+		ProjectRoot: projectRoot,
+		Command:     controlPlayModeCommandName,
+		NextActions: []string{
+			"Fix the compiler errors reported in the details.",
+			"Run `uloop compile` to verify the project compiles, then retry `uloop control-play-mode --action Play`.",
+		},
+		Details: map[string]any{
+			"requestedAction":   action,
+			"compileErrorCount": compileErrorCount,
+			"compileErrors":     response.CompileErrors,
+			"message":           response.Message,
 		},
 	}
 }

--- a/cli/internal/cli/control_play_mode_wait_test.go
+++ b/cli/internal/cli/control_play_mode_wait_test.go
@@ -311,6 +311,92 @@ func TestRunControlPlayModeWithStateWaitFailsImmediatelyWhenCompileErrorsBlockPl
 	}
 }
 
+// Verifies that compiler-error status polling fails immediately instead of waiting for the PlayMode timeout.
+func TestRunControlPlayModeWithStateWaitFailsWhenCompileErrorsAppearDuringPolling(t *testing.T) {
+	originalPoll := controlPlayModeStatePoll
+	controlPlayModeStatePoll = time.Millisecond
+	t.Cleanup(func() {
+		controlPlayModeStatePoll = originalPoll
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	requests := make(chan map[string]any, 3)
+	serverErr := make(chan error, 1)
+	go serveControlPlayModeResponses(
+		listener,
+		requests,
+		serverErr,
+		[]string{
+			`{"IsPlaying":false,"IsPaused":false,"Message":"Play mode started"}`,
+			`{"IsPlaying":false,"IsPaused":false,"BlockedByCompileErrors":true,"CompileErrorCount":1,"CompileErrors":[{"Message":"CS1525: invalid expression","File":"Assets/Scripts/Sample.cs","Line":3}],"Message":"Play mode could not start because Unity has compiler errors."}`,
+		})
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: "tcp",
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runControlPlayModeWithStateWait(
+		context.Background(),
+		connection,
+		map[string]any{
+			controlPlayModeActionParam:  "Play",
+			controlPlayModeTimeoutParam: 1,
+		},
+		&stdout,
+		&stderr)
+
+	if code != 1 {
+		t.Fatalf("expected compile error failure, got %d with stdout %s stderr %s", code, stdout.String(), stderr.String())
+	}
+
+	var envelope cliErrorEnvelope
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\n%s", err, stderr.String())
+	}
+	if envelope.Error.ErrorCode != errorCodeControlPlayModeCompileErrors {
+		t.Fatalf("error code mismatch: %#v", envelope.Error)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("CS1525")) {
+		t.Fatalf("compiler diagnostic missing from stderr: %s", stderr.String())
+	}
+
+	firstRequest := readControlPlayModeRequest(t, requests)
+	if _, ok := firstRequest[controlPlayModeStatusOnlyParam]; ok {
+		t.Fatalf("initial request should not be status-only: %#v", firstRequest)
+	}
+	secondRequest := readControlPlayModeRequest(t, requests)
+	if secondRequest[controlPlayModeStatusOnlyParam] != true {
+		t.Fatalf("status request mismatch: %#v", secondRequest)
+	}
+	if secondRequest[controlPlayModeActionParam] != "Play" {
+		t.Fatalf("status request action mismatch: %#v", secondRequest)
+	}
+	select {
+	case thirdRequest := <-requests:
+		t.Fatalf("blocked compile errors should stop status polling: %#v", thirdRequest)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
 // Verifies that live Unity tool caches using number schemas still drive integer wait budgets.
 func TestControlPlayModeTimeoutSecondsAcceptsFloatSchemaValue(t *testing.T) {
 	params := map[string]any{controlPlayModeTimeoutParam: 12.0}

--- a/cli/internal/cli/control_play_mode_wait_test.go
+++ b/cli/internal/cli/control_play_mode_wait_test.go
@@ -230,6 +230,87 @@ func TestRunControlPlayModeWithStateWaitFailsWhenStateNeverMatches(t *testing.T)
 	}
 }
 
+// Verifies that compiler-error PlayMode blocks fail immediately instead of waiting for state polling.
+func TestRunControlPlayModeWithStateWaitFailsImmediatelyWhenCompileErrorsBlockPlay(t *testing.T) {
+	originalPoll := controlPlayModeStatePoll
+	controlPlayModeStatePoll = time.Millisecond
+	t.Cleanup(func() {
+		controlPlayModeStatePoll = originalPoll
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	requests := make(chan map[string]any, 2)
+	serverErr := make(chan error, 1)
+	go serveControlPlayModeResponses(
+		listener,
+		requests,
+		serverErr,
+		[]string{
+			`{"IsPlaying":false,"IsPaused":false,"BlockedByCompileErrors":true,"CompileErrorCount":1,"CompileErrors":[{"Message":"CS1002: ; expected","File":"Assets/Scripts/Sample.cs","Line":12}],"Message":"Play mode could not start because Unity has compiler errors."}`,
+		})
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: "tcp",
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runControlPlayModeWithStateWait(
+		context.Background(),
+		connection,
+		map[string]any{
+			controlPlayModeActionParam:  "Play",
+			controlPlayModeTimeoutParam: 1,
+		},
+		&stdout,
+		&stderr)
+
+	if code != 1 {
+		t.Fatalf("expected compile error failure, got %d with stdout %s stderr %s", code, stdout.String(), stderr.String())
+	}
+
+	var envelope cliErrorEnvelope
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\n%s", err, stderr.String())
+	}
+	if envelope.Error.ErrorCode != errorCodeControlPlayModeCompileErrors {
+		t.Fatalf("error code mismatch: %#v", envelope.Error)
+	}
+	if envelope.Error.Details["compileErrorCount"] != float64(1) {
+		t.Fatalf("compile error count mismatch: %#v", envelope.Error.Details)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("CS1002")) {
+		t.Fatalf("compiler diagnostic missing from stderr: %s", stderr.String())
+	}
+
+	firstRequest := readControlPlayModeRequest(t, requests)
+	if _, ok := firstRequest[controlPlayModeStatusOnlyParam]; ok {
+		t.Fatalf("initial request should not be status-only: %#v", firstRequest)
+	}
+	select {
+	case secondRequest := <-requests:
+		t.Fatalf("blocked compile errors should not trigger status polling: %#v", secondRequest)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed: %v", err)
+	default:
+	}
+}
+
 // Verifies that live Unity tool caches using number schemas still drive integer wait budgets.
 func TestControlPlayModeTimeoutSecondsAcceptsFloatSchemaValue(t *testing.T) {
 	params := map[string]any{controlPlayModeTimeoutParam: 12.0}

--- a/cli/internal/cli/error_envelope.go
+++ b/cli/internal/cli/error_envelope.go
@@ -26,6 +26,7 @@ const (
 	errorCodeToolDisabled                    = "TOOL_DISABLED"
 	errorCodeCompileWaitTimeout              = "COMPILE_WAIT_TIMEOUT"
 	errorCodeControlPlayModeWaitTimeout      = "CONTROL_PLAY_MODE_WAIT_TIMEOUT"
+	errorCodeControlPlayModeCompileErrors    = "CONTROL_PLAY_MODE_COMPILE_ERRORS"
 	errorCodePausePointNotEnabled            = "PAUSE_POINT_NOT_ENABLED"
 	errorCodePausePointWaitTimeout           = "PAUSE_POINT_WAIT_TIMEOUT"
 	errorCodePausePointExpired               = "PAUSE_POINT_EXPIRED"


### PR DESCRIPTION
## Summary
- PlayMode start now fails fast with saved compiler diagnostics when Unity reports script compilation errors.
- The CLI returns a structured compiler-error envelope instead of waiting until the PlayMode transition times out.

## User Impact
- Before this change, running `uloop control-play-mode --action Play` with compiler errors could hang until the wait timeout and hide the actual cause.
- After this change, users immediately see the compiler error count and diagnostics, including errors that appear while the CLI is polling for PlayMode to finish starting.

## Changes
- Record Unity compiler errors from the editor compilation callbacks for the current editor domain.
- Gate PlayMode start on Unity script-compilation failure state and include saved diagnostics in the tool response.
- Teach the CLI to turn those responses into `CONTROL_PLAY_MODE_COMPILE_ERRORS` during both the initial request and polling.

## Verification
- `cli/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `cli/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "ControlPlayModeUseCaseTests"`
- `go test ./internal/cli -run TestRunControlPlayModeWithStateWait`
- `scripts/check-go-cli.sh`
- `/Users/a12115/dotfiles/.claude/skills/codex-review/scripts/codex-review v3-beta`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

