### PR TITLE
fix: Unity 6.5 projects compile without metadata type conflicts

### DIFF
--- a/Packages/src/Cli~/src/__tests__/package-metadata.test.ts
+++ b/Packages/src/Cli~/src/__tests__/package-metadata.test.ts
@@ -28,6 +28,7 @@ const METADATA_VALIDATION_DEPENDENCY_META_PATHS = [
   'Editor/MetadataValidation/Dependencies/uLoopMCP.System.Reflection.Metadata.dll.meta',
   'Editor/MetadataValidation/Dependencies/uLoopMCP.System.Runtime.CompilerServices.Unsafe.dll.meta',
 ] as const;
+const METADATA_VALIDATION_DEPENDENCY_DEFINE_CONSTRAINT = '!UNITY_6000_5_OR_NEWER';
 const METADATA_VALIDATION_PRIVATE_ASSEMBLIES = [
   {
     relativePath:
@@ -153,6 +154,14 @@ describe('package metadata', () => {
       const metaText = loadUnityPackageText(metaPath);
 
       expect(metaText).toContain('isExplicitlyReferenced: 1');
+    }
+  });
+
+  it('excludes bundled metadata validation dependencies from Unity 6000.5 and newer', () => {
+    for (const metaPath of METADATA_VALIDATION_DEPENDENCY_META_PATHS) {
+      const metaText = loadUnityPackageText(metaPath);
+
+      expect(metaText).toContain(`- '${METADATA_VALIDATION_DEPENDENCY_DEFINE_CONSTRAINT}'`);
     }
   });
 

--- a/Packages/src/Editor/MetadataValidation/Dependencies/uLoopMCP.System.Collections.Immutable.dll.meta
+++ b/Packages/src/Editor/MetadataValidation/Dependencies/uLoopMCP.System.Collections.Immutable.dll.meta
@@ -5,7 +5,8 @@ PluginImporter:
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
-  defineConstraints: []
+  defineConstraints:
+  - '!UNITY_6000_5_OR_NEWER'
   isPreloaded: 0
   isOverridable: 1
   isExplicitlyReferenced: 1

--- a/Packages/src/Editor/MetadataValidation/Dependencies/uLoopMCP.System.Reflection.Metadata.dll.meta
+++ b/Packages/src/Editor/MetadataValidation/Dependencies/uLoopMCP.System.Reflection.Metadata.dll.meta
@@ -5,7 +5,8 @@ PluginImporter:
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
-  defineConstraints: []
+  defineConstraints:
+  - '!UNITY_6000_5_OR_NEWER'
   isPreloaded: 0
   isOverridable: 1
   isExplicitlyReferenced: 1

--- a/Packages/src/Editor/MetadataValidation/Dependencies/uLoopMCP.System.Runtime.CompilerServices.Unsafe.dll.meta
+++ b/Packages/src/Editor/MetadataValidation/Dependencies/uLoopMCP.System.Runtime.CompilerServices.Unsafe.dll.meta
@@ -5,7 +5,8 @@ PluginImporter:
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
-  defineConstraints: []
+  defineConstraints:
+  - '!UNITY_6000_5_OR_NEWER'
   isPreloaded: 0
   isOverridable: 1
   isExplicitlyReferenced: 1


### PR DESCRIPTION
Fixes #1370
## Summary
- Unity 6.5 projects can compile Unity CLI Loop without duplicate metadata type errors.
- Older Unity versions keep using the bundled metadata validation dependencies.

## User Impact
- Before this change, Unity CLI Loop 2.1.8 and 2.1.9 failed to compile on Unity 6000.5 with CS0433 errors from metadata validation code.
- Unity 6000.5 now uses Unity-provided metadata assemblies while earlier supported Editors keep the bundled dependencies.

## Changes
- Exclude bundled metadata validation dependency plugins from Unity 6000.5 and newer with Unity define constraints.
- Keep the explicit-reference importer setting that prevents accidental implicit references.
- Add package metadata coverage for the Unity 6000.5 exclusion.

## Verification
- `uloop compile --force-recompile true --wait-for-domain-reload true`
- `npm --prefix Packages/src/Cli~ run test:cli -- --runTestsByPath src/__tests__/package-metadata.test.ts`
- `npm --prefix Packages/src/Cli~ run lint`
- `npm --prefix Packages/src/Cli~ run build`
- `codex review --commit HEAD`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes compilation failures in Unity CLI Loop when building with Unity 6.5 (version 6000.5 and newer) that were present in versions 2.1.8 and 2.1.9.

### Problem

The bundled metadata validation dependency packages caused CS0433 errors (duplicate metadata type conflicts) when compiling with Unity 6000.5 and newer, which now includes its own `System.Reflection.Metadata` reference during editor compilation.

### Solution

The fix excludes bundled metadata validation dependencies from Unity 6000.5+ through Unity define constraints, while maintaining explicit-reference importer settings for older Unity versions to prevent accidental implicit references. Package metadata coverage is added to document and enforce the exclusion.

### Changes

**Packages/src/Cli~/src/__tests__/package-metadata.test.ts**
- Added constant `METADATA_VALIDATION_DEPENDENCY_DEFINE_CONSTRAINT = '!UNITY_6000_5_OR_NEWER'`
- Introduced new test case: "excludes bundled metadata validation dependencies from Unity 6000.5 and newer"
- Test validates that each metadata validation dependency .meta file (System.Collections.Immutable, System.Reflection.Metadata, and System.Runtime.CompilerServices.Unsafe) contains the `!UNITY_6000_5_OR_NEWER` define constraint

The test verifies the define constraint is properly configured in the three bundled dependency .meta files to ensure they are excluded when compiling with Unity 6000.5 and newer versions.

### Verification

The fix has been verified through:
- Compilation with force-recompile and domain-reload options
- Package metadata tests
- Linting and building
- Code review

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
