### PR TITLE
fix: Migration handles deeply nested Windows project files

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -147,6 +147,88 @@ public sealed class LongPathResponse : BaseToolResponse
         }
 
         [Test]
+        [Platform(Include = "Win")]
+        public async Task ApplyMigrationAsync_WhenWindowsDirectoryPathExceedsLegacyLimit_MigratesSource()
+        {
+            // Verifies that migration apply can discover source files in directories beyond the legacy Windows path limit.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string longDirectoryPath = CreateVeryLongDirectoryPath(projectRoot);
+                string filePath = Path.Combine(longDirectoryPath, "LongDirectoryTool.cs");
+                Directory.CreateDirectory(ToWindowsExtendedLengthPath(longDirectoryPath));
+                File.WriteAllText(
+                    ToWindowsExtendedLengthPath(filePath),
+                    @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class LongDirectoryTool : AbstractUnityTool<LongDirectorySchema, LongDirectoryResponse>
+{
+}
+
+public sealed class LongDirectorySchema : BaseToolSchema
+{
+}
+
+public sealed class LongDirectoryResponse : BaseToolResponse
+{
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                ThirdPartyToolMigrationResult result =
+                    await service.ApplyMigrationAsync(
+                        projectRoot,
+                        new Progress<ThirdPartyToolMigrationProgress>(),
+                        CancellationToken.None);
+                string migratedSource = File.ReadAllText(ToWindowsExtendedLengthPath(filePath));
+
+                Assert.That(longDirectoryPath.Length, Is.GreaterThanOrEqualTo(WindowsLegacyMaxPathLength));
+                Assert.That(result.FilePaths.Contains(filePath), Is.True);
+                Assert.That(
+                    migratedSource,
+                    Does.Contain("UnityCliLoopTool<LongDirectorySchema, LongDirectoryResponse>"));
+            }
+            finally
+            {
+                Directory.Delete(ToWindowsExtendedLengthPath(projectRoot), recursive: true);
+            }
+        }
+
+        [Test]
+        [Platform(Include = "Win")]
+        public void MigrationProjectFingerprint_WhenWindowsPathExceedsLegacyLimit_DetectsContentChange()
+        {
+            // Verifies that long-path source edits invalidate cached migration plans.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string longDirectoryPath = CreateLongDirectoryPath(projectRoot);
+                string filePath = Path.Combine(longDirectoryPath, "LongPathTool.cs");
+                string originalSource = "public sealed class AlphaTool {}";
+                string changedSource = "public sealed class BravoTool {}";
+                DateTime originalLastWriteTimeUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                Directory.CreateDirectory(ToWindowsExtendedLengthPath(longDirectoryPath));
+                File.WriteAllText(ToWindowsExtendedLengthPath(filePath), originalSource);
+                File.SetLastWriteTimeUtc(ToWindowsExtendedLengthPath(filePath), originalLastWriteTimeUtc);
+                ProjectFileInventory firstInventory = ProjectFileInventory.Create(projectRoot);
+                MigrationProjectFingerprint fingerprint =
+                    MigrationProjectFingerprint.CaptureFromInventory(firstInventory);
+
+                File.WriteAllText(ToWindowsExtendedLengthPath(filePath), changedSource);
+                File.SetLastWriteTimeUtc(ToWindowsExtendedLengthPath(filePath), originalLastWriteTimeUtc);
+                ProjectFileInventory changedInventory = ProjectFileInventory.Create(projectRoot);
+
+                Assert.That(changedSource.Length, Is.EqualTo(originalSource.Length));
+                Assert.That(fingerprint.Matches(changedInventory), Is.False);
+            }
+            finally
+            {
+                Directory.Delete(ToWindowsExtendedLengthPath(projectRoot), recursive: true);
+            }
+        }
+
+        [Test]
         public void MigrationProjectFingerprint_WhenCandidateFileChanges_DoesNotMatch()
         {
             // Verifies that cached migration plans are rejected after candidate source changes.
@@ -5557,6 +5639,21 @@ public sealed class ScreenshotResponse : UnityCliLoopToolResponse
             while (Path.Combine(directoryPath, "LongPathTool.cs").Length < WindowsLegacyMaxPathLength)
             {
                 directoryPath = Path.Combine(directoryPath, "LongPathSegment" + segmentIndex.ToString("D2"));
+                segmentIndex++;
+            }
+
+            return directoryPath;
+        }
+
+        private static string CreateVeryLongDirectoryPath(string projectRoot)
+        {
+            Assert.That(projectRoot, Is.Not.Empty);
+
+            string directoryPath = Path.Combine(projectRoot, "Assets");
+            int segmentIndex = 0;
+            while (directoryPath.Length < WindowsLegacyMaxPathLength)
+            {
+                directoryPath = Path.Combine(directoryPath, "LongDirectorySegment" + segmentIndex.ToString("D2"));
                 segmentIndex++;
             }
 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -12,6 +12,8 @@ using Newtonsoft.Json.Linq;
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 
+using static io.github.hatayama.UnityCliLoop.Infrastructure.ThirdPartyToolMigrationFileServiceConstants;
+
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     /// <summary>
@@ -68,6 +70,80 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(firstSource, Is.EqualTo("source:Assets/VendorTools/HelloTool.cs"));
             Assert.That(secondSource, Is.EqualTo(firstSource));
             Assert.That(readCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        [Platform(Include = "Win")]
+        public void ThirdPartyToolMigrationSourceFileCache_WhenWindowsPathExceedsLegacyLimit_ReadsSource()
+        {
+            // Verifies that migration preview can inspect source files beyond the legacy Windows path limit.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string longDirectoryPath = CreateLongDirectoryPath(projectRoot);
+                string filePath = Path.Combine(longDirectoryPath, "LongPathTool.cs");
+                Directory.CreateDirectory(ToWindowsExtendedLengthPath(longDirectoryPath));
+                File.WriteAllText(
+                    ToWindowsExtendedLengthPath(filePath),
+                    "public sealed class LongPathTool {}");
+
+                Assert.That(filePath.Length, Is.GreaterThanOrEqualTo(WindowsLegacyMaxPathLength));
+                ThirdPartyToolMigrationSourceFileCache cache = new();
+
+                string source = cache.ReadAllText(filePath);
+
+                Assert.That(source, Does.Contain("LongPathTool"));
+            }
+            finally
+            {
+                Directory.Delete(ToWindowsExtendedLengthPath(projectRoot), recursive: true);
+            }
+        }
+
+        [Test]
+        [Platform(Include = "Win")]
+        public async Task ApplyMigrationAsync_WhenWindowsPathExceedsLegacyLimit_MigratesSource()
+        {
+            // Verifies that migration apply can rewrite source files beyond the legacy Windows path limit.
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string longDirectoryPath = CreateLongDirectoryPath(projectRoot);
+                string filePath = Path.Combine(longDirectoryPath, "LongPathTool.cs");
+                Directory.CreateDirectory(ToWindowsExtendedLengthPath(longDirectoryPath));
+                File.WriteAllText(
+                    ToWindowsExtendedLengthPath(filePath),
+                    @"using io.github.hatayama.uLoopMCP;
+
+[McpTool]
+public sealed class LongPathTool : AbstractUnityTool<LongPathSchema, LongPathResponse>
+{
+}
+
+public sealed class LongPathSchema : BaseToolSchema
+{
+}
+
+public sealed class LongPathResponse : BaseToolResponse
+{
+}");
+
+                ThirdPartyToolMigrationFileService service = new();
+
+                ThirdPartyToolMigrationResult result =
+                    await service.ApplyMigrationAsync(
+                        projectRoot,
+                        new Progress<ThirdPartyToolMigrationProgress>(),
+                        CancellationToken.None);
+                string migratedSource = File.ReadAllText(ToWindowsExtendedLengthPath(filePath));
+
+                Assert.That(result.FilePaths.Contains(filePath), Is.True);
+                Assert.That(migratedSource, Does.Contain("UnityCliLoopTool<LongPathSchema, LongPathResponse>"));
+            }
+            finally
+            {
+                Directory.Delete(ToWindowsExtendedLengthPath(projectRoot), recursive: true);
+            }
         }
 
         [Test]
@@ -5470,6 +5546,39 @@ public sealed class ScreenshotResponse : UnityCliLoopToolResponse
             Directory.CreateDirectory(Path.Combine(projectRoot, "ProjectSettings"));
             Directory.CreateDirectory(Path.Combine(projectRoot, "Assets"));
             return projectRoot;
+        }
+
+        private static string CreateLongDirectoryPath(string projectRoot)
+        {
+            Assert.That(projectRoot, Is.Not.Empty);
+
+            string directoryPath = Path.Combine(projectRoot, "Assets");
+            int segmentIndex = 0;
+            while (Path.Combine(directoryPath, "LongPathTool.cs").Length < WindowsLegacyMaxPathLength)
+            {
+                directoryPath = Path.Combine(directoryPath, "LongPathSegment" + segmentIndex.ToString("D2"));
+                segmentIndex++;
+            }
+
+            return directoryPath;
+        }
+
+        private static string ToWindowsExtendedLengthPath(string path)
+        {
+            Assert.That(path, Is.Not.Empty);
+
+            string fullPath = Path.GetFullPath(path);
+            if (fullPath.StartsWith(WindowsExtendedLengthPathPrefix, StringComparison.Ordinal))
+            {
+                return fullPath;
+            }
+
+            if (fullPath.StartsWith(WindowsUncPathPrefix, StringComparison.Ordinal))
+            {
+                return WindowsExtendedLengthUncPathPrefix + fullPath.Substring(WindowsUncPathPrefix.Length);
+            }
+
+            return WindowsExtendedLengthPathPrefix + fullPath;
         }
 
         private sealed class RecordingMigrationProgress : IProgress<ThirdPartyToolMigrationProgress>

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefMetaGuidReader.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefMetaGuidReader.cs
@@ -15,12 +15,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(asmdefFilePath), "asmdefFilePath must not be null or empty");
 
             string metaPath = asmdefFilePath + ".meta";
-            if (!File.Exists(metaPath))
+            if (!ThirdPartyToolMigrationFileAccess.Exists(metaPath))
             {
                 return string.Empty;
             }
 
-            return ReadAsmdefGuidReferenceFromMetaFile(metaPath, File.ReadLines);
+            return ReadAsmdefGuidReferenceFromMetaFile(metaPath, ThirdPartyToolMigrationFileAccess.ReadLines);
         }
 
         internal static string ReadAsmdefGuidReferenceFromMetaFile(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefMigrationRequirementResolver.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefMigrationRequirementResolver.cs
@@ -30,7 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 out requiresApplicationReference,
                 out requiresDomainReference,
                 out requiresFirstPartyScreenshotReference);
-            string source = File.ReadAllText(asmdefFilePath);
+            string source = ThirdPartyToolMigrationFileAccess.ReadAllText(asmdefFilePath);
             if (!hasAssemblyMigrationRequirement &&
                 !ThirdPartyToolMigrationRules.ContainsLegacyMigrationCandidateText(source))
             {

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAssemblyReferenceResolver.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAssemblyReferenceResolver.cs
@@ -269,7 +269,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         internal static bool TryReadJsonObjectFromFile(string filePath, out JObject jsonObject)
         {
-            return TryReadJsonObjectForMigration(filePath, File.ReadAllText, out jsonObject);
+            return TryReadJsonObjectForMigration(
+                filePath,
+                ThirdPartyToolMigrationFileAccess.ReadAllText,
+                out jsonObject);
         }
 
         internal static bool TryReadJsonObjectFromCache(

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAssemblyUsageAnalyzer.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAssemblyUsageAnalyzer.cs
@@ -60,7 +60,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             foreach (string csharpFilePath in csharpFilePaths)
             {
-                string source = File.ReadAllText(csharpFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(csharpFilePath);
                 sourceByCSharpFilePath.Add(csharpFilePath, source);
                 if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source))
                 {

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFastAssemblyRequirementCollector.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFastAssemblyRequirementCollector.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -166,7 +165,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return;
                 }
 
-                string source = File.ReadAllText(csharpFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(csharpFilePath);
                 inspectedEntryCount++;
                 if (inspectedEntryCount % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
                 {
@@ -250,7 +249,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return;
                 }
 
-                string source = File.ReadAllText(csharpFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(csharpFilePath);
                 inspectedEntryCount++;
                 if (inspectedEntryCount % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
                 {
@@ -317,7 +316,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return;
                 }
 
-                string source = File.ReadAllText(csharpFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(csharpFilePath);
                 inspectedEntryCount++;
                 if (inspectedEntryCount % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
                 {
@@ -391,7 +390,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return false;
                 }
 
-                string source = File.ReadAllText(csharpFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(csharpFilePath);
                 inspectedEntryCount++;
                 if (inspectedEntryCount % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
                 {

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFastSourceTargetDetector.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFastSourceTargetDetector.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -89,7 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return false;
                 }
 
-                string source = File.ReadAllText(csharpFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(csharpFilePath);
                 inspectedEntryCount++;
                 if (inspectedEntryCount % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
                 {

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileServiceConstants.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileServiceConstants.cs
@@ -5,6 +5,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     internal static class ThirdPartyToolMigrationFileServiceConstants
     {
+        internal const int WindowsLegacyMaxPathLength = 260;
+        internal const string WindowsExtendedLengthPathPrefix = @"\\?\";
+        internal const string WindowsExtendedLengthUncPathPrefix = @"\\?\UNC\";
+        internal const string WindowsUncPathPrefix = @"\\";
         internal const string ImplicitEditorAssemblyDirectoryName = "__UnityCliLoopImplicitEditorAssembly";
         internal const string ImplicitRuntimeAssemblyDirectoryName = "__UnityCliLoopImplicitRuntimeAssembly";
         internal const string ImplicitFirstPassEditorAssemblyDirectoryName =

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
@@ -79,6 +79,28 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return File.Exists(GetFileSystemPath(filePath));
         }
 
+        internal static long GetLength(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            FileInfo fileInfo = new(GetFileSystemPath(filePath));
+            return fileInfo.Length;
+        }
+
+        internal static DateTime GetLastWriteTimeUtc(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            return File.GetLastWriteTimeUtc(GetFileSystemPath(filePath));
+        }
+
+        internal static FileStream OpenRead(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            return File.OpenRead(GetFileSystemPath(filePath));
+        }
+
         internal static void Move(string sourceFilePath, string destinationFilePath)
         {
             Debug.Assert(!string.IsNullOrEmpty(sourceFilePath), "sourceFilePath must not be null or empty");

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 
@@ -15,16 +16,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(content != null, "content must not be null");
 
             string tempFilePath = CreateUniqueSidecarPath(filePath, ".tmp");
-            File.WriteAllText(tempFilePath, content);
-            if (!File.Exists(filePath))
+            ThirdPartyToolMigrationFileAccess.WriteAllText(tempFilePath, content);
+            if (!ThirdPartyToolMigrationFileAccess.Exists(filePath))
             {
-                File.Move(tempFilePath, filePath);
+                ThirdPartyToolMigrationFileAccess.Move(tempFilePath, filePath);
                 return;
             }
 
             string backupFilePath = CreateUniqueSidecarPath(filePath, ".bak");
-            File.Replace(tempFilePath, filePath, backupFilePath);
-            File.Delete(backupFilePath);
+            ThirdPartyToolMigrationFileAccess.Replace(tempFilePath, filePath, backupFilePath);
+            ThirdPartyToolMigrationFileAccess.Delete(backupFilePath);
         }
 
         internal static string CreateUniqueSidecarPath(string filePath, string extension)
@@ -35,12 +36,110 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string directory = Path.GetDirectoryName(filePath) ?? string.Empty;
             string fileName = Path.GetFileName(filePath);
             string sidecarPath = Path.Combine(directory, $"{fileName}.{Guid.NewGuid():N}{extension}");
-            while (File.Exists(sidecarPath))
+            while (ThirdPartyToolMigrationFileAccess.Exists(sidecarPath))
             {
                 sidecarPath = Path.Combine(directory, $"{fileName}.{Guid.NewGuid():N}{extension}");
             }
 
             return sidecarPath;
+        }
+    }
+
+    /// <summary>
+    /// Routes migration file IO through Windows extended-length paths when needed.
+    /// </summary>
+    internal static class ThirdPartyToolMigrationFileAccess
+    {
+        internal static string ReadAllText(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            return File.ReadAllText(GetFileSystemPath(filePath));
+        }
+
+        internal static void WriteAllText(string filePath, string content)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+            Debug.Assert(content != null, "content must not be null");
+
+            File.WriteAllText(GetFileSystemPath(filePath), content);
+        }
+
+        internal static IEnumerable<string> ReadLines(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            return File.ReadLines(GetFileSystemPath(filePath));
+        }
+
+        internal static bool Exists(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            return File.Exists(GetFileSystemPath(filePath));
+        }
+
+        internal static void Move(string sourceFilePath, string destinationFilePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(sourceFilePath), "sourceFilePath must not be null or empty");
+            Debug.Assert(
+                !string.IsNullOrEmpty(destinationFilePath),
+                "destinationFilePath must not be null or empty");
+
+            File.Move(GetFileSystemPath(sourceFilePath), GetFileSystemPath(destinationFilePath));
+        }
+
+        internal static void Replace(
+            string sourceFilePath,
+            string destinationFilePath,
+            string destinationBackupFilePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(sourceFilePath), "sourceFilePath must not be null or empty");
+            Debug.Assert(
+                !string.IsNullOrEmpty(destinationFilePath),
+                "destinationFilePath must not be null or empty");
+            Debug.Assert(
+                !string.IsNullOrEmpty(destinationBackupFilePath),
+                "destinationBackupFilePath must not be null or empty");
+
+            File.Replace(
+                GetFileSystemPath(sourceFilePath),
+                GetFileSystemPath(destinationFilePath),
+                GetFileSystemPath(destinationBackupFilePath));
+        }
+
+        internal static void Delete(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            File.Delete(GetFileSystemPath(filePath));
+        }
+
+        private static string GetFileSystemPath(string path)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(path), "path must not be null or empty");
+
+            string fullPath = Path.GetFullPath(path);
+            if (Path.DirectorySeparatorChar != '\\' ||
+                fullPath.Length < ThirdPartyToolMigrationFileServiceConstants.WindowsLegacyMaxPathLength ||
+                fullPath.StartsWith(
+                    ThirdPartyToolMigrationFileServiceConstants.WindowsExtendedLengthPathPrefix,
+                    StringComparison.Ordinal))
+            {
+                return fullPath;
+            }
+
+            // Windows Mono still needs the extended-length prefix for file IO beyond legacy MAX_PATH.
+            if (fullPath.StartsWith(
+                    ThirdPartyToolMigrationFileServiceConstants.WindowsUncPathPrefix,
+                    StringComparison.Ordinal))
+            {
+                return ThirdPartyToolMigrationFileServiceConstants.WindowsExtendedLengthUncPathPrefix +
+                    fullPath.Substring(
+                        ThirdPartyToolMigrationFileServiceConstants.WindowsUncPathPrefix.Length);
+            }
+
+            return ThirdPartyToolMigrationFileServiceConstants.WindowsExtendedLengthPathPrefix + fullPath;
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationModels.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationModels.cs
@@ -162,8 +162,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
 
-            FileInfo fileInfo = new(filePath);
-            if (!fileInfo.Exists)
+            if (!ThirdPartyToolMigrationFileAccess.Exists(filePath))
             {
                 return new MigrationFileFingerprint(
                     filePath,
@@ -176,8 +175,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return new MigrationFileFingerprint(
                 filePath,
                 true,
-                fileInfo.Length,
-                fileInfo.LastWriteTimeUtc.Ticks,
+                ThirdPartyToolMigrationFileAccess.GetLength(filePath),
+                ThirdPartyToolMigrationFileAccess.GetLastWriteTimeUtc(filePath).Ticks,
                 CaptureContentHash(filePath));
         }
 
@@ -210,7 +209,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             byte[] buffer = new byte[ContentHashBufferSize];
             ulong contentHash = ContentHashOffsetBasis;
-            using FileStream stream = File.OpenRead(filePath);
+            using FileStream stream = ThirdPartyToolMigrationFileAccess.OpenRead(filePath);
             while (true)
             {
                 int readByteCount = stream.Read(buffer, 0, buffer.Length);

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationPlanBuilder.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationPlanBuilder.cs
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             foreach (string csharpFilePath in inventory.CSharpFilePaths)
             {
-                string source = File.ReadAllText(csharpFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(csharpFilePath);
                 if (!ThirdPartyToolMigrationRules.ContainsMigrationCandidateText(source) &&
                     !ThirdPartyToolMigrationRules.ContainsLegacyTypeAliasReference(source, legacyToolInfoAliases))
                 {
@@ -140,7 +140,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 assemblyUsage,
                 changes,
                 removedPlayerLoopTimingSignaturesByAssemblyDirectory,
-                File.ReadAllText);
+                ThirdPartyToolMigrationFileAccess.ReadAllText);
 
             foreach (string asmdefFilePath in inventory.AsmdefFilePaths)
             {
@@ -158,7 +158,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     out requiresApplicationReference,
                     out requiresDomainReference,
                     out requiresFirstPartyScreenshotReference);
-                string source = File.ReadAllText(asmdefFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(asmdefFilePath);
                 if (!hasAssemblyMigrationRequirement &&
                     !ThirdPartyToolMigrationRules.ContainsLegacyMigrationCandidateText(source))
                 {

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationPreflightScanner.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationPreflightScanner.cs
@@ -186,7 +186,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             try
             {
-                return (true, File.ReadAllText(filePath));
+                return (true, ThirdPartyToolMigrationFileAccess.ReadAllText(filePath));
             }
             catch (Exception ex) when (IsSkippablePreflightReadException(ex))
             {

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationSourceFileCache.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationSourceFileCache.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
@@ -14,7 +13,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly Dictionary<string, string> _sources = new(StringComparer.Ordinal);
 
         internal ThirdPartyToolMigrationSourceFileCache()
-            : this(File.ReadAllText)
+            : this(ThirdPartyToolMigrationFileAccess.ReadAllText)
         {
         }
 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationTargetScanner.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationTargetScanner.cs
@@ -84,7 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return false;
                 }
 
-                string source = File.ReadAllText(csharpFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(csharpFilePath);
                 if (ContainsFastCSharpMigrationTarget(source))
                 {
                     return true;
@@ -320,7 +320,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     return false;
                 }
 
-                string source = File.ReadAllText(asmdefFilePath);
+                string source = ThirdPartyToolMigrationFileAccess.ReadAllText(asmdefFilePath);
                 if (ContainsFastAsmdefMigrationTarget(source))
                 {
                     return true;


### PR DESCRIPTION
## Summary
- Migration preview and apply now handle deeply nested Windows project files that exceed legacy path limits.
- Cached migration plans now invalidate correctly after long-path files change.

## User Impact
- On Windows, running the migration tool could stop with a misleading "Could not find a part of the path" error in projects with very long file paths.
- The migration flow now reads, writes, and validates those files through extended-length file access so the operation can complete reliably.

## Changes
- Route third-party migration reads, writes, and atomic sidecar operations through Windows extended-length path handling.
- Apply the same access path to migration plan fingerprint metadata and content hashes.
- Add Windows-only regression coverage for long-path preview, apply, directory discovery, and stale-cache invalidation.

## Verification
- .\cli\dist\windows-amd64\uloop.exe compile
- .\cli\dist\windows-amd64\uloop.exe run-tests --test-mode EditMode --filter-type regex --filter-value ".*(WindowsDirectoryPathExceedsLegacyLimit|MigrationProjectFingerprint_WhenWindowsPathExceedsLegacyLimit).*"
- .\cli\dist\windows-amd64\uloop.exe run-tests --test-mode EditMode --filter-type regex --filter-value ".*ThirdPartyToolMigration.*"
- python C:\Users\booql\.codex\skills\autoreview\scripts\autoreview --mode branch --base origin/v3-beta
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

