### PR TITLE
fix: Clarify skill guidance for pause points and Windows code execution

### DIFF
--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -25,7 +25,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
 - `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell-specific quoting**: For Windows/PowerShell, read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) before writing multiline commands. Use [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
+- **Shell-specific quoting**: Read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) for Windows/PowerShell multiline commands and [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
 - `--parameters {}` (advanced, optional): Pass a shell-quoted JSON object literal when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets. Do not pass a JSON string value such as `"{\"param0\":\"value\"}"`.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 

--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -17,7 +17,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute inline code: `uloop execute-dynamic-code --code '<code>'`
+3. Execute with `--code` or `--code-file` using the active shell's quoting guidance
 4. If execution fails, adjust code and retry
 5. Report the execution result
 
@@ -25,7 +25,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
 - `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell 7 (`pwsh`) can pass multiline snippets without `--code-file` by using a single-quoted here-string, for example `$code = @' ... '@; uloop execute-dynamic-code --code $code`. Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands; escape C# double quotes as `\"` for short inline snippets, or use `--code-file` when the snippet has many strings.
+- **Shell-specific quoting**: For Windows/PowerShell, read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) before writing multiline commands. Use [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
 - `--parameters {}` (advanced, optional): Pass a shell-quoted JSON object literal when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets. Do not pass a JSON string value such as `"{\"param0\":\"value\"}"`.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 
@@ -78,10 +78,10 @@ For detailed code examples, refer to these files:
   - Undo-aware operations: RecordObject, AddComponent, SetParent, grouping
 - **Selection operations**: See [references/selection-operations.md](references/selection-operations.md)
   - Get/set selection, multi-select, filter by type/editability
-- **PlayMode automation (zsh)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
-  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
-- **PlayMode automation (PowerShell)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
+- **PlayMode automation (PowerShell/Windows)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
   - Click UI buttons, invoke methods, set fields, tool combination workflows for PowerShell users
+- **PlayMode automation (zsh/macOS)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
+  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
 - **PlayMode UI controls**: See [references/playmode-ui-controls.md](references/playmode-ui-controls.md)
   - InputField, Slider, Toggle, Dropdown, drag & drop simulation, list all UI controls
 - **PlayMode inspection**: See [references/playmode-inspection.md](references/playmode-inspection.md)

--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -7,7 +7,7 @@ context: fork
 
 # Task
 
-Execute the following request using `uloop execute-dynamic-code`: $ARGUMENTS
+Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-code`.
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 

--- a/.agents/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.agents/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -24,9 +24,7 @@ Use `execute-dynamic-code` for direct automation and diagnostics, and switch to 
 
 ## PowerShell 7 Multiline Snippets
 
-Use this as the default Windows pattern for multiline C# in PowerShell 7 (`pwsh`).
-Put the snippet in a single-quoted here-string variable, then pass the variable to `--code`.
-This keeps C# double quotes unchanged and avoids mixing shell syntax into the C# sample.
+Default to a single-quoted here-string variable in PowerShell 7 (`pwsh`), then pass it to `--code`.
 
 ```powershell
 $code = @'
@@ -43,8 +41,7 @@ uloop execute-dynamic-code --code $code
 
 ### With parameters
 
-Pass a JSON object literal, not a JSON string value.
-Use a second single-quoted here-string when the parameters are easier to read on separate lines.
+Pass a JSON object literal, not a JSON string value. Use a second here-string when the parameters are easier to read on separate lines.
 
 ```powershell
 $code = @'
@@ -80,19 +77,17 @@ uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{
 
 ## Windows PowerShell 5.1
 
-Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
-For short inline snippets, escape C# double quotes as `\"`.
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands. Escape C# double quotes as `\"` in short inline snippets.
 
 ```powershell
 uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
 ```
 
-For multiline snippets or code with many string literals, prefer `--code-file` so the shell does not rewrite the code text.
+For multiline or string-heavy snippets, prefer `--code-file`.
 
 ## Native Launcher Check
 
-Multiline `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
-If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multiline inline snippets.
+Multiline `--code` expects the native Go `uloop.exe`. If `Get-Command uloop` resolves to an old `.cmd` shim, run `uloop install` and open a new terminal.
 
 ```powershell
 (Get-Command uloop).Source

--- a/.agents/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.agents/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -22,14 +22,14 @@ Choose the tool based on what you are trying to validate:
 In short: do not default everything to mouse simulation.
 Use `execute-dynamic-code` for direct automation and diagnostics, and switch to `simulate-mouse-ui` or `simulate-mouse-input` when reproducing the real input path is the thing you need to test.
 
-## PowerShell Quoting Notes
+## PowerShell 7 Multiline Snippets
 
-Use these patterns when you need shell-safe inline code.
-PowerShell's equivalent to a bash heredoc is a single-quoted here-string.
-In PowerShell 7 (`pwsh`), it can be passed to `--code` directly without creating a temporary file:
+Use this as the default Windows pattern for multiline C# in PowerShell 7 (`pwsh`).
+Put the snippet in a single-quoted here-string variable, then pass the variable to `--code`.
+This keeps C# double quotes unchanged and avoids mixing shell syntax into the C# sample.
 
 ```powershell
-uloop execute-dynamic-code --code @'
+$code = @'
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -37,83 +37,14 @@ Scene scene = SceneManager.GetActiveScene();
 GameObject[] objects = UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsInactive.Include, FindObjectsSortMode.None);
 return $"{scene.name}: {objects.Length} objects";
 '@
-```
-
-Use `--code-file` when the active shell or launcher cannot preserve inline code exactly, especially for Windows PowerShell 5.1 snippets with many C# string literals.
-
-### Native launcher check
-
-Multi-line `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
-If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multi-line inline snippets.
-
-```powershell
-(Get-Command uloop).Source
-```
-
-### Double quotes inside C# strings
-
-PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
-
-```powershell
-uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
-```
-
-Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
-Escape C# double quotes as `\"` when using inline `--code` from Windows PowerShell 5.1.
-
-```powershell
-uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
-```
-
-### Single quotes inside inline C# code
-
-If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
-
-```powershell
-uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
-```
-
-### JSON object values passed via `--parameters`
-
-Pass a JSON object literal, not a JSON string value. Wrap the object literal in single quotes so PowerShell passes the inner double quotes through unchanged.
-
-```powershell
-uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
-```
-
-### Multi-line C# snippets
-
-Use a here-string variable when you want to prepare or reuse a snippet before executing it in PowerShell 7 (`pwsh`).
-
-```powershell
-$code = @'
-using UnityEngine;
-
-GameObject obj = GameObject.Find("Player");
-if (obj == null) return "Player not found";
-
-return obj.name;
-'@
 
 uloop execute-dynamic-code --code $code
 ```
 
-When using Windows PowerShell 5.1, escape C# double quotes inside the here-string before passing it to native `uloop.exe`.
+### With parameters
 
-```powershell
-$code = @'
-using UnityEngine;
-
-GameObject obj = GameObject.Find(\"Player\");
-if (obj == null) return \"Player not found\";
-
-return obj.name;
-'@
-
-uloop execute-dynamic-code --code $code
-```
-
-You can combine multi-line code with a multi-line JSON object literal the same way.
+Pass a JSON object literal, not a JSON string value.
+Use a second single-quoted here-string when the parameters are easier to read on separate lines.
 
 ```powershell
 $code = @'
@@ -125,6 +56,46 @@ $parameters = @'
 '@
 
 uloop execute-dynamic-code --code $code --parameters $parameters
+```
+
+## Short Inline Snippets
+
+PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
+
+```powershell
+uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
+```
+
+If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
+
+```powershell
+uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
+```
+
+Wrap JSON object literals for `--parameters` in single quotes so PowerShell passes inner double quotes unchanged.
+
+```powershell
+uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
+```
+
+## Windows PowerShell 5.1
+
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
+For short inline snippets, escape C# double quotes as `\"`.
+
+```powershell
+uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
+```
+
+For multiline snippets or code with many string literals, prefer `--code-file` so the shell does not rewrite the code text.
+
+## Native Launcher Check
+
+Multiline `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
+If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multiline inline snippets.
+
+```powershell
+(Get-Command uloop).Source
 ```
 
 ## Click UI Button by Path

--- a/.agents/skills/uloop-wait-for-pause-point/SKILL.md
+++ b/.agents/skills/uloop-wait-for-pause-point/SKILL.md
@@ -7,7 +7,7 @@ description: "Pauses Unity's playback and allows you to inspect specific frames.
 
 Use this small loop for one representative frame you care about:
 
-If the target script is compiled by a custom asmdef, add an asmdef reference to `UnityCLILoop.PausePoints.Runtime` before using `UloopPausePoint.Pause`. Without that reference, Unity cannot resolve the pause point API. Scripts compiled into `Assembly-CSharp` generally do not need a manual reference because the pause point runtime assembly is auto-referenced.
+Custom asmdef scripts must reference `UnityCLILoop.PausePoints.Runtime` before calling `UloopPausePoint.Pause`. `Assembly-CSharp` scripts can usually use it without a manual reference.
 
 1. Put a focused log and marker at the natural transition point. Log only local/intermediate values that will be hard to inspect later:
 

--- a/.agents/skills/uloop-wait-for-pause-point/SKILL.md
+++ b/.agents/skills/uloop-wait-for-pause-point/SKILL.md
@@ -7,6 +7,8 @@ description: "Pauses Unity's playback and allows you to inspect specific frames.
 
 Use this small loop for one representative frame you care about:
 
+If the target script is compiled by a custom asmdef, add an asmdef reference to `UnityCLILoop.PausePoints.Runtime` before using `UloopPausePoint.Pause`. Without that reference, Unity cannot resolve the pause point API. Scripts compiled into `Assembly-CSharp` generally do not need a manual reference because the pause point runtime assembly is auto-referenced.
+
 1. Put a focused log and marker at the natural transition point. Log only local/intermediate values that will be hard to inspect later:
 
 ```csharp

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -25,7 +25,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
 - `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell-specific quoting**: For Windows/PowerShell, read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) before writing multiline commands. Use [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
+- **Shell-specific quoting**: Read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) for Windows/PowerShell multiline commands and [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
 - `--parameters {}` (advanced, optional): Pass a shell-quoted JSON object literal when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets. Do not pass a JSON string value such as `"{\"param0\":\"value\"}"`.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -17,7 +17,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute inline code: `uloop execute-dynamic-code --code '<code>'`
+3. Execute with `--code` or `--code-file` using the active shell's quoting guidance
 4. If execution fails, adjust code and retry
 5. Report the execution result
 
@@ -25,7 +25,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
 - `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell 7 (`pwsh`) can pass multiline snippets without `--code-file` by using a single-quoted here-string, for example `$code = @' ... '@; uloop execute-dynamic-code --code $code`. Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands; escape C# double quotes as `\"` for short inline snippets, or use `--code-file` when the snippet has many strings.
+- **Shell-specific quoting**: For Windows/PowerShell, read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) before writing multiline commands. Use [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
 - `--parameters {}` (advanced, optional): Pass a shell-quoted JSON object literal when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets. Do not pass a JSON string value such as `"{\"param0\":\"value\"}"`.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 
@@ -78,10 +78,10 @@ For detailed code examples, refer to these files:
   - Undo-aware operations: RecordObject, AddComponent, SetParent, grouping
 - **Selection operations**: See [references/selection-operations.md](references/selection-operations.md)
   - Get/set selection, multi-select, filter by type/editability
-- **PlayMode automation (zsh)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
-  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
-- **PlayMode automation (PowerShell)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
+- **PlayMode automation (PowerShell/Windows)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
   - Click UI buttons, invoke methods, set fields, tool combination workflows for PowerShell users
+- **PlayMode automation (zsh/macOS)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
+  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
 - **PlayMode UI controls**: See [references/playmode-ui-controls.md](references/playmode-ui-controls.md)
   - InputField, Slider, Toggle, Dropdown, drag & drop simulation, list all UI controls
 - **PlayMode inspection**: See [references/playmode-inspection.md](references/playmode-inspection.md)

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -7,7 +7,7 @@ context: fork
 
 # Task
 
-Execute the following request using `uloop execute-dynamic-code`: $ARGUMENTS
+Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-code`.
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -24,9 +24,7 @@ Use `execute-dynamic-code` for direct automation and diagnostics, and switch to 
 
 ## PowerShell 7 Multiline Snippets
 
-Use this as the default Windows pattern for multiline C# in PowerShell 7 (`pwsh`).
-Put the snippet in a single-quoted here-string variable, then pass the variable to `--code`.
-This keeps C# double quotes unchanged and avoids mixing shell syntax into the C# sample.
+Default to a single-quoted here-string variable in PowerShell 7 (`pwsh`), then pass it to `--code`.
 
 ```powershell
 $code = @'
@@ -43,8 +41,7 @@ uloop execute-dynamic-code --code $code
 
 ### With parameters
 
-Pass a JSON object literal, not a JSON string value.
-Use a second single-quoted here-string when the parameters are easier to read on separate lines.
+Pass a JSON object literal, not a JSON string value. Use a second here-string when the parameters are easier to read on separate lines.
 
 ```powershell
 $code = @'
@@ -80,19 +77,17 @@ uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{
 
 ## Windows PowerShell 5.1
 
-Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
-For short inline snippets, escape C# double quotes as `\"`.
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands. Escape C# double quotes as `\"` in short inline snippets.
 
 ```powershell
 uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
 ```
 
-For multiline snippets or code with many string literals, prefer `--code-file` so the shell does not rewrite the code text.
+For multiline or string-heavy snippets, prefer `--code-file`.
 
 ## Native Launcher Check
 
-Multiline `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
-If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multiline inline snippets.
+Multiline `--code` expects the native Go `uloop.exe`. If `Get-Command uloop` resolves to an old `.cmd` shim, run `uloop install` and open a new terminal.
 
 ```powershell
 (Get-Command uloop).Source

--- a/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.claude/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -22,14 +22,14 @@ Choose the tool based on what you are trying to validate:
 In short: do not default everything to mouse simulation.
 Use `execute-dynamic-code` for direct automation and diagnostics, and switch to `simulate-mouse-ui` or `simulate-mouse-input` when reproducing the real input path is the thing you need to test.
 
-## PowerShell Quoting Notes
+## PowerShell 7 Multiline Snippets
 
-Use these patterns when you need shell-safe inline code.
-PowerShell's equivalent to a bash heredoc is a single-quoted here-string.
-In PowerShell 7 (`pwsh`), it can be passed to `--code` directly without creating a temporary file:
+Use this as the default Windows pattern for multiline C# in PowerShell 7 (`pwsh`).
+Put the snippet in a single-quoted here-string variable, then pass the variable to `--code`.
+This keeps C# double quotes unchanged and avoids mixing shell syntax into the C# sample.
 
 ```powershell
-uloop execute-dynamic-code --code @'
+$code = @'
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -37,83 +37,14 @@ Scene scene = SceneManager.GetActiveScene();
 GameObject[] objects = UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsInactive.Include, FindObjectsSortMode.None);
 return $"{scene.name}: {objects.Length} objects";
 '@
-```
-
-Use `--code-file` when the active shell or launcher cannot preserve inline code exactly, especially for Windows PowerShell 5.1 snippets with many C# string literals.
-
-### Native launcher check
-
-Multi-line `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
-If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multi-line inline snippets.
-
-```powershell
-(Get-Command uloop).Source
-```
-
-### Double quotes inside C# strings
-
-PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
-
-```powershell
-uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
-```
-
-Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
-Escape C# double quotes as `\"` when using inline `--code` from Windows PowerShell 5.1.
-
-```powershell
-uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
-```
-
-### Single quotes inside inline C# code
-
-If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
-
-```powershell
-uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
-```
-
-### JSON object values passed via `--parameters`
-
-Pass a JSON object literal, not a JSON string value. Wrap the object literal in single quotes so PowerShell passes the inner double quotes through unchanged.
-
-```powershell
-uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
-```
-
-### Multi-line C# snippets
-
-Use a here-string variable when you want to prepare or reuse a snippet before executing it in PowerShell 7 (`pwsh`).
-
-```powershell
-$code = @'
-using UnityEngine;
-
-GameObject obj = GameObject.Find("Player");
-if (obj == null) return "Player not found";
-
-return obj.name;
-'@
 
 uloop execute-dynamic-code --code $code
 ```
 
-When using Windows PowerShell 5.1, escape C# double quotes inside the here-string before passing it to native `uloop.exe`.
+### With parameters
 
-```powershell
-$code = @'
-using UnityEngine;
-
-GameObject obj = GameObject.Find(\"Player\");
-if (obj == null) return \"Player not found\";
-
-return obj.name;
-'@
-
-uloop execute-dynamic-code --code $code
-```
-
-You can combine multi-line code with a multi-line JSON object literal the same way.
+Pass a JSON object literal, not a JSON string value.
+Use a second single-quoted here-string when the parameters are easier to read on separate lines.
 
 ```powershell
 $code = @'
@@ -125,6 +56,46 @@ $parameters = @'
 '@
 
 uloop execute-dynamic-code --code $code --parameters $parameters
+```
+
+## Short Inline Snippets
+
+PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
+
+```powershell
+uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
+```
+
+If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
+
+```powershell
+uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
+```
+
+Wrap JSON object literals for `--parameters` in single quotes so PowerShell passes inner double quotes unchanged.
+
+```powershell
+uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
+```
+
+## Windows PowerShell 5.1
+
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
+For short inline snippets, escape C# double quotes as `\"`.
+
+```powershell
+uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
+```
+
+For multiline snippets or code with many string literals, prefer `--code-file` so the shell does not rewrite the code text.
+
+## Native Launcher Check
+
+Multiline `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
+If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multiline inline snippets.
+
+```powershell
+(Get-Command uloop).Source
 ```
 
 ## Click UI Button by Path

--- a/.claude/skills/uloop-wait-for-pause-point/SKILL.md
+++ b/.claude/skills/uloop-wait-for-pause-point/SKILL.md
@@ -7,7 +7,7 @@ description: "Pauses Unity's playback and allows you to inspect specific frames.
 
 Use this small loop for one representative frame you care about:
 
-If the target script is compiled by a custom asmdef, add an asmdef reference to `UnityCLILoop.PausePoints.Runtime` before using `UloopPausePoint.Pause`. Without that reference, Unity cannot resolve the pause point API. Scripts compiled into `Assembly-CSharp` generally do not need a manual reference because the pause point runtime assembly is auto-referenced.
+Custom asmdef scripts must reference `UnityCLILoop.PausePoints.Runtime` before calling `UloopPausePoint.Pause`. `Assembly-CSharp` scripts can usually use it without a manual reference.
 
 1. Put a focused log and marker at the natural transition point. Log only local/intermediate values that will be hard to inspect later:
 

--- a/.claude/skills/uloop-wait-for-pause-point/SKILL.md
+++ b/.claude/skills/uloop-wait-for-pause-point/SKILL.md
@@ -7,6 +7,8 @@ description: "Pauses Unity's playback and allows you to inspect specific frames.
 
 Use this small loop for one representative frame you care about:
 
+If the target script is compiled by a custom asmdef, add an asmdef reference to `UnityCLILoop.PausePoints.Runtime` before using `UloopPausePoint.Pause`. Without that reference, Unity cannot resolve the pause point API. Scripts compiled into `Assembly-CSharp` generally do not need a manual reference because the pause point runtime assembly is auto-referenced.
+
 1. Put a focused log and marker at the natural transition point. Log only local/intermediate values that will be hard to inspect later:
 
 ```csharp

--- a/.codex/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.codex/skills/uloop-execute-dynamic-code/SKILL.md
@@ -25,7 +25,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
 - `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell-specific quoting**: For Windows/PowerShell, read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) before writing multiline commands. Use [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
+- **Shell-specific quoting**: Read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) for Windows/PowerShell multiline commands and [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
 - `--parameters {}` (advanced, optional): Pass a shell-quoted JSON object literal when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets. Do not pass a JSON string value such as `"{\"param0\":\"value\"}"`.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 

--- a/.codex/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.codex/skills/uloop-execute-dynamic-code/SKILL.md
@@ -17,7 +17,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute inline code: `uloop execute-dynamic-code --code '<code>'`
+3. Execute with `--code` or `--code-file` using the active shell's quoting guidance
 4. If execution fails, adjust code and retry
 5. Report the execution result
 
@@ -25,7 +25,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
 - `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell 7 (`pwsh`) can pass multiline snippets without `--code-file` by using a single-quoted here-string, for example `$code = @' ... '@; uloop execute-dynamic-code --code $code`. Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands; escape C# double quotes as `\"` for short inline snippets, or use `--code-file` when the snippet has many strings.
+- **Shell-specific quoting**: For Windows/PowerShell, read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) before writing multiline commands. Use [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
 - `--parameters {}` (advanced, optional): Pass a shell-quoted JSON object literal when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets. Do not pass a JSON string value such as `"{\"param0\":\"value\"}"`.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 
@@ -78,10 +78,10 @@ For detailed code examples, refer to these files:
   - Undo-aware operations: RecordObject, AddComponent, SetParent, grouping
 - **Selection operations**: See [references/selection-operations.md](references/selection-operations.md)
   - Get/set selection, multi-select, filter by type/editability
-- **PlayMode automation (zsh)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
-  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
-- **PlayMode automation (PowerShell)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
+- **PlayMode automation (PowerShell/Windows)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
   - Click UI buttons, invoke methods, set fields, tool combination workflows for PowerShell users
+- **PlayMode automation (zsh/macOS)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
+  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
 - **PlayMode UI controls**: See [references/playmode-ui-controls.md](references/playmode-ui-controls.md)
   - InputField, Slider, Toggle, Dropdown, drag & drop simulation, list all UI controls
 - **PlayMode inspection**: See [references/playmode-inspection.md](references/playmode-inspection.md)

--- a/.codex/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.codex/skills/uloop-execute-dynamic-code/SKILL.md
@@ -7,7 +7,7 @@ context: fork
 
 # Task
 
-Execute the following request using `uloop execute-dynamic-code`: $ARGUMENTS
+Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-code`.
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 

--- a/.codex/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.codex/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -24,9 +24,7 @@ Use `execute-dynamic-code` for direct automation and diagnostics, and switch to 
 
 ## PowerShell 7 Multiline Snippets
 
-Use this as the default Windows pattern for multiline C# in PowerShell 7 (`pwsh`).
-Put the snippet in a single-quoted here-string variable, then pass the variable to `--code`.
-This keeps C# double quotes unchanged and avoids mixing shell syntax into the C# sample.
+Default to a single-quoted here-string variable in PowerShell 7 (`pwsh`), then pass it to `--code`.
 
 ```powershell
 $code = @'
@@ -43,8 +41,7 @@ uloop execute-dynamic-code --code $code
 
 ### With parameters
 
-Pass a JSON object literal, not a JSON string value.
-Use a second single-quoted here-string when the parameters are easier to read on separate lines.
+Pass a JSON object literal, not a JSON string value. Use a second here-string when the parameters are easier to read on separate lines.
 
 ```powershell
 $code = @'
@@ -80,19 +77,17 @@ uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{
 
 ## Windows PowerShell 5.1
 
-Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
-For short inline snippets, escape C# double quotes as `\"`.
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands. Escape C# double quotes as `\"` in short inline snippets.
 
 ```powershell
 uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
 ```
 
-For multiline snippets or code with many string literals, prefer `--code-file` so the shell does not rewrite the code text.
+For multiline or string-heavy snippets, prefer `--code-file`.
 
 ## Native Launcher Check
 
-Multiline `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
-If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multiline inline snippets.
+Multiline `--code` expects the native Go `uloop.exe`. If `Get-Command uloop` resolves to an old `.cmd` shim, run `uloop install` and open a new terminal.
 
 ```powershell
 (Get-Command uloop).Source

--- a/.codex/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
+++ b/.codex/skills/uloop-execute-dynamic-code/references/playmode-automation-powershell.md
@@ -22,14 +22,14 @@ Choose the tool based on what you are trying to validate:
 In short: do not default everything to mouse simulation.
 Use `execute-dynamic-code` for direct automation and diagnostics, and switch to `simulate-mouse-ui` or `simulate-mouse-input` when reproducing the real input path is the thing you need to test.
 
-## PowerShell Quoting Notes
+## PowerShell 7 Multiline Snippets
 
-Use these patterns when you need shell-safe inline code.
-PowerShell's equivalent to a bash heredoc is a single-quoted here-string.
-In PowerShell 7 (`pwsh`), it can be passed to `--code` directly without creating a temporary file:
+Use this as the default Windows pattern for multiline C# in PowerShell 7 (`pwsh`).
+Put the snippet in a single-quoted here-string variable, then pass the variable to `--code`.
+This keeps C# double quotes unchanged and avoids mixing shell syntax into the C# sample.
 
 ```powershell
-uloop execute-dynamic-code --code @'
+$code = @'
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -37,83 +37,14 @@ Scene scene = SceneManager.GetActiveScene();
 GameObject[] objects = UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsInactive.Include, FindObjectsSortMode.None);
 return $"{scene.name}: {objects.Length} objects";
 '@
-```
-
-Use `--code-file` when the active shell or launcher cannot preserve inline code exactly, especially for Windows PowerShell 5.1 snippets with many C# string literals.
-
-### Native launcher check
-
-Multi-line `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
-If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multi-line inline snippets.
-
-```powershell
-(Get-Command uloop).Source
-```
-
-### Double quotes inside C# strings
-
-PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
-
-```powershell
-uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
-```
-
-Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
-Escape C# double quotes as `\"` when using inline `--code` from Windows PowerShell 5.1.
-
-```powershell
-uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
-```
-
-### Single quotes inside inline C# code
-
-If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
-
-```powershell
-uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
-```
-
-### JSON object values passed via `--parameters`
-
-Pass a JSON object literal, not a JSON string value. Wrap the object literal in single quotes so PowerShell passes the inner double quotes through unchanged.
-
-```powershell
-uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
-```
-
-### Multi-line C# snippets
-
-Use a here-string variable when you want to prepare or reuse a snippet before executing it in PowerShell 7 (`pwsh`).
-
-```powershell
-$code = @'
-using UnityEngine;
-
-GameObject obj = GameObject.Find("Player");
-if (obj == null) return "Player not found";
-
-return obj.name;
-'@
 
 uloop execute-dynamic-code --code $code
 ```
 
-When using Windows PowerShell 5.1, escape C# double quotes inside the here-string before passing it to native `uloop.exe`.
+### With parameters
 
-```powershell
-$code = @'
-using UnityEngine;
-
-GameObject obj = GameObject.Find(\"Player\");
-if (obj == null) return \"Player not found\";
-
-return obj.name;
-'@
-
-uloop execute-dynamic-code --code $code
-```
-
-You can combine multi-line code with a multi-line JSON object literal the same way.
+Pass a JSON object literal, not a JSON string value.
+Use a second single-quoted here-string when the parameters are easier to read on separate lines.
 
 ```powershell
 $code = @'
@@ -125,6 +56,46 @@ $parameters = @'
 '@
 
 uloop execute-dynamic-code --code $code --parameters $parameters
+```
+
+## Short Inline Snippets
+
+PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
+
+```powershell
+uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
+```
+
+If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
+
+```powershell
+uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
+```
+
+Wrap JSON object literals for `--parameters` in single quotes so PowerShell passes inner double quotes unchanged.
+
+```powershell
+uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
+```
+
+## Windows PowerShell 5.1
+
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
+For short inline snippets, escape C# double quotes as `\"`.
+
+```powershell
+uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
+```
+
+For multiline snippets or code with many string literals, prefer `--code-file` so the shell does not rewrite the code text.
+
+## Native Launcher Check
+
+Multiline `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
+If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multiline inline snippets.
+
+```powershell
+(Get-Command uloop).Source
 ```
 
 ## Click UI Button by Path

--- a/.codex/skills/uloop-wait-for-pause-point/SKILL.md
+++ b/.codex/skills/uloop-wait-for-pause-point/SKILL.md
@@ -7,7 +7,7 @@ description: "Pauses Unity's playback and allows you to inspect specific frames.
 
 Use this small loop for one representative frame you care about:
 
-If the target script is compiled by a custom asmdef, add an asmdef reference to `UnityCLILoop.PausePoints.Runtime` before using `UloopPausePoint.Pause`. Without that reference, Unity cannot resolve the pause point API. Scripts compiled into `Assembly-CSharp` generally do not need a manual reference because the pause point runtime assembly is auto-referenced.
+Custom asmdef scripts must reference `UnityCLILoop.PausePoints.Runtime` before calling `UloopPausePoint.Pause`. `Assembly-CSharp` scripts can usually use it without a manual reference.
 
 1. Put a focused log and marker at the natural transition point. Log only local/intermediate values that will be hard to inspect later:
 

--- a/.codex/skills/uloop-wait-for-pause-point/SKILL.md
+++ b/.codex/skills/uloop-wait-for-pause-point/SKILL.md
@@ -7,6 +7,8 @@ description: "Pauses Unity's playback and allows you to inspect specific frames.
 
 Use this small loop for one representative frame you care about:
 
+If the target script is compiled by a custom asmdef, add an asmdef reference to `UnityCLILoop.PausePoints.Runtime` before using `UloopPausePoint.Pause`. Without that reference, Unity cannot resolve the pause point API. Scripts compiled into `Assembly-CSharp` generally do not need a manual reference because the pause point runtime assembly is auto-referenced.
+
 1. Put a focused log and marker at the natural transition point. Log only local/intermediate values that will be hard to inspect later:
 
 ```csharp

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -7,7 +7,7 @@ description: "Pauses Unity's playback and allows you to inspect specific frames.
 
 Use this small loop for one representative frame you care about:
 
-If the target script is compiled by a custom asmdef, add an asmdef reference to `UnityCLILoop.PausePoints.Runtime` before using `UloopPausePoint.Pause`. Without that reference, Unity cannot resolve the pause point API. Scripts compiled into `Assembly-CSharp` generally do not need a manual reference because the pause point runtime assembly is auto-referenced.
+Custom asmdef scripts must reference `UnityCLILoop.PausePoints.Runtime` before calling `UloopPausePoint.Pause`. `Assembly-CSharp` scripts can usually use it without a manual reference.
 
 1. Put a focused log and marker at the natural transition point. Log only local/intermediate values that will be hard to inspect later:
 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -7,6 +7,8 @@ description: "Pauses Unity's playback and allows you to inspect specific frames.
 
 Use this small loop for one representative frame you care about:
 
+If the target script is compiled by a custom asmdef, add an asmdef reference to `UnityCLILoop.PausePoints.Runtime` before using `UloopPausePoint.Pause`. Without that reference, Unity cannot resolve the pause point API. Scripts compiled into `Assembly-CSharp` generally do not need a manual reference because the pause point runtime assembly is auto-referenced.
+
 1. Put a focused log and marker at the natural transition point. Log only local/intermediate values that will be hard to inspect later:
 
 ```csharp

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -25,7 +25,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
 - `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell-specific quoting**: For Windows/PowerShell, read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) before writing multiline commands. Use [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
+- **Shell-specific quoting**: Read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) for Windows/PowerShell multiline commands and [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
 - `--parameters {}` (advanced, optional): Pass a shell-quoted JSON object literal when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets. Do not pass a JSON string value such as `"{\"param0\":\"value\"}"`.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -17,7 +17,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 1. Read the relevant reference file(s) from the Code Examples section below
 2. Construct C# code based on the reference examples
-3. Execute inline code: `uloop execute-dynamic-code --code '<code>'`
+3. Execute with `--code` or `--code-file` using the active shell's quoting guidance
 4. If execution fails, adjust code and retry
 5. Report the execution result
 
@@ -25,7 +25,7 @@ This tool can inspect reachable Unity state, such as GameObjects, components, pu
 
 - `--code '<code>'`: Inline C# statements to execute. Use direct statements only; `return` is optional, and `using` directives may appear at the top of the snippet.
 - `--code-file <path>`: Read the C# statements from a file instead of `--code`. Use this when the active shell or launcher cannot preserve inline code exactly. Exactly one of `--code` or `--code-file` is required; combining them is an error.
-- **Shell quoting**: bash/zsh uses single quotes, for example `uloop execute-dynamic-code --code 'using UnityEngine; return Mathf.PI;'`. PowerShell 7 (`pwsh`) can pass multiline snippets without `--code-file` by using a single-quoted here-string, for example `$code = @' ... '@; uloop execute-dynamic-code --code $code`. Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands; escape C# double quotes as `\"` for short inline snippets, or use `--code-file` when the snippet has many strings.
+- **Shell-specific quoting**: For Windows/PowerShell, read [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md) before writing multiline commands. Use [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md) for zsh/macOS examples.
 - `--parameters {}` (advanced, optional): Pass a shell-quoted JSON object literal when reusing a snippet with varying data or when keeping values outside the code. Values are exposed as `parameters["param0"]`, `parameters["param1"]`, and so on. Omit this flag for most snippets. Do not pass a JSON string value such as `"{\"param0\":\"value\"}"`.
 - `--wait-for-domain-reload` (optional): Wait for Domain Reload recovery after snippets that intentionally trigger Unity script reload or import work. Omit this for normal inspection and editor-state workflows.
 
@@ -78,10 +78,10 @@ For detailed code examples, refer to these files:
   - Undo-aware operations: RecordObject, AddComponent, SetParent, grouping
 - **Selection operations**: See [references/selection-operations.md](references/selection-operations.md)
   - Get/set selection, multi-select, filter by type/editability
-- **PlayMode automation (zsh)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
-  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
-- **PlayMode automation (PowerShell)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
+- **PlayMode automation (PowerShell/Windows)**: See [references/playmode-automation-powershell.md](references/playmode-automation-powershell.md)
   - Click UI buttons, invoke methods, set fields, tool combination workflows for PowerShell users
+- **PlayMode automation (zsh/macOS)**: See [references/playmode-automation-zsh.md](references/playmode-automation-zsh.md)
+  - Click UI buttons, invoke methods, set fields, tool combination workflows for zsh users
 - **PlayMode UI controls**: See [references/playmode-ui-controls.md](references/playmode-ui-controls.md)
   - InputField, Slider, Toggle, Dropdown, drag & drop simulation, list all UI controls
 - **PlayMode inspection**: See [references/playmode-inspection.md](references/playmode-inspection.md)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -7,7 +7,7 @@ context: fork
 
 # Task
 
-Execute the following request using `uloop execute-dynamic-code`: $ARGUMENTS
+Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-code`.
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -24,9 +24,7 @@ Use `execute-dynamic-code` for direct automation and diagnostics, and switch to 
 
 ## PowerShell 7 Multiline Snippets
 
-Use this as the default Windows pattern for multiline C# in PowerShell 7 (`pwsh`).
-Put the snippet in a single-quoted here-string variable, then pass the variable to `--code`.
-This keeps C# double quotes unchanged and avoids mixing shell syntax into the C# sample.
+Default to a single-quoted here-string variable in PowerShell 7 (`pwsh`), then pass it to `--code`.
 
 ```powershell
 $code = @'
@@ -43,8 +41,7 @@ uloop execute-dynamic-code --code $code
 
 ### With parameters
 
-Pass a JSON object literal, not a JSON string value.
-Use a second single-quoted here-string when the parameters are easier to read on separate lines.
+Pass a JSON object literal, not a JSON string value. Use a second here-string when the parameters are easier to read on separate lines.
 
 ```powershell
 $code = @'
@@ -80,19 +77,17 @@ uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{
 
 ## Windows PowerShell 5.1
 
-Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
-For short inline snippets, escape C# double quotes as `\"`.
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands. Escape C# double quotes as `\"` in short inline snippets.
 
 ```powershell
 uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
 ```
 
-For multiline snippets or code with many string literals, prefer `--code-file` so the shell does not rewrite the code text.
+For multiline or string-heavy snippets, prefer `--code-file`.
 
 ## Native Launcher Check
 
-Multiline `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
-If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multiline inline snippets.
+Multiline `--code` expects the native Go `uloop.exe`. If `Get-Command uloop` resolves to an old `.cmd` shim, run `uloop install` and open a new terminal.
 
 ```powershell
 (Get-Command uloop).Source

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/references/playmode-automation-powershell.md
@@ -22,14 +22,14 @@ Choose the tool based on what you are trying to validate:
 In short: do not default everything to mouse simulation.
 Use `execute-dynamic-code` for direct automation and diagnostics, and switch to `simulate-mouse-ui` or `simulate-mouse-input` when reproducing the real input path is the thing you need to test.
 
-## PowerShell Quoting Notes
+## PowerShell 7 Multiline Snippets
 
-Use these patterns when you need shell-safe inline code.
-PowerShell's equivalent to a bash heredoc is a single-quoted here-string.
-In PowerShell 7 (`pwsh`), it can be passed to `--code` directly without creating a temporary file:
+Use this as the default Windows pattern for multiline C# in PowerShell 7 (`pwsh`).
+Put the snippet in a single-quoted here-string variable, then pass the variable to `--code`.
+This keeps C# double quotes unchanged and avoids mixing shell syntax into the C# sample.
 
 ```powershell
-uloop execute-dynamic-code --code @'
+$code = @'
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -37,83 +37,14 @@ Scene scene = SceneManager.GetActiveScene();
 GameObject[] objects = UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsInactive.Include, FindObjectsSortMode.None);
 return $"{scene.name}: {objects.Length} objects";
 '@
-```
-
-Use `--code-file` when the active shell or launcher cannot preserve inline code exactly, especially for Windows PowerShell 5.1 snippets with many C# string literals.
-
-### Native launcher check
-
-Multi-line `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
-If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multi-line inline snippets.
-
-```powershell
-(Get-Command uloop).Source
-```
-
-### Double quotes inside C# strings
-
-PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
-
-```powershell
-uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
-```
-
-Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
-Escape C# double quotes as `\"` when using inline `--code` from Windows PowerShell 5.1.
-
-```powershell
-uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
-```
-
-### Single quotes inside inline C# code
-
-If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
-
-```powershell
-uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
-```
-
-### JSON object values passed via `--parameters`
-
-Pass a JSON object literal, not a JSON string value. Wrap the object literal in single quotes so PowerShell passes the inner double quotes through unchanged.
-
-```powershell
-uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
-```
-
-### Multi-line C# snippets
-
-Use a here-string variable when you want to prepare or reuse a snippet before executing it in PowerShell 7 (`pwsh`).
-
-```powershell
-$code = @'
-using UnityEngine;
-
-GameObject obj = GameObject.Find("Player");
-if (obj == null) return "Player not found";
-
-return obj.name;
-'@
 
 uloop execute-dynamic-code --code $code
 ```
 
-When using Windows PowerShell 5.1, escape C# double quotes inside the here-string before passing it to native `uloop.exe`.
+### With parameters
 
-```powershell
-$code = @'
-using UnityEngine;
-
-GameObject obj = GameObject.Find(\"Player\");
-if (obj == null) return \"Player not found\";
-
-return obj.name;
-'@
-
-uloop execute-dynamic-code --code $code
-```
-
-You can combine multi-line code with a multi-line JSON object literal the same way.
+Pass a JSON object literal, not a JSON string value.
+Use a second single-quoted here-string when the parameters are easier to read on separate lines.
 
 ```powershell
 $code = @'
@@ -125,6 +56,46 @@ $parameters = @'
 '@
 
 uloop execute-dynamic-code --code $code --parameters $parameters
+```
+
+## Short Inline Snippets
+
+PowerShell 7 (`pwsh`) preserves C# double quotes inside single-quoted native command arguments.
+
+```powershell
+uloop execute-dynamic-code --code 'return "Hello from PowerShell";'
+```
+
+If the C# snippet itself contains a single quote, double it inside the PowerShell single-quoted string.
+
+```powershell
+uloop execute-dynamic-code --code 'char initial = ''A''; return initial.ToString();'
+```
+
+Wrap JSON object literals for `--parameters` in single quotes so PowerShell passes inner double quotes unchanged.
+
+```powershell
+uloop execute-dynamic-code --code 'return parameters["param0"];' --parameters '{"param0":"Hello from PowerShell"}'
+```
+
+## Windows PowerShell 5.1
+
+Windows PowerShell 5.1 removes unescaped double quotes when invoking native commands.
+For short inline snippets, escape C# double quotes as `\"`.
+
+```powershell
+uloop execute-dynamic-code --code 'return \"Hello from Windows PowerShell\";'
+```
+
+For multiline snippets or code with many string literals, prefer `--code-file` so the shell does not rewrite the code text.
+
+## Native Launcher Check
+
+Multiline `--code` expects PowerShell to call the native Go `uloop.exe` launcher directly.
+If `Get-Command uloop` resolves to an old `.cmd` shim from a previous installation, run `uloop install` and open a new terminal before relying on multiline inline snippets.
+
+```powershell
+(Get-Command uloop).Source
 ```
 
 ## Click UI Button by Path


### PR DESCRIPTION
## Summary
- Clarifies the pause point skill so custom asmdef users see the required `UnityCLILoop.PausePoints.Runtime` reference before using `UloopPausePoint.Pause`.
- Makes Windows PowerShell guidance for `execute-dynamic-code` easier to find, with PowerShell 7 multiline snippets presented first.

## User Impact
- Agents and users are less likely to hit a Unity compile error when adding pause point markers in asmdef-managed scripts.
- Windows users no longer have to untangle zsh and PowerShell quoting guidance before running multiline `execute-dynamic-code` snippets.

## Changes
- Added the asmdef reference reminder to the pause point source skill and refreshed generated skill copies.
- Kept `execute-dynamic-code` `SKILL.md` as a light entry point and moved shell-specific detail into references.
- Reworked the PowerShell reference around PowerShell 7 multiline snippets, short inline snippets, Windows PowerShell 5.1 fallback guidance, and native launcher checks.

## Verification
- `git diff --check`
- `cli/dist/darwin-arm64/uloop skills install --project-path <PROJECT_ROOT> --claude --agents --codex`
- `cli/dist/darwin-arm64/uloop skills list --project-path <PROJECT_ROOT>`
- Source and generated skill copy comparisons with `cmp`
- Frontmatter and reference-link smoke check with `python3`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

