### PR TITLE
chore: Document LF line ending policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
+# Repository text files use LF by default. Add explicit exceptions only when
+# a specific tool or file format requires CRLF.
 * text=auto eol=lf
+
+*.sh text eol=lf
+*.ps1 text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Most day-to-day development happens on macOS, but this project must keep working
 Before changing scripts, skill files, generated-file synchronization, path handling, or text parsing, assume Windows will expose bugs that macOS hides.
 
 - Treat encoding as explicit input. When PowerShell reads UTF-8 repository files, pass `-Encoding UTF8`; Windows PowerShell 5.1 otherwise uses a legacy default that can corrupt non-ASCII text and even report wrong line numbers.
-- Treat line endings as data. POSIX shell scripts must remain LF-friendly, and PowerShell/Markdown/skill files must be read in a way that works with both LF and CRLF. If a script fails only under bash, WSL, or Git Bash, check CRLF before changing logic.
+- Repository text files should use LF by default. Only keep CRLF when a specific tool or file format requires it. Preserve expected line endings when writing generated files, and normalize line endings before comparison only when logical text equality is intended. If a script fails only under bash, WSL, or Git Bash, check CRLF before changing logic.
 - Normalize relative paths at API boundaries. Do not compare raw path strings that may contain `/` on one side and `\` on another. Convert separators before storing, comparing, deleting, or syncing generated files.
 - Prefer forward slashes in JSON `file:` paths and other cross-platform config values. Use escaped backslashes only when the target format explicitly requires them.
 - Validate Windows-facing PowerShell with both `pwsh` and Windows PowerShell when practical, especially for multiline arguments, here-strings, UTF-8 files, and native executable calls.


### PR DESCRIPTION
## Summary
- Document that repository text files should use LF by default.
- Make common script and documentation file types explicitly use LF without renormalizing existing files in this PR.

## User Impact
- Future Windows and macOS changes have clearer line-ending rules, reducing accidental CRLF-sensitive script and generated-file regressions.
- Reviewers can see that this PR only documents and enforces the policy going forward, without introducing a large line-ending-only diff.

## Changes
- Added explicit LF attributes for shell scripts, PowerShell scripts, Markdown, JSON, YAML, and YML files.
- Updated AGENTS.md to say LF is the default for repository text files and CRLF should be kept only for explicit tool or format requirements.

## Verification
- git diff --check
- git check-attr text eol -- .gitattributes AGENTS.md scripts/test-meta-key-overlay.ps1 scripts/test-meta-key-overlay.sh cli/internal/cli/skills_test.go ProjectSettings/ProjectVersion.txt
- Build not run because this is a docs/config-only policy change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

