### PR TITLE
fix: Keep release PRs compatible with the CLI launcher

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,6 +57,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: go run ./cmd/check-protocol-minimum-version --base "origin/${{ github.base_ref }}" --head HEAD
 
+      - name: Check dispatcher minimum version
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        working-directory: cli
+        run: go run ./cmd/check-dispatcher-minimum-version
+
       - name: Install golangci-lint
         run: |
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0

--- a/cli/cmd/check-dispatcher-minimum-version/main.go
+++ b/cli/cmd/check-dispatcher-minimum-version/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	"github.com/hatayama/unity-cli-loop/cli/internal/automation"
+)
+
+func main() {
+	ref := flag.String("ref", "", "git ref to read dispatcher minimum metadata from")
+	flag.Parse()
+
+	os.Exit(automation.RunDispatcherMinimumVersionCheck(
+		context.Background(),
+		os.Stdout,
+		os.Stderr,
+		*ref))
+}

--- a/cli/cmd/check-dispatcher-minimum-version/main.go
+++ b/cli/cmd/check-dispatcher-minimum-version/main.go
@@ -2,19 +2,15 @@ package main
 
 import (
 	"context"
-	"flag"
 	"os"
 
 	"github.com/hatayama/unity-cli-loop/cli/internal/automation"
 )
 
 func main() {
-	ref := flag.String("ref", "", "git ref to read dispatcher minimum metadata from")
-	flag.Parse()
-
 	os.Exit(automation.RunDispatcherMinimumVersionCheck(
 		context.Background(),
 		os.Stdout,
 		os.Stderr,
-		*ref))
+		""))
 }

--- a/cli/cmd/check-dispatcher-minimum-version/main.go
+++ b/cli/cmd/check-dispatcher-minimum-version/main.go
@@ -3,14 +3,20 @@ package main
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/hatayama/unity-cli-loop/cli/internal/automation"
 )
 
+const dispatcherMinimumVersionCheckTimeout = 2 * time.Minute
+
 func main() {
-	os.Exit(automation.RunDispatcherMinimumVersionCheck(
-		context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), dispatcherMinimumVersionCheckTimeout)
+	exitCode := automation.RunDispatcherMinimumVersionCheck(
+		ctx,
 		os.Stdout,
 		os.Stderr,
-		""))
+		"")
+	cancel()
+	os.Exit(exitCode)
 }

--- a/cli/contract.go
+++ b/cli/contract.go
@@ -20,8 +20,11 @@ type Contract struct {
 	SchemaVersion int `json:"schemaVersion"`
 	// ProtocolVersion is the C# IPC contract generation this binary speaks. It moves only
 	// when the Unity package and the CLI can no longer interoperate, never per release.
-	ProtocolVersion int    `json:"protocolVersion"`
-	CliVersion      string `json:"cliVersion"`
+	ProtocolVersion int `json:"protocolVersion"`
+	// DispatcherContractVersion is the minimum launcher capability generation this binary
+	// provides. It moves only when project pins need a newer dispatcher contract.
+	DispatcherContractVersion int    `json:"dispatcherContractVersion"`
+	CliVersion                string `json:"cliVersion"`
 }
 
 func mustLoad() Contract {
@@ -40,6 +43,9 @@ func mustLoad() Contract {
 	requireString(contract.CliVersion, "cliVersion")
 	if contract.ProtocolVersion < 1 {
 		panic(fmt.Sprintf("CLI contract protocolVersion must be at least 1, got %d", contract.ProtocolVersion))
+	}
+	if contract.DispatcherContractVersion < 1 {
+		panic(fmt.Sprintf("CLI contract dispatcherContractVersion must be at least 1, got %d", contract.DispatcherContractVersion))
 	}
 	return contract
 }

--- a/cli/contract.json
+++ b/cli/contract.json
@@ -1,5 +1,6 @@
 {
   "schemaVersion": 1,
   "protocolVersion": 2,
+  "dispatcherContractVersion": 1,
   "cliVersion": "3.0.0-beta.39"
 }

--- a/cli/contract_test.go
+++ b/cli/contract_test.go
@@ -18,6 +18,13 @@ func TestCliContractProvidesProtocolVersion(t *testing.T) {
 	}
 }
 
+func TestCliContractProvidesDispatcherContractVersion(t *testing.T) {
+	// Verifies that the contract declares which dispatcher capability generation the binary provides.
+	if Current.DispatcherContractVersion < 1 {
+		t.Fatalf("dispatcherContractVersion must be at least 1, got %d", Current.DispatcherContractVersion)
+	}
+}
+
 func requireValidContractVersion(t *testing.T, label string, value string) {
 	t.Helper()
 

--- a/cli/internal/automation/dispatcher_minimum_version_guard.go
+++ b/cli/internal/automation/dispatcher_minimum_version_guard.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -47,6 +48,14 @@ type dispatcherMinimumVersionCliPin struct {
 	CliVersion               string `json:"cliVersion"`
 	RequiredProtocolVersion  int    `json:"requiredProtocolVersion"`
 	MinimumDispatcherVersion string `json:"minimumDispatcherVersion"`
+}
+
+type dispatcherMinimumVersionSyncableError struct {
+	message string
+}
+
+func (err dispatcherMinimumVersionSyncableError) Error() string {
+	return err.message
 }
 
 func RunDispatcherMinimumVersionCheck(ctx context.Context, stdout io.Writer, stderr io.Writer, ref string) int {
@@ -160,7 +169,9 @@ func parseDispatcherMinimumVersionContract(content []byte) (dispatcherMinimumVer
 		return dispatcherMinimumVersionContract{}, fmt.Errorf("%s does not define cliVersion", dispatcherContractFile)
 	}
 	if contract.DispatcherContractVersion < minimumDispatcherContractVersion {
-		return dispatcherMinimumVersionContract{}, fmt.Errorf("%s does not define dispatcherContractVersion", dispatcherContractFile)
+		return dispatcherMinimumVersionContract{}, dispatcherContractVersionTooLowError(
+			dispatcherContractFile,
+			contract.DispatcherContractVersion)
 	}
 	return contract, nil
 }
@@ -233,7 +244,7 @@ func verifyDispatcherMinimumVersionAtRef(
 
 func verifyCurrentDispatcherMinimumVersion(values dispatcherMinimumVersionValues) error {
 	if values.CurrentDispatcherContractVersion < minimumDispatcherContractVersion {
-		return fmt.Errorf("%s does not define dispatcherContractVersion", dispatcherContractFile)
+		return dispatcherContractVersionTooLowError(dispatcherContractFile, values.CurrentDispatcherContractVersion)
 	}
 	return nil
 }
@@ -251,34 +262,60 @@ func verifyMinimumCliReleaseDispatcherContract(values dispatcherMinimumVersionVa
 			contract.CliVersion)
 	}
 
-	dispatcherContractVersion, hasDispatcherContractVersion := dispatcherMinimumReleaseContractVersion(contract.DispatcherContractVersion)
+	releaseLabel := cliReleaseTagPrefix + values.MinimumDispatcherVersion
+	dispatcherContractVersion, hasDispatcherContractVersion, err := dispatcherMinimumReleaseContractVersion(
+		releaseLabel,
+		contract.DispatcherContractVersion)
+	if err != nil {
+		return err
+	}
 	if !hasDispatcherContractVersion {
-		return fmt.Errorf(
-			"CLI release %s%s does not define dispatcherContractVersion",
-			cliReleaseTagPrefix,
-			values.MinimumDispatcherVersion)
+		return dispatcherMinimumVersionSyncableError{
+			message: fmt.Sprintf("CLI release %s does not define dispatcherContractVersion", releaseLabel),
+		}
+	}
+	if dispatcherContractVersion < minimumDispatcherContractVersion {
+		return dispatcherContractVersionTooLowError("CLI release "+releaseLabel, dispatcherContractVersion)
 	}
 	if dispatcherContractVersion < values.CurrentDispatcherContractVersion {
-		return fmt.Errorf(
-			"unity package requires dispatcher contract %d, but CLI release %s%s advertises dispatcher contract %d",
-			values.CurrentDispatcherContractVersion,
-			cliReleaseTagPrefix,
-			values.MinimumDispatcherVersion,
-			dispatcherContractVersion)
+		return dispatcherMinimumVersionSyncableError{
+			message: fmt.Sprintf(
+				"unity package requires dispatcher contract %d, but CLI release %s advertises dispatcher contract %d",
+				values.CurrentDispatcherContractVersion,
+				releaseLabel,
+				dispatcherContractVersion),
+		}
 	}
 	return nil
 }
 
-func dispatcherMinimumReleaseContractVersion(value *json.RawMessage) (int, bool) {
+func dispatcherMinimumReleaseContractVersion(releaseLabel string, value *json.RawMessage) (int, bool, error) {
 	if value == nil {
-		return 0, false
+		return 0, false, nil
 	}
 
-	dispatcherContractVersion, err := strconv.Atoi(strings.TrimSpace(string(*value)))
+	rawValue := strings.TrimSpace(string(*value))
+	dispatcherContractVersion, err := strconv.Atoi(rawValue)
 	if err != nil {
-		return 0, false
+		return 0, true, fmt.Errorf(
+			"CLI release %s dispatcherContractVersion must be an integer, got %s",
+			releaseLabel,
+			rawValue)
 	}
-	return dispatcherContractVersion, true
+	return dispatcherContractVersion, true, nil
+}
+
+func dispatcherContractVersionTooLowError(subject string, value int) error {
+	return fmt.Errorf(
+		"%s dispatcherContractVersion must be at least %d, got %d",
+		subject,
+		minimumDispatcherContractVersion,
+		value)
+}
+
+func isDispatcherMinimumVersionSyncableError(err error) bool {
+	syncableError := dispatcherMinimumVersionSyncableError{}
+	return errors.As(err, &syncableError)
 }
 
 func syncDispatcherMinimumVersionFiles(repoRoot string, targetVersion string) (bool, error) {
@@ -322,16 +359,24 @@ func syncDispatcherMinimumVersionPin(path string, targetVersion string) (bool, e
 		return false, err
 	}
 
-	pin := dispatcherMinimumVersionCliPin{}
-	if err := json.Unmarshal(content, &pin); err != nil {
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(content, &fields); err != nil {
 		return false, fmt.Errorf("%s is invalid JSON: %w", path, err)
 	}
-	if pin.MinimumDispatcherVersion == targetVersion {
+	currentVersion, err := dispatcherMinimumVersionStringField(path, fields, minimumDispatcherVersionDescription)
+	if err != nil {
+		return false, err
+	}
+	if currentVersion == targetVersion {
 		return false, nil
 	}
 
-	pin.MinimumDispatcherVersion = targetVersion
-	updatedContent, err := json.MarshalIndent(pin, "", "  ")
+	updatedValue, err := json.Marshal(targetVersion)
+	if err != nil {
+		return false, err
+	}
+	fields[minimumDispatcherVersionDescription] = json.RawMessage(updatedValue)
+	updatedContent, err := json.MarshalIndent(fields, "", "  ")
 	if err != nil {
 		return false, err
 	}
@@ -340,6 +385,26 @@ func syncDispatcherMinimumVersionPin(path string, targetVersion string) (bool, e
 		return false, err
 	}
 	return true, nil
+}
+
+func dispatcherMinimumVersionStringField(
+	path string,
+	fields map[string]json.RawMessage,
+	fieldName string,
+) (string, error) {
+	rawValue, ok := fields[fieldName]
+	if !ok {
+		return "", fmt.Errorf("%s does not define %s", path, fieldName)
+	}
+
+	value := ""
+	if err := json.Unmarshal(rawValue, &value); err != nil {
+		return "", fmt.Errorf("%s %s must be a string: %w", path, fieldName, err)
+	}
+	if value == "" {
+		return "", fmt.Errorf("%s does not define %s", path, fieldName)
+	}
+	return value, nil
 }
 
 func writeDispatcherMinimumVersionLine(writer io.Writer, values ...any) {

--- a/cli/internal/automation/dispatcher_minimum_version_guard.go
+++ b/cli/internal/automation/dispatcher_minimum_version_guard.go
@@ -1,0 +1,347 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	dispatcherContractFile              = "cli/contract.json"
+	unityPackageCliPinFile              = "Packages/src/cli-pin.json"
+	unityProjectCliPinFile              = ".uloop/cli-pin.json"
+	minimumDispatcherContractVersion    = 1
+	minimumDispatcherVersionDescription = "minimumDispatcherVersion"
+)
+
+type dispatcherMinimumVersionValues struct {
+	CurrentCliVersion                  string
+	CurrentDispatcherContractVersion   int
+	MinimumDispatcherVersion           string
+	PackagePinCliVersion               string
+	PackagePinMinimumDispatcherVersion string
+	ProjectPinCliVersion               string
+	ProjectPinMinimumDispatcherVersion string
+}
+
+type dispatcherMinimumVersionContract struct {
+	CliVersion                string `json:"cliVersion"`
+	DispatcherContractVersion int    `json:"dispatcherContractVersion"`
+}
+
+type dispatcherMinimumVersionReleaseContract struct {
+	CliVersion                string           `json:"cliVersion"`
+	DispatcherContractVersion *json.RawMessage `json:"dispatcherContractVersion"`
+}
+
+type dispatcherMinimumVersionCliPin struct {
+	SchemaVersion            int    `json:"schemaVersion"`
+	PackageName              string `json:"packageName"`
+	PackageVersion           string `json:"packageVersion"`
+	CliVersion               string `json:"cliVersion"`
+	RequiredProtocolVersion  int    `json:"requiredProtocolVersion"`
+	MinimumDispatcherVersion string `json:"minimumDispatcherVersion"`
+}
+
+func RunDispatcherMinimumVersionCheck(ctx context.Context, stdout io.Writer, stderr io.Writer, ref string) int {
+	repoRoot, err := gitRepoRoot(ctx)
+	if err != nil {
+		writeDispatcherMinimumVersionLine(stderr, fmt.Sprintf("failed to resolve git repository root: %v", err))
+		return 1
+	}
+
+	values, err := dispatcherMinimumVersionValuesAtRef(ctx, repoRoot, ref)
+	if err != nil {
+		writeDispatcherMinimumVersionLine(stderr, err)
+		return 1
+	}
+	if err := verifyDispatcherMinimumVersionAtRef(ctx, repoRoot, values); err != nil {
+		writeDispatcherMinimumVersionLine(stderr, err)
+		return 1
+	}
+
+	writeDispatcherMinimumVersionLine(stdout, "Dispatcher minimum version guard passed.")
+	return 0
+}
+
+func dispatcherMinimumVersionValuesAtRef(
+	ctx context.Context,
+	repoRoot string,
+	ref string,
+) (dispatcherMinimumVersionValues, error) {
+	contractContent, err := dispatcherMinimumVersionFileAtRef(ctx, repoRoot, ref, dispatcherContractFile)
+	if err != nil {
+		return dispatcherMinimumVersionValues{}, err
+	}
+	constantsContent, err := dispatcherMinimumVersionFileAtRef(ctx, repoRoot, ref, protocolMinimumVersionFile)
+	if err != nil {
+		return dispatcherMinimumVersionValues{}, err
+	}
+	packagePinContent, err := dispatcherMinimumVersionFileAtRef(ctx, repoRoot, ref, unityPackageCliPinFile)
+	if err != nil {
+		return dispatcherMinimumVersionValues{}, err
+	}
+	projectPinContent, err := dispatcherMinimumVersionFileAtRef(ctx, repoRoot, ref, unityProjectCliPinFile)
+	if err != nil {
+		return dispatcherMinimumVersionValues{}, err
+	}
+
+	return parseDispatcherMinimumVersionValues(
+		[]byte(contractContent),
+		[]byte(constantsContent),
+		[]byte(packagePinContent),
+		[]byte(projectPinContent))
+}
+
+func dispatcherMinimumVersionFileAtRef(
+	ctx context.Context,
+	repoRoot string,
+	ref string,
+	file string,
+) (string, error) {
+	if ref != "" {
+		return protocolMinimumVersionFileAtRef(ctx, repoRoot, ref, file)
+	}
+
+	content, err := os.ReadFile(filepath.Join(repoRoot, file))
+	if err != nil {
+		return "", fmt.Errorf("failed to read %s: %w", file, err)
+	}
+	return string(content), nil
+}
+
+func parseDispatcherMinimumVersionValues(
+	contractContent []byte,
+	constantsContent []byte,
+	packagePinContent []byte,
+	projectPinContent []byte,
+) (dispatcherMinimumVersionValues, error) {
+	contract, err := parseDispatcherMinimumVersionContract(contractContent)
+	if err != nil {
+		return dispatcherMinimumVersionValues{}, err
+	}
+	constants, err := ParseProtocolMinimumVersionValues(constantsContent)
+	if err != nil {
+		return dispatcherMinimumVersionValues{}, err
+	}
+	packagePin, err := parseDispatcherMinimumVersionPin(unityPackageCliPinFile, packagePinContent)
+	if err != nil {
+		return dispatcherMinimumVersionValues{}, err
+	}
+	projectPin, err := parseDispatcherMinimumVersionPin(unityProjectCliPinFile, projectPinContent)
+	if err != nil {
+		return dispatcherMinimumVersionValues{}, err
+	}
+
+	values := dispatcherMinimumVersionValues{
+		CurrentCliVersion:                  contract.CliVersion,
+		CurrentDispatcherContractVersion:   contract.DispatcherContractVersion,
+		MinimumDispatcherVersion:           constants.MinimumCliVersion,
+		PackagePinCliVersion:               packagePin.CliVersion,
+		PackagePinMinimumDispatcherVersion: packagePin.MinimumDispatcherVersion,
+		ProjectPinCliVersion:               projectPin.CliVersion,
+		ProjectPinMinimumDispatcherVersion: projectPin.MinimumDispatcherVersion,
+	}
+	return values, validateDispatcherMinimumVersionValues(values)
+}
+
+func parseDispatcherMinimumVersionContract(content []byte) (dispatcherMinimumVersionContract, error) {
+	contract := dispatcherMinimumVersionContract{}
+	if err := json.Unmarshal(content, &contract); err != nil {
+		return dispatcherMinimumVersionContract{}, fmt.Errorf("%s is invalid JSON: %w", dispatcherContractFile, err)
+	}
+	if contract.CliVersion == "" {
+		return dispatcherMinimumVersionContract{}, fmt.Errorf("%s does not define cliVersion", dispatcherContractFile)
+	}
+	if contract.DispatcherContractVersion < minimumDispatcherContractVersion {
+		return dispatcherMinimumVersionContract{}, fmt.Errorf("%s does not define dispatcherContractVersion", dispatcherContractFile)
+	}
+	return contract, nil
+}
+
+func parseDispatcherMinimumVersionPin(path string, content []byte) (dispatcherMinimumVersionCliPin, error) {
+	pin := dispatcherMinimumVersionCliPin{}
+	if err := json.Unmarshal(content, &pin); err != nil {
+		return dispatcherMinimumVersionCliPin{}, fmt.Errorf("%s is invalid JSON: %w", path, err)
+	}
+	if pin.CliVersion == "" {
+		return dispatcherMinimumVersionCliPin{}, fmt.Errorf("%s does not define cliVersion", path)
+	}
+	if pin.MinimumDispatcherVersion == "" {
+		return dispatcherMinimumVersionCliPin{}, fmt.Errorf("%s does not define %s", path, minimumDispatcherVersionDescription)
+	}
+	return pin, nil
+}
+
+func validateDispatcherMinimumVersionValues(values dispatcherMinimumVersionValues) error {
+	if values.PackagePinCliVersion != values.CurrentCliVersion {
+		return fmt.Errorf("%s cliVersion %q does not match %s cliVersion %q",
+			unityPackageCliPinFile,
+			values.PackagePinCliVersion,
+			dispatcherContractFile,
+			values.CurrentCliVersion)
+	}
+	if values.ProjectPinCliVersion != values.PackagePinCliVersion {
+		return fmt.Errorf("%s cliVersion %q does not match %s cliVersion %q",
+			unityProjectCliPinFile,
+			values.ProjectPinCliVersion,
+			unityPackageCliPinFile,
+			values.PackagePinCliVersion)
+	}
+	if values.PackagePinMinimumDispatcherVersion != values.MinimumDispatcherVersion {
+		return fmt.Errorf("%s %s %q does not match %s MINIMUM_REQUIRED_CLI_VERSION %q",
+			unityPackageCliPinFile,
+			minimumDispatcherVersionDescription,
+			values.PackagePinMinimumDispatcherVersion,
+			protocolMinimumVersionFile,
+			values.MinimumDispatcherVersion)
+	}
+	if values.ProjectPinMinimumDispatcherVersion != values.PackagePinMinimumDispatcherVersion {
+		return fmt.Errorf("%s %s %q does not match %s %s %q",
+			unityProjectCliPinFile,
+			minimumDispatcherVersionDescription,
+			values.ProjectPinMinimumDispatcherVersion,
+			unityPackageCliPinFile,
+			minimumDispatcherVersionDescription,
+			values.PackagePinMinimumDispatcherVersion)
+	}
+	return nil
+}
+
+func verifyDispatcherMinimumVersionAtRef(
+	ctx context.Context,
+	repoRoot string,
+	values dispatcherMinimumVersionValues,
+) error {
+	if values.MinimumDispatcherVersion == values.CurrentCliVersion {
+		return verifyCurrentDispatcherMinimumVersion(values)
+	}
+
+	releaseTag := cliReleaseTagPrefix + values.MinimumDispatcherVersion
+	contractContent, err := protocolMinimumVersionFileAtRef(ctx, repoRoot, releaseTag, dispatcherContractFile)
+	if err != nil {
+		return fmt.Errorf("CLI release %s does not provide %s", releaseTag, dispatcherContractFile)
+	}
+	return verifyMinimumCliReleaseDispatcherContract(values, []byte(contractContent))
+}
+
+func verifyCurrentDispatcherMinimumVersion(values dispatcherMinimumVersionValues) error {
+	if values.CurrentDispatcherContractVersion < minimumDispatcherContractVersion {
+		return fmt.Errorf("%s does not define dispatcherContractVersion", dispatcherContractFile)
+	}
+	return nil
+}
+
+func verifyMinimumCliReleaseDispatcherContract(values dispatcherMinimumVersionValues, contractContent []byte) error {
+	contract := dispatcherMinimumVersionReleaseContract{}
+	if err := json.Unmarshal(contractContent, &contract); err != nil {
+		return fmt.Errorf("CLI release contract is invalid JSON: %w", err)
+	}
+	if contract.CliVersion != "" && contract.CliVersion != values.MinimumDispatcherVersion {
+		return fmt.Errorf(
+			"CLI release %s%s contract declares cliVersion %q",
+			cliReleaseTagPrefix,
+			values.MinimumDispatcherVersion,
+			contract.CliVersion)
+	}
+
+	dispatcherContractVersion, hasDispatcherContractVersion := dispatcherMinimumReleaseContractVersion(contract.DispatcherContractVersion)
+	if !hasDispatcherContractVersion {
+		return fmt.Errorf(
+			"CLI release %s%s does not define dispatcherContractVersion",
+			cliReleaseTagPrefix,
+			values.MinimumDispatcherVersion)
+	}
+	if dispatcherContractVersion < values.CurrentDispatcherContractVersion {
+		return fmt.Errorf(
+			"unity package requires dispatcher contract %d, but CLI release %s%s advertises dispatcher contract %d",
+			values.CurrentDispatcherContractVersion,
+			cliReleaseTagPrefix,
+			values.MinimumDispatcherVersion,
+			dispatcherContractVersion)
+	}
+	return nil
+}
+
+func dispatcherMinimumReleaseContractVersion(value *json.RawMessage) (int, bool) {
+	if value == nil {
+		return 0, false
+	}
+
+	dispatcherContractVersion, err := strconv.Atoi(strings.TrimSpace(string(*value)))
+	if err != nil {
+		return 0, false
+	}
+	return dispatcherContractVersion, true
+}
+
+func syncDispatcherMinimumVersionFiles(repoRoot string, targetVersion string) (bool, error) {
+	changedConstants, err := syncDispatcherMinimumVersionConstants(repoRoot, targetVersion)
+	if err != nil {
+		return false, err
+	}
+	changedPackagePin, err := syncDispatcherMinimumVersionPin(filepath.Join(repoRoot, unityPackageCliPinFile), targetVersion)
+	if err != nil {
+		return false, err
+	}
+	changedProjectPin, err := syncDispatcherMinimumVersionPin(filepath.Join(repoRoot, unityProjectCliPinFile), targetVersion)
+	if err != nil {
+		return false, err
+	}
+	return changedConstants || changedPackagePin || changedProjectPin, nil
+}
+
+func syncDispatcherMinimumVersionConstants(repoRoot string, targetVersion string) (bool, error) {
+	path := filepath.Join(repoRoot, protocolMinimumVersionFile)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	updatedContent := minimumCliVersionPattern.ReplaceAll(
+		content,
+		[]byte(`MINIMUM_REQUIRED_CLI_VERSION = "`+targetVersion+`"`))
+	if bytes.Equal(content, updatedContent) {
+		return false, nil
+	}
+	if err := os.WriteFile(path, updatedContent, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func syncDispatcherMinimumVersionPin(path string, targetVersion string) (bool, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	pin := dispatcherMinimumVersionCliPin{}
+	if err := json.Unmarshal(content, &pin); err != nil {
+		return false, fmt.Errorf("%s is invalid JSON: %w", path, err)
+	}
+	if pin.MinimumDispatcherVersion == targetVersion {
+		return false, nil
+	}
+
+	pin.MinimumDispatcherVersion = targetVersion
+	updatedContent, err := json.MarshalIndent(pin, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	updatedContent = append(updatedContent, '\n')
+	if err := os.WriteFile(path, updatedContent, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func writeDispatcherMinimumVersionLine(writer io.Writer, values ...any) {
+	_, _ = fmt.Fprintln(writer, values...)
+}

--- a/cli/internal/automation/dispatcher_minimum_version_guard_test.go
+++ b/cli/internal/automation/dispatcher_minimum_version_guard_test.go
@@ -3,6 +3,7 @@ package automation
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -54,6 +55,57 @@ func TestRunDispatcherMinimumVersionCheck_WhenProjectPinDiffersFromPackagePin_Fa
 		t.Fatalf("expected exit code 1, got %d\nstdout: %s", result.exitCode, result.stdout)
 	}
 	assertDispatcherMinimumVersionLogContains(t, result.stderr, ".uloop/cli-pin.json minimumDispatcherVersion")
+}
+
+// Verifies invalid dispatcher contract metadata reports the actual bad value.
+func TestRunDispatcherMinimumVersionCheck_WhenCurrentDispatcherContractIsInvalid_FailsWithValue(t *testing.T) {
+	result := runDispatcherMinimumVersionCheckCase(t, dispatcherMinimumVersionCase{
+		currentCliVersion:                "3.0.0-beta.40",
+		currentDispatcherContractVersion: 0,
+		minimumDispatcherVersion:         "3.0.0-beta.40",
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\nstdout: %s", result.exitCode, result.stdout)
+	}
+	assertDispatcherMinimumVersionLogContains(t, result.stderr, "dispatcherContractVersion must be at least 1, got 0")
+}
+
+// Verifies release PR sync only edits minimumDispatcherVersion and keeps future schema fields.
+func TestSyncDispatcherMinimumVersionPinPreservesUnknownFields(t *testing.T) {
+	workDir := t.TempDir()
+	path := filepath.Join(workDir, "cli-pin.json")
+	writeFile(t, path, `{"schemaVersion":1,"cliVersion":"3.0.0-beta.40","minimumDispatcherVersion":"3.0.0-beta.39","futureField":{"enabled":true}}`)
+
+	changed, err := syncDispatcherMinimumVersionPin(path, "3.0.0-beta.40")
+	if err != nil {
+		t.Fatalf("expected pin sync to pass, got %v", err)
+	}
+	if !changed {
+		t.Fatal("expected pin sync to report a change")
+	}
+
+	updatedContent := readFile(t, path)
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal([]byte(updatedContent), &fields); err != nil {
+		t.Fatalf("failed to parse updated pin: %v", err)
+	}
+	futureField := struct {
+		Enabled bool `json:"enabled"`
+	}{}
+	if err := json.Unmarshal(fields["futureField"], &futureField); err != nil {
+		t.Fatalf("failed to parse futureField: %v", err)
+	}
+	if !futureField.Enabled {
+		t.Fatalf("expected futureField to be preserved, got %s", fields["futureField"])
+	}
+	minimumDispatcherVersion := ""
+	if err := json.Unmarshal(fields["minimumDispatcherVersion"], &minimumDispatcherVersion); err != nil {
+		t.Fatalf("failed to parse minimumDispatcherVersion: %v", err)
+	}
+	if minimumDispatcherVersion != "3.0.0-beta.40" {
+		t.Fatalf("expected minimumDispatcherVersion to be updated, got %q", minimumDispatcherVersion)
+	}
 }
 
 type dispatcherMinimumVersionCase struct {

--- a/cli/internal/automation/dispatcher_minimum_version_guard_test.go
+++ b/cli/internal/automation/dispatcher_minimum_version_guard_test.go
@@ -1,0 +1,208 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Verifies release PRs cannot point minimumDispatcherVersion at a CLI tag without dispatcher metadata.
+func TestRunDispatcherMinimumVersionCheck_WhenMinimumReleaseLacksDispatcherContract_Fails(t *testing.T) {
+	result := runDispatcherMinimumVersionCheckCase(t, dispatcherMinimumVersionCase{
+		currentCliVersion:                "3.0.0-beta.40",
+		currentDispatcherContractVersion: 1,
+		minimumDispatcherVersion:         "3.0.0-beta.39",
+		releaseContract:                  `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.39"}`,
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\nstdout: %s", result.exitCode, result.stdout)
+	}
+	assertDispatcherMinimumVersionLogContains(t, result.stderr, "does not define dispatcherContractVersion")
+	assertDispatcherMinimumVersionLogContains(t, result.gitLog, "cli-v3.0.0-beta.39:cli/contract.json")
+}
+
+// Verifies release PRs pass when the pending CLI release itself is the minimum dispatcher version.
+func TestRunDispatcherMinimumVersionCheck_WhenMinimumIsCurrentRelease_Passes(t *testing.T) {
+	result := runDispatcherMinimumVersionCheckCase(t, dispatcherMinimumVersionCase{
+		currentCliVersion:                "3.0.0-beta.40",
+		currentDispatcherContractVersion: 1,
+		minimumDispatcherVersion:         "3.0.0-beta.40",
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertDispatcherMinimumVersionLogContains(t, result.stdout, "Dispatcher minimum version guard passed.")
+	assertDispatcherMinimumVersionLogDoesNotContain(t, result.gitLog, "cli-v3.0.0-beta.40:cli/contract.json")
+}
+
+// Verifies committed pin files cannot drift from the C# minimum dispatcher version.
+func TestRunDispatcherMinimumVersionCheck_WhenProjectPinDiffersFromPackagePin_Fails(t *testing.T) {
+	result := runDispatcherMinimumVersionCheckCase(t, dispatcherMinimumVersionCase{
+		currentCliVersion:                  "3.0.0-beta.40",
+		currentDispatcherContractVersion:   1,
+		minimumDispatcherVersion:           "3.0.0-beta.40",
+		projectPinMinimumDispatcherVersion: "3.0.0-beta.39",
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\nstdout: %s", result.exitCode, result.stdout)
+	}
+	assertDispatcherMinimumVersionLogContains(t, result.stderr, ".uloop/cli-pin.json minimumDispatcherVersion")
+}
+
+type dispatcherMinimumVersionCase struct {
+	currentCliVersion                  string
+	currentDispatcherContractVersion   int
+	minimumDispatcherVersion           string
+	projectPinMinimumDispatcherVersion string
+	releaseContract                    string
+}
+
+type dispatcherMinimumVersionRunResult struct {
+	exitCode int
+	stdout   string
+	stderr   string
+	gitLog   string
+}
+
+func runDispatcherMinimumVersionCheckCase(t *testing.T, testCase dispatcherMinimumVersionCase) dispatcherMinimumVersionRunResult {
+	t.Helper()
+
+	workDir := t.TempDir()
+	mockBin := filepath.Join(workDir, "bin")
+	err := os.MkdirAll(mockBin, 0o755)
+	if err != nil {
+		t.Fatalf("failed to create mock bin: %v", err)
+	}
+
+	gitLogPath := filepath.Join(workDir, "git.log")
+	writeDispatcherMinimumVersionMockGit(t, filepath.Join(mockBin, "git"))
+	prepareDispatcherMinimumVersionFiles(t, workDir, testCase)
+
+	t.Setenv("PATH", mockBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ULOOP_REPOSITORY_ROOT", workDir)
+	t.Setenv("GIT_LOG", gitLogPath)
+	if testCase.releaseContract != "" {
+		releaseContractPath := filepath.Join(workDir, "release-contract.json")
+		writeFile(t, releaseContractPath, testCase.releaseContract)
+		t.Setenv("GIT_RELEASE_CONTRACT", releaseContractPath)
+	}
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	exitCode := RunDispatcherMinimumVersionCheck(context.Background(), &stdout, &stderr, "")
+
+	return dispatcherMinimumVersionRunResult{
+		exitCode: exitCode,
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+		gitLog:   readFile(t, gitLogPath),
+	}
+}
+
+func prepareDispatcherMinimumVersionFiles(t *testing.T, workDir string, testCase dispatcherMinimumVersionCase) {
+	t.Helper()
+
+	projectMinimumDispatcherVersion := testCase.projectPinMinimumDispatcherVersion
+	if projectMinimumDispatcherVersion == "" {
+		projectMinimumDispatcherVersion = testCase.minimumDispatcherVersion
+	}
+
+	writeDispatcherMinimumVersionFile(t, filepath.Join(workDir, "cli/contract.json"), buildDispatcherMinimumVersionContract(
+		testCase.currentCliVersion,
+		testCase.currentDispatcherContractVersion))
+	writeDispatcherMinimumVersionFile(t, filepath.Join(workDir, protocolMinimumVersionFile), buildProtocolMinimumVersionConstants(
+		2,
+		testCase.minimumDispatcherVersion))
+	writeDispatcherMinimumVersionFile(t, filepath.Join(workDir, unityPackageCliPinFile), buildDispatcherMinimumVersionPin(
+		testCase.currentCliVersion,
+		testCase.minimumDispatcherVersion))
+	writeDispatcherMinimumVersionFile(t, filepath.Join(workDir, unityProjectCliPinFile), buildDispatcherMinimumVersionPin(
+		testCase.currentCliVersion,
+		projectMinimumDispatcherVersion))
+}
+
+func writeDispatcherMinimumVersionFile(t *testing.T, path string, content string) {
+	t.Helper()
+	err := os.MkdirAll(filepath.Dir(path), 0o755)
+	if err != nil {
+		t.Fatalf("failed to create parent directory for %s: %v", path, err)
+	}
+	writeFile(t, path, content)
+}
+
+func buildDispatcherMinimumVersionContract(cliVersion string, dispatcherContractVersion int) string {
+	return `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"` + cliVersion + `","dispatcherContractVersion":` +
+		strconv.Itoa(dispatcherContractVersion) +
+		`}`
+}
+
+func buildDispatcherMinimumVersionPin(cliVersion string, minimumDispatcherVersion string) string {
+	return `{"schemaVersion":1,"packageName":"test.package","packageVersion":"3.0.0-beta.40","cliVersion":"` +
+		cliVersion +
+		`","requiredProtocolVersion":2,"minimumDispatcherVersion":"` +
+		minimumDispatcherVersion +
+		`"}`
+}
+
+func writeDispatcherMinimumVersionMockGit(t *testing.T, path string) {
+	t.Helper()
+
+	content := `#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$GIT_LOG"
+
+if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then
+  printf '%s\n' "$ULOOP_REPOSITORY_ROOT"
+  exit 0
+fi
+
+if [ "$1" = "-C" ]; then
+  shift 2
+fi
+
+if [ "$1" = "show" ]; then
+  case "$2" in
+    cli-v*:cli/contract.json)
+      if [ -n "${GIT_RELEASE_CONTRACT:-}" ]; then
+        cat "$GIT_RELEASE_CONTRACT"
+      else
+        echo "release not found" >&2
+        exit 1
+      fi
+      ;;
+    *) echo "unexpected git show ref: $2" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+echo "unexpected git command: $*" >&2
+exit 1
+`
+	writeFile(t, path, content)
+	err := os.Chmod(path, 0o755)
+	if err != nil {
+		t.Fatalf("failed to chmod mock git: %v", err)
+	}
+}
+
+func assertDispatcherMinimumVersionLogContains(t *testing.T, actual string, expected string) {
+	t.Helper()
+	if !strings.Contains(actual, expected) {
+		t.Fatalf("expected log to contain %q, got:\n%s", expected, actual)
+	}
+}
+
+func assertDispatcherMinimumVersionLogDoesNotContain(t *testing.T, actual string, unexpected string) {
+	t.Helper()
+	if strings.Contains(actual, unexpected) {
+		t.Fatalf("expected log not to contain %q, got:\n%s", unexpected, actual)
+	}
+}

--- a/cli/internal/automation/release_pr_checks.go
+++ b/cli/internal/automation/release_pr_checks.go
@@ -72,6 +72,12 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 	}
 	writeReleasePRCheckLine(stdout, fmt.Sprintf("Marked release PR #%d as draft while checks run.", releasePR.Number))
 
+	releasePR, err = syncReleasePRDispatcherMinimum(ctx, stdout, config, releasePR)
+	if err != nil {
+		writeReleasePRCheckLine(stderr, err)
+		return 1
+	}
+
 	dispatchedAt := releasePRCheckNow().UTC().Truncate(time.Second)
 	writeReleasePRCheckLine(stdout, fmt.Sprintf("Dispatching %s for release PR #%d: %s", config.workflow, releasePR.Number, releasePR.URL))
 	err = dispatchReleasePRCheckWorkflow(ctx, config, releasePR)

--- a/cli/internal/automation/release_pr_checks_test.go
+++ b/cli/internal/automation/release_pr_checks_test.go
@@ -11,11 +11,15 @@ import (
 )
 
 type releasePRCheckRunResult struct {
-	exitCode int
-	stdout   string
-	stderr   string
-	ghLog    string
-	sleeps   []time.Duration
+	exitCode         int
+	stdout           string
+	stderr           string
+	ghLog            string
+	gitLog           string
+	constantsContent string
+	packagePin       string
+	projectPin       string
+	sleeps           []time.Duration
 }
 
 // Verifies that missing release PRs skip without dispatching checks.
@@ -56,6 +60,54 @@ func TestReleasePRChecksDispatchAndMarkReady(t *testing.T) {
 	assertReleasePRCheckLogContains(t, result.ghLog, "run list --repo owner/repository --workflow build-and-test.yml --branch release-please--branches--v3-beta --event workflow_dispatch --json databaseId,status,conclusion,headSha,createdAt,url --limit 20")
 	assertReleasePRCheckLogContains(t, result.ghLog, "run watch 4242 --repo owner/repository --exit-status --compact --interval 1")
 	assertReleasePRCheckLogContainsLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
+}
+
+// Verifies stale release PR dispatcher minimums are synced before checks are dispatched.
+func TestReleasePRChecksSyncDispatcherMinimumBeforeDispatch(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:           `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"stale123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		prListJSONAfterWatch: `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"synced456","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		runListJSON:          `[{"databaseId":4242,"headSha":"synced456","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
+		runWatchStatus:       "0",
+		dispatcherSync: releasePRDispatcherSyncCase{
+			currentCliVersion:        "3.0.0-beta.40",
+			minimumDispatcherVersion: "3.0.0-beta.39",
+			releaseContract:          `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.39"}`,
+		},
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertReleasePRCheckLogContains(t, result.stdout, "Updated release PR #1043 dispatcher minimum version to 3.0.0-beta.40.")
+	assertReleasePRCheckLogContains(t, result.gitLog, "commit -m "+releasePRDispatcherMinimumCommitMessage)
+	assertReleasePRCheckLogContains(t, result.gitLog, "push origin HEAD:refs/heads/release-please--branches--v3-beta")
+	assertReleasePRCheckLogContains(t, result.constantsContent, `MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.40"`)
+	assertReleasePRCheckLogContains(t, result.packagePin, `"minimumDispatcherVersion": "3.0.0-beta.40"`)
+	assertReleasePRCheckLogContains(t, result.projectPin, `"minimumDispatcherVersion": "3.0.0-beta.40"`)
+	assertReleasePRCheckLogContains(t, result.stdout, "Watching build-and-test.yml run 4242 for release PR #1043.")
+}
+
+// Verifies dispatcher-capable minimum releases are not bumped on ordinary CLI releases.
+func TestReleasePRChecksKeepDispatcherMinimumWhenReleaseIsCapable(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		runListJSON:    `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
+		runWatchStatus: "0",
+		dispatcherSync: releasePRDispatcherSyncCase{
+			currentCliVersion:        "3.0.0-beta.41",
+			minimumDispatcherVersion: "3.0.0-beta.40",
+			releaseContract:          `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.40","dispatcherContractVersion":1}`,
+		},
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertReleasePRCheckLogDoesNotContain(t, result.stdout, "Updated release PR #1043 dispatcher minimum version")
+	assertReleasePRCheckLogDoesNotContain(t, result.gitLog, "commit -m "+releasePRDispatcherMinimumCommitMessage)
+	assertReleasePRCheckLogContains(t, result.constantsContent, `MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.40"`)
+	assertReleasePRCheckLogContains(t, result.packagePin, `"minimumDispatcherVersion":"3.0.0-beta.40"`)
 }
 
 // Verifies that same-second workflow runs are accepted when GitHub rounds createdAt timestamps.
@@ -163,6 +215,13 @@ type releasePRCheckCase struct {
 	runListJSON          string
 	runWatchStatus       string
 	now                  time.Time
+	dispatcherSync       releasePRDispatcherSyncCase
+}
+
+type releasePRDispatcherSyncCase struct {
+	currentCliVersion        string
+	minimumDispatcherVersion string
+	releaseContract          string
 }
 
 func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRCheckRunResult {
@@ -176,12 +235,16 @@ func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRC
 	}
 
 	ghLogPath := filepath.Join(workDir, "gh.log")
+	gitLogPath := filepath.Join(workDir, "git.log")
 	prListCountPath := filepath.Join(workDir, "pr-list-count")
 	writeReleasePRCheckMockGH(t, filepath.Join(mockBin, "gh"))
+	writeReleasePRCheckMockGit(t, filepath.Join(mockBin, "git"))
+	prepareReleasePRDispatcherSyncFiles(t, workDir, testCase.dispatcherSync)
 
 	t.Setenv("PATH", mockBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("GITHUB_REPOSITORY", "owner/repository")
 	t.Setenv("TARGET_BRANCH", "v3-beta")
+	t.Setenv("ULOOP_REPOSITORY_ROOT", workDir)
 	t.Setenv("RELEASE_PR_CHECK_LOOKUP_ATTEMPTS", "1")
 	t.Setenv("RELEASE_PR_CHECK_LOOKUP_INTERVAL_SECONDS", "1")
 	t.Setenv("RELEASE_PR_CHECK_WATCH_INTERVAL_SECONDS", "1")
@@ -191,6 +254,12 @@ func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRC
 	t.Setenv("GH_RUN_LIST_JSON", testCase.runListJSON)
 	t.Setenv("GH_RUN_WATCH_STATUS", testCase.runWatchStatus)
 	t.Setenv("GH_LOG", ghLogPath)
+	t.Setenv("GIT_LOG", gitLogPath)
+	if testCase.dispatcherSync.releaseContract != "" {
+		releaseContractPath := filepath.Join(workDir, "release-contract.json")
+		writeFile(t, releaseContractPath, testCase.dispatcherSync.releaseContract)
+		t.Setenv("GIT_RELEASE_CONTRACT", releaseContractPath)
+	}
 
 	originalNow := releasePRCheckNow
 	originalSleep := releasePRCheckSleep
@@ -217,14 +286,45 @@ func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRC
 	if err != nil {
 		t.Fatalf("failed to read gh log: %v", err)
 	}
+	gitLog := readOptionalFile(t, gitLogPath)
 
 	return releasePRCheckRunResult{
-		exitCode: exitCode,
-		stdout:   stdout.String(),
-		stderr:   stderr.String(),
-		ghLog:    string(ghLogBytes),
-		sleeps:   sleeps,
+		exitCode:         exitCode,
+		stdout:           stdout.String(),
+		stderr:           stderr.String(),
+		ghLog:            string(ghLogBytes),
+		gitLog:           gitLog,
+		constantsContent: readFile(t, filepath.Join(workDir, protocolMinimumVersionFile)),
+		packagePin:       readFile(t, filepath.Join(workDir, unityPackageCliPinFile)),
+		projectPin:       readFile(t, filepath.Join(workDir, unityProjectCliPinFile)),
+		sleeps:           sleeps,
 	}
+}
+
+func prepareReleasePRDispatcherSyncFiles(t *testing.T, workDir string, testCase releasePRDispatcherSyncCase) {
+	t.Helper()
+
+	currentCliVersion := testCase.currentCliVersion
+	if currentCliVersion == "" {
+		currentCliVersion = "3.0.0-beta.40"
+	}
+	minimumDispatcherVersion := testCase.minimumDispatcherVersion
+	if minimumDispatcherVersion == "" {
+		minimumDispatcherVersion = currentCliVersion
+	}
+
+	writeDispatcherMinimumVersionFile(t, filepath.Join(workDir, "cli/contract.json"), buildDispatcherMinimumVersionContract(
+		currentCliVersion,
+		1))
+	writeDispatcherMinimumVersionFile(t, filepath.Join(workDir, protocolMinimumVersionFile), buildProtocolMinimumVersionConstants(
+		2,
+		minimumDispatcherVersion))
+	writeDispatcherMinimumVersionFile(t, filepath.Join(workDir, unityPackageCliPinFile), buildDispatcherMinimumVersionPin(
+		currentCliVersion,
+		minimumDispatcherVersion))
+	writeDispatcherMinimumVersionFile(t, filepath.Join(workDir, unityProjectCliPinFile), buildDispatcherMinimumVersionPin(
+		currentCliVersion,
+		minimumDispatcherVersion))
 }
 
 func writeReleasePRCheckMockGH(t *testing.T, path string) {
@@ -276,6 +376,84 @@ exit 1
 	if err != nil {
 		t.Fatalf("failed to write mock gh command: %v", err)
 	}
+}
+
+func writeReleasePRCheckMockGit(t *testing.T, path string) {
+	t.Helper()
+
+	content := `#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >> "$GIT_LOG"
+
+if [ "$1" = "rev-parse" ] && [ "$2" = "--show-toplevel" ]; then
+  printf '%s\n' "$ULOOP_REPOSITORY_ROOT"
+  exit 0
+fi
+
+if [ "$1" = "-C" ]; then
+  shift 2
+fi
+
+if [ "$1" = "fetch" ] && [ "$2" = "origin" ]; then
+  exit 0
+fi
+
+if [ "$1" = "switch" ] && [ "$2" = "--detach" ] && [ "$3" = "FETCH_HEAD" ]; then
+  exit 0
+fi
+
+if [ "$1" = "show" ]; then
+  case "$2" in
+    cli-v*:cli/contract.json)
+      if [ -n "${GIT_RELEASE_CONTRACT:-}" ]; then
+        cat "$GIT_RELEASE_CONTRACT"
+      else
+        echo "release not found" >&2
+        exit 1
+      fi
+      ;;
+    *) echo "unexpected git show ref: $2" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+if [ "$1" = "config" ]; then
+  exit 0
+fi
+
+if [ "$1" = "add" ]; then
+  exit 0
+fi
+
+if [ "$1" = "commit" ]; then
+  exit 0
+fi
+
+if [ "$1" = "push" ]; then
+  exit 0
+fi
+
+echo "unexpected git command: $*" >&2
+exit 1
+`
+	writeFile(t, path, content)
+	err := os.Chmod(path, 0o755)
+	if err != nil {
+		t.Fatalf("failed to chmod mock git: %v", err)
+	}
+}
+
+func readOptionalFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(content)
 }
 
 func assertReleasePRCheckLogContains(t *testing.T, actual string, expected string) {

--- a/cli/internal/automation/release_pr_checks_test.go
+++ b/cli/internal/automation/release_pr_checks_test.go
@@ -110,6 +110,28 @@ func TestReleasePRChecksKeepDispatcherMinimumWhenReleaseIsCapable(t *testing.T) 
 	assertReleasePRCheckLogContains(t, result.packagePin, `"minimumDispatcherVersion":"3.0.0-beta.40"`)
 }
 
+// Verifies structural release contract errors are reported instead of being hidden by auto-sync.
+func TestReleasePRChecksFailWhenMinimumReleaseContractVersionDiffers(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		runListJSON:    `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
+		runWatchStatus: "0",
+		dispatcherSync: releasePRDispatcherSyncCase{
+			currentCliVersion:        "3.0.0-beta.40",
+			minimumDispatcherVersion: "3.0.0-beta.39",
+			releaseContract:          `{"schemaVersion":1,"protocolVersion":2,"cliVersion":"3.0.0-beta.38","dispatcherContractVersion":1}`,
+		},
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\nstdout: %s", result.exitCode, result.stdout)
+	}
+	assertReleasePRCheckLogContains(t, result.stderr, `contract declares cliVersion "3.0.0-beta.38"`)
+	assertReleasePRCheckLogDoesNotContain(t, result.stdout, "Updated release PR #1043 dispatcher minimum version")
+	assertReleasePRCheckLogDoesNotContain(t, result.gitLog, "commit -m "+releasePRDispatcherMinimumCommitMessage)
+	assertReleasePRCheckLogDoesNotContain(t, result.ghLog, "workflow run")
+}
+
 // Verifies that same-second workflow runs are accepted when GitHub rounds createdAt timestamps.
 func TestReleasePRChecksAcceptSameSecondRunAfterDispatch(t *testing.T) {
 	result := runReleasePRCheckCase(t, releasePRCheckCase{

--- a/cli/internal/automation/release_pr_dispatcher_sync.go
+++ b/cli/internal/automation/release_pr_dispatcher_sync.go
@@ -26,7 +26,10 @@ func syncReleasePRDispatcherMinimum(
 	if err != nil {
 		return releasePullRequest{}, err
 	}
-	targetVersion, needsSync := dispatcherMinimumVersionSyncTarget(ctx, repoRoot, values)
+	targetVersion, needsSync, err := dispatcherMinimumVersionSyncTarget(ctx, repoRoot, values)
+	if err != nil {
+		return releasePullRequest{}, err
+	}
 	if !needsSync {
 		return releasePR, nil
 	}
@@ -65,12 +68,15 @@ func dispatcherMinimumVersionSyncTarget(
 	ctx context.Context,
 	repoRoot string,
 	values dispatcherMinimumVersionValues,
-) (string, bool) {
+) (string, bool, error) {
 	err := verifyDispatcherMinimumVersionAtRef(ctx, repoRoot, values)
 	if err == nil {
-		return "", false
+		return "", false, nil
 	}
-	return values.CurrentCliVersion, true
+	if !isDispatcherMinimumVersionSyncableError(err) {
+		return "", false, err
+	}
+	return values.CurrentCliVersion, true, nil
 }
 
 func checkoutReleasePRBranch(ctx context.Context, repoRoot string, releasePR releasePullRequest) error {

--- a/cli/internal/automation/release_pr_dispatcher_sync.go
+++ b/cli/internal/automation/release_pr_dispatcher_sync.go
@@ -1,0 +1,100 @@
+package automation
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+const releasePRDispatcherMinimumCommitMessage = "chore: sync dispatcher minimum for release PR"
+
+func syncReleasePRDispatcherMinimum(
+	ctx context.Context,
+	stdout io.Writer,
+	config releasePRCheckConfig,
+	releasePR releasePullRequest,
+) (releasePullRequest, error) {
+	repoRoot, err := gitRepoRoot(ctx)
+	if err != nil {
+		return releasePullRequest{}, fmt.Errorf("failed to resolve git repository root: %w", err)
+	}
+	if err := checkoutReleasePRBranch(ctx, repoRoot, releasePR); err != nil {
+		return releasePullRequest{}, err
+	}
+
+	values, err := dispatcherMinimumVersionValuesAtRef(ctx, repoRoot, "")
+	if err != nil {
+		return releasePullRequest{}, err
+	}
+	targetVersion, needsSync := dispatcherMinimumVersionSyncTarget(ctx, repoRoot, values)
+	if !needsSync {
+		return releasePR, nil
+	}
+
+	changed, err := syncDispatcherMinimumVersionFiles(repoRoot, targetVersion)
+	if err != nil {
+		return releasePullRequest{}, err
+	}
+	if !changed {
+		return releasePR, nil
+	}
+
+	if err := commitReleasePRDispatcherMinimum(ctx, repoRoot, releasePR); err != nil {
+		return releasePullRequest{}, err
+	}
+
+	updatedReleasePR, found, err := findReleasePRCheckPullRequest(ctx, config)
+	if err != nil {
+		return releasePullRequest{}, err
+	}
+	if !found {
+		return releasePullRequest{}, fmt.Errorf("release PR #%d is no longer pending after dispatcher minimum sync", releasePR.Number)
+	}
+	if updatedReleasePR.Number != releasePR.Number {
+		return releasePullRequest{}, fmt.Errorf("pending release PR changed from #%d to #%d after dispatcher minimum sync", releasePR.Number, updatedReleasePR.Number)
+	}
+
+	writeReleasePRCheckLine(stdout, fmt.Sprintf(
+		"Updated release PR #%d dispatcher minimum version to %s.",
+		releasePR.Number,
+		targetVersion))
+	return updatedReleasePR, nil
+}
+
+func dispatcherMinimumVersionSyncTarget(
+	ctx context.Context,
+	repoRoot string,
+	values dispatcherMinimumVersionValues,
+) (string, bool) {
+	err := verifyDispatcherMinimumVersionAtRef(ctx, repoRoot, values)
+	if err == nil {
+		return "", false
+	}
+	return values.CurrentCliVersion, true
+}
+
+func checkoutReleasePRBranch(ctx context.Context, repoRoot string, releasePR releasePullRequest) error {
+	_, err := runReleasePRCheckOutput(ctx, "git", "-C", repoRoot, "fetch", "origin", releasePR.HeadRefName)
+	if err != nil {
+		return err
+	}
+	_, err = runReleasePRCheckOutput(ctx, "git", "-C", repoRoot, "switch", "--detach", "FETCH_HEAD")
+	return err
+}
+
+func commitReleasePRDispatcherMinimum(ctx context.Context, repoRoot string, releasePR releasePullRequest) error {
+	commands := [][]string{
+		{"config", "user.name", "github-actions[bot]"},
+		{"config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"},
+		{"add", protocolMinimumVersionFile, unityPackageCliPinFile, unityProjectCliPinFile},
+		{"commit", "-m", releasePRDispatcherMinimumCommitMessage},
+		{"push", "origin", "HEAD:refs/heads/" + releasePR.HeadRefName},
+	}
+	for _, args := range commands {
+		commandArgs := append([]string{"-C", repoRoot}, args...)
+		if _, err := runReleasePRCheckOutput(ctx, "git", commandArgs...); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/scripts/test-protocol-minimum-version-workflow.sh
+++ b/scripts/test-protocol-minimum-version-workflow.sh
@@ -29,6 +29,12 @@ test_pull_request_guard_fails_on_minimum_version_omission() {
   assert_contains "$BUILD_WORKFLOW" '        run: go run ./cmd/check-protocol-minimum-version --base "origin/${{ github.base_ref }}" --head HEAD'
 }
 
+test_release_pr_guard_fails_on_stale_dispatcher_minimum() {
+  assert_contains "$BUILD_WORKFLOW" "      - name: Check dispatcher minimum version"
+  assert_contains "$BUILD_WORKFLOW" "        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'"
+  assert_contains "$BUILD_WORKFLOW" "        run: go run ./cmd/check-dispatcher-minimum-version"
+}
+
 test_pull_request_target_comment_workflow_is_trusted() {
   assert_file_exists "$COMMENT_WORKFLOW"
   assert_contains "$COMMENT_WORKFLOW" "name: Protocol Minimum Version Warning"
@@ -46,4 +52,5 @@ test_pull_request_target_comment_workflow_is_trusted() {
 }
 
 test_pull_request_guard_fails_on_minimum_version_omission
+test_release_pr_guard_fails_on_stale_dispatcher_minimum
 test_pull_request_target_comment_workflow_is_trusted


### PR DESCRIPTION
## Summary
- Release PRs now guard against stale CLI launcher minimums that would break pinned CLI dispatch.
- Ordinary CLI releases keep the existing minimum when it already supports the launcher contract.

## User Impact
- Before, a release PR could retain a minimum CLI release that predates the dispatcher, leaving generated pin metadata incompatible with version dispatch.
- After, release automation updates that minimum before checks when needed, and CI blocks stale metadata if it slips through.

## Changes
- Add launcher contract metadata to the native CLI contract.
- Add a dispatcher minimum version guard and run it in build checks for pull requests and workflow dispatches.
- Extend release PR check dispatch to sync the Unity constant and both cli-pin.json files only when the selected minimum release lacks the required launcher contract.

## Verification
- scripts/check-go-cli.sh
- sh scripts/test-protocol-minimum-version-workflow.sh
- cd cli && go run ./cmd/check-dispatcher-minimum-version
- git diff --check
- autoreview --mode branch --base origin/v3-beta

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

