### PR TITLE
feat: Projects can run pinned CLI versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,7 @@ jobs:
         run: go run ./cmd/check-ipc-protocol-reminder --base "origin/${{ github.base_ref }}" --head HEAD
 
       - name: Check protocol minimum version bump
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--branches--')
         working-directory: cli
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,6 +37,7 @@ jobs:
           scripts/test-is-release-please-release-commit.sh
           scripts/test-release-please-config.sh
           scripts/test-protocol-minimum-version-workflow.sh
+          scripts/test-verify-native-cli-release-assets.sh
           scripts/test-mark-release-pr-tagged.sh
           scripts/test-sync-published-release-pr-labels.sh
           scripts/test-sync-release-please-package-releases.sh
@@ -50,7 +51,7 @@ jobs:
         run: go run ./cmd/check-ipc-protocol-reminder --base "origin/${{ github.base_ref }}" --head HEAD
 
       - name: Check protocol minimum version bump
-        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--branches--')
+        if: github.event_name == 'pull_request' && !(startsWith(github.head_ref, 'release-please--branches--') && (github.event.pull_request.user.login == 'github-actions[bot]' || github.event.pull_request.user.login == 'release-please[bot]'))
         working-directory: cli
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,8 @@ memo.md
 Packages/src/Docs/**
 
 # uloop CLI cache and outputs
-**/.uloop/
+**/.uloop/*
+!**/.uloop/cli-pin.json
 
 # Node.js / TypeScript
 **/node_modules/

--- a/.uloop/cli-pin.json
+++ b/.uloop/cli-pin.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "packageName": "io.github.hatayama.uloopmcp",
+  "packageVersion": "3.0.0-beta.40",
+  "cliVersion": "3.0.0-beta.39",
+  "requiredProtocolVersion": 2,
+  "minimumDispatcherVersion": "3.0.0-beta.39"
+}

--- a/Assets/Tests/Editor/CliPinSynchronizerTests.cs
+++ b/Assets/Tests/Editor/CliPinSynchronizerTests.cs
@@ -121,6 +121,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
         }
 
+        [Test]
+        public void ResolveCurrentProjectRoot_WhenAssetsPathProvided_ShouldReturnUnityProjectRoot()
+        {
+            // Tests that startup derives the Unity project root from Application.dataPath semantics.
+            string projectRoot = Path.Combine(CreateTestRoot(), "UnityProject");
+            string assetsPath = Path.Combine(projectRoot, "Assets");
+
+            string resolvedProjectRoot = CliPinSynchronizer.ResolveCurrentProjectRoot(assetsPath);
+
+            Assert.That(resolvedProjectRoot, Is.EqualTo(projectRoot));
+        }
+
         private static string CreateTestRoot()
         {
             return Path.Combine(

--- a/Assets/Tests/Editor/CliPinSynchronizerTests.cs
+++ b/Assets/Tests/Editor/CliPinSynchronizerTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    public sealed class CliPinSynchronizerTests
+    {
+        [Test]
+        public void SyncProjectPinFile_WhenDestinationMissing_ShouldCopyPackagePin()
+        {
+            // Tests that the dispatcher pin contract is published into the project .uloop directory.
+            string root = CreateTestRoot();
+            string packageRoot = Path.Combine(root, "package");
+            string projectRoot = Path.Combine(root, "project");
+
+            try
+            {
+                Directory.CreateDirectory(packageRoot);
+                Directory.CreateDirectory(projectRoot);
+                File.WriteAllText(Path.Combine(packageRoot, "cli-pin.json"), "{\"schemaVersion\":1}");
+
+                bool changed = CliPinSynchronizer.SyncProjectPinFile(packageRoot, projectRoot);
+
+                Assert.That(changed, Is.True);
+                Assert.That(
+                    File.ReadAllText(Path.Combine(projectRoot, ".uloop", "cli-pin.json")),
+                    Is.EqualTo("{\"schemaVersion\":1}"));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public void SyncProjectPinFile_WhenDestinationMatches_ShouldSkipWrite()
+        {
+            // Tests that startup does not rewrite the project pin when package and project copies already match.
+            string root = CreateTestRoot();
+            string packageRoot = Path.Combine(root, "package");
+            string projectRoot = Path.Combine(root, "project");
+            string projectUloopRoot = Path.Combine(projectRoot, ".uloop");
+
+            try
+            {
+                Directory.CreateDirectory(packageRoot);
+                Directory.CreateDirectory(projectUloopRoot);
+                string sourcePath = Path.Combine(packageRoot, "cli-pin.json");
+                string destinationPath = Path.Combine(projectUloopRoot, "cli-pin.json");
+                File.WriteAllText(sourcePath, "{\"schemaVersion\":1}");
+                File.WriteAllText(destinationPath, "{\"schemaVersion\":1}");
+                DateTime previousWriteTime = File.GetLastWriteTimeUtc(destinationPath);
+
+                bool changed = CliPinSynchronizer.SyncProjectPinFile(packageRoot, projectRoot);
+
+                Assert.That(changed, Is.False);
+                Assert.That(File.GetLastWriteTimeUtc(destinationPath), Is.EqualTo(previousWriteTime));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public void SyncProjectPinFile_WhenPackagePinChanges_ShouldUpdateProjectPin()
+        {
+            // Tests that package upgrades update the project dispatcher pin contract.
+            string root = CreateTestRoot();
+            string packageRoot = Path.Combine(root, "package");
+            string projectRoot = Path.Combine(root, "project");
+            string projectUloopRoot = Path.Combine(projectRoot, ".uloop");
+
+            try
+            {
+                Directory.CreateDirectory(packageRoot);
+                Directory.CreateDirectory(projectUloopRoot);
+                File.WriteAllText(Path.Combine(packageRoot, "cli-pin.json"), "{\"schemaVersion\":2}");
+                string destinationPath = Path.Combine(projectUloopRoot, "cli-pin.json");
+                File.WriteAllText(destinationPath, "{\"schemaVersion\":1}");
+
+                bool changed = CliPinSynchronizer.SyncProjectPinFile(packageRoot, projectRoot);
+
+                Assert.That(changed, Is.True);
+                Assert.That(File.ReadAllText(destinationPath), Is.EqualTo("{\"schemaVersion\":2}"));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        private static string CreateTestRoot()
+        {
+            return Path.Combine(
+                Path.GetTempPath(),
+                "unity-cli-loop-tests",
+                Guid.NewGuid().ToString("N"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/CliPinSynchronizerTests.cs
+++ b/Assets/Tests/Editor/CliPinSynchronizerTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 
@@ -87,6 +89,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
                 Assert.That(changed, Is.True);
                 Assert.That(File.ReadAllText(destinationPath), Is.EqualTo("{\"schemaVersion\":2}"));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public void SyncProjectPinFile_WhenPackageRootMissing_ShouldSkipWrite()
+        {
+            // Tests that startup skips pin synchronization while Unity package resolution is incomplete.
+            string root = CreateTestRoot();
+            string projectRoot = Path.Combine(root, "project");
+
+            try
+            {
+                Directory.CreateDirectory(projectRoot);
+                LogAssert.Expect(
+                    LogType.Warning,
+                    "Unity CLI Loop skipped cli-pin.json synchronization because the package root is empty.");
+
+                bool changed = CliPinSynchronizer.SyncProjectPinFile(string.Empty, projectRoot);
+
+                Assert.That(changed, Is.False);
+                Assert.That(File.Exists(Path.Combine(projectRoot, ".uloop", "cli-pin.json")), Is.False);
             }
             finally
             {

--- a/Assets/Tests/Editor/CliPinSynchronizerTests.cs.meta
+++ b/Assets/Tests/Editor/CliPinSynchronizerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99b785a6fcb44c2e9bd333d3394b2408
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/ToolSettingsTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsTests.cs
@@ -15,7 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     {
         private static readonly string SettingsFilePath =
             Path.Combine(UnityCliLoopConstants.ULOOP_DIR, UnityCliLoopConstants.ULOOP_TOOL_SETTINGS_FILE_NAME);
-        private static readonly string SettingsBackupPath = SettingsFilePath + ".bak";
+        private static readonly string SettingsBackupPath = SettingsFilePath + AtomicFileWriter.BackupFileSuffix;
 
         private bool _settingsFileExisted;
         private string _settingsFileContent;

--- a/Assets/Tests/Editor/UnityCliLoopEditorSettingsRecoveryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSettingsRecoveryTests.cs
@@ -21,8 +21,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Path.Combine(UnityCliLoopConstants.USER_SETTINGS_FOLDER, UnityCliLoopConstants.SETTINGS_FILE_NAME);
         private static readonly string LegacySettingsFilePath =
             Path.Combine(UnityCliLoopConstants.USER_SETTINGS_FOLDER, UnityCliLoopConstants.LEGACY_SETTINGS_FILE_NAME);
-        private static readonly string BackupFilePath = SettingsFilePath + ".bak";
-        private static readonly string TempFilePath = SettingsFilePath + ".tmp";
+        private static readonly string BackupFilePath = SettingsFilePath + AtomicFileWriter.BackupFileSuffix;
+        private static readonly string TempFilePath = SettingsFilePath + AtomicFileWriter.CompletedTempFileSuffix;
 
         private bool _settingsFileExisted;
         private string _settingsFileContent;

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopEditorBootstrapper.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopEditorBootstrapper.cs
@@ -20,6 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
 
         internal void Initialize()
         {
+            CliPinSynchronizer.SyncCurrentProjectPin();
             UnityCliLoopApplicationServices applicationServices = _applicationRegistration.Register();
             ApplicationEditorStartup.Initialize(applicationServices.DomainReloadDetectionService);
             FirstPartyToolsEditorStartup.Initialize();

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -12,7 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const int REQUIRED_CLI_PROTOCOL_VERSION = 2;
         // Why: setup installs this pinned release; protocol bump PRs can advance it only after
         // the matching CLI tag is published.
-        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.39"; // x-release-please-version
+        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.39";
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         public const string VERSION_FLAG = "--version";
         public const string SHORT_VERSION_FLAG = "-v";

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -12,7 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const int REQUIRED_CLI_PROTOCOL_VERSION = 2;
         // Why: setup installs this pinned release; protocol bump PRs can advance it only after
         // the matching CLI tag is published.
-        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.39";
+        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.39"; // x-release-please-version
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         public const string VERSION_FLAG = "--version";
         public const string SHORT_VERSION_FLAG = "-v";

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -12,7 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const int REQUIRED_CLI_PROTOCOL_VERSION = 2;
         // Why: setup installs this pinned release; protocol bump PRs can advance it only after
         // the matching CLI tag is published.
-        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.33";
+        public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.39";
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         public const string VERSION_FLAG = "--version";
         public const string SHORT_VERSION_FLAG = "-v";

--- a/Packages/src/Editor/Infrastructure/CLI/CliPinSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliPinSynchronizer.cs
@@ -18,8 +18,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         internal static bool SyncProjectPinFile(string packageRoot, string projectRoot)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(packageRoot), "packageRoot must not be null or empty");
-            Debug.Assert(!string.IsNullOrWhiteSpace(projectRoot), "projectRoot must not be null or empty");
+            if (string.IsNullOrWhiteSpace(packageRoot))
+            {
+                Debug.LogWarning(
+                    $"Unity CLI Loop skipped {UnityCliLoopConstants.ULOOP_CLI_PIN_FILE_NAME} synchronization because the package root is empty.");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(projectRoot))
+            {
+                Debug.LogWarning(
+                    $"Unity CLI Loop skipped {UnityCliLoopConstants.ULOOP_CLI_PIN_FILE_NAME} synchronization because the project root is empty.");
+                return false;
+            }
 
             string sourcePath = Path.Combine(packageRoot, UnityCliLoopConstants.ULOOP_CLI_PIN_FILE_NAME);
             string destinationPath = Path.Combine(
@@ -45,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             AtomicFileWriter.Write(destinationPath, sourceContent);
-            AtomicFileWriter.CleanupBackup(destinationPath + ".bak");
+            AtomicFileWriter.CleanupBackup(destinationPath + AtomicFileWriter.BackupFileSuffix);
             return true;
         }
     }

--- a/Packages/src/Editor/Infrastructure/CLI/CliPinSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliPinSynchronizer.cs
@@ -1,0 +1,52 @@
+using System.IO;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Publishes the package CLI pin contract into the project .uloop directory for dispatcher lookup.
+    /// </summary>
+    internal static class CliPinSynchronizer
+    {
+        internal static void SyncCurrentProjectPin()
+        {
+            SyncProjectPinFile(UnityCliLoopConstants.PackageResolvedPath, Directory.GetCurrentDirectory());
+        }
+
+        internal static bool SyncProjectPinFile(string packageRoot, string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(packageRoot), "packageRoot must not be null or empty");
+            Debug.Assert(!string.IsNullOrWhiteSpace(projectRoot), "projectRoot must not be null or empty");
+
+            string sourcePath = Path.Combine(packageRoot, UnityCliLoopConstants.ULOOP_CLI_PIN_FILE_NAME);
+            string destinationPath = Path.Combine(
+                projectRoot,
+                UnityCliLoopConstants.ULOOP_DIR,
+                UnityCliLoopConstants.ULOOP_CLI_PIN_FILE_NAME);
+
+            if (!File.Exists(sourcePath))
+            {
+                return false;
+            }
+
+            string sourceContent = File.ReadAllText(sourcePath);
+            if (File.Exists(destinationPath) && string.Equals(File.ReadAllText(destinationPath), sourceContent))
+            {
+                return false;
+            }
+
+            string destinationDirectory = Path.GetDirectoryName(destinationPath);
+            if (!string.IsNullOrEmpty(destinationDirectory) && !Directory.Exists(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            AtomicFileWriter.Write(destinationPath, sourceContent);
+            AtomicFileWriter.CleanupBackup(destinationPath + ".bak");
+            return true;
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/CLI/CliPinSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliPinSynchronizer.cs
@@ -13,7 +13,23 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         internal static void SyncCurrentProjectPin()
         {
-            SyncProjectPinFile(UnityCliLoopConstants.PackageResolvedPath, Directory.GetCurrentDirectory());
+            SyncProjectPinFile(UnityCliLoopConstants.PackageResolvedPath, ResolveCurrentProjectRoot(UnityEngine.Application.dataPath));
+        }
+
+        internal static string ResolveCurrentProjectRoot(string assetsPath)
+        {
+            if (string.IsNullOrWhiteSpace(assetsPath))
+            {
+                return string.Empty;
+            }
+
+            DirectoryInfo assetsDirectory = Directory.GetParent(assetsPath);
+            if (assetsDirectory == null)
+            {
+                return string.Empty;
+            }
+
+            return assetsDirectory.FullName;
         }
 
         internal static bool SyncProjectPinFile(string packageRoot, string projectRoot)

--- a/Packages/src/Editor/Infrastructure/CLI/CliPinSynchronizer.cs.meta
+++ b/Packages/src/Editor/Infrastructure/CLI/CliPinSynchronizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ea33f1e6f5b4b52adbf97cc8a41ebc9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+userData:
+assetBundleName:
+assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/Settings/ToolSettingsRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/ToolSettingsRepository.cs
@@ -47,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             AtomicFileWriter.Write(SettingsFilePath, json);
             _cachedSettings = settings;
 
-            AtomicFileWriter.CleanupBackup(SettingsFilePath + ".bak");
+            AtomicFileWriter.CleanupBackup(SettingsFilePath + AtomicFileWriter.BackupFileSuffix);
         }
 
         public bool IsToolEnabled(string toolName)

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsRepository.cs
@@ -97,8 +97,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             AtomicFileWriter.Write(SettingsFilePath, json);
             _cachedSettings = settings;
 
-            // Best-effort cleanup: even if this fails, .bak is overwritten on next save
-            AtomicFileWriter.CleanupBackup(SettingsFilePath + ".bak");
+            // Best-effort cleanup: even if this fails, the backup sidecar is overwritten on next save.
+            AtomicFileWriter.CleanupBackup(SettingsFilePath + AtomicFileWriter.BackupFileSuffix);
         }
 
         /// <summary>

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -56,6 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         // .uloop directory
         public const string ULOOP_DIR = ".uloop";
         public const string ULOOP_TOOL_SETTINGS_FILE_NAME = "settings.tools.json";
+        public const string ULOOP_CLI_PIN_FILE_NAME = "cli-pin.json";
 
         // Command name constants
         public const string TOOL_NAME_COMPILE = "compile";

--- a/Packages/src/cli-pin.json
+++ b/Packages/src/cli-pin.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "packageName": "io.github.hatayama.uloopmcp",
+  "packageVersion": "3.0.0-beta.40",
+  "cliVersion": "3.0.0-beta.39",
+  "requiredProtocolVersion": 2,
+  "minimumDispatcherVersion": "3.0.0-beta.39"
+}

--- a/Packages/src/cli-pin.json.meta
+++ b/Packages/src/cli-pin.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f09ed8a74d942b8a4df327d06d79a23
+TextScriptImporter:
+  externalObjects: {}
+userData:
+assetBundleName:
+assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Scope(s): io.github.hatayama.uloopmcp
 
 Select Window > Unity CLI Loop > Settings. A dedicated window will open. If the **CLI** button is not highlighted in blue, press **Install CLI**.
 
+The installer places the global `uloop` dispatcher on PATH. Project-specific `uloop-cli` binaries are downloaded into the user cache automatically from each project's `.uloop/cli-pin.json`.
+
 To return to the v2 line, press **Uninstall CLI** in Settings, downgrade the U-LOOP package to a v2 version such as `2.1.1`, then press **Install CLI** again from Settings.
 
 <details>
@@ -610,6 +612,7 @@ The `.uloop/` directory at the project root stores CLI cache, tool registry, and
 
 | File | Purpose | Git-track? |
 |------|---------|------------|
+| `cli-pin.json` | Project CLI version contract used by the global dispatcher | Yes |
 | `settings.tools.json` | Per-tool enable/disable preferences | Optional |
 | `tools.json` | Auto-generated CLI tool registry | No |
 | `outputs/` | Runtime outputs (test results, screenshots, hierarchy dumps) | No |
@@ -619,10 +622,11 @@ The `.uloop/` directory at the project root stores CLI cache, tool registry, and
 >
 > ```gitignore
 > **/.uloop/*
+> !**/.uloop/cli-pin.json
 > !**/.uloop/settings.tools.json
 > ```
 >
-> This ignores auto-generated files and runtime outputs while allowing team-shared configuration to be tracked.
+> This ignores auto-generated files and runtime outputs while allowing the dispatcher pin and team-shared configuration to be tracked.
 > Remove the `!` line if you don't need to share tool enable/disable preferences.
 
 ## License

--- a/cli/cmd/uloop-cli/main.go
+++ b/cli/cmd/uloop-cli/main.go
@@ -8,5 +8,5 @@ import (
 )
 
 func main() {
-	os.Exit(cli.RunDispatcher(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+	os.Exit(cli.RunProjectLocal(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
 }

--- a/cli/internal/cli/dispatcher.go
+++ b/cli/internal/cli/dispatcher.go
@@ -125,15 +125,21 @@ func resolveDispatcherProjectRoot(startPath string, explicitProjectPath string, 
 
 func enforceDispatcherFreshness(ctx context.Context, pin dispatcherPin, stderr io.Writer) (bool, int) {
 	minimumVersion := strings.TrimSpace(pin.MinimumDispatcherVersion)
-	if minimumVersion == "" || dispatcherSelfUpdateDisabled() {
+	if minimumVersion == "" {
 		return false, 0
 	}
-	if _, ok := dispatcherSiblingRealCLIPath(pin); ok {
-		return false, 0
+	updateRequired := sharedversion.IsLessThan(version, minimumVersion)
+	if updateRequired && dispatcherSelfUpdateDisabled() {
+		writeDispatcherManualUpdateRequiredError(stderr, minimumVersion, "Automatic update is disabled.")
+		return true, 1
+	}
+	if !updateRequired {
+		if _, ok := dispatcherSiblingRealCLIPath(pin); ok {
+			return false, 0
+		}
 	}
 
-	updateRequired := sharedversion.IsLessThan(version, minimumVersion)
-	updateDue := dispatcherSelfUpdateDue()
+	updateDue := !dispatcherSelfUpdateDisabled() && dispatcherSelfUpdateDue()
 	if !updateRequired && !updateDue {
 		return false, 0
 	}
@@ -156,23 +162,27 @@ func enforceDispatcherFreshness(ctx context.Context, pin dispatcherPin, stderr i
 	}
 
 	if updateRequired {
-		writeErrorEnvelope(stderr, cliError{
-			ErrorCode:   errorCodeCLIUpdateRequired,
-			Phase:       errorPhaseExecution,
-			Message:     "This project requires uloop dispatcher >= " + minimumVersion + ". Automatic update failed: " + err.Error(),
-			Retryable:   true,
-			SafeToRetry: true,
-			NextActions: []string{"Run `uloop update` and retry the command."},
-			Details: map[string]any{
-				"CurrentDispatcherVersion": version,
-				"MinimumDispatcherVersion": minimumVersion,
-			},
-		})
+		writeDispatcherManualUpdateRequiredError(stderr, minimumVersion, "Automatic update failed: "+err.Error())
 		return true, 1
 	}
 
 	writeFormat(stderr, "warning: dispatcher self-update skipped: %v\n", err)
 	return false, 0
+}
+
+func writeDispatcherManualUpdateRequiredError(stderr io.Writer, minimumVersion string, reason string) {
+	writeErrorEnvelope(stderr, cliError{
+		ErrorCode:   errorCodeCLIUpdateRequired,
+		Phase:       errorPhaseExecution,
+		Message:     "This project requires uloop dispatcher >= " + minimumVersion + ". " + reason,
+		Retryable:   true,
+		SafeToRetry: true,
+		NextActions: []string{"Run `uloop update` and retry the command."},
+		Details: map[string]any{
+			"CurrentDispatcherVersion": version,
+			"MinimumDispatcherVersion": minimumVersion,
+		},
+	})
 }
 
 func dispatcherSelfUpdateDisabled() bool {

--- a/cli/internal/cli/dispatcher.go
+++ b/cli/internal/cli/dispatcher.go
@@ -1,0 +1,285 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/hatayama/unity-cli-loop/cli/internal/project"
+	sharedupdate "github.com/hatayama/unity-cli-loop/cli/internal/update"
+	sharedversion "github.com/hatayama/unity-cli-loop/cli/internal/version"
+)
+
+const (
+	dispatcherCacheDirEnvName              = "ULOOP_CACHE_DIR"
+	dispatcherDisableSelfUpdateEnvName     = "ULOOP_DISABLE_SELF_UPDATE"
+	dispatcherCacheDirectoryName           = "uloop"
+	dispatcherVersionsDirectoryName        = "versions"
+	dispatcherUpdateStateFileName          = "dispatcher-update.json"
+	dispatcherProjectPinRelativePath       = ".uloop/cli-pin.json"
+	dispatcherPackagePinFileName           = "cli-pin.json"
+	dispatcherUnityPackageName             = "io.github.hatayama.uloopmcp"
+	dispatcherRealCLIUnixFileName          = "uloop-cli"
+	dispatcherRealCLIWindowsFileName       = "uloop-cli.exe"
+	dispatcherLegacyUnixFileName           = "uloop"
+	dispatcherLegacyWindowsFileName        = "uloop.exe"
+	dispatcherReleaseRepository            = "hatayama/unity-cli-loop"
+	dispatcherReleaseBaseURL               = "https://github.com/" + dispatcherReleaseRepository + "/releases/download"
+	dispatcherSelfUpdateInterval           = 24 * time.Hour
+	dispatcherSelfUpdateRequiredRetryError = "Dispatcher update completed. Retry the command so the updated dispatcher can run."
+)
+
+var (
+	dispatcherNow        = time.Now
+	dispatcherRunRealCLI = runRealCLICommand
+	dispatcherRunUpdate  = runDispatcherUpdateCommand
+)
+
+type dispatcherUpdateState struct {
+	LastChecked time.Time `json:"lastChecked"`
+}
+
+func RunDispatcher(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
+	remainingArgs, projectPath, err := parseGlobalProjectPath(args)
+	if err != nil {
+		writeClassifiedError(stderr, err, errorContext{})
+		return 1
+	}
+
+	if shouldRunInDispatcherProcess(remainingArgs) {
+		return RunProjectLocal(ctx, args, stdout, stderr)
+	}
+
+	startPath, err := os.Getwd()
+	if err != nil {
+		writeClassifiedError(stderr, err, errorContext{})
+		return 1
+	}
+
+	projectRoot, err := resolveDispatcherProjectRoot(startPath, projectPath, remainingArgs)
+	if err != nil {
+		writeClassifiedError(stderr, err, errorContext{})
+		return 1
+	}
+
+	pin, err := loadDispatcherPin(projectRoot)
+	if err != nil {
+		writeErrorEnvelope(stderr, dispatcherPinResolutionError(projectRoot, err))
+		return 1
+	}
+
+	if handled, code := enforceDispatcherFreshness(ctx, pin, stderr); handled {
+		return code
+	}
+
+	realCLIPath, err := resolveDispatcherRealCLI(ctx, pin)
+	if err != nil {
+		writeErrorEnvelope(stderr, dispatcherRealCLIResolutionError(projectRoot, pin, err))
+		return 1
+	}
+
+	return dispatcherRunRealCLI(ctx, realCLIPath, args, stdout, stderr)
+}
+
+func shouldRunInDispatcherProcess(args []string) bool {
+	if len(args) == 0 || isHelpRequest(args) || isVersionRequest(args) || isVersionJSONRequest(args) {
+		return true
+	}
+	if shouldHandleCompletionRequest(args) {
+		return true
+	}
+
+	switch args[0] {
+	case installCommandName, updateCommandName, uninstallCommandName, skillsCommandName:
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveDispatcherProjectRoot(startPath string, explicitProjectPath string, args []string) (string, error) {
+	if len(args) > 0 && args[0] == launchCommandName {
+		options, err := parseLaunchOptions(args[1:], explicitProjectPath)
+		if err != nil {
+			return "", err
+		}
+		return resolveLaunchProjectRoot(startPath, options)
+	}
+
+	connection, err := project.ResolveConnection(startPath, explicitProjectPath)
+	if err != nil {
+		return "", err
+	}
+	return connection.ProjectRoot, nil
+}
+
+func enforceDispatcherFreshness(ctx context.Context, pin dispatcherPin, stderr io.Writer) (bool, int) {
+	minimumVersion := strings.TrimSpace(pin.MinimumDispatcherVersion)
+	if minimumVersion == "" || dispatcherSelfUpdateDisabled() {
+		return false, 0
+	}
+	if _, ok := dispatcherSiblingRealCLIPath(pin); ok {
+		return false, 0
+	}
+
+	updateRequired := sharedversion.IsLessThan(version, minimumVersion)
+	updateDue := dispatcherSelfUpdateDue()
+	if !updateRequired && !updateDue {
+		return false, 0
+	}
+
+	err := dispatcherRunUpdate(ctx)
+	markDispatcherSelfUpdateChecked()
+	if err == nil {
+		if updateRequired {
+			writeErrorEnvelope(stderr, cliError{
+				ErrorCode:   errorCodeCLIUpdateRequired,
+				Phase:       errorPhaseExecution,
+				Message:     dispatcherSelfUpdateRequiredRetryError,
+				Retryable:   true,
+				SafeToRetry: true,
+				NextActions: []string{"Retry the same uloop command."},
+			})
+			return true, 1
+		}
+		return false, 0
+	}
+
+	if updateRequired {
+		writeErrorEnvelope(stderr, cliError{
+			ErrorCode:   errorCodeCLIUpdateRequired,
+			Phase:       errorPhaseExecution,
+			Message:     "This project requires uloop dispatcher >= " + minimumVersion + ". Automatic update failed: " + err.Error(),
+			Retryable:   true,
+			SafeToRetry: true,
+			NextActions: []string{"Run `uloop update` and retry the command."},
+			Details: map[string]any{
+				"CurrentDispatcherVersion": version,
+				"MinimumDispatcherVersion": minimumVersion,
+			},
+		})
+		return true, 1
+	}
+
+	writeFormat(stderr, "warning: dispatcher self-update skipped: %v\n", err)
+	return false, 0
+}
+
+func dispatcherSelfUpdateDisabled() bool {
+	value := strings.TrimSpace(os.Getenv(dispatcherDisableSelfUpdateEnvName))
+	return value == "1" || strings.EqualFold(value, "true")
+}
+
+func dispatcherSelfUpdateDue() bool {
+	cacheRoot, err := dispatcherCacheRoot(runtime.GOOS)
+	if err != nil {
+		return false
+	}
+	statePath := filepath.Join(cacheRoot, dispatcherUpdateStateFileName)
+	content, err := os.ReadFile(statePath)
+	if err != nil {
+		return true
+	}
+	state := dispatcherUpdateState{}
+	if err := json.Unmarshal(content, &state); err != nil {
+		return true
+	}
+	return dispatcherNow().Sub(state.LastChecked) >= dispatcherSelfUpdateInterval
+}
+
+func markDispatcherSelfUpdateChecked() {
+	cacheRoot, err := dispatcherCacheRoot(runtime.GOOS)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+		return
+	}
+	content, err := json.Marshal(dispatcherUpdateState{LastChecked: dispatcherNow().UTC()})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(cacheRoot, dispatcherUpdateStateFileName), content, 0o644)
+}
+
+func runDispatcherUpdateCommand(ctx context.Context) error {
+	command, err := sharedupdate.CommandForOS(runtime.GOOS, sharedupdate.Options{
+		CurrentVersion: version,
+	})
+	if err != nil {
+		return err
+	}
+	updateCommand := exec.CommandContext(ctx, command.Name, command.Args...)
+	updateCommand.Stdout = io.Discard
+	updateCommand.Stderr = io.Discard
+	return updateCommand.Run()
+}
+
+func runRealCLICommand(ctx context.Context, realCLIPath string, args []string, stdout io.Writer, stderr io.Writer) int {
+	command := exec.CommandContext(ctx, realCLIPath, args...)
+	command.Stdout = stdout
+	command.Stderr = stderr
+	command.Stdin = os.Stdin
+	command.Env = os.Environ()
+	if err := command.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode()
+		}
+		writeErrorEnvelope(stderr, cliError{
+			ErrorCode:   errorCodeInternalError,
+			Phase:       errorPhaseExecution,
+			Message:     "Failed to run resolved uloop CLI: " + err.Error(),
+			Retryable:   true,
+			SafeToRetry: true,
+			NextActions: []string{"Retry after checking the cached uloop CLI file permissions."},
+			Details: map[string]any{
+				"ExecutablePath": realCLIPath,
+			},
+		})
+		return 1
+	}
+	return 0
+}
+
+func dispatcherPinResolutionError(projectRoot string, cause error) cliError {
+	return cliError{
+		ErrorCode:   errorCodeInternalError,
+		Phase:       errorPhaseProjectResolve,
+		Message:     "Could not resolve the required uloop CLI for this Unity project.",
+		Retryable:   true,
+		SafeToRetry: true,
+		ProjectRoot: projectRoot,
+		NextActions: []string{
+			"Open the Unity project once so Unity CLI Loop can write `.uloop/cli-pin.json`.",
+			"Run the CLI setup from Unity CLI Loop Settings if the pin file is still missing.",
+		},
+		Details: map[string]any{
+			"Cause": cause.Error(),
+		},
+	}
+}
+
+func dispatcherRealCLIResolutionError(projectRoot string, pin dispatcherPin, cause error) cliError {
+	return cliError{
+		ErrorCode:   errorCodeInternalError,
+		Phase:       errorPhaseExecution,
+		Message:     "Could not prepare the pinned uloop CLI version.",
+		Retryable:   true,
+		SafeToRetry: true,
+		ProjectRoot: projectRoot,
+		NextActions: []string{"Check network access to GitHub releases, then retry the command."},
+		Details: map[string]any{
+			"Cause":      cause.Error(),
+			"CliVersion": pin.CLIVersion,
+			"PinSource":  pin.SourcePath,
+		},
+	}
+}

--- a/cli/internal/cli/dispatcher.go
+++ b/cli/internal/cli/dispatcher.go
@@ -89,7 +89,10 @@ func RunDispatcher(ctx context.Context, args []string, stdout io.Writer, stderr 
 }
 
 func shouldRunInDispatcherProcess(args []string) bool {
-	if len(args) == 0 || isHelpRequest(args) || isVersionRequest(args) || isVersionJSONRequest(args) {
+	if len(args) == 0 || isHelpRequest(args) || containsHelpRequest(args) || isVersionRequest(args) || isVersionJSONRequest(args) {
+		return true
+	}
+	if isUnknownLeadingOption(args[0]) {
 		return true
 	}
 	if shouldHandleCompletionRequest(args) {

--- a/cli/internal/cli/dispatcher.go
+++ b/cli/internal/cli/dispatcher.go
@@ -100,7 +100,7 @@ func shouldRunInDispatcherProcess(args []string) bool {
 	}
 
 	switch args[0] {
-	case installCommandName, updateCommandName, uninstallCommandName, skillsCommandName:
+	case launchCommandName, installCommandName, updateCommandName, uninstallCommandName, skillsCommandName:
 		return true
 	default:
 		return false

--- a/cli/internal/cli/dispatcher.go
+++ b/cli/internal/cli/dispatcher.go
@@ -145,8 +145,8 @@ func enforceDispatcherFreshness(ctx context.Context, pin dispatcherPin, stderr i
 	}
 
 	err := dispatcherRunUpdate(ctx)
-	markDispatcherSelfUpdateChecked()
 	if err == nil {
+		markDispatcherSelfUpdateChecked()
 		if updateRequired {
 			writeErrorEnvelope(stderr, cliError{
 				ErrorCode:   errorCodeCLIUpdateRequired,

--- a/cli/internal/cli/dispatcher_download.go
+++ b/cli/internal/cli/dispatcher_download.go
@@ -257,16 +257,28 @@ func extractDispatcherRealCLI(archivePath string, assetName string, destinationP
 }
 
 func extractDispatcherRealCLIFromTarGz(archivePath string, destinationPath string, goos string) error {
+	found, err := extractDispatcherCLIFromTarGzEntry(archivePath, destinationPath, dispatcherRealCLIFileName(goos))
+	if err != nil || found {
+		return err
+	}
+	found, err = extractDispatcherCLIFromTarGzEntry(archivePath, destinationPath, dispatcherLegacyCLIFileName(goos))
+	if err != nil || found {
+		return err
+	}
+	return fmt.Errorf("archive does not contain %s", dispatcherRealCLIFileName(goos))
+}
+
+func extractDispatcherCLIFromTarGzEntry(archivePath string, destinationPath string, entryFileName string) (bool, error) {
 	file, err := os.Open(archivePath)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() {
 		_ = file.Close()
 	}()
 	gzipReader, err := gzip.NewReader(file)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() {
 		_ = gzipReader.Close()
@@ -278,17 +290,17 @@ func extractDispatcherRealCLIFromTarGz(archivePath string, destinationPath strin
 			break
 		}
 		if err != nil {
-			return err
+			return false, err
 		}
 		if header.Typeflag != tar.TypeReg {
 			continue
 		}
-		if !dispatcherArchiveEntryMatchesCLI(header.Name, goos) {
+		if !dispatcherArchiveEntryMatchesFileName(header.Name, entryFileName) {
 			continue
 		}
-		return writeDispatcherExtractedCLI(destinationPath, tarReader)
+		return true, writeDispatcherExtractedCLI(destinationPath, tarReader)
 	}
-	return fmt.Errorf("archive does not contain %s", dispatcherRealCLIFileName(goos))
+	return false, nil
 }
 
 func extractDispatcherRealCLIFromZip(archivePath string, destinationPath string, goos string) error {
@@ -299,28 +311,40 @@ func extractDispatcherRealCLIFromZip(archivePath string, destinationPath string,
 	defer func() {
 		_ = reader.Close()
 	}()
-	for _, entry := range reader.File {
-		if entry.FileInfo().IsDir() || !dispatcherArchiveEntryMatchesCLI(entry.Name, goos) {
-			continue
-		}
-		entryReader, err := entry.Open()
-		if err != nil {
-			return err
-		}
-		writeErr := writeDispatcherExtractedCLI(destinationPath, entryReader)
-		closeErr := entryReader.Close()
-		if writeErr != nil {
-			return writeErr
-		}
-		return closeErr
+	found, err := extractDispatcherCLIFromZipEntry(reader, destinationPath, dispatcherRealCLIFileName(goos))
+	if err != nil || found {
+		return err
+	}
+	found, err = extractDispatcherCLIFromZipEntry(reader, destinationPath, dispatcherLegacyCLIFileName(goos))
+	if err != nil || found {
+		return err
 	}
 	return fmt.Errorf("archive does not contain %s", dispatcherRealCLIFileName(goos))
 }
 
-func dispatcherArchiveEntryMatchesCLI(entryName string, goos string) bool {
+func extractDispatcherCLIFromZipEntry(reader *zip.ReadCloser, destinationPath string, entryFileName string) (bool, error) {
+	for _, entry := range reader.File {
+		if entry.FileInfo().IsDir() || !dispatcherArchiveEntryMatchesFileName(entry.Name, entryFileName) {
+			continue
+		}
+		entryReader, err := entry.Open()
+		if err != nil {
+			return false, err
+		}
+		writeErr := writeDispatcherExtractedCLI(destinationPath, entryReader)
+		closeErr := entryReader.Close()
+		if writeErr != nil {
+			return false, writeErr
+		}
+		return true, closeErr
+	}
+	return false, nil
+}
+
+func dispatcherArchiveEntryMatchesFileName(entryName string, fileName string) bool {
 	normalizedEntryName := strings.ReplaceAll(entryName, `\`, "/")
 	baseName := path.Base(normalizedEntryName)
-	return baseName == dispatcherRealCLIFileName(goos) || baseName == dispatcherLegacyCLIFileName(goos)
+	return baseName == fileName
 }
 
 func writeDispatcherExtractedCLI(destinationPath string, reader io.Reader) error {

--- a/cli/internal/cli/dispatcher_download.go
+++ b/cli/internal/cli/dispatcher_download.go
@@ -23,6 +23,10 @@ import (
 var dispatcherHTTPClient = http.DefaultClient
 
 func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin) (string, error) {
+	pin.CLIVersion = strings.TrimSpace(pin.CLIVersion)
+	if err := validateDispatcherCLIVersion(pin.CLIVersion); err != nil {
+		return "", err
+	}
 	if siblingPath, ok := dispatcherSiblingRealCLIPath(pin); ok {
 		return siblingPath, nil
 	}

--- a/cli/internal/cli/dispatcher_download.go
+++ b/cli/internal/cli/dispatcher_download.go
@@ -16,11 +16,12 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	sharedupdate "github.com/hatayama/unity-cli-loop/cli/internal/update"
 )
 
-var dispatcherHTTPClient = http.DefaultClient
+var dispatcherHTTPClient = &http.Client{Timeout: 2 * time.Minute}
 
 func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin) (string, error) {
 	pin.CLIVersion = strings.TrimSpace(pin.CLIVersion)
@@ -165,6 +166,19 @@ func downloadDispatcherRealCLI(ctx context.Context, cacheRoot string, cliVersion
 	}
 	if err := os.Chmod(tempRealCLIPath, 0o755); err != nil {
 		return "", err
+	}
+	return installDownloadedDispatcherRealCLI(tempRealCLIPath, realCLIPath)
+}
+
+func installDownloadedDispatcherRealCLI(tempRealCLIPath string, realCLIPath string) (string, error) {
+	if isExecutableFile(realCLIPath) {
+		return realCLIPath, nil
+	}
+	if err := os.Rename(tempRealCLIPath, realCLIPath); err == nil {
+		return realCLIPath, nil
+	}
+	if isExecutableFile(realCLIPath) {
+		return realCLIPath, nil
 	}
 	if err := os.Remove(realCLIPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return "", err

--- a/cli/internal/cli/dispatcher_download.go
+++ b/cli/internal/cli/dispatcher_download.go
@@ -1,0 +1,337 @@
+package cli
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	sharedupdate "github.com/hatayama/unity-cli-loop/cli/internal/update"
+)
+
+var dispatcherHTTPClient = http.DefaultClient
+
+func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin) (string, error) {
+	if siblingPath, ok := dispatcherSiblingRealCLIPath(pin); ok {
+		return siblingPath, nil
+	}
+
+	cacheRoot, err := dispatcherCacheRoot(runtime.GOOS)
+	if err != nil {
+		return "", err
+	}
+	realCLIPath := dispatcherCachedRealCLIPath(cacheRoot, pin.CLIVersion, runtime.GOOS, runtime.GOARCH)
+	if isExecutableFile(realCLIPath) {
+		return realCLIPath, nil
+	}
+
+	return downloadDispatcherRealCLI(ctx, cacheRoot, pin.CLIVersion, runtime.GOOS, runtime.GOARCH)
+}
+
+func dispatcherSiblingRealCLIPath(pin dispatcherPin) (string, bool) {
+	if pin.CLIVersion != version {
+		return "", false
+	}
+	executablePath, err := os.Executable()
+	if err != nil {
+		return "", false
+	}
+	if resolvedPath, err := filepath.EvalSymlinks(executablePath); err == nil {
+		executablePath = resolvedPath
+	}
+	candidate := filepath.Join(filepath.Dir(executablePath), dispatcherRealCLIFileName(runtime.GOOS))
+	if !isExecutableFile(candidate) {
+		return "", false
+	}
+	return candidate, true
+}
+
+func dispatcherCacheRoot(goos string) (string, error) {
+	if explicitCacheRoot := strings.TrimSpace(os.Getenv(dispatcherCacheDirEnvName)); explicitCacheRoot != "" {
+		return explicitCacheRoot, nil
+	}
+	switch goos {
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, "Library", "Caches", dispatcherCacheDirectoryName), nil
+	case "windows":
+		localAppData := os.Getenv(nativeLocalAppDataEnvName)
+		if localAppData == "" {
+			return "", errors.New("LOCALAPPDATA is required to resolve the uloop cache directory")
+		}
+		return filepath.Join(localAppData, dispatcherCacheDirectoryName), nil
+	default:
+		if xdgCacheHome := strings.TrimSpace(os.Getenv("XDG_CACHE_HOME")); xdgCacheHome != "" {
+			return filepath.Join(xdgCacheHome, dispatcherCacheDirectoryName), nil
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".cache", dispatcherCacheDirectoryName), nil
+	}
+}
+
+func dispatcherCachedRealCLIPath(cacheRoot string, cliVersion string, goos string, goarch string) string {
+	return filepath.Join(
+		cacheRoot,
+		dispatcherVersionsDirectoryName,
+		cliVersion,
+		dispatcherPlatformName(goos, goarch),
+		dispatcherRealCLIFileName(goos))
+}
+
+func dispatcherPlatformName(goos string, goarch string) string {
+	return goos + "-" + goarch
+}
+
+func dispatcherRealCLIFileName(goos string) string {
+	if goos == "windows" {
+		return dispatcherRealCLIWindowsFileName
+	}
+	return dispatcherRealCLIUnixFileName
+}
+
+func dispatcherLegacyCLIFileName(goos string) string {
+	if goos == "windows" {
+		return dispatcherLegacyWindowsFileName
+	}
+	return dispatcherLegacyUnixFileName
+}
+
+func isExecutableFile(filePath string) bool {
+	info, err := os.Stat(filePath)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode()&0o111 != 0
+}
+
+func downloadDispatcherRealCLI(ctx context.Context, cacheRoot string, cliVersion string, goos string, goarch string) (string, error) {
+	assetName, err := dispatcherReleaseAssetName(goos, goarch)
+	if err != nil {
+		return "", err
+	}
+	realCLIPath := dispatcherCachedRealCLIPath(cacheRoot, cliVersion, goos, goarch)
+	if err := os.MkdirAll(filepath.Dir(realCLIPath), 0o755); err != nil {
+		return "", err
+	}
+
+	tempDir, err := os.MkdirTemp(filepath.Dir(realCLIPath), "download-")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	archivePath := filepath.Join(tempDir, assetName)
+	checksumPath := archivePath + ".sha256"
+	assetURL := dispatcherReleaseAssetURL(cliVersion, assetName)
+	if err := downloadDispatcherFile(ctx, assetURL, archivePath); err != nil {
+		return "", err
+	}
+	if err := downloadDispatcherFile(ctx, assetURL+".sha256", checksumPath); err != nil {
+		return "", err
+	}
+	if err := verifyDispatcherChecksum(archivePath, checksumPath); err != nil {
+		return "", err
+	}
+
+	tempRealCLIPath := filepath.Join(tempDir, dispatcherRealCLIFileName(goos))
+	if err := extractDispatcherRealCLI(archivePath, assetName, tempRealCLIPath, goos); err != nil {
+		return "", err
+	}
+	if err := os.Chmod(tempRealCLIPath, 0o755); err != nil {
+		return "", err
+	}
+	if err := os.Remove(realCLIPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	if err := os.Rename(tempRealCLIPath, realCLIPath); err != nil {
+		return "", err
+	}
+	return realCLIPath, nil
+}
+
+func dispatcherReleaseAssetName(goos string, goarch string) (string, error) {
+	switch goos {
+	case "darwin":
+		if goarch != "arm64" && goarch != "amd64" {
+			return "", fmt.Errorf("unsupported darwin architecture: %s", goarch)
+		}
+		return "uloop-darwin-" + goarch + ".tar.gz", nil
+	case "windows":
+		if goarch != "amd64" {
+			return "", fmt.Errorf("unsupported windows architecture: %s", goarch)
+		}
+		return "uloop-windows-amd64.zip", nil
+	default:
+		return "", fmt.Errorf("unsupported platform: %s-%s", goos, goarch)
+	}
+}
+
+func dispatcherReleaseAssetURL(cliVersion string, assetName string) string {
+	return dispatcherReleaseBaseURL + "/" + sharedupdate.ReleaseTag(cliVersion) + "/" + assetName
+}
+
+func downloadDispatcherFile(ctx context.Context, url string, destinationPath string) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	response, err := dispatcherHTTPClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("download failed for %s: %s", url, response.Status)
+	}
+
+	file, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(file, response.Body)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}
+
+func verifyDispatcherChecksum(assetPath string, checksumPath string) error {
+	content, err := os.ReadFile(checksumPath)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(string(content))
+	if len(fields) == 0 {
+		return fmt.Errorf("checksum file is empty: %s", checksumPath)
+	}
+	expectedHash := strings.ToLower(fields[0])
+
+	file, err := os.Open(assetPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return err
+	}
+	actualHash := hex.EncodeToString(hash.Sum(nil))
+	if actualHash != expectedHash {
+		return fmt.Errorf("checksum mismatch for %s", filepath.Base(assetPath))
+	}
+	return nil
+}
+
+func extractDispatcherRealCLI(archivePath string, assetName string, destinationPath string, goos string) error {
+	if strings.HasSuffix(assetName, ".zip") {
+		return extractDispatcherRealCLIFromZip(archivePath, destinationPath, goos)
+	}
+	return extractDispatcherRealCLIFromTarGz(archivePath, destinationPath, goos)
+}
+
+func extractDispatcherRealCLIFromTarGz(archivePath string, destinationPath string, goos string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = gzipReader.Close()
+	}()
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if !dispatcherArchiveEntryMatchesCLI(header.Name, goos) {
+			continue
+		}
+		return writeDispatcherExtractedCLI(destinationPath, tarReader)
+	}
+	return fmt.Errorf("archive does not contain %s", dispatcherRealCLIFileName(goos))
+}
+
+func extractDispatcherRealCLIFromZip(archivePath string, destinationPath string, goos string) error {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+	for _, entry := range reader.File {
+		if entry.FileInfo().IsDir() || !dispatcherArchiveEntryMatchesCLI(entry.Name, goos) {
+			continue
+		}
+		entryReader, err := entry.Open()
+		if err != nil {
+			return err
+		}
+		writeErr := writeDispatcherExtractedCLI(destinationPath, entryReader)
+		closeErr := entryReader.Close()
+		if writeErr != nil {
+			return writeErr
+		}
+		return closeErr
+	}
+	return fmt.Errorf("archive does not contain %s", dispatcherRealCLIFileName(goos))
+}
+
+func dispatcherArchiveEntryMatchesCLI(entryName string, goos string) bool {
+	normalizedEntryName := strings.ReplaceAll(entryName, `\`, "/")
+	baseName := path.Base(normalizedEntryName)
+	return baseName == dispatcherRealCLIFileName(goos) || baseName == dispatcherLegacyCLIFileName(goos)
+}
+
+func writeDispatcherExtractedCLI(destinationPath string, reader io.Reader) error {
+	file, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(file, reader)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}

--- a/cli/internal/cli/dispatcher_pin.go
+++ b/cli/internal/cli/dispatcher_pin.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	dispatcherMinimumCliVersionPattern       = regexp.MustCompile(`MINIMUM_REQUIRED_CLI_VERSION\s*=\s*"([^"]+)"`)
+	dispatcherRequiredProtocolVersionPattern = regexp.MustCompile(`REQUIRED_CLI_PROTOCOL_VERSION\s*=\s*(\d+)`)
+)
+
+type dispatcherPin struct {
+	SchemaVersion            int    `json:"schemaVersion"`
+	PackageName              string `json:"packageName"`
+	PackageVersion           string `json:"packageVersion"`
+	CLIVersion               string `json:"cliVersion"`
+	RequiredProtocolVersion  int    `json:"requiredProtocolVersion"`
+	MinimumDispatcherVersion string `json:"minimumDispatcherVersion"`
+	SourcePath               string `json:"-"`
+}
+
+func loadDispatcherPin(projectRoot string) (dispatcherPin, error) {
+	for _, pinPath := range dispatcherPinCandidatePaths(projectRoot) {
+		pin, err := readDispatcherPin(pinPath)
+		if err == nil {
+			return pin, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return dispatcherPin{}, err
+		}
+	}
+
+	for _, constantsPath := range dispatcherCliConstantsCandidatePaths(projectRoot) {
+		pin, err := readDispatcherPinFromCliConstants(constantsPath)
+		if err == nil {
+			return pin, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return dispatcherPin{}, err
+		}
+	}
+
+	return dispatcherPin{}, fmt.Errorf("cli pin not found under %s", projectRoot)
+}
+
+func dispatcherPinCandidatePaths(projectRoot string) []string {
+	paths := []string{
+		filepath.Join(projectRoot, dispatcherProjectPinRelativePath),
+		filepath.Join(projectRoot, "Packages", "src", dispatcherPackagePinFileName),
+		filepath.Join(projectRoot, "Packages", dispatcherUnityPackageName, dispatcherPackagePinFileName),
+	}
+	packageCachePattern := filepath.Join(
+		projectRoot,
+		"Library",
+		"PackageCache",
+		dispatcherUnityPackageName+"@*",
+		dispatcherPackagePinFileName)
+	matches, err := filepath.Glob(packageCachePattern)
+	if err == nil {
+		paths = append(paths, matches...)
+	}
+	return paths
+}
+
+func dispatcherCliConstantsCandidatePaths(projectRoot string) []string {
+	paths := []string{
+		filepath.Join(projectRoot, "Packages", "src", "Editor", "Domain", "CliConstants.cs"),
+		filepath.Join(projectRoot, "Packages", dispatcherUnityPackageName, "Editor", "Domain", "CliConstants.cs"),
+	}
+	packageCachePattern := filepath.Join(
+		projectRoot,
+		"Library",
+		"PackageCache",
+		dispatcherUnityPackageName+"@*",
+		"Editor",
+		"Domain",
+		"CliConstants.cs")
+	matches, err := filepath.Glob(packageCachePattern)
+	if err == nil {
+		paths = append(paths, matches...)
+	}
+	return paths
+}
+
+func readDispatcherPin(pinPath string) (dispatcherPin, error) {
+	content, err := os.ReadFile(pinPath)
+	if err != nil {
+		return dispatcherPin{}, err
+	}
+
+	pin := dispatcherPin{}
+	if err := json.Unmarshal(content, &pin); err != nil {
+		return dispatcherPin{}, fmt.Errorf("failed to parse %s: %w", pinPath, err)
+	}
+	if strings.TrimSpace(pin.CLIVersion) == "" {
+		return dispatcherPin{}, fmt.Errorf("%s does not define cliVersion", pinPath)
+	}
+	if pin.SchemaVersion == 0 {
+		return dispatcherPin{}, fmt.Errorf("%s does not define schemaVersion", pinPath)
+	}
+	pin.SourcePath = pinPath
+	return pin, nil
+}
+
+func readDispatcherPinFromCliConstants(constantsPath string) (dispatcherPin, error) {
+	content, err := os.ReadFile(constantsPath)
+	if err != nil {
+		return dispatcherPin{}, err
+	}
+	text := string(content)
+	versionMatch := dispatcherMinimumCliVersionPattern.FindStringSubmatch(text)
+	if len(versionMatch) != 2 {
+		return dispatcherPin{}, fmt.Errorf("%s does not define MINIMUM_REQUIRED_CLI_VERSION", constantsPath)
+	}
+	protocolVersion := 0
+	protocolMatch := dispatcherRequiredProtocolVersionPattern.FindStringSubmatch(text)
+	if len(protocolMatch) == 2 {
+		_, _ = fmt.Sscanf(protocolMatch[1], "%d", &protocolVersion)
+	}
+
+	return dispatcherPin{
+		SchemaVersion:            1,
+		PackageName:              dispatcherUnityPackageName,
+		CLIVersion:               versionMatch[1],
+		RequiredProtocolVersion:  protocolVersion,
+		MinimumDispatcherVersion: versionMatch[1],
+		SourcePath:               constantsPath,
+	}, nil
+}

--- a/cli/internal/cli/dispatcher_pin.go
+++ b/cli/internal/cli/dispatcher_pin.go
@@ -26,14 +26,27 @@ type dispatcherPin struct {
 	SourcePath               string `json:"-"`
 }
 
+type dispatcherPinCandidatePath struct {
+	Path     string
+	Required bool
+}
+
 func loadDispatcherPin(projectRoot string) (dispatcherPin, error) {
-	for _, pinPath := range dispatcherPinCandidatePaths(projectRoot) {
-		pin, err := readDispatcherPin(pinPath)
+	var invalidPackagePinError error
+	for _, candidate := range dispatcherPinCandidatePaths(projectRoot) {
+		pin, err := readDispatcherPin(candidate.Path)
 		if err == nil {
 			return pin, nil
 		}
-		if !errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if candidate.Required {
 			return dispatcherPin{}, err
+		}
+		// Why: source package paths can contain stale pins during upgrades; PackageCache may still hold the resolved package pin.
+		if invalidPackagePinError == nil {
+			invalidPackagePinError = err
 		}
 	}
 
@@ -47,14 +60,17 @@ func loadDispatcherPin(projectRoot string) (dispatcherPin, error) {
 		}
 	}
 
+	if invalidPackagePinError != nil {
+		return dispatcherPin{}, invalidPackagePinError
+	}
 	return dispatcherPin{}, fmt.Errorf("cli pin not found under %s", projectRoot)
 }
 
-func dispatcherPinCandidatePaths(projectRoot string) []string {
-	paths := []string{
-		filepath.Join(projectRoot, dispatcherProjectPinRelativePath),
-		filepath.Join(projectRoot, "Packages", "src", dispatcherPackagePinFileName),
-		filepath.Join(projectRoot, "Packages", dispatcherUnityPackageName, dispatcherPackagePinFileName),
+func dispatcherPinCandidatePaths(projectRoot string) []dispatcherPinCandidatePath {
+	paths := []dispatcherPinCandidatePath{
+		{Path: filepath.Join(projectRoot, dispatcherProjectPinRelativePath), Required: true},
+		{Path: filepath.Join(projectRoot, "Packages", "src", dispatcherPackagePinFileName)},
+		{Path: filepath.Join(projectRoot, "Packages", dispatcherUnityPackageName, dispatcherPackagePinFileName)},
 	}
 	packageCachePattern := filepath.Join(
 		projectRoot,
@@ -64,7 +80,9 @@ func dispatcherPinCandidatePaths(projectRoot string) []string {
 		dispatcherPackagePinFileName)
 	matches, err := filepath.Glob(packageCachePattern)
 	if err == nil {
-		paths = append(paths, matches...)
+		for _, match := range matches {
+			paths = append(paths, dispatcherPinCandidatePath{Path: match})
+		}
 	}
 	return paths
 }

--- a/cli/internal/cli/dispatcher_pin.go
+++ b/cli/internal/cli/dispatcher_pin.go
@@ -13,6 +13,7 @@ import (
 var (
 	dispatcherMinimumCliVersionPattern       = regexp.MustCompile(`MINIMUM_REQUIRED_CLI_VERSION\s*=\s*"([^"]+)"`)
 	dispatcherRequiredProtocolVersionPattern = regexp.MustCompile(`REQUIRED_CLI_PROTOCOL_VERSION\s*=\s*(\d+)`)
+	dispatcherCLIVersionPattern              = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
 )
 
 type dispatcherPin struct {
@@ -98,8 +99,12 @@ func readDispatcherPin(pinPath string) (dispatcherPin, error) {
 	if err := json.Unmarshal(content, &pin); err != nil {
 		return dispatcherPin{}, fmt.Errorf("failed to parse %s: %w", pinPath, err)
 	}
-	if strings.TrimSpace(pin.CLIVersion) == "" {
+	pin.CLIVersion = strings.TrimSpace(pin.CLIVersion)
+	if pin.CLIVersion == "" {
 		return dispatcherPin{}, fmt.Errorf("%s does not define cliVersion", pinPath)
+	}
+	if err := validateDispatcherCLIVersion(pin.CLIVersion); err != nil {
+		return dispatcherPin{}, fmt.Errorf("%s defines invalid cliVersion: %w", pinPath, err)
 	}
 	if pin.SchemaVersion == 0 {
 		return dispatcherPin{}, fmt.Errorf("%s does not define schemaVersion", pinPath)
@@ -118,6 +123,10 @@ func readDispatcherPinFromCliConstants(constantsPath string) (dispatcherPin, err
 	if len(versionMatch) != 2 {
 		return dispatcherPin{}, fmt.Errorf("%s does not define MINIMUM_REQUIRED_CLI_VERSION", constantsPath)
 	}
+	cliVersion := strings.TrimSpace(versionMatch[1])
+	if err := validateDispatcherCLIVersion(cliVersion); err != nil {
+		return dispatcherPin{}, fmt.Errorf("%s defines invalid MINIMUM_REQUIRED_CLI_VERSION: %w", constantsPath, err)
+	}
 	protocolVersion := 0
 	protocolMatch := dispatcherRequiredProtocolVersionPattern.FindStringSubmatch(text)
 	if len(protocolMatch) == 2 {
@@ -127,9 +136,16 @@ func readDispatcherPinFromCliConstants(constantsPath string) (dispatcherPin, err
 	return dispatcherPin{
 		SchemaVersion:            1,
 		PackageName:              dispatcherUnityPackageName,
-		CLIVersion:               versionMatch[1],
+		CLIVersion:               cliVersion,
 		RequiredProtocolVersion:  protocolVersion,
-		MinimumDispatcherVersion: versionMatch[1],
+		MinimumDispatcherVersion: cliVersion,
 		SourcePath:               constantsPath,
 	}, nil
+}
+
+func validateDispatcherCLIVersion(cliVersion string) error {
+	if !dispatcherCLIVersionPattern.MatchString(cliVersion) {
+		return fmt.Errorf("expected semantic version, got %q", cliVersion)
+	}
+	return nil
 }

--- a/cli/internal/cli/dispatcher_pin.go
+++ b/cli/internal/cli/dispatcher_pin.go
@@ -117,12 +117,18 @@ func readDispatcherPin(pinPath string) (dispatcherPin, error) {
 	if err := json.Unmarshal(content, &pin); err != nil {
 		return dispatcherPin{}, fmt.Errorf("failed to parse %s: %w", pinPath, err)
 	}
-	pin.CLIVersion = strings.TrimSpace(pin.CLIVersion)
+	pin.CLIVersion = normalizeDispatcherVersion(pin.CLIVersion)
 	if pin.CLIVersion == "" {
 		return dispatcherPin{}, fmt.Errorf("%s does not define cliVersion", pinPath)
 	}
 	if err := validateDispatcherCLIVersion(pin.CLIVersion); err != nil {
 		return dispatcherPin{}, fmt.Errorf("%s defines invalid cliVersion: %w", pinPath, err)
+	}
+	pin.MinimumDispatcherVersion = normalizeDispatcherVersion(pin.MinimumDispatcherVersion)
+	if pin.MinimumDispatcherVersion != "" {
+		if err := validateDispatcherCLIVersion(pin.MinimumDispatcherVersion); err != nil {
+			return dispatcherPin{}, fmt.Errorf("%s defines invalid minimumDispatcherVersion: %w", pinPath, err)
+		}
 	}
 	if pin.SchemaVersion == 0 {
 		return dispatcherPin{}, fmt.Errorf("%s does not define schemaVersion", pinPath)
@@ -141,7 +147,7 @@ func readDispatcherPinFromCliConstants(constantsPath string) (dispatcherPin, err
 	if len(versionMatch) != 2 {
 		return dispatcherPin{}, fmt.Errorf("%s does not define MINIMUM_REQUIRED_CLI_VERSION", constantsPath)
 	}
-	cliVersion := strings.TrimSpace(versionMatch[1])
+	cliVersion := normalizeDispatcherVersion(versionMatch[1])
 	if err := validateDispatcherCLIVersion(cliVersion); err != nil {
 		return dispatcherPin{}, fmt.Errorf("%s defines invalid MINIMUM_REQUIRED_CLI_VERSION: %w", constantsPath, err)
 	}
@@ -159,6 +165,14 @@ func readDispatcherPinFromCliConstants(constantsPath string) (dispatcherPin, err
 		MinimumDispatcherVersion: cliVersion,
 		SourcePath:               constantsPath,
 	}, nil
+}
+
+func normalizeDispatcherVersion(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(trimmed, "v") || strings.HasPrefix(trimmed, "V") {
+		return trimmed[1:]
+	}
+	return trimmed
 }
 
 func validateDispatcherCLIVersion(cliVersion string) error {

--- a/cli/internal/cli/dispatcher_test.go
+++ b/cli/internal/cli/dispatcher_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
 
 type dispatcherArchiveTestEntry struct {
@@ -235,6 +236,35 @@ func TestExtractDispatcherRealCLIFromZipPrefersRealCLI(t *testing.T) {
 	assertFileContent(t, destinationPath, "real")
 }
 
+func TestDispatcherHTTPClientHasDownloadTimeout(t *testing.T) {
+	// Verifies dispatcher release downloads cannot hang indefinitely.
+	if dispatcherHTTPClient.Timeout != 2*time.Minute {
+		t.Fatalf("dispatcher HTTP timeout mismatch: %s", dispatcherHTTPClient.Timeout)
+	}
+}
+
+func TestInstallDownloadedDispatcherRealCLIKeepsExistingExecutable(t *testing.T) {
+	// Verifies concurrent downloads do not delete an executable another dispatcher already cached.
+	tempDir := t.TempDir()
+	realCLIPath := filepath.Join(tempDir, dispatcherRealCLIFileName(runtime.GOOS))
+	tempRealCLIPath := filepath.Join(tempDir, "downloaded-"+dispatcherRealCLIFileName(runtime.GOOS))
+	if err := os.WriteFile(realCLIPath, []byte("existing"), 0o755); err != nil {
+		t.Fatalf("failed to write existing real CLI: %v", err)
+	}
+	if err := os.WriteFile(tempRealCLIPath, []byte("downloaded"), 0o755); err != nil {
+		t.Fatalf("failed to write temp real CLI: %v", err)
+	}
+
+	path, err := installDownloadedDispatcherRealCLI(tempRealCLIPath, realCLIPath)
+	if err != nil {
+		t.Fatalf("installDownloadedDispatcherRealCLI failed: %v", err)
+	}
+	if path != realCLIPath {
+		t.Fatalf("real CLI path mismatch: %s", path)
+	}
+	assertFileContent(t, realCLIPath, "existing")
+}
+
 func TestLoadDispatcherPinFallsBackToPackagePin(t *testing.T) {
 	// Verifies dispatcher can read the package-level pin when the project copy is missing.
 	projectRoot := createDispatcherUnityProject(t)
@@ -275,6 +305,24 @@ func TestLoadDispatcherPinSkipsInvalidPackageCandidate(t *testing.T) {
 	}
 }
 
+func TestLoadDispatcherPinNormalizesVersionPrefixes(t *testing.T) {
+	// Verifies v-prefixed pin versions are normalized before semantic-version validation.
+	projectRoot := createDispatcherUnityProject(t)
+	pinPath := filepath.Join(projectRoot, dispatcherProjectPinRelativePath)
+	writeDispatcherPinFileWithMinimum(t, pinPath, "v3.0.0-beta.58", "V3.0.0-beta.39")
+
+	pin, err := loadDispatcherPin(projectRoot)
+	if err != nil {
+		t.Fatalf("loadDispatcherPin failed: %v", err)
+	}
+	if pin.CLIVersion != "3.0.0-beta.58" {
+		t.Fatalf("cliVersion mismatch: %s", pin.CLIVersion)
+	}
+	if pin.MinimumDispatcherVersion != "3.0.0-beta.39" {
+		t.Fatalf("minimumDispatcherVersion mismatch: %s", pin.MinimumDispatcherVersion)
+	}
+}
+
 func TestLoadDispatcherPinRejectsInvalidCLIVersion(t *testing.T) {
 	// Verifies project pin cliVersion must be a release version, not a filesystem path.
 	projectRoot := createDispatcherUnityProject(t)
@@ -291,6 +339,19 @@ func TestLoadDispatcherPinRejectsInvalidCLIVersion(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("expected invalid cliVersion error")
+	}
+}
+
+func TestLoadDispatcherPinRejectsInvalidMinimumDispatcherVersion(t *testing.T) {
+	// Verifies malformed dispatcher minimums fail closed instead of bypassing freshness checks.
+	projectRoot := createDispatcherUnityProject(t)
+	pinPath := filepath.Join(projectRoot, dispatcherProjectPinRelativePath)
+	writeDispatcherPinFileWithMinimum(t, pinPath, "3.0.0-beta.58", "../../payload")
+
+	_, err := loadDispatcherPin(projectRoot)
+
+	if err == nil {
+		t.Fatal("expected invalid minimumDispatcherVersion error")
 	}
 }
 
@@ -316,6 +377,31 @@ public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.56";`
 	}
 	if pin.RequiredProtocolVersion != 3 {
 		t.Fatalf("protocol mismatch: %d", pin.RequiredProtocolVersion)
+	}
+}
+
+func TestLoadDispatcherPinFromCliConstantsNormalizesVersionPrefix(t *testing.T) {
+	// Verifies v-prefixed fallback constants are normalized before dispatcher resolution.
+	projectRoot := createDispatcherUnityProject(t)
+	constantsPath := filepath.Join(projectRoot, "Packages", "src", "Editor", "Domain", "CliConstants.cs")
+	if err := os.MkdirAll(filepath.Dir(constantsPath), 0o755); err != nil {
+		t.Fatalf("failed to create constants directory: %v", err)
+	}
+	content := `public const int REQUIRED_CLI_PROTOCOL_VERSION = 3;
+public const string MINIMUM_REQUIRED_CLI_VERSION = "v3.0.0-beta.59";`
+	if err := os.WriteFile(constantsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write constants: %v", err)
+	}
+
+	pin, err := loadDispatcherPin(projectRoot)
+	if err != nil {
+		t.Fatalf("loadDispatcherPin failed: %v", err)
+	}
+	if pin.CLIVersion != "3.0.0-beta.59" {
+		t.Fatalf("cliVersion mismatch: %s", pin.CLIVersion)
+	}
+	if pin.MinimumDispatcherVersion != "3.0.0-beta.59" {
+		t.Fatalf("minimumDispatcherVersion mismatch: %s", pin.MinimumDispatcherVersion)
 	}
 }
 
@@ -347,13 +433,18 @@ func writeDispatcherProjectPin(t *testing.T, projectRoot string, cliVersion stri
 
 func writeDispatcherPinFile(t *testing.T, pinPath string, cliVersion string) {
 	t.Helper()
+	writeDispatcherPinFileWithMinimum(t, pinPath, cliVersion, version)
+}
+
+func writeDispatcherPinFileWithMinimum(t *testing.T, pinPath string, cliVersion string, minimumDispatcherVersion string) {
+	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(pinPath), 0o755); err != nil {
 		t.Fatalf("failed to create pin directory: %v", err)
 	}
 	content := `{"schemaVersion":1,"packageName":"io.github.hatayama.uloopmcp","packageVersion":"3.0.0-beta.1","cliVersion":"` +
 		cliVersion +
 		`","requiredProtocolVersion":2,"minimumDispatcherVersion":"` +
-		version +
+		minimumDispatcherVersion +
 		`"}`
 	if err := os.WriteFile(pinPath, []byte(content), 0o644); err != nil {
 		t.Fatalf("failed to write pin: %v", err)

--- a/cli/internal/cli/dispatcher_test.go
+++ b/cli/internal/cli/dispatcher_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -169,6 +170,37 @@ func TestEnforceDispatcherFreshnessRequiresManualUpdateWhenSelfUpdateDisabled(t 
 	}
 }
 
+func TestEnforceDispatcherFreshnessDoesNotMarkFailedOptionalUpdateChecked(t *testing.T) {
+	// Verifies transient optional update failures stay retryable on the next command.
+	cacheRoot := t.TempDir()
+	t.Setenv(dispatcherCacheDirEnvName, cacheRoot)
+
+	previousRunner := dispatcherRunUpdate
+	defer func() {
+		dispatcherRunUpdate = previousRunner
+	}()
+	dispatcherRunUpdate = func(context.Context) error {
+		return errors.New("network unavailable")
+	}
+
+	var stderr bytes.Buffer
+	handled, code := enforceDispatcherFreshness(
+		context.Background(),
+		dispatcherPin{MinimumDispatcherVersion: version},
+		&stderr)
+
+	if handled || code != 0 {
+		t.Fatalf("freshness result mismatch: handled=%t code=%d", handled, code)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("dispatcher self-update skipped")) {
+		t.Fatalf("freshness output mismatch: %s", stderr.String())
+	}
+	statePath := filepath.Join(cacheRoot, dispatcherUpdateStateFileName)
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no update state after failed optional update, got err=%v", err)
+	}
+}
+
 func TestExtractDispatcherRealCLIFromTarPrefersRealCLI(t *testing.T) {
 	// Verifies release archives that contain dispatcher first still extract the real CLI binary.
 	tempDir := t.TempDir()
@@ -217,6 +249,28 @@ func TestLoadDispatcherPinFallsBackToPackagePin(t *testing.T) {
 		t.Fatalf("loadDispatcherPin failed: %v", err)
 	}
 	if pin.CLIVersion != "3.0.0-beta.55" {
+		t.Fatalf("cliVersion mismatch: %s", pin.CLIVersion)
+	}
+}
+
+func TestLoadDispatcherPinSkipsInvalidPackageCandidate(t *testing.T) {
+	// Verifies stale package pins do not block a valid PackageCache pin during first startup.
+	projectRoot := createDispatcherUnityProject(t)
+	sourcePackageRoot := filepath.Join(projectRoot, "Packages", "src")
+	cachePackageRoot := filepath.Join(projectRoot, "Library", "PackageCache", dispatcherUnityPackageName+"@3.0.0-beta.57")
+	if err := os.MkdirAll(sourcePackageRoot, 0o755); err != nil {
+		t.Fatalf("failed to create source package root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourcePackageRoot, dispatcherPackagePinFileName), []byte("{"), 0o644); err != nil {
+		t.Fatalf("failed to write invalid package pin: %v", err)
+	}
+	writeDispatcherPinFile(t, filepath.Join(cachePackageRoot, dispatcherPackagePinFileName), "3.0.0-beta.57")
+
+	pin, err := loadDispatcherPin(projectRoot)
+	if err != nil {
+		t.Fatalf("loadDispatcherPin failed: %v", err)
+	}
+	if pin.CLIVersion != "3.0.0-beta.57" {
 		t.Fatalf("cliVersion mismatch: %s", pin.CLIVersion)
 	}
 }

--- a/cli/internal/cli/dispatcher_test.go
+++ b/cli/internal/cli/dispatcher_test.go
@@ -115,6 +115,42 @@ func TestRunDispatcherUnknownLeadingOptionDoesNotRequireProjectPin(t *testing.T)
 	}
 }
 
+func TestRunDispatcherLaunchQuitDoesNotRequireProjectPin(t *testing.T) {
+	// Verifies launch can bootstrap a project before Unity has generated the dispatcher pin.
+	projectRoot := createDispatcherUnityProject(t)
+	t.Chdir(t.TempDir())
+
+	previousFinder := findRunningUnityProcessForLaunch
+	findRunningUnityProcessForLaunch = func(context.Context, string) (*unityProcess, error) {
+		return nil, nil
+	}
+	defer func() {
+		findRunningUnityProcessForLaunch = previousFinder
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(context.Background(), []string{"launch", projectRoot, "--quit"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("dispatcher launch failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte(`"Quit": true`)) {
+		t.Fatalf("dispatcher launch output mismatch: %s", stdout.String())
+	}
+}
+
+func TestResolveDispatcherRealCLIRejectsInvalidCLIVersion(t *testing.T) {
+	// Verifies project pins cannot escape the dispatcher cache through cliVersion path segments.
+	t.Setenv(dispatcherCacheDirEnvName, t.TempDir())
+
+	_, err := resolveDispatcherRealCLI(context.Background(), dispatcherPin{CLIVersion: "../../../../payload"})
+
+	if err == nil {
+		t.Fatal("expected invalid cliVersion error")
+	}
+}
+
 func TestExtractDispatcherRealCLIFromTarPrefersRealCLI(t *testing.T) {
 	// Verifies release archives that contain dispatcher first still extract the real CLI binary.
 	tempDir := t.TempDir()
@@ -164,6 +200,25 @@ func TestLoadDispatcherPinFallsBackToPackagePin(t *testing.T) {
 	}
 	if pin.CLIVersion != "3.0.0-beta.55" {
 		t.Fatalf("cliVersion mismatch: %s", pin.CLIVersion)
+	}
+}
+
+func TestLoadDispatcherPinRejectsInvalidCLIVersion(t *testing.T) {
+	// Verifies project pin cliVersion must be a release version, not a filesystem path.
+	projectRoot := createDispatcherUnityProject(t)
+	pinPath := filepath.Join(projectRoot, dispatcherProjectPinRelativePath)
+	if err := os.MkdirAll(filepath.Dir(pinPath), 0o755); err != nil {
+		t.Fatalf("failed to create pin directory: %v", err)
+	}
+	content := `{"schemaVersion":1,"packageName":"io.github.hatayama.uloopmcp","packageVersion":"3.0.0-beta.1","cliVersion":"../../payload","requiredProtocolVersion":2,"minimumDispatcherVersion":"3.0.0-beta.39"}`
+	if err := os.WriteFile(pinPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write pin: %v", err)
+	}
+
+	_, err := loadDispatcherPin(projectRoot)
+
+	if err == nil {
+		t.Fatal("expected invalid cliVersion error")
 	}
 }
 

--- a/cli/internal/cli/dispatcher_test.go
+++ b/cli/internal/cli/dispatcher_test.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRunDispatcherUsesProjectPinAndCachedRealCLI(t *testing.T) {
+	// Verifies dispatcher reads the project pin and executes the cached real CLI.
+	projectRoot := createDispatcherUnityProject(t)
+	cacheRoot := t.TempDir()
+	writeDispatcherProjectPin(t, projectRoot, version)
+	expectedCLIPath := writeCachedDispatcherRealCLI(t, cacheRoot, version)
+	t.Setenv(dispatcherCacheDirEnvName, cacheRoot)
+	t.Setenv(dispatcherDisableSelfUpdateEnvName, "1")
+	t.Chdir(projectRoot)
+
+	previousRunner := dispatcherRunRealCLI
+	defer func() {
+		dispatcherRunRealCLI = previousRunner
+	}()
+	var actualPath string
+	var actualArgs []string
+	dispatcherRunRealCLI = func(ctx context.Context, realCLIPath string, args []string, stdout io.Writer, stderr io.Writer) int {
+		actualPath = realCLIPath
+		actualArgs = append([]string{}, args...)
+		return 7
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(context.Background(), []string{"compile", "--force-recompile"}, &stdout, &stderr)
+
+	if code != 7 {
+		t.Fatalf("exit code mismatch: %d stderr=%s", code, stderr.String())
+	}
+	if actualPath != expectedCLIPath {
+		t.Fatalf("real CLI path mismatch: %s", actualPath)
+	}
+	assertStringSliceEqual(t, actualArgs, []string{"compile", "--force-recompile"})
+}
+
+func TestRunDispatcherPreservesExplicitProjectPathForRealCLI(t *testing.T) {
+	// Verifies dispatcher accepts trailing --project-path and passes the original arguments onward.
+	projectRoot := createDispatcherUnityProject(t)
+	cacheRoot := t.TempDir()
+	writeDispatcherProjectPin(t, projectRoot, version)
+	writeCachedDispatcherRealCLI(t, cacheRoot, version)
+	t.Setenv(dispatcherCacheDirEnvName, cacheRoot)
+	t.Setenv(dispatcherDisableSelfUpdateEnvName, "1")
+	t.Chdir(t.TempDir())
+
+	previousRunner := dispatcherRunRealCLI
+	defer func() {
+		dispatcherRunRealCLI = previousRunner
+	}()
+	var actualArgs []string
+	dispatcherRunRealCLI = func(ctx context.Context, realCLIPath string, args []string, stdout io.Writer, stderr io.Writer) int {
+		actualArgs = append([]string{}, args...)
+		return 0
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(context.Background(), []string{"compile", "--project-path", projectRoot}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("dispatcher failed: code=%d stderr=%s", code, stderr.String())
+	}
+	assertStringSliceEqual(t, actualArgs, []string{"compile", "--project-path", projectRoot})
+}
+
+func TestLoadDispatcherPinFallsBackToPackagePin(t *testing.T) {
+	// Verifies dispatcher can read the package-level pin when the project copy is missing.
+	projectRoot := createDispatcherUnityProject(t)
+	packageRoot := filepath.Join(projectRoot, "Packages", "src")
+	if err := os.MkdirAll(packageRoot, 0o755); err != nil {
+		t.Fatalf("failed to create package root: %v", err)
+	}
+	writeDispatcherPinFile(t, filepath.Join(packageRoot, dispatcherPackagePinFileName), "3.0.0-beta.55")
+
+	pin, err := loadDispatcherPin(projectRoot)
+	if err != nil {
+		t.Fatalf("loadDispatcherPin failed: %v", err)
+	}
+	if pin.CLIVersion != "3.0.0-beta.55" {
+		t.Fatalf("cliVersion mismatch: %s", pin.CLIVersion)
+	}
+}
+
+func TestLoadDispatcherPinFallsBackToCliConstants(t *testing.T) {
+	// Verifies old package layouts can still resolve a CLI version from CliConstants.cs.
+	projectRoot := createDispatcherUnityProject(t)
+	constantsPath := filepath.Join(projectRoot, "Packages", "src", "Editor", "Domain", "CliConstants.cs")
+	if err := os.MkdirAll(filepath.Dir(constantsPath), 0o755); err != nil {
+		t.Fatalf("failed to create constants directory: %v", err)
+	}
+	content := `public const int REQUIRED_CLI_PROTOCOL_VERSION = 3;
+public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.56";`
+	if err := os.WriteFile(constantsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write constants: %v", err)
+	}
+
+	pin, err := loadDispatcherPin(projectRoot)
+	if err != nil {
+		t.Fatalf("loadDispatcherPin failed: %v", err)
+	}
+	if pin.CLIVersion != "3.0.0-beta.56" {
+		t.Fatalf("cliVersion mismatch: %s", pin.CLIVersion)
+	}
+	if pin.RequiredProtocolVersion != 3 {
+		t.Fatalf("protocol mismatch: %d", pin.RequiredProtocolVersion)
+	}
+}
+
+func TestDispatcherReleaseAssetNameRejectsUnsupportedPlatform(t *testing.T) {
+	// Verifies dispatcher does not invent download assets for unsupported platforms.
+	_, err := dispatcherReleaseAssetName("linux", "amd64")
+
+	if err == nil {
+		t.Fatal("expected unsupported platform error")
+	}
+}
+
+func createDispatcherUnityProject(t *testing.T) string {
+	t.Helper()
+	projectRoot := t.TempDir()
+	for _, dirName := range []string{"Assets", "ProjectSettings"} {
+		if err := os.MkdirAll(filepath.Join(projectRoot, dirName), 0o755); err != nil {
+			t.Fatalf("failed to create Unity project directory: %v", err)
+		}
+	}
+	return projectRoot
+}
+
+func writeDispatcherProjectPin(t *testing.T, projectRoot string, cliVersion string) {
+	t.Helper()
+	pinPath := filepath.Join(projectRoot, dispatcherProjectPinRelativePath)
+	writeDispatcherPinFile(t, pinPath, cliVersion)
+}
+
+func writeDispatcherPinFile(t *testing.T, pinPath string, cliVersion string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(pinPath), 0o755); err != nil {
+		t.Fatalf("failed to create pin directory: %v", err)
+	}
+	content := `{"schemaVersion":1,"packageName":"io.github.hatayama.uloopmcp","packageVersion":"3.0.0-beta.1","cliVersion":"` +
+		cliVersion +
+		`","requiredProtocolVersion":2,"minimumDispatcherVersion":"` +
+		version +
+		`"}`
+	if err := os.WriteFile(pinPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write pin: %v", err)
+	}
+}
+
+func writeCachedDispatcherRealCLI(t *testing.T, cacheRoot string, cliVersion string) string {
+	t.Helper()
+	realCLIPath := dispatcherCachedRealCLIPath(cacheRoot, cliVersion, runtime.GOOS, runtime.GOARCH)
+	if err := os.MkdirAll(filepath.Dir(realCLIPath), 0o755); err != nil {
+		t.Fatalf("failed to create cached CLI directory: %v", err)
+	}
+	if err := os.WriteFile(realCLIPath, []byte("cached real cli"), 0o755); err != nil {
+		t.Fatalf("failed to write cached CLI: %v", err)
+	}
+	return realCLIPath
+}
+
+func assertStringSliceEqual(t *testing.T, actual []string, expected []string) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Fatalf("length mismatch: actual=%#v expected=%#v", actual, expected)
+	}
+	for index, expectedValue := range expected {
+		if actual[index] != expectedValue {
+			t.Fatalf("value mismatch at %d: actual=%#v expected=%#v", index, actual, expected)
+		}
+	}
+}

--- a/cli/internal/cli/dispatcher_test.go
+++ b/cli/internal/cli/dispatcher_test.go
@@ -151,6 +151,24 @@ func TestResolveDispatcherRealCLIRejectsInvalidCLIVersion(t *testing.T) {
 	}
 }
 
+func TestEnforceDispatcherFreshnessRequiresManualUpdateWhenSelfUpdateDisabled(t *testing.T) {
+	// Verifies disabling mutation does not disable the minimum dispatcher version contract.
+	t.Setenv(dispatcherDisableSelfUpdateEnvName, "1")
+
+	var stderr bytes.Buffer
+	handled, code := enforceDispatcherFreshness(
+		context.Background(),
+		dispatcherPin{MinimumDispatcherVersion: "999.0.0"},
+		&stderr)
+
+	if !handled || code != 1 {
+		t.Fatalf("freshness result mismatch: handled=%t code=%d", handled, code)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte(errorCodeCLIUpdateRequired)) {
+		t.Fatalf("freshness output mismatch: %s", stderr.String())
+	}
+}
+
 func TestExtractDispatcherRealCLIFromTarPrefersRealCLI(t *testing.T) {
 	// Verifies release archives that contain dispatcher first still extract the real CLI binary.
 	tempDir := t.TempDir()

--- a/cli/internal/cli/dispatcher_test.go
+++ b/cli/internal/cli/dispatcher_test.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"archive/tar"
+	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"io"
 	"os"
@@ -9,6 +12,11 @@ import (
 	"runtime"
 	"testing"
 )
+
+type dispatcherArchiveTestEntry struct {
+	Name    string
+	Content string
+}
 
 func TestRunDispatcherUsesProjectPinAndCachedRealCLI(t *testing.T) {
 	// Verifies dispatcher reads the project pin and executes the cached real CLI.
@@ -73,6 +81,72 @@ func TestRunDispatcherPreservesExplicitProjectPathForRealCLI(t *testing.T) {
 		t.Fatalf("dispatcher failed: code=%d stderr=%s", code, stderr.String())
 	}
 	assertStringSliceEqual(t, actualArgs, []string{"compile", "--project-path", projectRoot})
+}
+
+func TestRunDispatcherCommandHelpDoesNotRequireProjectPin(t *testing.T) {
+	// Verifies dispatcher handles command help before project and pin resolution.
+	t.Chdir(t.TempDir())
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(context.Background(), []string{"compile", "--help"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("dispatcher command help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("uloop compile")) {
+		t.Fatalf("compile help output mismatch: %s", stdout.String())
+	}
+}
+
+func TestRunDispatcherUnknownLeadingOptionDoesNotRequireProjectPin(t *testing.T) {
+	// Verifies dispatcher reports leading option mistakes before project and pin resolution.
+	t.Chdir(t.TempDir())
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(context.Background(), []string{"--project-pathology"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("dispatcher unknown option code mismatch: code=%d stdout=%s", code, stdout.String())
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("Unknown global option")) {
+		t.Fatalf("dispatcher unknown option output mismatch: %s", stderr.String())
+	}
+}
+
+func TestExtractDispatcherRealCLIFromTarPrefersRealCLI(t *testing.T) {
+	// Verifies release archives that contain dispatcher first still extract the real CLI binary.
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "uloop-darwin-arm64.tar.gz")
+	writeDispatcherTarGzArchive(t, archivePath, []dispatcherArchiveTestEntry{
+		{Name: "uloop", Content: "dispatcher"},
+		{Name: "uloop-cli", Content: "real"},
+	})
+	destinationPath := filepath.Join(tempDir, "uloop-cli")
+
+	err := extractDispatcherRealCLI(archivePath, filepath.Base(archivePath), destinationPath, "darwin")
+	if err != nil {
+		t.Fatalf("extractDispatcherRealCLI failed: %v", err)
+	}
+	assertFileContent(t, destinationPath, "real")
+}
+
+func TestExtractDispatcherRealCLIFromZipPrefersRealCLI(t *testing.T) {
+	// Verifies Windows release archives that contain dispatcher first still extract the real CLI binary.
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "uloop-windows-amd64.zip")
+	writeDispatcherZipArchive(t, archivePath, []dispatcherArchiveTestEntry{
+		{Name: "uloop.exe", Content: "dispatcher"},
+		{Name: "uloop-cli.exe", Content: "real"},
+	})
+	destinationPath := filepath.Join(tempDir, "uloop-cli.exe")
+
+	err := extractDispatcherRealCLI(archivePath, filepath.Base(archivePath), destinationPath, "windows")
+	if err != nil {
+		t.Fatalf("extractDispatcherRealCLI failed: %v", err)
+	}
+	assertFileContent(t, destinationPath, "real")
 }
 
 func TestLoadDispatcherPinFallsBackToPackagePin(t *testing.T) {
@@ -169,6 +243,79 @@ func writeCachedDispatcherRealCLI(t *testing.T, cacheRoot string, cliVersion str
 		t.Fatalf("failed to write cached CLI: %v", err)
 	}
 	return realCLIPath
+}
+
+func writeDispatcherTarGzArchive(t *testing.T, archivePath string, entries []dispatcherArchiveTestEntry) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("failed to create tar archive: %v", err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for _, entry := range entries {
+		content := []byte(entry.Content)
+		header := &tar.Header{
+			Name: entry.Name,
+			Mode: 0o755,
+			Size: int64(len(content)),
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("failed to write tar header: %v", err)
+		}
+		if _, err := tarWriter.Write(content); err != nil {
+			t.Fatalf("failed to write tar content: %v", err)
+		}
+	}
+	closeErr := tarWriter.Close()
+	gzipCloseErr := gzipWriter.Close()
+	fileCloseErr := file.Close()
+	if closeErr != nil {
+		t.Fatalf("failed to close tar archive: %v", closeErr)
+	}
+	if gzipCloseErr != nil {
+		t.Fatalf("failed to close gzip archive: %v", gzipCloseErr)
+	}
+	if fileCloseErr != nil {
+		t.Fatalf("failed to close tar file: %v", fileCloseErr)
+	}
+}
+
+func writeDispatcherZipArchive(t *testing.T, archivePath string, entries []dispatcherArchiveTestEntry) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("failed to create zip archive: %v", err)
+	}
+	zipWriter := zip.NewWriter(file)
+	for _, entry := range entries {
+		writer, err := zipWriter.Create(entry.Name)
+		if err != nil {
+			t.Fatalf("failed to write zip header: %v", err)
+		}
+		if _, err := writer.Write([]byte(entry.Content)); err != nil {
+			t.Fatalf("failed to write zip content: %v", err)
+		}
+	}
+	closeErr := zipWriter.Close()
+	fileCloseErr := file.Close()
+	if closeErr != nil {
+		t.Fatalf("failed to close zip archive: %v", closeErr)
+	}
+	if fileCloseErr != nil {
+		t.Fatalf("failed to close zip file: %v", fileCloseErr)
+	}
+}
+
+func assertFileContent(t *testing.T, filePath string, expected string) {
+	t.Helper()
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", filePath, err)
+	}
+	if string(content) != expected {
+		t.Fatalf("file content mismatch: %q", string(content))
+	}
 }
 
 func assertStringSliceEqual(t *testing.T, actual []string, expected []string) {

--- a/cli/protocol_version_consistency_test.go
+++ b/cli/protocol_version_consistency_test.go
@@ -1,6 +1,7 @@
 package clicontract
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -10,9 +11,27 @@ import (
 
 // unityProtocolConstantPath is the C# source that declares the protocol generation the
 // Unity package accepts. It is relative to this package directory (the cli/ module root).
-const unityProtocolConstantPath = "../Packages/src/Editor/Domain/CliConstants.cs"
+const (
+	unityProtocolConstantPath = "../Packages/src/Editor/Domain/CliConstants.cs"
+	unityPackageManifestPath  = "../Packages/src/package.json"
+	unityPackageCliPinPath    = "../Packages/src/cli-pin.json"
+)
 
 var unityRequiredProtocolVersionPattern = regexp.MustCompile(`REQUIRED_CLI_PROTOCOL_VERSION\s*=\s*(\d+)`)
+
+type unityPackageManifest struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type unityPackageCliPin struct {
+	SchemaVersion            int    `json:"schemaVersion"`
+	PackageName              string `json:"packageName"`
+	PackageVersion           string `json:"packageVersion"`
+	CLIVersion               string `json:"cliVersion"`
+	RequiredProtocolVersion  int    `json:"requiredProtocolVersion"`
+	MinimumDispatcherVersion string `json:"minimumDispatcherVersion"`
+}
 
 // TestProtocolVersionMatchesUnityPackage is the keystone compatibility invariant: the
 // protocol generation the CLI advertises (cli/contract.json) and the generation the Unity
@@ -21,6 +40,48 @@ var unityRequiredProtocolVersionPattern = regexp.MustCompile(`REQUIRED_CLI_PROTO
 // two ever diverge, a CLI built from this commit would be wrongly rejected or accepted by
 // its own package. This check is deterministic and needs no git diff or release numbering.
 func TestProtocolVersionMatchesUnityPackage(t *testing.T) {
+	unityProtocolVersion := readUnityRequiredProtocolVersion(t)
+	if Current.ProtocolVersion != unityProtocolVersion {
+		t.Fatalf(
+			"protocol version mismatch: cli/contract.json declares %d but %s requires %d; "+
+				"bump both together on a breaking IPC change",
+			Current.ProtocolVersion, unityProtocolConstantPath, unityProtocolVersion)
+	}
+}
+
+// TestUnityPackageCliPinMatchesReleaseContracts verifies the dispatcher pin copied into
+// projects points at the package release, CLI release, and protocol generation from their
+// canonical declarations.
+func TestUnityPackageCliPinMatchesReleaseContracts(t *testing.T) {
+	manifest := readJSONFile[unityPackageManifest](t, unityPackageManifestPath)
+	pin := readJSONFile[unityPackageCliPin](t, unityPackageCliPinPath)
+
+	if pin.SchemaVersion != 1 {
+		t.Fatalf("expected %s schemaVersion to be 1, got %d", unityPackageCliPinPath, pin.SchemaVersion)
+	}
+	if pin.PackageName != manifest.Name {
+		t.Fatalf("expected %s packageName to match %s name: %q != %q", unityPackageCliPinPath, unityPackageManifestPath, pin.PackageName, manifest.Name)
+	}
+	if pin.PackageVersion != manifest.Version {
+		t.Fatalf("expected %s packageVersion to match %s version: %q != %q", unityPackageCliPinPath, unityPackageManifestPath, pin.PackageVersion, manifest.Version)
+	}
+	if pin.CLIVersion != Current.CliVersion {
+		t.Fatalf("expected %s cliVersion to match cli/contract.json cliVersion: %q != %q", unityPackageCliPinPath, pin.CLIVersion, Current.CliVersion)
+	}
+	if pin.RequiredProtocolVersion != Current.ProtocolVersion {
+		t.Fatalf("expected %s requiredProtocolVersion to match cli/contract.json protocolVersion: %d != %d", unityPackageCliPinPath, pin.RequiredProtocolVersion, Current.ProtocolVersion)
+	}
+	if pin.RequiredProtocolVersion != readUnityRequiredProtocolVersion(t) {
+		t.Fatalf("expected %s requiredProtocolVersion to match %s", unityPackageCliPinPath, unityProtocolConstantPath)
+	}
+	if pin.MinimumDispatcherVersion == "" {
+		t.Fatalf("expected %s minimumDispatcherVersion to be set", unityPackageCliPinPath)
+	}
+}
+
+func readUnityRequiredProtocolVersion(t *testing.T) int {
+	t.Helper()
+
 	content, err := os.ReadFile(filepath.Clean(unityProtocolConstantPath))
 	if err != nil {
 		t.Fatalf("failed to read Unity protocol constant from %s: %v", unityProtocolConstantPath, err)
@@ -36,10 +97,20 @@ func TestProtocolVersionMatchesUnityPackage(t *testing.T) {
 		t.Fatalf("REQUIRED_CLI_PROTOCOL_VERSION is not an integer: %v", err)
 	}
 
-	if Current.ProtocolVersion != unityProtocolVersion {
-		t.Fatalf(
-			"protocol version mismatch: cli/contract.json declares %d but %s requires %d; "+
-				"bump both together on a breaking IPC change",
-			Current.ProtocolVersion, unityProtocolConstantPath, unityProtocolVersion)
+	return unityProtocolVersion
+}
+
+func readJSONFile[T any](t *testing.T, path string) T {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
 	}
+
+	var value T
+	if err := json.Unmarshal(content, &value); err != nil {
+		t.Fatalf("failed to parse %s: %v", path, err)
+	}
+	return value
 }

--- a/cli/protocol_version_consistency_test.go
+++ b/cli/protocol_version_consistency_test.go
@@ -15,6 +15,7 @@ const (
 	unityProtocolConstantPath = "../Packages/src/Editor/Domain/CliConstants.cs"
 	unityPackageManifestPath  = "../Packages/src/package.json"
 	unityPackageCliPinPath    = "../Packages/src/cli-pin.json"
+	unityProjectCliPinPath    = "../.uloop/cli-pin.json"
 )
 
 var (
@@ -82,6 +83,17 @@ func TestUnityPackageCliPinMatchesReleaseContracts(t *testing.T) {
 	}
 	if pin.MinimumDispatcherVersion != readUnityMinimumRequiredCLIVersion(t) {
 		t.Fatalf("expected %s minimumDispatcherVersion to match %s MINIMUM_REQUIRED_CLI_VERSION", unityPackageCliPinPath, unityProtocolConstantPath)
+	}
+}
+
+// TestUnityProjectCliPinMatchesPackageCliPin verifies the committed project pin does not
+// shadow the package pin with stale dispatcher metadata.
+func TestUnityProjectCliPinMatchesPackageCliPin(t *testing.T) {
+	packagePin := readJSONFile[unityPackageCliPin](t, unityPackageCliPinPath)
+	projectPin := readJSONFile[unityPackageCliPin](t, unityProjectCliPinPath)
+
+	if projectPin != packagePin {
+		t.Fatalf("expected %s to match %s", unityProjectCliPinPath, unityPackageCliPinPath)
 	}
 }
 

--- a/cli/protocol_version_consistency_test.go
+++ b/cli/protocol_version_consistency_test.go
@@ -17,7 +17,10 @@ const (
 	unityPackageCliPinPath    = "../Packages/src/cli-pin.json"
 )
 
-var unityRequiredProtocolVersionPattern = regexp.MustCompile(`REQUIRED_CLI_PROTOCOL_VERSION\s*=\s*(\d+)`)
+var (
+	unityRequiredProtocolVersionPattern = regexp.MustCompile(`REQUIRED_CLI_PROTOCOL_VERSION\s*=\s*(\d+)`)
+	unityMinimumCLIVersionPattern       = regexp.MustCompile(`MINIMUM_REQUIRED_CLI_VERSION\s*=\s*"([^"]+)"`)
+)
 
 type unityPackageManifest struct {
 	Name    string `json:"name"`
@@ -77,6 +80,9 @@ func TestUnityPackageCliPinMatchesReleaseContracts(t *testing.T) {
 	if pin.MinimumDispatcherVersion == "" {
 		t.Fatalf("expected %s minimumDispatcherVersion to be set", unityPackageCliPinPath)
 	}
+	if pin.MinimumDispatcherVersion != readUnityMinimumRequiredCLIVersion(t) {
+		t.Fatalf("expected %s minimumDispatcherVersion to match %s MINIMUM_REQUIRED_CLI_VERSION", unityPackageCliPinPath, unityProtocolConstantPath)
+	}
 }
 
 func readUnityRequiredProtocolVersion(t *testing.T) int {
@@ -98,6 +104,22 @@ func readUnityRequiredProtocolVersion(t *testing.T) int {
 	}
 
 	return unityProtocolVersion
+}
+
+func readUnityMinimumRequiredCLIVersion(t *testing.T) string {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Clean(unityProtocolConstantPath))
+	if err != nil {
+		t.Fatalf("failed to read Unity CLI version constant from %s: %v", unityProtocolConstantPath, err)
+	}
+
+	matches := unityMinimumCLIVersionPattern.FindStringSubmatch(string(content))
+	if len(matches) != 2 {
+		t.Fatalf("%s does not define MINIMUM_REQUIRED_CLI_VERSION", unityProtocolConstantPath)
+	}
+
+	return matches[1]
 }
 
 func readJSONFile[T any](t *testing.T, path string) T {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -58,6 +58,20 @@
           "type": "json",
           "path": "/.uloop/cli-pin.json",
           "jsonpath": "$.cliVersion"
+        },
+        {
+          "type": "json",
+          "path": "/Packages/src/cli-pin.json",
+          "jsonpath": "$.minimumDispatcherVersion"
+        },
+        {
+          "type": "json",
+          "path": "/.uloop/cli-pin.json",
+          "jsonpath": "$.minimumDispatcherVersion"
+        },
+        {
+          "type": "generic",
+          "path": "/Packages/src/Editor/Domain/CliConstants.cs"
         }
       ]
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,11 @@
           "type": "json",
           "path": "Packages/src/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "Packages/src/cli-pin.json",
+          "jsonpath": "$.packageVersion"
         }
       ]
     },
@@ -37,6 +42,11 @@
         {
           "type": "json",
           "path": "contract.json",
+          "jsonpath": "$.cliVersion"
+        },
+        {
+          "type": "json",
+          "path": "/Packages/src/cli-pin.json",
           "jsonpath": "$.cliVersion"
         }
       ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,6 +21,11 @@
           "type": "json",
           "path": "Packages/src/cli-pin.json",
           "jsonpath": "$.packageVersion"
+        },
+        {
+          "type": "json",
+          "path": ".uloop/cli-pin.json",
+          "jsonpath": "$.packageVersion"
         }
       ]
     },
@@ -47,6 +52,11 @@
         {
           "type": "json",
           "path": "/Packages/src/cli-pin.json",
+          "jsonpath": "$.cliVersion"
+        },
+        {
+          "type": "json",
+          "path": "/.uloop/cli-pin.json",
           "jsonpath": "$.cliVersion"
         }
       ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -58,20 +58,6 @@
           "type": "json",
           "path": "/.uloop/cli-pin.json",
           "jsonpath": "$.cliVersion"
-        },
-        {
-          "type": "json",
-          "path": "/Packages/src/cli-pin.json",
-          "jsonpath": "$.minimumDispatcherVersion"
-        },
-        {
-          "type": "json",
-          "path": "/.uloop/cli-pin.json",
-          "jsonpath": "$.minimumDispatcherVersion"
-        },
-        {
-          "type": "generic",
-          "path": "/Packages/src/Editor/Domain/CliConstants.cs"
         }
       ]
     }

--- a/scripts/build-go-cli.sh
+++ b/scripts/build-go-cli.sh
@@ -29,5 +29,8 @@ build_binary() {
 }
 
 build_binary darwin arm64 uloop "$CLI_DIR" ./cmd/uloop
+build_binary darwin arm64 uloop-cli "$CLI_DIR" ./cmd/uloop-cli
 build_binary darwin amd64 uloop "$CLI_DIR" ./cmd/uloop
+build_binary darwin amd64 uloop-cli "$CLI_DIR" ./cmd/uloop-cli
 build_binary windows amd64 uloop "$CLI_DIR" ./cmd/uloop
+build_binary windows amd64 uloop-cli "$CLI_DIR" ./cmd/uloop-cli

--- a/scripts/package-go-cli.sh
+++ b/scripts/package-go-cli.sh
@@ -14,10 +14,12 @@ package_unix() {
   tmp_dir="$RELEASE_DIR/tmp-$platform"
   mkdir -p "$tmp_dir"
   cp "$DIST_DIR/$platform/uloop" "$tmp_dir/uloop"
+  cp "$DIST_DIR/$platform/uloop-cli" "$tmp_dir/uloop-cli"
   chmod +x "$tmp_dir/uloop"
+  chmod +x "$tmp_dir/uloop-cli"
   (
     cd "$tmp_dir"
-    tar -czf "$RELEASE_DIR/uloop-$platform.tar.gz" uloop
+    tar -czf "$RELEASE_DIR/uloop-$platform.tar.gz" uloop uloop-cli
   )
   rm -rf "$tmp_dir"
 }
@@ -27,9 +29,10 @@ package_windows() {
   tmp_dir="$RELEASE_DIR/tmp-$platform"
   mkdir -p "$tmp_dir"
   cp "$DIST_DIR/$platform/uloop.exe" "$tmp_dir/uloop.exe"
+  cp "$DIST_DIR/$platform/uloop-cli.exe" "$tmp_dir/uloop-cli.exe"
   (
     cd "$tmp_dir"
-    zip -q "$RELEASE_DIR/uloop-$platform.zip" uloop.exe
+    zip -q "$RELEASE_DIR/uloop-$platform.zip" uloop.exe uloop-cli.exe
   )
   rm -rf "$tmp_dir"
 }

--- a/scripts/test-protocol-minimum-version-workflow.sh
+++ b/scripts/test-protocol-minimum-version-workflow.sh
@@ -24,7 +24,7 @@ assert_file_exists() {
 
 test_pull_request_guard_fails_on_minimum_version_omission() {
   assert_contains "$BUILD_WORKFLOW" "      - name: Check protocol minimum version bump"
-  assert_contains "$BUILD_WORKFLOW" "        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--branches--')"
+  assert_contains "$BUILD_WORKFLOW" "        if: github.event_name == 'pull_request' && !(startsWith(github.head_ref, 'release-please--branches--') && (github.event.pull_request.user.login == 'github-actions[bot]' || github.event.pull_request.user.login == 'release-please[bot]'))"
   assert_contains "$BUILD_WORKFLOW" "          GH_TOKEN: \${{ github.token }}"
   assert_contains "$BUILD_WORKFLOW" '        run: go run ./cmd/check-protocol-minimum-version --base "origin/${{ github.base_ref }}" --head HEAD'
 }

--- a/scripts/test-protocol-minimum-version-workflow.sh
+++ b/scripts/test-protocol-minimum-version-workflow.sh
@@ -24,7 +24,7 @@ assert_file_exists() {
 
 test_pull_request_guard_fails_on_minimum_version_omission() {
   assert_contains "$BUILD_WORKFLOW" "      - name: Check protocol minimum version bump"
-  assert_contains "$BUILD_WORKFLOW" "        if: github.event_name == 'pull_request'"
+  assert_contains "$BUILD_WORKFLOW" "        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--branches--')"
   assert_contains "$BUILD_WORKFLOW" "          GH_TOKEN: \${{ github.token }}"
   assert_contains "$BUILD_WORKFLOW" '        run: go run ./cmd/check-protocol-minimum-version --base "origin/${{ github.base_ref }}" --head HEAD'
 }

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -132,12 +132,6 @@ assert_json_value '.packages["cli"].["extra-files"][2].path' '/Packages/src/cli-
 assert_json_value '.packages["cli"].["extra-files"][2].jsonpath' '$.cliVersion'
 assert_json_value '.packages["cli"].["extra-files"][3].path' '/.uloop/cli-pin.json'
 assert_json_value '.packages["cli"].["extra-files"][3].jsonpath' '$.cliVersion'
-assert_json_value '.packages["cli"].["extra-files"][4].path' '/Packages/src/cli-pin.json'
-assert_json_value '.packages["cli"].["extra-files"][4].jsonpath' '$.minimumDispatcherVersion'
-assert_json_value '.packages["cli"].["extra-files"][5].path' '/.uloop/cli-pin.json'
-assert_json_value '.packages["cli"].["extra-files"][5].jsonpath' '$.minimumDispatcherVersion'
-assert_json_value '.packages["cli"].["extra-files"][6].type' 'generic'
-assert_json_value '.packages["cli"].["extra-files"][6].path' '/Packages/src/Editor/Domain/CliConstants.cs'
 
 assert_file_contains "$RELEASE_WORKFLOW" 'id: package_release_sync'
 assert_file_contains "$RELEASE_WORKFLOW" "steps.package_release_sync.outputs.ready != 'false'"

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -117,12 +117,17 @@ assert_changelog_exists() {
 assert_json_value '.packages["."].["changelog-path"]' 'Packages/src/CHANGELOG.md'
 assert_json_value '.packages["."].["include-component-in-tag"]' 'false'
 assert_json_value '.packages["."].["exclude-paths"][0]' 'cli'
+assert_json_value '.packages["."].["extra-files"][0].path' 'Packages/src/package.json'
+assert_json_value '.packages["."].["extra-files"][1].path' 'Packages/src/cli-pin.json'
+assert_json_value '.packages["."].["extra-files"][1].jsonpath' '$.packageVersion'
 
 assert_json_value '.packages["cli"].component' 'cli'
 assert_json_value '.packages["cli"].["include-component-in-tag"]' 'true'
 assert_json_value '.packages["cli"].["changelog-path"]' 'CHANGELOG.md'
 assert_json_value '.packages["cli"].["extra-files"][0].path' 'internal/tools/default-tools.json'
 assert_json_value '.packages["cli"].["extra-files"][1].path' 'contract.json'
+assert_json_value '.packages["cli"].["extra-files"][2].path' '/Packages/src/cli-pin.json'
+assert_json_value '.packages["cli"].["extra-files"][2].jsonpath' '$.cliVersion'
 
 assert_file_contains "$RELEASE_WORKFLOW" 'id: package_release_sync'
 assert_file_contains "$RELEASE_WORKFLOW" "steps.package_release_sync.outputs.ready != 'false'"

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -120,6 +120,8 @@ assert_json_value '.packages["."].["exclude-paths"][0]' 'cli'
 assert_json_value '.packages["."].["extra-files"][0].path' 'Packages/src/package.json'
 assert_json_value '.packages["."].["extra-files"][1].path' 'Packages/src/cli-pin.json'
 assert_json_value '.packages["."].["extra-files"][1].jsonpath' '$.packageVersion'
+assert_json_value '.packages["."].["extra-files"][2].path' '.uloop/cli-pin.json'
+assert_json_value '.packages["."].["extra-files"][2].jsonpath' '$.packageVersion'
 
 assert_json_value '.packages["cli"].component' 'cli'
 assert_json_value '.packages["cli"].["include-component-in-tag"]' 'true'
@@ -128,6 +130,8 @@ assert_json_value '.packages["cli"].["extra-files"][0].path' 'internal/tools/def
 assert_json_value '.packages["cli"].["extra-files"][1].path' 'contract.json'
 assert_json_value '.packages["cli"].["extra-files"][2].path' '/Packages/src/cli-pin.json'
 assert_json_value '.packages["cli"].["extra-files"][2].jsonpath' '$.cliVersion'
+assert_json_value '.packages["cli"].["extra-files"][3].path' '/.uloop/cli-pin.json'
+assert_json_value '.packages["cli"].["extra-files"][3].jsonpath' '$.cliVersion'
 
 assert_file_contains "$RELEASE_WORKFLOW" 'id: package_release_sync'
 assert_file_contains "$RELEASE_WORKFLOW" "steps.package_release_sync.outputs.ready != 'false'"

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -118,6 +118,7 @@ assert_json_value '.packages["."].["changelog-path"]' 'Packages/src/CHANGELOG.md
 assert_json_value '.packages["."].["include-component-in-tag"]' 'false'
 assert_json_value '.packages["."].["exclude-paths"][0]' 'cli'
 assert_json_value '.packages["."].["extra-files"][0].path' 'Packages/src/package.json'
+assert_json_value '.packages["."].["extra-files"][0].jsonpath' '$.version'
 assert_json_value '.packages["."].["extra-files"][1].path' 'Packages/src/cli-pin.json'
 assert_json_value '.packages["."].["extra-files"][1].jsonpath' '$.packageVersion'
 assert_json_value '.packages["."].["extra-files"][2].path' '.uloop/cli-pin.json'

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -132,6 +132,12 @@ assert_json_value '.packages["cli"].["extra-files"][2].path' '/Packages/src/cli-
 assert_json_value '.packages["cli"].["extra-files"][2].jsonpath' '$.cliVersion'
 assert_json_value '.packages["cli"].["extra-files"][3].path' '/.uloop/cli-pin.json'
 assert_json_value '.packages["cli"].["extra-files"][3].jsonpath' '$.cliVersion'
+assert_json_value '.packages["cli"].["extra-files"][4].path' '/Packages/src/cli-pin.json'
+assert_json_value '.packages["cli"].["extra-files"][4].jsonpath' '$.minimumDispatcherVersion'
+assert_json_value '.packages["cli"].["extra-files"][5].path' '/.uloop/cli-pin.json'
+assert_json_value '.packages["cli"].["extra-files"][5].jsonpath' '$.minimumDispatcherVersion'
+assert_json_value '.packages["cli"].["extra-files"][6].type' 'generic'
+assert_json_value '.packages["cli"].["extra-files"][6].path' '/Packages/src/Editor/Domain/CliConstants.cs'
 
 assert_file_contains "$RELEASE_WORKFLOW" 'id: package_release_sync'
 assert_file_contains "$RELEASE_WORKFLOW" "steps.package_release_sync.outputs.ready != 'false'"

--- a/scripts/test-verify-native-cli-release-assets.sh
+++ b/scripts/test-verify-native-cli-release-assets.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+TEST_ROOT=$(mktemp -d)
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+RELEASE_DIR="$TEST_ROOT/release"
+PAYLOAD_DIR="$TEST_ROOT/payload"
+mkdir -p "$RELEASE_DIR" "$PAYLOAD_DIR"
+
+write_executable() {
+  path="$1"
+  content="$2"
+  printf '%s\n' "$content" > "$path"
+  chmod +x "$path"
+}
+
+write_checksum() {
+  asset_name="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    (
+      cd "$RELEASE_DIR"
+      sha256sum "$asset_name" > "$asset_name.sha256"
+    )
+    return
+  fi
+
+  (
+    cd "$RELEASE_DIR"
+    shasum -a 256 "$asset_name" | awk '{print $1 "  " $2}' > "$asset_name.sha256"
+  )
+}
+
+write_executable "$RELEASE_DIR/install.sh" "install"
+printf '%s\n' "install" > "$RELEASE_DIR/install.ps1"
+write_executable "$PAYLOAD_DIR/uloop" "dispatcher"
+write_executable "$PAYLOAD_DIR/uloop-cli" "real"
+
+tar -czf "$RELEASE_DIR/uloop-darwin-amd64.tar.gz" -C "$PAYLOAD_DIR" ./uloop ./uloop-cli
+tar -czf "$RELEASE_DIR/uloop-darwin-arm64.tar.gz" -C "$PAYLOAD_DIR" ./uloop ./uloop-cli
+write_checksum "uloop-darwin-amd64.tar.gz"
+write_checksum "uloop-darwin-arm64.tar.gz"
+
+if ! command -v zip >/dev/null 2>&1; then
+  echo "zip is required to test native CLI release asset verification" >&2
+  exit 1
+fi
+
+write_executable "$PAYLOAD_DIR/uloop.exe" "dispatcher"
+write_executable "$PAYLOAD_DIR/uloop-cli.exe" "real"
+(
+  cd "$PAYLOAD_DIR"
+  zip -q "$RELEASE_DIR/uloop-windows-amd64.zip" uloop.exe uloop-cli.exe
+)
+write_checksum "uloop-windows-amd64.zip"
+
+"$ROOT_DIR/scripts/verify-native-cli-release-assets.sh" "$RELEASE_DIR"

--- a/scripts/verify-go-cli-dist.sh
+++ b/scripts/verify-go-cli-dist.sh
@@ -5,8 +5,11 @@ ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
 
 DIST_FILES="
 cli/dist/darwin-arm64/uloop
+cli/dist/darwin-arm64/uloop-cli
 cli/dist/darwin-amd64/uloop
+cli/dist/darwin-amd64/uloop-cli
 cli/dist/windows-amd64/uloop.exe
+cli/dist/windows-amd64/uloop-cli.exe
 "
 
 "$ROOT_DIR/scripts/build-go-cli.sh"

--- a/scripts/verify-native-cli-release-assets.sh
+++ b/scripts/verify-native-cli-release-assets.sh
@@ -70,6 +70,28 @@ verify_checksum() {
   fi
 }
 
+require_tar_entry() {
+  archive_name="$1"
+  entry_name="$2"
+
+  if ! tar -tzf "$RELEASE_DIR/$archive_name" | grep -Fx "$entry_name" >/dev/null; then
+    fail "Native CLI release asset $archive_name does not contain $entry_name"
+  fi
+}
+
+require_zip_entry() {
+  archive_name="$1"
+  entry_name="$2"
+
+  if ! command -v unzip >/dev/null 2>&1; then
+    fail "unzip is required to inspect $archive_name"
+  fi
+
+  if ! unzip -Z1 "$RELEASE_DIR/$archive_name" | grep -Fx "$entry_name" >/dev/null; then
+    fail "Native CLI release asset $archive_name does not contain $entry_name"
+  fi
+}
+
 if [ ! -d "$RELEASE_DIR" ]; then
   fail "Native CLI release asset directory does not exist: $RELEASE_DIR"
 fi
@@ -81,5 +103,12 @@ done
 verify_checksum "uloop-darwin-amd64.tar.gz"
 verify_checksum "uloop-darwin-arm64.tar.gz"
 verify_checksum "uloop-windows-amd64.zip"
+
+require_tar_entry "uloop-darwin-amd64.tar.gz" "uloop"
+require_tar_entry "uloop-darwin-amd64.tar.gz" "uloop-cli"
+require_tar_entry "uloop-darwin-arm64.tar.gz" "uloop"
+require_tar_entry "uloop-darwin-arm64.tar.gz" "uloop-cli"
+require_zip_entry "uloop-windows-amd64.zip" "uloop.exe"
+require_zip_entry "uloop-windows-amd64.zip" "uloop-cli.exe"
 
 echo "Native CLI release assets are complete."

--- a/scripts/verify-native-cli-release-assets.sh
+++ b/scripts/verify-native-cli-release-assets.sh
@@ -74,7 +74,7 @@ require_tar_entry() {
   archive_name="$1"
   entry_name="$2"
 
-  if ! tar -tzf "$RELEASE_DIR/$archive_name" | grep -Fx "$entry_name" >/dev/null; then
+  if ! tar -tzf "$RELEASE_DIR/$archive_name" | sed 's#^\./##' | grep -Fx "$entry_name" >/dev/null; then
     fail "Native CLI release asset $archive_name does not contain $entry_name"
   fi
 }


### PR DESCRIPTION
## Summary
- Projects can keep one stable global `uloop` command while running the CLI version pinned by the Unity package.
- Unity writes a tracked `.uloop/cli-pin.json` contract so hand-run commands resolve the right project CLI.

## User Impact
- Users no longer need to manually keep one globally installed CLI aligned with every Unity package version.
- Fresh setup still installs a global `uloop` command, and project commands can download and cache the matching `uloop-cli` automatically.
- Release note: the first dispatcher-capable CLI version must be stamped by the follow-up release-please PR before this package release is shipped.

## Changes
- Split the native CLI into a global dispatcher and a project-local `uloop-cli` executable.
- Added project pin generation and synchronization for Unity projects, plus dispatcher fallback loading from package metadata.
- Updated release packaging, release-please metadata, install minimum handling, and validation tests so pin files stay aligned.
- Hardened dispatcher cache paths, command help handling, launch bootstrap behavior, and self-update minimum-version enforcement.

## Verification
- `scripts/check-go-cli.sh`
- `scripts/check-code-complexity.sh`
- `scripts/test-release-please-config.sh`
- `scripts/test-protocol-minimum-version-workflow.sh`
- `scripts/package-go-cli.sh && scripts/verify-native-cli-release-assets.sh`
- `cli/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`
- `cli/dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value ".*(CliSetupApplicationServiceTests|CliPinSynchronizerTests).*"`
- Manual E2E: removed `.uloop/cli-pin.json`, restarted Unity with `cli/dist/darwin-arm64/uloop launch <PROJECT_ROOT> -r`, and confirmed the pin was regenerated and matched `Packages/src/cli-pin.json`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

