### PR TITLE
fix: Keep beta dispatcher releases out of Latest

### DIFF
--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -125,7 +125,9 @@ jobs:
         if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_PRERELEASE: ${{ steps.release.outputs.prerelease }}
           TARGET_SHA: ${{ steps.release.outputs.sha }}
         run: |
           set -eu
@@ -146,6 +148,11 @@ jobs:
           if gh release view "${RELEASE_TAG}" --json isDraft --jq '.isDraft' >"${DRAFT_STATE_PATH}" 2>/dev/null; then
             IS_DRAFT=$(cat "${DRAFT_STATE_PATH}")
             if [ "${IS_DRAFT}" != "true" ]; then
+              if [ "${RELEASE_PRERELEASE}" = "true" ]; then
+                RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.id')
+                gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F prerelease=true -F make_latest=false >/dev/null
+              fi
+
               echo "release_published=true" >> "$GITHUB_OUTPUT"
               echo "Dispatcher release ${RELEASE_TAG} is already published; verifying existing assets."
               exit 0
@@ -157,18 +164,19 @@ jobs:
           fi
 
           PRERELEASE_FLAG=""
-          case "${RELEASE_TAG}" in
-            *-beta.*)
-              PRERELEASE_FLAG="--prerelease"
-              ;;
-          esac
+          LATEST_FLAG=""
+          if [ "${RELEASE_PRERELEASE}" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+            LATEST_FLAG="--latest=false"
+          fi
 
           gh release create "${RELEASE_TAG}" \
             --draft \
             --title "${RELEASE_TAG}" \
             --notes "Dispatcher release ${RELEASE_TAG}." \
             --target "${TARGET_SHA}" \
-            ${PRERELEASE_FLAG}
+            ${PRERELEASE_FLAG} \
+            ${LATEST_FLAG}
 
           echo "release_published=false" >> "$GITHUB_OUTPUT"
 
@@ -214,17 +222,18 @@ jobs:
         if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true' && steps.draft.outputs.release_published != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_PRERELEASE: ${{ steps.release.outputs.prerelease }}
         run: |
           set -eu
-          case "${RELEASE_TAG}" in
-            *-beta.*)
-              gh release edit "${RELEASE_TAG}" --draft=false --prerelease
-              ;;
-            *)
-              gh release edit "${RELEASE_TAG}" --draft=false
-              ;;
-          esac
+          if [ "${RELEASE_PRERELEASE}" = "true" ]; then
+            gh release edit "${RELEASE_TAG}" --draft=false --prerelease
+            RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.id')
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F prerelease=true -F make_latest=false >/dev/null
+          else
+            gh release edit "${RELEASE_TAG}" --draft=false
+          fi
 
       - name: Sync release-please package releases
         id: package_release_sync

--- a/scripts/resolve-dispatcher-release-target.sh
+++ b/scripts/resolve-dispatcher-release-target.sh
@@ -110,6 +110,19 @@ dispatcher_release_target_sha() {
   git rev-parse HEAD
 }
 
+dispatcher_release_is_prerelease() {
+  version=$1
+  ref_name=$2
+
+  case "$version" in
+    *-*)
+      return 0
+      ;;
+  esac
+
+  [ "$ref_name" = "v3-beta" ]
+}
+
 VERSION=$(jq -r '.dispatcherVersion' cli/dispatcher-contract.json)
 if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
   echo "Could not resolve dispatcherVersion from cli/dispatcher-contract.json." >&2
@@ -148,6 +161,10 @@ if [ "$EVENT_NAME" = "push" ]; then
 fi
 
 TARGET_SHA=$(dispatcher_release_target_sha "$RELEASE_TAG")
+IS_PRERELEASE=false
+if dispatcher_release_is_prerelease "$VERSION" "$EVENT_REF_NAME"; then
+  IS_PRERELEASE=true
+fi
 
 if [ "$CAN_EVALUATE_DISPATCHER_RELEASE" != "true" ]; then
   SHOULD_PUBLISH=false
@@ -174,6 +191,7 @@ printf 'release=%s\n' "$SHOULD_RELEASE"
 printf 'tag=%s\n' "$RELEASE_TAG"
 printf 'version=%s\n' "$VERSION"
 printf 'sha=%s\n' "$TARGET_SHA"
+printf 'prerelease=%s\n' "$IS_PRERELEASE"
 printf 'dry_run=%s\n' "$DRY_RUN"
 
 echo "Dispatcher publish: $SHOULD_PUBLISH" >&2

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -81,11 +81,20 @@ test_dispatcher_draft_state_uses_runner_temp() {
 }
 
 test_dispatcher_beta_releases_are_marked_prerelease() {
+  assert_contains "$WORKFLOW" '          RELEASE_PRERELEASE: ${{ steps.release.outputs.prerelease }}'
+  assert_contains "$WORKFLOW" '          GITHUB_REPOSITORY: ${{ github.repository }}'
   assert_contains "$WORKFLOW" '          PRERELEASE_FLAG=""'
-  assert_contains "$WORKFLOW" '              PRERELEASE_FLAG="--prerelease"'
-  assert_contains "$WORKFLOW" '              gh release edit "${RELEASE_TAG}" --draft=false --prerelease'
-  assert_before "$WORKFLOW" '              PRERELEASE_FLAG="--prerelease"' '          gh release create "${RELEASE_TAG}" \'
-  assert_before "$WORKFLOW" '              gh release edit "${RELEASE_TAG}" --draft=false --prerelease' '      - name: Sync release-please package releases'
+  assert_contains "$WORKFLOW" '          LATEST_FLAG=""'
+  assert_contains "$WORKFLOW" '          if [ "${RELEASE_PRERELEASE}" = "true" ]; then'
+  assert_contains "$WORKFLOW" '            PRERELEASE_FLAG="--prerelease"'
+  assert_contains "$WORKFLOW" '            LATEST_FLAG="--latest=false"'
+  assert_contains "$WORKFLOW" '            ${PRERELEASE_FLAG} \'
+  assert_contains "$WORKFLOW" '            ${LATEST_FLAG}'
+  assert_contains "$WORKFLOW" '            gh release edit "${RELEASE_TAG}" --draft=false --prerelease'
+  assert_contains "$WORKFLOW" '            RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '"'"'.id'"'"')'
+  assert_contains "$WORKFLOW" '            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F prerelease=true -F make_latest=false >/dev/null'
+  assert_before "$WORKFLOW" '            PRERELEASE_FLAG="--prerelease"' '          gh release create "${RELEASE_TAG}" \'
+  assert_before "$WORKFLOW" '            gh release edit "${RELEASE_TAG}" --draft=false --prerelease' '      - name: Sync release-please package releases'
 }
 
 test_package_release_sync_runs_after_dispatcher_publish() {

--- a/scripts/test-resolve-dispatcher-release-target.sh
+++ b/scripts/test-resolve-dispatcher-release-target.sh
@@ -88,6 +88,7 @@ run_case() {
   release_state=$2
   has_assets=$3
   tag_sha=${4:-}
+  ref_name=${5:-v3-beta}
   work_dir="$TMP_DIR/$name"
   mkdir -p "$work_dir"
   (
@@ -97,7 +98,7 @@ run_case() {
     write_mock_commands "$mock_bin"
     PATH="$mock_bin:$ORIGINAL_PATH" \
       EVENT_NAME=push \
-      EVENT_REF_NAME=v3-beta \
+      EVENT_REF_NAME="$ref_name" \
       DISPATCHER_RELEASE_STATE="$release_state" \
       DISPATCHER_RELEASE_HAS_ASSETS="$has_assets" \
       DISPATCHER_TAG_SHA_VALUE="$tag_sha" \
@@ -120,6 +121,7 @@ test_missing_release_publishes() {
   assert_contains "$output" "publish=true"
   assert_contains "$output" "release=true"
   assert_contains "$output" "tag=dispatcher-v3.0.0"
+  assert_contains "$output" "prerelease=true"
 }
 
 test_complete_release_skips() {
@@ -141,7 +143,15 @@ test_published_release_with_missing_assets_uses_existing_tag_sha() {
   assert_contains "$output" "sha=release-sha"
 }
 
+test_main_branch_release_is_not_prerelease() {
+  output=$(run_case main-missing-release missing false "" main)
+  assert_contains "$output" "publish=true"
+  assert_contains "$output" "release=true"
+  assert_contains "$output" "prerelease=false"
+}
+
 test_missing_release_publishes
 test_complete_release_skips
 test_published_release_with_missing_assets_uploads_assets
 test_published_release_with_missing_assets_uses_existing_tag_sha
+test_main_branch_release_is_not_prerelease


### PR DESCRIPTION
## Summary
- Keep dispatcher releases produced from v3-beta marked as prereleases.
- Prevent beta dispatcher releases from becoming the repository Latest release.

## User Impact
- The Releases page no longer presents beta dispatcher artifacts as the stable/latest project release.
- Installer and dispatcher assets remain available from the dispatcher release tag.

## Changes
- Emit a prerelease flag from the dispatcher release resolver for v3-beta.
- Publish prerelease dispatcher releases with latest disabled.
- Patch existing published dispatcher releases back to prerelease/not-latest when the workflow reuses them for asset verification.

## Verification
- scripts/test-resolve-dispatcher-release-target.sh
- scripts/test-dispatcher-publish-workflow.sh
- git diff --check


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

