### PR TITLE
chore: Distinguish Unity package releases in release PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "packages": {
     ".": {
+      "component": "unity-package",
       "release-type": "go",
       "versioning": "prerelease",
       "prerelease": true,

--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -25,6 +25,10 @@ mark_package_release_sync_ready() {
   fi
 }
 
+strip_carriage_returns() {
+  tr -d '\015'
+}
+
 resolve_package_path() {
   package_path=$1
   file_path=$2
@@ -194,7 +198,7 @@ ensure_release_points_to_commit() {
   expected_sha=$2
   release_data=$3
 
-  release_target=$(printf '%s\n' "$release_data" | jq -r '.targetCommitish')
+  release_target=$(printf '%s\n' "$release_data" | jq -r '.targetCommitish' | strip_carriage_returns)
   resolved_release_target=$(resolve_release_target_commit "$release_target")
   resolved_expected_sha=$(git rev-parse "$expected_sha^{commit}")
 
@@ -266,7 +270,7 @@ create_package_release() {
   case "$release_status" in
     0)
       ensure_release_points_to_commit "$release_tag" "$target_sha" "$release_data"
-      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
+      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft' | strip_carriage_returns)
       if [ "$is_draft" != "false" ]; then
         publish_existing_draft_release "$release_tag" "$version"
       else
@@ -288,7 +292,7 @@ release_has_all_cli_assets() {
 
   asset_names=$("${ROOT_DIR}/scripts/verify-native-cli-release-assets.sh" --list) || return 1
   for asset_name in $asset_names; do
-    asset_count=$(printf '%s\n' "$release_data" | jq --arg name "$asset_name" '[.assets[]? | select(.name == $name and .size > 0)] | length')
+    asset_count=$(printf '%s\n' "$release_data" | jq --arg name "$asset_name" '[.assets[]? | select(.name == $name and .size > 0)] | length' | strip_carriage_returns)
     if [ "$asset_count" -eq 0 ]; then
       return 1
     fi
@@ -300,7 +304,7 @@ release_has_all_dispatcher_assets() {
 
   asset_names=$("${ROOT_DIR}/scripts/verify-dispatcher-release-assets.sh" --list) || return 1
   for asset_name in $asset_names; do
-    asset_count=$(printf '%s\n' "$release_data" | jq --arg name "$asset_name" '[.assets[]? | select(.name == $name and .size > 0)] | length')
+    asset_count=$(printf '%s\n' "$release_data" | jq --arg name "$asset_name" '[.assets[]? | select(.name == $name and .size > 0)] | length' | strip_carriage_returns)
     if [ "$asset_count" -eq 0 ]; then
       return 1
     fi
@@ -317,7 +321,7 @@ cli_release_is_ready() {
 
   case "$release_status" in
     0)
-      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
+      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft' | strip_carriage_returns)
       if [ "$is_draft" != "false" ]; then
         return 1
       fi
@@ -343,7 +347,7 @@ dispatcher_release_is_ready() {
 
   case "$release_status" in
     0)
-      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
+      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft' | strip_carriage_returns)
       if [ "$is_draft" != "false" ]; then
         return 1
       fi
@@ -456,7 +460,7 @@ release_tag_from_config() {
         ($package["include-v-in-tag"] // false)
       ]
     | @tsv
-  ' "$CONFIG" |
+  ' "$CONFIG" | strip_carriage_returns |
   while IFS='	' read -r component include_component include_v; do
     if [ "$component" = "__ULOOP_EMPTY_COMPONENT__" ]; then
       component=""
@@ -471,7 +475,7 @@ mark_package_release_sync_ready true
 
 fetch_release_refs
 
-cli_version=$(jq -r --arg package_path "$CLI_PACKAGE_PATH" '.[$package_path] // empty' "$MANIFEST")
+cli_version=$(jq -r --arg package_path "$CLI_PACKAGE_PATH" '.[$package_path] // empty' "$MANIFEST" | strip_carriage_returns)
 if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packages[$package_path] != null' "$CONFIG" >/dev/null; then
   cli_release_tag=$(release_tag_from_config "$CLI_PACKAGE_PATH" "$cli_version")
   if ! wait_for_cli_release_ready "$cli_release_tag"; then
@@ -482,7 +486,7 @@ if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packa
   fetch_cli_release_tag "$cli_release_tag"
 fi
 
-minimum_dispatcher_version=$(jq -r '.minimumDispatcherVersion // empty' "$ROOT_DIR/$UNITY_PACKAGE_CLI_PIN_FILE")
+minimum_dispatcher_version=$(jq -r '.minimumDispatcherVersion // empty' "$ROOT_DIR/$UNITY_PACKAGE_CLI_PIN_FILE" | strip_carriage_returns)
 if [ -n "$minimum_dispatcher_version" ]; then
   dispatcher_release_tag="dispatcher-v$minimum_dispatcher_version"
   if ! wait_for_dispatcher_release_ready "$dispatcher_release_tag"; then
@@ -504,13 +508,13 @@ jq -r --arg skip "$CLI_PACKAGE_PATH" '
       (.value["include-v-in-tag"] // false)
     ]
   | @tsv
-' "$CONFIG" |
+' "$CONFIG" | strip_carriage_returns |
 while IFS='	' read -r package_path changelog_config_path component include_component include_v; do
   if [ "$component" = "__ULOOP_EMPTY_COMPONENT__" ]; then
     component=""
   fi
 
-  version=$(jq -r --arg package_path "$package_path" '.[$package_path] // empty' "$MANIFEST")
+  version=$(jq -r --arg package_path "$package_path" '.[$package_path] // empty' "$MANIFEST" | strip_carriage_returns)
   if [ -z "$version" ]; then
     echo "Skipping $package_path because it has no release-please manifest version."
     continue
@@ -540,7 +544,7 @@ while IFS='	' read -r package_path changelog_config_path component include_compo
         ensure_release_points_to_commit "$release_tag" "$release_commit_sha" "$release_data"
       fi
 
-      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft')
+      is_draft=$(printf '%s\n' "$release_data" | jq -r '.isDraft' | strip_carriage_returns)
       if [ "$is_draft" != "false" ]; then
         if [ -z "$release_commit_sha" ]; then
           echo "Draft release $release_tag cannot be protocol-verified because no release-please commit for $package_path version $version was found." >&2

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -6,10 +6,14 @@ CONFIG="$ROOT_DIR/release-please-config.json"
 MANIFEST="$ROOT_DIR/.release-please-manifest.json"
 RELEASE_WORKFLOW="$ROOT_DIR/.github/workflows/release-please.yml"
 
+strip_carriage_returns() {
+  tr -d '\015'
+}
+
 assert_json_value() {
   expression=$1
   expected=$2
-  actual=$(jq -r "$expression" "$CONFIG")
+  actual=$(jq -r "$expression" "$CONFIG" | strip_carriage_returns)
 
   if [ "$actual" != "$expected" ]; then
     echo "Expected $expression to be $expected, got $actual." >&2
@@ -19,7 +23,7 @@ assert_json_value() {
 
 assert_manifest_semver() {
   expression=$1
-  actual=$(jq -r "$expression // empty" "$MANIFEST")
+  actual=$(jq -r "$expression // empty" "$MANIFEST" | strip_carriage_returns)
 
   if [ -z "$actual" ]; then
     echo "Expected manifest $expression to exist." >&2
@@ -115,6 +119,7 @@ assert_changelog_exists() {
 }
 
 assert_json_value '.packages["."].["changelog-path"]' 'Packages/src/CHANGELOG.md'
+assert_json_value '.packages["."].component' 'unity-package'
 assert_json_value '.packages["."].["include-component-in-tag"]' 'false'
 assert_json_value '.packages["."].["exclude-paths"][0]' 'cli'
 assert_json_value '.packages["."].["extra-files"] | length' '3'
@@ -147,18 +152,20 @@ assert_file_contains "$RELEASE_WORKFLOW" '        working-directory: cli'
 assert_file_contains "$RELEASE_WORKFLOW" '        run: go run ./cmd/dispatch-release-please-pr-checks'
 assert_step_contains "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' "        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'"
 assert_step_contains "$RELEASE_WORKFLOW" '      - name: Dispatch release PR checks' "        if: steps.target.outputs.branch == 'v3-beta' && steps.release_commit.outputs.skip != 'true' && steps.package_release_sync.outputs.ready != 'false'"
-assert_file_order "$RELEASE_WORKFLOW" '      - name: Setup Go for package release sync' '      - name: 🏷️ Sync release-please package releases'
+assert_file_order "$RELEASE_WORKFLOW" '      - name: Setup Go for package release sync' 'Sync release-please package releases'
 assert_file_order "$RELEASE_WORKFLOW" '      - name: Setup Go for release PR automation' '      - name: Dispatch release PR checks'
 
 assert_manifest_semver '.["."]'
 assert_manifest_semver '.["cli"]'
 
 jq -r '.packages | to_entries[] | [.key, .value["changelog-path"]] | @tsv' "$CONFIG" |
+strip_carriage_returns |
 while IFS='	' read -r package_path changelog_path; do
   assert_changelog_exists "$package_path" "$changelog_path"
 done
 
 jq -r '.packages | to_entries[] | .key as $package_path | .value["extra-files"][]?.path as $extra_file_path | [$package_path, $extra_file_path] | @tsv' "$CONFIG" |
+strip_carriage_returns |
 while IFS='	' read -r package_path extra_file_path; do
   assert_package_path_exists "$package_path" "$extra_file_path"
 done

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -171,6 +171,7 @@ write_release_files() {
 {
   "packages": {
     ".": {
+      "component": "unity-package",
       "release-type": "go",
       "include-v-in-tag": true,
       "include-component-in-tag": false,


### PR DESCRIPTION
## Summary
- Release PRs now label the Unity package component separately from the project runner component.
- Release sync scripts tolerate Windows jq CRLF output so tag calculations stay stable in local and CI-style checks.

## User Impact
- Before this change, release PRs could make it look like two Unity package releases were running because the root package had no component label.
- After this change, release reviewers can tell Unity package releases from project runner releases without inferring from tag names.

## Changes
- Add the unity-package component label while keeping the existing v-prefixed Unity package tag format.
- Normalize raw jq output in release sync helpers and release config tests before comparing booleans, tags, versions, and paths.

## Verification
- scripts/test-release-please-config.sh
- scripts/test-sync-release-please-package-releases.sh
- Release workflow helper tests, except local asset verification scripts that require zip.
- git diff --check

Note: scripts/test-verify-native-cli-release-assets.sh and scripts/test-verify-dispatcher-release-assets.sh were not run locally because this Windows Git Bash environment does not have zip installed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

