### PR TITLE
fix: get-logs works with active Console search filters

### DIFF
--- a/Assets/Tests/Editor/ConsoleLogRetrieverTests.cs
+++ b/Assets/Tests/Editor/ConsoleLogRetrieverTests.cs
@@ -411,4 +411,70 @@ namespace io.github.hatayama.uLoopMCP
                 $"Mixed message should match exactly. Expected: '{mixedMessage}', Actual: '{testLog.Message.Trim()}'");
         }
     }
+
+    /// <summary>
+    /// Unit tests for temporarily clearing Unity Console text filtering.
+    /// </summary>
+    public class ConsoleFilteringTextScopeTests
+    {
+        private string filteringText;
+        private List<string> assignedFilteringTexts;
+
+        [SetUp]
+        public void SetUp()
+        {
+            filteringText = "active-filter";
+            assignedFilteringTexts = new List<string>();
+        }
+
+        [Test]
+        public void Dispose_RestoresOriginalFilteringText()
+        {
+            // The scope must restore user-visible Console state because get-logs is a read-only command.
+            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText))
+            {
+                Assert.AreEqual(string.Empty, filteringText);
+            }
+
+            Assert.AreEqual("active-filter", filteringText);
+            CollectionAssert.AreEqual(new[] { string.Empty, "active-filter" }, assignedFilteringTexts);
+        }
+
+        [Test]
+        public void Constructor_WhenFilteringTextIsEmpty_DoesNotAssignEmptyText()
+        {
+            // Avoiding a redundant write keeps the Console UI untouched when there is no active text filter.
+            filteringText = string.Empty;
+
+            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText))
+            {
+                Assert.AreEqual(string.Empty, filteringText);
+            }
+
+            CollectionAssert.IsEmpty(assignedFilteringTexts);
+        }
+
+        [Test]
+        public void Dispose_WhenFilteringTextChangedInsideScope_RestoresOriginalFilteringText()
+        {
+            // The original text must win even if retrieval code changes the filter before cleanup runs.
+            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText))
+            {
+                filteringText = "changed-during-retrieval";
+            }
+
+            Assert.AreEqual("active-filter", filteringText);
+        }
+
+        private string GetFilteringText()
+        {
+            return filteringText;
+        }
+
+        private void SetFilteringText(string value)
+        {
+            filteringText = value;
+            assignedFilteringTexts.Add(value);
+        }
+    }
 }

--- a/Packages/src/Editor/Core/CoreTools/ConsoleUtility/ConsoleLogRetriever.cs
+++ b/Packages/src/Editor/Core/CoreTools/ConsoleUtility/ConsoleLogRetriever.cs
@@ -12,7 +12,12 @@ namespace io.github.hatayama.uLoopMCP
     /// </summary>
     public class ConsoleLogRetriever
     {
+        private const string GetFilteringTextMethodName = "GetFilteringText";
+        private const string SetFilteringTextMethodName = "SetFilteringText";
+
         private readonly Type _logEntriesType;
+        private readonly MethodInfo _getFilteringTextMethod;
+        private readonly MethodInfo _setFilteringTextMethod;
 
         /// <summary>
         /// Initializes the retriever with necessary reflection types
@@ -27,6 +32,9 @@ namespace io.github.hatayama.uLoopMCP
             {
                 throw new InvalidOperationException("LogEntries type not found. Unity version compatibility issue.");
             }
+
+            _getFilteringTextMethod = _logEntriesType.GetMethod(GetFilteringTextMethodName, BindingFlags.Public | BindingFlags.Static);
+            _setFilteringTextMethod = _logEntriesType.GetMethod(SetFilteringTextMethodName, BindingFlags.Public | BindingFlags.Static);
         }
 
         /// <summary>
@@ -37,33 +45,36 @@ namespace io.github.hatayama.uLoopMCP
             // Save original mask to restore later
             int originalMask = GetCurrentMask();
 
-            try
+            using (ConsoleFilteringTextScope filteringTextScope = CreateFilteringTextScope())
             {
-                // Temporarily set mask to show all log types (0x387 = Error + Warning + Log + Base)
-                SetMask(7); // This will convert to Unity's 0x387
-
-                List<LogEntryDto> logs = new();
-                int logCount = GetLogCount();
-
-                for (int i = 0; i < logCount; i++)
+                try
                 {
-                    LogEntryDto entry = GetLogEntryAt(i);
-                    if (entry != null)
-                    {
-                        logs.Add(entry);
-                    }
-                    else
-                    {
-                        Debug.LogWarning($"GetAllLogs: Failed to get log at index {i}");
-                    }
-                }
+                    // Temporarily set mask to show all log types (0x387 = Error + Warning + Log + Base)
+                    SetMask(7); // This will convert to Unity's 0x387
 
-                return logs;
-            }
-            finally
-            {
-                // Always restore original mask, even if an exception occurred
-                RestoreOriginalMask(originalMask);
+                    List<LogEntryDto> logs = new();
+                    int logCount = GetLogCount();
+
+                    for (int i = 0; i < logCount; i++)
+                    {
+                        LogEntryDto entry = GetLogEntryAt(i);
+                        if (entry != null)
+                        {
+                            logs.Add(entry);
+                        }
+                        else
+                        {
+                            Debug.LogWarning($"GetAllLogs: Failed to get log at index {i}");
+                        }
+                    }
+
+                    return logs;
+                }
+                finally
+                {
+                    // Always restore original mask, even if an exception occurred
+                    RestoreOriginalMask(originalMask);
+                }
             }
         }
 
@@ -104,40 +115,78 @@ namespace io.github.hatayama.uLoopMCP
             // Save original mask to restore later
             int originalMask = GetCurrentMask();
 
-            try
+            using (ConsoleFilteringTextScope filteringTextScope = CreateFilteringTextScope())
             {
-                // Temporarily enable the specific log type we want
-                int targetMask = GetMaskForLogType(logType);
-                if (targetMask > 0)
+                try
                 {
-                    SetMask(targetMask);
-                }
-                else
-                {
-                    // If unknown type, show all types
-                    SetMask(7);
-                }
-
-                List<LogEntryDto> logs = new();
-                int logCount = GetLogCount();
-                string targetMcpLogType = ConvertLogTypeToMcpLogType(logType);
-
-                for (int i = 0; i < logCount; i++)
-                {
-                    LogEntryDto entry = GetLogEntryAt(i);
-                    if (entry != null && entry.LogType == targetMcpLogType)
+                    // Temporarily enable the specific log type we want
+                    int targetMask = GetMaskForLogType(logType);
+                    if (targetMask > 0)
                     {
-                        logs.Add(entry);
+                        SetMask(targetMask);
                     }
-                }
+                    else
+                    {
+                        // If unknown type, show all types
+                        SetMask(7);
+                    }
 
-                return logs;
+                    List<LogEntryDto> logs = new();
+                    int logCount = GetLogCount();
+                    string targetMcpLogType = ConvertLogTypeToMcpLogType(logType);
+
+                    for (int i = 0; i < logCount; i++)
+                    {
+                        LogEntryDto entry = GetLogEntryAt(i);
+                        if (entry != null && entry.LogType == targetMcpLogType)
+                        {
+                            logs.Add(entry);
+                        }
+                    }
+
+                    return logs;
+                }
+                finally
+                {
+                    // Always restore original mask
+                    RestoreOriginalMask(originalMask);
+                }
             }
-            finally
+        }
+
+        /// <summary>
+        /// Creates a scope that temporarily disables Console text filtering during log retrieval.
+        /// </summary>
+        private ConsoleFilteringTextScope CreateFilteringTextScope()
+        {
+            if (_getFilteringTextMethod == null || _setFilteringTextMethod == null)
             {
-                // Always restore original mask
-                RestoreOriginalMask(originalMask);
+                return null;
             }
+
+            return new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText);
+        }
+
+        /// <summary>
+        /// Gets the current Unity Console text filter through Unity's internal API.
+        /// </summary>
+        private string GetFilteringText()
+        {
+            Debug.Assert(_getFilteringTextMethod != null, "Filtering text getter must be available before use.");
+
+            object result = _getFilteringTextMethod.Invoke(null, null);
+            return result?.ToString() ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Sets the current Unity Console text filter through Unity's internal API.
+        /// </summary>
+        private void SetFilteringText(string filteringText)
+        {
+            Debug.Assert(_setFilteringTextMethod != null, "Filtering text setter must be available before use.");
+            Debug.Assert(filteringText != null, "Filtering text must not be null.");
+
+            _setFilteringTextMethod.Invoke(null, new object[] { filteringText });
         }
 
         /// <summary>
@@ -393,5 +442,51 @@ namespace io.github.hatayama.uLoopMCP
             return 7; // Default to show all
         }
 
+    }
+
+    /// <summary>
+    /// Temporarily clears Unity Console text filtering and restores the original filter on dispose.
+    /// </summary>
+    internal sealed class ConsoleFilteringTextScope : IDisposable
+    {
+        private readonly Action<string> _setFilteringText;
+        private readonly string _originalFilteringText;
+        private readonly bool _shouldRestoreFilteringText;
+        private bool _disposed;
+
+        public ConsoleFilteringTextScope(Func<string> getFilteringText, Action<string> setFilteringText)
+        {
+            Debug.Assert(getFilteringText != null, "Filtering text getter must not be null.");
+            Debug.Assert(setFilteringText != null, "Filtering text setter must not be null.");
+
+            _setFilteringText = setFilteringText;
+            _originalFilteringText = getFilteringText() ?? string.Empty;
+            _shouldRestoreFilteringText = !string.IsNullOrEmpty(_originalFilteringText);
+
+            if (!_shouldRestoreFilteringText)
+            {
+                return;
+            }
+
+            // Unity applies this text filter to LogEntries.GetCount/GetEntryInternal, so clear it for raw retrieval.
+            _setFilteringText(string.Empty);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            if (!_shouldRestoreFilteringText)
+            {
+                return;
+            }
+
+            _setFilteringText(_originalFilteringText);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- get-logs now retrieves logs even when the Unity Console search field contains text.
- The Console search text is restored after retrieval, so the visible Console state is preserved.

## User Impact
- Before this change, an active Console text filter could hide logs from get-logs.
- Users can now keep their Console search filter in place and still rely on get-logs for complete log retrieval.

## Changes
- Temporarily clear Unity Console text filtering while reading Console entries, then restore the original filter.
- Added focused tests for filter clearing and restoration behavior.

## Verification
- uloop compile
- uloop run-tests --test-mode EditMode --filter-type regex --filter-value "ConsoleFilteringTextScopeTests"
- Codex review against origin/main with focused tests
- Manual smoke check with an active Console filter and get-logs

Fixes #1371

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes an issue where the `get-logs` command fails to retrieve logs when the Unity Console window has an active text search filter. The root cause is that Unity's internal `GetCount` and `GetEntryInternal` APIs apply the Console's visible text filter to log retrieval operations.

## Solution Architecture

The fix implements a disposable scope pattern (`ConsoleFilteringTextScope`) that temporarily clears the Console's text filter during log retrieval and restores the original filter afterward:

```
ConsoleLogRetriever
├── GetAllLogs()
│   └── uses ConsoleFilteringTextScope to:
│       ├── Clear filter before enumeration
│       └── Restore filter in finally block
├── GetLogsByType(LogType)
│   └── uses ConsoleFilteringTextScope (same pattern)
└── Private helpers
    ├── GetFilteringText() [reflection-based getter]
    ├── SetFilteringText(string) [reflection-based setter]
    └── CreateFilteringTextScope() [factory method]

ConsoleFilteringTextScope : IDisposable
├── Constructor: Captures original filter, clears if non-empty
├── Dispose: Restores original filter (with double-disposal guards)
└── Behavior:
    ├── Avoids redundant writes when no filter is active
    ├── Handles filter changes during scope execution
    └── Maintains read-only semantics for get-logs command
```

## Technical Changes

### ConsoleLogRetriever.cs

**Added reflection infrastructure:**
- Two method-name constants: `GetFilteringTextMethodName` and `SetFilteringTextMethodName`
- Corresponding cached `MethodInfo` fields initialized in constructor
- Null handling for cases where reflection methods are unavailable

**Modified log retrieval methods:**
- `GetAllLogs()`: Wraps the existing mask-temporarily-all-logs logic inside `using (ConsoleFilteringTextScope ...)`
- `GetLogsByType(LogType)`: Similarly wrapped with filtering scope around mask adjustment and log filtering

**Added helper methods:**
- `GetFilteringText()`: Invokes reflected Unity API to read current filter
- `SetFilteringText(string)`: Invokes reflected Unity API to write filter
- `CreateFilteringTextScope()`: Factory method with null-safety checks

**New ConsoleFilteringTextScope class:**
- Implements `IDisposable` for use with `using` statements
- Constructor: Captures original filter text; clears filter (sets to empty) only if an active filter exists
- `Dispose()`: Conditionally restores original filter text with safeguards against double-disposal
- Uses delegates passed in constructor to decouple from reflection details

### ConsoleLogRetrieverTests.cs

**New test class: ConsoleFilteringTextScopeTests**

Tests the filtering scope behavior in isolation using mock getter/setter delegates:

1. **`Dispose_RestoresOriginalFilteringText()`**: Verifies that the scope clears the filter during execution and restores the original filter after the scope exits, preserving user-visible Console state.

2. **`Constructor_WhenFilteringTextIsEmpty_DoesNotAssignEmptyText()`**: Verifies that when no filter is active, the constructor avoids redundant writes that would unnecessarily interact with the Console UI.

3. **`Dispose_WhenFilteringTextChangedInsideScope_RestoresOriginalFilteringText()`**: Verifies that the scope correctly restores the original filter even if the filter text is changed during log retrieval (e.g., by interleaved Console UI operations).

## Behavior Guarantees

- **Read-only semantics**: The `get-logs` command maintains its read-only nature from the user's perspective; the Console's visible filter state is restored after log retrieval completes.
- **Fail-safe restoration**: Filter restoration occurs in `Dispose()` (called by `using` statement), ensuring restoration even if log retrieval throws an exception.
- **Minimal UI interaction**: Avoids writing empty filter text when no filter is active, reducing unnecessary Console UI updates.
- **Reflection safety**: Gracefully handles cases where reflection methods are unavailable by returning null from the factory method.

## Verification

- Standard compilation (`uloop compile`) passes
- Focused unit tests target the new filtering scope behavior
- Code reviewed against main branch
- Manual testing confirms `get-logs` successfully retrieves logs when Console has an active text filter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->