### PR TITLE
fix: Correct misleading dispatcher error and help messages

### DIFF
--- a/dispatcher/internal/dispatcher/bootstrap_platform_errors.go
+++ b/dispatcher/internal/dispatcher/bootstrap_platform_errors.go
@@ -21,7 +21,7 @@ func unsupportedPlatformError(message string, context clicore.ErrorContext) (cli
 			message,
 			context,
 			[]string{
-				"Run `uloop install` on Windows.",
+				"Run `uloop install` on macOS or Windows.",
 				"Use the platform-specific installer for this system.",
 			}), true
 	case uninstallUnsupportedOSMessage:

--- a/dispatcher/internal/dispatcher/error_envelope_test.go
+++ b/dispatcher/internal/dispatcher/error_envelope_test.go
@@ -72,7 +72,7 @@ func TestClassifyInstallUnsupportedOS(t *testing.T) {
 	if cliErr.Phase != clicore.ErrorPhaseExecution {
 		t.Fatalf("phase mismatch: %#v", cliErr)
 	}
-	expectedAction := "Run `uloop install` on Windows."
+	expectedAction := "Run `uloop install` on macOS or Windows."
 	if len(cliErr.NextActions) == 0 || cliErr.NextActions[0] != expectedAction {
 		t.Fatalf("next actions mismatch: %#v", cliErr.NextActions)
 	}

--- a/dispatcher/internal/dispatcher/launch.go
+++ b/dispatcher/internal/dispatcher/launch.go
@@ -478,7 +478,7 @@ func printLaunchHelp(stdout io.Writer) {
 	clicore.WriteLine(stdout, "      --editor-version <version>")
 	clicore.WriteLine(stdout, "                          Use this Unity Editor version instead of ProjectVersion.txt")
 	clicore.WriteLine(stdout, "  -p, --platform <name>  Pass Unity -buildTarget when launching")
-	clicore.WriteLine(stdout, "      --max-depth <n>    Accepted for compatibility when searching from the current directory")
+	clicore.WriteLine(stdout, "      --max-depth <n>    Max directory depth when auto-searching for the project (default: 3, -1 = unlimited)")
 	clicore.WriteLine(stdout, "")
 	clicore.WriteLine(stdout, "Compiler errors are ignored by default during Unity startup.")
 	clicore.WriteLine(stdout, "")

--- a/dispatcher/internal/dispatcher/skills_discovery.go
+++ b/dispatcher/internal/dispatcher/skills_discovery.go
@@ -35,7 +35,7 @@ func collectSkillDefinitions(projectRoot string) ([]skillDefinition, error) {
 func collectV3MigrationSkillDefinition(projectRoot string) ([]skillDefinition, error) {
 	packageRoot := clicore.ResolvePackageRoot(projectRoot)
 	if packageRoot == "" {
-		return nil, errors.New("unity CLI Loop package root was not found")
+		return nil, errors.New("the Unity CLI Loop package root was not found")
 	}
 
 	skillDirectory := filepath.Join(


### PR DESCRIPTION
## Summary
- Dispatcher error hints and help text no longer mislead users about supported platforms and options.

## User Impact
- Before: the install unsupported-platform hint said `uloop install` runs "on Windows." only (macOS is fully supported), the skills migration error spelled the product name "unity CLI Loop", and `uloop launch --help` described `--max-depth` as a compatibility-only flag.
- After: the install hint says "on macOS or Windows." like its update/uninstall siblings, the product name reads "Unity CLI Loop", and the help explains that `--max-depth` caps the project auto-search depth (default 3, `-1` = unlimited).

## Changes
- Align the install next-action hint with the update/uninstall wording.
- Reword the skills package-root error so the canonical product name fits the lowercase error-string convention.
- Describe what `--max-depth` actually does in the launch help.

## Verification
- `scripts/check-go-cli.sh` (fmt, vet, lint, tests, builds across all Go modules)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

