### PR TITLE
fix: Simulated UI clicks now reach clipped overlay controls

### DIFF
--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Runtime;
@@ -119,6 +120,362 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.IsTrue(tracker.PointerUpCalled, "PointerUp should be fired");
             Assert.IsTrue(tracker.PointerClickCalled, "PointerClick should be fired");
             Assert.AreEqual("ClickTarget", lastResponse.HitGameObjectName);
+        }
+
+        // Verifies clipped overlay UI wins over a non-GraphicRaycaster hit behind it.
+        [UnityTest]
+        public IEnumerator Click_Should_PreferClippedOverlayUiOverNonUiRaycastHit()
+        {
+            GameObject nonUiRoot = new GameObject("NonUiRaycasterRoot");
+
+            try
+            {
+                GameObject nonUiTarget = new GameObject("NonUiTarget");
+                nonUiTarget.transform.SetParent(nonUiRoot.transform, false);
+                ClickTracker nonUiTracker = nonUiTarget.AddComponent<ClickTracker>();
+                AlwaysHitRaycaster nonUiRaycaster = nonUiRoot.AddComponent<AlwaysHitRaycaster>();
+                nonUiRaycaster.Target = nonUiTarget;
+
+                Vector2 offscreenOffset = new Vector2(Screen.width, 0f);
+                ClickTracker overlayTracker = CreateClickableElement(
+                    "OffscreenOverlayTarget", offscreenOffset, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the non-UI raycaster should hit.");
+                Assert.IsFalse(raycastResults[0].module is GraphicRaycaster,
+                    "Setup: EventSystem's first hit should not come from a GraphicRaycaster.");
+                Assert.IsFalse(
+                    raycastResults.Exists(result => result.gameObject == overlayTracker.gameObject),
+                    "Setup: overlay UI must be clipped out of EventSystem results for this regression test.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(overlayTracker.PointerClickCalled, "Overlay UI should receive the click");
+                Assert.IsFalse(nonUiTracker.PointerClickCalled, "Non-UI target behind overlay UI should not receive the click");
+                Assert.AreEqual("OffscreenOverlayTarget", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(nonUiRoot);
+            }
+        }
+
+        // Verifies overlay UI wins over a prioritized Physics2D raycast hit.
+        [UnityTest]
+        public IEnumerator Click_Should_PreferOverlayUiOverPhysics2DRaycastHit()
+        {
+            GameObject physicsRoot = new GameObject("Physics2DRaycasterRoot");
+
+            try
+            {
+                GameObject cameraGo = new GameObject("Physics2DCamera");
+                cameraGo.transform.SetParent(physicsRoot.transform, false);
+                cameraGo.transform.position = new Vector3(0f, 0f, -10f);
+                Camera physicsCamera = cameraGo.AddComponent<Camera>();
+                physicsCamera.orthographic = true;
+                physicsCamera.orthographicSize = 5f;
+                cameraGo.AddComponent<HighPriorityPhysics2DRaycaster>();
+
+                canvasGo.GetComponent<Canvas>().sortingOrder = 100;
+                ClickTracker overlayTracker = CreateClickableElement(
+                    "PhysicsOverlayTarget", Vector2.zero, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+                GameObject physicsTarget = new GameObject("Physics2DTarget");
+                physicsTarget.transform.SetParent(physicsRoot.transform, false);
+                physicsTarget.transform.position = GetWorldPointOnPhysicsPlane(physicsCamera, screenPos);
+                BoxCollider2D collider = physicsTarget.AddComponent<BoxCollider2D>();
+                collider.size = new Vector2(2f, 2f);
+                ClickTracker physicsTracker = physicsTarget.AddComponent<ClickTracker>();
+                yield return null;
+
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the Physics2D raycaster should hit.");
+                Assert.AreEqual(physicsTarget, raycastResults[0].gameObject,
+                    "Setup: EventSystem should expose the prioritized Physics2D hit first.");
+                Assert.IsTrue(
+                    raycastResults.Exists(result => result.gameObject == overlayTracker.gameObject),
+                    "Setup: overlay UI should also be a normal EventSystem hit.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(overlayTracker.PointerClickCalled, "Overlay UI should receive the click");
+                Assert.IsFalse(physicsTracker.PointerClickCalled, "Physics2D target behind overlay UI should not receive the click");
+                Assert.AreEqual("PhysicsOverlayTarget", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(physicsRoot);
+            }
+        }
+
+        // Verifies higher-order clipped overlay UI wins over a lower GraphicRaycaster hit.
+        [UnityTest]
+        public IEnumerator Click_Should_PreferClippedHigherOrderOverlayUiOverLowerGraphicRaycasterHit()
+        {
+            GameObject lowerCameraGo = new GameObject("LowerGraphicCamera");
+            GameObject lowerCanvasGo = new GameObject("LowerGraphicCanvas");
+
+            try
+            {
+                lowerCameraGo.transform.position = new Vector3(0f, 0f, -10f);
+                Camera lowerCamera = lowerCameraGo.AddComponent<Camera>();
+                lowerCamera.orthographic = true;
+
+                Canvas lowerCanvas = lowerCanvasGo.AddComponent<Canvas>();
+                lowerCanvas.renderMode = RenderMode.ScreenSpaceCamera;
+                lowerCanvas.worldCamera = lowerCamera;
+                lowerCanvas.sortingOrder = 0;
+
+                GameObject lowerMask = CreateChildUIElement(
+                    "LowerGraphicMask", lowerCanvasGo.transform, Vector2.zero, new Vector2(2000f, 2000f));
+                lowerMask.AddComponent<Image>();
+                ClickTracker lowerTracker = lowerMask.AddComponent<ClickTracker>();
+                AlwaysHitGraphicRaycaster lowerRaycaster = lowerCanvasGo.AddComponent<AlwaysHitGraphicRaycaster>();
+                lowerRaycaster.Target = lowerMask;
+
+                canvasGo.GetComponent<Canvas>().sortingOrder = 100;
+                Vector2 clippedOverlayOffset = new Vector2(Screen.width, 0f);
+                ClickTracker overlayTracker = CreateClickableElement(
+                    "FrontOverlayButton", clippedOverlayOffset, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(overlayTracker.gameObject);
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the lower GraphicRaycaster should hit.");
+                Assert.AreEqual(lowerMask, raycastResults[0].gameObject,
+                    "Setup: EventSystem should expose the lower-priority GraphicRaycaster hit first.");
+                Assert.IsFalse(
+                    raycastResults.Exists(result => result.gameObject == overlayTracker.gameObject),
+                    "Setup: overlay UI must be clipped out of EventSystem results for this regression test.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(overlayTracker.PointerClickCalled, "Higher-order overlay UI should receive the click");
+                Assert.IsFalse(lowerTracker.PointerClickCalled, "Lower GraphicRaycaster target should not receive the click");
+                Assert.AreEqual("FrontOverlayButton", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(lowerCanvasGo);
+                Object.Destroy(lowerCameraGo);
+            }
+        }
+
+        // Verifies canvas-space fallback ignores graphics rejected by GraphicRaycaster's reversed-graphic filter.
+        [UnityTest]
+        public IEnumerator Click_Should_IgnoreReversedOverlayGraphicWhenFallbackRanksCanvasSpaceHit()
+        {
+            const int lowerSortingOrder = 32001;
+            const int reversedSortingOrder = 32002;
+
+            DestroyInputVisualizationCanvases();
+            yield return null;
+
+            ClickTracker lowerTracker = CreateClickableElement("LowerTarget", Vector2.zero, new Vector2(200f, 100f));
+            canvasGo.GetComponent<Canvas>().sortingOrder = lowerSortingOrder;
+            GameObject overlayCanvasGo = new GameObject("ReversedOverlayCanvas");
+
+            try
+            {
+                Canvas overlayCanvas = overlayCanvasGo.AddComponent<Canvas>();
+                overlayCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+                overlayCanvas.sortingOrder = reversedSortingOrder;
+                overlayCanvasGo.AddComponent<GraphicRaycaster>();
+
+                GameObject reversedOverlay = CreateChildUIElement(
+                    "ReversedOverlayTarget", overlayCanvasGo.transform, Vector2.zero, new Vector2(200f, 100f));
+                reversedOverlay.transform.localRotation = Quaternion.Euler(0f, 180f, 0f);
+                reversedOverlay.AddComponent<Image>();
+                ClickTracker reversedTracker = reversedOverlay.AddComponent<ClickTracker>();
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(lowerTracker.gameObject);
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the lower target should remain clickable.");
+                Assert.AreEqual(lowerTracker.gameObject, raycastResults[0].gameObject,
+                    "Setup: EventSystem should ignore the reversed overlay graphic.");
+                Assert.IsFalse(
+                    raycastResults.Exists(result => result.gameObject == reversedOverlay),
+                    "Setup: reversed overlay UI must be excluded by GraphicRaycaster.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(lowerTracker.PointerClickCalled, "Lower UI should receive the click");
+                Assert.IsFalse(reversedTracker.PointerClickCalled, "Reversed overlay UI should not receive the click");
+                Assert.AreEqual("LowerTarget", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(overlayCanvasGo);
+            }
+        }
+
+        // Verifies canvas-space fallback honors GraphicRaycaster's raycast padding filter.
+        [UnityTest]
+        public IEnumerator Click_Should_IgnoreOverlayGraphicOutsideRaycastPaddingWhenFallbackRanksCanvasSpaceHit()
+        {
+            const int lowerSortingOrder = 32001;
+            const int paddedSortingOrder = 32002;
+
+            DestroyInputVisualizationCanvases();
+            yield return null;
+
+            ClickTracker lowerTracker = CreateClickableElement("LowerPaddedTarget", Vector2.zero, new Vector2(300f, 120f));
+            canvasGo.GetComponent<Canvas>().sortingOrder = lowerSortingOrder;
+            GameObject overlayCanvasGo = new GameObject("PaddedOverlayCanvas");
+
+            try
+            {
+                Canvas overlayCanvas = overlayCanvasGo.AddComponent<Canvas>();
+                overlayCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+                overlayCanvas.sortingOrder = paddedSortingOrder;
+                overlayCanvasGo.AddComponent<GraphicRaycaster>();
+
+                GameObject paddedOverlay = CreateChildUIElement(
+                    "PaddedOverlayTarget", overlayCanvasGo.transform, Vector2.zero, new Vector2(200f, 100f));
+                Image paddedImage = paddedOverlay.AddComponent<Image>();
+                paddedImage.raycastPadding = new Vector4(80f, 40f, 80f, 40f);
+                ClickTracker paddedTracker = paddedOverlay.AddComponent<ClickTracker>();
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(lowerTracker.gameObject) + new Vector2(70f, 0f);
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the lower target should remain clickable.");
+                Assert.AreEqual(lowerTracker.gameObject, raycastResults[0].gameObject,
+                    "Setup: EventSystem should ignore the overlay outside its padded raycast rect.");
+                Assert.IsFalse(
+                    raycastResults.Exists(result => result.gameObject == paddedOverlay),
+                    "Setup: padded overlay UI must be excluded by GraphicRaycaster.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(lowerTracker.PointerClickCalled, "Lower UI should receive the click");
+                Assert.IsFalse(paddedTracker.PointerClickCalled, "Padded overlay UI should not receive the click");
+                Assert.AreEqual("LowerPaddedTarget", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(overlayCanvasGo);
+            }
+        }
+
+        // Verifies canvas-space fallback does not treat child Canvas graphics as parent-raycaster hits.
+        [UnityTest]
+        public IEnumerator Click_Should_IgnoreNestedCanvasGraphicWithoutRaycasterWhenFallbackRanksCanvasSpaceHit()
+        {
+            const int parentSortingOrder = 32001;
+
+            DestroyInputVisualizationCanvases();
+            yield return null;
+
+            ClickTracker parentTracker = CreateClickableElement("ParentCanvasTarget", Vector2.zero, new Vector2(300f, 120f));
+            canvasGo.GetComponent<Canvas>().sortingOrder = parentSortingOrder;
+            GameObject childCanvasGo = CreateUIElement("NestedCanvasWithoutRaycaster", Vector2.zero, new Vector2(240f, 120f));
+
+            try
+            {
+                childCanvasGo.AddComponent<Canvas>();
+                GameObject childTarget = CreateChildUIElement(
+                    "NestedCanvasTarget", childCanvasGo.transform, Vector2.zero, new Vector2(200f, 100f));
+                childTarget.AddComponent<Image>();
+                ClickTracker childTracker = childTarget.AddComponent<ClickTracker>();
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(parentTracker.gameObject);
+                PointerEventData pointerData = new PointerEventData(EventSystem.current)
+                {
+                    position = screenPos
+                };
+                List<RaycastResult> raycastResults = new List<RaycastResult>();
+                EventSystem.current.RaycastAll(pointerData, raycastResults);
+
+                Assert.IsNotEmpty(raycastResults, "Setup: the parent target should remain clickable.");
+                Assert.AreEqual(parentTracker.gameObject, raycastResults[0].gameObject,
+                    "Setup: EventSystem should ignore nested Canvas graphics without a raycaster.");
+                Assert.IsFalse(
+                    raycastResults.Exists(result => result.gameObject == childTarget),
+                    "Setup: nested Canvas UI must be excluded by the parent GraphicRaycaster.");
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(parentTracker.PointerClickCalled, "Parent Canvas UI should receive the click");
+                Assert.IsFalse(childTracker.PointerClickCalled, "Nested Canvas UI without raycaster should not receive the click");
+                Assert.AreEqual("ParentCanvasTarget", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(childCanvasGo);
+            }
         }
 
         [UnityTest]
@@ -623,6 +980,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             return (Vector2)go.GetComponent<RectTransform>().position;
         }
 
+        private Vector3 GetWorldPointOnPhysicsPlane(Camera physicsCamera, Vector2 screenPos)
+        {
+            Vector3 screenPoint = new Vector3(screenPos.x, screenPos.y, -physicsCamera.transform.position.z);
+            Vector3 worldPoint = physicsCamera.ScreenToWorldPoint(screenPoint);
+            worldPoint.z = 0f;
+            return worldPoint;
+        }
+
+        private static void DestroyInputVisualizationCanvases()
+        {
+            InputVisualizationCanvas[] canvases =
+                Object.FindObjectsByType<InputVisualizationCanvas>(FindObjectsSortMode.None);
+            foreach (InputVisualizationCanvas canvas in canvases)
+            {
+                Object.Destroy(canvas.gameObject);
+            }
+        }
+
         // simulate-mouse uses top-left origin; Unity screen space uses bottom-left origin
         private Vector2 ScreenToInput(Vector2 screenPos)
         {
@@ -661,6 +1036,59 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// Test raycaster that always reports a non-UI hit.
+    /// </summary>
+    public class AlwaysHitRaycaster : BaseRaycaster
+    {
+        public GameObject Target = null!;
+
+        public override Camera eventCamera => null!;
+
+        public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)
+        {
+            resultAppendList.Add(new RaycastResult
+            {
+                gameObject = Target,
+                module = this,
+                distance = 0f,
+                screenPosition = eventData.position
+            });
+        }
+    }
+
+    /// <summary>
+    /// Test GraphicRaycaster that reports a deterministic lower-priority UI hit.
+    /// </summary>
+    public class AlwaysHitGraphicRaycaster : GraphicRaycaster
+    {
+        public GameObject Target = null!;
+
+        public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)
+        {
+            Canvas canvas = GetComponent<Canvas>();
+            resultAppendList.Add(new RaycastResult
+            {
+                gameObject = Target,
+                module = this,
+                distance = 0f,
+                screenPosition = eventData.position,
+                sortingLayer = canvas.sortingLayerID,
+                sortingOrder = canvas.sortingOrder,
+                depth = 0
+            });
+        }
+    }
+
+    /// <summary>
+    /// Test Physics2D raycaster with priority high enough to expose UI priority handling.
+    /// </summary>
+    public class HighPriorityPhysics2DRaycaster : Physics2DRaycaster
+    {
+        public override int sortOrderPriority => int.MaxValue;
+        public override int renderOrderPriority => int.MaxValue;
     }
 
     // Tracks pointer click events for testing

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -8,6 +8,7 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.inputsystem": "1.14.2",
     "com.unity.memoryprofiler": "1.1.12",
+    "com.unity.modules.physics2d": "1.0.0",
     "com.unity.render-pipelines.universal": "14.0.12",
     "com.unity.terrain-tools": "5.0.6",
     "com.unity.test-framework": "1.3.9",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -283,6 +283,12 @@
       "source": "builtin",
       "dependencies": {}
     },
+    "com.unity.modules.physics2d": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
+    },
     "com.unity.modules.physics": {
       "version": "1.0.0",
       "depth": 2,

--- a/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UiRaycastHelper.cs
@@ -20,15 +20,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
             List<RaycastResult> results = new();
             eventSystem.RaycastAll(pointerData, results);
+            RaycastResult? canvasSpaceHit = RaycastCanvasSpace(screenPosition);
 
             if (results.Count > 0)
             {
-                return results[0];
+                RaycastResult firstHit = results[0];
+
+                if (canvasSpaceHit != null && ShouldPreferCanvasSpaceHit(canvasSpaceHit.Value, firstHit))
+                {
+                    return canvasSpaceHit;
+                }
+
+                return firstHit;
             }
 
             // EventSystem clips at Screen.width/height, which can be smaller than the
             // Canvas layout space (Game view target resolution). Fall back to manual hit testing.
-            return RaycastCanvasSpace(screenPosition);
+            return canvasSpaceHit;
         }
 
         // Bypass EventSystem's Screen-bounds clipping by directly testing Graphic rects in Canvas space.
@@ -36,9 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static RaycastResult? RaycastCanvasSpace(Vector2 canvasPosition)
         {
             Canvas[] canvases = Object.FindObjectsByType<Canvas>(FindObjectsSortMode.None);
-            Graphic? bestHit = null;
-            int bestSortingOrder = int.MinValue;
-            int bestDepth = -1;
+            RaycastResult? bestHit = null;
 
             foreach (Canvas canvas in canvases)
             {
@@ -61,39 +67,41 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Graphic[] graphics = canvas.GetComponentsInChildren<Graphic>();
                 foreach (Graphic graphic in graphics)
                 {
-                    if (!IsRaycastCandidate(graphic, canvasPosition))
+                    if (!IsRaycastCandidate(graphic, canvas, raycaster, canvasPosition))
                     {
                         continue;
                     }
 
-                    int sortingOrder = canvas.sortingOrder;
-
-                    if (sortingOrder > bestSortingOrder ||
-                        (sortingOrder == bestSortingOrder && graphic.depth > bestDepth))
+                    RaycastResult candidate = new RaycastResult
                     {
-                        bestHit = graphic;
-                        bestSortingOrder = sortingOrder;
-                        bestDepth = graphic.depth;
+                        gameObject = graphic.gameObject,
+                        module = raycaster,
+                        screenPosition = canvasPosition,
+                        sortingLayer = canvas.sortingLayerID,
+                        sortingOrder = canvas.sortingOrder,
+                        depth = graphic.depth
+                    };
+
+                    if (bestHit == null || CompareRaycastPriority(candidate, bestHit.Value) > 0)
+                    {
+                        bestHit = candidate;
                     }
                 }
             }
 
-            if (bestHit == null)
-            {
-                return null;
-            }
-
-            return new RaycastResult
-            {
-                gameObject = bestHit.gameObject,
-                sortingOrder = bestSortingOrder
-            };
+            return bestHit;
         }
 
         // Respects CanvasGroup.blocksRaycasts, Mask, RectMask2D, and custom ICanvasRaycastFilter
-        private static bool IsRaycastCandidate(Graphic graphic, Vector2 canvasPosition)
+        private static bool IsRaycastCandidate(Graphic graphic, Canvas canvas, GraphicRaycaster raycaster, Vector2 canvasPosition)
         {
             if (!graphic.gameObject.activeInHierarchy || !graphic.enabled)
+            {
+                return false;
+            }
+
+            // Why: GraphicRaycaster reads GraphicRegistry per Canvas; child Canvas graphics belong to their own raycaster.
+            if (graphic.canvas != canvas)
             {
                 return false;
             }
@@ -104,12 +112,118 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             if (!RectTransformUtility.RectangleContainsScreenPoint(
-                    graphic.rectTransform, canvasPosition, null))
+                    graphic.rectTransform, canvasPosition, null, graphic.raycastPadding))
+            {
+                return false;
+            }
+
+            // Why: Canvas-space fallback bypasses GraphicRaycaster.Raycast, so mirror its default reversed-graphic filter.
+            if (raycaster.ignoreReversedGraphics && !IsFacingForward(graphic))
             {
                 return false;
             }
 
             return graphic.Raycast(canvasPosition, null);
+        }
+
+        private static bool IsFacingForward(Graphic graphic)
+        {
+            Transform transform = graphic.transform;
+            Vector3 direction = transform.rotation * Vector3.forward;
+            return Vector3.Dot(Vector3.forward, direction) > 0f;
+        }
+
+        private static bool ShouldPreferCanvasSpaceHit(RaycastResult canvasSpaceHit, RaycastResult eventSystemHit)
+        {
+            if (!IsGraphicRaycast(canvasSpaceHit))
+            {
+                return false;
+            }
+
+            if (!IsGraphicRaycast(eventSystemHit))
+            {
+                return true;
+            }
+
+            // Why: for normal in-screen UI hits, EventSystem ordering is authoritative; fallback is only for Screen-bounds clipping.
+            if (IsInsideScreenBounds(canvasSpaceHit.screenPosition))
+            {
+                return false;
+            }
+
+            return CompareRaycastPriority(canvasSpaceHit, eventSystemHit) > 0;
+        }
+
+        private static bool IsGraphicRaycast(RaycastResult raycastResult)
+        {
+            return raycastResult.module is GraphicRaycaster;
+        }
+
+        private static bool IsInsideScreenBounds(Vector2 screenPosition)
+        {
+            return screenPosition.x >= 0f &&
+                   screenPosition.x <= Screen.width &&
+                   screenPosition.y >= 0f &&
+                   screenPosition.y <= Screen.height;
+        }
+
+        private static int CompareRaycastPriority(RaycastResult left, RaycastResult right)
+        {
+            int sortOrderPriority = Compare(GetSortOrderPriority(left), GetSortOrderPriority(right));
+            if (sortOrderPriority != 0)
+            {
+                return sortOrderPriority;
+            }
+
+            int renderOrderPriority = Compare(GetRenderOrderPriority(left), GetRenderOrderPriority(right));
+            if (renderOrderPriority != 0)
+            {
+                return renderOrderPriority;
+            }
+
+            int sortingLayer = Compare(GetSortingLayerValue(left), GetSortingLayerValue(right));
+            if (sortingLayer != 0)
+            {
+                return sortingLayer;
+            }
+
+            int sortingOrder = Compare(left.sortingOrder, right.sortingOrder);
+            if (sortingOrder != 0)
+            {
+                return sortingOrder;
+            }
+
+            return Compare(left.depth, right.depth);
+        }
+
+        private static int GetSortOrderPriority(RaycastResult result)
+        {
+            return result.module != null ? result.module.sortOrderPriority : 0;
+        }
+
+        private static int GetRenderOrderPriority(RaycastResult result)
+        {
+            return result.module != null ? result.module.renderOrderPriority : 0;
+        }
+
+        private static int GetSortingLayerValue(RaycastResult result)
+        {
+            return SortingLayer.GetLayerValueFromID(result.sortingLayer);
+        }
+
+        private static int Compare(int left, int right)
+        {
+            if (left > right)
+            {
+                return 1;
+            }
+
+            if (left < right)
+            {
+                return -1;
+            }
+
+            return 0;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -671,18 +670,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private void UpdatePointerRaycast(PointerEventData pointerData)
         {
-            List<RaycastResult> results = new();
-            EventSystem.current.RaycastAll(pointerData, results);
-
-            if (results.Count > 0)
-            {
-                pointerData.pointerCurrentRaycast = results[0];
-                return;
-            }
-
-            // Same Canvas-space fallback as RaycastUI for scaled Game view
-            RaycastResult? fallback = UiRaycastHelper.RaycastCanvasSpace(pointerData.position);
-            pointerData.pointerCurrentRaycast = fallback ?? new RaycastResult();
+            RaycastResult? hit = UiRaycastHelper.RaycastUI(pointerData.position, EventSystem.current);
+            pointerData.pointerCurrentRaycast = hit ?? new RaycastResult();
         }
 
         private async Task<bool> InterpolateDragPosition(


### PR DESCRIPTION
## Summary
- Simulated UI clicks now reach overlay controls that are inside Canvas layout space even when Unity EventSystem screen-bounds clipping drops them.
- The fallback keeps normal Unity raycast behavior for reversed graphics, raycast padding, nested canvases, and regular in-screen hits.

## User Impact
- Before this change, mouse simulation could miss visible overlay UI when the Game view target resolution did not match Screen.width/Screen.height.
- After this change, UI automation can click those controls while preserving the usual Unity hit target for ordinary UI layouts.

## Changes
- Add Canvas-space fallback raycast support for Screen Space Overlay canvases.
- Route simulated pointer raycasts through the shared helper.
- Add PlayMode regression coverage for clipped overlays, raycast priority, reversed graphics, raycast padding, nested canvases, and Physics2D priority handling.
- Add Physics2D module dependency required by the regression tests.

## Verification
- cli/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"
- cli/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode PlayMode --filter-type regex --filter-value io.github.hatayama.UnityCliLoop.Tests.PlayMode.SimulateMouseUiTests
- cli/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode PlayMode
- codex --disable shell_tool review --base origin/v3-beta

Fixes #1317.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

