### PR TITLE
fix: get-logs keeps the Console selection stable

### DIFF
--- a/Assets/Tests/Editor/ConsoleLogRetrieverTests.cs
+++ b/Assets/Tests/Editor/ConsoleLogRetrieverTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -217,7 +218,7 @@ namespace io.github.hatayama.uLoopMCP
                 "Message should not contain stack trace content");
             
             // Cleanup
-            Object.DestroyImmediate(testObject);
+            UnityEngine.Object.DestroyImmediate(testObject);
         }
 
         [Test]
@@ -418,20 +419,24 @@ namespace io.github.hatayama.uLoopMCP
     public class ConsoleFilteringTextScopeTests
     {
         private string filteringText;
+        private string consoleState;
         private List<string> assignedFilteringTexts;
+        private List<string> consoleStateEvents;
 
         [SetUp]
         public void SetUp()
         {
             filteringText = "active-filter";
+            consoleState = "selected-row";
             assignedFilteringTexts = new List<string>();
+            consoleStateEvents = new List<string>();
         }
 
         [Test]
         public void Dispose_RestoresOriginalFilteringText()
         {
             // The scope must restore user-visible Console state because get-logs is a read-only command.
-            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText))
+            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText, CreateConsoleStateScope))
             {
                 Assert.AreEqual(string.Empty, filteringText);
             }
@@ -446,24 +451,40 @@ namespace io.github.hatayama.uLoopMCP
             // Avoiding a redundant write keeps the Console UI untouched when there is no active text filter.
             filteringText = string.Empty;
 
-            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText))
+            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText, CreateConsoleStateScope))
             {
                 Assert.AreEqual(string.Empty, filteringText);
             }
 
             CollectionAssert.IsEmpty(assignedFilteringTexts);
+            CollectionAssert.IsEmpty(consoleStateEvents);
         }
 
         [Test]
         public void Dispose_WhenFilteringTextChangedInsideScope_RestoresOriginalFilteringText()
         {
             // The original text must win even if retrieval code changes the filter before cleanup runs.
-            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText))
+            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText, CreateConsoleStateScope))
             {
                 filteringText = "changed-during-retrieval";
             }
 
             Assert.AreEqual("active-filter", filteringText);
+        }
+
+        [Test]
+        public void Dispose_RestoresConsoleStateAfterFilteringText()
+        {
+            // Console selection restoration must run after text restoration because SetFilteringText can alter selection.
+            using (new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText, CreateConsoleStateScope))
+            {
+                consoleState = "changed-during-retrieval";
+            }
+
+            Assert.AreEqual("selected-row", consoleState);
+            CollectionAssert.AreEqual(
+                new[] { "capture:selected-row", "restore:selected-row:filter=active-filter" },
+                consoleStateEvents);
         }
 
         private string GetFilteringText()
@@ -475,6 +496,38 @@ namespace io.github.hatayama.uLoopMCP
         {
             filteringText = value;
             assignedFilteringTexts.Add(value);
+        }
+
+        private IDisposable CreateConsoleStateScope()
+        {
+            return new FakeConsoleStateScope(
+                consoleState,
+                value =>
+                {
+                    consoleState = value;
+                    consoleStateEvents.Add($"restore:{value}:filter={filteringText}");
+                },
+                consoleStateEvents);
+        }
+
+        private sealed class FakeConsoleStateScope : IDisposable
+        {
+            private readonly string capturedState;
+            private readonly Action<string> restoreState;
+            private readonly List<string> events;
+
+            public FakeConsoleStateScope(string capturedState, Action<string> restoreState, List<string> events)
+            {
+                this.capturedState = capturedState;
+                this.restoreState = restoreState;
+                this.events = events;
+                this.events.Add($"capture:{capturedState}");
+            }
+
+            public void Dispose()
+            {
+                restoreState(capturedState);
+            }
         }
     }
 }

--- a/Packages/src/Editor/Core/CoreTools/ConsoleUtility/ConsoleLogRetriever.cs
+++ b/Packages/src/Editor/Core/CoreTools/ConsoleUtility/ConsoleLogRetriever.cs
@@ -14,8 +14,10 @@ namespace io.github.hatayama.uLoopMCP
     {
         private const string GetFilteringTextMethodName = "GetFilteringText";
         private const string SetFilteringTextMethodName = "SetFilteringText";
+        private const string ConsoleWindowTypeName = "UnityEditor.ConsoleWindow";
 
         private readonly Type _logEntriesType;
+        private readonly Type _consoleWindowType;
         private readonly MethodInfo _getFilteringTextMethod;
         private readonly MethodInfo _setFilteringTextMethod;
 
@@ -26,7 +28,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             Assembly editorAssembly = Assembly.GetAssembly(typeof(EditorWindow));
             _logEntriesType = editorAssembly.GetType("UnityEditor.LogEntries");
-            editorAssembly.GetType("UnityEditor.ConsoleWindow");
+            _consoleWindowType = editorAssembly.GetType(ConsoleWindowTypeName);
 
             if (_logEntriesType == null)
             {
@@ -164,7 +166,15 @@ namespace io.github.hatayama.uLoopMCP
                 return null;
             }
 
-            return new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText);
+            return new ConsoleFilteringTextScope(GetFilteringText, SetFilteringText, CreateConsoleWindowStateScope);
+        }
+
+        /// <summary>
+        /// Captures the visible Console window state that can be affected by filtering changes.
+        /// </summary>
+        private IDisposable CreateConsoleWindowStateScope()
+        {
+            return ConsoleWindowStateScope.Create(_consoleWindowType);
         }
 
         /// <summary>
@@ -451,13 +461,18 @@ namespace io.github.hatayama.uLoopMCP
     {
         private readonly Action<string> _setFilteringText;
         private readonly string _originalFilteringText;
+        private readonly IDisposable _consoleWindowStateScope;
         private readonly bool _shouldRestoreFilteringText;
         private bool _disposed;
 
-        public ConsoleFilteringTextScope(Func<string> getFilteringText, Action<string> setFilteringText)
+        public ConsoleFilteringTextScope(
+            Func<string> getFilteringText,
+            Action<string> setFilteringText,
+            Func<IDisposable> createConsoleWindowStateScope)
         {
             Debug.Assert(getFilteringText != null, "Filtering text getter must not be null.");
             Debug.Assert(setFilteringText != null, "Filtering text setter must not be null.");
+            Debug.Assert(createConsoleWindowStateScope != null, "Console window state scope factory must not be null.");
 
             _setFilteringText = setFilteringText;
             _originalFilteringText = getFilteringText() ?? string.Empty;
@@ -467,6 +482,8 @@ namespace io.github.hatayama.uLoopMCP
             {
                 return;
             }
+
+            _consoleWindowStateScope = createConsoleWindowStateScope();
 
             // Unity applies this text filter to LogEntries.GetCount/GetEntryInternal, so clear it for raw retrieval.
             _setFilteringText(string.Empty);
@@ -487,6 +504,167 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             _setFilteringText(_originalFilteringText);
+            _consoleWindowStateScope?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Restores visible Unity Console selection state after temporary internal filtering changes.
+    /// </summary>
+    internal sealed class ConsoleWindowStateScope : IDisposable
+    {
+        private const string ConsoleWindowInstanceFieldName = "ms_ConsoleWindow";
+        private const string ListViewFieldName = "m_ListView";
+        private const string ActiveTextFieldName = "m_ActiveText";
+        private const string ActiveModeFieldName = "m_ActiveMode";
+        private const string CallstackTextStartFieldName = "m_CallstackTextStart";
+        private const string RowFieldName = "row";
+        private const string SelectedItemsFieldName = "selectedItems";
+        private const string ScrollPositionFieldName = "scrollPos";
+
+        private readonly EditorWindow _consoleWindow;
+        private readonly object _listView;
+        private readonly FieldInfo _activeTextField;
+        private readonly FieldInfo _activeModeField;
+        private readonly FieldInfo _callstackTextStartField;
+        private readonly FieldInfo _rowField;
+        private readonly FieldInfo _selectedItemsField;
+        private readonly FieldInfo _scrollPositionField;
+        private readonly string _activeText;
+        private readonly object _activeMode;
+        private readonly int _callstackTextStart;
+        private readonly int _row;
+        private readonly bool[] _selectedItems;
+        private readonly Vector2 _scrollPosition;
+        private bool _disposed;
+
+        private ConsoleWindowStateScope(
+            EditorWindow consoleWindow,
+            object listView,
+            FieldInfo activeTextField,
+            FieldInfo activeModeField,
+            FieldInfo callstackTextStartField,
+            FieldInfo rowField,
+            FieldInfo selectedItemsField,
+            FieldInfo scrollPositionField)
+        {
+            Debug.Assert(consoleWindow != null, "Console window must not be null.");
+            Debug.Assert(listView != null, "Console ListView state must not be null.");
+            Debug.Assert(activeTextField != null, "Active text field must not be null.");
+            Debug.Assert(activeModeField != null, "Active mode field must not be null.");
+            Debug.Assert(callstackTextStartField != null, "Callstack start field must not be null.");
+            Debug.Assert(rowField != null, "ListView row field must not be null.");
+            Debug.Assert(selectedItemsField != null, "ListView selected items field must not be null.");
+            Debug.Assert(scrollPositionField != null, "ListView scroll position field must not be null.");
+
+            _consoleWindow = consoleWindow;
+            _listView = listView;
+            _activeTextField = activeTextField;
+            _activeModeField = activeModeField;
+            _callstackTextStartField = callstackTextStartField;
+            _rowField = rowField;
+            _selectedItemsField = selectedItemsField;
+            _scrollPositionField = scrollPositionField;
+
+            _activeText = _activeTextField.GetValue(_consoleWindow)?.ToString() ?? string.Empty;
+            _activeMode = _activeModeField.GetValue(_consoleWindow);
+            _callstackTextStart = (int)(_callstackTextStartField.GetValue(_consoleWindow) ?? 0);
+            _row = (int)(_rowField.GetValue(_listView) ?? -1);
+
+            bool[] selectedItems = _selectedItemsField.GetValue(_listView) as bool[];
+            _selectedItems = selectedItems != null ? (bool[])selectedItems.Clone() : null;
+
+            object scrollPosition = _scrollPositionField.GetValue(_listView);
+            _scrollPosition = scrollPosition is Vector2 vector ? vector : Vector2.zero;
+        }
+
+        public static ConsoleWindowStateScope Create(Type consoleWindowType)
+        {
+            if (consoleWindowType == null)
+            {
+                return null;
+            }
+
+            FieldInfo consoleWindowField = consoleWindowType.GetField(
+                ConsoleWindowInstanceFieldName,
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (consoleWindowField == null)
+            {
+                return null;
+            }
+
+            EditorWindow consoleWindow = consoleWindowField.GetValue(null) as EditorWindow;
+            if (consoleWindow == null)
+            {
+                return null;
+            }
+
+            FieldInfo listViewField = consoleWindowType.GetField(
+                ListViewFieldName,
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            FieldInfo activeTextField = consoleWindowType.GetField(
+                ActiveTextFieldName,
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            FieldInfo activeModeField = consoleWindowType.GetField(
+                ActiveModeFieldName,
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            FieldInfo callstackTextStartField = consoleWindowType.GetField(
+                CallstackTextStartFieldName,
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (listViewField == null ||
+                activeTextField == null ||
+                activeModeField == null ||
+                callstackTextStartField == null)
+            {
+                return null;
+            }
+
+            object listView = listViewField.GetValue(consoleWindow);
+            if (listView == null)
+            {
+                return null;
+            }
+
+            Type listViewType = listView.GetType();
+            FieldInfo rowField = listViewType.GetField(RowFieldName, BindingFlags.Public | BindingFlags.Instance);
+            FieldInfo selectedItemsField = listViewType.GetField(SelectedItemsFieldName, BindingFlags.Public | BindingFlags.Instance);
+            FieldInfo scrollPositionField = listViewType.GetField(ScrollPositionFieldName, BindingFlags.Public | BindingFlags.Instance);
+
+            if (rowField == null || selectedItemsField == null || scrollPositionField == null)
+            {
+                return null;
+            }
+
+            return new ConsoleWindowStateScope(
+                consoleWindow,
+                listView,
+                activeTextField,
+                activeModeField,
+                callstackTextStartField,
+                rowField,
+                selectedItemsField,
+                scrollPositionField);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            _activeTextField.SetValue(_consoleWindow, _activeText);
+            _activeModeField.SetValue(_consoleWindow, _activeMode);
+            _callstackTextStartField.SetValue(_consoleWindow, _callstackTextStart);
+            _rowField.SetValue(_listView, _row);
+            _selectedItemsField.SetValue(_listView, _selectedItems != null ? (bool[])_selectedItems.Clone() : null);
+            _scrollPositionField.SetValue(_listView, _scrollPosition);
+
+            // Repaint because the restored selection/details are visible EditorWindow state.
+            _consoleWindow.Repaint();
         }
     }
 }


### PR DESCRIPTION
## Summary
- get-logs now preserves the visible Unity Console selection while reading logs with an active Console search filter.
- The original Console search text is still restored after retrieval.

## User Impact
- Before this change, running get-logs could disturb the selected Console row or details when a Console search filter was active.
- Users can now inspect logs without losing their current Console selection context.

## Changes
- Snapshot the visible Console window selection state before temporarily clearing the internal text filter.
- Restore the Console selection state after restoring the original filter text.
- Added focused tests for filter restoration and Console state restoration order.

## Verification
- uloop compile
- uloop run-tests --test-mode EditMode --filter-type regex --filter-value "ConsoleFilteringTextScopeTests"
- Dynamic smoke check that GetAllLogs restores filter, row, selected items, scroll position, active text, and callstack state
- codex-review against main with focused tests

Follow-up to #1379.
Addresses https://github.com/hatayama/unity-cli-loop/pull/1379#discussion_r3446174485

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary

## Overview
This PR fixes an issue where the `get-logs` command disturbs the selected Console row or details when a Console search filter is active. The fix preserves the visible Unity Console selection state by snapshotting and restoring Console window UI state during log retrieval when filtering is temporarily cleared.

## Changes

### ConsoleLogRetriever.cs
**New Type: `ConsoleWindowStateScope`**
- Internal disposable class that captures and restores Unity Console UI state via reflection
- Snapshots on construction: active text, active mode, callstack start, selected rows, selected items, scroll position
- Restores all captured state on `Dispose()` and repaints the Console window

**Updated `ConsoleFilteringTextScope` Constructor**
- Added parameter: `Func<IDisposable> createConsoleWindowStateScope` 
- Now creates and stores a console window state scope when filter clearing is needed
- Critical ordering: `Dispose()` restores filter text first, then disposes the console state scope (ensuring state restoration happens after filter restoration, which can affect selection)

**Updated `CreateFilteringTextScope()` Method**
- Now passes `CreateConsoleWindowStateScope` delegate to `ConsoleFilteringTextScope` constructor

**New Method: `CreateConsoleWindowStateScope()`**
- Factory method that creates a `ConsoleWindowStateScope` instance
- Uses reflection to discover ConsoleWindow type and its internal state fields

### ConsoleLogRetrieverTests.cs
**Updated Cleanup**
- Fully qualified `UnityEngine.Object.DestroyImmediate` in test teardown

**Expanded `ConsoleFilteringTextScopeTests`**
- Added test fields: `consoleState` and `consoleStateEvents` (event log for test assertions)
- New test `Dispose_RestoresConsoleStateAfterFilteringText()`: Verifies console state restoration occurs after text filter restoration by checking event ordering
- New helper method `CreateConsoleStateScope()`: Returns a disposable fake scope for testing
- New nested class `FakeConsoleStateScope`: Fake implementation that logs capture/restore events with filter value context

## Key Technical Details

**State Preservation via Reflection**
The `ConsoleWindowStateScope` uses reflection to access Unity's internal ConsoleWindow and ListView fields:
- ConsoleWindow fields: `m_ActiveText`, `m_ActiveMode`, `m_CallstackTextStart`  
- ListView fields: `row`, `selectedItems`, `scrollPos`

**Restoration Order**
The disposal order is critical (in `ConsoleFilteringTextScope.Dispose()`):
1. Restore original filter text via `SetFilteringText(_originalFilteringText)`
2. Dispose console state scope to restore selection/UI state

This ordering ensures that the Console window is properly updated when the filter text is restored, as the text change can affect the visible selection.

**Lines Changed:** +238/-7

**Estimated Complexity:** High - involves reflection-based state management and careful ordering of restoration operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->