### PR TITLE
fix: Dynamic code now accepts bare Unity Object calls

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/AutoInjectedNamespacesTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/AutoInjectedNamespacesTests.cs
@@ -13,7 +13,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -25,7 +25,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -37,7 +37,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             string body = "int x = 42;\nreturn x;";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -49,7 +49,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             string body = "StringBuilder sb = new StringBuilder();\nRegex r = new Regex(\"x\");\nreturn sb.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -62,7 +62,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             List<string> usings = new List<string> { "using System.Text;" };
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
-            string wrappedSource = WrapperTemplate.Build(usings, "TestNs", "TestClass", body);
+            string wrappedSource = WrapperTemplate.Build(usings, System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
@@ -304,6 +304,5 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
             Assert.AreEqual(0, prepared.HoistedLiteralBindings.Count);
             StringAssert.Contains("return 3000000000;", prepared.PreparedSource);
         }
-
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
@@ -62,7 +62,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
             Assert.IsNotNull(prepared.PreparedSource);
             Assert.AreEqual(
                 1,
-                CountSubstring(prepared.PreparedSource, "using Object = UnityEngine.Object;"));
+                DynamicCodeTestStringUtility.CountSubstring(prepared.PreparedSource, "using Object = UnityEngine.Object;"));
         }
 
         [Test]
@@ -76,7 +76,33 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
             Assert.IsNotNull(prepared.PreparedSource);
             Assert.AreEqual(
                 1,
-                CountSubstring(prepared.PreparedSource, "using Object = "));
+                DynamicCodeTestStringUtility.CountSubstring(prepared.PreparedSource, "using Object = "));
+        }
+
+        [Test]
+        public void Prepare_WhenVerbatimObjectAliasAlreadyExists_ShouldRespectUserAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "using @Object = System.Object;\nreturn new @Object();",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            Assert.AreEqual(
+                0,
+                DynamicCodeTestStringUtility.CountSubstring(prepared.PreparedSource, "using Object = UnityEngine.Object;"));
+        }
+
+        [Test]
+        public void Prepare_WhenScriptUsesBareUnityRandom_ShouldAddRandomAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "int value = Random.Range(0, 10);\nreturn value;",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            StringAssert.Contains("using Random = UnityEngine.Random;", prepared.PreparedSource);
         }
 
         [Test]
@@ -270,17 +296,5 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
             StringAssert.Contains("return 3000000000;", prepared.PreparedSource);
         }
 
-        private static int CountSubstring(string source, string target)
-        {
-            int count = 0;
-            int index = 0;
-            while ((index = source.IndexOf(target, index, System.StringComparison.Ordinal)) >= 0)
-            {
-                count++;
-                index += target.Length;
-            }
-
-            return count;
-        }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
@@ -88,6 +88,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
                 DynamicCodeConstants.DEFAULT_CLASS_NAME);
 
             Assert.IsNotNull(prepared.PreparedSource);
+            StringAssert.Contains("using @Object = System.Object;", prepared.PreparedSource);
             Assert.AreEqual(
                 0,
                 DynamicCodeTestStringUtility.CountSubstring(prepared.PreparedSource, "using Object = UnityEngine.Object;"));
@@ -103,6 +104,14 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
 
             Assert.IsNotNull(prepared.PreparedSource);
             StringAssert.Contains("using Random = UnityEngine.Random;", prepared.PreparedSource);
+        }
+
+        [Test]
+        public void CountSubstring_WhenTargetIsEmpty_ShouldReturnZero()
+        {
+            int count = DynamicCodeTestStringUtility.CountSubstring("source", "");
+
+            Assert.AreEqual(0, count);
         }
 
         [Test]

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
@@ -40,6 +40,46 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         }
 
         [Test]
+        public void Prepare_WhenScriptUsesBareUnityObject_ShouldAddObjectAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "GameObject go = new GameObject(\"source\");\nObject.Instantiate(go);\nreturn null;",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            StringAssert.Contains("using Object = UnityEngine.Object;", prepared.PreparedSource);
+        }
+
+        [Test]
+        public void Prepare_WhenObjectAliasAlreadyExists_ShouldNotAddDuplicateAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "using Object = UnityEngine.Object;\nObject.Instantiate(new GameObject(\"source\"));\nreturn null;",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            Assert.AreEqual(
+                1,
+                CountSubstring(prepared.PreparedSource, "using Object = UnityEngine.Object;"));
+        }
+
+        [Test]
+        public void Prepare_WhenCustomObjectAliasAlreadyExists_ShouldRespectUserAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "using Object = System.Object;\nreturn new Object();",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            Assert.AreEqual(
+                1,
+                CountSubstring(prepared.PreparedSource, "using Object = "));
+        }
+
+        [Test]
         public void Prepare_WhenInterpolatedStringExists_ShouldSkipLiteralHoisting()
         {
             PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
@@ -228,6 +268,19 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
             Assert.IsNotNull(prepared.PreparedSource);
             Assert.AreEqual(0, prepared.HoistedLiteralBindings.Count);
             StringAssert.Contains("return 3000000000;", prepared.PreparedSource);
+        }
+
+        private static int CountSubstring(string source, string target)
+        {
+            int count = 0;
+            int index = 0;
+            while ((index = source.IndexOf(target, index, System.StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += target.Length;
+            }
+
+            return count;
         }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs
@@ -4,6 +4,11 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
     {
         public static int CountSubstring(string source, string target)
         {
+            if (string.IsNullOrEmpty(target))
+            {
+                return 0;
+            }
+
             int count = 0;
             int index = 0;
             while ((index = source.IndexOf(target, index, System.StringComparison.Ordinal)) >= 0)

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs
@@ -1,0 +1,18 @@
+namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
+{
+    internal static class DynamicCodeTestStringUtility
+    {
+        public static int CountSubstring(string source, string target)
+        {
+            int count = 0;
+            int index = 0;
+            while ((index = source.IndexOf(target, index, System.StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += target.Length;
+            }
+
+            return count;
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d538646e6b4674bc9b4b03f8cfe7b8b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/PreUsingResolverTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/PreUsingResolverTests.cs
@@ -165,7 +165,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -178,7 +178,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -190,11 +190,11 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             List<string> usings = new List<string> { "using System.Text;" };
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
-            string wrappedSource = WrapperTemplate.Build(usings, "TestNs", "TestClass", body);
+            string wrappedSource = WrapperTemplate.Build(usings, System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
-            int occurrences = CountSubstring(result.UpdatedSource, "using System.Text;");
+            int occurrences = DynamicCodeTestStringUtility.CountSubstring(result.UpdatedSource, "using System.Text;");
             Assert.AreEqual(1, occurrences, "Should not add duplicate using System.Text");
         }
 
@@ -203,23 +203,11 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             string body = "int x = 42;\nreturn x;";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
             Assert.That(result.UpdatedSource, Does.Not.Contain("using System.Text;"));
-        }
-
-        private static int CountSubstring(string source, string target)
-        {
-            int count = 0;
-            int index = 0;
-            while ((index = source.IndexOf(target, index, System.StringComparison.Ordinal)) >= 0)
-            {
-                count++;
-                index += target.Length;
-            }
-            return count;
         }
 
         [Test]
@@ -227,7 +215,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             string body = "StringBuilder sb = new StringBuilder();\nRegex r = new Regex(\"x\");\nreturn sb.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -240,7 +228,7 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
         {
             string body = "System.Text.StringBuilder builder = new System.Text.StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperTests.cs
@@ -42,5 +42,23 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
 
             Assert.IsTrue(hasReturn);
         }
+
+        [Test]
+        public void Analyze_WhenVerbatimUsingAlias_ShouldRecordNormalizedAliasName()
+        {
+            SourceShapeResult result = SourceShaper.Analyze(
+                "using @Object = System.Object;\nreturn new @Object();");
+
+            Assert.That(result.AliasedNames, Does.Contain("Object"));
+        }
+
+        [Test]
+        public void Analyze_WhenGlobalUsingAliasHasComments_ShouldRecordAliasName()
+        {
+            SourceShapeResult result = SourceShaper.Analyze(
+                "global /* comment */ using /* comment */ Random /* comment */ = UnityEngine.Random;\nreturn Random.Range(0, 1);");
+
+            Assert.That(result.AliasedNames, Does.Contain("Random"));
+        }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperTests.cs
@@ -60,5 +60,14 @@ namespace io.github.hatayama.uLoopMCP.DynamicCodeToolTests
 
             Assert.That(result.AliasedNames, Does.Contain("Random"));
         }
+
+        [Test]
+        public void Analyze_WhenUsingAliasHasComments_ShouldRecordAliasName()
+        {
+            SourceShapeResult result = SourceShaper.Analyze(
+                "using /* comment */ Object /* comment */ = UnityEngine.Object;\nreturn null;");
+
+            Assert.That(result.AliasedNames, Does.Contain("Object"));
+        }
     }
 }

--- a/Packages/src/Editor/Compilation/DynamicCodeSourcePreparer.cs
+++ b/Packages/src/Editor/Compilation/DynamicCodeSourcePreparer.cs
@@ -57,6 +57,7 @@ namespace io.github.hatayama.uLoopMCP
                 : DynamicCodeLiteralHoister.Rewrite(body);
             string preparedSource = WrapperTemplate.Build(
                 shape.UsingDirectives,
+                shape.AliasedNames,
                 namespaceName,
                 className,
                 hoistedResult.RewrittenSource,

--- a/Packages/src/Editor/Compilation/SourceShaper.cs
+++ b/Packages/src/Editor/Compilation/SourceShaper.cs
@@ -47,7 +47,7 @@ namespace io.github.hatayama.uLoopMCP
                         if (StartsWithKeyword(source, afterUsing, "static"))
                         {
                             int end = FindSemicolon(source, segmentStart);
-                            result.UsingDirectives.Add(source.Substring(segmentStart, end - segmentStart + 1).TrimEnd());
+                            RegisterUsingDirective(result, source, segmentStart, end);
                             pos = end + 1;
                             continue;
                         }
@@ -63,7 +63,7 @@ namespace io.github.hatayama.uLoopMCP
                         }
 
                         int semiEnd = FindSemicolon(source, segmentStart);
-                        result.UsingDirectives.Add(source.Substring(segmentStart, semiEnd - segmentStart + 1).TrimEnd());
+                        RegisterUsingDirective(result, source, segmentStart, semiEnd);
                         pos = semiEnd + 1;
                         continue;
                     }
@@ -82,11 +82,12 @@ namespace io.github.hatayama.uLoopMCP
                         continue;
                     }
 
-                    if (StartsWithKeyword(source, pos, "global") && StartsWithKeyword(source, SkipWhitespace(source, pos + 6), "using"))
+                    if (StartsWithKeyword(source, pos, "global") &&
+                        StartsWithKeyword(source, SkipWhitespaceAndComments(source, pos + "global".Length), "using"))
                     {
                         int segmentStart = pos;
                         int semiEnd = FindSemicolon(source, segmentStart);
-                        result.UsingDirectives.Add(source.Substring(segmentStart, semiEnd - segmentStart + 1).TrimEnd());
+                        RegisterUsingDirective(result, source, segmentStart, semiEnd);
                         pos = semiEnd + 1;
                         continue;
                     }
@@ -156,7 +157,7 @@ namespace io.github.hatayama.uLoopMCP
                     : body + "\nreturn null;";
             }
 
-            return WrapperTemplate.Build(shape.UsingDirectives, namespaceName, className, body);
+            return WrapperTemplate.Build(shape.UsingDirectives, shape.AliasedNames, namespaceName, className, body);
         }
 
         internal static int SkipWhitespace(string s, int pos)
@@ -184,6 +185,109 @@ namespace io.github.hatayama.uLoopMCP
                 return false;
             }
             return true;
+        }
+
+        private static void RegisterUsingDirective(
+            SourceShapeResult result,
+            string source,
+            int segmentStart,
+            int semiEnd)
+        {
+            result.UsingDirectives.Add(source.Substring(segmentStart, semiEnd - segmentStart + 1).TrimEnd());
+
+            string aliasName = ExtractUsingAliasName(source, segmentStart, semiEnd);
+            if (!string.IsNullOrEmpty(aliasName))
+            {
+                result.AliasedNames.Add(aliasName);
+            }
+        }
+
+        private static string ExtractUsingAliasName(string source, int segmentStart, int semiEnd)
+        {
+            int position = segmentStart;
+            if (StartsWithKeyword(source, position, "global"))
+            {
+                position = SkipWhitespaceAndComments(source, position + "global".Length);
+            }
+
+            if (!StartsWithKeyword(source, position, "using"))
+            {
+                return null;
+            }
+
+            position = SkipWhitespaceAndComments(source, position + "using".Length);
+            if (StartsWithKeyword(source, position, "static"))
+            {
+                return null;
+            }
+
+            AliasNameParseResult aliasName = ReadAliasName(source, position, semiEnd);
+            if (aliasName.Name == null)
+            {
+                return null;
+            }
+
+            int equalsPosition = SkipWhitespaceAndComments(source, aliasName.EndPosition);
+            if (equalsPosition > semiEnd || source[equalsPosition] != '=')
+            {
+                return null;
+            }
+
+            return aliasName.Name;
+        }
+
+        private static AliasNameParseResult ReadAliasName(string source, int position, int semiEnd)
+        {
+            int currentPosition = position;
+            if (currentPosition <= semiEnd && source[currentPosition] == '@')
+            {
+                currentPosition++;
+            }
+
+            if (currentPosition > semiEnd || !IsIdentifierStart(source[currentPosition]))
+            {
+                return new AliasNameParseResult(null, position);
+            }
+
+            int nameStart = currentPosition;
+            currentPosition++;
+            while (currentPosition <= semiEnd && IsIdentifierPart(source[currentPosition]))
+            {
+                currentPosition++;
+            }
+
+            return new AliasNameParseResult(
+                source.Substring(nameStart, currentPosition - nameStart),
+                currentPosition);
+        }
+
+        private static bool IsIdentifierStart(char value)
+        {
+            return char.IsLetter(value) || value == '_';
+        }
+
+        private static bool IsIdentifierPart(char value)
+        {
+            return char.IsLetterOrDigit(value) || value == '_';
+        }
+
+        private static int SkipWhitespaceAndComments(string source, int position)
+        {
+            int currentPosition = SkipWhitespace(source, position);
+            while (IsCommentStart(source, currentPosition))
+            {
+                int nextPosition = AdvanceOneToken(source, currentPosition);
+                currentPosition = SkipWhitespace(source, nextPosition);
+            }
+
+            return currentPosition;
+        }
+
+        private static bool IsCommentStart(string source, int position)
+        {
+            return position + 1 < source.Length &&
+                   source[position] == '/' &&
+                   (source[position + 1] == '/' || source[position + 1] == '*');
         }
 
         private static bool IsTypeDeclarationKeyword(string s, int pos)
@@ -578,14 +682,29 @@ namespace io.github.hatayama.uLoopMCP
 
             return end < s.Length ? end + 1 : s.Length;
         }
+
+        private sealed class AliasNameParseResult
+        {
+            public string Name { get; }
+
+            public int EndPosition { get; }
+
+            public AliasNameParseResult(string name, int endPosition)
+            {
+                Name = name;
+                EndPosition = endPosition;
+            }
+        }
     }
 
     internal sealed class SourceShapeResult
     {
         public List<string> UsingDirectives { get; } = new List<string>();
+        public HashSet<string> AliasedNames { get; } = new HashSet<string>(System.StringComparer.Ordinal);
         public bool HasNamespaceDeclaration { get; set; }
         public bool HasTypeDeclaration { get; set; }
         public bool HasTopLevelStatements { get; set; }
         public StringBuilder TopLevelBodyBuilder { get; } = new StringBuilder();
     }
+
 }

--- a/Packages/src/Editor/Compilation/SourceShaper.cs
+++ b/Packages/src/Editor/Compilation/SourceShaper.cs
@@ -26,15 +26,10 @@ namespace io.github.hatayama.uLoopMCP
 
                 if (braceDepth == 0)
                 {
-                    if (TryMatchLineComment(source, pos, out int afterComment))
+                    (bool Matched, int NextPosition) commentMatch = TryMatchComment(source, pos);
+                    if (commentMatch.Matched)
                     {
-                        pos = afterComment;
-                        continue;
-                    }
-
-                    if (TryMatchBlockComment(source, pos, out int afterBlock))
-                    {
-                        pos = afterBlock;
+                        pos = commentMatch.NextPosition;
                         continue;
                     }
 
@@ -42,7 +37,7 @@ namespace io.github.hatayama.uLoopMCP
                     {
                         int segmentStart = pos;
                         int afterUsing = pos + 5;
-                        afterUsing = SkipWhitespace(source, afterUsing);
+                        afterUsing = SkipWhitespaceAndComments(source, afterUsing);
 
                         if (StartsWithKeyword(source, afterUsing, "static"))
                         {
@@ -274,20 +269,18 @@ namespace io.github.hatayama.uLoopMCP
         private static int SkipWhitespaceAndComments(string source, int position)
         {
             int currentPosition = SkipWhitespace(source, position);
-            while (IsCommentStart(source, currentPosition))
+            while (true)
             {
-                int nextPosition = AdvanceOneToken(source, currentPosition);
-                currentPosition = SkipWhitespace(source, nextPosition);
+                (bool Matched, int NextPosition) commentMatch = TryMatchComment(source, currentPosition);
+                if (!commentMatch.Matched)
+                {
+                    break;
+                }
+
+                currentPosition = SkipWhitespace(source, commentMatch.NextPosition);
             }
 
             return currentPosition;
-        }
-
-        private static bool IsCommentStart(string source, int position)
-        {
-            return position + 1 < source.Length &&
-                   source[position] == '/' &&
-                   (source[position + 1] == '/' || source[position + 1] == '*');
         }
 
         private static bool IsTypeDeclarationKeyword(string s, int pos)
@@ -322,31 +315,29 @@ namespace io.github.hatayama.uLoopMCP
             return pos;
         }
 
-        private static bool TryMatchLineComment(string s, int pos, out int afterComment)
+        private static (bool Matched, int NextPosition) TryMatchComment(string s, int pos)
         {
-            afterComment = pos;
-            if (pos + 1 < s.Length && s[pos] == '/' && s[pos + 1] == '/')
+            if (pos + 1 >= s.Length || s[pos] != '/')
+            {
+                return (false, pos);
+            }
+
+            if (s[pos + 1] == '/')
             {
                 int end = pos + 2;
                 while (end < s.Length && s[end] != '\n') end++;
                 if (end < s.Length) end++; // skip \n
-                afterComment = end;
-                return true;
+                return (true, end);
             }
-            return false;
-        }
 
-        private static bool TryMatchBlockComment(string s, int pos, out int afterBlock)
-        {
-            afterBlock = pos;
-            if (pos + 1 < s.Length && s[pos] == '/' && s[pos + 1] == '*')
+            if (s[pos + 1] == '*')
             {
                 int end = pos + 2;
                 while (end + 1 < s.Length && !(s[end] == '*' && s[end + 1] == '/')) end++;
-                afterBlock = end + 2 < s.Length ? end + 2 : s.Length;
-                return true;
+                return (true, end + 2 < s.Length ? end + 2 : s.Length);
             }
-            return false;
+
+            return (false, pos);
         }
 
         private static int FindSemicolon(string s, int pos)
@@ -433,20 +424,10 @@ namespace io.github.hatayama.uLoopMCP
             if (pos >= s.Length) return s.Length;
             char c = s[pos];
 
-            // Line comment
-            if (c == '/' && pos + 1 < s.Length && s[pos + 1] == '/')
+            (bool Matched, int NextPosition) commentMatch = TryMatchComment(s, pos);
+            if (commentMatch.Matched)
             {
-                int end = pos + 2;
-                while (end < s.Length && s[end] != '\n') end++;
-                return end < s.Length ? end + 1 : s.Length;
-            }
-
-            // Block comment
-            if (c == '/' && pos + 1 < s.Length && s[pos + 1] == '*')
-            {
-                int end = pos + 2;
-                while (end + 1 < s.Length && !(s[end] == '*' && s[end + 1] == '/')) end++;
-                return end + 2 < s.Length ? end + 2 : s.Length;
+                return commentMatch.NextPosition;
             }
 
             // Verbatim string (@"...")
@@ -706,5 +687,4 @@ namespace io.github.hatayama.uLoopMCP
         public bool HasTopLevelStatements { get; set; }
         public StringBuilder TopLevelBodyBuilder { get; } = new StringBuilder();
     }
-
 }

--- a/Packages/src/Editor/Compilation/WrapperTemplate.cs
+++ b/Packages/src/Editor/Compilation/WrapperTemplate.cs
@@ -30,6 +30,10 @@ namespace io.github.hatayama.uLoopMCP
             sb.AppendLine("using System.Threading.Tasks;");
             sb.AppendLine("using UnityEngine;");
             sb.AppendLine("using UnityEditor;");
+            if (!HasObjectAlias(usingDirectives))
+            {
+                sb.AppendLine("using Object = UnityEngine.Object;");
+            }
 
             foreach (string directive in usingDirectives)
             {
@@ -74,6 +78,72 @@ namespace io.github.hatayama.uLoopMCP
             sb.AppendLine("}");
 
             return sb.ToString();
+        }
+
+        private static bool HasObjectAlias(IReadOnlyList<string> usingDirectives)
+        {
+            if (usingDirectives == null)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < usingDirectives.Count; index++)
+            {
+                string directive = usingDirectives[index]?.TrimStart();
+                if (string.IsNullOrEmpty(directive))
+                {
+                    continue;
+                }
+
+                if (IsObjectAliasDirective(directive))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsObjectAliasDirective(string directive)
+        {
+            int usingPosition = 0;
+            if (SourceShaper.StartsWithKeyword(directive, usingPosition, "global"))
+            {
+                usingPosition = SkipWhitespaceAndComments(directive, usingPosition + "global".Length);
+            }
+
+            if (!SourceShaper.StartsWithKeyword(directive, usingPosition, "using"))
+            {
+                return false;
+            }
+
+            int aliasStart = SkipWhitespaceAndComments(directive, usingPosition + "using".Length);
+            if (!SourceShaper.StartsWithKeyword(directive, aliasStart, "Object"))
+            {
+                return false;
+            }
+
+            int equalsPosition = SkipWhitespaceAndComments(directive, aliasStart + "Object".Length);
+            return equalsPosition < directive.Length && directive[equalsPosition] == '=';
+        }
+
+        private static int SkipWhitespaceAndComments(string source, int position)
+        {
+            int currentPosition = SourceShaper.SkipWhitespace(source, position);
+            while (IsCommentStart(source, currentPosition))
+            {
+                int nextPosition = SourceShaper.AdvanceOneTokenPublic(source, currentPosition);
+                currentPosition = SourceShaper.SkipWhitespace(source, nextPosition);
+            }
+
+            return currentPosition;
+        }
+
+        private static bool IsCommentStart(string source, int position)
+        {
+            return position + 1 < source.Length &&
+                   source[position] == '/' &&
+                   (source[position + 1] == '/' || source[position + 1] == '*');
         }
     }
 }

--- a/Packages/src/Editor/Compilation/WrapperTemplate.cs
+++ b/Packages/src/Editor/Compilation/WrapperTemplate.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Text;
 
 namespace io.github.hatayama.uLoopMCP
@@ -25,8 +27,8 @@ namespace io.github.hatayama.uLoopMCP
             string body,
             IReadOnlyList<string> preambleLines = null)
         {
-            System.Diagnostics.Debug.Assert(usingDirectives != null, "usingDirectives must not be null");
-            System.Diagnostics.Debug.Assert(aliasedNames != null, "aliasedNames must not be null");
+            Debug.Assert(usingDirectives != null, "usingDirectives must not be null");
+            Debug.Assert(aliasedNames != null, "aliasedNames must not be null");
 
             StringBuilder sb = new StringBuilder();
 
@@ -93,28 +95,13 @@ namespace io.github.hatayama.uLoopMCP
             for (int index = 0; index < DefaultUsingAliases.Length; index++)
             {
                 DefaultUsingAlias alias = DefaultUsingAliases[index];
-                if (ContainsAliasName(aliasedNames, alias.Name))
+                if (aliasedNames.Contains(alias.Name))
                 {
                     continue;
                 }
 
                 sb.AppendLine($"using {alias.Name} = {alias.TargetTypeName};");
             }
-        }
-
-        private static bool ContainsAliasName(
-            IReadOnlyCollection<string> aliasedNames,
-            string aliasName)
-        {
-            foreach (string existingAliasName in aliasedNames)
-            {
-                if (existingAliasName == aliasName)
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private sealed class DefaultUsingAlias

--- a/Packages/src/Editor/Compilation/WrapperTemplate.cs
+++ b/Packages/src/Editor/Compilation/WrapperTemplate.cs
@@ -11,14 +11,23 @@ namespace io.github.hatayama.uLoopMCP
     {
         internal const string UserCodeStartMarker = "#line 1 \"user-snippet.cs\"";
         internal const string UserCodeEndMarker = "#line default";
+        private static readonly DefaultUsingAlias[] DefaultUsingAliases =
+        {
+            new DefaultUsingAlias("Object", "UnityEngine.Object"),
+            new DefaultUsingAlias("Random", "UnityEngine.Random")
+        };
 
         public static string Build(
             IReadOnlyList<string> usingDirectives,
+            IReadOnlyCollection<string> aliasedNames,
             string namespaceName,
             string className,
             string body,
             IReadOnlyList<string> preambleLines = null)
         {
+            System.Diagnostics.Debug.Assert(usingDirectives != null, "usingDirectives must not be null");
+            System.Diagnostics.Debug.Assert(aliasedNames != null, "aliasedNames must not be null");
+
             StringBuilder sb = new StringBuilder();
 
             sb.AppendLine("#pragma warning disable CS0162");
@@ -30,10 +39,7 @@ namespace io.github.hatayama.uLoopMCP
             sb.AppendLine("using System.Threading.Tasks;");
             sb.AppendLine("using UnityEngine;");
             sb.AppendLine("using UnityEditor;");
-            if (!HasObjectAlias(usingDirectives))
-            {
-                sb.AppendLine("using Object = UnityEngine.Object;");
-            }
+            AppendDefaultUsingAliases(sb, aliasedNames);
 
             foreach (string directive in usingDirectives)
             {
@@ -80,22 +86,29 @@ namespace io.github.hatayama.uLoopMCP
             return sb.ToString();
         }
 
-        private static bool HasObjectAlias(IReadOnlyList<string> usingDirectives)
+        private static void AppendDefaultUsingAliases(
+            StringBuilder sb,
+            IReadOnlyCollection<string> aliasedNames)
         {
-            if (usingDirectives == null)
+            for (int index = 0; index < DefaultUsingAliases.Length; index++)
             {
-                return false;
-            }
-
-            for (int index = 0; index < usingDirectives.Count; index++)
-            {
-                string directive = usingDirectives[index]?.TrimStart();
-                if (string.IsNullOrEmpty(directive))
+                DefaultUsingAlias alias = DefaultUsingAliases[index];
+                if (ContainsAliasName(aliasedNames, alias.Name))
                 {
                     continue;
                 }
 
-                if (IsObjectAliasDirective(directive))
+                sb.AppendLine($"using {alias.Name} = {alias.TargetTypeName};");
+            }
+        }
+
+        private static bool ContainsAliasName(
+            IReadOnlyCollection<string> aliasedNames,
+            string aliasName)
+        {
+            foreach (string existingAliasName in aliasedNames)
+            {
+                if (existingAliasName == aliasName)
                 {
                     return true;
                 }
@@ -104,46 +117,17 @@ namespace io.github.hatayama.uLoopMCP
             return false;
         }
 
-        private static bool IsObjectAliasDirective(string directive)
+        private sealed class DefaultUsingAlias
         {
-            int usingPosition = 0;
-            if (SourceShaper.StartsWithKeyword(directive, usingPosition, "global"))
+            public string Name { get; }
+
+            public string TargetTypeName { get; }
+
+            public DefaultUsingAlias(string name, string targetTypeName)
             {
-                usingPosition = SkipWhitespaceAndComments(directive, usingPosition + "global".Length);
+                Name = name;
+                TargetTypeName = targetTypeName;
             }
-
-            if (!SourceShaper.StartsWithKeyword(directive, usingPosition, "using"))
-            {
-                return false;
-            }
-
-            int aliasStart = SkipWhitespaceAndComments(directive, usingPosition + "using".Length);
-            if (!SourceShaper.StartsWithKeyword(directive, aliasStart, "Object"))
-            {
-                return false;
-            }
-
-            int equalsPosition = SkipWhitespaceAndComments(directive, aliasStart + "Object".Length);
-            return equalsPosition < directive.Length && directive[equalsPosition] == '=';
-        }
-
-        private static int SkipWhitespaceAndComments(string source, int position)
-        {
-            int currentPosition = SourceShaper.SkipWhitespace(source, position);
-            while (IsCommentStart(source, currentPosition))
-            {
-                int nextPosition = SourceShaper.AdvanceOneTokenPublic(source, currentPosition);
-                currentPosition = SourceShaper.SkipWhitespace(source, nextPosition);
-            }
-
-            return currentPosition;
-        }
-
-        private static bool IsCommentStart(string source, int position)
-        {
-            return position + 1 < source.Length &&
-                   source[position] == '/' &&
-                   (source[position + 1] == '/' || source[position + 1] == '*');
         }
     }
 }


### PR DESCRIPTION
## Summary
- Dynamic code snippets can now use bare `Object.Instantiate` and related Unity object calls without qualifying `UnityEngine.Object`.
- Existing custom `Object` aliases are respected, so snippets that define their own alias do not get duplicate using directives.

## User Impact
- Before this change, snippets could fail with an ambiguous `Object` reference because the wrapper imported both `System` and `UnityEngine`.
- After this change, common Unity-style snippets using `Object` compile as expected in script mode.

## Changes
- Add a default `Object = UnityEngine.Object` alias to wrapped script snippets.
- Skip alias injection when a snippet already declares an `Object` alias.
- Add tests for alias injection, duplicate prevention, and custom alias preservation.

## Verification
- `uloop compile`
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "DynamicCodeSourcePreparerTests"`
- `uloop execute-dynamic-code --compile-only true --code "GameObject go = new GameObject(\"compile-only\"); Object.Instantiate(go); return null;"`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates dynamic code preparation/wrapping so Unity-style calls like `Object.Instantiate` work without requiring `UnityEngine.Object`, while preventing ambiguous `Object` references with `System.Object`.

### What changed
- `SourceShaper.Analyze` now centralizes `using`-directive collection via a helper that also extracts alias declarations from `using ... = Alias` (supports optional `global`, inline comments, and verbatim identifier aliases like `using `@Object` = ...`).
- The analysis result now includes `AliasedNames`, which is passed through `DynamicCodeSourcePreparer` into `WrapperTemplate.Build`.
- `WrapperTemplate.Build` now accepts `aliasedNames` and injects default wrapper aliases only when the corresponding alias is requested/needed (currently:
  - `using Object = UnityEngine.Object;`
  - `using Random = UnityEngine.Random;`),
  while using the parsed alias set to avoid duplicate injection when the user already defines `Object` (including verbatim `@Object`) or `Random`.
- `SourceShaper` also refactors comment-aware scanning used during parsing/advancing, improving robustness for alias detection around comments.

### Tests
- Added/extended NUnit coverage for wrapper alias injection and duplicate prevention in `DynamicCodeSourcePreparerTests`:
  - inject `using Object = UnityEngine.Object;` when the snippet uses bare `Object`
  - avoid duplicating the alias when `using Object = UnityEngine.Object;` already exists
  - preserve user-defined aliases like `using Object = System.Object;`
  - respect verbatim aliases like `using `@Object` = System.Object;`
  - inject `using Random = UnityEngine.Random;` when bare `Random` is used
- Added `DynamicCodeTestStringUtility.CountSubstring` and used it to safely assert substring counts (including returning `0` for empty targets).
- Expanded `SourceShaperTests` to verify alias extraction correctness, including `global using` with comments and verbatim alias syntax.
- Updated existing wrapper/pre-using resolver tests to match the new `WrapperTemplate.Build` signature (including added empty alias-collection arguments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->