### PR TITLE
fix: Dispatcher releases no longer look stable during v3 beta

### DIFF
--- a/.uloop/cli-pin.json
+++ b/.uloop/cli-pin.json
@@ -1,6 +1,6 @@
 {
   "cliVersion": "3.0.0-beta.41",
-  "minimumDispatcherVersion": "3.0.0-beta.42",
+  "minimumDispatcherVersion": "3.0.1-beta.1",
   "packageName": "io.github.hatayama.uloopmcp",
   "packageVersion": "3.0.0-beta.42",
   "requiredProtocolVersion": 2,

--- a/.uloop/cli-pin.json
+++ b/.uloop/cli-pin.json
@@ -1,6 +1,6 @@
 {
   "cliVersion": "3.0.0-beta.41",
-  "minimumDispatcherVersion": "3.0.0",
+  "minimumDispatcherVersion": "3.0.0-beta.42",
   "packageName": "io.github.hatayama.uloopmcp",
   "packageVersion": "3.0.0-beta.42",
   "requiredProtocolVersion": 2,

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -15,7 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.40";
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         // Why: global uloop is a dispatcher; project-local CLI versions are downloaded separately.
-        public const string MINIMUM_REQUIRED_DISPATCHER_VERSION = "3.0.0";
+        public const string MINIMUM_REQUIRED_DISPATCHER_VERSION = "3.0.0-beta.42";
         public const string MINIMUM_REQUIRED_DISPATCHER_RELEASE_TAG = DISPATCHER_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_DISPATCHER_VERSION;
         // Why: dispatcher setup compatibility is a launcher contract generation, not the IPC protocol generation.
         public const int REQUIRED_DISPATCHER_CONTRACT_VERSION = 1;

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -15,7 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.40";
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         // Why: global uloop is a dispatcher; project-local CLI versions are downloaded separately.
-        public const string MINIMUM_REQUIRED_DISPATCHER_VERSION = "3.0.0-beta.42";
+        public const string MINIMUM_REQUIRED_DISPATCHER_VERSION = "3.0.1-beta.1";
         public const string MINIMUM_REQUIRED_DISPATCHER_RELEASE_TAG = DISPATCHER_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_DISPATCHER_VERSION;
         // Why: dispatcher setup compatibility is a launcher contract generation, not the IPC protocol generation.
         public const int REQUIRED_DISPATCHER_CONTRACT_VERSION = 1;

--- a/Packages/src/cli-pin.json
+++ b/Packages/src/cli-pin.json
@@ -1,6 +1,6 @@
 {
   "cliVersion": "3.0.0-beta.41",
-  "minimumDispatcherVersion": "3.0.0-beta.42",
+  "minimumDispatcherVersion": "3.0.1-beta.1",
   "packageName": "io.github.hatayama.uloopmcp",
   "packageVersion": "3.0.0-beta.42",
   "requiredProtocolVersion": 2,

--- a/Packages/src/cli-pin.json
+++ b/Packages/src/cli-pin.json
@@ -1,6 +1,6 @@
 {
   "cliVersion": "3.0.0-beta.41",
-  "minimumDispatcherVersion": "3.0.0",
+  "minimumDispatcherVersion": "3.0.0-beta.42",
   "packageName": "io.github.hatayama.uloopmcp",
   "packageVersion": "3.0.0-beta.42",
   "requiredProtocolVersion": 2,

--- a/cli/dispatcher-contract.json
+++ b/cli/dispatcher-contract.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "dispatcherVersion": "3.0.0",
+  "dispatcherVersion": "3.0.0-beta.42",
   "dispatcherContractVersion": 1
 }

--- a/cli/dispatcher-contract.json
+++ b/cli/dispatcher-contract.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "dispatcherVersion": "3.0.0-beta.42",
+  "dispatcherVersion": "3.0.1-beta.1",
   "dispatcherContractVersion": 1
 }


### PR DESCRIPTION
## Summary
- Keep dispatcher release metadata on the v3 beta line so GitHub Releases and `uloop -v` no longer look like stable v3 output.
- Align Unity setup and committed CLI pins with the beta dispatcher version.

## User Impact
- Before this change, the dispatcher appeared as `dispatcher-v3.0.0` while the package and CLI were still beta releases.
- After this change, beta users see consistent prerelease versioning across the package, CLI, and dispatcher.

## Changes
- Set the dispatcher release contract to `3.0.0-beta.42`.
- Update Unity setup constants and committed CLI pins to require `3.0.0-beta.42`.

## Verification
- `scripts/check-go-cli.sh`
- `cli/dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `EVENT_NAME=push EVENT_REF_NAME=v3-beta scripts/resolve-dispatcher-release-target.sh`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

