### PR TITLE
fix: First dispatcher commands now show CLI download status

### DIFF
--- a/.uloop/cli-pin.json
+++ b/.uloop/cli-pin.json
@@ -1,6 +1,6 @@
 {
   "cliVersion": "3.0.0-beta.41",
-  "minimumDispatcherVersion": "3.0.1-beta.1",
+  "minimumDispatcherVersion": "3.0.1-beta.2",
   "packageName": "io.github.hatayama.uloopmcp",
   "packageVersion": "3.0.0-beta.42",
   "requiredProtocolVersion": 2,

--- a/Packages/src/Editor/Domain/CliConstants.cs
+++ b/Packages/src/Editor/Domain/CliConstants.cs
@@ -15,7 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string MINIMUM_REQUIRED_CLI_VERSION = "3.0.0-beta.40";
         public const string MINIMUM_REQUIRED_CLI_RELEASE_TAG = CLI_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_CLI_VERSION;
         // Why: global uloop is a dispatcher; project-local CLI versions are downloaded separately.
-        public const string MINIMUM_REQUIRED_DISPATCHER_VERSION = "3.0.1-beta.1";
+        public const string MINIMUM_REQUIRED_DISPATCHER_VERSION = "3.0.1-beta.2";
         public const string MINIMUM_REQUIRED_DISPATCHER_RELEASE_TAG = DISPATCHER_RELEASE_TAG_PREFIX + MINIMUM_REQUIRED_DISPATCHER_VERSION;
         // Why: dispatcher setup compatibility is a launcher contract generation, not the IPC protocol generation.
         public const int REQUIRED_DISPATCHER_CONTRACT_VERSION = 1;

--- a/Packages/src/cli-pin.json
+++ b/Packages/src/cli-pin.json
@@ -1,6 +1,6 @@
 {
   "cliVersion": "3.0.0-beta.41",
-  "minimumDispatcherVersion": "3.0.1-beta.1",
+  "minimumDispatcherVersion": "3.0.1-beta.2",
   "packageName": "io.github.hatayama.uloopmcp",
   "packageVersion": "3.0.0-beta.42",
   "requiredProtocolVersion": 2,

--- a/cli/dispatcher-contract.json
+++ b/cli/dispatcher-contract.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "dispatcherVersion": "3.0.1-beta.1",
+  "dispatcherVersion": "3.0.1-beta.2",
   "dispatcherContractVersion": 1
 }

--- a/cli/internal/cli/dispatcher.go
+++ b/cli/internal/cli/dispatcher.go
@@ -81,7 +81,7 @@ func RunDispatcher(ctx context.Context, args []string, stdout io.Writer, stderr 
 		return code
 	}
 
-	realCLIPath, err := resolveDispatcherRealCLI(ctx, pin)
+	realCLIPath, err := resolveDispatcherRealCLI(ctx, pin, stderr)
 	if err != nil {
 		writeErrorEnvelope(stderr, dispatcherRealCLIResolutionError(projectRoot, pin, err))
 		return 1

--- a/cli/internal/cli/dispatcher_download.go
+++ b/cli/internal/cli/dispatcher_download.go
@@ -23,7 +23,7 @@ import (
 
 var dispatcherHTTPClient = &http.Client{Timeout: 2 * time.Minute}
 
-func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin) (string, error) {
+func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin, stderr io.Writer) (string, error) {
 	pin.CLIVersion = strings.TrimSpace(pin.CLIVersion)
 	if err := validateDispatcherCLIVersion(pin.CLIVersion); err != nil {
 		return "", err
@@ -41,7 +41,7 @@ func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin) (string, e
 		return realCLIPath, nil
 	}
 
-	return downloadDispatcherRealCLI(ctx, cacheRoot, pin.CLIVersion, runtime.GOOS, runtime.GOARCH)
+	return downloadDispatcherRealCLI(ctx, cacheRoot, pin.CLIVersion, runtime.GOOS, runtime.GOARCH, stderr)
 }
 
 func dispatcherSiblingRealCLIPath(pin dispatcherPin) (string, bool) {
@@ -122,7 +122,7 @@ func isExecutableFile(filePath string) bool {
 	return info.Mode()&0o111 != 0
 }
 
-func downloadDispatcherRealCLI(ctx context.Context, cacheRoot string, cliVersion string, goos string, goarch string) (string, error) {
+func downloadDispatcherRealCLI(ctx context.Context, cacheRoot string, cliVersion string, goos string, goarch string, stderr io.Writer) (string, error) {
 	assetName, err := dispatcherReleaseAssetName(goos, goarch)
 	if err != nil {
 		return "", err
@@ -143,6 +143,7 @@ func downloadDispatcherRealCLI(ctx context.Context, cacheRoot string, cliVersion
 	archivePath := filepath.Join(tempDir, assetName)
 	checksumPath := archivePath + ".sha256"
 	assetURL := dispatcherReleaseAssetURL(cliVersion, assetName)
+	writeFormat(stderr, "uloop: downloading pinned CLI %s for %s...\n", cliVersion, dispatcherPlatformName(goos, goarch))
 	if err := downloadDispatcherFile(ctx, assetURL, archivePath); err != nil {
 		return "", err
 	}

--- a/cli/internal/cli/dispatcher_test.go
+++ b/cli/internal/cli/dispatcher_test.go
@@ -6,8 +6,11 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,6 +22,12 @@ import (
 type dispatcherArchiveTestEntry struct {
 	Name    string
 	Content string
+}
+
+type dispatcherRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (roundTrip dispatcherRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
 }
 
 func TestRunDispatcherUsesProjectPinAndCachedRealCLI(t *testing.T) {
@@ -52,6 +61,9 @@ func TestRunDispatcherUsesProjectPinAndCachedRealCLI(t *testing.T) {
 	}
 	if actualPath != expectedCLIPath {
 		t.Fatalf("real CLI path mismatch: %s", actualPath)
+	}
+	if stderr.String() != "" {
+		t.Fatalf("cached CLI should not write dispatcher download status: %s", stderr.String())
 	}
 	assertStringSliceEqual(t, actualArgs, []string{"compile", "--force-recompile"})
 }
@@ -163,7 +175,7 @@ func TestResolveDispatcherRealCLIRejectsInvalidCLIVersion(t *testing.T) {
 	// Verifies project pins cannot escape the dispatcher cache through cliVersion path segments.
 	t.Setenv(dispatcherCacheDirEnvName, t.TempDir())
 
-	_, err := resolveDispatcherRealCLI(context.Background(), dispatcherPin{CLIVersion: "../../../../payload"})
+	_, err := resolveDispatcherRealCLI(context.Background(), dispatcherPin{CLIVersion: "../../../../payload"}, io.Discard)
 
 	if err == nil {
 		t.Fatal("expected invalid cliVersion error")
@@ -290,6 +302,62 @@ func TestDispatcherHTTPClientHasDownloadTimeout(t *testing.T) {
 	if dispatcherHTTPClient.Timeout != 2*time.Minute {
 		t.Fatalf("dispatcher HTTP timeout mismatch: %s", dispatcherHTTPClient.Timeout)
 	}
+}
+
+func TestDownloadDispatcherRealCLIWritesDownloadStatus(t *testing.T) {
+	// Verifies cache misses tell callers that dispatcher is downloading the pinned CLI.
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "uloop-cli-darwin-arm64.tar.gz")
+	writeDispatcherTarGzArchive(t, archivePath, []dispatcherArchiveTestEntry{
+		{Name: "uloop-cli", Content: "real"},
+	})
+	archiveContent, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("failed to read archive: %v", err)
+	}
+	checksum := sha256.Sum256(archiveContent)
+	checksumContent := []byte(hex.EncodeToString(checksum[:]) + "  " + filepath.Base(archivePath) + "\n")
+
+	previousHTTPClient := dispatcherHTTPClient
+	defer func() {
+		dispatcherHTTPClient = previousHTTPClient
+	}()
+	dispatcherHTTPClient = &http.Client{
+		Transport: dispatcherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			content := []byte{}
+			statusCode := http.StatusNotFound
+			if strings.HasSuffix(request.URL.Path, "/uloop-cli-darwin-arm64.tar.gz") {
+				content = archiveContent
+				statusCode = http.StatusOK
+			}
+			if strings.HasSuffix(request.URL.Path, "/uloop-cli-darwin-arm64.tar.gz.sha256") {
+				content = checksumContent
+				statusCode = http.StatusOK
+			}
+			return &http.Response{
+				StatusCode: statusCode,
+				Status:     http.StatusText(statusCode),
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}),
+	}
+
+	var stderr bytes.Buffer
+	realCLIPath, err := downloadDispatcherRealCLI(
+		context.Background(),
+		t.TempDir(),
+		"3.0.0-beta.88",
+		"darwin",
+		"arm64",
+		&stderr)
+	if err != nil {
+		t.Fatalf("downloadDispatcherRealCLI failed: %v", err)
+	}
+	expectedStatus := "uloop: downloading pinned CLI 3.0.0-beta.88 for darwin-arm64...\n"
+	if stderr.String() != expectedStatus {
+		t.Fatalf("download status mismatch: %q", stderr.String())
+	}
+	assertFileContent(t, realCLIPath, "real")
 }
 
 func TestInstallDownloadedDispatcherRealCLIKeepsExistingExecutable(t *testing.T) {


### PR DESCRIPTION
## Summary
- First-time dispatcher commands now tell users when the pinned CLI is being downloaded.
- The download-status dispatcher change is released as the next beta dispatcher version.

## User Impact
- Before this change, the first command after installing the dispatcher could appear stuck while the project-pinned CLI downloaded.
- After this change, users and agents see a short status line before the download starts.

## Changes
- Pass stderr into the pinned CLI resolution path so the dispatcher can report download startup.
- Keep the message off stdout so command JSON output remains parseable.
- Bump the dispatcher beta requirement to 3.0.1-beta.2 for the launcher behavior change.
- Add regression coverage for cached and uncached pinned CLI resolution.

## Verification
- scripts/check-go-cli.sh
- cli/dist/darwin-arm64/uloop compile --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2"
- go run ./cmd/check-dispatcher-version-bump --base origin/v3-beta --head HEAD
- EVENT_NAME=push EVENT_REF_NAME=v3-beta scripts/resolve-dispatcher-release-target.sh