### PR TITLE
fix: UI drags now keep game mouse coordinates in sync

### DIFF
--- a/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs
@@ -1,0 +1,152 @@
+#if ULOOPMCP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Collections;
+using System.Threading.Tasks;
+using io.github.hatayama.uLoopMCP;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace Tests.PlayMode
+{
+    public class SimulateMouseUiInputSystemTests : InputTestFixture
+    {
+        private const float POSITION_TOLERANCE = 0.01f;
+
+        private GameObject canvasGo = null!;
+        private GameObject eventSystemGo = null!;
+        private SimulateMouseUiTool tool = null!;
+        private SimulateMouseUiResponse lastResponse = null!;
+        private Mouse mouse = null!;
+
+        public override void Setup()
+        {
+            base.Setup();
+
+            canvasGo = new GameObject("TestCanvas");
+            Canvas canvas = canvasGo.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvasGo.AddComponent<CanvasScaler>();
+            canvasGo.AddComponent<GraphicRaycaster>();
+
+            eventSystemGo = new GameObject("TestEventSystem");
+            eventSystemGo.AddComponent<EventSystem>();
+            eventSystemGo.AddComponent<StandaloneInputModule>();
+
+            tool = new SimulateMouseUiTool();
+            mouse = InputSystem.AddDevice<Mouse>();
+        }
+
+        public override void TearDown()
+        {
+            MouseDragState.Clear();
+            Object.DestroyImmediate(canvasGo);
+            Object.DestroyImmediate(eventSystemGo);
+            base.TearDown();
+        }
+
+        [UnityTest]
+        public IEnumerator DragOneShot_Should_UpdateMouseCurrentPositionToDragPosition()
+        {
+            MouseAwareDragTracker tracker = CreateDraggableElement(
+                "DragTarget", new Vector2(120f, 80f), new Vector2(200f, 100f));
+            yield return null;
+
+            Vector2 startScreenPosition = GetScreenPosition(tracker.gameObject);
+            Vector2 endScreenPosition = startScreenPosition + new Vector2(140f, -60f);
+            Vector2 startInputPosition = ScreenToInput(startScreenPosition);
+            Vector2 endInputPosition = ScreenToInput(endScreenPosition);
+            SetMousePosition(Vector2.zero);
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = MouseAction.Drag.ToString(),
+                ["fromX"] = startInputPosition.x,
+                ["fromY"] = startInputPosition.y,
+                ["x"] = endInputPosition.x,
+                ["y"] = endInputPosition.y,
+                ["dragSpeed"] = 0f
+            });
+
+            Assert.IsTrue(lastResponse.Success);
+            AssertPositionEquals(endScreenPosition, tracker.LastPointerPosition, "PointerEventData position should reach the drag end.");
+            AssertPositionEquals(endScreenPosition, tracker.LastMousePosition, "Mouse.current position should match PointerEventData during drag.");
+        }
+
+        private IEnumerator RunTool(JObject parameters)
+        {
+            Task<BaseToolResponse> task = tool.ExecuteAsync(parameters);
+            float timeoutAt = Time.realtimeSinceStartup + 5f;
+            yield return new WaitUntil(() =>
+                task.IsCompleted || Time.realtimeSinceStartup >= timeoutAt);
+            Assert.IsTrue(task.IsCompleted, "Tool execution timed out.");
+            Assert.IsFalse(task.IsFaulted, $"Tool execution should not fault: {task.Exception}");
+            lastResponse = (SimulateMouseUiResponse)task.Result;
+        }
+
+        private MouseAwareDragTracker CreateDraggableElement(
+            string name, Vector2 anchoredPosition, Vector2 sizeDelta)
+        {
+            GameObject go = new GameObject(name);
+            go.transform.SetParent(canvasGo.transform, false);
+            RectTransform rect = go.AddComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = anchoredPosition;
+            rect.sizeDelta = sizeDelta;
+            go.AddComponent<Image>();
+            return go.AddComponent<MouseAwareDragTracker>();
+        }
+
+        private Vector2 GetScreenPosition(GameObject go)
+        {
+            return (Vector2)go.GetComponent<RectTransform>().position;
+        }
+
+        private Vector2 ScreenToInput(Vector2 screenPosition)
+        {
+            float targetHeight = Handles.GetMainGameViewSize().y;
+            return new Vector2(screenPosition.x, targetHeight - screenPosition.y);
+        }
+
+        private void SetMousePosition(Vector2 position)
+        {
+            Set(mouse.position, position);
+        }
+
+        private void AssertPositionEquals(Vector2 expected, Vector2 actual, string message)
+        {
+            float distance = Vector2.Distance(expected, actual);
+            Assert.LessOrEqual(distance, POSITION_TOLERANCE, $"{message} Expected {expected}, got {actual}.");
+        }
+    }
+
+    public class MouseAwareDragTracker : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+    {
+        public Vector2 LastPointerPosition { get; private set; }
+        public Vector2 LastMousePosition { get; private set; }
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            Mouse? currentMouse = Mouse.current;
+            Assert.IsNotNull(currentMouse, "Mouse.current should exist for this test.");
+
+            LastPointerPosition = eventData.position;
+            LastMousePosition = currentMouse!.position.ReadValue();
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+        }
+    }
+}
+#endif

--- a/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs
@@ -22,7 +22,6 @@ namespace Tests.PlayMode
         private GameObject eventSystemGo = null!;
         private SimulateMouseUiTool tool = null!;
         private SimulateMouseUiResponse lastResponse = null!;
-        private Mouse mouse = null!;
 
         public override void Setup()
         {
@@ -39,7 +38,7 @@ namespace Tests.PlayMode
             eventSystemGo.AddComponent<StandaloneInputModule>();
 
             tool = new SimulateMouseUiTool();
-            mouse = InputSystem.AddDevice<Mouse>();
+            InputSystem.AddDevice<Mouse>();
         }
 
         public override void TearDown()
@@ -116,7 +115,9 @@ namespace Tests.PlayMode
 
         private void SetMousePosition(Vector2 position)
         {
-            Set(mouse.position, position);
+            Mouse? currentMouse = Mouse.current;
+            Assert.IsNotNull(currentMouse, "Mouse.current should exist after adding a Mouse device.");
+            Set(currentMouse!.position, position);
         }
 
         private void AssertPositionEquals(Vector2 expected, Vector2 actual, string message)

--- a/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs.meta
+++ b/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac565f2eee83e4e0a8898951bc8beb97
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
@@ -219,7 +219,7 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             InputSystem.QueueDeltaStateEvent(mouse.position, screenPos);
-            InputSystem.Update();
+            InputSystemUpdateHelper.RunExplicitUpdate(InputUpdateTypeResolver.Resolve());
 #endif
         }
 

--- a/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
+++ b/Packages/src/Editor/Api/McpTools/SimulateMouseUi/SimulateMouseUiTool.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;
+#if ULOOPMCP_HAS_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 namespace io.github.hatayama.uLoopMCP
 {
@@ -205,6 +208,21 @@ namespace io.github.hatayama.uLoopMCP
             return new Vector2(screenPos.x, targetHeight - screenPos.y);
         }
 
+        // UI handlers can read Mouse.current alongside PointerEventData, so both paths must observe one position.
+        private static void SyncMousePosition(Vector2 screenPos)
+        {
+#if ULOOPMCP_HAS_INPUT_SYSTEM
+            Mouse? mouse = Mouse.current;
+            if (mouse == null)
+            {
+                return;
+            }
+
+            InputSystem.QueueDeltaStateEvent(mouse.position, screenPos);
+            InputSystem.Update();
+#endif
+        }
+
         private async Task<SimulateMouseUiResponse> ExecuteClick(
             SimulateMouseUiSchema parameters, EventSystem eventSystem, CancellationToken ct)
         {
@@ -219,6 +237,7 @@ namespace io.github.hatayama.uLoopMCP
                 pressPosition = screenPos,
                 button = inputButton
             };
+            SyncMousePosition(screenPos);
 
             GameObject? target = null;
             GameObject? pressTarget = null;
@@ -345,6 +364,7 @@ namespace io.github.hatayama.uLoopMCP
                 pressPosition = screenPos,
                 button = inputButton
             };
+            SyncMousePosition(screenPos);
 
             GameObject? target = null;
             GameObject? rawTarget = null;
@@ -471,6 +491,7 @@ namespace io.github.hatayama.uLoopMCP
                 pointerDrag = dragTarget,
                 rawPointerPress = raycastResult.gameObject
             };
+            SyncMousePosition(screenPos);
 
             // Slider.OnPointerDown initializes m_Offset for handle positioning
             GameObject? pressTarget = ExecuteEvents.ExecuteHierarchy(
@@ -645,6 +666,7 @@ namespace io.github.hatayama.uLoopMCP
                 Vector2 previousPosition = pointerData.position;
                 pointerData.position = endPos;
                 pointerData.delta = endPos - previousPosition;
+                SyncMousePosition(endPos);
                 ExecuteEvents.Execute(target, pointerData, ExecuteEvents.dragHandler);
 
                 SimulateMouseUiOverlayState.UpdatePosition(ScreenToInput(endPos));
@@ -666,6 +688,7 @@ namespace io.github.hatayama.uLoopMCP
                     pointerData.position = currentPosition;
                     pointerData.delta = currentPosition - previousPosition;
 
+                    SyncMousePosition(currentPosition);
                     ExecuteEvents.Execute(target, pointerData, ExecuteEvents.dragHandler);
 
                     SimulateMouseUiOverlayState.UpdatePosition(ScreenToInput(currentPosition));


### PR DESCRIPTION
## Summary
- UI drag simulation now keeps the game-side mouse position aligned with the pointer events it sends.
- Added PlayMode coverage so future changes keep the two coordinate paths in sync.

## User Impact
- Before, UI drag coordinates could differ from the coordinates game code read from `Mouse.current`, which made tests and workflows that combine UI dragging with Input System logic behave inconsistently.
- After, the simulated drag position is visible through both UI pointer events and the game mouse input path.

## Changes
- Queue the simulated screen position into the active Input System mouse before click, long-press, and drag event dispatch.
- Add a PlayMode regression test for one-shot UI drag behavior with Input System mouse reads.

## Verification
- `uloop compile --wait-for-domain-reload true`
- `uloop run-tests --test-mode PlayMode --filter-type regex --filter-value ".*SimulateMouseUi.*"`
- `/Users/a12115/dotfiles/.claude/skills/autoreview/scripts/autoreview --mode branch --base main`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the UI mouse simulation to keep UI pointer coordinates and `UnityEngine.InputSystem.Mouse.current.position` aligned when the Input System is enabled.

- Enhanced `SimulateMouseUiTool` with Input System–aware mouse synchronization, updating the shared simulated mouse position before dispatching click and long-press events and throughout drag start/interpolation so both UI handlers and game code reading `Mouse.current` observe the same coordinates.
- Added a PlayMode regression test (`SimulateMouseUiInputSystemTests`, behind `ULOOPMCP_HAS_INPUT_SYSTEM`) that drives a draggable UI element via `SimulateMouseUiTool.ExecuteAsync` and asserts the end drag screen/input position matches `PointerEventData.position` and `Mouse.current.position` within tolerance, using a tracker that records values during `OnDrag`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->