### PR TITLE
chore: Separate CLI entrypoints by binary role

### DIFF
--- a/cli/cmd/uloop-cli/main.go
+++ b/cli/cmd/uloop-cli/main.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/hatayama/unity-cli-loop/cli/internal/cli"
+	"github.com/hatayama/unity-cli-loop/cli/internal/projectcli"
 )
 
 func main() {
-	os.Exit(cli.RunProjectLocal(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+	os.Exit(projectcli.Run(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
 }

--- a/cli/cmd/uloop/main.go
+++ b/cli/cmd/uloop/main.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/hatayama/unity-cli-loop/cli/internal/cli"
+	"github.com/hatayama/unity-cli-loop/cli/internal/dispatcher"
 )
 
 func main() {
-	os.Exit(cli.RunDispatcher(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+	os.Exit(dispatcher.Run(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
 }

--- a/cli/dispatcher-contract.json
+++ b/cli/dispatcher-contract.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "dispatcherVersion": "3.0.1-beta.4",
+  "dispatcherVersion": "3.0.1-beta.5",
   "dispatcherContractVersion": 1
 }

--- a/cli/internal/architecture/architecture_test.go
+++ b/cli/internal/architecture/architecture_test.go
@@ -46,7 +46,10 @@ func TestCliFeaturePackagesDoNotImportCli(t *testing.T) {
 	moduleRoot := findModuleRoot(t)
 	packages := listPackages(t, moduleRoot)
 	for _, goPackage := range packages {
-		if goPackage.ImportPath == cliModulePath+"/internal/cli" || strings.HasPrefix(goPackage.ImportPath, cliModulePath+"/cmd/") {
+		if goPackage.ImportPath == cliModulePath+"/internal/cli" ||
+			goPackage.ImportPath == cliModulePath+"/internal/dispatcher" ||
+			goPackage.ImportPath == cliModulePath+"/internal/projectcli" ||
+			strings.HasPrefix(goPackage.ImportPath, cliModulePath+"/cmd/") {
 			continue
 		}
 		for _, importedPath := range goPackage.Imports {
@@ -68,7 +71,7 @@ func TestCliInternalPackagesStayInsideExplicitBoundaries(t *testing.T) {
 		if goPackage.ImportPath == cliModulePath+"/internal/architecture" {
 			continue
 		}
-		for _, boundary := range []string{"/internal/automation", "/internal/cli", "/internal/install", "/internal/project", "/internal/skills", "/internal/tools", "/internal/uninstall", "/internal/unityipc", "/internal/update", "/internal/version"} {
+		for _, boundary := range []string{"/internal/automation", "/internal/cli", "/internal/dispatcher", "/internal/install", "/internal/project", "/internal/projectcli", "/internal/skills", "/internal/tools", "/internal/uninstall", "/internal/unityipc", "/internal/update", "/internal/version"} {
 			if strings.Contains(goPackage.ImportPath, boundary) {
 				goto nextPackage
 			}
@@ -78,10 +81,20 @@ func TestCliInternalPackagesStayInsideExplicitBoundaries(t *testing.T) {
 	}
 }
 
-// Tests that the native CLI command only enters the CLI orchestration package.
-func TestCliCommandOnlyDependsOnCliEntrypoint(t *testing.T) {
+// Tests that the dispatcher command only enters the dispatcher package.
+func TestDispatcherCommandOnlyDependsOnDispatcherEntrypoint(t *testing.T) {
+	assertCommandOnlyDependsOnInternalEntrypoint(t, "./cmd/uloop", cliModulePath+"/internal/dispatcher")
+}
+
+// Tests that the project-local CLI command only enters the project CLI package.
+func TestProjectCliCommandOnlyDependsOnProjectCliEntrypoint(t *testing.T) {
+	assertCommandOnlyDependsOnInternalEntrypoint(t, "./cmd/uloop-cli", cliModulePath+"/internal/projectcli")
+}
+
+func assertCommandOnlyDependsOnInternalEntrypoint(t *testing.T, commandPath string, expectedEntrypoint string) {
+	t.Helper()
 	moduleRoot := findModuleRoot(t)
-	command := exec.Command("go", "list", "-json", "./cmd/uloop")
+	command := exec.Command("go", "list", "-json", commandPath)
 	command.Dir = moduleRoot
 	output, err := command.Output()
 	if err != nil {
@@ -101,8 +114,8 @@ func TestCliCommandOnlyDependsOnCliEntrypoint(t *testing.T) {
 		if !strings.HasPrefix(dependency, cliModulePath+"/internal/") {
 			continue
 		}
-		if dependency != cliModulePath+"/internal/cli" {
-			t.Fatalf("CLI command must enter internal code through internal/cli, got %s", dependency)
+		if dependency != expectedEntrypoint {
+			t.Fatalf("%s must enter internal code through %s, got %s", commandPath, expectedEntrypoint, dependency)
 		}
 	}
 }

--- a/cli/internal/dispatcher/dispatcher.go
+++ b/cli/internal/dispatcher/dispatcher.go
@@ -1,0 +1,12 @@
+package dispatcher
+
+import (
+	"context"
+	"io"
+
+	"github.com/hatayama/unity-cli-loop/cli/internal/cli"
+)
+
+func Run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
+	return cli.RunDispatcher(ctx, args, stdout, stderr)
+}

--- a/cli/internal/projectcli/projectcli.go
+++ b/cli/internal/projectcli/projectcli.go
@@ -1,0 +1,12 @@
+package projectcli
+
+import (
+	"context"
+	"io"
+
+	"github.com/hatayama/unity-cli-loop/cli/internal/cli"
+)
+
+func Run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
+	return cli.RunProjectLocal(ctx, args, stdout, stderr)
+}


### PR DESCRIPTION
## Summary
- Keep the existing `uloop` and `uloop-cli` behavior unchanged while separating their command entrypoints by binary role.
- Make it easier to keep dispatcher-only and project-local CLI capabilities separated in future updates.

## User Impact
- There is no user-facing command behavior change in this PR.
- This creates a clearer foundation for future CLI-only functionality without requiring unrelated Unity package changes.

## Changes
- Route the dispatcher binary through its own entrypoint package.
- Route the project-local CLI binary through its own entrypoint package.
- Update architecture tests so each command depends only on the expected entrypoint package.
- Leave Unity package files and generated skill copies unchanged.

## Verification
- `scripts/check-go-cli.sh`
- `go run ./cmd/uloop --version`
- `go run ./cmd/uloop-cli --version`