### PR TITLE
fix: Skill updates no longer show a completion dialog

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -779,6 +779,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(label, Is.EqualTo(expectedLabel));
         }
 
+        [Test]
+        public void ShouldShowSkillsInstalledDialog_WhenTargetsAreMissing_ReturnsTrue()
+        {
+            // Verifies that Setup Wizard keeps the success dialog for first install.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateSkillTarget(
+                    hasSkillsDirectory: true,
+                    SkillInstallState.Missing)
+            };
+
+            bool shouldShowDialog = SetupWizardWindow.ShouldShowSkillsInstalledDialog(targets);
+
+            Assert.That(shouldShowDialog, Is.True);
+        }
+
+        [Test]
+        public void ShouldShowSkillsInstalledDialog_WhenAnyTargetIsOutdated_ReturnsFalse()
+        {
+            // Verifies that Setup Wizard suppresses the success dialog for skill updates.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateSkillTarget(
+                    hasSkillsDirectory: true,
+                    SkillInstallState.Missing),
+                CreateSkillTarget(
+                    hasSkillsDirectory: true,
+                    SkillInstallState.Outdated)
+            };
+
+            bool shouldShowDialog = SetupWizardWindow.ShouldShowSkillsInstalledDialog(targets);
+
+            Assert.That(shouldShowDialog, Is.False);
+        }
+
         [TestCase(SkillInstallState.Installed, false, true, "setup-target-item__status--installed")]
         [TestCase(SkillInstallState.Checking, false, true, "setup-target-item__status--checking")]
         [TestCase(SkillInstallState.Outdated, false, true, "setup-target-item__status--outdated")]

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -814,6 +814,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(shouldShowDialog, Is.False);
         }
 
+        [Test]
+        public void ShouldShowSkillsInstalledDialog_WhenAnyTargetUsesDifferentLayout_ReturnsFalse()
+        {
+            // Verifies that Setup Wizard suppresses the success dialog for skill layout updates.
+            List<SkillSetupTargetInfo> targets = new()
+            {
+                CreateSkillTarget(
+                    hasSkillsDirectory: true,
+                    SkillInstallState.Missing,
+                    hasDifferentLayoutSkills: true)
+            };
+
+            bool shouldShowDialog = SetupWizardWindow.ShouldShowSkillsInstalledDialog(targets);
+
+            Assert.That(shouldShowDialog, Is.False);
+        }
+
         [TestCase(SkillInstallState.Installed, false, true, "setup-target-item__status--installed")]
         [TestCase(SkillInstallState.Checking, false, true, "setup-target-item__status--checking")]
         [TestCase(SkillInstallState.Outdated, false, true, "setup-target-item__status--outdated")]

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -132,16 +132,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result, Is.EqualTo(expected));
         }
 
-        [TestCase(SkillInstallState.Missing, true)]
-        [TestCase(SkillInstallState.Outdated, false)]
+        [TestCase(SkillInstallState.Missing, false, true)]
+        [TestCase(SkillInstallState.Outdated, false, false)]
+        [TestCase(SkillInstallState.Missing, true, false)]
         public void ShouldShowSkillsInstalledDialog_ReturnsExpectedValue(
             SkillInstallState installState,
+            bool hasDifferentLayoutSkills,
             bool expected)
         {
             // Verifies that Settings keeps the success dialog for first install only.
-            bool result = UnityCliLoopSettingsWindow.ShouldShowSkillsInstalledDialog(installState);
+            SkillSetupTargetInfo targetInfo = CreateSkillTarget(installState, hasDifferentLayoutSkills);
+
+            bool result = UnityCliLoopSettingsWindow.ShouldShowSkillsInstalledDialog(targetInfo);
 
             Assert.That(result, Is.EqualTo(expected));
+        }
+
+        private static SkillSetupTargetInfo CreateSkillTarget(
+            SkillInstallState installState,
+            bool hasDifferentLayoutSkills)
+        {
+            return new SkillSetupTargetInfo(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true,
+                hasDifferentLayoutSkills,
+                installState);
         }
 
         private static UnityCliLoopSettingsWindow.CliPrimaryButtonAction ParseAction(string action)

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Presentation;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
@@ -127,6 +128,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies that the settings UI updates non-dispatcher or older dispatcher installs.
             bool result = UnityCliLoopSettingsWindow.IsCliUpdateNeeded(cliVersion, cliIsDispatcher);
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [TestCase(SkillInstallState.Missing, true)]
+        [TestCase(SkillInstallState.Outdated, false)]
+        public void ShouldShowSkillsInstalledDialog_ReturnsExpectedValue(
+            SkillInstallState installState,
+            bool expected)
+        {
+            // Verifies that Settings keeps the success dialog for first install only.
+            bool result = UnityCliLoopSettingsWindow.ShouldShowSkillsInstalledDialog(installState);
 
             Assert.That(result, Is.EqualTo(expected));
         }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -783,7 +783,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             IEnumerable<SkillSetupTargetInfo> targets)
         {
             Debug.Assert(targets != null, "targets must not be null");
-            return targets.All(target => target.InstallState != SkillInstallState.Outdated);
+            return targets.All(target =>
+                target.InstallState != SkillInstallState.Outdated
+                && !target.HasDifferentLayoutSkills);
         }
 
         internal static bool ShouldUseFirstInstallSkillsUi(string lastSeenSetupWizardVersion)

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -779,6 +779,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                         || target.HasDifferentLayoutSkills));
         }
 
+        internal static bool ShouldShowSkillsInstalledDialog(
+            IEnumerable<SkillSetupTargetInfo> targets)
+        {
+            Debug.Assert(targets != null, "targets must not be null");
+            return targets.All(target => target.InstallState != SkillInstallState.Outdated);
+        }
+
         internal static bool ShouldUseFirstInstallSkillsUi(string lastSeenSetupWizardVersion)
         {
             return string.IsNullOrEmpty(lastSeenSetupWizardVersion);
@@ -1316,6 +1323,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 : FilterInstallableSkillTargets(targets);
             if (installableTargets.Count == 0) return;
 
+            bool shouldShowSkillsInstalledDialog = ShouldShowSkillsInstalledDialog(installableTargets);
             _isInstallingSkills = true;
             UpdateSkillsStep(true, targets);
 
@@ -1325,7 +1333,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                     installableTargets,
                     !_installSkillsFlat,
                     CancellationToken.None);
-                EditorDialogHelper.ShowSkillsInstalledDialog();
+                if (shouldShowSkillsInstalledDialog)
+                {
+                    EditorDialogHelper.ShowSkillsInstalledDialog();
+                }
             }
             finally
             {

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -967,6 +967,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return EvaluateCliSetupCompatibility(cliVersion, cliIsDispatcher).NeedsUpdate;
         }
 
+        internal static bool ShouldShowSkillsInstalledDialog(SkillInstallState installState)
+        {
+            return installState != SkillInstallState.Outdated;
+        }
+
         private static CliSetupCompatibilityState EvaluateCliSetupCompatibility(
             string cliVersion,
             bool cliIsDispatcher)
@@ -1019,6 +1024,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
+            bool shouldShowSkillsInstalledDialog =
+                ShouldShowSkillsInstalledDialog(_selectedTargetInstallState);
             CancelSkillInstallStateRefresh();
             _isInstallingSkills = true;
             RefreshCliSetupSection();
@@ -1040,7 +1047,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                     new List<SkillSetupTargetInfo> { target },
                     !_installSkillsFlat,
                     CancellationToken.None);
-                EditorDialogHelper.ShowSkillsInstalledDialog();
+                if (shouldShowSkillsInstalledDialog)
+                {
+                    EditorDialogHelper.ShowSkillsInstalledDialog();
+                }
             }
             finally
             {

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -737,6 +737,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string projectRoot,
             bool includeFreshnessCheck)
         {
+            SkillSetupTargetInfo targetInfo = GetSelectedTargetInfo(projectRoot, includeFreshnessCheck);
+            return string.IsNullOrEmpty(targetInfo.DirName)
+                ? SkillInstallState.Missing
+                : targetInfo.InstallState;
+        }
+
+        private SkillSetupTargetInfo GetSelectedTargetInfo(
+            string projectRoot,
+            bool includeFreshnessCheck)
+        {
             SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
                 _skillsTarget,
                 !_installSkillsFlat);
@@ -746,9 +756,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             SkillSetupTargetInfo targetInfo = targets
                 .FirstOrDefault(target => target.DirName == selection.DirectoryName);
 
-            return string.IsNullOrEmpty(targetInfo.DirName)
-                ? SkillInstallState.Missing
-                : targetInfo.InstallState;
+            return targetInfo;
         }
 
         private void CancelSkillInstallStateRefresh()
@@ -967,9 +975,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return EvaluateCliSetupCompatibility(cliVersion, cliIsDispatcher).NeedsUpdate;
         }
 
-        internal static bool ShouldShowSkillsInstalledDialog(SkillInstallState installState)
+        internal static bool ShouldShowSkillsInstalledDialog(SkillSetupTargetInfo targetInfo)
         {
-            return installState != SkillInstallState.Outdated;
+            return targetInfo.InstallState != SkillInstallState.Outdated
+                && !targetInfo.HasDifferentLayoutSkills;
         }
 
         private static CliSetupCompatibilityState EvaluateCliSetupCompatibility(
@@ -1024,8 +1033,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
-            bool shouldShowSkillsInstalledDialog =
-                ShouldShowSkillsInstalledDialog(_selectedTargetInstallState);
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            SkillSetupTargetInfo selectedTargetInfo =
+                GetSelectedTargetInfo(projectRoot, includeFreshnessCheck: true);
+            bool shouldShowSkillsInstalledDialog = ShouldShowSkillsInstalledDialog(selectedTargetInfo);
             CancelSkillInstallStateRefresh();
             _isInstallingSkills = true;
             RefreshCliSetupSection();


### PR DESCRIPTION
## Summary
- Skill updates in Setup Wizard and Settings now finish by refreshing the UI to Installed without showing a success dialog.
- First-time skill installs still show the Skills Installed confirmation.

## User Impact
- Updating existing skills no longer interrupts the flow with an unnecessary completion popup.
- Users still get confirmation when they install skills for the first time.

## Changes
- Track whether the selected skill target or install target list is outdated before running skill installation.
- Show the success dialog only when the operation is a first-time install.
- Add editor tests for the update-vs-install dialog decision.

## Verification
- Passed: cli/dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>
- Passed: cli/dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value ".*ShouldShowSkillsInstalledDialog.*"
- Note: The broader filtered run for SetupWizardWindowTests and UnityCliLoopSettingsWindowCliActionTests still has existing CLI dispatcher-version expectation failures outside this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

