### PR TITLE
chore: Narrow shared release input triggers

### DIFF
--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "877ff1081972c76a09540528e9ff7ab512798e2e"
+  "sharedInputsHash": "389d631572f0757ab163b1aaac9665c67e146037"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "6ad3a706746115af4b5b558cdc58eafe1f9dec40"
+  "sharedInputsHash": "a1debd3bc92378afca481f7cb6e7d7ba84ea6771"
 }

--- a/cli/release-automation/internal/automation/release_trigger_guard.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard.go
@@ -23,16 +23,19 @@ type releaseTriggerRule struct {
 // consuming package root or the change never reaches a release.
 //
 // These rules are re-encoded as shell in scripts/stamp-release-inputs.sh
-// (list_common_inputs / list_installer_inputs); update both together.
-// TODO: When a third rule lands here, add an equivalence test that verifies
-// scripts/stamp-release-inputs.sh enumerates the same input set — with two
-// rules, the cross-references and scripts/test-stamp-release-inputs.sh keep
-// the implementations aligned.
+// (list_shared_common_inputs / list_dispatcher_only_common_inputs /
+// list_installer_inputs); update both together. scripts/test-stamp-release-inputs.sh
+// covers the same shared, dispatcher-only, installer, and ignored input cases.
 var releaseTriggerRules = []releaseTriggerRule{
 	{
-		inputDescription: "common module sources",
-		matchesInput:     isCommonModuleSource,
+		inputDescription: "common module sources shared by dispatcher and project runner",
+		matchesInput:     isSharedCommonModuleInput,
 		triggerRoots:     []string{"cli/dispatcher/", "cli/project-runner/"},
+	},
+	{
+		inputDescription: "common module sources used only by dispatcher",
+		matchesInput:     isDispatcherOnlyCommonModuleInput,
+		triggerRoots:     []string{"cli/dispatcher/"},
 	},
 	{
 		inputDescription: "installer scripts shipped as dispatcher release assets",
@@ -143,12 +146,38 @@ func AnalyzeReleaseTriggerGuard(changedFiles []string) ReleaseTriggerGuardResult
 	return ReleaseTriggerGuardResult{Violations: violations}
 }
 
-func isCommonModuleSource(file string) bool {
-	if !strings.HasPrefix(file, "cli/common/") {
-		return false
-	}
+var sharedCommonPackageRoots = []string{
+	// Keep this whitelist aligned with `go list -deps ./...` for the dispatcher
+	// and project-runner modules. Test helpers such as cli/common/clitest are
+	// intentionally excluded because they never ship in release binaries.
+	"cli/common/clicontract/",
+	"cli/common/clicore/",
+	"cli/common/project/",
+	"cli/common/skills/",
+	"cli/common/tools/",
+	"cli/common/unityipc/",
+}
+
+var dispatcherOnlyCommonPackageRoots = []string{
+	// This package is imported by the dispatcher update path, not by the
+	// project runner.
+	"cli/common/version/",
+}
+
+func isSharedCommonModuleInput(file string) bool {
 	if file == "cli/common/go.mod" || file == "cli/common/go.sum" {
 		return true
+	}
+	return isCommonGoSourceUnderPackageRoots(file, sharedCommonPackageRoots)
+}
+
+func isDispatcherOnlyCommonModuleInput(file string) bool {
+	return isCommonGoSourceUnderPackageRoots(file, dispatcherOnlyCommonPackageRoots)
+}
+
+func isCommonGoSourceUnderPackageRoots(file string, packageRoots []string) bool {
+	if !strings.HasPrefix(file, "cli/common/") {
+		return false
 	}
 	// JSON files under common (contract.json, default-tools.json) are
 	// release-please stamp targets rather than binary inputs, and test files
@@ -156,7 +185,12 @@ func isCommonModuleSource(file string) bool {
 	if !strings.HasSuffix(file, ".go") || strings.HasSuffix(file, "_test.go") {
 		return false
 	}
-	return true
+	for _, packageRoot := range packageRoots {
+		if strings.HasPrefix(file, packageRoot) {
+			return true
+		}
+	}
+	return false
 }
 
 func isDispatcherInstallerScript(file string) bool {

--- a/cli/release-automation/internal/automation/release_trigger_guard_test.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard_test.go
@@ -18,8 +18,8 @@ func TestReleaseTriggerGuardPassesWithoutSharedInputChanges(t *testing.T) {
 	}
 }
 
-// Verifies common source changes require triggers in both release package roots.
-func TestReleaseTriggerGuardRequiresBothTriggersForCommonChanges(t *testing.T) {
+// Verifies shared common source changes require triggers in both release package roots.
+func TestReleaseTriggerGuardRequiresBothTriggersForSharedCommonChanges(t *testing.T) {
 	result := AnalyzeReleaseTriggerGuard([]string{"cli/common/clicore/output.go"})
 
 	if len(result.Violations) != 1 {
@@ -40,7 +40,7 @@ func TestReleaseTriggerGuardRequiresBothTriggersForCommonChanges(t *testing.T) {
 	}
 }
 
-// Verifies a partial trigger still fails for the missing package root.
+// Verifies a partial trigger for shared common changes still fails for the missing package root.
 func TestReleaseTriggerGuardDetectsMissingDispatcherTrigger(t *testing.T) {
 	result := AnalyzeReleaseTriggerGuard([]string{
 		"cli/common/clicore/output.go",
@@ -56,8 +56,8 @@ func TestReleaseTriggerGuardDetectsMissingDispatcherTrigger(t *testing.T) {
 	}
 }
 
-// Verifies common changes pass once both release package roots are touched.
-func TestReleaseTriggerGuardAcceptsCommonChangesWithBothTriggers(t *testing.T) {
+// Verifies shared common changes pass once both release package roots are touched.
+func TestReleaseTriggerGuardAcceptsSharedCommonChangesWithBothTriggers(t *testing.T) {
 	result := AnalyzeReleaseTriggerGuard([]string{
 		"cli/common/clicore/output.go",
 		"cli/dispatcher/shared-inputs-stamp.json",
@@ -69,10 +69,11 @@ func TestReleaseTriggerGuardAcceptsCommonChangesWithBothTriggers(t *testing.T) {
 	}
 }
 
-// Verifies release-please stamp targets and test-only files under common are not release inputs.
+// Verifies release-please stamp targets, test-only files, and test helper packages under common are not release inputs.
 func TestReleaseTriggerGuardIgnoresNonBinaryCommonChanges(t *testing.T) {
 	result := AnalyzeReleaseTriggerGuard([]string{
 		"cli/common/clicore/output_test.go",
+		"cli/common/clitest/clitest.go",
 		"cli/common/clicontract/contract.json",
 		"cli/common/tools/default-tools.json",
 	})
@@ -82,7 +83,7 @@ func TestReleaseTriggerGuardIgnoresNonBinaryCommonChanges(t *testing.T) {
 	}
 }
 
-// Verifies common go.mod and go.sum changes count as shared release inputs.
+// Verifies common go.mod and go.sum changes count as shared release inputs for both binaries.
 func TestReleaseTriggerGuardCoversCommonModuleFiles(t *testing.T) {
 	result := AnalyzeReleaseTriggerGuard([]string{"cli/common/go.mod", "cli/common/go.sum"})
 
@@ -91,6 +92,31 @@ func TestReleaseTriggerGuardCoversCommonModuleFiles(t *testing.T) {
 	}
 	if len(result.Violations[0].ChangedInputs) != 2 {
 		t.Fatalf("expected both module files to be listed, got %v", result.Violations[0].ChangedInputs)
+	}
+}
+
+// Verifies dispatcher-only common package changes require only a dispatcher trigger.
+func TestReleaseTriggerGuardRequiresDispatcherTriggerForDispatcherOnlyCommonChanges(t *testing.T) {
+	result := AnalyzeReleaseTriggerGuard([]string{"cli/common/version/compare.go"})
+
+	if len(result.Violations) != 1 {
+		t.Fatalf("expected one violation, got %v", result.Violations)
+	}
+	violation := result.Violations[0]
+	if len(violation.MissingTriggerRoots) != 1 || violation.MissingTriggerRoots[0] != "cli/dispatcher/" {
+		t.Fatalf("expected only cli/dispatcher/ to be missing, got %v", violation.MissingTriggerRoots)
+	}
+}
+
+// Verifies dispatcher-only common changes pass once the dispatcher package root is touched.
+func TestReleaseTriggerGuardAcceptsDispatcherOnlyCommonChangesWithDispatcherTrigger(t *testing.T) {
+	result := AnalyzeReleaseTriggerGuard([]string{
+		"cli/common/version/compare.go",
+		"cli/dispatcher/shared-inputs-stamp.json",
+	})
+
+	if len(result.Violations) != 0 {
+		t.Fatalf("expected no violations, got %v", result.Violations)
 	}
 }
 

--- a/cli/release-automation/internal/automation/release_trigger_guard_test.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard_test.go
@@ -1,6 +1,10 @@
 package automation
 
 import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -120,6 +124,27 @@ func TestReleaseTriggerGuardAcceptsDispatcherOnlyCommonChangesWithDispatcherTrig
 	}
 }
 
+// Verifies common package trigger whitelists match the packages imported by release binaries.
+func TestReleaseTriggerGuardCommonPackageWhitelistsMatchGoDependencies(t *testing.T) {
+	repoRoot, err := gitRepoRoot(context.Background())
+	if err != nil {
+		t.Fatalf("failed to resolve repository root: %v", err)
+	}
+
+	dispatcherCommonRoots := commonPackageRootsImportedByModule(t, filepath.Join(repoRoot, "cli", "dispatcher"))
+	projectRunnerCommonRoots := commonPackageRootsImportedByModule(t, filepath.Join(repoRoot, "cli", "project-runner"))
+
+	expectedSharedRoots := intersectSortedStrings(dispatcherCommonRoots, projectRunnerCommonRoots)
+	expectedDispatcherOnlyRoots := subtractSortedStrings(dispatcherCommonRoots, projectRunnerCommonRoots)
+	projectRunnerOnlyRoots := subtractSortedStrings(projectRunnerCommonRoots, dispatcherCommonRoots)
+
+	assertStringSlicesEqual(t, sharedCommonPackageRoots, expectedSharedRoots, "shared common package roots")
+	assertStringSlicesEqual(t, dispatcherOnlyCommonPackageRoots, expectedDispatcherOnlyRoots, "dispatcher-only common package roots")
+	if len(projectRunnerOnlyRoots) != 0 {
+		t.Fatalf("project-runner-only common package roots need a release trigger rule: %v", projectRunnerOnlyRoots)
+	}
+}
+
 // Verifies installer script changes require a dispatcher release trigger only.
 func TestReleaseTriggerGuardRequiresDispatcherTriggerForInstallerChanges(t *testing.T) {
 	result := AnalyzeReleaseTriggerGuard([]string{"scripts/install.sh"})
@@ -130,6 +155,70 @@ func TestReleaseTriggerGuardRequiresDispatcherTriggerForInstallerChanges(t *test
 	violation := result.Violations[0]
 	if len(violation.MissingTriggerRoots) != 1 || violation.MissingTriggerRoots[0] != "cli/dispatcher/" {
 		t.Fatalf("expected only cli/dispatcher/ to be missing, got %v", violation.MissingTriggerRoots)
+	}
+}
+
+func commonPackageRootsImportedByModule(t *testing.T, moduleDir string) []string {
+	t.Helper()
+	command := exec.Command("go", "list", "-deps", "./...")
+	command.Dir = moduleDir
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("go list -deps failed in %s: %v", moduleDir, err)
+	}
+
+	rootsByPath := map[string]struct{}{}
+	for _, dependency := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if !strings.HasPrefix(dependency, "github.com/hatayama/unity-cli-loop/common/") {
+			continue
+		}
+		commonPackage := strings.TrimPrefix(dependency, "github.com/hatayama/unity-cli-loop/common/")
+		commonRoot, _, _ := strings.Cut(commonPackage, "/")
+		rootsByPath["cli/common/"+commonRoot+"/"] = struct{}{}
+	}
+
+	roots := []string{}
+	for root := range rootsByPath {
+		roots = append(roots, root)
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+func intersectSortedStrings(left []string, right []string) []string {
+	values := []string{}
+	for _, leftValue := range left {
+		if sortedStringsContain(right, leftValue) {
+			values = append(values, leftValue)
+		}
+	}
+	return values
+}
+
+func subtractSortedStrings(left []string, right []string) []string {
+	values := []string{}
+	for _, leftValue := range left {
+		if !sortedStringsContain(right, leftValue) {
+			values = append(values, leftValue)
+		}
+	}
+	return values
+}
+
+func sortedStringsContain(values []string, target string) bool {
+	index := sort.SearchStrings(values, target)
+	return index < len(values) && values[index] == target
+}
+
+func assertStringSlicesEqual(t *testing.T, actual []string, expected []string, label string) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Fatalf("expected %s %v, got %v", label, expected, actual)
+	}
+	for index, expectedValue := range expected {
+		if actual[index] != expectedValue {
+			t.Fatalf("expected %s %v, got %v", label, expected, actual)
+		}
 	}
 }
 

--- a/scripts/stamp-release-inputs.sh
+++ b/scripts/stamp-release-inputs.sh
@@ -17,17 +17,19 @@ list_shared_common_inputs() {
   git ls-files -- \
     cli/common/go.mod \
     cli/common/go.sum \
-    'cli/common/clicontract/*.go' \
-    'cli/common/clicore/*.go' \
-    'cli/common/project/*.go' \
-    'cli/common/skills/*.go' \
-    'cli/common/tools/*.go' \
-    'cli/common/unityipc/*.go' |
+    'cli/common/clicontract/' \
+    'cli/common/clicore/' \
+    'cli/common/project/' \
+    'cli/common/skills/' \
+    'cli/common/tools/' \
+    'cli/common/unityipc/' |
+    grep -E '\.go$|/go\.mod$|/go\.sum$' |
     grep -v '_test\.go$' || true
 }
 
 list_dispatcher_only_common_inputs() {
-  git ls-files -- 'cli/common/version/*.go' |
+  git ls-files -- 'cli/common/version/' |
+    grep '\.go$' |
     grep -v '_test\.go$' || true
 }
 

--- a/scripts/stamp-release-inputs.sh
+++ b/scripts/stamp-release-inputs.sh
@@ -11,10 +11,23 @@ cd "$ROOT_DIR"
 
 # Input selection mirrors the release trigger guard
 # (cli/release-automation/internal/automation/release_trigger_guard.go):
-# non-test Go sources and module files count; release-please stamp targets
-# such as contract.json and default-tools.json do not.
-list_common_inputs() {
-  git ls-files -- 'cli/common/*.go' cli/common/go.mod cli/common/go.sum |
+# only package roots imported by shipped binaries count; release-please stamp
+# targets such as contract.json and default-tools.json do not.
+list_shared_common_inputs() {
+  git ls-files -- \
+    cli/common/go.mod \
+    cli/common/go.sum \
+    'cli/common/clicontract/*.go' \
+    'cli/common/clicore/*.go' \
+    'cli/common/project/*.go' \
+    'cli/common/skills/*.go' \
+    'cli/common/tools/*.go' \
+    'cli/common/unityipc/*.go' |
+    grep -v '_test\.go$' || true
+}
+
+list_dispatcher_only_common_inputs() {
+  git ls-files -- 'cli/common/version/*.go' |
     grep -v '_test\.go$' || true
 }
 
@@ -50,8 +63,8 @@ write_stamp() {
   echo "Stamped $stamp_path"
 }
 
-common_hash=$(list_common_inputs | hash_input_list)
-dispatcher_hash=$({ list_common_inputs; list_installer_inputs; } | hash_input_list)
+common_hash=$(list_shared_common_inputs | hash_input_list)
+dispatcher_hash=$({ list_shared_common_inputs; list_dispatcher_only_common_inputs; list_installer_inputs; } | hash_input_list)
 
 write_stamp cli/project-runner/shared-inputs-stamp.json "$common_hash"
 write_stamp cli/dispatcher/shared-inputs-stamp.json "$dispatcher_hash"

--- a/scripts/test-stamp-release-inputs.sh
+++ b/scripts/test-stamp-release-inputs.sh
@@ -21,11 +21,13 @@ create_fixture_repo() {
     git config user.email "test@example.com"
     git config user.name "Test User"
 
-    mkdir -p cli/common/clicore cli/common/clitest cli/common/version cli/dispatcher cli/project-runner scripts
+    mkdir -p cli/common/clicore/subpkg cli/common/clitest cli/common/version/subpkg cli/dispatcher cli/project-runner scripts
     printf 'package clicore\n' > cli/common/clicore/core.go
+    printf 'package subpkg\n' > cli/common/clicore/subpkg/core.go
     printf 'package clicore\n\n// test-only content\n' > cli/common/clicore/core_test.go
     printf 'package clitest\n' > cli/common/clitest/clitest.go
     printf 'package version\n' > cli/common/version/compare.go
+    printf 'package subpkg\n' > cli/common/version/subpkg/compare.go
     printf 'module example.test/common\n' > cli/common/go.mod
     printf '{"projectRunnerVersion": "1.0.0"}\n' > cli/common/contract.json
     printf 'echo install\n' > scripts/install.sh
@@ -123,15 +125,27 @@ if [ "$runner_hash_after_common" = "$runner_hash_initial" ] ||
   exit 1
 fi
 
+# Verifies a nested shared common Go source change also moves both stamps.
+commit_fixture_change "$work_dir" "shared common change"
+printf 'package subpkg\n\nconst changed = true\n' > "$work_dir/cli/common/clicore/subpkg/core.go"
+run_stamp "$work_dir"
+runner_hash_after_nested_common=$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)
+dispatcher_hash_after_nested_common=$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)
+if [ "$runner_hash_after_nested_common" = "$runner_hash_after_common" ] ||
+  [ "$dispatcher_hash_after_nested_common" = "$dispatcher_hash_after_common" ]; then
+  echo "Expected a nested common source change to move both stamps." >&2
+  exit 1
+fi
+
 # Verifies an installer-only change moves only the dispatcher stamp.
-commit_fixture_change "$work_dir" "common change"
+commit_fixture_change "$work_dir" "nested shared common change"
 printf 'echo install v2\n' > "$work_dir/scripts/install.sh"
 run_stamp "$work_dir"
-if [ "$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)" != "$runner_hash_after_common" ]; then
+if [ "$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)" != "$runner_hash_after_nested_common" ]; then
   echo "Expected an installer-only change to keep the project-runner stamp." >&2
   exit 1
 fi
-if [ "$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)" = "$dispatcher_hash_after_common" ]; then
+if [ "$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)" = "$dispatcher_hash_after_nested_common" ]; then
   echo "Expected an installer-only change to move the dispatcher stamp." >&2
   exit 1
 fi
@@ -166,8 +180,23 @@ if [ "$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)" = "$dis
   exit 1
 fi
 
-# Verifies test-only and stamp-target changes under common move neither stamp.
+# Verifies a nested dispatcher-only common package change also moves only the dispatcher stamp.
 commit_fixture_change "$work_dir" "dispatcher-only common change"
+runner_hash_before_nested_dispatcher_only=$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)
+dispatcher_hash_before_nested_dispatcher_only=$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)
+printf 'package subpkg\n\nconst changed = true\n' > "$work_dir/cli/common/version/subpkg/compare.go"
+run_stamp "$work_dir"
+if [ "$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)" != "$runner_hash_before_nested_dispatcher_only" ]; then
+  echo "Expected a nested dispatcher-only common package change to keep the project-runner stamp." >&2
+  exit 1
+fi
+if [ "$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)" = "$dispatcher_hash_before_nested_dispatcher_only" ]; then
+  echo "Expected a nested dispatcher-only common package change to move the dispatcher stamp." >&2
+  exit 1
+fi
+
+# Verifies test-only and stamp-target changes under common move neither stamp.
+commit_fixture_change "$work_dir" "nested dispatcher-only common change"
 runner_hash_before_test_only=$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)
 dispatcher_hash_before_test_only=$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)
 printf 'package clicore\n\n// updated test-only content\n' > "$work_dir/cli/common/clicore/core_test.go"

--- a/scripts/test-stamp-release-inputs.sh
+++ b/scripts/test-stamp-release-inputs.sh
@@ -21,9 +21,11 @@ create_fixture_repo() {
     git config user.email "test@example.com"
     git config user.name "Test User"
 
-    mkdir -p cli/common/clicore cli/dispatcher cli/project-runner scripts
+    mkdir -p cli/common/clicore cli/common/clitest cli/common/version cli/dispatcher cli/project-runner scripts
     printf 'package clicore\n' > cli/common/clicore/core.go
     printf 'package clicore\n\n// test-only content\n' > cli/common/clicore/core_test.go
+    printf 'package clitest\n' > cli/common/clitest/clitest.go
+    printf 'package version\n' > cli/common/version/compare.go
     printf 'module example.test/common\n' > cli/common/go.mod
     printf '{"projectRunnerVersion": "1.0.0"}\n' > cli/common/contract.json
     printf 'echo install\n' > scripts/install.sh
@@ -149,11 +151,27 @@ if [ "$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)" = "$dis
   exit 1
 fi
 
-# Verifies test-only and stamp-target changes under common move neither stamp.
+# Verifies a dispatcher-only common package change moves only the dispatcher stamp.
 commit_fixture_change "$work_dir" "windows installer change"
+runner_hash_before_dispatcher_only=$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)
+dispatcher_hash_before_dispatcher_only=$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)
+printf 'package version\n\nconst changed = true\n' > "$work_dir/cli/common/version/compare.go"
+run_stamp "$work_dir"
+if [ "$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)" != "$runner_hash_before_dispatcher_only" ]; then
+  echo "Expected a dispatcher-only common package change to keep the project-runner stamp." >&2
+  exit 1
+fi
+if [ "$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)" = "$dispatcher_hash_before_dispatcher_only" ]; then
+  echo "Expected a dispatcher-only common package change to move the dispatcher stamp." >&2
+  exit 1
+fi
+
+# Verifies test-only and stamp-target changes under common move neither stamp.
+commit_fixture_change "$work_dir" "dispatcher-only common change"
 runner_hash_before_test_only=$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)
 dispatcher_hash_before_test_only=$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)
 printf 'package clicore\n\n// updated test-only content\n' > "$work_dir/cli/common/clicore/core_test.go"
+printf 'package clitest\n\nconst helper = true\n' > "$work_dir/cli/common/clitest/clitest.go"
 printf '{"projectRunnerVersion": "1.0.1"}\n' > "$work_dir/cli/common/contract.json"
 run_stamp "$work_dir"
 if [ "$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)" != "$runner_hash_before_test_only" ] ||


### PR DESCRIPTION
## Summary
- Keep release trigger checks focused on the release packages that actually consume each shared input.
- Prevent dispatcher-only common changes from forcing unnecessary project-runner release stamps.

## User Impact
- Release automation becomes less noisy for maintainers when dispatcher-only inputs change.
- Product, CLI, and Unity runtime behavior are unchanged.

## Changes
- Split shared common inputs from dispatcher-only common inputs in the release trigger guard.
- Updated the stamp script and generated stamp files to match the narrower input sets.
- Added regression coverage for dispatcher-only common files and ignored test helper packages.

## Verification
- sh scripts/test-stamp-release-inputs.sh
- go test ./internal/automation (in cli/release-automation)
- scripts/check-go-cli.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

