### PR TITLE
feat: Skills use the project-matched CLI by default

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -274,6 +274,36 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
+        public void ShouldUseTargetSelectionSkillsUi_WhenFirstInstall_ReturnsTrue()
+        {
+            bool shouldUseTargetSelectionUi = SetupWizardWindow.ShouldUseTargetSelectionSkillsUi(
+                shouldUseFirstInstallSkillsUi: true,
+                installableTargetCount: 1);
+
+            Assert.That(shouldUseTargetSelectionUi, Is.True);
+        }
+
+        [Test]
+        public void ShouldUseTargetSelectionSkillsUi_WhenNoInstallableTargets_ReturnsTrue()
+        {
+            bool shouldUseTargetSelectionUi = SetupWizardWindow.ShouldUseTargetSelectionSkillsUi(
+                shouldUseFirstInstallSkillsUi: false,
+                installableTargetCount: 0);
+
+            Assert.That(shouldUseTargetSelectionUi, Is.True);
+        }
+
+        [Test]
+        public void ShouldUseTargetSelectionSkillsUi_WhenInstallableTargetsExistAfterFirstInstall_ReturnsFalse()
+        {
+            bool shouldUseTargetSelectionUi = SetupWizardWindow.ShouldUseTargetSelectionSkillsUi(
+                shouldUseFirstInstallSkillsUi: false,
+                installableTargetCount: 1);
+
+            Assert.That(shouldUseTargetSelectionUi, Is.False);
+        }
+
+        [Test]
         public void CanManageSkills_WhenCliIsMissing_ReturnsFalse()
         {
             bool canManageSkills = SetupWizardWindow.CanManageSkills(
@@ -405,6 +435,52 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             Assert.That(installableTargets.Count, Is.EqualTo(1));
             Assert.That(installableTargets[0].DirName, Is.EqualTo(".claude"));
             Assert.That(installableTargets[0].InstallState, Is.EqualTo(SkillInstallState.Missing));
+        }
+
+        [Test]
+        public void GetSetupWizardInstallableSkillTargets_WhenNoInstallableTargetsAfterFirstInstall_ReturnsSelectedTarget()
+        {
+            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets =
+                SetupWizardWindow.GetSetupWizardInstallableSkillTargets(
+                    new List<ToolSkillSynchronizer.SkillTargetInfo>(),
+                    SkillsTarget.Codex,
+                    groupSkillsUnderUnityCliLoop: false,
+                    shouldUseFirstInstallSkillsUi: false);
+
+            Assert.That(installableTargets.Count, Is.EqualTo(1));
+            Assert.That(installableTargets[0].DirName, Is.EqualTo(".codex"));
+            Assert.That(installableTargets[0].HasSkillsDirectory, Is.False);
+            Assert.That(installableTargets[0].InstallState, Is.EqualTo(SkillInstallState.Missing));
+        }
+
+        [Test]
+        public void GetSetupWizardInstallableSkillTargets_WhenInstallableTargetsExistAfterFirstInstall_ReturnsExistingTargets()
+        {
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = new()
+            {
+                new(
+                    "Claude Code",
+                    ".claude",
+                    "--claude",
+                    hasSkillsDirectory: true,
+                    hasExistingSkills: false),
+                new(
+                    "Codex CLI",
+                    ".codex",
+                    "--codex",
+                    hasSkillsDirectory: false,
+                    hasExistingSkills: false)
+            };
+
+            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets =
+                SetupWizardWindow.GetSetupWizardInstallableSkillTargets(
+                    targets,
+                    SkillsTarget.Codex,
+                    groupSkillsUnderUnityCliLoop: false,
+                    shouldUseFirstInstallSkillsUi: false);
+
+            Assert.That(installableTargets.Count, Is.EqualTo(1));
+            Assert.That(installableTargets[0].DirName, Is.EqualTo(".claude"));
         }
 
         [TestCase(SkillInstallState.Installed, false, true, "Installed")]

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -276,7 +276,9 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         [Test]
         public void CanManageSkills_WhenCliIsMissing_ReturnsFalse()
         {
-            bool canManageSkills = SetupWizardWindow.CanManageSkills(cliInstalled: false);
+            bool canManageSkills = SetupWizardWindow.CanManageSkills(
+                cliInstalled: false,
+                useProjectCliVersion: false);
 
             Assert.That(canManageSkills, Is.False);
         }
@@ -284,7 +286,19 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         [Test]
         public void CanManageSkills_WhenCliIsInstalled_ReturnsTrue()
         {
-            bool canManageSkills = SetupWizardWindow.CanManageSkills(cliInstalled: true);
+            bool canManageSkills = SetupWizardWindow.CanManageSkills(
+                cliInstalled: true,
+                useProjectCliVersion: false);
+
+            Assert.That(canManageSkills, Is.True);
+        }
+
+        [Test]
+        public void CanManageSkills_WhenProjectCliVersionIsEnabled_ReturnsTrue()
+        {
+            bool canManageSkills = SetupWizardWindow.CanManageSkills(
+                cliInstalled: false,
+                useProjectCliVersion: true);
 
             Assert.That(canManageSkills, Is.True);
         }

--- a/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
+++ b/Assets/Tests/Editor/SkillsTargetSelectionResolverTests.cs
@@ -53,6 +53,7 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
                 selectedTargetInstallState: SkillInstallState.Installed,
                 selectedTarget: target,
                 groupSkillsUnderUnityCliLoop: true,
+                useProjectCliVersion: false,
                 isInstallingSkills: false);
 
             bool isInstalled = SkillsTargetSelectionResolver.IsInstalled(data, target);

--- a/Assets/Tests/Editor/ToolSettingsTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsTests.cs
@@ -104,6 +104,39 @@ namespace io.github.hatayama.uLoopMCP
             Assert.IsTrue(ToolSettings.IsToolEnabled("clear-console"));
         }
 
+        [Test]
+        public void GetSkillCliInvocation_WhenSettingsMissing_ShouldReturnGlobal()
+        {
+            DeleteIfExists(SettingsFilePath);
+            ToolSettings.InvalidateCache();
+
+            string result = ToolSettings.GetSkillCliInvocation();
+
+            Assert.AreEqual(CliConstants.SKILL_CLI_INVOCATION_GLOBAL, result);
+        }
+
+        [Test]
+        public void SetSkillCliInvocation_ShouldPersistAcrossCacheInvalidation()
+        {
+            ToolSettings.SetToolEnabled("compile", false);
+            ToolSettings.SetSkillCliInvocation(CliConstants.SKILL_CLI_INVOCATION_NPX);
+            ToolSettings.InvalidateCache();
+
+            Assert.AreEqual(CliConstants.SKILL_CLI_INVOCATION_NPX, ToolSettings.GetSkillCliInvocation());
+            Assert.IsFalse(ToolSettings.IsToolEnabled("compile"));
+        }
+
+        [Test]
+        public void GetSkillCliInvocation_WhenValueIsInvalid_ShouldReturnGlobal()
+        {
+            File.WriteAllText(SettingsFilePath, "{\"disabledTools\":[],\"skillCliInvocation\":\"invalid\"}");
+            ToolSettings.InvalidateCache();
+
+            string result = ToolSettings.GetSkillCliInvocation();
+
+            Assert.AreEqual(CliConstants.SKILL_CLI_INVOCATION_GLOBAL, result);
+        }
+
         // ── Deduplication ──────────────────────────────────────────────
 
         [Test]

--- a/Assets/Tests/Editor/ToolSettingsTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsTests.cs
@@ -105,18 +105,18 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
-        public void GetSkillCliInvocation_WhenSettingsMissing_ShouldReturnGlobal()
+        public void GetSkillCliInvocation_WhenSettingsMissing_ShouldReturnNpx()
         {
             DeleteIfExists(SettingsFilePath);
             ToolSettings.InvalidateCache();
 
             string result = ToolSettings.GetSkillCliInvocation();
 
-            Assert.AreEqual(CliConstants.SKILL_CLI_INVOCATION_GLOBAL, result);
+            Assert.AreEqual(CliConstants.SKILL_CLI_INVOCATION_NPX, result);
         }
 
         [Test]
-        public void SetSkillCliInvocation_ShouldPersistAcrossCacheInvalidation()
+        public void SetSkillCliInvocation_WhenSetToNpx_ShouldPersistAcrossCacheInvalidation()
         {
             ToolSettings.SetToolEnabled("compile", false);
             ToolSettings.SetSkillCliInvocation(CliConstants.SKILL_CLI_INVOCATION_NPX);
@@ -127,14 +127,23 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
-        public void GetSkillCliInvocation_WhenValueIsInvalid_ShouldReturnGlobal()
+        public void SetSkillCliInvocation_WhenSetToGlobal_ShouldPersistAcrossCacheInvalidation()
+        {
+            ToolSettings.SetSkillCliInvocation(CliConstants.SKILL_CLI_INVOCATION_GLOBAL);
+            ToolSettings.InvalidateCache();
+
+            Assert.AreEqual(CliConstants.SKILL_CLI_INVOCATION_GLOBAL, ToolSettings.GetSkillCliInvocation());
+        }
+
+        [Test]
+        public void GetSkillCliInvocation_WhenValueIsInvalid_ShouldReturnNpx()
         {
             File.WriteAllText(SettingsFilePath, "{\"disabledTools\":[],\"skillCliInvocation\":\"invalid\"}");
             ToolSettings.InvalidateCache();
 
             string result = ToolSettings.GetSkillCliInvocation();
 
-            Assert.AreEqual(CliConstants.SKILL_CLI_INVOCATION_GLOBAL, result);
+            Assert.AreEqual(CliConstants.SKILL_CLI_INVOCATION_NPX, result);
         }
 
         // ── Deduplication ──────────────────────────────────────────────

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -1024,6 +1024,92 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public async Task InstallSkillFilesAtProjectRoot_WhenSkillCliInvocationIsNpx_RewritesSkillMarkdownOnly()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkillWithContent(
+                temporaryRoot,
+                "uloop-npx-skill",
+                "NpxTool",
+                "---\nname: uloop-npx-skill\n---\nRun `uloop compile` for this project.\n",
+                "reference.md",
+                "Run `uloop compile` in references.");
+            ToolSettings.SaveSettings(new ToolSettingsData
+            {
+                skillCliInvocation = CliConstants.SKILL_CLI_INVOCATION_NPX
+            });
+
+            ToolSkillSynchronizer.SkillTargetInfo target = new(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: false);
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
+                    temporaryRoot,
+                    new[] { target },
+                    groupSkillsUnderUnityCliLoop: false);
+
+            string installedSkillDir = Path.Combine(
+                temporaryRoot,
+                ".claude",
+                SkillInstallLayout.SkillsDirName,
+                "uloop-npx-skill");
+            string skillContent = File.ReadAllText(Path.Combine(
+                installedSkillDir,
+                SkillInstallLayout.SkillFileName));
+            string referenceContent = File.ReadAllText(Path.Combine(installedSkillDir, "reference.md"));
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(skillContent, Does.Contain("name: uloop-npx-skill"));
+            Assert.That(
+                skillContent,
+                Does.Contain($"`npx --yes uloop-cli@{McpConstants.PackageInfo.version} compile`"));
+            Assert.That(referenceContent, Is.EqualTo("Run `uloop compile` in references."));
+        }
+
+        [Test]
+        public async Task DetectTargets_WhenNpxSkillIsInstalledButSettingIsGlobal_ReportsOutdated()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkillWithContent(
+                temporaryRoot,
+                "uloop-npx-switch-skill",
+                "NpxSwitchTool",
+                "---\nname: uloop-npx-switch-skill\n---\nRun `uloop compile` for this project.\n",
+                "reference.md",
+                "reference");
+            ToolSettings.SaveSettings(new ToolSettingsData
+            {
+                skillCliInvocation = CliConstants.SKILL_CLI_INVOCATION_NPX
+            });
+
+            ToolSkillSynchronizer.SkillTargetInfo target = new(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: false);
+
+            await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
+                temporaryRoot,
+                new[] { target },
+                groupSkillsUnderUnityCliLoop: false);
+            ToolSettings.SetSkillCliInvocation(CliConstants.SKILL_CLI_INVOCATION_GLOBAL);
+
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+                    temporaryRoot,
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: false)
+                .ToArray();
+
+            Assert.That(detectedTargets.Length, Is.EqualTo(1));
+            Assert.That(detectedTargets[0].InstallState, Is.EqualTo(SkillInstallState.Outdated));
+        }
+
+        [Test]
         public void DetectTargets_WhenOnlyInternalSkillsAreMissing_IgnoresThem()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
@@ -1363,6 +1449,26 @@ namespace io.github.hatayama.uLoopMCP
             {
                 File.WriteAllText(Path.Combine(skillDir, sourceMetaFileRelativePath), "meta");
             }
+        }
+
+        private static void CreateFakeSourceSkillWithContent(
+            string projectRoot,
+            string skillName,
+            string toolDirectoryName,
+            string skillContent,
+            string additionalFileRelativePath,
+            string additionalFileContent)
+        {
+            string skillDir = Path.Combine(
+                projectRoot,
+                "Packages",
+                "com.example.fake",
+                "Editor",
+                toolDirectoryName,
+                "Skill");
+            Directory.CreateDirectory(skillDir);
+            File.WriteAllText(Path.Combine(skillDir, SkillInstallLayout.SkillFileName), skillContent);
+            File.WriteAllText(Path.Combine(skillDir, additionalFileRelativePath), additionalFileContent);
         }
 
         private static string CreateFakeProjectLocalSkill(

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -1024,7 +1024,7 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
-        public async Task InstallSkillFilesAtProjectRoot_WhenSkillCliInvocationIsNpx_RewritesSkillMarkdownOnly()
+        public async Task InstallSkillFilesAtProjectRoot_WhenSkillCliInvocationIsNpx_RewritesSkillMarkdownFiles()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
             CreateFakeSourceSkillWithContent(
@@ -1067,7 +1067,9 @@ namespace io.github.hatayama.uLoopMCP
             Assert.That(
                 skillContent,
                 Does.Contain($"`npx --yes uloop-cli@{McpConstants.PackageInfo.version} compile`"));
-            Assert.That(referenceContent, Is.EqualTo("Run `uloop compile` in references."));
+            Assert.That(
+                referenceContent,
+                Is.EqualTo($"Run `npx --yes uloop-cli@{McpConstants.PackageInfo.version} compile` in references."));
         }
 
         [Test]

--- a/Packages/src/Cli~/src/__tests__/skills-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/skills-command.test.ts
@@ -13,7 +13,7 @@ interface MockUninstallResult {
 }
 
 const mockGetAllSkillStatuses = jest.fn<unknown[], [unknown, boolean, boolean]>();
-const mockInstallAllSkills = jest.fn<MockInstallResult, [unknown, boolean, boolean]>();
+const mockInstallAllSkills = jest.fn<MockInstallResult, [unknown, boolean, boolean, unknown?]>();
 const mockUninstallAllSkills = jest.fn<MockUninstallResult, [unknown, boolean, boolean]>();
 const mockGetInstallDir = jest.fn<string, [unknown, boolean, boolean]>();
 const mockGetTotalSkillCount = jest.fn<number, []>();
@@ -26,7 +26,8 @@ jest.mock('../skills/skills-manager.js', () => ({
     target: unknown,
     global: boolean,
     groupManagedSkills: boolean,
-  ): MockInstallResult => mockInstallAllSkills(target, global, groupManagedSkills),
+    cliInvocation?: unknown,
+  ): MockInstallResult => mockInstallAllSkills(target, global, groupManagedSkills, cliInvocation),
   uninstallAllSkills: (
     target: unknown,
     global: boolean,
@@ -74,6 +75,50 @@ describe('skills command', () => {
       expect.objectContaining({ id: 'claude' }),
       true,
       false,
+      undefined,
+    );
+  });
+
+  it('passes npx invocation to project installs', async () => {
+    const program = new Command();
+    registerSkillsCommand(program);
+
+    await program.parseAsync([
+      'node',
+      'uloop',
+      'skills',
+      'install',
+      '--claude',
+      '--cli-invocation',
+      'npx',
+    ]);
+
+    expect(mockInstallAllSkills).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'claude' }),
+      false,
+      false,
+      'npx',
+    );
+  });
+
+  it('rejects npx invocation for global installs', async () => {
+    const program = new Command();
+    registerSkillsCommand(program);
+
+    await program.parseAsync([
+      'node',
+      'uloop',
+      'skills',
+      'install',
+      '--claude',
+      '--global',
+      '--cli-invocation',
+      'npx',
+    ]);
+
+    expect(mockInstallAllSkills).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      'The --cli-invocation npx option is only available for project installs.',
     );
   });
 });

--- a/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
+++ b/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
@@ -214,6 +214,42 @@ describe('skill install layout', () => {
     return projectRoot;
   }
 
+  function writeProjectPackageVersion(projectRoot: string, version: string): void {
+    const packageRoot = join(projectRoot, 'Packages', 'src');
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({ version }), 'utf-8');
+  }
+
+  function writePackageSkill(
+    projectRoot: string,
+    skillName: string,
+    body: string,
+    additionalFiles?: Record<string, string>,
+  ): string {
+    const skillDir = join(
+      projectRoot,
+      'Packages',
+      'src',
+      'Editor',
+      'Api',
+      'McpTools',
+      skillName,
+      'Skill',
+    );
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      ['---', `name: ${skillName}`, '---', '', body, ''].join('\n'),
+      'utf-8',
+    );
+
+    for (const [relativePath, content] of Object.entries(additionalFiles ?? {})) {
+      writeFileSync(join(skillDir, relativePath), content, 'utf-8');
+    }
+
+    return skillDir;
+  }
+
   it('should resolve managed skills under the unity-cli-loop namespace', () => {
     expect(getManagedSkillsDir('/tmp/example/skills')).toBe(
       join('/tmp/example/skills', 'unity-cli-loop'),
@@ -360,6 +396,47 @@ describe('skill install layout', () => {
     expect(
       existsSync(join(projectRoot, '.claude', 'skills', 'unity-cli-loop', 'uloop-run-tests')),
     ).toBe(true);
+  });
+
+  it('should install project skills with npx invocation when requested', () => {
+    const projectRoot = createUnityProjectRoot();
+    const skillName = 'uloop-test-npx-skill';
+    writeProjectPackageVersion(projectRoot, '2.9.0');
+    writePackageSkill(projectRoot, skillName, 'Run `uloop compile` for this project.', {
+      'reference.md': 'Run `uloop compile` in examples.',
+    });
+
+    process.chdir(projectRoot);
+
+    installAllSkills(getTargetConfig('claude'), false, true, 'npx');
+
+    const installedSkillDir = join(projectRoot, '.claude', 'skills', 'unity-cli-loop', skillName);
+    const installedSkill = readFileSync(join(installedSkillDir, 'SKILL.md'), 'utf-8');
+    const installedReference = readFileSync(join(installedSkillDir, 'reference.md'), 'utf-8');
+
+    expect(installedSkill).toContain('name: uloop-test-npx-skill');
+    expect(installedSkill).toContain('`npx --yes uloop-cli@2.9.0 compile`');
+    expect(installedReference).toBe('Run `uloop compile` in examples.');
+  });
+
+  it('should mark npx-installed skills as outdated when the project setting returns to global', () => {
+    const projectRoot = createUnityProjectRoot();
+    const skillName = 'uloop-test-switch-skill';
+    writeProjectPackageVersion(projectRoot, '2.9.0');
+    writePackageSkill(projectRoot, skillName, 'Run `uloop compile` for this project.');
+
+    process.chdir(projectRoot);
+
+    installAllSkills(getTargetConfig('claude'), false, true, 'npx');
+    writeFileSync(
+      join(projectRoot, '.uloop', 'settings.tools.json'),
+      JSON.stringify({ skillCliInvocation: 'global' }),
+      'utf-8',
+    );
+
+    const statuses = getAllSkillStatuses(getTargetConfig('claude'), false, true);
+
+    expect(statuses.find((skill) => skill.name === skillName)?.status).toBe('outdated');
   });
 
   it('should ignore sibling implementation files beside a direct SKILL.md in the tool folder', () => {

--- a/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
+++ b/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
@@ -367,6 +367,37 @@ describe('skill install layout', () => {
     ).toBeDefined();
   });
 
+  it('should not assert when project CLI mode cannot resolve a package version during status checks', () => {
+    const projectRoot = createUnityProjectRoot();
+    const toolDir = join(
+      projectRoot,
+      'Assets',
+      'Vision',
+      'Editor',
+      'McpExtensions',
+      'FallbackTool',
+    );
+    mkdirSync(toolDir, { recursive: true });
+    writeFileSync(
+      join(toolDir, 'SKILL.md'),
+      ['---', 'name: uloop-fallback-tool', '---', '', 'Run `uloop compile`.', ''].join('\n'),
+      'utf-8',
+    );
+
+    process.chdir(projectRoot);
+
+    expect(() => getAllSkillStatuses(getTargetConfig('claude'), false, true)).not.toThrow();
+  });
+
+  it('should reject project CLI installs when the package version cannot be resolved', () => {
+    const projectRoot = createUnityProjectRoot();
+    process.chdir(projectRoot);
+
+    expect(() => installAllSkills(getTargetConfig('claude'), false, true, 'npx')).toThrow(
+      'Cannot install skills with project CLI version because Unity CLI Loop package root was not found.',
+    );
+  });
+
   it('should install run-tests skill when test framework package is missing', () => {
     const projectRoot = createUnityProjectRoot();
     writeProjectPackageVersion(projectRoot, '2.9.0');

--- a/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
+++ b/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
@@ -217,6 +217,7 @@ describe('skill install layout', () => {
   function writeProjectPackageVersion(projectRoot: string, version: string): void {
     const packageRoot = join(projectRoot, 'Packages', 'src');
     mkdirSync(packageRoot, { recursive: true });
+    mkdirSync(join(packageRoot, 'Editor', 'Api', 'McpTools'), { recursive: true });
     writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({ version }), 'utf-8');
   }
 
@@ -340,6 +341,7 @@ describe('skill install layout', () => {
 
   it('should discover project skills from a direct SKILL.md in the tool folder', () => {
     const projectRoot = createUnityProjectRoot();
+    writeProjectPackageVersion(projectRoot, '2.9.0');
     const toolDir = join(projectRoot, 'Assets', 'Vision', 'Editor', 'McpExtensions', 'ReplayTool');
     mkdirSync(toolDir, { recursive: true });
     writeFileSync(
@@ -367,6 +369,7 @@ describe('skill install layout', () => {
 
   it('should install run-tests skill when test framework package is missing', () => {
     const projectRoot = createUnityProjectRoot();
+    writeProjectPackageVersion(projectRoot, '2.9.0');
     const runTestsSkillDir = join(
       projectRoot,
       'Packages',
@@ -441,6 +444,7 @@ describe('skill install layout', () => {
 
   it('should ignore sibling implementation files beside a direct SKILL.md in the tool folder', () => {
     const projectRoot = createUnityProjectRoot();
+    writeProjectPackageVersion(projectRoot, '2.9.0');
     const toolDir = join(projectRoot, 'Assets', 'Vision', 'Editor', 'McpExtensions', 'CaptureTool');
     mkdirSync(toolDir, { recursive: true });
     const skillContent = [

--- a/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
+++ b/Packages/src/Cli~/src/__tests__/skills-manager.test.ts
@@ -416,7 +416,7 @@ describe('skill install layout', () => {
 
     expect(installedSkill).toContain('name: uloop-test-npx-skill');
     expect(installedSkill).toContain('`npx --yes uloop-cli@2.9.0 compile`');
-    expect(installedReference).toBe('Run `uloop compile` in examples.');
+    expect(installedReference).toBe('Run `npx --yes uloop-cli@2.9.0 compile` in examples.');
   });
 
   it('should mark npx-installed skills as outdated when the project setting returns to global', () => {

--- a/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
+++ b/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
@@ -163,6 +163,17 @@ describe('tool-settings-loader', () => {
       expect(saved.disabledTools).toEqual(['compile']);
       expect(saved.skillCliInvocation).toBe('npx');
     });
+
+    it('should replace array settings when saving invocation', () => {
+      writeFileSync(join(testDir, '.uloop', 'settings.tools.json'), JSON.stringify([]));
+
+      saveSkillCliInvocation('global');
+
+      const saved = JSON.parse(
+        readFileSync(join(testDir, '.uloop', 'settings.tools.json'), 'utf-8'),
+      ) as { skillCliInvocation?: string };
+      expect(saved.skillCliInvocation).toBe('global');
+    });
   });
 
   // ── isToolEnabled ──────────────────────────────────────────────

--- a/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
+++ b/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
@@ -110,10 +110,10 @@ describe('tool-settings-loader', () => {
   // ── skill CLI invocation ───────────────────────────────────────
 
   describe('skill CLI invocation', () => {
-    it('should return global when settings file does not exist', () => {
+    it('should return npx when settings file does not exist', () => {
       const result = loadSkillCliInvocation();
 
-      expect(result).toBe('global');
+      expect(result).toBe('npx');
     });
 
     it('should return npx from settings file', () => {
@@ -127,10 +127,21 @@ describe('tool-settings-loader', () => {
       expect(result).toBe('npx');
     });
 
-    it('should return global for invalid settings value', () => {
+    it('should return npx for invalid settings value', () => {
       writeFileSync(
         join(testDir, '.uloop', 'settings.tools.json'),
         JSON.stringify({ skillCliInvocation: 'invalid' }),
+      );
+
+      const result = loadSkillCliInvocation();
+
+      expect(result).toBe('npx');
+    });
+
+    it('should return global from settings file', () => {
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ skillCliInvocation: 'global' }),
       );
 
       const result = loadSkillCliInvocation();

--- a/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
+++ b/Packages/src/Cli~/src/__tests__/tool-settings-loader.test.ts
@@ -5,7 +5,7 @@
  * Uses temporary directories to avoid affecting real project settings.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -17,7 +17,13 @@ jest.mock('../project-root.js', () => ({
 }));
 
 // Import after mocking
-import { loadDisabledTools, isToolEnabled, filterEnabledTools } from '../tool-settings-loader.js';
+import {
+  filterEnabledTools,
+  isToolEnabled,
+  loadDisabledTools,
+  loadSkillCliInvocation,
+  saveSkillCliInvocation,
+} from '../tool-settings-loader.js';
 import type { ToolDefinition } from '../tool-cache.js';
 
 describe('tool-settings-loader', () => {
@@ -98,6 +104,53 @@ describe('tool-settings-loader', () => {
       const result: string[] = loadDisabledTools();
 
       expect(result).toEqual([]);
+    });
+  });
+
+  // ── skill CLI invocation ───────────────────────────────────────
+
+  describe('skill CLI invocation', () => {
+    it('should return global when settings file does not exist', () => {
+      const result = loadSkillCliInvocation();
+
+      expect(result).toBe('global');
+    });
+
+    it('should return npx from settings file', () => {
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ skillCliInvocation: 'npx' }),
+      );
+
+      const result = loadSkillCliInvocation();
+
+      expect(result).toBe('npx');
+    });
+
+    it('should return global for invalid settings value', () => {
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ skillCliInvocation: 'invalid' }),
+      );
+
+      const result = loadSkillCliInvocation();
+
+      expect(result).toBe('global');
+    });
+
+    it('should save invocation while preserving disabled tools', () => {
+      writeFileSync(
+        join(testDir, '.uloop', 'settings.tools.json'),
+        JSON.stringify({ disabledTools: ['compile'] }),
+      );
+
+      saveSkillCliInvocation('npx');
+
+      const saved = JSON.parse(
+        readFileSync(join(testDir, '.uloop', 'settings.tools.json'), 'utf-8'),
+      ) as { disabledTools?: string[]; skillCliInvocation?: string };
+      expect(saved.disabledTools).toEqual(['compile']);
+      expect(saved.skillCliInvocation).toBe('npx');
     });
   });
 

--- a/Packages/src/Cli~/src/skills/skills-command.ts
+++ b/Packages/src/Cli~/src/skills/skills-command.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_GROUP_MANAGED_SKILLS,
 } from './skills-manager.js';
 import { TargetConfig, ALL_TARGET_IDS, getTargetConfig } from './target-config.js';
+import type { SkillCliInvocation } from '../tool-settings-loader.js';
 
 interface SkillsOptions {
   global?: boolean;
@@ -26,6 +27,7 @@ interface SkillsOptions {
   agents?: boolean;
   windsurf?: boolean;
   antigravity?: boolean;
+  cliInvocation?: string;
 }
 
 export function registerSkillsCommand(program: Command): void {
@@ -63,13 +65,23 @@ export function registerSkillsCommand(program: Command): void {
     .option('--agents', 'Install to generic .agents target')
     .option('--windsurf', 'Install to Windsurf')
     .option('--antigravity', 'Install to Antigravity')
+    .option('--cli-invocation <mode>', 'Skill CLI invocation mode: global or npx')
     .action((options: SkillsOptions) => {
       const targets = resolveTargets(options);
       if (targets.length === 0) {
         showTargetGuidance('install');
         return;
       }
-      installSkills(targets, options.global ?? false, DEFAULT_GROUP_MANAGED_SKILLS);
+      const cliInvocation = resolveCliInvocationOption(options.cliInvocation);
+      if (cliInvocation === null) {
+        return;
+      }
+      const global = options.global ?? false;
+      if (global && cliInvocation === 'npx') {
+        console.log('The --cli-invocation npx option is only available for project installs.');
+        return;
+      }
+      installSkills(targets, global, DEFAULT_GROUP_MANAGED_SKILLS, cliInvocation);
     });
 
   skillsCmd
@@ -200,6 +212,7 @@ function installSkills(
   targets: TargetConfig[],
   global: boolean,
   groupManagedSkills: boolean,
+  cliInvocation?: SkillCliInvocation,
 ): void {
   const location = global ? 'global' : 'project';
 
@@ -208,7 +221,7 @@ function installSkills(
 
   for (const target of targets) {
     const dir = getInstallDir(target, global, groupManagedSkills);
-    const result = installAllSkills(target, global, groupManagedSkills);
+    const result = installAllSkills(target, global, groupManagedSkills, cliInvocation);
 
     console.log(`${target.displayName}:`);
     console.log(`  \x1b[32m✓\x1b[0m Installed: ${result.installed}`);
@@ -220,6 +233,21 @@ function installSkills(
     console.log(`  Location: ${dir}`);
     console.log('');
   }
+}
+
+function resolveCliInvocationOption(
+  value: string | undefined,
+): SkillCliInvocation | undefined | null {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === 'global' || value === 'npx') {
+    return value;
+  }
+
+  console.log('The --cli-invocation option must be either global or npx.');
+  return null;
 }
 
 function uninstallSkills(

--- a/Packages/src/Cli~/src/skills/skills-manager.ts
+++ b/Packages/src/Cli~/src/skills/skills-manager.ts
@@ -19,7 +19,7 @@ import {
   readdirSync,
   renameSync,
 } from 'fs';
-import { join, dirname, resolve, isAbsolute, sep } from 'path';
+import { join, dirname, resolve, isAbsolute, sep, extname } from 'path';
 import { homedir } from 'os';
 import { TargetConfig } from './target-config.js';
 import { findUnityProjectRoot, getUnityProjectStatus } from '../project-root.js';
@@ -88,6 +88,7 @@ class SkillsPathConstants {
   public static readonly NPX_COMMAND = 'npx';
   public static readonly NPX_YES_FLAG = '--yes';
   public static readonly NPM_CLI_PACKAGE_NAME = 'uloop-cli';
+  public static readonly MARKDOWN_FILE_EXTENSION = '.md';
   public static readonly PACKAGE_NAMES = [
     SkillsPathConstants.PACKAGE_NAME,
     SkillsPathConstants.PACKAGE_NAME_ALIAS,
@@ -1018,7 +1019,31 @@ function formatSkillsForCliInvocation(
   return skills.map((skill) => ({
     ...skill,
     content: formatSkillContentForNpx(skill.content, packageVersion),
+    additionalFiles: formatAdditionalSkillFilesForNpx(skill.additionalFiles, packageVersion),
   }));
+}
+
+function formatAdditionalSkillFilesForNpx(
+  additionalFiles: Record<string, Buffer> | undefined,
+  packageVersion: string,
+): Record<string, Buffer> | undefined {
+  if (!additionalFiles) {
+    return undefined;
+  }
+
+  const formattedFiles: Record<string, Buffer> = {};
+  for (const [relativePath, content] of Object.entries(additionalFiles)) {
+    const formattedContent = isMarkdownSkillFile(relativePath)
+      ? Buffer.from(formatSkillContentForNpx(content.toString('utf-8'), packageVersion), 'utf-8')
+      : content;
+    // eslint-disable-next-line security/detect-object-injection -- Paths are controlled by package files, not user input.
+    formattedFiles[relativePath] = formattedContent;
+  }
+  return formattedFiles;
+}
+
+function isMarkdownSkillFile(relativePath: string): boolean {
+  return extname(relativePath).toLowerCase() === SkillsPathConstants.MARKDOWN_FILE_EXTENSION;
 }
 
 function formatSkillContentForNpx(content: string, packageVersion: string): string {

--- a/Packages/src/Cli~/src/skills/skills-manager.ts
+++ b/Packages/src/Cli~/src/skills/skills-manager.ts
@@ -783,12 +783,13 @@ export function installAllSkills(
   };
 
   const cliInvocation = resolveSkillCliInvocation(global, requestedInvocation);
+  const baseDir = getSkillsBaseDir(target, global);
+  ensurePackageVersionForNpxInstall(cliInvocation);
   if (!global && requestedInvocation !== undefined) {
     saveSkillCliInvocation(requestedInvocation);
   }
 
   const allSkills = collectAllSkills(cliInvocation);
-  const baseDir = getSkillsBaseDir(target, global);
   result.deprecatedRemoved = removeDeprecatedSkillDirs(baseDir);
   if (groupManagedSkills) {
     migrateLegacyManagedSkills(
@@ -1015,12 +1016,32 @@ function formatSkillsForCliInvocation(
     return skills;
   }
 
-  assert(packageVersion !== null, 'packageVersion must be resolved for npx skill invocation');
+  if (packageVersion === null) {
+    return skills;
+  }
+
   return skills.map((skill) => ({
     ...skill,
     content: formatSkillContentForNpx(skill.content, packageVersion),
     additionalFiles: formatAdditionalSkillFilesForNpx(skill.additionalFiles, packageVersion),
   }));
+}
+
+function ensurePackageVersionForNpxInstall(cliInvocation: SkillCliInvocation): void {
+  if (cliInvocation === 'global') {
+    return;
+  }
+
+  const projectRoot = findUnityProjectRoot();
+  const packageRoot = projectRoot ? resolvePackageRoot(projectRoot) : null;
+  if (packageRoot !== null) {
+    readPackageVersion(packageRoot);
+    return;
+  }
+
+  throw new Error(
+    `Cannot install skills with project CLI version because ${PRODUCT_DISPLAY_NAME} package root was not found.`,
+  );
 }
 
 function formatAdditionalSkillFilesForNpx(

--- a/Packages/src/Cli~/src/skills/skills-manager.ts
+++ b/Packages/src/Cli~/src/skills/skills-manager.ts
@@ -24,7 +24,13 @@ import { homedir } from 'os';
 import { TargetConfig } from './target-config.js';
 import { findUnityProjectRoot, getUnityProjectStatus } from '../project-root.js';
 import { DEPRECATED_SKILLS } from './deprecated-skills.js';
-import { isToolEnabled, loadDisabledTools } from '../tool-settings-loader.js';
+import {
+  isToolEnabled,
+  loadDisabledTools,
+  loadSkillCliInvocation,
+  saveSkillCliInvocation,
+  type SkillCliInvocation,
+} from '../tool-settings-loader.js';
 
 type SkillStatus = 'installed' | 'not_installed' | 'outdated';
 
@@ -78,11 +84,17 @@ class SkillsPathConstants {
   public static readonly PATH_PROTOCOL = 'path:';
   public static readonly PACKAGE_NAME = 'io.github.hatayama.uloopmcp';
   public static readonly PACKAGE_NAME_ALIAS = 'io.github.hatayama.uLoopMCP';
+  public static readonly PACKAGE_JSON_FILE = 'package.json';
+  public static readonly NPX_COMMAND = 'npx';
+  public static readonly NPX_YES_FLAG = '--yes';
+  public static readonly NPM_CLI_PACKAGE_NAME = 'uloop-cli';
   public static readonly PACKAGE_NAMES = [
     SkillsPathConstants.PACKAGE_NAME,
     SkillsPathConstants.PACKAGE_NAME_ALIAS,
   ];
 }
+
+const ULOOP_COMMAND_PATTERN = /(^|[^A-Za-z0-9_-])uloop(?=\s)/g;
 
 function getGlobalSkillsRoot(target: TargetConfig): string {
   return join(homedir(), target.projectDir, 'skills');
@@ -628,7 +640,8 @@ export function getAllSkillStatuses(
   global: boolean,
   groupManagedSkills: boolean = DEFAULT_GROUP_MANAGED_SKILLS,
 ): SkillInfo[] {
-  const allSkills = collectAllSkills();
+  const cliInvocation = resolveSkillCliInvocation(global);
+  const allSkills = collectAllSkills(cliInvocation);
   return allSkills.map((skill) => ({
     name: skill.name,
     status: getSkillStatus(skill, target, global, groupManagedSkills),
@@ -757,6 +770,7 @@ export function installAllSkills(
   target: TargetConfig,
   global: boolean,
   groupManagedSkills: boolean = DEFAULT_GROUP_MANAGED_SKILLS,
+  requestedInvocation?: SkillCliInvocation,
 ): InstallResult {
   const result: InstallResult = {
     installed: 0,
@@ -767,7 +781,12 @@ export function installAllSkills(
     deprecatedRemoved: 0,
   };
 
-  const allSkills = collectAllSkills();
+  const cliInvocation = resolveSkillCliInvocation(global, requestedInvocation);
+  if (!global && requestedInvocation !== undefined) {
+    saveSkillCliInvocation(requestedInvocation);
+  }
+
+  const allSkills = collectAllSkills(cliInvocation);
   const baseDir = getSkillsBaseDir(target, global);
   result.deprecatedRemoved = removeDeprecatedSkillDirs(baseDir);
   if (groupManagedSkills) {
@@ -834,7 +853,7 @@ export function uninstallAllSkills(
   const baseDir = getSkillsBaseDir(target, global);
   result.removed += removeDeprecatedSkillDirs(baseDir);
 
-  const allSkills = collectAllSkills();
+  const allSkills = collectAllSkills('global');
   for (const skill of allSkills) {
     const removed = groupManagedSkills
       ? uninstallSkill(skill, target, global, groupManagedSkills)
@@ -860,17 +879,23 @@ export function getInstallDir(
 }
 
 export function getTotalSkillCount(): number {
-  return collectAllSkills().length;
+  return collectAllSkills('global').length;
 }
 
-function collectAllSkills(): SkillDefinition[] {
+function collectAllSkills(cliInvocation: SkillCliInvocation): SkillDefinition[] {
   const projectRoot = findUnityProjectRoot();
   const packageRoot = projectRoot ? resolvePackageRoot(projectRoot) : null;
   const packageSkills = packageRoot ? collectPackageSkillsFromRoot(packageRoot) : [];
   const cliOnlySkills = collectCliOnlySkills();
   const projectSkills = collectProjectSkills(packageRoot ? [packageRoot] : []);
+  const packageVersion =
+    cliInvocation === 'npx' && packageRoot ? readPackageVersion(packageRoot) : null;
 
-  return dedupeSkillsByName([packageSkills, cliOnlySkills, projectSkills]);
+  return formatSkillsForCliInvocation(
+    dedupeSkillsByName([packageSkills, cliOnlySkills, projectSkills]),
+    cliInvocation,
+    packageVersion,
+  );
 }
 
 function collectPackageSkillsFromRoot(packageRoot: string): SkillDefinition[] {
@@ -967,6 +992,71 @@ function dedupeSkillsByName(skillGroups: SkillDefinition[][]): SkillDefinition[]
     }
   }
   return merged;
+}
+
+function resolveSkillCliInvocation(
+  global: boolean,
+  requestedInvocation?: SkillCliInvocation,
+): SkillCliInvocation {
+  if (global) {
+    return 'global';
+  }
+
+  return requestedInvocation ?? loadSkillCliInvocation();
+}
+
+function formatSkillsForCliInvocation(
+  skills: SkillDefinition[],
+  cliInvocation: SkillCliInvocation,
+  packageVersion: string | null,
+): SkillDefinition[] {
+  if (cliInvocation === 'global') {
+    return skills;
+  }
+
+  assert(packageVersion !== null, 'packageVersion must be resolved for npx skill invocation');
+  return skills.map((skill) => ({
+    ...skill,
+    content: formatSkillContentForNpx(skill.content, packageVersion),
+  }));
+}
+
+function formatSkillContentForNpx(content: string, packageVersion: string): string {
+  const npxCommand = [
+    SkillsPathConstants.NPX_COMMAND,
+    SkillsPathConstants.NPX_YES_FLAG,
+    `${SkillsPathConstants.NPM_CLI_PACKAGE_NAME}@${packageVersion}`,
+  ].join(' ');
+  const { frontmatter, body } = splitFrontmatter(content);
+
+  return `${frontmatter}${body.replace(
+    ULOOP_COMMAND_PATTERN,
+    (_match: string, prefix: string) => `${prefix}${npxCommand}`,
+  )}`;
+}
+
+function splitFrontmatter(content: string): { frontmatter: string; body: string } {
+  const match = content.match(/^(---\r?\n[\s\S]*?\r?\n---)(\r?\n?)([\s\S]*)$/);
+  if (!match) {
+    return { frontmatter: '', body: content };
+  }
+
+  return {
+    frontmatter: `${match[1]}${match[2]}`,
+    body: match[3],
+  };
+}
+
+function readPackageVersion(packageRoot: string): string {
+  const packageJsonPath = join(packageRoot, SkillsPathConstants.PACKAGE_JSON_FILE);
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+    version?: unknown;
+  };
+  assert(
+    typeof packageJson.version === 'string' && packageJson.version.length > 0,
+    'package.json version must be a non-empty string',
+  );
+  return packageJson.version;
 }
 
 function resolvePackageRoot(projectRoot: string): string | null {

--- a/Packages/src/Cli~/src/tool-settings-loader.ts
+++ b/Packages/src/Cli~/src/tool-settings-loader.ts
@@ -6,7 +6,7 @@
 // File paths are constructed from Unity project root, not from untrusted user input
 /* eslint-disable security/detect-non-literal-fs-filename */
 
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { findUnityProjectRoot } from './project-root.js';
 import type { ToolDefinition } from './tool-cache.js';
@@ -20,8 +20,15 @@ const RUN_TESTS_TOOL_NAME = 'run-tests';
 const UNITY_TEST_FRAMEWORK_DEPENDENCY_PATTERN = /"com\.unity\.test-framework"\s*:/;
 
 interface ToolSettingsData {
-  disabledTools: string[];
+  disabledTools?: unknown;
+  skillCliInvocation?: unknown;
+  [key: string]: unknown;
 }
+
+export type SkillCliInvocation = 'global' | 'npx';
+
+const DEFAULT_SKILL_CLI_INVOCATION: SkillCliInvocation = 'global';
+const SKILL_CLI_INVOCATIONS = new Set<SkillCliInvocation>(['global', 'npx']);
 
 export function loadDisabledTools(projectPath?: string): string[] {
   const projectRoot: string | null = resolveProjectRoot(projectPath);
@@ -74,36 +81,76 @@ function resolveProjectRoot(projectPath?: string): string | null {
 }
 
 function loadDisabledToolsFromProjectRoot(projectRoot: string): string[] {
+  const data = loadToolSettingsFromProjectRoot(projectRoot);
+  if (!Array.isArray(data.disabledTools)) {
+    return [];
+  }
+
+  return data.disabledTools as string[];
+}
+
+export function loadSkillCliInvocation(projectPath?: string): SkillCliInvocation {
+  const projectRoot: string | null = resolveProjectRoot(projectPath);
+  if (projectRoot === null) {
+    return DEFAULT_SKILL_CLI_INVOCATION;
+  }
+
+  const data = loadToolSettingsFromProjectRoot(projectRoot);
+  return normalizeSkillCliInvocation(data.skillCliInvocation);
+}
+
+export function saveSkillCliInvocation(invocation: SkillCliInvocation, projectPath?: string): void {
+  const projectRoot: string | null = resolveProjectRoot(projectPath);
+  if (projectRoot === null) {
+    throw new Error('Unity project root is required to save skill CLI invocation settings.');
+  }
+
+  const settingsDir: string = join(projectRoot, ULOOP_DIR);
+  mkdirSync(settingsDir, { recursive: true });
+
+  const data = loadToolSettingsFromProjectRoot(projectRoot);
+  data.skillCliInvocation = normalizeSkillCliInvocation(invocation);
+  writeFileSync(join(settingsDir, TOOL_SETTINGS_FILE), JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function loadToolSettingsFromProjectRoot(projectRoot: string): ToolSettingsData {
   const settingsPath: string = join(projectRoot, ULOOP_DIR, TOOL_SETTINGS_FILE);
 
   let content: string;
   try {
     content = readFileSync(settingsPath, 'utf-8');
   } catch {
-    return [];
+    return {};
   }
 
   if (!content.trim()) {
-    return [];
+    return {};
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);
   } catch {
-    return [];
+    return {};
   }
 
   if (typeof parsed !== 'object' || parsed === null) {
-    return [];
+    return {};
   }
 
-  const data = parsed as ToolSettingsData;
-  if (!Array.isArray(data.disabledTools)) {
-    return [];
+  return parsed as ToolSettingsData;
+}
+
+function normalizeSkillCliInvocation(value: unknown): SkillCliInvocation {
+  if (typeof value !== 'string') {
+    return DEFAULT_SKILL_CLI_INVOCATION;
   }
 
-  return data.disabledTools;
+  if (!SKILL_CLI_INVOCATIONS.has(value as SkillCliInvocation)) {
+    return DEFAULT_SKILL_CLI_INVOCATION;
+  }
+
+  return value as SkillCliInvocation;
 }
 
 function shouldBypassDisabledSettingForDependencyError(

--- a/Packages/src/Cli~/src/tool-settings-loader.ts
+++ b/Packages/src/Cli~/src/tool-settings-loader.ts
@@ -134,7 +134,7 @@ function loadToolSettingsFromProjectRoot(projectRoot: string): ToolSettingsData 
     return {};
   }
 
-  if (typeof parsed !== 'object' || parsed === null) {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     return {};
   }
 

--- a/Packages/src/Cli~/src/tool-settings-loader.ts
+++ b/Packages/src/Cli~/src/tool-settings-loader.ts
@@ -27,7 +27,7 @@ interface ToolSettingsData {
 
 export type SkillCliInvocation = 'global' | 'npx';
 
-const DEFAULT_SKILL_CLI_INVOCATION: SkillCliInvocation = 'global';
+const DEFAULT_SKILL_CLI_INVOCATION: SkillCliInvocation = 'npx';
 const SKILL_CLI_INVOCATIONS = new Set<SkillCliInvocation>(['global', 'npx']);
 
 export function loadDisabledTools(projectPath?: string): string[] {

--- a/Packages/src/Editor/CLI/CliConstants.cs
+++ b/Packages/src/Editor/CLI/CliConstants.cs
@@ -3,10 +3,14 @@ namespace io.github.hatayama.uLoopMCP
     public static class CliConstants
     {
         public const string EXECUTABLE_NAME = "uloop";
+        public const string NPX_EXECUTABLE_NAME = "npx";
+        public const string NPX_YES_FLAG = "--yes";
         public const string NPM_PACKAGE_NAME = "uloop-cli";
         public const string VERSION_FLAG = "--version";
         public const int NPM_INSTALL_TIMEOUT_MS = 30000;
         public const string SKILL_DIR_PREFIX = "uloop-";
         public const string SKILL_DIR_GLOB = "uloop-*";
+        public const string SKILL_CLI_INVOCATION_GLOBAL = "global";
+        public const string SKILL_CLI_INVOCATION_NPX = "npx";
     }
 }

--- a/Packages/src/Editor/Config/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Config/SkillInstallLayout.cs
@@ -17,6 +17,7 @@ namespace io.github.hatayama.uLoopMCP
         private const string CliPackageDirName = "Cli~";
         private const string CliSkillDefinitionsDirName = "skill-definitions";
         private const string CliOnlySkillDefinitionsDirName = "cli-only";
+        private const string MarkdownFileExtension = ".md";
         private static readonly HashSet<string> ExcludedFileNames = new()
         {
             ".meta",
@@ -359,12 +360,29 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             Debug.Assert(skillFiles.ContainsKey(SkillFileName), "skillFiles must contain SKILL.md");
-            string skillContent = Encoding.UTF8.GetString(skillFiles[SkillFileName]);
-            string formattedContent = FormatSkillMarkdownForNpx(
-                skillContent,
-                McpConstants.PackageInfo.version);
-            skillFiles[SkillFileName] = Encoding.UTF8.GetBytes(formattedContent);
+            foreach (string relativePath in skillFiles.Keys.ToArray())
+            {
+                if (!IsMarkdownSkillFile(relativePath))
+                {
+                    continue;
+                }
+
+                string skillContent = Encoding.UTF8.GetString(skillFiles[relativePath]);
+                string formattedContent = FormatSkillMarkdownForNpx(
+                    skillContent,
+                    McpConstants.PackageInfo.version);
+                skillFiles[relativePath] = Encoding.UTF8.GetBytes(formattedContent);
+            }
             return skillFiles;
+        }
+
+        private static bool IsMarkdownSkillFile(string relativePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(relativePath), "relativePath must not be null or empty");
+            return string.Equals(
+                Path.GetExtension(relativePath),
+                MarkdownFileExtension,
+                StringComparison.OrdinalIgnoreCase);
         }
 
         private static string FormatSkillMarkdownForNpx(string content, string packageVersion)

--- a/Packages/src/Editor/Config/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Config/SkillInstallLayout.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using UnityEngine;
@@ -22,6 +23,9 @@ namespace io.github.hatayama.uLoopMCP
             ".DS_Store",
             ".gitkeep"
         };
+        private static readonly Regex UloopCommandPattern = new(
+            "(^|[^A-Za-z0-9_-])uloop(?=\\s)",
+            RegexOptions.Compiled);
 
         private sealed class SkillSourceDefinition
         {
@@ -330,15 +334,60 @@ namespace io.github.hatayama.uLoopMCP
             Debug.Assert(!string.IsNullOrEmpty(skillDirectory), "skillDirectory must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(skillFilePath), "skillFilePath must not be null or empty");
 
+            Dictionary<string, byte[]> sourceFiles;
             if (string.Equals(Path.GetFileName(skillDirectory), "Skill", StringComparison.Ordinal))
             {
-                return CollectInstalledSkillFiles(skillDirectory);
+                sourceFiles = CollectInstalledSkillFiles(skillDirectory);
+                return FormatSkillFilesForCliInvocation(sourceFiles);
             }
 
-            return new Dictionary<string, byte[]>(StringComparer.Ordinal)
+            sourceFiles = new Dictionary<string, byte[]>(StringComparer.Ordinal)
             {
                 [SkillFileName] = File.ReadAllBytes(skillFilePath)
             };
+            return FormatSkillFilesForCliInvocation(sourceFiles);
+        }
+
+        private static Dictionary<string, byte[]> FormatSkillFilesForCliInvocation(
+            Dictionary<string, byte[]> skillFiles)
+        {
+            Debug.Assert(skillFiles != null, "skillFiles must not be null");
+
+            if (ToolSettings.GetSkillCliInvocation() == CliConstants.SKILL_CLI_INVOCATION_GLOBAL)
+            {
+                return skillFiles;
+            }
+
+            Debug.Assert(skillFiles.ContainsKey(SkillFileName), "skillFiles must contain SKILL.md");
+            string skillContent = Encoding.UTF8.GetString(skillFiles[SkillFileName]);
+            string formattedContent = FormatSkillMarkdownForNpx(
+                skillContent,
+                McpConstants.PackageInfo.version);
+            skillFiles[SkillFileName] = Encoding.UTF8.GetBytes(formattedContent);
+            return skillFiles;
+        }
+
+        private static string FormatSkillMarkdownForNpx(string content, string packageVersion)
+        {
+            Debug.Assert(content != null, "content must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(packageVersion), "packageVersion must not be null or empty");
+
+            string npxCommand =
+                $"{CliConstants.NPX_EXECUTABLE_NAME} {CliConstants.NPX_YES_FLAG} {CliConstants.NPM_PACKAGE_NAME}@{packageVersion}";
+            Match frontmatterMatch = Regex.Match(
+                content,
+                "^(---\\r?\\n[\\s\\S]*?\\r?\\n---)(\\r?\\n?)([\\s\\S]*)$");
+            if (!frontmatterMatch.Success)
+            {
+                return UloopCommandPattern.Replace(content, match => $"{match.Groups[1].Value}{npxCommand}");
+            }
+
+            string frontmatter = $"{frontmatterMatch.Groups[1].Value}{frontmatterMatch.Groups[2].Value}";
+            string body = frontmatterMatch.Groups[3].Value;
+            string formattedBody = UloopCommandPattern.Replace(
+                body,
+                match => $"{match.Groups[1].Value}{npxCommand}");
+            return $"{frontmatter}{formattedBody}";
         }
 
         private static Dictionary<string, SkillSourceDefinition> GetSkillSources(string projectRoot)

--- a/Packages/src/Editor/Config/ToolSettings.cs
+++ b/Packages/src/Editor/Config/ToolSettings.cs
@@ -157,9 +157,9 @@ namespace io.github.hatayama.uLoopMCP
 
         private static string NormalizeSkillCliInvocation(string invocation)
         {
-            return invocation == CliConstants.SKILL_CLI_INVOCATION_NPX
-                ? CliConstants.SKILL_CLI_INVOCATION_NPX
-                : CliConstants.SKILL_CLI_INVOCATION_GLOBAL;
+            return invocation == CliConstants.SKILL_CLI_INVOCATION_GLOBAL
+                ? CliConstants.SKILL_CLI_INVOCATION_GLOBAL
+                : CliConstants.SKILL_CLI_INVOCATION_NPX;
         }
     }
 }

--- a/Packages/src/Editor/Config/ToolSettings.cs
+++ b/Packages/src/Editor/Config/ToolSettings.cs
@@ -30,19 +30,20 @@ namespace io.github.hatayama.uLoopMCP
         {
             Debug.Assert(settings != null, "settings must not be null");
 
+            ToolSettingsData normalizedSettings = NormalizeSettings(settings);
             string directory = Path.GetDirectoryName(SettingsFilePath);
             if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
             {
                 Directory.CreateDirectory(directory);
             }
 
-            string json = JsonUtility.ToJson(settings, true);
+            string json = JsonUtility.ToJson(normalizedSettings, true);
 
             Debug.Assert(json.Length <= McpConstants.MAX_SETTINGS_SIZE_BYTES,
                 "Settings JSON content exceeds size limit");
 
             AtomicFileWriter.Write(SettingsFilePath, json);
-            _cachedSettings = settings;
+            _cachedSettings = normalizedSettings;
 
             AtomicFileWriter.CleanupBackup(SettingsFilePath + ".bak");
         }
@@ -85,6 +86,26 @@ namespace io.github.hatayama.uLoopMCP
             return GetSettings().disabledTools;
         }
 
+        public static string GetSkillCliInvocation()
+        {
+            return NormalizeSkillCliInvocation(GetSettings().skillCliInvocation);
+        }
+
+        public static void SetSkillCliInvocation(string invocation)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(invocation), "invocation must not be null or empty");
+
+            ToolSettingsData settings = GetSettings();
+            string normalizedInvocation = NormalizeSkillCliInvocation(invocation);
+            if (settings.skillCliInvocation == normalizedInvocation)
+            {
+                return;
+            }
+
+            ToolSettingsData updated = settings with { skillCliInvocation = normalizedInvocation };
+            SaveSettings(updated);
+        }
+
         public static void InvalidateCache()
         {
             _cachedSettings = null;
@@ -109,17 +130,36 @@ namespace io.github.hatayama.uLoopMCP
                 }
 
                 ToolSettingsData loaded = JsonUtility.FromJson<ToolSettingsData>(json);
-                // disabledTools can be null when JSON is hand-edited with "disabledTools": null
-                if (loaded == null || loaded.disabledTools == null)
+                if (loaded == null)
                 {
                     _cachedSettings = new ToolSettingsData();
                     return;
                 }
-                _cachedSettings = loaded;
+                _cachedSettings = NormalizeSettings(loaded);
                 return;
             }
 
             _cachedSettings = new ToolSettingsData();
+        }
+
+        private static ToolSettingsData NormalizeSettings(ToolSettingsData settings)
+        {
+            Debug.Assert(settings != null, "settings must not be null");
+
+            string[] disabledTools = settings.disabledTools ?? Array.Empty<string>();
+            string skillCliInvocation = NormalizeSkillCliInvocation(settings.skillCliInvocation);
+            return settings with
+            {
+                disabledTools = disabledTools,
+                skillCliInvocation = skillCliInvocation
+            };
+        }
+
+        private static string NormalizeSkillCliInvocation(string invocation)
+        {
+            return invocation == CliConstants.SKILL_CLI_INVOCATION_NPX
+                ? CliConstants.SKILL_CLI_INVOCATION_NPX
+                : CliConstants.SKILL_CLI_INVOCATION_GLOBAL;
         }
     }
 }

--- a/Packages/src/Editor/Config/ToolSettingsData.cs
+++ b/Packages/src/Editor/Config/ToolSettingsData.cs
@@ -6,5 +6,6 @@ namespace io.github.hatayama.uLoopMCP
     public record ToolSettingsData
     {
         public string[] disabledTools = Array.Empty<string>();
+        public string skillCliInvocation = CliConstants.SKILL_CLI_INVOCATION_GLOBAL;
     }
 }

--- a/Packages/src/Editor/Config/ToolSettingsData.cs
+++ b/Packages/src/Editor/Config/ToolSettingsData.cs
@@ -6,6 +6,6 @@ namespace io.github.hatayama.uLoopMCP
     public record ToolSettingsData
     {
         public string[] disabledTools = Array.Empty<string>();
-        public string skillCliInvocation = CliConstants.SKILL_CLI_INVOCATION_GLOBAL;
+        public string skillCliInvocation = CliConstants.SKILL_CLI_INVOCATION_NPX;
     }
 }

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -100,6 +100,7 @@ namespace io.github.hatayama.uLoopMCP
                 RefreshSelectedTargetInstallStateInBackground();
             };
             _view.OnGroupSkillsChanged += HandleGroupSkillsChanged;
+            _view.OnUseProjectCliVersionChanged += HandleUseProjectCliVersionChanged;
             _view.OnConfigurationFoldoutChanged += UpdateShowConfiguration;
             _view.OnConnectedToolsFoldoutChanged += UpdateShowConnectedTools;
             _view.OnEditorTypeChanged += UpdateSelectedEditorType;
@@ -788,6 +789,8 @@ namespace io.github.hatayama.uLoopMCP
                 needsDowngrade = comparisonAvailable && cliVersionComparison > 0;
             }
             bool groupSkillsUnderUnityCliLoop = !_installSkillsFlat;
+            bool useProjectCliVersion =
+                ToolSettings.GetSkillCliInvocation() == CliConstants.SKILL_CLI_INVOCATION_NPX;
             SkillInstallState selectedTargetInstallState = includeSkillDirectoryChecks
                 ? _selectedTargetInstallState
                 : SkillInstallState.Checking;
@@ -809,6 +812,7 @@ namespace io.github.hatayama.uLoopMCP
                 selectedTargetInstallState,
                 _skillsTarget,
                 groupSkillsUnderUnityCliLoop,
+                useProjectCliVersion,
                 _isInstallingSkills);
         }
 
@@ -1000,6 +1004,16 @@ namespace io.github.hatayama.uLoopMCP
         private void HandleGroupSkillsChanged(bool groupSkillsUnderUnityCliLoop)
         {
             ApplyFlatSkillInstallPreference();
+            RefreshSelectedTargetInstallStateFast();
+            RefreshSelectedTargetInstallStateInBackground();
+        }
+
+        private void HandleUseProjectCliVersionChanged(bool useProjectCliVersion)
+        {
+            string invocation = useProjectCliVersion
+                ? CliConstants.SKILL_CLI_INVOCATION_NPX
+                : CliConstants.SKILL_CLI_INVOCATION_GLOBAL;
+            ToolSettings.SetSkillCliInvocation(invocation);
             RefreshSelectedTargetInstallStateFast();
             RefreshSelectedTargetInstallStateInBackground();
         }

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -818,7 +818,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private void RefreshSelectedTargetInstallStateFast()
         {
-            if (!CliInstallationDetector.IsCliInstalled())
+            if (!CanManageSkills())
             {
                 _selectedTargetInstallState = SkillInstallState.Missing;
                 RefreshCliSetupSection();
@@ -832,7 +832,7 @@ namespace io.github.hatayama.uLoopMCP
         private void RefreshSelectedTargetInstallStateInBackground()
         {
             CancelSkillInstallStateRefresh();
-            if (!CliInstallationDetector.IsCliInstalled() || _isRefreshingVersion || _isInstallingSkills)
+            if (!CanManageSkills() || _isRefreshingVersion || _isInstallingSkills)
             {
                 return;
             }
@@ -963,11 +963,11 @@ namespace io.github.hatayama.uLoopMCP
 
         private async void HandleInstallSkills()
         {
-            if (!CliInstallationDetector.IsCliInstalled())
+            if (!CanManageSkills())
             {
                 EditorUtility.DisplayDialog(
                     "CLI Not Found",
-                    "uloop-cli is not installed. Please install the CLI first.",
+                    "uloop-cli is not installed. Please install the CLI first or enable project CLI version.",
                     "OK");
                 return;
             }
@@ -1016,6 +1016,12 @@ namespace io.github.hatayama.uLoopMCP
             ToolSettings.SetSkillCliInvocation(invocation);
             RefreshSelectedTargetInstallStateFast();
             RefreshSelectedTargetInstallStateInBackground();
+        }
+
+        private static bool CanManageSkills()
+        {
+            return CliInstallationDetector.IsCliInstalled()
+                || ToolSettings.GetSkillCliInvocation() == CliConstants.SKILL_CLI_INVOCATION_NPX;
         }
 
         private void RefreshRepositoryRootSupport()

--- a/Packages/src/Editor/UI/McpEditorWindowViewData.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowViewData.cs
@@ -163,6 +163,7 @@ namespace io.github.hatayama.uLoopMCP
         public readonly SkillInstallState SelectedTargetInstallState;
         public readonly SkillsTarget SelectedTarget;
         public readonly bool GroupSkillsUnderUnityCliLoop;
+        public readonly bool UseProjectCliVersion;
         public readonly bool IsInstallingSkills;
 
         public CliSetupData(
@@ -182,6 +183,7 @@ namespace io.github.hatayama.uLoopMCP
             SkillInstallState selectedTargetInstallState,
             SkillsTarget selectedTarget,
             bool groupSkillsUnderUnityCliLoop,
+            bool useProjectCliVersion,
             bool isInstallingSkills)
         {
             IsCliInstalled = isCliInstalled;
@@ -200,6 +202,7 @@ namespace io.github.hatayama.uLoopMCP
             SelectedTargetInstallState = selectedTargetInstallState;
             SelectedTarget = selectedTarget;
             GroupSkillsUnderUnityCliLoop = groupSkillsUnderUnityCliLoop;
+            UseProjectCliVersion = useProjectCliVersion;
             IsInstallingSkills = isInstallingSkills;
         }
     }

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -195,6 +195,7 @@ namespace io.github.hatayama.uLoopMCP
         private bool _isSkillsTargetFieldInitialized;
         private bool _shouldUseFirstInstallSkillsUi;
         private bool _installSkillsFlat;
+        private bool _projectCliVersionChangedByToggle;
         [SerializeField]
         private string _lastSeenSetupWizardVersionBeforeOpen = string.Empty;
         private IVisualElementScheduledItem _initialRefreshScheduledItem;
@@ -341,6 +342,8 @@ namespace io.github.hatayama.uLoopMCP
             _projectCliVersionToggle.RegisterValueChangedCallback(evt =>
             {
                 evt.StopPropagation();
+                _projectCliVersionChangedByToggle = true;
+                _projectCliVersionToggle.schedule.Execute(() => _projectCliVersionChangedByToggle = false);
                 HandleProjectCliVersionChanged(evt.newValue);
             });
             _projectCliVersionRow.RegisterCallback<ClickEvent>(HandleProjectCliVersionRowClicked);
@@ -981,8 +984,9 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            if (evt.target is VisualElement targetElement && _projectCliVersionToggle.Contains(targetElement))
+            if (_projectCliVersionChangedByToggle)
             {
+                _projectCliVersionChangedByToggle = false;
                 return;
             }
 

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -159,12 +159,13 @@ namespace io.github.hatayama.uLoopMCP
         private VisualElement _nodejsOk;
         private Button _refreshButton;
 
-        // Step 1
+        // Global CLI
+        private VisualElement _globalCliSection;
         private VisualElement _cliStatusIcon;
         private Label _cliStatusLabel;
         private Button _installCliButton;
 
-        // Step 2
+        // Skills
         private VisualElement _groupSkillsRow;
         private VisualElement _projectCliVersionRow;
         private VisualElement _skillsTargetRow;
@@ -244,6 +245,7 @@ namespace io.github.hatayama.uLoopMCP
             _nodejsOk = rootVisualElement.Q<VisualElement>("nodejs-ok");
             _refreshButton = rootVisualElement.Q<Button>("refresh-button");
 
+            _globalCliSection = rootVisualElement.Q<VisualElement>("step-1");
             _cliStatusIcon = rootVisualElement.Q<VisualElement>("cli-status-icon");
             _cliStatusLabel = rootVisualElement.Q<Label>("cli-status-label");
             _installCliButton = rootVisualElement.Q<Button>("install-cli-button");
@@ -346,9 +348,17 @@ namespace io.github.hatayama.uLoopMCP
 
         private void RefreshProjectCliVersionToggle()
         {
-            bool useProjectCliVersion =
-                ToolSettings.GetSkillCliInvocation() == CliConstants.SKILL_CLI_INVOCATION_NPX;
-            _projectCliVersionToggle.SetValueWithoutNotify(useProjectCliVersion);
+            _projectCliVersionToggle.SetValueWithoutNotify(IsProjectCliVersionEnabled());
+        }
+
+        private static bool IsProjectCliVersionEnabled()
+        {
+            return ToolSettings.GetSkillCliInvocation() == CliConstants.SKILL_CLI_INVOCATION_NPX;
+        }
+
+        private void UpdateGlobalCliSectionVisibility()
+        {
+            ViewDataBinder.SetVisible(_globalCliSection, !IsProjectCliVersionEnabled());
         }
 
         private void BindSizeUpdates()
@@ -378,6 +388,7 @@ namespace io.github.hatayama.uLoopMCP
             ViewDataBinder.SetVisible(_groupSkillsRow, false);
             _groupSkillsToggle.SetEnabled(false);
             RefreshProjectCliVersionToggle();
+            UpdateGlobalCliSectionVisibility();
             _projectCliVersionToggle.SetEnabled(false);
             UpdateSkillsStatusLabel("Checking installed skills...");
             _installSkillsButton.SetEnabled(false);
@@ -407,7 +418,10 @@ namespace io.github.hatayama.uLoopMCP
             bool cliInstalled = !string.IsNullOrEmpty(cachedCliVersion);
             string projectRoot = UnityMcpPathResolver.GetProjectRoot();
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
-            bool canManageSkills = CanManageSkills(cliInstalled) && !_isInstallingCli;
+            RefreshProjectCliVersionToggle();
+            UpdateGlobalCliSectionVisibility();
+            _projectCliVersionToggle.SetEnabled(!_isInstallingCli && !_isInstallingSkills);
+            bool canManageSkills = CanManageSkills(cliInstalled, IsProjectCliVersionEnabled()) && !_isInstallingCli;
             UpdateSkillsStep(canManageSkills, targets);
             BeginRefreshDisplayedSkillTargets(canManageSkills);
             ScheduleResizeToContent();
@@ -429,6 +443,7 @@ namespace io.github.hatayama.uLoopMCP
                 ViewDataBinder.SetVisible(_groupSkillsRow, false);
                 _groupSkillsToggle.SetEnabled(false);
                 RefreshProjectCliVersionToggle();
+                UpdateGlobalCliSectionVisibility();
                 _projectCliVersionToggle.SetEnabled(false);
                 UpdateSkillsStatusLabel("Checking installed skills...");
                 _installSkillsButton.SetEnabled(false);
@@ -468,6 +483,9 @@ namespace io.github.hatayama.uLoopMCP
             bool cliVersionMatched = IsCliVersionMatched(cliVersion);
 
             UpdateCliStep(cliInstalled, cliVersion, cliVersionMatched);
+            RefreshProjectCliVersionToggle();
+            UpdateGlobalCliSectionVisibility();
+            _projectCliVersionToggle.SetEnabled(!_isInstallingCli && !_isInstallingSkills);
 
             if (!refreshSkillsSection)
             {
@@ -477,7 +495,8 @@ namespace io.github.hatayama.uLoopMCP
 
             string projectRoot = UnityMcpPathResolver.GetProjectRoot();
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
-            bool canManageSkills = CanManageSkills(cliInstalled) && !_isInstallingCli;
+            bool canManageSkills = CanManageSkills(cliInstalled, IsProjectCliVersionEnabled())
+                && !_isInstallingCli;
             UpdateSkillsStep(canManageSkills, targets);
             BeginRefreshDisplayedSkillTargets(canManageSkills);
             ScheduleResizeToContent();
@@ -546,9 +565,9 @@ namespace io.github.hatayama.uLoopMCP
             return string.IsNullOrEmpty(lastSeenSetupWizardVersion);
         }
 
-        internal static bool CanManageSkills(bool cliInstalled)
+        internal static bool CanManageSkills(bool cliInstalled, bool useProjectCliVersion)
         {
-            return cliInstalled;
+            return cliInstalled || useProjectCliVersion;
         }
 
         internal static ToolSkillSynchronizer.SkillTargetInfo CreateFirstInstallSkillTarget(
@@ -645,7 +664,8 @@ namespace io.github.hatayama.uLoopMCP
                     _isInstallingSkills,
                     hasOutdatedSkills: false);
                 _groupSkillsToggle.SetEnabled(false);
-                _projectCliVersionToggle.SetEnabled(false);
+                RefreshProjectCliVersionToggle();
+                _projectCliVersionToggle.SetEnabled(!_isInstallingCli && !_isInstallingSkills);
                 ViewDataBinder.SetVisible(_skillsTargetRow, false);
                 ViewDataBinder.SetVisible(_skillsTargetList, false);
                 return;
@@ -977,6 +997,8 @@ namespace io.github.hatayama.uLoopMCP
                 ? CliConstants.SKILL_CLI_INVOCATION_NPX
                 : CliConstants.SKILL_CLI_INVOCATION_GLOBAL;
             ToolSettings.SetSkillCliInvocation(invocation);
+            RefreshProjectCliVersionToggle();
+            UpdateGlobalCliSectionVisibility();
             RefreshSkillsSection();
         }
 

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -173,7 +173,6 @@ namespace io.github.hatayama.uLoopMCP
         private Toggle _groupSkillsToggle;
         private Label _groupSkillsLabel;
         private Toggle _projectCliVersionToggle;
-        private Label _projectCliVersionLabel;
         private VisualElement _skillsTargetList;
         private VisualElement _skillsStatusDivider;
         private Label _skillsStatusLabel;
@@ -195,7 +194,6 @@ namespace io.github.hatayama.uLoopMCP
         private bool _isSkillsTargetFieldInitialized;
         private bool _shouldUseFirstInstallSkillsUi;
         private bool _installSkillsFlat;
-        private bool _projectCliVersionChangedByToggle;
         [SerializeField]
         private string _lastSeenSetupWizardVersionBeforeOpen = string.Empty;
         private IVisualElementScheduledItem _initialRefreshScheduledItem;
@@ -258,7 +256,6 @@ namespace io.github.hatayama.uLoopMCP
             _groupSkillsToggle = rootVisualElement.Q<Toggle>("group-skills-toggle");
             _groupSkillsLabel = rootVisualElement.Q<Label>("group-skills-label");
             _projectCliVersionToggle = rootVisualElement.Q<Toggle>("project-cli-version-toggle");
-            _projectCliVersionLabel = rootVisualElement.Q<Label>("project-cli-version-label");
             _skillsTargetList = rootVisualElement.Q<VisualElement>("skills-target-list");
             _skillsStatusDivider = rootVisualElement.Q<VisualElement>("skills-status-divider");
             _skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
@@ -348,8 +345,6 @@ namespace io.github.hatayama.uLoopMCP
             _projectCliVersionToggle.RegisterValueChangedCallback(evt =>
             {
                 evt.StopPropagation();
-                _projectCliVersionChangedByToggle = true;
-                _projectCliVersionToggle.schedule.Execute(() => _projectCliVersionChangedByToggle = false);
                 HandleProjectCliVersionChanged(evt.newValue);
             });
             _projectCliVersionRow.RegisterCallback<ClickEvent>(HandleProjectCliVersionRowClicked);
@@ -1015,9 +1010,8 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            if (_projectCliVersionChangedByToggle)
+            if (evt.target is VisualElement targetElement && _projectCliVersionToggle.Contains(targetElement))
             {
-                _projectCliVersionChangedByToggle = false;
                 return;
             }
 

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -322,6 +322,12 @@ namespace io.github.hatayama.uLoopMCP
             _isSkillsTargetFieldInitialized = true;
         }
 
+        private void RefreshSkillsTargetField()
+        {
+            Debug.Assert(_isSkillsTargetFieldInitialized, "skills target field must be initialized");
+            _skillsTargetField.SetValueWithoutNotify(_skillsTarget);
+        }
+
         private void InitializeGroupSkillsToggle()
         {
             ApplyFlatSkillInstallPreference();
@@ -568,6 +574,14 @@ namespace io.github.hatayama.uLoopMCP
             return string.IsNullOrEmpty(lastSeenSetupWizardVersion);
         }
 
+        internal static bool ShouldUseTargetSelectionSkillsUi(
+            bool shouldUseFirstInstallSkillsUi,
+            int installableTargetCount)
+        {
+            Debug.Assert(installableTargetCount >= 0, "installableTargetCount must not be negative");
+            return shouldUseFirstInstallSkillsUi || installableTargetCount == 0;
+        }
+
         internal static bool CanManageSkills(bool cliInstalled, bool useProjectCliVersion)
         {
             return cliInstalled || useProjectCliVersion;
@@ -618,6 +632,27 @@ namespace io.github.hatayama.uLoopMCP
                    || selectedTargetInfo.InstallState == SkillInstallState.Checking
                 ? new List<ToolSkillSynchronizer.SkillTargetInfo>()
                 : new List<ToolSkillSynchronizer.SkillTargetInfo> { selectedTargetInfo };
+        }
+
+        internal static List<ToolSkillSynchronizer.SkillTargetInfo> GetSetupWizardInstallableSkillTargets(
+            IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
+            SkillsTarget target,
+            bool groupSkillsUnderUnityCliLoop,
+            bool shouldUseFirstInstallSkillsUi)
+        {
+            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets =
+                FilterInstallableSkillTargets(targets);
+            if (!ShouldUseTargetSelectionSkillsUi(
+                    shouldUseFirstInstallSkillsUi,
+                    installableTargets.Count))
+            {
+                return installableTargets;
+            }
+
+            return GetFirstInstallableSkillTargets(
+                targets,
+                target,
+                groupSkillsUnderUnityCliLoop);
         }
 
         private void UpdateCliStep(bool cliInstalled, string cliVersion, bool cliVersionMatched)
@@ -678,12 +713,16 @@ namespace io.github.hatayama.uLoopMCP
             RefreshProjectCliVersionToggle();
             _projectCliVersionToggle.SetEnabled(!_isInstallingSkills);
 
-            bool useFirstInstallSkillsUi = _shouldUseFirstInstallSkillsUi;
-            ViewDataBinder.SetVisible(_skillsTargetRow, useFirstInstallSkillsUi);
-            ViewDataBinder.SetVisible(_skillsTargetList, !useFirstInstallSkillsUi);
+            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
+            bool useTargetSelectionSkillsUi = ShouldUseTargetSelectionSkillsUi(
+                _shouldUseFirstInstallSkillsUi,
+                installableTargets.Count);
+            ViewDataBinder.SetVisible(_skillsTargetRow, useTargetSelectionSkillsUi);
+            ViewDataBinder.SetVisible(_skillsTargetList, !useTargetSelectionSkillsUi);
 
-            if (useFirstInstallSkillsUi)
+            if (useTargetSelectionSkillsUi)
             {
+                RefreshSkillsTargetField();
                 ToolSkillSynchronizer.SkillTargetInfo selectedTargetInfo = GetSelectedSkillTargetInfo(
                     targets,
                     _skillsTarget,
@@ -700,8 +739,6 @@ namespace io.github.hatayama.uLoopMCP
                     selectedTargetInfo.InstallState));
                 return;
             }
-
-            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
 
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in installableTargets)
             {
@@ -724,15 +761,6 @@ namespace io.github.hatayama.uLoopMCP
                 item.Add(statusLabel);
 
                 _skillsTargetList.Add(item);
-            }
-
-            if (installableTargets.Count == 0)
-            {
-                UpdateSkillsStatusLabel(
-                    "Create a tool folder to enable skill installation (.claude/, .agents/, etc.)");
-                _installSkillsButton.SetEnabled(false);
-                _installSkillsButton.text = "Install Skills";
-                return;
             }
 
             bool isCheckingSkills = installableTargets.Any(
@@ -906,9 +934,12 @@ namespace io.github.hatayama.uLoopMCP
             CancelSkillInstallStateRefresh();
             string projectRoot = UnityMcpPathResolver.GetProjectRoot();
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargets(projectRoot);
-            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets = _shouldUseFirstInstallSkillsUi
-                ? GetFirstInstallableSkillTargets(targets, _skillsTarget, !_installSkillsFlat)
-                : FilterInstallableSkillTargets(targets);
+            List<ToolSkillSynchronizer.SkillTargetInfo> installableTargets =
+                GetSetupWizardInstallableSkillTargets(
+                    targets,
+                    _skillsTarget,
+                    !_installSkillsFlat,
+                    _shouldUseFirstInstallSkillsUi);
             if (installableTargets.Count == 0) return;
 
             _isInstallingSkills = true;

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.cs
@@ -166,10 +166,13 @@ namespace io.github.hatayama.uLoopMCP
 
         // Step 2
         private VisualElement _groupSkillsRow;
+        private VisualElement _projectCliVersionRow;
         private VisualElement _skillsTargetRow;
         private EnumField _skillsTargetField;
         private Toggle _groupSkillsToggle;
         private Label _groupSkillsLabel;
+        private Toggle _projectCliVersionToggle;
+        private Label _projectCliVersionLabel;
         private VisualElement _skillsTargetList;
         private VisualElement _skillsStatusDivider;
         private Label _skillsStatusLabel;
@@ -246,10 +249,13 @@ namespace io.github.hatayama.uLoopMCP
             _installCliButton = rootVisualElement.Q<Button>("install-cli-button");
 
             _groupSkillsRow = rootVisualElement.Q<VisualElement>("group-skills-row");
+            _projectCliVersionRow = rootVisualElement.Q<VisualElement>("project-cli-version-row");
             _skillsTargetRow = rootVisualElement.Q<VisualElement>("skills-target-row");
             _skillsTargetField = rootVisualElement.Q<EnumField>("skills-target-field");
             _groupSkillsToggle = rootVisualElement.Q<Toggle>("group-skills-toggle");
             _groupSkillsLabel = rootVisualElement.Q<Label>("group-skills-label");
+            _projectCliVersionToggle = rootVisualElement.Q<Toggle>("project-cli-version-toggle");
+            _projectCliVersionLabel = rootVisualElement.Q<Label>("project-cli-version-label");
             _skillsTargetList = rootVisualElement.Q<VisualElement>("skills-target-list");
             _skillsStatusDivider = rootVisualElement.Q<VisualElement>("skills-status-divider");
             _skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
@@ -271,6 +277,7 @@ namespace io.github.hatayama.uLoopMCP
             _installSkillsButton.clicked += HandleInstallSkills;
             InitializeSkillsTargetField();
             InitializeGroupSkillsToggle();
+            InitializeProjectCliVersionToggle();
             _suppressAutoShowToggle.RegisterValueChangedCallback(evt => HandleSuppressAutoShowChanged(evt.newValue));
             _openSettingsButton.clicked += HandleOpenSettings;
             _closeButton.clicked += HandleClose;
@@ -326,6 +333,24 @@ namespace io.github.hatayama.uLoopMCP
             _groupSkillsLabel.RegisterCallback<ClickEvent>(HandleGroupSkillsRowClicked);
         }
 
+        private void InitializeProjectCliVersionToggle()
+        {
+            RefreshProjectCliVersionToggle();
+            _projectCliVersionToggle.RegisterValueChangedCallback(evt =>
+            {
+                evt.StopPropagation();
+                HandleProjectCliVersionChanged(evt.newValue);
+            });
+            _projectCliVersionRow.RegisterCallback<ClickEvent>(HandleProjectCliVersionRowClicked);
+        }
+
+        private void RefreshProjectCliVersionToggle()
+        {
+            bool useProjectCliVersion =
+                ToolSettings.GetSkillCliInvocation() == CliConstants.SKILL_CLI_INVOCATION_NPX;
+            _projectCliVersionToggle.SetValueWithoutNotify(useProjectCliVersion);
+        }
+
         private void BindSizeUpdates()
         {
             rootVisualElement.RegisterCallback<GeometryChangedEvent>(_ =>
@@ -352,6 +377,8 @@ namespace io.github.hatayama.uLoopMCP
             _installCliButton.text = "Checking...";
             ViewDataBinder.SetVisible(_groupSkillsRow, false);
             _groupSkillsToggle.SetEnabled(false);
+            RefreshProjectCliVersionToggle();
+            _projectCliVersionToggle.SetEnabled(false);
             UpdateSkillsStatusLabel("Checking installed skills...");
             _installSkillsButton.SetEnabled(false);
             _installSkillsButton.text = "Checking...";
@@ -380,7 +407,7 @@ namespace io.github.hatayama.uLoopMCP
             bool cliInstalled = !string.IsNullOrEmpty(cachedCliVersion);
             string projectRoot = UnityMcpPathResolver.GetProjectRoot();
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
-            bool canManageSkills = CanManageSkills(cliInstalled);
+            bool canManageSkills = CanManageSkills(cliInstalled) && !_isInstallingCli;
             UpdateSkillsStep(canManageSkills, targets);
             BeginRefreshDisplayedSkillTargets(canManageSkills);
             ScheduleResizeToContent();
@@ -401,6 +428,8 @@ namespace io.github.hatayama.uLoopMCP
             {
                 ViewDataBinder.SetVisible(_groupSkillsRow, false);
                 _groupSkillsToggle.SetEnabled(false);
+                RefreshProjectCliVersionToggle();
+                _projectCliVersionToggle.SetEnabled(false);
                 UpdateSkillsStatusLabel("Checking installed skills...");
                 _installSkillsButton.SetEnabled(false);
                 _installSkillsButton.text = "Checking...";
@@ -426,6 +455,7 @@ namespace io.github.hatayama.uLoopMCP
                 _installCliButton.SetEnabled(false);
                 _installSkillsButton.SetEnabled(false);
                 _groupSkillsToggle.SetEnabled(false);
+                _projectCliVersionToggle.SetEnabled(false);
                 UpdateSkillsStatusLabel(string.Empty);
                 _skillsTargetList.Clear();
                 ScheduleResizeToContent();
@@ -447,7 +477,7 @@ namespace io.github.hatayama.uLoopMCP
 
             string projectRoot = UnityMcpPathResolver.GetProjectRoot();
             List<ToolSkillSynchronizer.SkillTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
-            bool canManageSkills = CanManageSkills(cliInstalled);
+            bool canManageSkills = CanManageSkills(cliInstalled) && !_isInstallingCli;
             UpdateSkillsStep(canManageSkills, targets);
             BeginRefreshDisplayedSkillTargets(canManageSkills);
             ScheduleResizeToContent();
@@ -615,12 +645,15 @@ namespace io.github.hatayama.uLoopMCP
                     _isInstallingSkills,
                     hasOutdatedSkills: false);
                 _groupSkillsToggle.SetEnabled(false);
+                _projectCliVersionToggle.SetEnabled(false);
                 ViewDataBinder.SetVisible(_skillsTargetRow, false);
                 ViewDataBinder.SetVisible(_skillsTargetList, false);
                 return;
             }
 
             _groupSkillsToggle.SetEnabled(!_isInstallingSkills);
+            RefreshProjectCliVersionToggle();
+            _projectCliVersionToggle.SetEnabled(!_isInstallingSkills);
 
             bool useFirstInstallSkillsUi = _shouldUseFirstInstallSkillsUi;
             ViewDataBinder.SetVisible(_skillsTargetRow, useFirstInstallSkillsUi);
@@ -819,7 +852,9 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             _isInstallingCli = true;
+            CancelSkillInstallStateRefresh();
             UpdateCliStep(false, null, false);
+            RefreshSkillsSection();
 
             try
             {
@@ -915,6 +950,33 @@ namespace io.github.hatayama.uLoopMCP
             bool newValue = !_groupSkillsToggle.value;
             _groupSkillsToggle.SetValueWithoutNotify(newValue);
             ApplyFlatSkillInstallPreference();
+            RefreshSkillsSection();
+        }
+
+        private void HandleProjectCliVersionRowClicked(ClickEvent evt)
+        {
+            evt.StopPropagation();
+            if (!_projectCliVersionToggle.enabledSelf)
+            {
+                return;
+            }
+
+            if (evt.target is VisualElement targetElement && _projectCliVersionToggle.Contains(targetElement))
+            {
+                return;
+            }
+
+            bool newValue = !_projectCliVersionToggle.value;
+            _projectCliVersionToggle.SetValueWithoutNotify(newValue);
+            HandleProjectCliVersionChanged(newValue);
+        }
+
+        private void HandleProjectCliVersionChanged(bool useProjectCliVersion)
+        {
+            string invocation = useProjectCliVersion
+                ? CliConstants.SKILL_CLI_INVOCATION_NPX
+                : CliConstants.SKILL_CLI_INVOCATION_GLOBAL;
+            ToolSettings.SetSkillCliInvocation(invocation);
             RefreshSkillsSection();
         }
 

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -34,6 +34,14 @@
                         text="Group in subfolder"
                         class="setup-toggle-row__label" />
                 </ui:VisualElement>
+                <ui:VisualElement name="project-cli-version-row" class="setup-toggle-row">
+                    <ui:Toggle name="project-cli-version-toggle" class="setup-toggle-row__toggle" />
+                    <ui:Label
+                        name="project-cli-version-label"
+                        text="Use project CLI version"
+                        tooltip="Run installed skills through the Unity package version of uloop-cli."
+                        class="setup-toggle-row__label" />
+                </ui:VisualElement>
                 <ui:VisualElement name="skills-target-row" class="setup-target-row">
                     <ui:Label text="Target:" class="setup-target-row__label" />
                     <uie:EnumField name="skills-target-field" class="setup-target-row__field" />

--- a/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
+++ b/Packages/src/Editor/UI/Setup/SetupWizardWindow.uxml
@@ -11,9 +11,18 @@
             <ui:Label text="✓ Node.js detected" class="setup-prerequisite__title" />
         </ui:VisualElement>
 
-        <!-- Step 1: Install CLI -->
+        <ui:VisualElement name="project-cli-version-row" class="setup-toggle-row">
+            <ui:Toggle name="project-cli-version-toggle" class="setup-toggle-row__toggle" />
+            <ui:Label
+                name="project-cli-version-label"
+                text="Use project CLI version"
+                tooltip="Run installed skills through the Unity package version of uloop-cli."
+                class="setup-toggle-row__label" />
+        </ui:VisualElement>
+
+        <!-- Global CLI -->
         <ui:VisualElement name="step-1" class="setup-step">
-            <ui:Label text="Step 1: Install CLI" class="setup-step__title" />
+            <ui:Label text="Global CLI" class="setup-step__title" />
             <ui:VisualElement class="setup-step__content">
                 <ui:VisualElement class="setup-step__status-row">
                     <ui:VisualElement name="cli-status-icon" class="setup-status-icon" />
@@ -23,23 +32,15 @@
             </ui:VisualElement>
         </ui:VisualElement>
 
-        <!-- Step 2: Install Skills -->
+        <!-- Skills -->
         <ui:VisualElement name="step-2" class="setup-step">
-            <ui:Label text="Step 2: Install Skills (Optional)" class="setup-step__title" />
+            <ui:Label text="Skills" class="setup-step__title" />
             <ui:VisualElement class="setup-step__content">
                 <ui:VisualElement name="group-skills-row" class="setup-toggle-row">
                     <ui:Toggle name="group-skills-toggle" class="setup-toggle-row__toggle" />
                     <ui:Label
                         name="group-skills-label"
                         text="Group in subfolder"
-                        class="setup-toggle-row__label" />
-                </ui:VisualElement>
-                <ui:VisualElement name="project-cli-version-row" class="setup-toggle-row">
-                    <ui:Toggle name="project-cli-version-toggle" class="setup-toggle-row__toggle" />
-                    <ui:Label
-                        name="project-cli-version-label"
-                        text="Use project CLI version"
-                        tooltip="Run installed skills through the Unity package version of uloop-cli."
                         class="setup-toggle-row__label" />
                 </ui:VisualElement>
                 <ui:VisualElement name="skills-target-row" class="setup-target-row">

--- a/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
@@ -15,6 +15,9 @@ namespace io.github.hatayama.uLoopMCP
         private readonly VisualElement _groupSkillsRow;
         private readonly Toggle _groupSkillsToggle;
         private readonly Label _groupSkillsLabel;
+        private readonly VisualElement _projectCliVersionRow;
+        private readonly Toggle _projectCliVersionToggle;
+        private readonly Label _projectCliVersionLabel;
         private readonly Button _installSkillsButton;
         private readonly VisualElement _skillsSubsection;
 
@@ -27,6 +30,7 @@ namespace io.github.hatayama.uLoopMCP
         public event Action OnRefreshSkillsState;
         public event Action<SkillsTarget> OnSkillsTargetChanged;
         public event Action<bool> OnGroupSkillsChanged;
+        public event Action<bool> OnUseProjectCliVersionChanged;
 
         public CliSetupSection(VisualElement root)
         {
@@ -39,6 +43,9 @@ namespace io.github.hatayama.uLoopMCP
             _groupSkillsRow = root.Q<VisualElement>("group-skills-row");
             _groupSkillsToggle = root.Q<Toggle>("group-skills-toggle");
             _groupSkillsLabel = root.Q<Label>("group-skills-label");
+            _projectCliVersionRow = root.Q<VisualElement>("project-cli-version-row");
+            _projectCliVersionToggle = root.Q<Toggle>("project-cli-version-toggle");
+            _projectCliVersionLabel = root.Q<Label>("project-cli-version-label");
             _installSkillsButton = root.Q<Button>("install-skills-button");
             _skillsSubsection = root.Q<VisualElement>("skills-subsection");
         }
@@ -55,6 +62,12 @@ namespace io.github.hatayama.uLoopMCP
                 OnGroupSkillsChanged?.Invoke(evt.newValue);
             });
             _groupSkillsRow.RegisterCallback<ClickEvent>(HandleGroupSkillsRowClicked);
+            _projectCliVersionToggle.RegisterValueChangedCallback(evt =>
+            {
+                evt.StopPropagation();
+                OnUseProjectCliVersionChanged?.Invoke(evt.newValue);
+            });
+            _projectCliVersionRow.RegisterCallback<ClickEvent>(HandleProjectCliVersionRowClicked);
         }
 
         public void Update(CliSetupData data)
@@ -72,6 +85,7 @@ namespace io.github.hatayama.uLoopMCP
             InitializeTargetFieldIfNeeded(data);
             UpdateRefreshSkillsButton(data);
             UpdateGroupSkillsToggle(data);
+            UpdateProjectCliVersionToggle(data);
             UpdateSkillsSubsection(data);
             UpdateInstallSkillsButton(data);
         }
@@ -167,7 +181,10 @@ namespace io.github.hatayama.uLoopMCP
 
         private void UpdateRefreshSkillsButton(CliSetupData data)
         {
-            bool enabled = data.IsCliInstalled && !data.IsChecking && !data.IsInstallingSkills;
+            bool enabled = data.IsCliInstalled
+                && !data.IsChecking
+                && !data.IsInstallingCli
+                && !data.IsInstallingSkills;
             _refreshSkillsStateButton.SetEnabled(enabled);
             ViewDataBinder.ToggleClass(_refreshSkillsStateButton, "mcp-button--disabled", !enabled);
         }
@@ -176,12 +193,24 @@ namespace io.github.hatayama.uLoopMCP
         {
             ViewDataBinder.SetVisible(_groupSkillsRow, false);
             ViewDataBinder.UpdateToggle(_groupSkillsToggle, data.GroupSkillsUnderUnityCliLoop);
-            _groupSkillsToggle.SetEnabled(data.IsCliInstalled && !data.IsChecking && !data.IsInstallingSkills);
+            _groupSkillsToggle.SetEnabled(data.IsCliInstalled
+                && !data.IsChecking
+                && !data.IsInstallingCli
+                && !data.IsInstallingSkills);
+        }
+
+        private void UpdateProjectCliVersionToggle(CliSetupData data)
+        {
+            ViewDataBinder.UpdateToggle(_projectCliVersionToggle, data.UseProjectCliVersion);
+            _projectCliVersionToggle.SetEnabled(data.IsCliInstalled
+                && !data.IsChecking
+                && !data.IsInstallingCli
+                && !data.IsInstallingSkills);
         }
 
         private void UpdateSkillsSubsection(CliSetupData data)
         {
-            bool enabled = data.IsCliInstalled && !data.IsChecking;
+            bool enabled = data.IsCliInstalled && !data.IsChecking && !data.IsInstallingCli;
             _skillsSubsection.SetEnabled(enabled);
         }
 
@@ -194,7 +223,7 @@ namespace io.github.hatayama.uLoopMCP
             bool enabled = IsInstallSkillsButtonEnabled(
                 data.IsCliInstalled,
                 data.IsInstallingSkills,
-                data.IsChecking,
+                data.IsChecking || data.IsInstallingCli,
                 data.SelectedTargetInstallState);
             SetSkillsButton(label, enabled);
         }
@@ -265,6 +294,24 @@ namespace io.github.hatayama.uLoopMCP
             bool newValue = !_groupSkillsToggle.value;
             _groupSkillsToggle.SetValueWithoutNotify(newValue);
             OnGroupSkillsChanged?.Invoke(newValue);
+        }
+
+        private void HandleProjectCliVersionRowClicked(ClickEvent evt)
+        {
+            evt.StopPropagation();
+            if (!_projectCliVersionToggle.enabledSelf)
+            {
+                return;
+            }
+
+            if (evt.target is VisualElement targetElement && _projectCliVersionToggle.Contains(targetElement))
+            {
+                return;
+            }
+
+            bool newValue = !_projectCliVersionToggle.value;
+            _projectCliVersionToggle.SetValueWithoutNotify(newValue);
+            OnUseProjectCliVersionChanged?.Invoke(newValue);
         }
     }
 }

--- a/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
@@ -7,9 +7,11 @@ namespace io.github.hatayama.uLoopMCP
     public class CliSetupSection
     {
         private readonly VisualElement _cliStatusIcon;
+        private readonly VisualElement _globalCliStatusRow;
         private readonly Label _cliStatusLabel;
         private readonly Button _refreshCliVersionButton;
         private readonly Button _installCliButton;
+        private readonly VisualElement _globalCliSeparator;
         private readonly EnumField _skillsTargetField;
         private readonly Button _refreshSkillsStateButton;
         private readonly VisualElement _groupSkillsRow;
@@ -35,9 +37,11 @@ namespace io.github.hatayama.uLoopMCP
         public CliSetupSection(VisualElement root)
         {
             _cliStatusIcon = root.Q<VisualElement>("cli-status-icon");
+            _globalCliStatusRow = root.Q<VisualElement>("global-cli-status-row");
             _cliStatusLabel = root.Q<Label>("cli-status-label");
             _refreshCliVersionButton = root.Q<Button>("refresh-cli-version-button");
             _installCliButton = root.Q<Button>("install-cli-button");
+            _globalCliSeparator = root.Q<VisualElement>("global-cli-separator");
             _skillsTargetField = root.Q<EnumField>("skills-target-field");
             _refreshSkillsStateButton = root.Q<Button>("refresh-skills-state-button");
             _groupSkillsRow = root.Q<VisualElement>("group-skills-row");
@@ -80,6 +84,7 @@ namespace io.github.hatayama.uLoopMCP
             _lastData = data;
 
             UpdateCliStatus(data);
+            UpdateGlobalCliVisibility(data);
             UpdateRefreshButton(data);
             UpdateInstallCliButton(data);
             InitializeTargetFieldIfNeeded(data);
@@ -115,6 +120,14 @@ namespace io.github.hatayama.uLoopMCP
         private void UpdateRefreshButton(CliSetupData data)
         {
             _refreshCliVersionButton.SetEnabled(!data.IsChecking);
+        }
+
+        private void UpdateGlobalCliVisibility(CliSetupData data)
+        {
+            bool visible = !data.UseProjectCliVersion;
+            ViewDataBinder.SetVisible(_globalCliStatusRow, visible);
+            ViewDataBinder.SetVisible(_installCliButton, visible);
+            ViewDataBinder.SetVisible(_globalCliSeparator, visible);
         }
 
         private void UpdateInstallCliButton(CliSetupData data)
@@ -181,7 +194,8 @@ namespace io.github.hatayama.uLoopMCP
 
         private void UpdateRefreshSkillsButton(CliSetupData data)
         {
-            bool enabled = data.IsCliInstalled
+            bool canManageSkills = CanManageSkills(data);
+            bool enabled = canManageSkills
                 && !data.IsChecking
                 && !data.IsInstallingCli
                 && !data.IsInstallingSkills;
@@ -193,7 +207,7 @@ namespace io.github.hatayama.uLoopMCP
         {
             ViewDataBinder.SetVisible(_groupSkillsRow, false);
             ViewDataBinder.UpdateToggle(_groupSkillsToggle, data.GroupSkillsUnderUnityCliLoop);
-            _groupSkillsToggle.SetEnabled(data.IsCliInstalled
+            _groupSkillsToggle.SetEnabled(CanManageSkills(data)
                 && !data.IsChecking
                 && !data.IsInstallingCli
                 && !data.IsInstallingSkills);
@@ -202,30 +216,34 @@ namespace io.github.hatayama.uLoopMCP
         private void UpdateProjectCliVersionToggle(CliSetupData data)
         {
             ViewDataBinder.UpdateToggle(_projectCliVersionToggle, data.UseProjectCliVersion);
-            _projectCliVersionToggle.SetEnabled(data.IsCliInstalled
-                && !data.IsChecking
+            _projectCliVersionToggle.SetEnabled(!data.IsChecking
                 && !data.IsInstallingCli
                 && !data.IsInstallingSkills);
         }
 
         private void UpdateSkillsSubsection(CliSetupData data)
         {
-            bool enabled = data.IsCliInstalled && !data.IsChecking && !data.IsInstallingCli;
+            bool enabled = CanManageSkills(data) && !data.IsChecking && !data.IsInstallingCli;
             _skillsSubsection.SetEnabled(enabled);
         }
 
         private void UpdateInstallSkillsButton(CliSetupData data)
         {
             string label = GetInstallSkillsButtonText(
-                data.IsCliInstalled,
+                CanManageSkills(data),
                 data.IsInstallingSkills,
                 data.SelectedTargetInstallState);
             bool enabled = IsInstallSkillsButtonEnabled(
-                data.IsCliInstalled,
+                CanManageSkills(data),
                 data.IsInstallingSkills,
                 data.IsChecking || data.IsInstallingCli,
                 data.SelectedTargetInstallState);
             SetSkillsButton(label, enabled);
+        }
+
+        private static bool CanManageSkills(CliSetupData data)
+        {
+            return data.IsCliInstalled || data.UseProjectCliVersion;
         }
 
         private void SetSkillsButton(string text, bool enabled)

--- a/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
@@ -25,6 +25,7 @@ namespace io.github.hatayama.uLoopMCP
 
         private CliSetupData _lastData;
         private bool _isTargetFieldInitialized;
+        private bool _projectCliVersionChangedByToggle;
 
         public event Action OnRefreshCliVersion;
         public event Action OnInstallCli;
@@ -69,6 +70,8 @@ namespace io.github.hatayama.uLoopMCP
             _projectCliVersionToggle.RegisterValueChangedCallback(evt =>
             {
                 evt.StopPropagation();
+                _projectCliVersionChangedByToggle = true;
+                _projectCliVersionToggle.schedule.Execute(() => _projectCliVersionChangedByToggle = false);
                 OnUseProjectCliVersionChanged?.Invoke(evt.newValue);
             });
             _projectCliVersionRow.RegisterCallback<ClickEvent>(HandleProjectCliVersionRowClicked);
@@ -322,8 +325,9 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            if (evt.target is VisualElement targetElement && _projectCliVersionToggle.Contains(targetElement))
+            if (_projectCliVersionChangedByToggle)
             {
+                _projectCliVersionChangedByToggle = false;
                 return;
             }
 

--- a/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
+++ b/Packages/src/Editor/UI/UIToolkit/Components/CliSetupSection.cs
@@ -19,13 +19,11 @@ namespace io.github.hatayama.uLoopMCP
         private readonly Label _groupSkillsLabel;
         private readonly VisualElement _projectCliVersionRow;
         private readonly Toggle _projectCliVersionToggle;
-        private readonly Label _projectCliVersionLabel;
         private readonly Button _installSkillsButton;
         private readonly VisualElement _skillsSubsection;
 
         private CliSetupData _lastData;
         private bool _isTargetFieldInitialized;
-        private bool _projectCliVersionChangedByToggle;
 
         public event Action OnRefreshCliVersion;
         public event Action OnInstallCli;
@@ -50,7 +48,6 @@ namespace io.github.hatayama.uLoopMCP
             _groupSkillsLabel = root.Q<Label>("group-skills-label");
             _projectCliVersionRow = root.Q<VisualElement>("project-cli-version-row");
             _projectCliVersionToggle = root.Q<Toggle>("project-cli-version-toggle");
-            _projectCliVersionLabel = root.Q<Label>("project-cli-version-label");
             _installSkillsButton = root.Q<Button>("install-skills-button");
             _skillsSubsection = root.Q<VisualElement>("skills-subsection");
         }
@@ -70,8 +67,6 @@ namespace io.github.hatayama.uLoopMCP
             _projectCliVersionToggle.RegisterValueChangedCallback(evt =>
             {
                 evt.StopPropagation();
-                _projectCliVersionChangedByToggle = true;
-                _projectCliVersionToggle.schedule.Execute(() => _projectCliVersionChangedByToggle = false);
                 OnUseProjectCliVersionChanged?.Invoke(evt.newValue);
             });
             _projectCliVersionRow.RegisterCallback<ClickEvent>(HandleProjectCliVersionRowClicked);
@@ -325,9 +320,8 @@ namespace io.github.hatayama.uLoopMCP
                 return;
             }
 
-            if (_projectCliVersionChangedByToggle)
+            if (evt.target is VisualElement targetElement && _projectCliVersionToggle.Contains(targetElement))
             {
-                _projectCliVersionChangedByToggle = false;
                 return;
             }
 

--- a/Packages/src/Editor/UI/UIToolkit/McpEditorWindow.uxml
+++ b/Packages/src/Editor/UI/UIToolkit/McpEditorWindow.uxml
@@ -29,6 +29,14 @@
                                     text="Group in subfolder"
                                     class="mcp-toggle-row__label" />
                             </ui:VisualElement>
+                            <ui:VisualElement name="project-cli-version-row" class="mcp-toggle-row">
+                                <ui:Toggle name="project-cli-version-toggle" class="mcp-toggle-row__toggle" />
+                                <ui:Label
+                                    name="project-cli-version-label"
+                                    text="Use project CLI version"
+                                    tooltip="Run installed skills through the Unity package version of uloop-cli."
+                                    class="mcp-toggle-row__label" />
+                            </ui:VisualElement>
                             <ui:VisualElement class="mcp-target-row">
                                 <ui:Label text="Target:" class="mcp-target-row__label" />
                                 <uie:EnumField name="skills-target-field" class="mcp-target-row__field" />

--- a/Packages/src/Editor/UI/UIToolkit/McpEditorWindow.uxml
+++ b/Packages/src/Editor/UI/UIToolkit/McpEditorWindow.uxml
@@ -12,13 +12,21 @@
 
                     <!-- CLI Content -->
                     <ui:VisualElement name="cli-content">
-                        <ui:VisualElement class="mcp-cli-status-row">
+                        <ui:VisualElement name="project-cli-version-row" class="mcp-toggle-row">
+                            <ui:Toggle name="project-cli-version-toggle" class="mcp-toggle-row__toggle" />
+                            <ui:Label
+                                name="project-cli-version-label"
+                                text="Use project CLI version"
+                                tooltip="Run installed skills through the Unity package version of uloop-cli."
+                                class="mcp-toggle-row__label" />
+                        </ui:VisualElement>
+                        <ui:VisualElement name="global-cli-status-row" class="mcp-cli-status-row">
                             <ui:VisualElement name="cli-status-icon" class="mcp-cli-status-icon mcp-cli-status-icon--not-installed" />
                             <ui:Label name="cli-status-label" text="uloop-cli: Checking..." />
                             <ui:Button name="refresh-cli-version-button" text="↻" class="mcp-button--refresh" />
                         </ui:VisualElement>
                         <ui:Button name="install-cli-button" text="Install CLI" class="mcp-button mcp-button--configure" />
-                        <ui:VisualElement class="mcp-cli-separator" />
+                        <ui:VisualElement name="global-cli-separator" class="mcp-cli-separator" />
 
                         <ui:VisualElement name="skills-subsection">
                             <ui:Label text="Skills" class="mcp-cli-subsection-header" />
@@ -27,14 +35,6 @@
                                 <ui:Label
                                     name="group-skills-label"
                                     text="Group in subfolder"
-                                    class="mcp-toggle-row__label" />
-                            </ui:VisualElement>
-                            <ui:VisualElement name="project-cli-version-row" class="mcp-toggle-row">
-                                <ui:Toggle name="project-cli-version-toggle" class="mcp-toggle-row__toggle" />
-                                <ui:Label
-                                    name="project-cli-version-label"
-                                    text="Use project CLI version"
-                                    tooltip="Run installed skills through the Unity package version of uloop-cli."
                                     class="mcp-toggle-row__label" />
                             </ui:VisualElement>
                             <ui:VisualElement class="mcp-target-row">

--- a/Packages/src/Editor/UI/UIToolkit/McpEditorWindowUI.cs
+++ b/Packages/src/Editor/UI/UIToolkit/McpEditorWindowUI.cs
@@ -38,6 +38,7 @@ namespace io.github.hatayama.uLoopMCP
         public event Action OnRefreshSkillsState;
         public event Action<SkillsTarget> OnSkillsTargetChanged;
         public event Action<bool> OnGroupSkillsChanged;
+        public event Action<bool> OnUseProjectCliVersionChanged;
         public event Action<bool> OnConfigurationFoldoutChanged;
         public event Action<bool> OnConnectedToolsFoldoutChanged;
         public event Action<McpEditorType> OnEditorTypeChanged;
@@ -104,6 +105,7 @@ namespace io.github.hatayama.uLoopMCP
             _cliSetupSection.OnRefreshSkillsState += () => OnRefreshSkillsState?.Invoke();
             _cliSetupSection.OnSkillsTargetChanged += value => OnSkillsTargetChanged?.Invoke(value);
             _cliSetupSection.OnGroupSkillsChanged += value => OnGroupSkillsChanged?.Invoke(value);
+            _cliSetupSection.OnUseProjectCliVersionChanged += value => OnUseProjectCliVersionChanged?.Invoke(value);
 
             _mainScrollView = _root.Q<ScrollView>("main-scroll-view");
             ConfigureScrollView();


### PR DESCRIPTION
## Summary
- Skills installed from Unity now use the project-matched CLI version by default via version-pinned `npx`.
- Users can still switch back to the global `uloop` command from the setup/settings UI.
- Setup and Settings now expose the project CLI mode consistently for skill installation and updates.

## User Impact
- Multi-project users are less likely to hit CLI/package version mismatches after installing skills.
- Existing users who prefer a globally installed CLI can opt out by disabling project CLI mode.

## Changes
- Add skill CLI invocation settings for `global` and `npx` modes.
- Rewrite installed skill markdown commands to `npx --yes uloop-cli@<packageVersion>` in project CLI mode.
- Add UI controls and setup flow handling for project CLI mode.
- Make project CLI mode the default for new or invalid tool settings.

## Verification
- `uloop compile`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value ".*ToolSettingsTests.*|.*ToolSkillSynchronizerTests.*SkillCliInvocation.*"`
- `npm run test:unit -- --runTestsByPath src/__tests__/tool-settings-loader.test.ts src/__tests__/skills-manager.test.ts src/__tests__/skills-command.test.ts --runInBand`
- `npm run lint`
- `npm run build`

Closes #1385

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds project-scoped CLI invocation support for skills, defaulting to `npx`-based execution so generated/installed skill markdown invokes the Unity project’s pinned `uloop-cli` version rather than the globally installed binary.

Key changes:
- Introduced `global` vs `npx` skill CLI invocation mode persisted in `.uloop/settings.tools.json` via new `skillCliInvocation` setting, with normalization and safe defaults (defaulting to `npx` when settings are missing/invalid/unreadable).
- Updated skill installation/content packaging to rewrite installed skill markdown (and related referenced files when applicable) so `uloop` invocations become `npx --yes uloop-cli@<packageVersion>`, using the project’s installed Unity CLI Loop package `package.json` `version` (and bypassing rewriting when `global` is selected).
- Exposed a “Use project CLI version” toggle across Setup Wizard and Editor UI, including state wiring/events and eligibility gating (`IsCliInstalled || UseProjectCliVersion`) for managing skills.
- Updated skill install/refresh flows so switching from `npx` back to `global` marks previously `npx`-installed skills as outdated.
- Extended the CLI install command to accept `--cli-invocation npx|global`, validating inputs and rejecting conflicting `--cli-invocation` usage with `--global`.

Tests were added/updated to cover:
- Setup Wizard decision logic for when to show target-selection UI and installable-skill target handling.
- Tool settings loading/saving and defaulting/normalization behavior for `skillCliInvocation`.
- Skill installation rewriting correctness for `npx` mode and outdated detection when toggling back to `global`.
- CLI command behavior for forwarding/rejecting `--cli-invocation`, plus project CLI version resolution and install failure/error cases when the Unity CLI Loop package root/version can’t be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->