### PR TITLE
fix: Setup now prompts when dispatcher requirements change

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -58,27 +58,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _originalSessionState.Restore(_sessionStateService);
         }
 
-        [TestCase("", "1.7.3", false, false, false, true)]
-        [TestCase("1.7.2", "1.7.3", false, false, false, false)]
-        [TestCase("1.7.2", "1.7.3", false, true, false, true)]
-        [TestCase("1.7.2", "1.7.3", false, false, true, true)]
-        [TestCase("1.7.4", "1.7.3", false, false, true, true)]
-        [TestCase("1.7.3", "1.7.3", false, true, true, false)]
-        [TestCase("", "1.7.3", true, true, true, false)]
-        [TestCase("1.7.2", "1.7.3", true, true, true, false)]
+        [TestCase("", "1.7.3", "", "3.0.1", false, false, false, true)]
+        [TestCase("1.7.2", "1.7.3", "3.0.1", "3.0.1", false, false, false, false)]
+        [TestCase("1.7.2", "1.7.3", "3.0.1", "3.0.1", false, true, false, true)]
+        [TestCase("1.7.2", "1.7.3", "3.0.1", "3.0.1", false, false, true, true)]
+        [TestCase("1.7.4", "1.7.3", "3.0.1", "3.0.1", false, false, true, true)]
+        [TestCase("1.7.3", "1.7.3", "3.0.1", "3.0.1", false, true, true, false)]
+        [TestCase("1.7.3", "1.7.3", "3.0.1", "3.0.2", false, true, false, true)]
+        [TestCase("1.7.3", "1.7.3", "3.0.1", "3.0.2", false, false, false, false)]
+        [TestCase("", "1.7.3", "", "3.0.1", true, true, true, false)]
+        [TestCase("1.7.2", "1.7.3", "3.0.1", "3.0.1", true, true, true, false)]
+        [TestCase("1.7.3", "1.7.3", "3.0.1", "3.0.2", true, true, true, false)]
         public void ShouldAutoShowForVersion_ReturnsExpectedValue(
             string lastSeenVersion,
             string currentVersion,
+            string lastSeenMinimumDispatcherVersion,
+            string currentMinimumDispatcherVersion,
             bool suppressAutoShow,
             bool needsCliUpdate,
             bool hasSkillUpdate,
             bool expected)
         {
-            // Verifies that package upgrades auto-show only for first install or actionable updates.
+            // Verifies that package and dispatcher requirement changes auto-show only for actionable updates.
             bool shouldAutoShow =
                 SetupWizardWindow.ShouldAutoShowForVersion(
                     currentVersion,
                     lastSeenVersion,
+                    currentMinimumDispatcherVersion,
+                    lastSeenMinimumDispatcherVersion,
                     suppressAutoShow,
                     needsCliUpdate,
                     hasSkillUpdate);
@@ -192,55 +199,71 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void MaybeRecordLastSeenVersion_WhenAutoShow_UpdatesStoredVersion()
+        public void MaybeRecordLastSeenSetupWizardState_WhenAutoShow_UpdatesStoredState()
         {
             _editorSettingsService.SaveSettings(new UnityCliLoopEditorSettingsData
             {
-                lastSeenSetupWizardVersion = "1.7.2"
+                lastSeenSetupWizardVersion = "1.7.2",
+                lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
-            SetupWizardWindow.MaybeRecordLastSeenVersion(true, "1.7.3");
+            SetupWizardWindow.MaybeRecordLastSeenSetupWizardState(true, "1.7.3", "3.0.2");
 
             Assert.That(_editorSettingsService.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.3"));
+            Assert.That(
+                _editorSettingsService.GetSettings().lastSeenSetupWizardMinimumDispatcherVersion,
+                Is.EqualTo("3.0.2"));
         }
 
         [Test]
-        public void MaybeRecordLastSeenVersion_WhenManualShow_KeepsStoredVersion()
+        public void MaybeRecordLastSeenSetupWizardState_WhenManualShow_KeepsStoredState()
         {
             _editorSettingsService.SaveSettings(new UnityCliLoopEditorSettingsData
             {
-                lastSeenSetupWizardVersion = "1.7.2"
+                lastSeenSetupWizardVersion = "1.7.2",
+                lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
-            SetupWizardWindow.MaybeRecordLastSeenVersion(false, "1.7.3");
+            SetupWizardWindow.MaybeRecordLastSeenSetupWizardState(false, "1.7.3", "3.0.2");
 
             Assert.That(_editorSettingsService.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
+            Assert.That(
+                _editorSettingsService.GetSettings().lastSeenSetupWizardMinimumDispatcherVersion,
+                Is.EqualTo("3.0.1"));
         }
 
         [Test]
-        public void MaybeRecordSuppressedVersion_WhenAutoShowSuppressed_UpdatesStoredVersion()
+        public void MaybeRecordSuppressedSetupWizardState_WhenAutoShowSuppressed_UpdatesStoredState()
         {
             _editorSettingsService.SaveSettings(new UnityCliLoopEditorSettingsData
             {
-                lastSeenSetupWizardVersion = "1.7.2"
+                lastSeenSetupWizardVersion = "1.7.2",
+                lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
-            SetupWizardWindow.MaybeRecordSuppressedVersion(true, "1.7.3");
+            SetupWizardWindow.MaybeRecordSuppressedSetupWizardState(true, "1.7.3", "3.0.2");
 
             Assert.That(_editorSettingsService.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.3"));
+            Assert.That(
+                _editorSettingsService.GetSettings().lastSeenSetupWizardMinimumDispatcherVersion,
+                Is.EqualTo("3.0.2"));
         }
 
         [Test]
-        public void MaybeRecordSuppressedVersion_WhenAutoShowAllowed_KeepsStoredVersion()
+        public void MaybeRecordSuppressedSetupWizardState_WhenAutoShowAllowed_KeepsStoredState()
         {
             _editorSettingsService.SaveSettings(new UnityCliLoopEditorSettingsData
             {
-                lastSeenSetupWizardVersion = "1.7.2"
+                lastSeenSetupWizardVersion = "1.7.2",
+                lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
-            SetupWizardWindow.MaybeRecordSuppressedVersion(false, "1.7.3");
+            SetupWizardWindow.MaybeRecordSuppressedSetupWizardState(false, "1.7.3", "3.0.2");
 
             Assert.That(_editorSettingsService.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
+            Assert.That(
+                _editorSettingsService.GetSettings().lastSeenSetupWizardMinimumDispatcherVersion,
+                Is.EqualTo("3.0.1"));
         }
 
         [Test]
@@ -249,18 +272,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool focusedExistingWindow = false;
             _editorSettingsService.SaveSettings(new UnityCliLoopEditorSettingsData
             {
-                lastSeenSetupWizardVersion = "1.7.2"
+                lastSeenSetupWizardVersion = "1.7.2",
+                lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
             bool reused = SetupWizardWindow.TryReuseOpenWindow(
                 hasOpenWindow: true,
                 shouldRecordVersion: true,
                 currentVersion: "1.7.3",
+                currentMinimumDispatcherVersion: "3.0.2",
                 focusExistingWindow: () => focusedExistingWindow = true);
 
             Assert.That(reused, Is.True);
             Assert.That(focusedExistingWindow, Is.True);
             Assert.That(_editorSettingsService.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.3"));
+            Assert.That(
+                _editorSettingsService.GetSettings().lastSeenSetupWizardMinimumDispatcherVersion,
+                Is.EqualTo("3.0.2"));
         }
 
         [Test]
@@ -269,18 +297,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool focusedExistingWindow = false;
             _editorSettingsService.SaveSettings(new UnityCliLoopEditorSettingsData
             {
-                lastSeenSetupWizardVersion = "1.7.2"
+                lastSeenSetupWizardVersion = "1.7.2",
+                lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
             bool reused = SetupWizardWindow.TryReuseOpenWindow(
                 hasOpenWindow: true,
                 shouldRecordVersion: false,
                 currentVersion: "1.7.3",
+                currentMinimumDispatcherVersion: "3.0.2",
                 focusExistingWindow: () => focusedExistingWindow = true);
 
             Assert.That(reused, Is.True);
             Assert.That(focusedExistingWindow, Is.True);
             Assert.That(_editorSettingsService.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
+            Assert.That(
+                _editorSettingsService.GetSettings().lastSeenSetupWizardMinimumDispatcherVersion,
+                Is.EqualTo("3.0.1"));
         }
 
         [Test]
@@ -289,18 +322,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool focusedExistingWindow = false;
             _editorSettingsService.SaveSettings(new UnityCliLoopEditorSettingsData
             {
-                lastSeenSetupWizardVersion = "1.7.2"
+                lastSeenSetupWizardVersion = "1.7.2",
+                lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
             bool reused = SetupWizardWindow.TryReuseOpenWindow(
                 hasOpenWindow: false,
                 shouldRecordVersion: true,
                 currentVersion: "1.7.3",
+                currentMinimumDispatcherVersion: "3.0.2",
                 focusExistingWindow: () => focusedExistingWindow = true);
 
             Assert.That(reused, Is.False);
             Assert.That(focusedExistingWindow, Is.False);
             Assert.That(_editorSettingsService.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
+            Assert.That(
+                _editorSettingsService.GetSettings().lastSeenSetupWizardMinimumDispatcherVersion,
+                Is.EqualTo("3.0.1"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/UnityCliLoopPackageRemovalSettingsResetterTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopPackageRemovalSettingsResetterTests.cs
@@ -96,6 +96,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 UnityCliLoopPackageRemovalSettingsResetter.ResetSetupWizardState(settings);
 
             Assert.That(resetSettings.lastSeenSetupWizardVersion, Is.Empty);
+            Assert.That(resetSettings.lastSeenSetupWizardMinimumDispatcherVersion, Is.Empty);
             Assert.That(resetSettings.suppressSetupWizardAutoShow, Is.False);
             Assert.That(resetSettings.showDeveloperTools, Is.EqualTo(settings.showDeveloperTools));
             Assert.That(resetSettings.showToolSettings, Is.EqualTo(settings.showToolSettings));
@@ -116,6 +117,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             UnityCliLoopEditorSettingsData updatedSettings = _editorSettingsService.GetSettings();
             Assert.That(updatedSettings.lastSeenSetupWizardVersion, Is.Empty);
+            Assert.That(updatedSettings.lastSeenSetupWizardMinimumDispatcherVersion, Is.Empty);
             Assert.That(updatedSettings.suppressSetupWizardAutoShow, Is.False);
             Assert.That(updatedSettings.showDeveloperTools, Is.EqualTo(settings.showDeveloperTools));
             Assert.That(updatedSettings.showToolSettings, Is.EqualTo(settings.showToolSettings));
@@ -128,6 +130,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 showDeveloperTools = true,
                 lastSeenSetupWizardVersion = "3.0.0-beta.7",
+                lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1-beta.1",
                 suppressSetupWizardAutoShow = true,
                 showUnityCliLoopSecuritySetting = false,
                 showToolSettings = false,

--- a/Packages/src/Editor/Domain/UnityCliLoopEditorSettingsData.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopEditorSettingsData.cs
@@ -7,6 +7,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     {
         public bool showDeveloperTools = false;
         public string lastSeenSetupWizardVersion = "";
+        public string lastSeenSetupWizardMinimumDispatcherVersion = "";
         public bool suppressSetupWizardAutoShow = false;
         public bool legacySetupWizardStateMigrated = false;
         public bool showUnityCliLoopSecuritySetting = true;

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPackageRemovalSettingsResetter.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPackageRemovalSettingsResetter.cs
@@ -62,6 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return settings with
             {
                 lastSeenSetupWizardVersion = string.Empty,
+                lastSeenSetupWizardMinimumDispatcherVersion = string.Empty,
                 suppressSetupWizardAutoShow = false
             };
         }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -65,17 +65,23 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool ShouldAutoShowForVersion(
             string currentVersion,
             string lastSeenVersion,
+            string currentMinimumDispatcherVersion,
+            string lastSeenMinimumDispatcherVersion,
             bool suppressAutoShow,
             bool needsCliUpdate,
             bool hasSkillUpdate)
         {
             bool versionChanged = !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
-            if (!versionChanged) return false;
+            bool minimumDispatcherVersionChanged = !string.Equals(
+                currentMinimumDispatcherVersion,
+                lastSeenMinimumDispatcherVersion,
+                System.StringComparison.Ordinal);
+            if (!versionChanged && !minimumDispatcherVersionChanged) return false;
             if (suppressAutoShow) return false;
 
             return string.IsNullOrEmpty(lastSeenVersion)
                 || needsCliUpdate
-                || hasSkillUpdate;
+                || (versionChanged && hasSkillUpdate);
         }
 
         internal static bool ShouldAutoScanThirdPartyToolMigration(string currentVersion, string lastSeenVersion)
@@ -108,20 +114,33 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             GetSessionStateService().SetShouldAutoScanThirdPartyToolMigration(true);
         }
 
-        internal static void MaybeRecordLastSeenVersion(bool shouldRecordVersion, string version)
+        internal static void MaybeRecordLastSeenSetupWizardState(
+            bool shouldRecordState,
+            string version,
+            string minimumDispatcherVersion)
         {
-            if (!shouldRecordVersion) return;
+            if (!shouldRecordState) return;
 
             Debug.Assert(!string.IsNullOrEmpty(version), "version must not be null or empty");
-            GetEditorSettingsService().SetLastSeenSetupWizardVersion(version);
+            Debug.Assert(
+                !string.IsNullOrEmpty(minimumDispatcherVersion),
+                "minimumDispatcherVersion must not be null or empty");
+
+            GetEditorSettingsService().UpdateSettings((UnityCliLoopEditorSettingsData settings) => settings with
+            {
+                lastSeenSetupWizardVersion = version,
+                lastSeenSetupWizardMinimumDispatcherVersion = minimumDispatcherVersion
+            });
         }
 
-        internal static void MaybeRecordSuppressedVersion(bool suppressAutoShow, string version)
+        internal static void MaybeRecordSuppressedSetupWizardState(
+            bool suppressAutoShow,
+            string version,
+            string minimumDispatcherVersion)
         {
             if (!suppressAutoShow) return;
 
-            Debug.Assert(!string.IsNullOrEmpty(version), "version must not be null or empty");
-            GetEditorSettingsService().SetLastSeenSetupWizardVersion(version);
+            MaybeRecordLastSeenSetupWizardState(true, version, minimumDispatcherVersion);
         }
 
         private static void TryShowOnVersionChange()
@@ -132,9 +151,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private static async void EvaluateVersionChange(CancellationToken ct)
         {
             string currentVersion = UnityCliLoopConstants.PackageInfo.version;
+            string currentMinimumDispatcherVersion = GetMinimumRequiredCliVersion();
             UnityCliLoopEditorSettingsService editorSettingsService = GetEditorSettingsService();
-            bool suppressAutoShow = editorSettingsService.GetSuppressSetupWizardAutoShow();
-            string lastSeenVersion = editorSettingsService.GetLastSeenSetupWizardVersion();
+            UnityCliLoopEditorSettingsData settings = editorSettingsService.GetSettings();
+            bool suppressAutoShow = settings.suppressSetupWizardAutoShow;
+            string lastSeenVersion = settings.lastSeenSetupWizardVersion ?? string.Empty;
+            string lastSeenMinimumDispatcherVersion =
+                settings.lastSeenSetupWizardMinimumDispatcherVersion ?? string.Empty;
             if (ct.IsCancellationRequested)
             {
                 return;
@@ -149,9 +172,21 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 currentVersion,
                 lastSeenVersion,
                 System.StringComparison.Ordinal);
-            if (!versionChanged || suppressAutoShow)
+            bool minimumDispatcherVersionChanged = !string.Equals(
+                currentMinimumDispatcherVersion,
+                lastSeenMinimumDispatcherVersion,
+                System.StringComparison.Ordinal);
+            if (suppressAutoShow)
             {
-                MaybeRecordSuppressedVersion(suppressAutoShow, currentVersion);
+                MaybeRecordSuppressedSetupWizardState(
+                    suppressAutoShow,
+                    currentVersion,
+                    currentMinimumDispatcherVersion);
+                return;
+            }
+
+            if (!versionChanged && !minimumDispatcherVersionChanged)
+            {
                 return;
             }
 
@@ -165,7 +200,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                     return;
                 }
 
-                if (!needsCliUpdate)
+                if (versionChanged && !needsCliUpdate)
                 {
                     hasSkillUpdate = await HasSkillUpdateForSetupWizardAsync(ct);
                     if (ct.IsCancellationRequested)
@@ -178,13 +213,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool shouldAutoShow = ShouldAutoShowForVersion(
                 currentVersion,
                 lastSeenVersion,
+                currentMinimumDispatcherVersion,
+                lastSeenMinimumDispatcherVersion,
                 suppressAutoShow,
                 needsCliUpdate,
                 hasSkillUpdate);
 
             if (!shouldAutoShow)
             {
-                MaybeRecordLastSeenVersion(true, currentVersion);
+                MaybeRecordLastSeenSetupWizardState(
+                    true,
+                    currentVersion,
+                    currentMinimumDispatcherVersion);
                 return;
             }
 
@@ -232,10 +272,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private static void ShowWindowInternal(bool shouldRecordVersion)
         {
             string currentVersion = UnityCliLoopConstants.PackageInfo.version;
+            string currentMinimumDispatcherVersion = GetMinimumRequiredCliVersion();
             if (TryReuseOpenWindow(
                 HasOpenInstances<SetupWizardWindow>(),
                 shouldRecordVersion,
                 currentVersion,
+                currentMinimumDispatcherVersion,
                 FocusExistingWindow))
             {
                 return;
@@ -279,14 +321,21 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool hasOpenWindow,
             bool shouldRecordVersion,
             string currentVersion,
+            string currentMinimumDispatcherVersion,
             System.Action focusExistingWindow)
         {
             if (!hasOpenWindow) return false;
 
             Debug.Assert(focusExistingWindow != null, "focusExistingWindow must not be null");
             Debug.Assert(!string.IsNullOrEmpty(currentVersion), "currentVersion must not be null or empty");
+            Debug.Assert(
+                !string.IsNullOrEmpty(currentMinimumDispatcherVersion),
+                "currentMinimumDispatcherVersion must not be null or empty");
             focusExistingWindow();
-            MaybeRecordLastSeenVersion(shouldRecordVersion, currentVersion);
+            MaybeRecordLastSeenSetupWizardState(
+                shouldRecordVersion,
+                currentVersion,
+                currentMinimumDispatcherVersion);
             return true;
         }
 
@@ -416,7 +465,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ApplyInitialCheckingState();
             ScheduleInitialRefresh();
             ScheduleResizeToContent();
-            RecordLastSeenVersionAfterSuccessfulCreateGui();
+            RecordLastSeenSetupWizardStateAfterSuccessfulCreateGui();
         }
 
         private void InitializeApplicationServices()
@@ -431,11 +480,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _lastSeenSetupWizardVersionBeforeOpen);
         }
 
-        private void RecordLastSeenVersionAfterSuccessfulCreateGui()
+        private void RecordLastSeenSetupWizardStateAfterSuccessfulCreateGui()
         {
-            MaybeRecordLastSeenVersion(
+            MaybeRecordLastSeenSetupWizardState(
                 _shouldRecordLastSeenVersionAfterCreateGui,
-                UnityCliLoopConstants.PackageInfo.version);
+                UnityCliLoopConstants.PackageInfo.version,
+                GetMinimumRequiredCliVersion());
             _shouldRecordLastSeenVersionAfterCreateGui = false;
         }
 
@@ -1292,7 +1342,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void HandleSuppressAutoShowChanged(bool suppressAutoShow)
         {
             _editorSettingsService.SetSuppressSetupWizardAutoShow(suppressAutoShow);
-            MaybeRecordSuppressedVersion(suppressAutoShow, UnityCliLoopConstants.PackageInfo.version);
+            MaybeRecordSuppressedSetupWizardState(
+                suppressAutoShow,
+                UnityCliLoopConstants.PackageInfo.version,
+                GetMinimumRequiredCliVersion());
             ScheduleResizeToContent();
         }
 


### PR DESCRIPTION
## Summary
- Setup can now open automatically when the required dispatcher version changes, even if the Unity package version has not changed.
- Dispatcher-only fixes can prompt users to update the global uloop command instead of being silently missed.

## User Impact
- Before this change, a dispatcher requirement bump could be skipped because Setup only keyed auto-show decisions on the package version.
- After this change, users with an outdated dispatcher see the Setup Wizard again when the required dispatcher version changes.

## Changes
- Store the last dispatcher minimum version seen by Setup alongside the last seen package version.
- Include dispatcher minimum changes in the auto-show decision while keeping the existing suppression setting respected.
- Reset the new Setup state when the package is removed.

## Verification
- cli/dist/darwin-arm64/uloop compile --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2"
- cli/dist/darwin-arm64/uloop run-tests --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" --test-mode EditMode --filter-type regex --filter-value ".*(SetupWizardWindowTests|UnityCliLoopPackageRemovalSettingsResetterTests).*"
- git diff --check
- /Users/a12115/dotfiles/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/v3-beta

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

