### PR TITLE
fix: Dynamic code cancellation no longer leaves Unity busy

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+using DynamicExecutionContext = io.github.hatayama.UnityCliLoop.FirstPartyTools.ExecutionContext;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Test fixture that verifies CommandRunner cancellation behavior.
+    /// </summary>
+    [TestFixture]
+    public class CommandRunnerCancellationTests
+    {
+        private static readonly TimeSpan CancellationPropagationTimeout = TimeSpan.FromSeconds(1);
+
+        [Test]
+        public async Task ExecuteAsync_WhenAsyncResultIgnoresCancellation_ShouldCancelAndAllowNextExecution()
+        {
+            // Verifies user tasks are cancellation-bound so the runner does not stay busy forever.
+            WrappedDynamicCommandState.PrepareBlockingCommand();
+            CommandRunner runner = new();
+            using CancellationTokenSource cancellationTokenSource = new();
+
+            try
+            {
+                Task<ExecutionResult> firstExecution = runner.ExecuteAsync(
+                    CreateContext(cancellationTokenSource.Token));
+                await WrappedDynamicCommandState.StartedTask;
+
+                cancellationTokenSource.Cancel();
+
+                ExecutionResult firstResult = await AwaitResultWithinTimeoutAsync(firstExecution);
+                Assert.That(firstResult.Success, Is.False);
+                Assert.That(firstResult.ErrorMessage, Is.EqualTo(UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED));
+                Assert.That(runner.IsRunning, Is.False);
+
+                WrappedDynamicCommandState.PrepareReturningCommand("ready");
+
+                ExecutionResult secondResult = await runner.ExecuteAsync(
+                    CreateContext(CancellationToken.None));
+
+                Assert.That(secondResult.Success, Is.True);
+                Assert.That(secondResult.Result, Is.EqualTo("ready"));
+                Assert.That(runner.IsRunning, Is.False);
+            }
+            finally
+            {
+                WrappedDynamicCommandState.CompleteBlockingCommand();
+            }
+        }
+
+        private static DynamicExecutionContext CreateContext(CancellationToken cancellationToken)
+        {
+            return new DynamicExecutionContext
+            {
+                CompiledAssembly = typeof(global::UnityCliLoop.Dynamic.DynamicCommand).Assembly,
+                CancellationToken = cancellationToken
+            };
+        }
+
+        private static async Task<ExecutionResult> AwaitResultWithinTimeoutAsync(
+            Task<ExecutionResult> executionTask)
+        {
+            Task timeoutTask = Task.Delay(CancellationPropagationTimeout);
+            Task completedTask = await Task.WhenAny(executionTask, timeoutTask);
+            if (completedTask == timeoutTask)
+            {
+                Assert.Fail("CommandRunner did not complete after cancellation.");
+            }
+
+            ExecutionResult result = await executionTask;
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Holds mutable test state for the wrapped dynamic command entry point.
+    /// </summary>
+    internal static class WrappedDynamicCommandState
+    {
+        private static string _returnValue = "";
+        private static bool _shouldComplete;
+        private static TaskCompletionSource<object> _blockingCompletionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource<bool> _startedCompletionSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static Task StartedTask => _startedCompletionSource.Task;
+
+        public static void PrepareBlockingCommand()
+        {
+            _shouldComplete = false;
+            _returnValue = "";
+            _blockingCompletionSource = new TaskCompletionSource<object>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _startedCompletionSource = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static void PrepareReturningCommand(string returnValue)
+        {
+            _shouldComplete = true;
+            _returnValue = returnValue;
+            _startedCompletionSource = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static void CompleteBlockingCommand()
+        {
+            _blockingCompletionSource.TrySetResult(null);
+        }
+
+        public static Task<object> ExecuteAsync(CancellationToken ct)
+        {
+            // This intentionally ignores ct because the regression occurs when user code does not observe it.
+            _startedCompletionSource.TrySetResult(true);
+            if (_shouldComplete)
+            {
+                return Task.FromResult<object>(_returnValue);
+            }
+
+            return _blockingCompletionSource.Task;
+        }
+    }
+}
+
+namespace UnityCliLoop.Dynamic
+{
+    /// <summary>
+    /// Test dynamic-code wrapper type used by CommandRunner entry point resolution.
+    /// </summary>
+    public class DynamicCommand
+    {
+        public Task<object> ExecuteAsync(CancellationToken ct)
+        {
+            return io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+                .WrappedDynamicCommandState.ExecuteAsync(ct);
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs
@@ -29,7 +29,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             {
                 Task<ExecutionResult> firstExecution = runner.ExecuteAsync(
                     CreateContext(cancellationTokenSource.Token));
-                await WrappedDynamicCommandState.StartedTask;
+                await AwaitStartSignalWithinTimeoutAsync(WrappedDynamicCommandState.StartedTask);
 
                 cancellationTokenSource.Cancel();
 
@@ -53,6 +53,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             }
         }
 
+        [Test]
+        public async Task ObserveAbandonedTaskFaultAsync_WhenTaskFaultsLater_ShouldObserveFault()
+        {
+            // Verifies abandoned user task faults are consumed after cancellation releases the runner.
+            TaskCompletionSource<object> completionSource = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Task observationTask = AwaitableHelper.ObserveAbandonedTaskFaultAsync(completionSource.Task);
+
+            completionSource.SetException(new InvalidOperationException("late failure"));
+
+            await AwaitFaultObservationWithinTimeoutAsync(observationTask);
+            Assert.That(observationTask.IsCompletedSuccessfully, Is.True);
+        }
+
+        [Test]
+        public async Task AwaitIfNeeded_WhenTokenAlreadyCanceledButTaskCompleted_ShouldReturnTaskResult()
+        {
+            // Verifies completed user tasks win over cancellation that arrives after the task already finished.
+            using CancellationTokenSource cancellationTokenSource = new();
+            cancellationTokenSource.Cancel();
+
+            object result = await AwaitableHelper.AwaitIfNeeded(
+                Task.FromResult<object>("finished"),
+                cancellationTokenSource.Token);
+
+            Assert.That(result, Is.EqualTo("finished"));
+        }
+
+        [Test]
+        public void AwaitIfNeeded_WhenTokenAlreadyCanceledButTaskFaulted_ShouldSurfaceTaskFault()
+        {
+            // Verifies completed user task faults are not hidden by cancellation that arrives after completion.
+            using CancellationTokenSource cancellationTokenSource = new();
+            cancellationTokenSource.Cancel();
+            Task<object> faultedTask = Task.FromException<object>(
+                new InvalidOperationException("finished failure"));
+
+            InvalidOperationException exception = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await AwaitableHelper.AwaitIfNeeded(
+                    faultedTask,
+                    cancellationTokenSource.Token));
+
+            Assert.That(exception.Message, Is.EqualTo("finished failure"));
+        }
+
         private static DynamicExecutionContext CreateContext(CancellationToken cancellationToken)
         {
             return new DynamicExecutionContext
@@ -74,6 +119,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
 
             ExecutionResult result = await executionTask;
             return result;
+        }
+
+        private static async Task AwaitStartSignalWithinTimeoutAsync(Task startedTask)
+        {
+            Task timeoutTask = Task.Delay(CancellationPropagationTimeout);
+            Task completedTask = await Task.WhenAny(startedTask, timeoutTask);
+            if (completedTask == timeoutTask)
+            {
+                Assert.Fail("CommandRunner did not invoke the dynamic command before the timeout.");
+            }
+
+            await startedTask;
+        }
+
+        private static async Task AwaitFaultObservationWithinTimeoutAsync(Task observationTask)
+        {
+            Task timeoutTask = Task.Delay(CancellationPropagationTimeout);
+            Task completedTask = await Task.WhenAny(observationTask, timeoutTask);
+            if (completedTask == timeoutTask)
+            {
+                Assert.Fail("Abandoned task fault observation did not complete before the timeout.");
+            }
+
+            await observationTask;
         }
     }
 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/CommandRunnerCancellationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28c8e33537f5c4a66adf45be8aa5c9f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/AwaitableHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/AwaitableHelper.cs
@@ -25,7 +25,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (typeof(Task).IsAssignableFrom(valueType))
             {
                 Task task = (Task)value;
-                await AwaitTaskWithCancellationAsync(task, cancellationToken);
+                await AwaitTaskWithCancellationAsync(task, cancellationToken).ConfigureAwait(false);
 
                 if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(Task<>))
                 {
@@ -44,13 +44,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (IsValueTask(valueType))
             {
                 Task asTask = ConvertValueTaskToTask(value);
-                await AwaitTaskWithCancellationAsync(asTask, cancellationToken);
+                await AwaitTaskWithCancellationAsync(asTask, cancellationToken).ConfigureAwait(false);
                 return null;
             }
             if (IsGenericValueTask(valueType))
             {
                 Task asTask = ConvertGenericValueTaskToTask(value);
-                await AwaitTaskWithCancellationAsync(asTask, cancellationToken);
+                await AwaitTaskWithCancellationAsync(asTask, cancellationToken).ConfigureAwait(false);
 
                 Type[] genericArgs = valueType.GetGenericArguments();
                 if (genericArgs != null && genericArgs.Length == 1)
@@ -127,7 +127,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return immediateResult;
                 }
 
-                object awaited = await AwaitObjectTaskWithCancellationAsync(tcs.Task, cancellationToken);
+                object awaited = await AwaitObjectTaskWithCancellationAsync(tcs.Task, cancellationToken)
+                    .ConfigureAwait(false);
                 return awaited;
             }
 
@@ -143,7 +144,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationToken cancellationToken)
         {
             System.Diagnostics.Debug.Assert(task != null, "Task must not be null.");
-            cancellationToken.ThrowIfCancellationRequested();
+            if (task.IsCompleted)
+            {
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _ = ObserveAbandonedTaskFaultAsync(task);
+                throw new OperationCanceledException(cancellationToken);
+            }
+
             if (!cancellationToken.CanBeCanceled)
             {
                 await task.ConfigureAwait(false);
@@ -159,10 +171,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 .ConfigureAwait(false);
             if (completedTask == cancellationCompletionSource.Task && !task.IsCompleted)
             {
+                _ = ObserveAbandonedTaskFaultAsync(task);
                 throw new OperationCanceledException(cancellationToken);
             }
 
             await task.ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Observes a task fault after cancellation stops awaiting it.
+        /// </summary>
+        internal static Task ObserveAbandonedTaskFaultAsync(Task task)
+        {
+            System.Diagnostics.Debug.Assert(task != null, "Task must not be null.");
+            // Why: cancellation releases CommandRunner before user code finishes, so late faults must stay observed.
+            return task.ContinueWith(
+                static observedTask => _ = observedTask.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
 
         /// <summary>
@@ -172,7 +199,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Task<object> task,
             CancellationToken cancellationToken)
         {
-            await AwaitTaskWithCancellationAsync(task, cancellationToken);
+            await AwaitTaskWithCancellationAsync(task, cancellationToken).ConfigureAwait(false);
             object result = await task.ConfigureAwait(false);
             return result;
         }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/AwaitableHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/AwaitableHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -11,7 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class AwaitableHelper
     {
-        public static async Task<object> AwaitIfNeeded(object value)
+        public static async Task<object> AwaitIfNeeded(object value, CancellationToken cancellationToken)
         {
             if (value == null)
             {
@@ -24,7 +25,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (typeof(Task).IsAssignableFrom(valueType))
             {
                 Task task = (Task)value;
-                await task.ConfigureAwait(false);
+                await AwaitTaskWithCancellationAsync(task, cancellationToken);
 
                 if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(Task<>))
                 {
@@ -43,13 +44,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (IsValueTask(valueType))
             {
                 Task asTask = ConvertValueTaskToTask(value);
-                await asTask.ConfigureAwait(false);
+                await AwaitTaskWithCancellationAsync(asTask, cancellationToken);
                 return null;
             }
             if (IsGenericValueTask(valueType))
             {
                 Task asTask = ConvertGenericValueTaskToTask(value);
-                await asTask.ConfigureAwait(false);
+                await AwaitTaskWithCancellationAsync(asTask, cancellationToken);
 
                 Type[] genericArgs = valueType.GetGenericArguments();
                 if (genericArgs != null && genericArgs.Length == 1)
@@ -126,12 +127,54 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return immediateResult;
                 }
 
-                object awaited = await tcs.Task.ConfigureAwait(false);
+                object awaited = await AwaitObjectTaskWithCancellationAsync(tcs.Task, cancellationToken);
                 return awaited;
             }
 
             // Not awaitable; return as-is
             return value;
+        }
+
+        /// <summary>
+        /// Awaits a Task while allowing request cancellation to release CommandRunner.
+        /// </summary>
+        private static async Task AwaitTaskWithCancellationAsync(
+            Task task,
+            CancellationToken cancellationToken)
+        {
+            System.Diagnostics.Debug.Assert(task != null, "Task must not be null.");
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!cancellationToken.CanBeCanceled)
+            {
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            TaskCompletionSource<bool> cancellationCompletionSource =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using CancellationTokenRegistration cancellationRegistration =
+                cancellationToken.Register(() => cancellationCompletionSource.TrySetResult(true));
+
+            Task completedTask = await Task.WhenAny(task, cancellationCompletionSource.Task)
+                .ConfigureAwait(false);
+            if (completedTask == cancellationCompletionSource.Task && !task.IsCompleted)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+
+            await task.ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Awaits an object Task with the same cancellation boundary as non-generic Task values.
+        /// </summary>
+        private static async Task<object> AwaitObjectTaskWithCancellationAsync(
+            Task<object> task,
+            CancellationToken cancellationToken)
+        {
+            await AwaitTaskWithCancellationAsync(task, cancellationToken);
+            object result = await task.ConfigureAwait(false);
+            return result;
         }
 
         private static bool IsValueTask(Type type)
@@ -363,5 +406,3 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
     }
 }
-
-

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -299,7 +299,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         cancellationToken);
                     object invoked = executeAsyncMethod.Invoke(instance, callArgs);
 
-                    object awaitedResult = await AwaitableHelper.AwaitIfNeeded(invoked);
+                    object awaitedResult = await AwaitableHelper.AwaitIfNeeded(invoked, cancellationToken);
                     string resultString = awaitedResult?.ToString() ?? "";
 
                     return CreateSuccessResult(resultString);


### PR DESCRIPTION
## Summary
- Dynamic code execution now releases cancellation promptly even when the executed code returns an async task that ignores cancellation.
- Late task failures remain observed, and completed task results or failures are preserved when cancellation arrives at the same time.

## User Impact
- Before this change, canceling a dynamic-code operation could leave Unity or the CLI communication path appearing stuck until the editor was restarted.
- After this change, cancellation returns a clean canceled result and the next dynamic-code request can run normally.

## Changes
- Make dynamic-code awaiting cancellation-aware while keeping await continuations context-free.
- Observe late faults from abandoned user tasks so they do not surface as unrelated unobserved exceptions.
- Add EditMode coverage for cancellation release, late-fault observation, completed result preservation, and completed fault preservation.

## Verification
- `cli/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `cli/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io\\.github\\.hatayama\\.UnityCliLoop\\.Tests\\.Editor\\.DynamicCodeToolTests\\.CommandRunnerCancellationTests\\..*"`
- `cli/dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io\\.github\\.hatayama\\.UnityCliLoop\\.Tests\\.Editor\\.DynamicCodeToolTests\\..*"`
- `~/.codex/skills/codex-review/scripts/codex-review --parallel-tests ... v3-beta` returned clean with no accepted/actionable findings.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

