### PR TITLE
fix: Screenshot annotations only mark reachable controls as clickable

### DIFF
--- a/Assets/Tests/Editor/UIElementAnnotatorTests.cs
+++ b/Assets/Tests/Editor/UIElementAnnotatorTests.cs
@@ -1,12 +1,36 @@
+using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
 using UnityEngine.UI;
 
 namespace io.github.hatayama.uLoopMCP
 {
     public class UIElementAnnotatorTests
     {
+        private readonly List<GameObject> _createdObjects = new List<GameObject>();
+
+        [SetUp]
+        public void SetUp()
+        {
+            GameObject eventSystem = CreateGameObject("UIElementAnnotatorTestsEventSystem");
+            eventSystem.AddComponent<EventSystem>();
+            eventSystem.AddComponent<StandaloneInputModule>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (int i = _createdObjects.Count - 1; i >= 0; i--)
+            {
+                Object.DestroyImmediate(_createdObjects[i]);
+            }
+
+            _createdObjects.Clear();
+        }
+
         [Test]
         public void GetAnnotationColorForElement_WhenLabelsAreDifferent_ShouldReturnDifferentColors()
         {
@@ -198,6 +222,32 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
+        [UnityTest]
+        public IEnumerator CollectInteractiveElements_WhenCanvasIsDisabled_ShouldSkipButton()
+        {
+            GameObject canvas = CreateCanvas("DisabledCanvas", 0, false);
+            CreateButton("HiddenButton", canvas.transform, Vector2.zero);
+            Canvas.ForceUpdateCanvases();
+            yield return null;
+
+            List<UIElementInfo> elements = UIElementAnnotator.CollectInteractiveElements();
+
+            Assert.That(ContainsPath(elements, "DisabledCanvas/HiddenButton"), Is.False);
+        }
+
+        [UnityTest]
+        public IEnumerator CollectInteractiveElements_WhenButtonIsVisible_ShouldIncludeButton()
+        {
+            GameObject canvas = CreateCanvas("VisibleCanvas", 0, true);
+            CreateButton("VisibleButton", canvas.transform, Vector2.zero);
+            Canvas.ForceUpdateCanvases();
+            yield return null;
+
+            List<UIElementInfo> elements = UIElementAnnotator.CollectInteractiveElements();
+
+            Assert.That(ContainsPath(elements, "VisibleCanvas/VisibleButton"), Is.True);
+        }
+
         [Test]
         public void GetInteractionForType_WhenTypeIsButton_ShouldReturnClick()
         {
@@ -248,6 +298,51 @@ namespace io.github.hatayama.uLoopMCP
         private static string CreateColorKey(Color color)
         {
             return $"{color.r:F3}:{color.g:F3}:{color.b:F3}:{color.a:F3}";
+        }
+
+        private GameObject CreateCanvas(string name, int sortingOrder, bool enabled)
+        {
+            GameObject canvasGo = CreateGameObject(name);
+            Canvas canvas = canvasGo.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.sortingOrder = sortingOrder;
+            canvas.enabled = enabled;
+            canvasGo.AddComponent<GraphicRaycaster>();
+            return canvasGo;
+        }
+
+        private Button CreateButton(string name, Transform parent, Vector2 anchoredPosition)
+        {
+            GameObject buttonGo = CreateGameObject(name);
+            buttonGo.transform.SetParent(parent, false);
+            RectTransform rectTransform = buttonGo.AddComponent<RectTransform>();
+            rectTransform.anchoredPosition = anchoredPosition;
+            rectTransform.sizeDelta = new Vector2(120f, 80f);
+            Image image = buttonGo.AddComponent<Image>();
+            image.raycastTarget = true;
+            Button button = buttonGo.AddComponent<Button>();
+            button.targetGraphic = image;
+            return button;
+        }
+
+        private GameObject CreateGameObject(string name)
+        {
+            GameObject go = new GameObject(name);
+            _createdObjects.Add(go);
+            return go;
+        }
+
+        private static bool ContainsPath(List<UIElementInfo> elements, string path)
+        {
+            foreach (UIElementInfo element in elements)
+            {
+                if (element.Path == path)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Assets/Tests/Editor/UIElementAnnotatorTests.cs
+++ b/Assets/Tests/Editor/UIElementAnnotatorTests.cs
@@ -225,27 +225,31 @@ namespace io.github.hatayama.uLoopMCP
         [UnityTest]
         public IEnumerator CollectInteractiveElements_WhenCanvasIsDisabled_ShouldSkipButton()
         {
-            GameObject canvas = CreateCanvas("DisabledCanvas", 0, false);
+            GameObject canvas = CreateCanvas("DisabledCanvas", false);
             CreateButton("HiddenButton", canvas.transform, Vector2.zero);
             Canvas.ForceUpdateCanvases();
             yield return null;
 
             List<UIElementInfo> elements = UIElementAnnotator.CollectInteractiveElements();
 
-            Assert.That(ContainsPath(elements, "DisabledCanvas/HiddenButton"), Is.False);
+            Assert.That(
+                elements.Exists((UIElementInfo element) => element.Path == "DisabledCanvas/HiddenButton"),
+                Is.False);
         }
 
         [UnityTest]
         public IEnumerator CollectInteractiveElements_WhenButtonIsVisible_ShouldIncludeButton()
         {
-            GameObject canvas = CreateCanvas("VisibleCanvas", 0, true);
+            GameObject canvas = CreateCanvas("VisibleCanvas", true);
             CreateButton("VisibleButton", canvas.transform, Vector2.zero);
             Canvas.ForceUpdateCanvases();
             yield return null;
 
             List<UIElementInfo> elements = UIElementAnnotator.CollectInteractiveElements();
 
-            Assert.That(ContainsPath(elements, "VisibleCanvas/VisibleButton"), Is.True);
+            Assert.That(
+                elements.Exists((UIElementInfo element) => element.Path == "VisibleCanvas/VisibleButton"),
+                Is.True);
         }
 
         [Test]
@@ -300,12 +304,11 @@ namespace io.github.hatayama.uLoopMCP
             return $"{color.r:F3}:{color.g:F3}:{color.b:F3}:{color.a:F3}";
         }
 
-        private GameObject CreateCanvas(string name, int sortingOrder, bool enabled)
+        private GameObject CreateCanvas(string name, bool enabled)
         {
             GameObject canvasGo = CreateGameObject(name);
             Canvas canvas = canvasGo.AddComponent<Canvas>();
             canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-            canvas.sortingOrder = sortingOrder;
             canvas.enabled = enabled;
             canvasGo.AddComponent<GraphicRaycaster>();
             return canvasGo;
@@ -330,19 +333,6 @@ namespace io.github.hatayama.uLoopMCP
             GameObject go = new GameObject(name);
             _createdObjects.Add(go);
             return go;
-        }
-
-        private static bool ContainsPath(List<UIElementInfo> elements, string path)
-        {
-            foreach (UIElementInfo element in elements)
-            {
-                if (element.Path == path)
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/Assets/Tests/Editor/UIElementAnnotatorTests.cs
+++ b/Assets/Tests/Editor/UIElementAnnotatorTests.cs
@@ -185,6 +185,61 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         [Test]
+        public void CreateAnnotationOverlay_WhenMultipleElementsAreAnnotated_ShouldDrawLabelsAboveAllBorders()
+        {
+            List<UIElementInfo> elements = new List<UIElementInfo>
+            {
+                new UIElementInfo
+                {
+                    Label = "A",
+                    Type = "Button",
+                    Interaction = "Click",
+                    BoundsMinX = 10f,
+                    BoundsMinY = 20f,
+                    BoundsMaxX = 110f,
+                    BoundsMaxY = 70f
+                },
+                new UIElementInfo
+                {
+                    Label = "B",
+                    Type = "Slider",
+                    Interaction = "Drag",
+                    BoundsMinX = 80f,
+                    BoundsMinY = 90f,
+                    BoundsMaxX = 210f,
+                    BoundsMaxY = 130f
+                }
+            };
+            GameObject overlay = UIElementAnnotator.CreateAnnotationOverlay(elements, 1f);
+
+            try
+            {
+                int lastBorderSiblingIndex = -1;
+                int firstLabelSiblingIndex = int.MaxValue;
+
+                for (int i = 0; i < overlay.transform.childCount; i++)
+                {
+                    Transform child = overlay.transform.GetChild(i);
+                    if (child.name.StartsWith("Border_"))
+                    {
+                        lastBorderSiblingIndex = i;
+                    }
+
+                    if (child.name == "LabelBg" && firstLabelSiblingIndex == int.MaxValue)
+                    {
+                        firstLabelSiblingIndex = i;
+                    }
+                }
+
+                Assert.That(firstLabelSiblingIndex, Is.GreaterThan(lastBorderSiblingIndex));
+            }
+            finally
+            {
+                UIElementAnnotator.DestroyAnnotationOverlay(overlay);
+            }
+        }
+
+        [Test]
         public void CreateAnnotationOverlay_WhenResolutionScaleIsHalf_ShouldCompensateBorderThickness()
         {
             List<UIElementInfo> elements = new List<UIElementInfo>

--- a/Assets/Tests/Editor/UIElementAnnotatorTests.cs
+++ b/Assets/Tests/Editor/UIElementAnnotatorTests.cs
@@ -11,10 +11,20 @@ namespace io.github.hatayama.uLoopMCP
     public class UIElementAnnotatorTests
     {
         private readonly List<GameObject> _createdObjects = new List<GameObject>();
+        private EventSystem _previousEventSystem;
+        private bool _previousEventSystemEnabled;
 
         [SetUp]
         public void SetUp()
         {
+            _previousEventSystem = EventSystem.current;
+            if (_previousEventSystem != null)
+            {
+                _previousEventSystemEnabled = _previousEventSystem.enabled;
+                // EditMode EventSystems are not reliably registered, so clear stale scene state instead.
+                _previousEventSystem.enabled = false;
+            }
+
             GameObject eventSystem = CreateGameObject("UIElementAnnotatorTestsEventSystem");
             eventSystem.AddComponent<EventSystem>();
             eventSystem.AddComponent<StandaloneInputModule>();
@@ -23,6 +33,14 @@ namespace io.github.hatayama.uLoopMCP
         [TearDown]
         public void TearDown()
         {
+            if (_previousEventSystem != null)
+            {
+                _previousEventSystem.enabled = _previousEventSystemEnabled;
+            }
+
+            _previousEventSystem = null;
+            _previousEventSystemEnabled = false;
+
             for (int i = _createdObjects.Count - 1; i >= 0; i--)
             {
                 Object.DestroyImmediate(_createdObjects[i]);

--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -300,6 +300,61 @@ namespace Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator Click_Should_IgnoreDisabledCanvasSpaceOverlay()
+        {
+            GameObject disabledCanvasGo = new GameObject("DisabledOverlayCanvas");
+
+            try
+            {
+                Canvas disabledCanvas = disabledCanvasGo.AddComponent<Canvas>();
+                disabledCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+                disabledCanvas.sortingOrder = 100;
+                disabledCanvas.enabled = false;
+                disabledCanvasGo.AddComponent<GraphicRaycaster>();
+
+                ClickTracker hiddenTracker = CreateChildClickableElement(
+                    "HiddenOverlayButton", disabledCanvasGo.transform, Vector2.zero, new Vector2(240f, 140f));
+                ClickTracker visibleTracker = CreateClickableElement(
+                    "VisibleButton", Vector2.zero, new Vector2(200f, 100f));
+                yield return null;
+
+                Vector2 screenPos = GetScreenPosition(visibleTracker.gameObject);
+
+                yield return RunTool(new JObject
+                {
+                    ["action"] = MouseAction.Click.ToString(),
+                    ["x"] = screenPos.x,
+                    ["y"] = screenPos.y
+                });
+
+                Assert.IsTrue(lastResponse.Success);
+                Assert.IsTrue(visibleTracker.PointerClickCalled, "Visible button should receive the click");
+                Assert.IsFalse(hiddenTracker.PointerClickCalled, "Disabled Canvas content should not receive the click");
+                Assert.AreEqual("VisibleButton", lastResponse.HitGameObjectName);
+            }
+            finally
+            {
+                Object.Destroy(disabledCanvasGo);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator CollectInteractiveElements_Should_SkipButtonCoveredByFrontGraphic()
+        {
+            CreateClickableElement("CoveredAnnotationButton", Vector2.zero, new Vector2(200f, 100f));
+            GameObject blocker = CreateUIElement("AnnotationBlocker", Vector2.zero, new Vector2(240f, 140f));
+            blocker.AddComponent<Image>();
+            yield return null;
+            Canvas.ForceUpdateCanvases();
+
+            List<UIElementInfo> elements = UIElementAnnotator.CollectInteractiveElements();
+
+            Assert.IsFalse(
+                ContainsAnnotatedPath(elements, "TestCanvas/CoveredAnnotationButton"),
+                "Covered UI should not be advertised as directly clickable");
+        }
+
+        [UnityTest]
         public IEnumerator Click_WithBypassRaycast_Should_UseTargetPathWhenNamesDuplicate()
         {
             GameObject firstPanel = CreateUIElement("FirstPanel", new Vector2(-120f, 0f), new Vector2(240f, 160f));
@@ -737,6 +792,19 @@ namespace Tests.PlayMode
         }
 
         #endregion
+
+        private static bool ContainsAnnotatedPath(List<UIElementInfo> elements, string path)
+        {
+            foreach (UIElementInfo element in elements)
+            {
+                if (element.Path == path)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         #region Helpers
 

--- a/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiTests.cs
@@ -350,7 +350,7 @@ namespace Tests.PlayMode
             List<UIElementInfo> elements = UIElementAnnotator.CollectInteractiveElements();
 
             Assert.IsFalse(
-                ContainsAnnotatedPath(elements, "TestCanvas/CoveredAnnotationButton"),
+                elements.Exists((UIElementInfo element) => element.Path == "TestCanvas/CoveredAnnotationButton"),
                 "Covered UI should not be advertised as directly clickable");
         }
 
@@ -792,19 +792,6 @@ namespace Tests.PlayMode
         }
 
         #endregion
-
-        private static bool ContainsAnnotatedPath(List<UIElementInfo> elements, string path)
-        {
-            foreach (UIElementInfo element in elements)
-            {
-                if (element.Path == path)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
 
         #region Helpers
 

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -45,7 +45,7 @@ namespace io.github.hatayama.uLoopMCP
 
             foreach (Canvas canvas in canvases)
             {
-                if (!canvas.gameObject.activeInHierarchy)
+                if (!canvas.isActiveAndEnabled)
                 {
                     continue;
                 }
@@ -56,7 +56,7 @@ namespace io.github.hatayama.uLoopMCP
                 }
 
                 GraphicRaycaster? raycaster = canvas.GetComponent<GraphicRaycaster>();
-                if (raycaster == null || !raycaster.enabled)
+                if (raycaster == null || !raycaster.isActiveAndEnabled)
                 {
                     continue;
                 }

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -17,6 +17,7 @@ namespace io.github.hatayama.uLoopMCP
 
         // Reuses EventSystem and Canvas-space raycast buffers for callers that test
         // many positions in one frame, such as screenshot annotation collection.
+        // Keep this scoped to one frame because it snapshots Canvas and Graphic state.
         internal sealed class RaycastContext
         {
             private readonly EventSystem _eventSystem;

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -11,37 +11,70 @@ namespace io.github.hatayama.uLoopMCP
     {
         public static RaycastResult? RaycastUI(Vector2 screenPosition, EventSystem eventSystem)
         {
-            PointerEventData pointerData = new PointerEventData(eventSystem)
+            RaycastContext context = CreateRaycastContext(eventSystem);
+            return context.Raycast(screenPosition);
+        }
+
+        internal static RaycastContext CreateRaycastContext(EventSystem eventSystem)
+        {
+            Debug.Assert(eventSystem != null, "EventSystem is required for UI raycasting.");
+            return new RaycastContext(eventSystem!);
+        }
+
+        // Reuses EventSystem and Canvas-space raycast buffers for callers that test
+        // many positions in one frame, such as screenshot annotation collection.
+        internal sealed class RaycastContext
+        {
+            private readonly EventSystem _eventSystem;
+            private readonly PointerEventData _pointerData;
+            private readonly List<RaycastResult> _eventSystemResults = new List<RaycastResult>();
+            private readonly List<CanvasRaycastSource> _canvasRaycastSources;
+
+            internal RaycastContext(EventSystem eventSystem)
             {
-                position = screenPosition
-            };
-            List<RaycastResult> results = new List<RaycastResult>();
-            eventSystem.RaycastAll(pointerData, results);
-            RaycastResult? canvasSpaceHit = RaycastCanvasSpace(screenPosition);
-
-            if (results.Count > 0)
-            {
-                RaycastResult firstHit = results[0];
-
-                if (canvasSpaceHit != null && ShouldPreferCanvasSpaceHit(canvasSpaceHit.Value, firstHit))
-                {
-                    return canvasSpaceHit;
-                }
-
-                return firstHit;
+                Debug.Assert(eventSystem != null, "EventSystem is required for UI raycasting.");
+                _eventSystem = eventSystem!;
+                _pointerData = new PointerEventData(eventSystem!);
+                _canvasRaycastSources = CollectCanvasRaycastSources();
             }
 
-            // EventSystem clips at Screen.width/height, which can be smaller than the
-            // Canvas layout space (Game view target resolution). Fall back to manual hit testing.
-            return canvasSpaceHit;
+            public RaycastResult? Raycast(Vector2 screenPosition)
+            {
+                _eventSystemResults.Clear();
+                _pointerData.position = screenPosition;
+                _eventSystem.RaycastAll(_pointerData, _eventSystemResults);
+                RaycastResult? canvasSpaceHit = RaycastCanvasSpaceFromSources(screenPosition, _canvasRaycastSources);
+
+                if (_eventSystemResults.Count > 0)
+                {
+                    RaycastResult firstHit = _eventSystemResults[0];
+
+                    if (canvasSpaceHit != null && ShouldPreferCanvasSpaceHit(canvasSpaceHit.Value, firstHit))
+                    {
+                        return canvasSpaceHit;
+                    }
+
+                    return firstHit;
+                }
+
+                // EventSystem clips at Screen.width/height, which can be smaller than the
+                // Canvas layout space (Game view target resolution). Fall back to manual hit testing.
+                return canvasSpaceHit;
+            }
         }
 
         // Bypass EventSystem's Screen-bounds clipping by directly testing Graphic rects in Canvas space.
         // Only supports ScreenSpaceOverlay canvases where world positions equal Canvas-space positions.
         public static RaycastResult? RaycastCanvasSpace(Vector2 canvasPosition)
         {
+            List<CanvasRaycastSource> canvasRaycastSources = CollectCanvasRaycastSources();
+            return RaycastCanvasSpaceFromSources(canvasPosition, canvasRaycastSources);
+        }
+
+        private static List<CanvasRaycastSource> CollectCanvasRaycastSources()
+        {
             Canvas[] canvases = Object.FindObjectsByType<Canvas>(FindObjectsSortMode.None);
-            RaycastResult? bestHit = null;
+            List<CanvasRaycastSource> canvasRaycastSources = new List<CanvasRaycastSource>();
 
             foreach (Canvas canvas in canvases)
             {
@@ -62,7 +95,26 @@ namespace io.github.hatayama.uLoopMCP
                 }
 
                 Graphic[] graphics = canvas.GetComponentsInChildren<Graphic>();
-                foreach (Graphic graphic in graphics)
+                canvasRaycastSources.Add(new CanvasRaycastSource(canvas, raycaster, graphics));
+            }
+
+            return canvasRaycastSources;
+        }
+
+        private static RaycastResult? RaycastCanvasSpaceFromSources(
+            Vector2 canvasPosition,
+            List<CanvasRaycastSource> canvasRaycastSources)
+        {
+            RaycastResult? bestHit = null;
+
+            foreach (CanvasRaycastSource source in canvasRaycastSources)
+            {
+                if (!source.Canvas.isActiveAndEnabled || !source.Raycaster.isActiveAndEnabled)
+                {
+                    continue;
+                }
+
+                foreach (Graphic graphic in source.Graphics)
                 {
                     if (!IsRaycastCandidate(graphic, canvasPosition))
                     {
@@ -72,10 +124,10 @@ namespace io.github.hatayama.uLoopMCP
                     RaycastResult candidate = new RaycastResult
                     {
                         gameObject = graphic.gameObject,
-                        module = raycaster,
+                        module = source.Raycaster,
                         screenPosition = canvasPosition,
-                        sortingLayer = canvas.sortingLayerID,
-                        sortingOrder = canvas.sortingOrder,
+                        sortingLayer = source.Canvas.sortingLayerID,
+                        sortingOrder = source.Canvas.sortingOrder,
                         depth = graphic.depth
                     };
 
@@ -87,6 +139,20 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             return bestHit;
+        }
+
+        private readonly struct CanvasRaycastSource
+        {
+            public Canvas Canvas { get; }
+            public GraphicRaycaster Raycaster { get; }
+            public Graphic[] Graphics { get; }
+
+            public CanvasRaycastSource(Canvas canvas, GraphicRaycaster raycaster, Graphic[] graphics)
+            {
+                Canvas = canvas;
+                Raycaster = raycaster;
+                Graphics = graphics;
+            }
         }
 
         // Respects CanvasGroup.blocksRaycasts, Mask, RectMask2D, and custom ICanvasRaycastFilter

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/UiRaycastHelper.cs
@@ -11,14 +11,8 @@ namespace io.github.hatayama.uLoopMCP
     {
         public static RaycastResult? RaycastUI(Vector2 screenPosition, EventSystem eventSystem)
         {
-            RaycastContext context = CreateRaycastContext(eventSystem);
+            RaycastContext context = new RaycastContext(eventSystem);
             return context.Raycast(screenPosition);
-        }
-
-        internal static RaycastContext CreateRaycastContext(EventSystem eventSystem)
-        {
-            Debug.Assert(eventSystem != null, "EventSystem is required for UI raycasting.");
-            return new RaycastContext(eventSystem!);
         }
 
         // Reuses EventSystem and Canvas-space raycast buffers for callers that test
@@ -63,14 +57,6 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
-        // Bypass EventSystem's Screen-bounds clipping by directly testing Graphic rects in Canvas space.
-        // Only supports ScreenSpaceOverlay canvases where world positions equal Canvas-space positions.
-        public static RaycastResult? RaycastCanvasSpace(Vector2 canvasPosition)
-        {
-            List<CanvasRaycastSource> canvasRaycastSources = CollectCanvasRaycastSources();
-            return RaycastCanvasSpaceFromSources(canvasPosition, canvasRaycastSources);
-        }
-
         private static List<CanvasRaycastSource> CollectCanvasRaycastSources()
         {
             Canvas[] canvases = Object.FindObjectsByType<Canvas>(FindObjectsSortMode.None);
@@ -109,11 +95,6 @@ namespace io.github.hatayama.uLoopMCP
 
             foreach (CanvasRaycastSource source in canvasRaycastSources)
             {
-                if (!source.Canvas.isActiveAndEnabled || !source.Raycaster.isActiveAndEnabled)
-                {
-                    continue;
-                }
-
                 foreach (Graphic graphic in source.Graphics)
                 {
                     if (!IsRaycastCandidate(graphic, canvasPosition))

--- a/Packages/src/Editor/Utils/UIElementAnnotator.cs
+++ b/Packages/src/Editor/Utils/UIElementAnnotator.cs
@@ -113,15 +113,21 @@ namespace io.github.hatayama.uLoopMCP
             canvas.sortingOrder = OVERLAY_SORT_ORDER;
 
             Font font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            List<AnnotationDrawInfo> drawInfos = new List<AnnotationDrawInfo>(elements.Count);
 
             foreach (UIElementInfo element in elements)
             {
-                CreateAnnotationBorderForElement(root.transform, element, borderMetrics);
+                drawInfos.Add(CreateAnnotationDrawInfo(element));
             }
 
-            foreach (UIElementInfo element in elements)
+            foreach (AnnotationDrawInfo drawInfo in drawInfos)
             {
-                CreateAnnotationLabelForElement(root.transform, element, font, borderMetrics);
+                CreateAnnotationBorderForElement(root.transform, drawInfo, borderMetrics);
+            }
+
+            foreach (AnnotationDrawInfo drawInfo in drawInfos)
+            {
+                CreateAnnotationLabelForElement(root.transform, drawInfo, font, borderMetrics);
             }
 
             return root;
@@ -312,7 +318,7 @@ namespace io.github.hatayama.uLoopMCP
                 return null;
             }
 
-            return UiRaycastHelper.CreateRaycastContext(eventSystem);
+            return new UiRaycastHelper.RaycastContext(eventSystem);
         }
 
         // Writes 4 corners into SharedScreenCorners in screen pixel coordinates (bottom-left origin).
@@ -364,59 +370,71 @@ namespace io.github.hatayama.uLoopMCP
 
         private static void CreateAnnotationBorderForElement(
             Transform parent,
-            UIElementInfo element,
+            AnnotationDrawInfo drawInfo,
             AnnotationBorderMetrics borderMetrics)
         {
-            float screenMinX = element.BoundsMinX;
-            float screenMaxX = element.BoundsMaxX;
-            float screenMinY = element.BoundsMinY;
-            float screenMaxY = element.BoundsMaxY;
-
-            Color color = GetAnnotationColorForElement(element);
-            AnnotationBorderColors borderColors = GetAnnotationBorderColors(color);
-
             CreateBorder(
                 parent,
                 "LightOuter",
-                screenMinX - borderMetrics.OuterOffset,
-                screenMinY - borderMetrics.OuterOffset,
-                screenMaxX + borderMetrics.OuterOffset,
-                screenMaxY + borderMetrics.OuterOffset,
+                drawInfo.ScreenMinX - borderMetrics.OuterOffset,
+                drawInfo.ScreenMinY - borderMetrics.OuterOffset,
+                drawInfo.ScreenMaxX + borderMetrics.OuterOffset,
+                drawInfo.ScreenMaxY + borderMetrics.OuterOffset,
                 borderMetrics.NeutralThickness,
-                borderColors.Outer);
+                drawInfo.BorderColors.Outer);
             CreateBorder(
                 parent,
                 "ColorMiddle",
-                screenMinX - borderMetrics.ColorOffset,
-                screenMinY - borderMetrics.ColorOffset,
-                screenMaxX + borderMetrics.ColorOffset,
-                screenMaxY + borderMetrics.ColorOffset,
+                drawInfo.ScreenMinX - borderMetrics.ColorOffset,
+                drawInfo.ScreenMinY - borderMetrics.ColorOffset,
+                drawInfo.ScreenMaxX + borderMetrics.ColorOffset,
+                drawInfo.ScreenMaxY + borderMetrics.ColorOffset,
                 borderMetrics.ColorThickness,
-                borderColors.Middle);
-            CreateBorder(parent, "DarkInner", screenMinX, screenMinY, screenMaxX, screenMaxY, borderMetrics.NeutralThickness, borderColors.Inner);
+                drawInfo.BorderColors.Middle);
+            CreateBorder(
+                parent,
+                "DarkInner",
+                drawInfo.ScreenMinX,
+                drawInfo.ScreenMinY,
+                drawInfo.ScreenMaxX,
+                drawInfo.ScreenMaxY,
+                borderMetrics.NeutralThickness,
+                drawInfo.BorderColors.Inner);
         }
 
         private static void CreateAnnotationLabelForElement(
             Transform parent,
-            UIElementInfo element,
+            AnnotationDrawInfo drawInfo,
             Font font,
             AnnotationBorderMetrics borderMetrics)
         {
-            float screenMinX = element.BoundsMinX;
-            float screenMaxY = element.BoundsMaxY;
-            Color color = GetAnnotationColorForElement(element);
-            Color contrastColor = GetContrastingTextColor(color);
-
-            string labelText = CreateDisplayLabel(element);
             CreateLabel(
                 parent,
-                labelText,
-                screenMinX,
-                screenMaxY + borderMetrics.OuterOffset + borderMetrics.LabelOutlineDistance + borderMetrics.LabelToBorderGap,
-                color,
-                contrastColor,
+                drawInfo.DisplayLabel,
+                drawInfo.ScreenMinX,
+                drawInfo.ScreenMaxY + borderMetrics.OuterOffset + borderMetrics.LabelOutlineDistance + borderMetrics.LabelToBorderGap,
+                drawInfo.Color,
+                drawInfo.ContrastColor,
                 font,
                 borderMetrics.LabelOutlineDistance);
+        }
+
+        private static AnnotationDrawInfo CreateAnnotationDrawInfo(UIElementInfo element)
+        {
+            Color color = GetAnnotationColorForElement(element);
+            Color contrastColor = GetContrastingTextColor(color);
+            AnnotationBorderColors borderColors = GetAnnotationBorderColors(color);
+            string displayLabel = CreateDisplayLabel(element);
+
+            return new AnnotationDrawInfo(
+                element.BoundsMinX,
+                element.BoundsMinY,
+                element.BoundsMaxX,
+                element.BoundsMaxY,
+                color,
+                contrastColor,
+                borderColors,
+                displayLabel);
         }
 
         private static void CreateBorder(
@@ -670,6 +688,38 @@ namespace io.github.hatayama.uLoopMCP
                 Inner = inner;
                 Middle = middle;
                 Outer = outer;
+            }
+        }
+
+        private readonly struct AnnotationDrawInfo
+        {
+            public readonly float ScreenMinX;
+            public readonly float ScreenMinY;
+            public readonly float ScreenMaxX;
+            public readonly float ScreenMaxY;
+            public readonly Color Color;
+            public readonly Color ContrastColor;
+            public readonly AnnotationBorderColors BorderColors;
+            public readonly string DisplayLabel;
+
+            public AnnotationDrawInfo(
+                float screenMinX,
+                float screenMinY,
+                float screenMaxX,
+                float screenMaxY,
+                Color color,
+                Color contrastColor,
+                AnnotationBorderColors borderColors,
+                string displayLabel)
+            {
+                ScreenMinX = screenMinX;
+                ScreenMinY = screenMinY;
+                ScreenMaxX = screenMaxX;
+                ScreenMaxY = screenMaxY;
+                Color = color;
+                ContrastColor = contrastColor;
+                BorderColors = borderColors;
+                DisplayLabel = displayLabel;
             }
         }
 

--- a/Packages/src/Editor/Utils/UIElementAnnotator.cs
+++ b/Packages/src/Editor/Utils/UIElementAnnotator.cs
@@ -53,9 +53,10 @@ namespace io.github.hatayama.uLoopMCP
         {
             List<UIElementInfo> elements = new List<UIElementInfo>();
             HashSet<GameObject> processedObjects = new HashSet<GameObject>();
+            UiRaycastHelper.RaycastContext raycastContext = CreateRaycastContextForCurrentEventSystem();
 
-            CollectSelectables(elements, processedObjects);
-            CollectEventHandlers(elements, processedObjects);
+            CollectSelectables(elements, processedObjects, raycastContext);
+            CollectEventHandlers(elements, processedObjects, raycastContext);
 
             return elements;
         }
@@ -129,7 +130,10 @@ namespace io.github.hatayama.uLoopMCP
             }
         }
 
-        private static void CollectSelectables(List<UIElementInfo> elements, HashSet<GameObject> processedObjects)
+        private static void CollectSelectables(
+            List<UIElementInfo> elements,
+            HashSet<GameObject> processedObjects,
+            UiRaycastHelper.RaycastContext raycastContext)
         {
             Selectable[] selectables = Selectable.allSelectablesArray;
             foreach (Selectable selectable in selectables)
@@ -142,13 +146,16 @@ namespace io.github.hatayama.uLoopMCP
                 processedObjects.Add(selectable.gameObject);
 
                 string type = ClassifySelectable(selectable);
-                AddElementInfo(elements, selectable.gameObject, selectable.name, type);
+                AddElementInfo(elements, selectable.gameObject, selectable.name, type, raycastContext);
             }
         }
 
         // Collects non-Selectable MonoBehaviours that implement pointer/drag event interfaces.
         // Priority: IDragHandler > IDropHandler > IPointerClickHandler > IPointerDownHandler
-        private static void CollectEventHandlers(List<UIElementInfo> elements, HashSet<GameObject> processedObjects)
+        private static void CollectEventHandlers(
+            List<UIElementInfo> elements,
+            HashSet<GameObject> processedObjects,
+            UiRaycastHelper.RaycastContext raycastContext)
         {
             MonoBehaviour[] allBehaviours = Object.FindObjectsOfType<MonoBehaviour>();
             foreach (MonoBehaviour behaviour in allBehaviours)
@@ -170,7 +177,7 @@ namespace io.github.hatayama.uLoopMCP
                 }
 
                 processedObjects.Add(behaviour.gameObject);
-                AddElementInfo(elements, behaviour.gameObject, behaviour.name, type);
+                AddElementInfo(elements, behaviour.gameObject, behaviour.name, type, raycastContext);
             }
         }
 
@@ -200,7 +207,12 @@ namespace io.github.hatayama.uLoopMCP
         private static readonly Vector3[] SharedWorldCorners = new Vector3[4];
         private static readonly Vector2[] SharedScreenCorners = new Vector2[4];
 
-        private static void AddElementInfo(List<UIElementInfo> elements, GameObject go, string name, string type)
+        private static void AddElementInfo(
+            List<UIElementInfo> elements,
+            GameObject go,
+            string name,
+            string type,
+            UiRaycastHelper.RaycastContext raycastContext)
         {
             RectTransform rectTransform = go.GetComponent<RectTransform>();
             if (rectTransform == null)
@@ -233,7 +245,7 @@ namespace io.github.hatayama.uLoopMCP
             float centerX = (minX + maxX) / 2f;
             float centerY = (minY + maxY) / 2f;
 
-            if (!IsRaycastReachable(go, centerX, centerY))
+            if (!IsRaycastReachable(go, centerX, centerY, raycastContext))
             {
                 return;
             }
@@ -261,17 +273,20 @@ namespace io.github.hatayama.uLoopMCP
             return canvas.isActiveAndEnabled && raycaster != null && raycaster.isActiveAndEnabled;
         }
 
-        // Uses the same raycast path as simulate-mouse so annotations only advertise
-        // elements that can receive the advertised interaction at their center point.
-        private static bool IsRaycastReachable(GameObject go, float centerX, float centerY)
+        // Uses the same raycast path as simulate-mouse so annotations match UI input behavior.
+        // Skips the check when no EventSystem exists, such as annotation-only scenes without interaction.
+        private static bool IsRaycastReachable(
+            GameObject go,
+            float centerX,
+            float centerY,
+            UiRaycastHelper.RaycastContext raycastContext)
         {
-            EventSystem eventSystem = EventSystem.current;
-            if (eventSystem == null)
+            if (raycastContext == null)
             {
                 return true;
             }
 
-            RaycastResult? raycastResult = UiRaycastHelper.RaycastUI(new Vector2(centerX, centerY), eventSystem);
+            RaycastResult? raycastResult = raycastContext.Raycast(new Vector2(centerX, centerY));
             if (raycastResult == null)
             {
                 return false;
@@ -280,6 +295,19 @@ namespace io.github.hatayama.uLoopMCP
             Transform targetTransform = go.transform;
             Transform hitTransform = raycastResult.Value.gameObject.transform;
             return hitTransform == targetTransform || hitTransform.IsChildOf(targetTransform);
+        }
+
+        // Reuses one raycast context while collecting annotations because a screenshot can
+        // test many UI elements in one frame.
+        private static UiRaycastHelper.RaycastContext CreateRaycastContextForCurrentEventSystem()
+        {
+            EventSystem eventSystem = EventSystem.current;
+            if (eventSystem == null)
+            {
+                return null;
+            }
+
+            return UiRaycastHelper.CreateRaycastContext(eventSystem);
         }
 
         // Writes 4 corners into SharedScreenCorners in screen pixel coordinates (bottom-left origin).

--- a/Packages/src/Editor/Utils/UIElementAnnotator.cs
+++ b/Packages/src/Editor/Utils/UIElementAnnotator.cs
@@ -116,7 +116,12 @@ namespace io.github.hatayama.uLoopMCP
 
             foreach (UIElementInfo element in elements)
             {
-                CreateAnnotationForElement(root.transform, element, font, borderMetrics);
+                CreateAnnotationBorderForElement(root.transform, element, borderMetrics);
+            }
+
+            foreach (UIElementInfo element in elements)
+            {
+                CreateAnnotationLabelForElement(root.transform, element, font, borderMetrics);
             }
 
             return root;
@@ -357,10 +362,9 @@ namespace io.github.hatayama.uLoopMCP
             return true;
         }
 
-        private static void CreateAnnotationForElement(
+        private static void CreateAnnotationBorderForElement(
             Transform parent,
             UIElementInfo element,
-            Font font,
             AnnotationBorderMetrics borderMetrics)
         {
             float screenMinX = element.BoundsMinX;
@@ -369,7 +373,6 @@ namespace io.github.hatayama.uLoopMCP
             float screenMaxY = element.BoundsMaxY;
 
             Color color = GetAnnotationColorForElement(element);
-            Color contrastColor = GetContrastingTextColor(color);
             AnnotationBorderColors borderColors = GetAnnotationBorderColors(color);
 
             CreateBorder(
@@ -391,6 +394,18 @@ namespace io.github.hatayama.uLoopMCP
                 borderMetrics.ColorThickness,
                 borderColors.Middle);
             CreateBorder(parent, "DarkInner", screenMinX, screenMinY, screenMaxX, screenMaxY, borderMetrics.NeutralThickness, borderColors.Inner);
+        }
+
+        private static void CreateAnnotationLabelForElement(
+            Transform parent,
+            UIElementInfo element,
+            Font font,
+            AnnotationBorderMetrics borderMetrics)
+        {
+            float screenMinX = element.BoundsMinX;
+            float screenMaxY = element.BoundsMaxY;
+            Color color = GetAnnotationColorForElement(element);
+            Color contrastColor = GetContrastingTextColor(color);
 
             string labelText = CreateDisplayLabel(element);
             CreateLabel(

--- a/Packages/src/Editor/Utils/UIElementAnnotator.cs
+++ b/Packages/src/Editor/Utils/UIElementAnnotator.cs
@@ -199,9 +199,6 @@ namespace io.github.hatayama.uLoopMCP
         // Reusable buffers to avoid per-element allocations in AddElementInfo → GetScreenCorners
         private static readonly Vector3[] SharedWorldCorners = new Vector3[4];
         private static readonly Vector2[] SharedScreenCorners = new Vector2[4];
-        private static readonly List<RaycastResult> SharedRaycastResults = new List<RaycastResult>();
-        private static PointerEventData SharedPointerEventData;
-        private static EventSystem SharedPointerEventSystem;
 
         private static void AddElementInfo(List<UIElementInfo> elements, GameObject go, string name, string type)
         {
@@ -261,12 +258,11 @@ namespace io.github.hatayama.uLoopMCP
         private static bool HasActiveGraphicRaycaster(Canvas canvas)
         {
             GraphicRaycaster raycaster = canvas.GetComponent<GraphicRaycaster>();
-            return raycaster != null && raycaster.isActiveAndEnabled;
+            return canvas.isActiveAndEnabled && raycaster != null && raycaster.isActiveAndEnabled;
         }
 
-        // simulate-mouse uses EventSystem.RaycastAll, so only advertise elements whose
-        // center point is actually hittable. Skips the check when no EventSystem exists
-        // (e.g. annotation-only scenes without interaction).
+        // Uses the same raycast path as simulate-mouse so annotations only advertise
+        // elements that can receive the advertised interaction at their center point.
         private static bool IsRaycastReachable(GameObject go, float centerX, float centerY)
         {
             EventSystem eventSystem = EventSystem.current;
@@ -275,36 +271,15 @@ namespace io.github.hatayama.uLoopMCP
                 return true;
             }
 
-            if (SharedPointerEventData == null || SharedPointerEventSystem != eventSystem)
+            RaycastResult? raycastResult = UiRaycastHelper.RaycastUI(new Vector2(centerX, centerY), eventSystem);
+            if (raycastResult == null)
             {
-                SharedPointerEventData = new PointerEventData(eventSystem);
-                SharedPointerEventSystem = eventSystem;
+                return false;
             }
-            SharedPointerEventData.position = new Vector2(centerX, centerY);
-
-            SharedRaycastResults.Clear();
-            eventSystem.RaycastAll(SharedPointerEventData, SharedRaycastResults);
 
             Transform targetTransform = go.transform;
-            foreach (RaycastResult raycastResult in SharedRaycastResults)
-            {
-                Transform hitTransform = raycastResult.gameObject.transform;
-                if (hitTransform == targetTransform || hitTransform.IsChildOf(targetTransform))
-                {
-                    return true;
-                }
-            }
-
-            // EventSystem clips at Screen.width/height which can be smaller than the
-            // Canvas layout space (Game view target resolution). Check Canvas space directly.
-            RectTransform rectTransform = go.GetComponent<RectTransform>();
-            if (rectTransform != null)
-            {
-                return RectTransformUtility.RectangleContainsScreenPoint(
-                    rectTransform, new Vector2(centerX, centerY), null);
-            }
-
-            return false;
+            Transform hitTransform = raycastResult.Value.gameObject.transform;
+            return hitTransform == targetTransform || hitTransform.IsChildOf(targetTransform);
         }
 
         // Writes 4 corners into SharedScreenCorners in screen pixel coordinates (bottom-left origin).


### PR DESCRIPTION
## Summary
- Screenshot annotations now avoid labeling disabled, covered, or otherwise unreachable UI controls as clickable.

## User Impact
- Button-like UI that cannot receive clicks is no longer shown as an actionable target in annotated screenshots.
- Annotation output now matches what UI click simulation can actually interact with.

## Changes
- Reused the existing UI raycast reachability check when collecting screenshot annotation targets.
- Skipped disabled canvases and raycasters consistently across annotation and UI simulation paths.
- Added EditMode and PlayMode coverage for disabled canvases, visible buttons, and covered controls.

## Verification
- `uloop compile --wait-for-domain-reload true`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "UIElementAnnotatorTests"`
- `uloop run-tests --test-mode PlayMode --filter-type regex --filter-value "SimulateMouseUiTests"`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Updated screenshot annotation target collection to mark only UI controls that are actually raycast-reachable/clickable, reusing the same `UiRaycastHelper` reachability logic used by UI mouse click simulation.
- Refactored `UiRaycastHelper` to centralize UI hit-testing in a frame-scoped `RaycastContext` that snapshots EventSystem pointer/Canvas+Graphic raycast inputs and selects the preferred hit using the existing priority rule.
- Aligned canvas and raycaster handling with click simulation: disabled canvases/graphics are excluded, and covered/unreachable controls are not treated as actionable.
- Improved annotation overlay rendering by switching to a two-pass approach (borders first, then labels) so label hierarchy remains visible when elements overlap.

## Tests
- **EditMode (`UIElementAnnotatorTests`)**: added fixture setup/teardown cleanup and new coroutine coverage to verify `CollectInteractiveElements()` skips buttons under disabled canvases and includes buttons when visible; added coverage for overlay render ordering (labels above borders).
- **PlayMode (`SimulateMouseUiTests`)**: added regression tests to ensure clicks ignore disabled ScreenSpaceOverlay contents and to ensure interactables covered by a front UI graphic are excluded from collected interactive elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->