### PR TITLE
chore: Keep Release Please PRs readable and unblocked

### DIFF
--- a/cli/internal/automation/release_pr_body.go
+++ b/cli/internal/automation/release_pr_body.go
@@ -1,0 +1,94 @@
+package automation
+
+import (
+	"regexp"
+	"strings"
+)
+
+const releasePRCheckVersionPattern = `(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?`
+
+var (
+	releasePRCheckPlainUnityPackageSummary = regexp.MustCompile(`<details><summary>(` + releasePRCheckVersionPattern + `)</summary>`)
+	releasePRCheckDetailsBlock             = regexp.MustCompile(`(?s)<details><summary>[^<]+</summary>.*?</details>`)
+	releasePRCheckComponentSummary         = regexp.MustCompile(`<details><summary>([^<:]+): (` + releasePRCheckVersionPattern + `)</summary>`)
+)
+
+func clarifyReleasePRCheckComponentLabels(body string) (string, bool) {
+	clarifiedBody, summaryChanged := clarifyReleasePRCheckPlainUnityPackageSummary(body)
+	clarifiedBody, headingChanged := clarifyReleasePRCheckComponentHeadings(clarifiedBody)
+	return clarifiedBody, summaryChanged || headingChanged
+}
+
+func clarifyReleasePRCheckPlainUnityPackageSummary(body string) (string, bool) {
+	if strings.Contains(body, "<details><summary>unity-package: ") {
+		return body, false
+	}
+
+	matches := releasePRCheckPlainUnityPackageSummary.FindStringSubmatchIndex(body)
+	if matches == nil {
+		return body, false
+	}
+
+	version := body[matches[2]:matches[3]]
+	replacement := "<details><summary>unity-package: " + version + "</summary>"
+	return body[:matches[0]] + replacement + body[matches[1]:], true
+}
+
+func clarifyReleasePRCheckComponentHeadings(body string) (string, bool) {
+	matches := releasePRCheckDetailsBlock.FindAllStringIndex(body, -1)
+	if matches == nil {
+		return body, false
+	}
+
+	builder := strings.Builder{}
+	changed := false
+	lastIndex := 0
+	for _, match := range matches {
+		block := body[match[0]:match[1]]
+		clarifiedBlock, blockChanged := clarifyReleasePRCheckComponentHeadingBlock(block)
+
+		builder.WriteString(body[lastIndex:match[0]])
+		builder.WriteString(clarifiedBlock)
+		lastIndex = match[1]
+		changed = changed || blockChanged
+	}
+
+	if !changed {
+		return body, false
+	}
+
+	builder.WriteString(body[lastIndex:])
+	return builder.String(), true
+}
+
+func clarifyReleasePRCheckComponentHeadingBlock(block string) (string, bool) {
+	matches := releasePRCheckComponentSummary.FindStringSubmatch(block)
+	if matches == nil {
+		return block, false
+	}
+
+	displayName, found := releasePRCheckComponentDisplayName(matches[1])
+	if !found {
+		return block, false
+	}
+
+	version := matches[2]
+	heading := "## [" + version + "]("
+	if !strings.Contains(block, heading) {
+		return block, false
+	}
+
+	clarifiedHeading := "## [" + displayName + " " + version + "]("
+	return strings.Replace(block, heading, clarifiedHeading, 1), true
+}
+
+func releasePRCheckComponentDisplayName(component string) (string, bool) {
+	switch component {
+	case "unity-package":
+		return "Unity Package", true
+	case "uloop-project-runner":
+		return "U-LOOP Project Runner", true
+	default:
+		return "", false
+	}
+}

--- a/cli/internal/automation/release_pr_body.go
+++ b/cli/internal/automation/release_pr_body.go
@@ -87,7 +87,7 @@ func releasePRCheckComponentDisplayName(component string) (string, bool) {
 	case "unity-package":
 		return "Unity Package", true
 	case "uloop-project-runner":
-		return "U-LOOP Project Runner", true
+		return "uloop Project Runner", true
 	default:
 		return "", false
 	}

--- a/cli/internal/automation/release_pr_checks.go
+++ b/cli/internal/automation/release_pr_checks.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -34,8 +33,6 @@ var (
 			return nil
 		}
 	}
-
-	releasePRCheckPlainUnityPackageSummary = regexp.MustCompile(`<details><summary>((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?)</summary>`)
 )
 
 type releasePRCheckConfig struct {
@@ -88,7 +85,7 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 		return 1
 	}
 	if bodyChanged {
-		writeReleasePRCheckLine(stdout, fmt.Sprintf("Updated release PR #%d body to label the Unity package summary.", releasePR.Number))
+		writeReleasePRCheckLine(stdout, fmt.Sprintf("Updated release PR #%d body to clarify release component labels.", releasePR.Number))
 	}
 
 	err = markReleasePRCheckDraft(ctx, config, releasePR)
@@ -296,7 +293,7 @@ func clarifyReleasePRCheckBody(ctx context.Context, config releasePRCheckConfig,
 		return false, fmt.Errorf("failed to parse release PR body: %w", err)
 	}
 
-	clarifiedBody, changed := clarifyReleasePRCheckUnityPackageSummary(prBody.Body)
+	clarifiedBody, changed := clarifyReleasePRCheckComponentLabels(prBody.Body)
 	if !changed {
 		return false, nil
 	}
@@ -312,21 +309,6 @@ func clarifyReleasePRCheckBody(ctx context.Context, config releasePRCheckConfig,
 		return false, err
 	}
 	return true, nil
-}
-
-func clarifyReleasePRCheckUnityPackageSummary(body string) (string, bool) {
-	if strings.Contains(body, "<details><summary>unity-package: ") {
-		return body, false
-	}
-
-	matches := releasePRCheckPlainUnityPackageSummary.FindStringSubmatchIndex(body)
-	if matches == nil {
-		return body, false
-	}
-
-	version := body[matches[2]:matches[3]]
-	replacement := "<details><summary>unity-package: " + version + "</summary>"
-	return body[:matches[0]] + replacement + body[matches[1]:], true
 }
 
 func writeReleasePRCheckBodyFile(body string) (string, func(), error) {

--- a/cli/internal/automation/release_pr_checks_test.go
+++ b/cli/internal/automation/release_pr_checks_test.go
@@ -73,7 +73,7 @@ func TestReleasePRCheckComponentHeadingsAreClarified(t *testing.T) {
 		t.Fatal("expected component release headings to change")
 	}
 	assertReleasePRCheckLogContains(t, clarifiedBody, "## [Unity Package 3.0.0-beta.48](https://example.test/compare/v3.0.0-beta.47...v3.0.0-beta.48) (2026-07-01)")
-	assertReleasePRCheckLogContains(t, clarifiedBody, "## [U-LOOP Project Runner 3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop Project Runner 3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)")
 }
 
 // Verifies that missing release PRs skip without dispatching checks.

--- a/cli/internal/automation/release_pr_checks_test.go
+++ b/cli/internal/automation/release_pr_checks_test.go
@@ -32,7 +32,7 @@ func TestReleasePRCheckUnityPackageSummaryIsClarified(t *testing.T) {
 		"* Project runner notes\n" +
 		"</details>\n"
 
-	clarifiedBody, changed := clarifyReleasePRCheckUnityPackageSummary(body)
+	clarifiedBody, changed := clarifyReleasePRCheckComponentLabels(body)
 
 	if !changed {
 		t.Fatal("expected plain Unity package summary to change")
@@ -48,7 +48,7 @@ func TestReleasePRCheckUnityPackageSummaryAlreadyClarified(t *testing.T) {
 		"* Release note content that should not be relabeled.\n" +
 		"</details>\n"
 
-	clarifiedBody, changed := clarifyReleasePRCheckUnityPackageSummary(body)
+	clarifiedBody, changed := clarifyReleasePRCheckComponentLabels(body)
 
 	if changed {
 		t.Fatal("expected labeled Unity package summary to stay unchanged")
@@ -56,6 +56,24 @@ func TestReleasePRCheckUnityPackageSummaryAlreadyClarified(t *testing.T) {
 	if clarifiedBody != body {
 		t.Fatalf("expected body to stay unchanged, got:\n%s", clarifiedBody)
 	}
+}
+
+// Verifies that component release headings show human-readable component names.
+func TestReleasePRCheckComponentHeadingsAreClarified(t *testing.T) {
+	body := "<details><summary>unity-package: 3.0.0-beta.48</summary>\n\n" +
+		"## [3.0.0-beta.48](https://example.test/compare/v3.0.0-beta.47...v3.0.0-beta.48) (2026-07-01)\n" +
+		"</details>\n" +
+		"<details><summary>uloop-project-runner: 3.0.0-beta.45</summary>\n\n" +
+		"## [3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)\n" +
+		"</details>\n"
+
+	clarifiedBody, changed := clarifyReleasePRCheckComponentLabels(body)
+
+	if !changed {
+		t.Fatal("expected component release headings to change")
+	}
+	assertReleasePRCheckLogContains(t, clarifiedBody, "## [Unity Package 3.0.0-beta.48](https://example.test/compare/v3.0.0-beta.47...v3.0.0-beta.48) (2026-07-01)")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "## [U-LOOP Project Runner 3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)")
 }
 
 // Verifies that missing release PRs skip without dispatching checks.
@@ -110,7 +128,7 @@ func TestReleasePRChecksClarifyUnityPackageSummaryBeforeDispatch(t *testing.T) {
 	if result.exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
 	}
-	assertReleasePRCheckLogContains(t, result.stdout, "Updated release PR #1043 body to label the Unity package summary.")
+	assertReleasePRCheckLogContains(t, result.stdout, "Updated release PR #1043 body to clarify release component labels.")
 	assertReleasePRCheckLogContains(t, result.ghLog, "pr view 1043 --repo owner/repository --json body")
 	assertReleasePRCheckLogContains(t, result.ghLog, "pr edit 1043 --repo owner/repository --body-file")
 	assertReleasePRCheckLogContains(t, result.ghLog, "workflow run build-and-test.yml --repo owner/repository --ref release-please--branches--v3-beta")

--- a/scripts/sync-published-release-pr-labels.sh
+++ b/scripts/sync-published-release-pr-labels.sh
@@ -7,33 +7,45 @@ REPO_FULL_NAME=${GITHUB_REPOSITORY:-hatayama/unity-cli-loop}
 PENDING_LABEL="autorelease: pending"
 TAGGED_LABEL="autorelease: tagged"
 
-release_version_from_title() {
+release_tag_from_title() {
   title=$1
 
   printf '%s\n' "$title" | jq -R -r '
-    try capture("^chore(\\([^)]*\\))?: release (?<version>[0-9][A-Za-z0-9._-]*)$").version catch ""
+    try (capture("^chore(\\([^)]*\\))?: release (?<version>[0-9][A-Za-z0-9._-]*)$") | "v" + .version) catch ""
   '
 }
 
-release_version_from_body() {
+release_tag_from_body() {
   body=$1
 
   printf '%s\n' "$body" | jq -R -s -r '
-    try capture("<summary>(?:[^<:]+:\\s*)?(?<version>[0-9][A-Za-z0-9._-]*)</summary>").version catch ""
+    def release_tag($component; $version):
+      if $component == "" or $component == "unity-package" then
+        "v" + $version
+      elif $component == "uloop-project-runner" then
+        "uloop-project-runner-v" + $version
+      else
+        ""
+      end;
+
+    try (
+      capture("<summary>(?:(?<component>[^<:]+):\\s*)?(?<version>[0-9][A-Za-z0-9._-]*)</summary>") |
+      release_tag((.component // ""); .version)
+    ) catch ""
   '
 }
 
-release_version_from_pr() {
+release_tag_from_pr() {
   title=$1
   body=$2
-  release_version=$(release_version_from_title "$title")
+  release_tag=$(release_tag_from_title "$title")
 
-  if [ -n "$release_version" ]; then
-    printf '%s\n' "$release_version"
+  if [ -n "$release_tag" ]; then
+    printf '%s\n' "$release_tag"
     return
   fi
 
-  release_version_from_body "$body"
+  release_tag_from_body "$body"
 }
 
 release_is_published_at_sha() {
@@ -81,14 +93,13 @@ printf '%s\n' "$PENDING_RELEASE_PRS" | jq -c '.[]' | while IFS= read -r release_
   release_pr_title=$(printf '%s\n' "$release_pr_json" | jq -r '.title')
   release_pr_body=$(printf '%s\n' "$release_pr_json" | jq -r '.body // ""')
   release_pr_sha=$(printf '%s\n' "$release_pr_json" | jq -r '.mergeCommit.oid')
-  release_version=$(release_version_from_pr "$release_pr_title" "$release_pr_body")
+  release_tag=$(release_tag_from_pr "$release_pr_title" "$release_pr_body")
 
-  if [ -z "$release_version" ]; then
+  if [ -z "$release_tag" ]; then
     echo "Skipping pending PR #$release_pr_number because the title is not a release-please release title: $release_pr_title"
     continue
   fi
 
-  release_tag="v$release_version"
   set +e
   release_is_published_at_sha "$release_tag" "$release_pr_sha"
   release_status=$?

--- a/scripts/sync-published-release-pr-labels.sh
+++ b/scripts/sync-published-release-pr-labels.sh
@@ -19,7 +19,7 @@ release_version_from_body() {
   body=$1
 
   printf '%s\n' "$body" | jq -R -s -r '
-    try capture("<summary>(?<version>[0-9][A-Za-z0-9._-]*)</summary>").version catch ""
+    try capture("<summary>(?:[^<:]+:\\s*)?(?<version>[0-9][A-Za-z0-9._-]*)</summary>").version catch ""
   '
 }
 

--- a/scripts/sync-published-release-pr-labels.sh
+++ b/scripts/sync-published-release-pr-labels.sh
@@ -38,14 +38,14 @@ release_tag_from_body() {
 release_tag_from_pr() {
   title=$1
   body=$2
-  release_tag=$(release_tag_from_title "$title")
+  release_tag=$(release_tag_from_body "$body")
 
   if [ -n "$release_tag" ]; then
     printf '%s\n' "$release_tag"
     return
   fi
 
-  release_tag_from_body "$body"
+  release_tag_from_title "$title"
 }
 
 release_is_published_at_sha() {

--- a/scripts/test-sync-published-release-pr-labels.sh
+++ b/scripts/test-sync-published-release-pr-labels.sh
@@ -172,6 +172,7 @@ test_marks_project_runner_component_summary_release_pr_before_numeric_title() {
 
   assert_file_equals "$TMP_DIR/project-runner-component-before-title/status.txt" "0"
   assert_contains "$TMP_DIR/project-runner-component-before-title/gh.log" "release view uloop-project-runner-v3.0.0-beta.45 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish"
+  assert_not_contains "$TMP_DIR/project-runner-component-before-title/gh.log" "release view v3.0.0-beta.45 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish"
   assert_contains "$TMP_DIR/project-runner-component-before-title/output.txt" "Marked release PR #1452 as tagged for uloop-project-runner-v3.0.0-beta.45."
 }
 

--- a/scripts/test-sync-published-release-pr-labels.sh
+++ b/scripts/test-sync-published-release-pr-labels.sh
@@ -153,6 +153,17 @@ test_marks_component_summary_release_pr_from_body() {
   assert_contains "$TMP_DIR/component-summary/output.txt" "Marked release PR #1448 as tagged for v3.0.0-beta.47."
 }
 
+# Verifies component-prefixed project runner summaries use the component release tag.
+test_marks_project_runner_component_summary_release_pr_from_body() {
+  run_case project-runner-component-summary \
+    '[{"number":1450,"title":"chore: release v3-beta","body":"<details><summary>uloop-project-runner: 3.0.0-beta.45</summary></details>","mergeCommit":{"oid":"abc123"}}]' \
+    '{"uloop-project-runner-v3.0.0-beta.45":{"isDraft":false,"targetCommitish":"abc123"}}'
+
+  assert_file_equals "$TMP_DIR/project-runner-component-summary/status.txt" "0"
+  assert_contains "$TMP_DIR/project-runner-component-summary/gh.log" "pr edit 1450 --repo hatayama/unity-cli-loop --remove-label autorelease: pending --add-label autorelease: tagged"
+  assert_contains "$TMP_DIR/project-runner-component-summary/output.txt" "Marked release PR #1450 as tagged for uloop-project-runner-v3.0.0-beta.45."
+}
+
 # Verifies draft releases remain pending so release completion is not hidden.
 test_keeps_draft_release_pending() {
   run_case draft-release \
@@ -199,6 +210,7 @@ test_fails_when_release_lookup_fails_unexpectedly() {
 test_marks_stale_pending_release_pr
 test_marks_branch_title_release_pr_from_body
 test_marks_component_summary_release_pr_from_body
+test_marks_project_runner_component_summary_release_pr_from_body
 test_keeps_draft_release_pending
 test_keeps_mismatched_release_pending
 test_exits_when_no_pending_release_pr_exists

--- a/scripts/test-sync-published-release-pr-labels.sh
+++ b/scripts/test-sync-published-release-pr-labels.sh
@@ -164,6 +164,17 @@ test_marks_project_runner_component_summary_release_pr_from_body() {
   assert_contains "$TMP_DIR/project-runner-component-summary/output.txt" "Marked release PR #1450 as tagged for uloop-project-runner-v3.0.0-beta.45."
 }
 
+# Verifies component summaries take precedence over legacy numeric release titles.
+test_marks_project_runner_component_summary_release_pr_before_numeric_title() {
+  run_case project-runner-component-before-title \
+    '[{"number":1452,"title":"chore(v3-beta): release 3.0.0-beta.45","body":"<details><summary>uloop-project-runner: 3.0.0-beta.45</summary></details>","mergeCommit":{"oid":"abc123"}}]' \
+    '{"uloop-project-runner-v3.0.0-beta.45":{"isDraft":false,"targetCommitish":"abc123"}}'
+
+  assert_file_equals "$TMP_DIR/project-runner-component-before-title/status.txt" "0"
+  assert_contains "$TMP_DIR/project-runner-component-before-title/gh.log" "release view uloop-project-runner-v3.0.0-beta.45 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish"
+  assert_contains "$TMP_DIR/project-runner-component-before-title/output.txt" "Marked release PR #1452 as tagged for uloop-project-runner-v3.0.0-beta.45."
+}
+
 # Verifies draft releases remain pending so release completion is not hidden.
 test_keeps_draft_release_pending() {
   run_case draft-release \
@@ -211,6 +222,7 @@ test_marks_stale_pending_release_pr
 test_marks_branch_title_release_pr_from_body
 test_marks_component_summary_release_pr_from_body
 test_marks_project_runner_component_summary_release_pr_from_body
+test_marks_project_runner_component_summary_release_pr_before_numeric_title
 test_keeps_draft_release_pending
 test_keeps_mismatched_release_pending
 test_exits_when_no_pending_release_pr_exists

--- a/scripts/test-sync-published-release-pr-labels.sh
+++ b/scripts/test-sync-published-release-pr-labels.sh
@@ -142,6 +142,17 @@ test_marks_branch_title_release_pr_from_body() {
   assert_contains "$TMP_DIR/branch-title/output.txt" "Marked release PR #1105 as tagged for v3.0.0-beta.7."
 }
 
+# Verifies component-prefixed release summaries still repair stale release PR labels.
+test_marks_component_summary_release_pr_from_body() {
+  run_case component-summary \
+    '[{"number":1448,"title":"chore: release v3-beta","body":"<details><summary>unity-package: 3.0.0-beta.47</summary></details>","mergeCommit":{"oid":"abc123"}}]' \
+    '{"v3.0.0-beta.47":{"isDraft":false,"targetCommitish":"abc123"}}'
+
+  assert_file_equals "$TMP_DIR/component-summary/status.txt" "0"
+  assert_contains "$TMP_DIR/component-summary/gh.log" "pr edit 1448 --repo hatayama/unity-cli-loop --remove-label autorelease: pending --add-label autorelease: tagged"
+  assert_contains "$TMP_DIR/component-summary/output.txt" "Marked release PR #1448 as tagged for v3.0.0-beta.47."
+}
+
 # Verifies draft releases remain pending so release completion is not hidden.
 test_keeps_draft_release_pending() {
   run_case draft-release \
@@ -187,6 +198,7 @@ test_fails_when_release_lookup_fails_unexpectedly() {
 
 test_marks_stale_pending_release_pr
 test_marks_branch_title_release_pr_from_body
+test_marks_component_summary_release_pr_from_body
 test_keeps_draft_release_pending
 test_keeps_mismatched_release_pending
 test_exits_when_no_pending_release_pr_exists


### PR DESCRIPTION
## Summary
- Release Please can recover after merged release PRs whose summaries include component names before versions.
- Generated release PRs now label component headings as Unity Package and uloop Project Runner instead of showing version-only headings.

## User Impact
- The next release PR should appear after a component-formatted release PR is merged and published.
- Release reviewers can distinguish Unity package and project runner entries from the blue Markdown headings without relying on the collapsed summary text.
- Maintainers should not need to manually relabel completed release PRs to unblock Release Please.

## Changes
- Resolve release tags from component-prefixed summaries, including `unity-package: 3.0.0-beta.47` and `uloop-project-runner: 3.0.0-beta.45`.
- Clarify Release Please component headings during release PR check dispatch.
- Add regression tests for stale pending labels, component release tags, and component heading text.

## Verification
- `go test ./internal/automation -count=1`
- `scripts/test-release-please-config.sh`
- `scripts/test-sync-published-release-pr-labels.sh`
- `scripts/test-mark-release-pr-tagged.sh`
- `git diff --check`
- `scripts/check-go-cli.sh`
- `autoreview --mode branch --base origin/v3-beta`