### PR TITLE
chore: Release PR checks now run without manual approval

### DIFF
--- a/tools/release-automation/internal/automation/release_pr_check_runs.go
+++ b/tools/release-automation/internal/automation/release_pr_check_runs.go
@@ -1,0 +1,120 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type releaseWorkflowRun struct {
+	DatabaseID int64  `json:"databaseId"`
+	HeadSHA    string `json:"headSha"`
+	CreatedAt  string `json:"createdAt"`
+}
+
+func dispatchReleasePRCheckWorkflow(ctx context.Context, config releasePRCheckConfig, workflow string, releasePR releasePullRequest) error {
+	_, err := runReleasePRCheckOutput(ctx, "gh", "workflow", "run", workflow, "--repo", config.repository, "--ref", releasePR.HeadRefName)
+	return err
+}
+
+func findDispatchedReleasePRCheckRun(
+	ctx context.Context,
+	config releasePRCheckConfig,
+	workflow string,
+	releasePR releasePullRequest,
+	dispatchedAt time.Time,
+) (releaseWorkflowRun, error) {
+	for attempt := 0; attempt < config.lookupAttempts; attempt++ {
+		run, found, err := latestReleasePRCheckRun(ctx, config, workflow, releasePR, dispatchedAt)
+		if err != nil {
+			return releaseWorkflowRun{}, err
+		}
+		if found {
+			return run, nil
+		}
+		if attempt+1 < config.lookupAttempts {
+			err = releasePRCheckSleep(ctx, time.Duration(config.lookupIntervalSeconds)*time.Second)
+			if err != nil {
+				return releaseWorkflowRun{}, err
+			}
+		}
+	}
+	return releaseWorkflowRun{}, fmt.Errorf("could not find dispatched %s workflow run for %s", workflow, releasePR.HeadRefOID)
+}
+
+func latestReleasePRCheckRun(
+	ctx context.Context,
+	config releasePRCheckConfig,
+	workflow string,
+	releasePR releasePullRequest,
+	dispatchedAt time.Time,
+) (releaseWorkflowRun, bool, error) {
+	output, err := runReleasePRCheckOutput(
+		ctx,
+		"gh",
+		"run",
+		"list",
+		"--repo",
+		config.repository,
+		"--workflow",
+		workflow,
+		"--branch",
+		releasePR.HeadRefName,
+		"--event",
+		"workflow_dispatch",
+		"--json",
+		"databaseId,status,conclusion,headSha,createdAt,url",
+		"--limit",
+		"20",
+	)
+	if err != nil {
+		return releaseWorkflowRun{}, false, err
+	}
+
+	runs := []releaseWorkflowRun{}
+	err = json.Unmarshal([]byte(output), &runs)
+	if err != nil {
+		return releaseWorkflowRun{}, false, fmt.Errorf("failed to parse workflow runs: %w", err)
+	}
+
+	var latestRun releaseWorkflowRun
+	var latestCreatedAt time.Time
+	found := false
+	for _, run := range runs {
+		createdAt, err := time.Parse(time.RFC3339, run.CreatedAt)
+		if err != nil {
+			return releaseWorkflowRun{}, false, fmt.Errorf("failed to parse workflow run createdAt %q: %w", run.CreatedAt, err)
+		}
+		if createdAt.Before(dispatchedAt) {
+			continue
+		}
+		if !found || createdAt.After(latestCreatedAt) {
+			latestRun = run
+			latestCreatedAt = createdAt
+			found = true
+		}
+	}
+	if !found {
+		return releaseWorkflowRun{}, false, nil
+	}
+	return latestRun, true, nil
+}
+
+func watchReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, runID int64) error {
+	_, err := runReleasePRCheckOutput(
+		ctx,
+		"gh",
+		"run",
+		"watch",
+		strconv.FormatInt(runID, 10),
+		"--repo",
+		config.repository,
+		"--exit-status",
+		"--compact",
+		"--interval",
+		strconv.Itoa(config.watchIntervalSeconds),
+	)
+	return err
+}

--- a/tools/release-automation/internal/automation/release_pr_checks.go
+++ b/tools/release-automation/internal/automation/release_pr_checks.go
@@ -14,7 +14,12 @@ import (
 )
 
 const (
-	defaultReleasePRCheckWorkflow              = "build-and-test.yml"
+	// GITHUB_TOKEN-created release PRs never trigger pull_request workflows on
+	// their own, so every workflow that produces a required status check must be
+	// dispatched here: build-cli, test-unity-package, and test-windows-installers
+	// come from build-and-test.yml, while Compile Check (Linux) comes from
+	// unity-compile-check-and-test-runner.yml.
+	defaultReleasePRCheckWorkflows             = "build-and-test.yml,unity-compile-check-and-test-runner.yml"
 	defaultReleasePRCheckLookupAttempts        = 30
 	defaultReleasePRCheckLookupIntervalSeconds = 10
 	defaultReleasePRCheckWatchIntervalSeconds  = 10
@@ -38,7 +43,7 @@ var (
 type releasePRCheckConfig struct {
 	repository            string
 	targetBranch          string
-	workflow              string
+	workflows             []string
 	lookupAttempts        int
 	lookupIntervalSeconds int
 	watchIntervalSeconds  int
@@ -54,12 +59,6 @@ type releasePullRequest struct {
 
 type releasePullRequestBody struct {
 	Body string `json:"body"`
-}
-
-type releaseWorkflowRun struct {
-	DatabaseID int64  `json:"databaseId"`
-	HeadSHA    string `json:"headSha"`
-	CreatedAt  string `json:"createdAt"`
 }
 
 func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.Writer) int {
@@ -96,27 +95,48 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 	writeReleasePRCheckLine(stdout, fmt.Sprintf("Marked release PR #%d as draft while checks run.", releasePR.Number))
 
 	dispatchedAt := releasePRCheckNow().UTC().Truncate(time.Second)
-	writeReleasePRCheckLine(stdout, fmt.Sprintf("Dispatching %s for release PR #%d: %s", config.workflow, releasePR.Number, releasePR.URL))
-	err = dispatchReleasePRCheckWorkflow(ctx, config, releasePR)
-	if err != nil {
-		writeReleasePRCheckLine(stderr, err)
-		return 1
+	for _, workflow := range config.workflows {
+		writeReleasePRCheckLine(stdout, fmt.Sprintf("Dispatching %s for release PR #%d: %s", workflow, releasePR.Number, releasePR.URL))
+		err = dispatchReleasePRCheckWorkflow(ctx, config, workflow, releasePR)
+		if err != nil {
+			writeReleasePRCheckLine(stderr, err)
+			return 1
+		}
 	}
 
-	run, err := findDispatchedReleasePRCheckRun(ctx, config, releasePR, dispatchedAt)
-	if err != nil {
-		writeReleasePRCheckLine(stderr, err)
-		return 1
+	checkedHeadSHA := ""
+	checkedHeadWorkflow := ""
+	for _, workflow := range config.workflows {
+		run, err := findDispatchedReleasePRCheckRun(ctx, config, workflow, releasePR, dispatchedAt)
+		if err != nil {
+			writeReleasePRCheckLine(stderr, err)
+			return 1
+		}
+
+		writeReleasePRCheckLine(stdout, fmt.Sprintf("Watching %s run %d for release PR #%d.", workflow, run.DatabaseID, releasePR.Number))
+		err = watchReleasePRCheckRun(ctx, config, run.DatabaseID)
+		if err != nil {
+			writeReleasePRCheckLine(stderr, err)
+			return 1
+		}
+
+		// A release-please force-push between two dispatches would let each
+		// workflow validate a different commit, so a mixed set of green runs
+		// must not mark the PR ready.
+		if checkedHeadSHA == "" {
+			checkedHeadSHA = run.HeadSHA
+			checkedHeadWorkflow = workflow
+			continue
+		}
+		if run.HeadSHA != checkedHeadSHA {
+			writeReleasePRCheckLine(stderr, fmt.Errorf(
+				"release PR #%d checks ran on different heads: %s checked %s but %s checked %s",
+				releasePR.Number, checkedHeadWorkflow, checkedHeadSHA, workflow, run.HeadSHA))
+			return 1
+		}
 	}
 
-	writeReleasePRCheckLine(stdout, fmt.Sprintf("Watching %s run %d for release PR #%d.", config.workflow, run.DatabaseID, releasePR.Number))
-	err = watchReleasePRCheckRun(ctx, config, run.DatabaseID)
-	if err != nil {
-		writeReleasePRCheckLine(stderr, err)
-		return 1
-	}
-
-	err = verifyReleasePRCheckHeadMatchesRun(ctx, config, releasePR, run.HeadSHA)
+	err = verifyReleasePRCheckHeadMatchesRun(ctx, config, releasePR, checkedHeadSHA)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
@@ -141,9 +161,9 @@ func releasePRCheckConfigFromEnvironment() (releasePRCheckConfig, error) {
 		return releasePRCheckConfig{}, fmt.Errorf("TARGET_BRANCH is required")
 	}
 
-	workflow := os.Getenv("RELEASE_PR_CHECK_WORKFLOW")
-	if workflow == "" {
-		workflow = defaultReleasePRCheckWorkflow
+	workflows, err := releasePRCheckWorkflowsFromEnvironment()
+	if err != nil {
+		return releasePRCheckConfig{}, err
 	}
 
 	lookupAttempts, err := releasePRCheckPositiveIntFromEnvironment("RELEASE_PR_CHECK_LOOKUP_ATTEMPTS", defaultReleasePRCheckLookupAttempts)
@@ -162,11 +182,31 @@ func releasePRCheckConfigFromEnvironment() (releasePRCheckConfig, error) {
 	return releasePRCheckConfig{
 		repository:            repository,
 		targetBranch:          targetBranch,
-		workflow:              workflow,
+		workflows:             workflows,
 		lookupAttempts:        lookupAttempts,
 		lookupIntervalSeconds: lookupIntervalSeconds,
 		watchIntervalSeconds:  watchIntervalSeconds,
 	}, nil
+}
+
+func releasePRCheckWorkflowsFromEnvironment() ([]string, error) {
+	value := os.Getenv("RELEASE_PR_CHECK_WORKFLOWS")
+	if value == "" {
+		value = defaultReleasePRCheckWorkflows
+	}
+
+	workflows := []string{}
+	for _, workflow := range strings.Split(value, ",") {
+		workflow = strings.TrimSpace(workflow)
+		if workflow == "" {
+			continue
+		}
+		workflows = append(workflows, workflow)
+	}
+	if len(workflows) == 0 {
+		return nil, fmt.Errorf("RELEASE_PR_CHECK_WORKFLOWS must list at least one workflow")
+	}
+	return workflows, nil
 }
 
 func releasePRCheckPositiveIntFromEnvironment(name string, defaultValue int) (int, error) {
@@ -276,11 +316,6 @@ func markReleasePRCheckReady(ctx context.Context, config releasePRCheckConfig, r
 	return err
 }
 
-func dispatchReleasePRCheckWorkflow(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) error {
-	_, err := runReleasePRCheckOutput(ctx, "gh", "workflow", "run", config.workflow, "--repo", config.repository, "--ref", releasePR.HeadRefName)
-	return err
-}
-
 func clarifyReleasePRCheckBody(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) (bool, error) {
 	output, err := runReleasePRCheckOutput(ctx, "gh", "pr", "view", strconv.Itoa(releasePR.Number), "--repo", config.repository, "--json", "body")
 	if err != nil {
@@ -329,104 +364,6 @@ func writeReleasePRCheckBodyFile(body string) (string, func(), error) {
 		return "", func() {}, fmt.Errorf("failed to close release PR body file: %w", closeErr)
 	}
 	return bodyFile.Name(), cleanup, nil
-}
-
-func findDispatchedReleasePRCheckRun(
-	ctx context.Context,
-	config releasePRCheckConfig,
-	releasePR releasePullRequest,
-	dispatchedAt time.Time,
-) (releaseWorkflowRun, error) {
-	for attempt := 0; attempt < config.lookupAttempts; attempt++ {
-		run, found, err := latestReleasePRCheckRun(ctx, config, releasePR, dispatchedAt)
-		if err != nil {
-			return releaseWorkflowRun{}, err
-		}
-		if found {
-			return run, nil
-		}
-		if attempt+1 < config.lookupAttempts {
-			err = releasePRCheckSleep(ctx, time.Duration(config.lookupIntervalSeconds)*time.Second)
-			if err != nil {
-				return releaseWorkflowRun{}, err
-			}
-		}
-	}
-	return releaseWorkflowRun{}, fmt.Errorf("could not find dispatched %s workflow run for %s", config.workflow, releasePR.HeadRefOID)
-}
-
-func latestReleasePRCheckRun(
-	ctx context.Context,
-	config releasePRCheckConfig,
-	releasePR releasePullRequest,
-	dispatchedAt time.Time,
-) (releaseWorkflowRun, bool, error) {
-	output, err := runReleasePRCheckOutput(
-		ctx,
-		"gh",
-		"run",
-		"list",
-		"--repo",
-		config.repository,
-		"--workflow",
-		config.workflow,
-		"--branch",
-		releasePR.HeadRefName,
-		"--event",
-		"workflow_dispatch",
-		"--json",
-		"databaseId,status,conclusion,headSha,createdAt,url",
-		"--limit",
-		"20",
-	)
-	if err != nil {
-		return releaseWorkflowRun{}, false, err
-	}
-
-	runs := []releaseWorkflowRun{}
-	err = json.Unmarshal([]byte(output), &runs)
-	if err != nil {
-		return releaseWorkflowRun{}, false, fmt.Errorf("failed to parse workflow runs: %w", err)
-	}
-
-	var latestRun releaseWorkflowRun
-	var latestCreatedAt time.Time
-	found := false
-	for _, run := range runs {
-		createdAt, err := time.Parse(time.RFC3339, run.CreatedAt)
-		if err != nil {
-			return releaseWorkflowRun{}, false, fmt.Errorf("failed to parse workflow run createdAt %q: %w", run.CreatedAt, err)
-		}
-		if createdAt.Before(dispatchedAt) {
-			continue
-		}
-		if !found || createdAt.After(latestCreatedAt) {
-			latestRun = run
-			latestCreatedAt = createdAt
-			found = true
-		}
-	}
-	if !found {
-		return releaseWorkflowRun{}, false, nil
-	}
-	return latestRun, true, nil
-}
-
-func watchReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, runID int64) error {
-	_, err := runReleasePRCheckOutput(
-		ctx,
-		"gh",
-		"run",
-		"watch",
-		strconv.FormatInt(runID, 10),
-		"--repo",
-		config.repository,
-		"--exit-status",
-		"--compact",
-		"--interval",
-		strconv.Itoa(config.watchIntervalSeconds),
-	)
-	return err
 }
 
 func verifyReleasePRCheckHeadMatchesRun(

--- a/tools/release-automation/internal/automation/release_pr_checks_test.go
+++ b/tools/release-automation/internal/automation/release_pr_checks_test.go
@@ -94,12 +94,13 @@ func TestReleasePRChecksSkipWhenNoReleasePRExists(t *testing.T) {
 	assertReleasePRCheckLogDoesNotContain(t, result.ghLog, "pr ready")
 }
 
-// Verifies that the matching release PR is drafted, dispatched, watched, and marked ready.
+// Verifies that the matching release PR is drafted, dispatched to every check workflow, watched, and marked ready.
 func TestReleasePRChecksDispatchAndMarkReady(t *testing.T) {
 	result := runReleasePRCheckCase(t, releasePRCheckCase{
-		prListJSON:     `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore(v3-beta): release 3.0.0-beta.5","url":"https://example.test/pr/1043"}]`,
-		runListJSON:    `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
-		runWatchStatus: "0",
+		prListJSON:              `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore(v3-beta): release 3.0.0-beta.5","url":"https://example.test/pr/1043"}]`,
+		runListJSON:             `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
+		compileCheckRunListJSON: `[{"databaseId":5353,"headSha":"abc123","createdAt":"2026-05-30T01:00:02Z","status":"queued","conclusion":"","url":"https://example.test/run/5353"}]`,
+		runWatchStatus:          "0",
 	})
 
 	if result.exitCode != 0 {
@@ -107,13 +108,67 @@ func TestReleasePRChecksDispatchAndMarkReady(t *testing.T) {
 	}
 	assertReleasePRCheckLogContains(t, result.stdout, "Marked release PR #1043 as draft while checks run.")
 	assertReleasePRCheckLogContains(t, result.stdout, "Dispatching build-and-test.yml for release PR #1043: https://example.test/pr/1043")
+	assertReleasePRCheckLogContains(t, result.stdout, "Dispatching unity-compile-check-and-test-runner.yml for release PR #1043: https://example.test/pr/1043")
 	assertReleasePRCheckLogContains(t, result.stdout, "Watching build-and-test.yml run 4242 for release PR #1043.")
+	assertReleasePRCheckLogContains(t, result.stdout, "Watching unity-compile-check-and-test-runner.yml run 5353 for release PR #1043.")
 	assertReleasePRCheckLogContains(t, result.stdout, "Marked release PR #1043 as ready after checks passed.")
 	assertReleasePRCheckLogContains(t, result.ghLog, "pr ready 1043 --repo owner/repository --undo")
 	assertReleasePRCheckLogContains(t, result.ghLog, "workflow run build-and-test.yml --repo owner/repository --ref release-please--branches--v3-beta")
+	assertReleasePRCheckLogContains(t, result.ghLog, "workflow run unity-compile-check-and-test-runner.yml --repo owner/repository --ref release-please--branches--v3-beta")
 	assertReleasePRCheckLogContains(t, result.ghLog, "run list --repo owner/repository --workflow build-and-test.yml --branch release-please--branches--v3-beta --event workflow_dispatch --json databaseId,status,conclusion,headSha,createdAt,url --limit 20")
+	assertReleasePRCheckLogContains(t, result.ghLog, "run list --repo owner/repository --workflow unity-compile-check-and-test-runner.yml --branch release-please--branches--v3-beta --event workflow_dispatch --json databaseId,status,conclusion,headSha,createdAt,url --limit 20")
 	assertReleasePRCheckLogContains(t, result.ghLog, "run watch 4242 --repo owner/repository --exit-status --compact --interval 1")
+	assertReleasePRCheckLogContains(t, result.ghLog, "run watch 5353 --repo owner/repository --exit-status --compact --interval 1")
 	assertReleasePRCheckLogContainsLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
+}
+
+// Verifies that the RELEASE_PR_CHECK_WORKFLOWS environment override replaces the default workflow list.
+func TestReleasePRChecksDispatchOnlyOverriddenWorkflows(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		runListJSON:    `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
+		runWatchStatus: "0",
+		workflows:      "override-checks.yml",
+	})
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr: %s", result.exitCode, result.stderr)
+	}
+	assertReleasePRCheckLogContains(t, result.ghLog, "workflow run override-checks.yml --repo owner/repository --ref release-please--branches--v3-beta")
+	assertReleasePRCheckLogDoesNotContain(t, result.ghLog, "workflow run build-and-test.yml")
+	assertReleasePRCheckLogDoesNotContain(t, result.ghLog, "workflow run unity-compile-check-and-test-runner.yml")
+}
+
+// Verifies that a blank workflow list override fails instead of silently dispatching nothing.
+func TestReleasePRChecksFailWhenWorkflowListIsBlank(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:     `[]`,
+		runListJSON:    `[]`,
+		runWatchStatus: "0",
+		workflows:      " , ",
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	}
+	assertReleasePRCheckLogContains(t, result.stderr, "RELEASE_PR_CHECK_WORKFLOWS must list at least one workflow")
+}
+
+// Verifies that check runs watching different branch heads fail while leaving the PR drafted.
+func TestReleasePRChecksFailWhenRunsCheckDifferentHeads(t *testing.T) {
+	result := runReleasePRCheckCase(t, releasePRCheckCase{
+		prListJSON:              `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`,
+		runListJSON:             `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`,
+		compileCheckRunListJSON: `[{"databaseId":5353,"headSha":"def456","createdAt":"2026-05-30T01:00:02Z","status":"queued","conclusion":"","url":"https://example.test/run/5353"}]`,
+		runWatchStatus:          "0",
+	})
+
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	}
+	assertReleasePRCheckLogContains(t, result.stderr, "release PR #1043 checks ran on different heads: build-and-test.yml checked abc123 but unity-compile-check-and-test-runner.yml checked def456")
+	assertReleasePRCheckLogContains(t, result.ghLog, "pr ready 1043 --repo owner/repository --undo")
+	assertReleasePRCheckLogDoesNotContainLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
 }
 
 // Verifies that matching release PRs are updated when the body has a plain Unity package summary.
@@ -274,14 +329,16 @@ func TestReleasePRChecksFailWhenHeadChangesBeforeReady(t *testing.T) {
 }
 
 type releasePRCheckCase struct {
-	ctx                  context.Context
-	prListJSON           string
-	prListJSONAfterWatch string
-	prViewJSON           string
-	runListJSON          string
-	runWatchStatus       string
-	lookupAttempts       string
-	now                  time.Time
+	ctx                     context.Context
+	prListJSON              string
+	prListJSONAfterWatch    string
+	prViewJSON              string
+	runListJSON             string
+	compileCheckRunListJSON string
+	runWatchStatus          string
+	lookupAttempts          string
+	workflows               string
+	now                     time.Time
 }
 
 func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRCheckRunResult {
@@ -325,7 +382,11 @@ func runReleasePRCheckCase(t *testing.T, testCase releasePRCheckCase) releasePRC
 	t.Setenv("GH_PR_LIST_COUNT_PATH", prListCountPath)
 	t.Setenv("GH_PR_VIEW_JSON", prViewJSON)
 	t.Setenv("GH_RUN_LIST_JSON", testCase.runListJSON)
+	t.Setenv("GH_RUN_LIST_JSON_COMPILE_CHECK", testCase.compileCheckRunListJSON)
 	t.Setenv("GH_RUN_WATCH_STATUS", testCase.runWatchStatus)
+	if testCase.workflows != "" {
+		t.Setenv("RELEASE_PR_CHECK_WORKFLOWS", testCase.workflows)
+	}
 	t.Setenv("GH_LOG", ghLogPath)
 	t.Setenv("GIT_LOG", gitLogPath)
 
@@ -417,6 +478,14 @@ if [ "$1" = "workflow" ] && [ "$2" = "run" ]; then
 fi
 
 if [ "$1" = "run" ] && [ "$2" = "list" ]; then
+  case "$*" in
+    *unity-compile-check-and-test-runner.yml*)
+      if [ -n "${GH_RUN_LIST_JSON_COMPILE_CHECK:-}" ]; then
+        printf '%s\n' "$GH_RUN_LIST_JSON_COMPILE_CHECK"
+        exit 0
+      fi
+      ;;
+  esac
   printf '%s\n' "$GH_RUN_LIST_JSON"
   exit 0
 fi
@@ -536,6 +605,11 @@ if "%~1"=="pr" if "%~2"=="edit" exit /b 0
 if "%~1"=="workflow" if "%~2"=="run" exit /b 0
 
 if "%~1"=="run" if "%~2"=="list" (
+  echo %* | findstr /c:"unity-compile-check-and-test-runner.yml" >nul
+  if not errorlevel 1 if not "%GH_RUN_LIST_JSON_COMPILE_CHECK%"=="" (
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "[Console]::Out.WriteLine($env:GH_RUN_LIST_JSON_COMPILE_CHECK)"
+    exit /b 0
+  )
   powershell -NoProfile -ExecutionPolicy Bypass -Command "[Console]::Out.WriteLine($env:GH_RUN_LIST_JSON)"
   exit /b 0
 )


### PR DESCRIPTION
## Summary
- Release PR required checks now start automatically; merging a release PR no longer needs a manual "Approve and run" click.

## User Impact
- Before: release PRs are created with `GITHUB_TOKEN`, which never triggers `pull_request` workflows, and the dispatch fallback only covered `build-and-test.yml`. The `Compile Check (Linux)` required check stayed missing until someone approved the held workflow runs, so every release PR was blocked from merging until a manual click.
- After: the release-please workflow dispatches every workflow that produces a required check and watches all of them, so the release PR reaches a mergeable state unattended.

## Changes
- Replace the single-workflow dispatch with a configurable list (`RELEASE_PR_CHECK_WORKFLOWS`, default `build-and-test.yml,unity-compile-check-and-test-runner.yml`).
- Refuse to mark the PR ready when the watched runs validated different branch heads (a release-please force-push between dispatches could otherwise slip through).
- Split the run lookup/watch helpers into `release_pr_check_runs.go` to keep the file under the 500-line architecture limit.

## Verification
- `scripts/check-go-cli.sh` (fmt, vet, lint, tests, builds across all Go modules)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

