### PR TITLE
fix: Verify dispatcher self-update installers

### DIFF
--- a/cli/dispatcher/dispatchercontract/dispatcher-contract.json
+++ b/cli/dispatcher/dispatchercontract/dispatcher-contract.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "dispatcherVersion": "3.0.1-beta.13",
+  "dispatcherVersion": "3.0.1-beta.12",
   "dispatcherContractVersion": 1
 }

--- a/cli/dispatcher/dispatchercontract/dispatcher-contract.json
+++ b/cli/dispatcher/dispatchercontract/dispatcher-contract.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "dispatcherVersion": "3.0.1-beta.12",
+  "dispatcherVersion": "3.0.1-beta.13",
   "dispatcherContractVersion": 1
 }

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -297,10 +297,7 @@ func runDispatcherUpdateCommand(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	updateCommand := exec.CommandContext(ctx, command.Name, command.Args...)
-	updateCommand.Stdout = io.Discard
-	updateCommand.Stderr = io.Discard
-	return updateCommand.Run()
+	return runUpdateCommand(ctx, command, io.Discard, io.Discard)
 }
 
 func runRealCLICommand(ctx context.Context, realCLIPath string, args []string, stdout io.Writer, stderr io.Writer) int {

--- a/cli/dispatcher/internal/dispatcher/update.go
+++ b/cli/dispatcher/internal/dispatcher/update.go
@@ -3,7 +3,9 @@ package dispatcher
 import (
 	"context"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 
 	"github.com/hatayama/unity-cli-loop/common/clicore"
@@ -80,10 +82,47 @@ func updateCommandForOSWithOptions(goos string, options updateOptions) (string, 
 }
 
 func runUpdateCommand(ctx context.Context, updateCommand update.Command, stdout io.Writer, stderr io.Writer) error {
-	command := exec.CommandContext(ctx, updateCommand.Name, updateCommand.Args...)
+	tempDir, err := os.MkdirTemp("", "uloop-update-")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	installerPath, err := downloadVerifiedUpdateInstaller(ctx, updateCommand, tempDir)
+	if err != nil {
+		return err
+	}
+
+	args := updateExecutionArgs(updateCommand, installerPath)
+	command := exec.CommandContext(ctx, updateCommand.Name, args...)
 	command.Stdout = stdout
 	command.Stderr = stderr
+	command.Env = append(os.Environ(), updateCommand.Env...)
 	return command.Run()
+}
+
+func downloadVerifiedUpdateInstaller(ctx context.Context, updateCommand update.Command, tempDir string) (string, error) {
+	installerPath := filepath.Join(tempDir, updateCommand.InstallerName)
+	checksumPath := installerPath + ".sha256"
+	if err := downloadDispatcherFile(ctx, updateCommand.InstallerURL, installerPath); err != nil {
+		return "", err
+	}
+	if err := downloadDispatcherFile(ctx, updateCommand.InstallerChecksumURL, checksumPath); err != nil {
+		return "", err
+	}
+	if err := verifyDispatcherChecksum(installerPath, checksumPath); err != nil {
+		return "", err
+	}
+	return installerPath, nil
+}
+
+func updateExecutionArgs(updateCommand update.Command, installerPath string) []string {
+	if updateCommand.Name == "powershell" {
+		return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", installerPath}
+	}
+	return append(updateCommand.Args, installerPath)
 }
 
 func printUpdateHelp(stdout io.Writer) {

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -3,7 +3,11 @@ package dispatcher
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
+	"net/http"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -14,143 +18,142 @@ import (
 )
 
 func TestUpdateCommandForDarwinUsesDirectInstaller(t *testing.T) {
-	// Verifies dispatcher update downloads the shared installer before running it on the matching channel.
-	commandName, args, err := updateCommandForOS("darwin")
+	// Verifies dispatcher update downloads and verifies the release installer before running it on the matching channel.
+	command, err := update.CommandForOS("darwin", update.Options{
+		CurrentVersion: dispatcherVersion,
+	})
 	if err != nil {
 		t.Fatalf("updateCommandForOS failed: %v", err)
 	}
 
-	if commandName != "sh" {
-		t.Fatalf("command mismatch: %s", commandName)
+	if command.Name != "sh" {
+		t.Fatalf("command mismatch: %s", command.Name)
 	}
-	joinedArgs := strings.Join(args, " ")
-	expectedScriptURL := update.ScriptURL(dispatchercontract.DispatcherCurrent.DispatcherVersion, update.PosixScriptName)
+	expectedScriptURL := update.ScriptAssetURL(dispatchercontract.DispatcherCurrent.DispatcherVersion, update.PosixScriptName)
 	expectedReleaseTag := update.UpdateSelectorForVersion(dispatchercontract.DispatcherCurrent.DispatcherVersion)
-	if !strings.Contains(joinedArgs, expectedScriptURL) {
-		t.Fatalf("installer URL missing: %s", joinedArgs)
+	if command.InstallerURL != expectedScriptURL {
+		t.Fatalf("installer URL mismatch: %s", command.InstallerURL)
 	}
-	if !strings.Contains(joinedArgs, "ULOOP_VERSION='"+expectedReleaseTag+"'") {
-		t.Fatalf("installer version missing: %s", joinedArgs)
+	if command.InstallerChecksumURL != expectedScriptURL+".sha256" {
+		t.Fatalf("installer checksum URL mismatch: %s", command.InstallerChecksumURL)
 	}
-	if !strings.Contains(joinedArgs, "curl -fSL") || !strings.Contains(joinedArgs, "-o \"$tmp\"") {
-		t.Fatalf("update command should download before executing: %s", joinedArgs)
+	if !stringSliceContains(command.Env, "ULOOP_VERSION="+expectedReleaseTag) {
+		t.Fatalf("installer version missing: %v", command.Env)
 	}
-	if strings.Contains(joinedArgs, "npm") {
-		t.Fatalf("update command still references npm: %s", joinedArgs)
+	if command.InstallerName != update.PosixScriptName {
+		t.Fatalf("installer name mismatch: %s", command.InstallerName)
 	}
 }
 
 func TestUpdateCommandForWindowsUsesPowerShellInstaller(t *testing.T) {
-	// Verifies dispatcher update calls the Windows installer script quietly on the matching channel.
-	commandName, args, err := updateCommandForOS("windows")
+	// Verifies dispatcher update downloads and verifies the Windows release installer on the matching channel.
+	command, err := update.CommandForOS("windows", update.Options{
+		CurrentVersion: dispatcherVersion,
+	})
 	if err != nil {
 		t.Fatalf("updateCommandForOS failed: %v", err)
 	}
 
-	if commandName != "powershell" {
-		t.Fatalf("command mismatch: %s", commandName)
+	if command.Name != "powershell" {
+		t.Fatalf("command mismatch: %s", command.Name)
 	}
-	joinedArgs := strings.Join(args, " ")
-	expectedScriptURL := update.ScriptURL(dispatchercontract.DispatcherCurrent.DispatcherVersion, update.WindowsScriptName)
+	expectedScriptURL := update.ScriptAssetURL(dispatchercontract.DispatcherCurrent.DispatcherVersion, update.WindowsScriptName)
 	expectedReleaseTag := update.UpdateSelectorForVersion(dispatchercontract.DispatcherCurrent.DispatcherVersion)
-	if !strings.Contains(joinedArgs, expectedScriptURL) {
-		t.Fatalf("installer URL missing: %s", joinedArgs)
+	if command.InstallerURL != expectedScriptURL {
+		t.Fatalf("installer URL mismatch: %s", command.InstallerURL)
 	}
-	if !strings.Contains(joinedArgs, "$env:ULOOP_VERSION='"+expectedReleaseTag+"'") {
-		t.Fatalf("installer version missing: %s", joinedArgs)
+	if command.InstallerChecksumURL != expectedScriptURL+".sha256" {
+		t.Fatalf("installer checksum URL mismatch: %s", command.InstallerChecksumURL)
 	}
-	if !strings.Contains(joinedArgs, "$ProgressPreference='SilentlyContinue'") {
-		t.Fatalf("installer progress suppression missing: %s", joinedArgs)
+	if !stringSliceContains(command.Env, "ULOOP_VERSION="+expectedReleaseTag) {
+		t.Fatalf("installer version missing: %v", command.Env)
 	}
-	if strings.Contains(joinedArgs, "npm") {
-		t.Fatalf("update command still references npm: %s", joinedArgs)
+	if command.InstallerName != update.WindowsScriptName {
+		t.Fatalf("installer name mismatch: %s", command.InstallerName)
 	}
 }
 
 func TestUpdateCommandForDarwinUsesRequestedVersion(t *testing.T) {
 	// Verifies dispatcher update can target the minimum release version requested by Unity.
-	commandName, args, err := updateCommandForOSWithOptions("darwin", updateOptions{
-		targetVersion: "3.0.0-beta.6",
+	command, err := update.CommandForOS("darwin", update.Options{
+		CurrentVersion: dispatcherVersion,
+		TargetVersion:  "3.0.0-beta.6",
 	})
 	if err != nil {
 		t.Fatalf("updateCommandForOSWithOptions failed: %v", err)
 	}
 
-	if commandName != "sh" {
-		t.Fatalf("command mismatch: %s", commandName)
+	if command.Name != "sh" {
+		t.Fatalf("command mismatch: %s", command.Name)
 	}
-	joinedArgs := strings.Join(args, " ")
-	if !strings.Contains(joinedArgs, "dispatcher-v3.0.0-beta.6/scripts/install.sh") {
-		t.Fatalf("installer URL mismatch: %s", joinedArgs)
+	if !strings.Contains(command.InstallerURL, "dispatcher-v3.0.0-beta.6/install.sh") {
+		t.Fatalf("installer URL mismatch: %s", command.InstallerURL)
 	}
-	if !strings.Contains(joinedArgs, "ULOOP_VERSION='dispatcher-v3.0.0-beta.6'") {
-		t.Fatalf("installer version missing: %s", joinedArgs)
+	if !stringSliceContains(command.Env, "ULOOP_VERSION=dispatcher-v3.0.0-beta.6") {
+		t.Fatalf("installer version missing: %v", command.Env)
 	}
 }
 
 func TestUpdateCommandForDarwinNormalizesRequestedVersionPrefix(t *testing.T) {
 	// Verifies accepted v-prefixed semantic versions still resolve to valid dispatcher release tags.
-	commandName, args, err := updateCommandForOSWithOptions("darwin", updateOptions{
-		targetVersion: "v3.0.0-beta.6",
+	command, err := update.CommandForOS("darwin", update.Options{
+		CurrentVersion: dispatcherVersion,
+		TargetVersion:  "v3.0.0-beta.6",
 	})
 	if err != nil {
 		t.Fatalf("updateCommandForOSWithOptions failed: %v", err)
 	}
 
-	if commandName != "sh" {
-		t.Fatalf("command mismatch: %s", commandName)
+	if command.Name != "sh" {
+		t.Fatalf("command mismatch: %s", command.Name)
 	}
-	joinedArgs := strings.Join(args, " ")
-	if !strings.Contains(joinedArgs, "ULOOP_VERSION='dispatcher-v3.0.0-beta.6'") {
-		t.Fatalf("installer version should not contain a doubled v prefix: %s", joinedArgs)
+	if !stringSliceContains(command.Env, "ULOOP_VERSION=dispatcher-v3.0.0-beta.6") {
+		t.Fatalf("installer version should not contain a doubled v prefix: %v", command.Env)
 	}
-	if strings.Contains(joinedArgs, "dispatcher-vv3.0.0-beta.6") {
-		t.Fatalf("installer version contains doubled v prefix: %s", joinedArgs)
+	if strings.Contains(command.InstallerURL, "dispatcher-vv3.0.0-beta.6") {
+		t.Fatalf("installer URL contains doubled v prefix: %s", command.InstallerURL)
 	}
 }
 
 func TestUpdateCommandForDarwinNormalizesProjectRunnerReleaseTag(t *testing.T) {
 	// Verifies project runner release tags resolve to the matching dispatcher release.
-	commandName, args, err := updateCommandForOSWithOptions("darwin", updateOptions{
-		targetVersion: "uloop-project-runner-v3.0.0-beta.6",
+	command, err := update.CommandForOS("darwin", update.Options{
+		CurrentVersion: dispatcherVersion,
+		TargetVersion:  "uloop-project-runner-v3.0.0-beta.6",
 	})
 	if err != nil {
 		t.Fatalf("updateCommandForOSWithOptions failed: %v", err)
 	}
 
-	if commandName != "sh" {
-		t.Fatalf("command mismatch: %s", commandName)
+	if command.Name != "sh" {
+		t.Fatalf("command mismatch: %s", command.Name)
 	}
-	joinedArgs := strings.Join(args, " ")
-	if !strings.Contains(joinedArgs, "dispatcher-v3.0.0-beta.6/scripts/install.sh") {
-		t.Fatalf("installer URL mismatch: %s", joinedArgs)
+	if !strings.Contains(command.InstallerURL, "dispatcher-v3.0.0-beta.6/install.sh") {
+		t.Fatalf("installer URL mismatch: %s", command.InstallerURL)
 	}
-	if strings.Contains(joinedArgs, "dispatcher-vuloop-project-runner-v3.0.0-beta.6") {
-		t.Fatalf("installer version contains project runner prefix: %s", joinedArgs)
+	if strings.Contains(command.InstallerURL, "dispatcher-vuloop-project-runner-v3.0.0-beta.6") {
+		t.Fatalf("installer URL contains project runner prefix: %s", command.InstallerURL)
 	}
 }
 
 func TestUpdateCommandForWindowsUsesRequestedVersion(t *testing.T) {
 	// Verifies Windows dispatcher update can quietly target the minimum release version requested by Unity.
-	commandName, args, err := updateCommandForOSWithOptions("windows", updateOptions{
-		targetVersion: "3.0.0",
+	command, err := update.CommandForOS("windows", update.Options{
+		CurrentVersion: dispatcherVersion,
+		TargetVersion:  "3.0.0",
 	})
 	if err != nil {
 		t.Fatalf("updateCommandForOSWithOptions failed: %v", err)
 	}
 
-	if commandName != "powershell" {
-		t.Fatalf("command mismatch: %s", commandName)
+	if command.Name != "powershell" {
+		t.Fatalf("command mismatch: %s", command.Name)
 	}
-	joinedArgs := strings.Join(args, " ")
-	if !strings.Contains(joinedArgs, "dispatcher-v3.0.0/scripts/install.ps1") {
-		t.Fatalf("installer URL mismatch: %s", joinedArgs)
+	if !strings.Contains(command.InstallerURL, "dispatcher-v3.0.0/install.ps1") {
+		t.Fatalf("installer URL mismatch: %s", command.InstallerURL)
 	}
-	if !strings.Contains(joinedArgs, "$env:ULOOP_VERSION='dispatcher-v3.0.0'") {
-		t.Fatalf("installer version missing: %s", joinedArgs)
-	}
-	if !strings.Contains(joinedArgs, "$ProgressPreference='SilentlyContinue'") {
-		t.Fatalf("installer progress suppression missing: %s", joinedArgs)
+	if !stringSliceContains(command.Env, "ULOOP_VERSION=dispatcher-v3.0.0") {
+		t.Fatalf("installer version missing: %v", command.Env)
 	}
 }
 
@@ -195,6 +198,59 @@ func TestParseUpdateOptionsRejectsInvalidVersion(t *testing.T) {
 	_, err := parseUpdateOptions([]string{"--to-version", "not-a-version"})
 	if err == nil {
 		t.Fatal("expected invalid version error")
+	}
+}
+
+func TestDownloadVerifiedUpdateInstallerRejectsChecksumMismatch(t *testing.T) {
+	// Verifies update installers are not executable unless the downloaded checksum matches.
+	restoreHTTPClient := stubUpdateInstallerHTTPClient([]byte("echo install\n"), []byte("bad  install.sh\n"))
+	defer restoreHTTPClient()
+
+	_, err := downloadVerifiedUpdateInstaller(context.Background(), update.Command{
+		InstallerName:        update.PosixScriptName,
+		InstallerURL:         "https://example.test/install.sh",
+		InstallerChecksumURL: "https://example.test/install.sh.sha256",
+	}, t.TempDir())
+
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch, got %v", err)
+	}
+}
+
+func TestDownloadVerifiedUpdateInstallerReturnsVerifiedFile(t *testing.T) {
+	// Verifies update installers are written to disk only after checksum verification succeeds.
+	installerContent := []byte("echo install\n")
+	checksum := sha256.Sum256(installerContent)
+	checksumContent := []byte(hex.EncodeToString(checksum[:]) + "  install.sh\n")
+	restoreHTTPClient := stubUpdateInstallerHTTPClient(installerContent, checksumContent)
+	defer restoreHTTPClient()
+
+	installerPath, err := downloadVerifiedUpdateInstaller(context.Background(), update.Command{
+		InstallerName:        update.PosixScriptName,
+		InstallerURL:         "https://example.test/install.sh",
+		InstallerChecksumURL: "https://example.test/install.sh.sha256",
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("downloadVerifiedUpdateInstaller failed: %v", err)
+	}
+
+	assertFileContent(t, installerPath, string(installerContent))
+	if filepath.Base(installerPath) != update.PosixScriptName {
+		t.Fatalf("installer path mismatch: %s", installerPath)
+	}
+}
+
+func TestUpdateExecutionArgsRunsDownloadedInstallerFile(t *testing.T) {
+	// Verifies update execution runs the verified installer path directly.
+	posixArgs := updateExecutionArgs(update.Command{Name: "sh"}, "/tmp/install.sh")
+	if len(posixArgs) != 1 || posixArgs[0] != "/tmp/install.sh" {
+		t.Fatalf("posix update args mismatch: %v", posixArgs)
+	}
+
+	windowsArgs := updateExecutionArgs(update.Command{Name: "powershell"}, `C:\Temp\install.ps1`)
+	expected := []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", `C:\Temp\install.ps1`}
+	if !stringSlicesEqual(windowsArgs, expected) {
+		t.Fatalf("windows update args mismatch: %v", windowsArgs)
 	}
 }
 
@@ -283,4 +339,51 @@ func stubManualUpdateHooks(t *testing.T, updatedVersion string) func() {
 		updateRunCommand = previousRunner
 		dispatcherReadInstalledVersion = previousReader
 	}
+}
+
+func stubUpdateInstallerHTTPClient(installerContent []byte, checksumContent []byte) func() {
+	previousHTTPClient := dispatcherHTTPClient
+	dispatcherHTTPClient = &http.Client{
+		Transport: dispatcherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			content := []byte{}
+			statusCode := http.StatusNotFound
+			if strings.HasSuffix(request.URL.Path, ".sha256") {
+				content = checksumContent
+				statusCode = http.StatusOK
+			}
+			if strings.HasSuffix(request.URL.Path, ".sh") || strings.HasSuffix(request.URL.Path, ".ps1") {
+				content = installerContent
+				statusCode = http.StatusOK
+			}
+			return &http.Response{
+				StatusCode: statusCode,
+				Status:     http.StatusText(statusCode),
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}),
+	}
+	return func() {
+		dispatcherHTTPClient = previousHTTPClient
+	}
+}
+
+func stringSliceContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSlicesEqual(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }

--- a/cli/dispatcher/internal/update/command.go
+++ b/cli/dispatcher/internal/update/command.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	sharedversion "github.com/hatayama/unity-cli-loop/common/version"
@@ -18,8 +17,12 @@ type Options struct {
 }
 
 type Command struct {
-	Name string
-	Args []string
+	Name                 string
+	Args                 []string
+	Env                  []string
+	InstallerName        string
+	InstallerURL         string
+	InstallerChecksumURL string
 }
 
 func CommandForOS(goos string, options Options) (Command, error) {
@@ -27,20 +30,22 @@ func CommandForOS(goos string, options Options) (Command, error) {
 	updateSelector := Selector(options)
 	switch goos {
 	case "darwin":
-		scriptURL := ScriptURL(version, PosixScriptName)
-		script := fmt.Sprintf(`tmp=$(mktemp) && curl -fSL %s -o "$tmp" && ULOOP_VERSION=%s sh "$tmp"; ec=$?; rm -f "$tmp"; exit $ec`, shellQuote(scriptURL), shellQuote(updateSelector))
-		return Command{Name: "sh", Args: []string{"-c", script}}, nil
+		return commandForScript("sh", PosixScriptName, version, updateSelector), nil
 	case "windows":
-		scriptURL := ScriptURL(version, WindowsScriptName)
-		return Command{Name: "powershell", Args: []string{
-			"-NoProfile",
-			"-ExecutionPolicy",
-			"Bypass",
-			"-Command",
-			fmt.Sprintf("$ProgressPreference='SilentlyContinue'; $env:ULOOP_VERSION=%s; irm %s | iex", shellQuote(updateSelector), shellQuote(scriptURL)),
-		}}, nil
+		return commandForScript("powershell", WindowsScriptName, version, updateSelector), nil
 	default:
 		return Command{}, errors.New(UnsupportedOSMessage)
+	}
+}
+
+func commandForScript(name string, scriptName string, version string, updateSelector string) Command {
+	installerURL := ScriptAssetURL(version, scriptName)
+	return Command{
+		Name:                 name,
+		Env:                  []string{"ULOOP_VERSION=" + updateSelector},
+		InstallerName:        scriptName,
+		InstallerURL:         installerURL,
+		InstallerChecksumURL: installerURL + ".sha256",
 	}
 }
 
@@ -76,8 +81,4 @@ func Selector(options Options) string {
 		return DispatcherReleaseTag(NormalizeTargetVersion(options.TargetVersion))
 	}
 	return UpdateSelectorForVersion(options.CurrentVersion)
-}
-
-func shellQuote(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }

--- a/cli/dispatcher/internal/update/installer.go
+++ b/cli/dispatcher/internal/update/installer.go
@@ -9,6 +9,7 @@ const (
 	LatestBeta        = "latest-beta"
 
 	repositoryRawBaseURL          = "https://raw.githubusercontent.com/hatayama/unity-cli-loop"
+	repositoryReleaseBaseURL      = "https://github.com/hatayama/unity-cli-loop/releases/download"
 	projectRunnerReleaseTagPrefix = "uloop-project-runner-v"
 	dispatcherTagPrefix           = "dispatcher-v"
 	betaVersionMarker             = "-beta."
@@ -16,6 +17,10 @@ const (
 
 func ScriptURL(version string, scriptName string) string {
 	return repositoryRawBaseURL + "/" + DispatcherReleaseTag(version) + "/scripts/" + scriptName
+}
+
+func ScriptAssetURL(version string, scriptName string) string {
+	return repositoryReleaseBaseURL + "/" + DispatcherReleaseTag(version) + "/" + scriptName
 }
 
 func ProjectRunnerReleaseTag(version string) string {

--- a/cli/dispatcher/internal/update/installer_test.go
+++ b/cli/dispatcher/internal/update/installer_test.go
@@ -22,6 +22,16 @@ func TestScriptURLForStableVersionUsesReleaseInstaller(t *testing.T) {
 	}
 }
 
+func TestScriptAssetURLForStableVersionUsesReleaseAsset(t *testing.T) {
+	// Verifies dispatcher self-update downloads installer scripts from signed release assets.
+	url := ScriptAssetURL("3.0.0", WindowsScriptName)
+
+	expected := "https://github.com/hatayama/unity-cli-loop/releases/download/dispatcher-v3.0.0/install.ps1"
+	if url != expected {
+		t.Fatalf("script asset URL mismatch: got %q want %q", url, expected)
+	}
+}
+
 func TestProjectRunnerReleaseTagAddsMissingPrefix(t *testing.T) {
 	// Verifies project runner downloads use the GitHub release tag format.
 	tag := ProjectRunnerReleaseTag("3.0.0-beta.3")

--- a/scripts/package-dispatcher.sh
+++ b/scripts/package-dispatcher.sh
@@ -59,6 +59,6 @@ package_unix darwin-amd64
 package_windows
 package_installers
 
-for asset_path in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR"/*.zip; do
+for asset_path in "$RELEASE_DIR"/install.sh "$RELEASE_DIR"/install.ps1 "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR"/*.zip; do
   create_checksum "$asset_path"
 done

--- a/scripts/test-resolve-dispatcher-release-target.sh
+++ b/scripts/test-resolve-dispatcher-release-target.sh
@@ -44,7 +44,7 @@ set -eu
 asset_json() {
   has_assets=$1
   if [ "$has_assets" = "true" ]; then
-    printf '[{"name":"install.sh","size":1},{"name":"install.ps1","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-windows-amd64.zip","size":1},{"name":"uloop-dispatcher-windows-amd64.zip.sha256","size":1}]'
+    printf '[{"name":"install.sh","size":1},{"name":"install.sh.sha256","size":1},{"name":"install.ps1","size":1},{"name":"install.ps1.sha256","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-windows-amd64.zip","size":1},{"name":"uloop-dispatcher-windows-amd64.zip.sha256","size":1}]'
     return
   fi
   printf '[]'

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -40,7 +40,7 @@ asset_json() {
 dispatcher_asset_json() {
   case "${DISPATCHER_RELEASE_ASSETS:-complete}" in
     complete)
-      printf '[{"name":"install.sh","size":1},{"name":"install.ps1","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-windows-amd64.zip","size":1},{"name":"uloop-dispatcher-windows-amd64.zip.sha256","size":1}]'
+      printf '[{"name":"install.sh","size":1},{"name":"install.sh.sha256","size":1},{"name":"install.ps1","size":1},{"name":"install.ps1.sha256","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-windows-amd64.zip","size":1},{"name":"uloop-dispatcher-windows-amd64.zip.sha256","size":1}]'
       ;;
     missing)
       printf '[]'
@@ -276,7 +276,9 @@ fi
 if [ "${1:-}" = "--list" ]; then
   printf '%s\n' \
     install.sh \
+    install.sh.sha256 \
     install.ps1 \
+    install.ps1.sha256 \
     uloop-dispatcher-darwin-amd64.tar.gz \
     uloop-dispatcher-darwin-amd64.tar.gz.sha256 \
     uloop-dispatcher-darwin-arm64.tar.gz \

--- a/scripts/test-verify-dispatcher-release-assets.sh
+++ b/scripts/test-verify-dispatcher-release-assets.sh
@@ -38,6 +38,8 @@ write_checksum() {
 
 write_executable "$RELEASE_DIR/install.sh" "install"
 printf '%s\n' "install" > "$RELEASE_DIR/install.ps1"
+write_checksum "install.sh"
+write_checksum "install.ps1"
 write_executable "$PAYLOAD_DIR/uloop" "dispatcher"
 
 tar -czf "$RELEASE_DIR/uloop-dispatcher-darwin-amd64.tar.gz" -C "$PAYLOAD_DIR" ./uloop

--- a/scripts/verify-dispatcher-release-assets.sh
+++ b/scripts/verify-dispatcher-release-assets.sh
@@ -4,7 +4,9 @@ set -eu
 ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
 EXPECTED_ASSETS="
 install.sh
+install.sh.sha256
 install.ps1
+install.ps1.sha256
 uloop-dispatcher-darwin-amd64.tar.gz
 uloop-dispatcher-darwin-amd64.tar.gz.sha256
 uloop-dispatcher-darwin-arm64.tar.gz
@@ -103,6 +105,8 @@ done
 verify_checksum "uloop-dispatcher-darwin-amd64.tar.gz"
 verify_checksum "uloop-dispatcher-darwin-arm64.tar.gz"
 verify_checksum "uloop-dispatcher-windows-amd64.zip"
+verify_checksum "install.sh"
+verify_checksum "install.ps1"
 
 require_tar_entry "uloop-dispatcher-darwin-amd64.tar.gz" "uloop"
 require_tar_entry "uloop-dispatcher-darwin-arm64.tar.gz" "uloop"


### PR DESCRIPTION
## Summary
- Dispatcher self-update now downloads installer scripts from release assets and verifies their SHA-256 checksum before execution.
- Dispatcher release packaging now publishes checksum files for `install.sh` and `install.ps1`.

## User Impact
- `uloop update` and automatic dispatcher self-update no longer execute an unverified downloaded installer script.
- If an older or incomplete dispatcher release does not publish installer checksum assets, update fails fast instead of silently falling back to unverified execution.

## Changes
- Move installer download and checksum verification into Go before invoking `sh` or PowerShell.
- Add `install.sh.sha256` and `install.ps1.sha256` to dispatcher release assets and release asset verification.
- Leave `dispatcherVersion` release-managed so release-please remains the only writer of version metadata.

## Verification
- go test ./internal/update ./internal/dispatcher (in cli/dispatcher)
- go test ./dispatchercontract (in cli/dispatcher)
- sh scripts/test-verify-dispatcher-release-assets.sh
- sh scripts/test-resolve-dispatcher-release-target.sh
- sh scripts/test-sync-release-please-package-releases.sh
- scripts/check-go-cli.sh