### PR TITLE
fix: Tool Settings now hides pause point helper tools

### DIFF
--- a/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
@@ -16,10 +16,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     public class ToolSettingsUseCaseTests
     {
         [Test]
-        public void TryGetToolCatalog_WhenRegistryAvailable_IncludesNativePausePointCommands()
+        public void TryGetToolCatalog_WhenRegistryAvailable_ShowsOnlyWaitForPausePointCommand()
         {
-            // Verifies CLI-native pause point commands are user-toggleable built-in tools.
-            ToolSettingsService toolSettingsService = new(new ToolSettingsRepository());
+            // Verifies Tool Settings exposes only the parent pause point command.
+            ToolSettingsService toolSettingsService = new(new InMemoryToolSettingsPort());
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
@@ -35,14 +35,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(isAvailable, Is.True);
             Assert.That(toolNames, Does.Contain(UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT));
-            Assert.That(toolNames, Does.Contain(UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS));
+            Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT));
+            Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT));
+            Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS));
+        }
+
+        [Test]
+        public void IsToolEnabled_WhenWaitForPausePointDisabled_DisablesPausePointAuxiliaryTools()
+        {
+            // Verifies pause point auxiliary tools follow the wait-for-pause-point setting.
+            ToolSettingsService toolSettingsService = new(new InMemoryToolSettingsPort());
+            UnityCliLoopToolRegistrarService toolRegistrarService = new(
+                new EmptyInternalToolNameProvider(),
+                toolSettingsService,
+                new UnityCliLoopToolExecutionService());
+            ToolSettingsUseCase useCase = new(
+                toolSettingsService,
+                toolRegistrarService,
+                new StaticToolSkillDescriptionProvider(new Dictionary<string, string>()));
+
+            useCase.SetToolEnabled(UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT, false);
+
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT), Is.False);
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT), Is.False);
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT), Is.False);
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS), Is.False);
         }
 
         [Test]
         public void TryGetToolCatalog_WhenSkillDescriptionExists_IncludesDescription()
         {
             // Verifies Tool Settings can show source skill descriptions without changing public tool metadata.
-            ToolSettingsService toolSettingsService = new(new ToolSettingsRepository());
+            ToolSettingsService toolSettingsService = new(new InMemoryToolSettingsPort());
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
@@ -77,6 +101,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public IReadOnlyDictionary<string, string> GetSkillDescriptionsByToolName()
             {
                 return _descriptions;
+            }
+        }
+
+        private sealed class InMemoryToolSettingsPort : IToolSettingsPort
+        {
+            private readonly HashSet<string> _disabledTools = new();
+
+            public bool IsToolEnabled(string toolName)
+            {
+                return !_disabledTools.Contains(toolName);
+            }
+
+            public void SetToolEnabled(string toolName, bool enabled)
+            {
+                if (enabled)
+                {
+                    _disabledTools.Remove(toolName);
+                    return;
+                }
+
+                _disabledTools.Add(toolName);
+            }
+
+            public string[] GetDisabledTools()
+            {
+                return _disabledTools.ToArray();
+            }
+
+            public void InvalidateCache()
+            {
             }
         }
     }

--- a/Packages/src/Editor/Application/UseCases/ToolSettingsUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ToolSettingsUseCase.cs
@@ -78,7 +78,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             IReadOnlyDictionary<string, string> descriptions =
                 _toolSkillDescriptionProvider.GetSkillDescriptionsByToolName();
             ToolCatalogItem[] registryTools = registry.GetToolSettingsCatalog()
-                .Where(item => ToolSettingsToolLinkPolicy.IsUserFacingToolSettingsTool(item.Name))
                 .Select(item => new ToolCatalogItem(
                     item.Name,
                     item.DisplayDevelopmentOnly,

--- a/Packages/src/Editor/Application/UseCases/ToolSettingsUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ToolSettingsUseCase.cs
@@ -17,8 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
     {
         private static readonly string[] NativeToolNames =
         {
-            UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT,
-            UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS
+            UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT
         };
 
         private readonly ToolSettingsService _toolSettingsService;
@@ -42,12 +41,13 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
         internal bool IsToolEnabled(string toolName)
         {
-            return _toolSettingsService.IsToolEnabled(toolName);
+            return ToolSettingsToolLinkPolicy.IsToolEnabled(toolName, _toolSettingsService);
         }
 
         internal void SetToolEnabled(string toolName, bool enabled)
         {
-            _toolSettingsService.SetToolEnabled(toolName, enabled);
+            string settingsToolName = ToolSettingsToolLinkPolicy.GetSettingsToolName(toolName);
+            _toolSettingsService.SetToolEnabled(settingsToolName, enabled);
             _toolRegistrarService.NotifyToolChanges();
         }
 
@@ -78,6 +78,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
             IReadOnlyDictionary<string, string> descriptions =
                 _toolSkillDescriptionProvider.GetSkillDescriptionsByToolName();
             ToolCatalogItem[] registryTools = registry.GetToolSettingsCatalog()
+                .Where(item => ToolSettingsToolLinkPolicy.IsUserFacingToolSettingsTool(item.Name))
                 .Select(item => new ToolCatalogItem(
                     item.Name,
                     item.DisplayDevelopmentOnly,

--- a/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs
+++ b/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Resolves Tool Settings visibility and parent-toggle behavior for auxiliary tools.
+    /// </summary>
+    internal static class ToolSettingsToolLinkPolicy
+    {
+        private static readonly HashSet<string> PausePointAuxiliaryToolNames = new(System.StringComparer.Ordinal)
+        {
+            UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT,
+            UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT,
+            UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS
+        };
+
+        internal static bool IsUserFacingToolSettingsTool(string toolName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
+
+            return !PausePointAuxiliaryToolNames.Contains(toolName);
+        }
+
+        internal static bool IsToolEnabled(string toolName, ToolSettingsService toolSettingsService)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
+            Debug.Assert(toolSettingsService != null, "toolSettingsService must not be null");
+
+            return toolSettingsService.IsToolEnabled(GetSettingsToolName(toolName));
+        }
+
+        internal static string GetSettingsToolName(string toolName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
+
+            if (PausePointAuxiliaryToolNames.Contains(toolName))
+            {
+                return UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT;
+            }
+
+            return toolName;
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs.meta
+++ b/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64bb6bf33f693406aa71fb605b543f49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/UnityCliLoopToolRegistry.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopToolRegistry.cs
@@ -114,7 +114,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
 
         public bool IsToolEnabled(string toolName)
         {
-            return _toolSettingsService.IsToolEnabled(toolName);
+            return ToolSettingsToolLinkPolicy.IsToolEnabled(toolName, _toolSettingsService);
         }
 
         public ToolInfo[] GetRegisteredTools()
@@ -128,7 +128,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return _tools.Values
                 .Where(tool => ToolExecutionAvailability.ShouldExposeInRegisteredTools(
                     tool.ToolName,
-                    _toolSettingsService.IsToolEnabled(tool.ToolName)))
+                    ToolSettingsToolLinkPolicy.IsToolEnabled(tool.ToolName, _toolSettingsService)))
                 .Where(tool => !internalToolNames.Contains(tool.ToolName))
                 .Select(tool =>
             {
@@ -152,6 +152,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         {
             HashSet<string> internalToolNames = _internalToolNameProvider.GetInternalToolNames(projectRoot);
             return _tools.Values
+                .Where(tool => ToolSettingsToolLinkPolicy.IsUserFacingToolSettingsTool(tool.ToolName))
                 .Where(tool => !internalToolNames.Contains(tool.ToolName))
                 .Select(tool =>
             {


### PR DESCRIPTION
## Summary
- Tool Settings now shows only the user-facing wait-for-pause-point command instead of listing its helper tools separately.
- Disabling wait-for-pause-point also disables the related pause point helper tools used behind the scenes.

## User Impact
- Users no longer need to manage clear-pause-point, enable-pause-point, or pause-point-status as separate Tool Settings entries.
- The pause point tools now behave as one grouped capability from the Settings UI, matching how users think about Wait for Pause Point.

## Changes
- Add a Tool Settings link policy that maps pause point helper tools to wait-for-pause-point.
- Filter pause point helper tools out of the Tool Settings catalog while preserving their runtime registration.
- Update use case tests to cover the hidden helper tools and parent toggle behavior.

## Verification
- cli/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>
- cli/dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value ".*ToolSettingsUseCaseTests.*"
- cli/dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value ".*UnityCliLoopToolRegistryTests.*"

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

