### PR TITLE
chore: Inject clicore focus and readiness dependencies

### DIFF
--- a/cli/common/clicore/focus.go
+++ b/cli/common/clicore/focus.go
@@ -16,13 +16,11 @@ import (
 const windowsPowerShellCommand = "powershell"
 
 var (
-	macUnityExecutablePattern             = regexp.MustCompile(`(?i)Unity\.app/Contents/MacOS/Unity`)
-	windowsUnityExecutablePattern         = regexp.MustCompile(`(?i)Unity\.exe`)
-	macProcessLinePattern                 = regexp.MustCompile(`^\s*(\d+)\s+(.*)$`)
-	projectPathFlagPattern                = regexp.MustCompile(`(?i)-projectpath(?:=|\s+)(.+)$`)
-	nextUnityFlagPattern                  = regexp.MustCompile(`\s-[A-Za-z][A-Za-z0-9-]*(?:=|\s|$)`)
-	findRunningUnityProcessForFocusWindow = FindRunningUnityProcess
-	focusUnityProcessForFocusWindow       = FocusUnityProcess
+	macUnityExecutablePattern     = regexp.MustCompile(`(?i)Unity\.app/Contents/MacOS/Unity`)
+	windowsUnityExecutablePattern = regexp.MustCompile(`(?i)Unity\.exe`)
+	macProcessLinePattern         = regexp.MustCompile(`^\s*(\d+)\s+(.*)$`)
+	projectPathFlagPattern        = regexp.MustCompile(`(?i)-projectpath(?:=|\s+)(.+)$`)
+	nextUnityFlagPattern          = regexp.MustCompile(`\s-[A-Za-z][A-Za-z0-9-]*(?:=|\s|$)`)
 )
 
 type UnityProcess struct {
@@ -37,8 +35,24 @@ type focusResponse struct {
 
 type RestoreFocusFunc func(context.Context) error
 
+type focusWindowDeps struct {
+	findRunningUnityProcess func(context.Context, string) (*UnityProcess, error)
+	focusUnityProcess       func(context.Context, int) error
+}
+
 func RunFocusWindow(ctx context.Context, projectRoot string, stdout io.Writer, stderr io.Writer) int {
-	runningProcess, err := findRunningUnityProcessForFocusWindow(ctx, projectRoot)
+	return runFocusWindow(ctx, projectRoot, stdout, stderr, defaultFocusWindowDeps())
+}
+
+func defaultFocusWindowDeps() focusWindowDeps {
+	return focusWindowDeps{
+		findRunningUnityProcess: FindRunningUnityProcess,
+		focusUnityProcess:       FocusUnityProcess,
+	}
+}
+
+func runFocusWindow(ctx context.Context, projectRoot string, stdout io.Writer, stderr io.Writer, deps focusWindowDeps) int {
+	runningProcess, err := deps.findRunningUnityProcess(ctx, projectRoot)
 	if err != nil {
 		writeFocusResponse(stderr, false, err.Error())
 		return 1
@@ -50,7 +64,7 @@ func RunFocusWindow(ctx context.Context, projectRoot string, stdout io.Writer, s
 
 	correlationID := NewCLIVibeCorrelationID()
 	logFocusWindowFocusAttempt(projectRoot, runningProcess.Pid, correlationID)
-	if err := focusUnityProcessForFocusWindow(ctx, runningProcess.Pid); err != nil {
+	if err := deps.focusUnityProcess(ctx, runningProcess.Pid); err != nil {
 		logFocusWindowFocusFailure(projectRoot, runningProcess.Pid, err, correlationID)
 		writeFocusResponse(stderr, false, fmt.Sprintf("Failed to focus Unity window: %s", err.Error()))
 		return 1

--- a/cli/common/clicore/focus_test.go
+++ b/cli/common/clicore/focus_test.go
@@ -153,24 +153,20 @@ func TestParseWindowsForegroundHandle(t *testing.T) {
 func TestRunFocusWindowWritesFocusSuccessVibeLog(t *testing.T) {
 	enableCliVibeLog(t)
 
-	originalFinder := findRunningUnityProcessForFocusWindow
-	originalFocus := focusUnityProcessForFocusWindow
-	findRunningUnityProcessForFocusWindow = func(context.Context, string) (*UnityProcess, error) {
-		return &UnityProcess{Pid: 321}, nil
+	deps := focusWindowDeps{
+		findRunningUnityProcess: func(context.Context, string) (*UnityProcess, error) {
+			return &UnityProcess{Pid: 321}, nil
+		},
+		focusUnityProcess: func(context.Context, int) error {
+			return nil
+		},
 	}
-	focusUnityProcessForFocusWindow = func(context.Context, int) error {
-		return nil
-	}
-	t.Cleanup(func() {
-		findRunningUnityProcessForFocusWindow = originalFinder
-		focusUnityProcessForFocusWindow = originalFocus
-	})
 
 	projectRoot := t.TempDir()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	code := RunFocusWindow(context.Background(), projectRoot, &stdout, &stderr)
+	code := runFocusWindow(context.Background(), projectRoot, &stdout, &stderr, deps)
 
 	if code != 0 {
 		t.Fatalf("exit code mismatch: %d stderr=%s", code, stderr.String())
@@ -192,24 +188,20 @@ func TestRunFocusWindowWritesFocusSuccessVibeLog(t *testing.T) {
 func TestRunFocusWindowWritesFocusFailureVibeLog(t *testing.T) {
 	enableCliVibeLog(t)
 
-	originalFinder := findRunningUnityProcessForFocusWindow
-	originalFocus := focusUnityProcessForFocusWindow
-	findRunningUnityProcessForFocusWindow = func(context.Context, string) (*UnityProcess, error) {
-		return &UnityProcess{Pid: 654}, nil
+	deps := focusWindowDeps{
+		findRunningUnityProcess: func(context.Context, string) (*UnityProcess, error) {
+			return &UnityProcess{Pid: 654}, nil
+		},
+		focusUnityProcess: func(context.Context, int) error {
+			return fmt.Errorf("window denied")
+		},
 	}
-	focusUnityProcessForFocusWindow = func(context.Context, int) error {
-		return fmt.Errorf("window denied")
-	}
-	t.Cleanup(func() {
-		findRunningUnityProcessForFocusWindow = originalFinder
-		focusUnityProcessForFocusWindow = originalFocus
-	})
 
 	projectRoot := t.TempDir()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	code := RunFocusWindow(context.Background(), projectRoot, &stdout, &stderr)
+	code := runFocusWindow(context.Background(), projectRoot, &stdout, &stderr, deps)
 
 	if code != 1 {
 		t.Fatalf("exit code mismatch: %d stdout=%s", code, stdout.String())

--- a/cli/common/clicore/tool_readiness.go
+++ b/cli/common/clicore/tool_readiness.go
@@ -22,16 +22,27 @@ const (
 
 const executeDynamicCodeReadinessProbe = `return "Unity CLI Loop dynamic code prewarm";`
 
-var (
-	findRunningUnityProcessForReadiness    = FindRunningUnityProcess
-	probeToolReadinessSequenceForReadiness = ProbeToolReadinessSequence
-)
+type toolReadinessDeps struct {
+	findRunningUnityProcess    func(context.Context, string) (*UnityProcess, error)
+	probeToolReadinessSequence func(context.Context, string) error
+}
 
 func WaitForToolReadiness(ctx context.Context, projectRoot string) error {
 	return WaitForToolReadinessWithTimeout(ctx, projectRoot, ToolReadinessTimeout)
 }
 
 func WaitForToolReadinessWithTimeout(ctx context.Context, projectRoot string, timeout time.Duration) error {
+	return waitForToolReadinessWithDeps(ctx, projectRoot, timeout, defaultToolReadinessDeps())
+}
+
+func defaultToolReadinessDeps() toolReadinessDeps {
+	return toolReadinessDeps{
+		findRunningUnityProcess:    FindRunningUnityProcess,
+		probeToolReadinessSequence: ProbeToolReadinessSequence,
+	}
+}
+
+func waitForToolReadinessWithDeps(ctx context.Context, projectRoot string, timeout time.Duration, deps toolReadinessDeps) error {
 	// Why: launch and compile can both recreate Unity's project IPC server; a real
 	// tool request proves the user-visible command will not be the cold transport probe.
 	timeoutContext, cancel := context.WithTimeout(ctx, timeout)
@@ -41,7 +52,7 @@ func WaitForToolReadinessWithTimeout(ctx context.Context, projectRoot string, ti
 	ticker := time.NewTicker(ToolReadinessPoll)
 	defer ticker.Stop()
 	for {
-		if err := probeToolReadinessSequenceForReadiness(timeoutContext, projectRoot); err == nil {
+		if err := deps.probeToolReadinessSequence(timeoutContext, projectRoot); err == nil {
 			return nil
 		} else {
 			if IsReadinessCLIUpdateRequiredError(err) {
@@ -52,17 +63,21 @@ func WaitForToolReadinessWithTimeout(ctx context.Context, projectRoot string, ti
 
 		select {
 		case <-timeoutContext.Done():
-			return toolReadinessDoneError(ctx, projectRoot, lastErr)
+			return toolReadinessDoneErrorWithDeps(ctx, projectRoot, lastErr, deps)
 		case <-ticker.C:
 		}
 	}
 }
 
 func toolReadinessDoneError(ctx context.Context, projectRoot string, cause error) error {
+	return toolReadinessDoneErrorWithDeps(ctx, projectRoot, cause, defaultToolReadinessDeps())
+}
+
+func toolReadinessDoneErrorWithDeps(ctx context.Context, projectRoot string, cause error, deps toolReadinessDeps) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	runningProcess, err := findRunningUnityProcessForReadiness(context.Background(), projectRoot)
+	runningProcess, err := deps.findRunningUnityProcess(context.Background(), projectRoot)
 	if err == nil && runningProcess != nil {
 		return UnityServerNotRespondingError{
 			ProjectRoot: projectRoot,

--- a/cli/common/clicore/tool_readiness_test.go
+++ b/cli/common/clicore/tool_readiness_test.go
@@ -12,43 +12,39 @@ import (
 
 // Verifies shared readiness waits keep the shorter non-launch timeout.
 func TestWaitForToolReadinessUsesDefaultTimeout(t *testing.T) {
-	originalProbe := probeToolReadinessSequenceForReadiness
-	probeToolReadinessSequenceForReadiness = func(ctx context.Context, projectRoot string) error {
-		deadline, ok := ctx.Deadline()
-		if !ok {
-			t.Fatal("readiness probe context should have a deadline")
-		}
-		remaining := time.Until(deadline)
-		if remaining < ToolReadinessTimeout-time.Second || remaining > ToolReadinessTimeout {
-			t.Fatalf("readiness timeout mismatch: %s", remaining)
-		}
-		return nil
+	deps := toolReadinessDeps{
+		probeToolReadinessSequence: func(ctx context.Context, projectRoot string) error {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("readiness probe context should have a deadline")
+			}
+			remaining := time.Until(deadline)
+			if remaining < ToolReadinessTimeout-time.Second || remaining > ToolReadinessTimeout {
+				t.Fatalf("readiness timeout mismatch: %s", remaining)
+			}
+			return nil
+		},
 	}
-	t.Cleanup(func() {
-		probeToolReadinessSequenceForReadiness = originalProbe
-	})
 
-	if err := WaitForToolReadiness(context.Background(), t.TempDir()); err != nil {
+	if err := waitForToolReadinessWithDeps(context.Background(), t.TempDir(), ToolReadinessTimeout, deps); err != nil {
 		t.Fatalf("waitForToolReadiness failed: %v", err)
 	}
 }
 
 // Verifies protocol mismatch responses surface immediately instead of waiting for readiness timeout.
 func TestWaitForToolReadinessReturnsCliUpdateRequiredImmediately(t *testing.T) {
-	originalProbe := probeToolReadinessSequenceForReadiness
 	expectedErr := &unityipc.RPCError{
 		Code:    -32603,
 		Message: "The installed uloop CLI uses an IPC protocol that does not match this Unity package.",
 		Data:    json.RawMessage(`{"type":"cli_update_required"}`),
 	}
-	probeToolReadinessSequenceForReadiness = func(context.Context, string) error {
-		return expectedErr
+	deps := toolReadinessDeps{
+		probeToolReadinessSequence: func(context.Context, string) error {
+			return expectedErr
+		},
 	}
-	t.Cleanup(func() {
-		probeToolReadinessSequenceForReadiness = originalProbe
-	})
 
-	err := WaitForToolReadinessWithTimeout(context.Background(), t.TempDir(), time.Hour)
+	err := waitForToolReadinessWithDeps(context.Background(), t.TempDir(), time.Hour, deps)
 
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected cli update error, got %v", err)
@@ -69,15 +65,13 @@ func TestToolReadinessDoneErrorPropagatesParentCancellation(t *testing.T) {
 
 // Verifies that readiness timeout still uses the user-facing timeout message.
 func TestToolReadinessDoneErrorReportsTimeoutWhenParentIsActive(t *testing.T) {
-	originalFinder := findRunningUnityProcessForReadiness
-	findRunningUnityProcessForReadiness = func(context.Context, string) (*UnityProcess, error) {
-		return nil, nil
+	deps := toolReadinessDeps{
+		findRunningUnityProcess: func(context.Context, string) (*UnityProcess, error) {
+			return nil, nil
+		},
 	}
-	t.Cleanup(func() {
-		findRunningUnityProcessForReadiness = originalFinder
-	})
 
-	err := toolReadinessDoneError(context.Background(), t.TempDir(), nil)
+	err := toolReadinessDoneErrorWithDeps(context.Background(), t.TempDir(), nil, deps)
 
 	if err == nil || err.Error() != "timed out waiting for Unity tool readiness" {
 		t.Fatalf("timeout error mismatch: %v", err)
@@ -86,15 +80,13 @@ func TestToolReadinessDoneErrorReportsTimeoutWhenParentIsActive(t *testing.T) {
 
 // Verifies that readiness timeout reports a live Unity process whose IPC server does not respond.
 func TestToolReadinessDoneErrorReportsServerNotRespondingWhenUnityRuns(t *testing.T) {
-	originalFinder := findRunningUnityProcessForReadiness
-	findRunningUnityProcessForReadiness = func(context.Context, string) (*UnityProcess, error) {
-		return &UnityProcess{Pid: 123}, nil
+	deps := toolReadinessDeps{
+		findRunningUnityProcess: func(context.Context, string) (*UnityProcess, error) {
+			return &UnityProcess{Pid: 123}, nil
+		},
 	}
-	t.Cleanup(func() {
-		findRunningUnityProcessForReadiness = originalFinder
-	})
 
-	err := toolReadinessDoneError(context.Background(), t.TempDir(), errors.New("probe failed"))
+	err := toolReadinessDoneErrorWithDeps(context.Background(), t.TempDir(), errors.New("probe failed"), deps)
 
 	var notRespondingErr UnityServerNotRespondingError
 	if !errors.As(err, &notRespondingErr) {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "389d631572f0757ab163b1aaac9665c67e146037"
+  "sharedInputsHash": "a556368434de848422cb045b2e5290c07d1a919f"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "a1debd3bc92378afca481f7cb6e7d7ba84ea6771"
+  "sharedInputsHash": "89c6319df7684d530be31c15b3e324efcbea09f4"
 }


### PR DESCRIPTION
## Summary
- Replace mutable test seam globals in focus-window and tool readiness with explicit dependency structs.
- Keep focus and readiness runtime behavior unchanged while making tests isolate collaborators without package-level mutation.

## User Impact
- No user-facing behavior changes.
- Maintainers get safer, more localized tests for focus-window and readiness behavior.

## Changes
- Route `RunFocusWindow` through an internal dependency-injected helper.
- Route tool readiness wait/error paths through dependency-injected helpers.
- Refresh shared release input stamps for the common clicore change.

## Verification
- go test ./clicore (in cli/common)
- scripts/check-go-cli.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

