### PR TITLE
chore: Inject project runner retry dependencies

### DIFF
--- a/cli/project-runner/internal/projectrunner/compile_wait.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait.go
@@ -41,8 +41,6 @@ type compileStatusResponse struct {
 	Message                  string          `json:"Message"`
 }
 
-var queryCompileStatus = queryCompileStatusFromUnity
-
 func shouldWaitForCompileDomainReload(command string, params map[string]any) bool {
 	if command != clicore.CompileCommandName {
 		return false
@@ -101,7 +99,7 @@ func isSafeCompileRequestID(requestID string) bool {
 	return true
 }
 
-func waitForCompileCompletion(ctx context.Context, options compileCompletionOptions) (json.RawMessage, bool, error) {
+func waitForCompileCompletionWithDeps(ctx context.Context, options compileCompletionOptions, deps compileWaitDeps) (json.RawMessage, bool, error) {
 	startedAt := time.Now()
 	deadline := startedAt.Add(options.timeout)
 	attempts := 0
@@ -120,7 +118,7 @@ func waitForCompileCompletion(ctx context.Context, options compileCompletionOpti
 		}
 
 		attempts++
-		status, err := queryCompileStatus(ctx, options.connection, options.requestID)
+		status, err := deps.queryCompileStatus(ctx, options.connection, options.requestID)
 		lastErr = err
 		if err == nil && status.Ready && status.HasResult && len(status.Result) > 0 {
 			logCompileStatusPollObservedIfChanged(options, startedAt, attempts, status, nil, &lastObservationKey)

--- a/cli/project-runner/internal/projectrunner/compile_wait_deps.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_deps.go
@@ -1,0 +1,17 @@
+package projectrunner
+
+import (
+	"context"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+type compileWaitDeps struct {
+	queryCompileStatus func(context.Context, unityipc.Connection, string) (compileStatusResponse, error)
+}
+
+func defaultCompileWaitDeps() compileWaitDeps {
+	return compileWaitDeps{
+		queryCompileStatus: queryCompileStatusFromUnity,
+	}
+}

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -172,7 +172,7 @@ func TestWaitForCompileCompletionReturnsReadyStatusResult(t *testing.T) {
 	connection := compileWaitTestConnection(t)
 	requestID := "compile_test"
 	callCount := 0
-	replaceQueryCompileStatus(t, func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
 		callCount++
 		if callCount == 1 {
 			return compileStatusResponse{Ready: false, HasResult: true, Result: json.RawMessage(`{"Success":true}`)}, nil
@@ -180,12 +180,12 @@ func TestWaitForCompileCompletionReturnsReadyStatusResult(t *testing.T) {
 		return compileStatusResponse{Ready: true, HasResult: true, Result: json.RawMessage(`{"Success":true}`)}, nil
 	})
 
-	result, completed, err := waitForCompileCompletion(context.Background(), compileCompletionOptions{
+	result, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:   connection,
 		requestID:    requestID,
 		timeout:      time.Second,
 		pollInterval: 5 * time.Millisecond,
-	})
+	}, deps)
 	if err != nil {
 		t.Fatalf("waitForCompileCompletion failed: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestWaitForCompileCompletionWritesPollLifecycleVibeLogs(t *testing.T) {
 	connection := compileWaitTestConnection(t)
 	requestID := "compile_poll_lifecycle_test"
 	callCount := 0
-	replaceQueryCompileStatus(t, func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
 		callCount++
 		if callCount == 1 {
 			return compileStatusResponse{
@@ -221,12 +221,12 @@ func TestWaitForCompileCompletionWritesPollLifecycleVibeLogs(t *testing.T) {
 		}, nil
 	})
 
-	result, completed, err := waitForCompileCompletion(context.Background(), compileCompletionOptions{
+	result, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:   connection,
 		requestID:    requestID,
 		timeout:      time.Second,
 		pollInterval: 5 * time.Millisecond,
-	})
+	}, deps)
 	if err != nil {
 		t.Fatalf("waitForCompileCompletion failed: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestWaitForCompileCompletionForceCompileWaitsForStoredResult(t *testing.T) 
 	connection := compileWaitTestConnection(t)
 	requestID := "compile_force_unknown"
 	callCount := 0
-	replaceQueryCompileStatus(t, func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
 		callCount++
 		if callCount == 1 {
 			return compileStatusResponse{Ready: true, HasResult: false}, nil
@@ -271,13 +271,13 @@ func TestWaitForCompileCompletionForceCompileWaitsForStoredResult(t *testing.T) 
 		}, nil
 	})
 
-	result, completed, err := waitForCompileCompletion(context.Background(), compileCompletionOptions{
+	result, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:     connection,
 		requestID:      requestID,
 		forceRecompile: true,
 		timeout:        time.Second,
 		pollInterval:   5 * time.Millisecond,
-	})
+	}, deps)
 	if err != nil {
 		t.Fatalf("waitForCompileCompletion failed: %v", err)
 	}
@@ -308,17 +308,17 @@ func TestWaitForCompileCompletionForceCompileWaitsForStoredResult(t *testing.T) 
 func TestWaitForCompileCompletionForceCompileTimesOutWithoutStoredResult(t *testing.T) {
 	connection := compileWaitTestConnection(t)
 	requestID := "compile_force_no_result"
-	replaceQueryCompileStatus(t, func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
 		return compileStatusResponse{Ready: true, HasResult: false}, nil
 	})
 
-	_, completed, err := waitForCompileCompletion(context.Background(), compileCompletionOptions{
+	_, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:     connection,
 		requestID:      requestID,
 		forceRecompile: true,
 		timeout:        20 * time.Millisecond,
 		pollInterval:   5 * time.Millisecond,
-	})
+	}, deps)
 	if err != nil {
 		t.Fatalf("waitForCompileCompletion failed: %v", err)
 	}
@@ -332,16 +332,16 @@ func TestWaitForCompileCompletionWritesTimeoutVibeLog(t *testing.T) {
 	enableCliVibeLog(t)
 	connection := compileWaitTestConnection(t)
 	requestID := "compile_timeout_log_test"
-	replaceQueryCompileStatus(t, func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
 		return compileStatusResponse{Ready: false, IsCompiling: true, Message: "Compiling"}, nil
 	})
 
-	_, completed, err := waitForCompileCompletion(context.Background(), compileCompletionOptions{
+	_, completed, err := waitForCompileCompletionWithDeps(context.Background(), compileCompletionOptions{
 		connection:   connection,
 		requestID:    requestID,
 		timeout:      20 * time.Millisecond,
 		pollInterval: 5 * time.Millisecond,
-	})
+	}, deps)
 	if err != nil {
 		t.Fatalf("waitForCompileCompletion failed: %v", err)
 	}
@@ -370,17 +370,17 @@ func TestWaitForCompileCompletionWritesCancellationVibeLog(t *testing.T) {
 	connection := compileWaitTestConnection(t)
 	requestID := "compile_cancel_log_test"
 	ctx, cancel := context.WithCancel(context.Background())
-	replaceQueryCompileStatus(t, func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
 		cancel()
 		return compileStatusResponse{Ready: false, IsDomainReloadInProgress: true}, nil
 	})
 
-	_, completed, err := waitForCompileCompletion(ctx, compileCompletionOptions{
+	_, completed, err := waitForCompileCompletionWithDeps(ctx, compileCompletionOptions{
 		connection:   connection,
 		requestID:    requestID,
 		timeout:      time.Second,
 		pollInterval: time.Second,
-	})
+	}, deps)
 	if err == nil {
 		t.Fatal("waitForCompileCompletion should return the cancellation error")
 	}
@@ -445,7 +445,7 @@ func TestRunCompileWithDomainReloadWaitWritesRequestLifecycleVibeLogs(t *testing
 		}
 	}()
 
-	replaceQueryCompileStatus(t, func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
+	deps := compileWaitTestDeps(func(context.Context, unityipc.Connection, string) (compileStatusResponse, error) {
 		return compileStatusResponse{
 			Ready:     true,
 			HasResult: true,
@@ -468,7 +468,7 @@ func TestRunCompileWithDomainReloadWaitWritesRequestLifecycleVibeLogs(t *testing
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	code := runCompileWithDomainReloadWait(context.Background(), connection, params, &stdout, &stderr)
+	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, params, &stdout, &stderr, deps)
 	if code != 0 {
 		t.Fatalf("runCompileWithDomainReloadWait failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -594,14 +594,10 @@ func compileWaitTestConnection(t *testing.T) unityipc.Connection {
 	}
 }
 
-func replaceQueryCompileStatus(
-	t *testing.T,
+func compileWaitTestDeps(
 	replacement func(context.Context, unityipc.Connection, string) (compileStatusResponse, error),
-) {
-	t.Helper()
-	original := queryCompileStatus
-	queryCompileStatus = replacement
-	t.Cleanup(func() {
-		queryCompileStatus = original
-	})
+) compileWaitDeps {
+	return compileWaitDeps{
+		queryCompileStatus: replacement,
+	}
 }

--- a/cli/project-runner/internal/projectrunner/connection_retry.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry.go
@@ -12,14 +12,27 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
-var (
-	findRunningUnityProcessForConnectionRetry = clicore.FindRunningUnityProcess
-	focusUnityProcessForConnectionRetry       = clicore.FocusUnityProcessWithRestore
-	serverConnectionRetryTimeout              = 10 * time.Second
-	serverConnectionRetryPoll                 = 1 * time.Second
+const (
+	focusRestoreTimeout                 = 2 * time.Second
+	serverConnectionRetryDefaultTimeout = 10 * time.Second
+	serverConnectionRetryDefaultPoll    = 1 * time.Second
 )
 
-const focusRestoreTimeout = 2 * time.Second
+type connectionRetryDeps struct {
+	findRunningUnityProcess func(context.Context, string) (*clicore.UnityProcess, error)
+	focusUnityProcess       func(context.Context, int) (clicore.RestoreFocusFunc, error)
+	retryTimeout            time.Duration
+	retryPoll               time.Duration
+}
+
+func defaultConnectionRetryDeps() connectionRetryDeps {
+	return connectionRetryDeps{
+		findRunningUnityProcess: clicore.FindRunningUnityProcess,
+		focusUnityProcess:       clicore.FocusUnityProcessWithRestore,
+		retryTimeout:            serverConnectionRetryDefaultTimeout,
+		retryPoll:               serverConnectionRetryDefaultPoll,
+	}
+}
 
 type connectionRetryFocusReason string
 
@@ -39,21 +52,23 @@ const (
 // is alive and surfacing it quickly lets the caller decide.
 const serverConnectionRetryUnityAliveFactor = 6
 
-func unityAliveRetryWindow() time.Duration {
-	return serverConnectionRetryTimeout * serverConnectionRetryUnityAliveFactor
+func unityAliveRetryWindow(deps connectionRetryDeps) time.Duration {
+	return deps.retryTimeout * serverConnectionRetryUnityAliveFactor
 }
 
 type connectionRetryFocusController struct {
 	connection   unityipc.Connection
 	method       string
+	deps         connectionRetryDeps
 	attempted    bool
 	restoreFocus clicore.RestoreFocusFunc
 }
 
-func newConnectionRetryFocusController(connection unityipc.Connection, method string) *connectionRetryFocusController {
+func newConnectionRetryFocusController(connection unityipc.Connection, method string, deps connectionRetryDeps) *connectionRetryFocusController {
 	return &connectionRetryFocusController{
 		connection: connection,
 		method:     method,
+		deps:       deps,
 	}
 }
 
@@ -79,7 +94,7 @@ func (controller *connectionRetryFocusController) tryFocus(
 		return
 	}
 
-	runningProcess, err := findRunningUnityProcessForConnectionRetry(ctx, controller.connection.ProjectRoot)
+	runningProcess, err := controller.deps.findRunningUnityProcess(ctx, controller.connection.ProjectRoot)
 	if err != nil || runningProcess == nil {
 		return
 	}
@@ -99,7 +114,7 @@ func (controller *connectionRetryFocusController) tryFocusProcess(
 
 	correlationID := clicore.NewCLIVibeCorrelationID()
 	logConnectionRetryFocusAttempt(controller.connection, controller.method, pid, reason, cause, correlationID)
-	restorer, focusErr := focusUnityProcessForConnectionRetry(ctx, pid)
+	restorer, focusErr := controller.deps.focusUnityProcess(ctx, pid)
 	if focusErr == nil {
 		controller.restoreFocus = restorer
 		logConnectionRetryFocusSuccess(controller.connection, controller.method, pid, reason, cause, correlationID)
@@ -123,13 +138,14 @@ func sendWithTransientConnectionRetry(
 	params map[string]any,
 	progress unityipc.ProgressFunc,
 ) (unityipc.UnitySendOutcome, error) {
-	return sendWithTransientConnectionRetryAndResponseTimeout(
+	return sendWithTransientConnectionRetryWithDeps(
 		ctx,
 		connection,
 		method,
 		params,
 		progress,
 		0,
+		defaultConnectionRetryDeps(),
 	)
 }
 
@@ -141,20 +157,40 @@ func sendWithTransientConnectionRetryAndResponseTimeout(
 	progress unityipc.ProgressFunc,
 	responseTimeout time.Duration,
 ) (unityipc.UnitySendOutcome, error) {
+	return sendWithTransientConnectionRetryWithDeps(
+		ctx,
+		connection,
+		method,
+		params,
+		progress,
+		responseTimeout,
+		defaultConnectionRetryDeps(),
+	)
+}
+
+func sendWithTransientConnectionRetryWithDeps(
+	ctx context.Context,
+	connection unityipc.Connection,
+	method string,
+	params map[string]any,
+	progress unityipc.ProgressFunc,
+	responseTimeout time.Duration,
+	deps connectionRetryDeps,
+) (unityipc.UnitySendOutcome, error) {
 	startedAt := time.Now()
-	retryContext, cancel := context.WithTimeout(ctx, unityAliveRetryWindow())
+	retryContext, cancel := context.WithTimeout(ctx, unityAliveRetryWindow(deps))
 	defer cancel()
 
 	var lastOutcome unityipc.UnitySendOutcome
 	var lastErr error
-	focusController := newConnectionRetryFocusController(connection, method)
+	focusController := newConnectionRetryFocusController(connection, method, deps)
 	defer func() {
 		restoreContext, cancel := context.WithTimeout(context.Background(), focusRestoreTimeout)
 		defer cancel()
 		focusController.restore(restoreContext)
 	}()
 
-	retryTicker := time.NewTicker(serverConnectionRetryPoll)
+	retryTicker := time.NewTicker(deps.retryPoll)
 	defer retryTicker.Stop()
 	for {
 		client := newConnectionRetryClient(connection, responseTimeout, func(stallSeconds float64) {
@@ -163,7 +199,7 @@ func sendWithTransientConnectionRetryAndResponseTimeout(
 		// Each attempt keeps the base accept bound: a dispatched request that never gets
 		// acked must still fail at the base window. Only the dial-retry loop as a whole
 		// uses the extended unity-alive window.
-		attemptContext, cancelAttempt := context.WithTimeout(retryContext, serverConnectionRetryTimeout)
+		attemptContext, cancelAttempt := context.WithTimeout(retryContext, deps.retryTimeout)
 		outcome, err := client.SendWithProgressOutcomeAcceptContext(ctx, attemptContext, method, params, progress)
 		cancelAttempt()
 		if isUnityServerBusyRPCError(err) {
@@ -178,6 +214,7 @@ func sendWithTransientConnectionRetryAndResponseTimeout(
 				retryTicker,
 				lastOutcome,
 				lastErr,
+				deps,
 			); finished {
 				return finalOutcome, finalErr
 			}
@@ -195,7 +232,7 @@ func sendWithTransientConnectionRetryAndResponseTimeout(
 			)
 		}
 
-		runningProcess, processErr := findRunningUnityProcessForConnectionRetry(retryContext, connection.ProjectRoot)
+		runningProcess, processErr := deps.findRunningUnityProcess(retryContext, connection.ProjectRoot)
 		if finished, finalOutcome, finalErr := finishUndispatchedRetryProbe(
 			ctx,
 			retryContext,
@@ -226,6 +263,7 @@ func sendWithTransientConnectionRetryAndResponseTimeout(
 			connection,
 			lastOutcome,
 			lastErr,
+			deps,
 		); finished {
 			return finalOutcome, finalErr
 		}

--- a/cli/project-runner/internal/projectrunner/connection_retry_flow.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_flow.go
@@ -27,8 +27,9 @@ func finishBusyRetry(
 	retryTicker *time.Ticker,
 	lastOutcome unityipc.UnitySendOutcome,
 	lastErr error,
+	deps connectionRetryDeps,
 ) (bool, unityipc.UnitySendOutcome, error) {
-	if time.Since(startedAt) >= serverConnectionRetryTimeout {
+	if time.Since(startedAt) >= deps.retryTimeout {
 		if ctx.Err() != nil {
 			return true, lastOutcome, ctx.Err()
 		}
@@ -118,8 +119,9 @@ func finishUnityAliveRetryWait(
 	connection unityipc.Connection,
 	lastOutcome unityipc.UnitySendOutcome,
 	lastErr error,
+	deps connectionRetryDeps,
 ) (bool, unityipc.UnitySendOutcome, error) {
-	if time.Since(startedAt) >= unityAliveRetryWindow() {
+	if time.Since(startedAt) >= unityAliveRetryWindow(deps) {
 		finalOutcome, finalErr := finishUnityAliveRetry(ctx, connection, lastOutcome, lastErr)
 		return true, finalOutcome, finalErr
 	}

--- a/cli/project-runner/internal/projectrunner/connection_retry_test.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_test.go
@@ -19,30 +19,21 @@ import (
 
 // Verifies transient IPC connection failures focus Unity once and restore focus before reporting server-not-responding.
 func TestSendWithTransientConnectionRetryReportsUnityServerNotResponding(t *testing.T) {
-	originalFinder := findRunningUnityProcessForConnectionRetry
-	originalFocus := focusUnityProcessForConnectionRetry
-	originalTimeout := serverConnectionRetryTimeout
-	originalPoll := serverConnectionRetryPoll
+	deps := defaultConnectionRetryDeps()
 	focusCallCount := 0
 	restoreCallCount := 0
-	findRunningUnityProcessForConnectionRetry = func(context.Context, string) (*clicore.UnityProcess, error) {
+	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
 		return &clicore.UnityProcess{Pid: 123}, nil
 	}
-	focusUnityProcessForConnectionRetry = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
+	deps.focusUnityProcess = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
 		focusCallCount++
 		return func(context.Context) error {
 			restoreCallCount++
 			return nil
 		}, nil
 	}
-	serverConnectionRetryTimeout = time.Nanosecond
-	serverConnectionRetryPoll = time.Nanosecond
-	t.Cleanup(func() {
-		findRunningUnityProcessForConnectionRetry = originalFinder
-		focusUnityProcessForConnectionRetry = originalFocus
-		serverConnectionRetryTimeout = originalTimeout
-		serverConnectionRetryPoll = originalPoll
-	})
+	deps.retryTimeout = time.Nanosecond
+	deps.retryPoll = time.Nanosecond
 
 	connection := unityipc.Connection{
 		Endpoint: unityipc.Endpoint{
@@ -52,12 +43,14 @@ func TestSendWithTransientConnectionRetryReportsUnityServerNotResponding(t *test
 		ProjectRoot: t.TempDir(),
 	}
 
-	_, err := sendWithTransientConnectionRetry(
+	_, err := sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"get-logs",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 
 	var notRespondingErr clicore.UnityServerNotRespondingError
 	if !errors.As(err, &notRespondingErr) {
@@ -75,24 +68,15 @@ func TestSendWithTransientConnectionRetryReportsUnityServerNotResponding(t *test
 func TestSendWithTransientConnectionRetryWritesFocusSuccessVibeLog(t *testing.T) {
 	enableCliVibeLog(t)
 
-	originalFinder := findRunningUnityProcessForConnectionRetry
-	originalFocus := focusUnityProcessForConnectionRetry
-	originalTimeout := serverConnectionRetryTimeout
-	originalPoll := serverConnectionRetryPoll
-	findRunningUnityProcessForConnectionRetry = func(context.Context, string) (*clicore.UnityProcess, error) {
+	deps := defaultConnectionRetryDeps()
+	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
 		return &clicore.UnityProcess{Pid: 456}, nil
 	}
-	focusUnityProcessForConnectionRetry = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
+	deps.focusUnityProcess = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
 		return nil, nil
 	}
-	serverConnectionRetryTimeout = time.Nanosecond
-	serverConnectionRetryPoll = time.Nanosecond
-	t.Cleanup(func() {
-		findRunningUnityProcessForConnectionRetry = originalFinder
-		focusUnityProcessForConnectionRetry = originalFocus
-		serverConnectionRetryTimeout = originalTimeout
-		serverConnectionRetryPoll = originalPoll
-	})
+	deps.retryTimeout = time.Nanosecond
+	deps.retryPoll = time.Nanosecond
 
 	projectRoot := t.TempDir()
 	connection := unityipc.Connection{
@@ -103,12 +87,14 @@ func TestSendWithTransientConnectionRetryWritesFocusSuccessVibeLog(t *testing.T)
 		ProjectRoot: projectRoot,
 	}
 
-	_, _ = sendWithTransientConnectionRetry(
+	_, _ = sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"get-logs",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 
 	logContent := readOnlyCliVibeLog(t, projectRoot)
 	for _, expected := range []string{
@@ -128,24 +114,15 @@ func TestSendWithTransientConnectionRetryWritesFocusSuccessVibeLog(t *testing.T)
 func TestSendWithTransientConnectionRetryWritesFocusFailureVibeLog(t *testing.T) {
 	enableCliVibeLog(t)
 
-	originalFinder := findRunningUnityProcessForConnectionRetry
-	originalFocus := focusUnityProcessForConnectionRetry
-	originalTimeout := serverConnectionRetryTimeout
-	originalPoll := serverConnectionRetryPoll
-	findRunningUnityProcessForConnectionRetry = func(context.Context, string) (*clicore.UnityProcess, error) {
+	deps := defaultConnectionRetryDeps()
+	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
 		return &clicore.UnityProcess{Pid: 789}, nil
 	}
-	focusUnityProcessForConnectionRetry = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
+	deps.focusUnityProcess = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
 		return nil, fmt.Errorf("focus denied")
 	}
-	serverConnectionRetryTimeout = time.Nanosecond
-	serverConnectionRetryPoll = time.Nanosecond
-	t.Cleanup(func() {
-		findRunningUnityProcessForConnectionRetry = originalFinder
-		focusUnityProcessForConnectionRetry = originalFocus
-		serverConnectionRetryTimeout = originalTimeout
-		serverConnectionRetryPoll = originalPoll
-	})
+	deps.retryTimeout = time.Nanosecond
+	deps.retryPoll = time.Nanosecond
 
 	projectRoot := t.TempDir()
 	connection := unityipc.Connection{
@@ -156,12 +133,14 @@ func TestSendWithTransientConnectionRetryWritesFocusFailureVibeLog(t *testing.T)
 		ProjectRoot: projectRoot,
 	}
 
-	_, _ = sendWithTransientConnectionRetry(
+	_, _ = sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"compile",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 
 	logContent := readOnlyCliVibeLog(t, projectRoot)
 	for _, expected := range []string{
@@ -180,20 +159,13 @@ func TestSendWithTransientConnectionRetryWritesFocusFailureVibeLog(t *testing.T)
 
 // Verifies process probe timeouts keep the structured server-not-responding error.
 func TestSendWithTransientConnectionRetryClassifiesProcessProbeTimeout(t *testing.T) {
-	originalFinder := findRunningUnityProcessForConnectionRetry
-	originalTimeout := serverConnectionRetryTimeout
-	originalPoll := serverConnectionRetryPoll
-	findRunningUnityProcessForConnectionRetry = func(ctx context.Context, projectRoot string) (*clicore.UnityProcess, error) {
+	deps := defaultConnectionRetryDeps()
+	deps.findRunningUnityProcess = func(ctx context.Context, projectRoot string) (*clicore.UnityProcess, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	serverConnectionRetryTimeout = time.Nanosecond
-	serverConnectionRetryPoll = time.Nanosecond
-	t.Cleanup(func() {
-		findRunningUnityProcessForConnectionRetry = originalFinder
-		serverConnectionRetryTimeout = originalTimeout
-		serverConnectionRetryPoll = originalPoll
-	})
+	deps.retryTimeout = time.Nanosecond
+	deps.retryPoll = time.Nanosecond
 
 	connection := unityipc.Connection{
 		Endpoint: unityipc.Endpoint{
@@ -203,12 +175,14 @@ func TestSendWithTransientConnectionRetryClassifiesProcessProbeTimeout(t *testin
 		ProjectRoot: t.TempDir(),
 	}
 
-	_, err := sendWithTransientConnectionRetry(
+	_, err := sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"get-logs",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 
 	var notRespondingErr clicore.UnityServerNotRespondingError
 	if !errors.As(err, &notRespondingErr) {
@@ -342,28 +316,23 @@ func TestConnectionRetryFocusReasonClassifiesEditorUnresponsive(t *testing.T) {
 
 // Verifies a transient process discovery miss does not suppress a later focus attempt.
 func TestConnectionRetryFocusControllerRetriesAfterProcessDiscoveryMiss(t *testing.T) {
-	originalFinder := findRunningUnityProcessForConnectionRetry
-	originalFocus := focusUnityProcessForConnectionRetry
+	deps := defaultConnectionRetryDeps()
 	findCallCount := 0
 	focusCallCount := 0
-	findRunningUnityProcessForConnectionRetry = func(context.Context, string) (*clicore.UnityProcess, error) {
+	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
 		findCallCount++
 		if findCallCount == 1 {
 			return nil, nil
 		}
 		return &clicore.UnityProcess{Pid: 123}, nil
 	}
-	focusUnityProcessForConnectionRetry = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
+	deps.focusUnityProcess = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
 		focusCallCount++
 		return nil, nil
 	}
-	t.Cleanup(func() {
-		findRunningUnityProcessForConnectionRetry = originalFinder
-		focusUnityProcessForConnectionRetry = originalFocus
-	})
 
 	connection := unityipc.Connection{ProjectRoot: t.TempDir()}
-	controller := newConnectionRetryFocusController(connection, "get-logs")
+	controller := newConnectionRetryFocusController(connection, "get-logs", deps)
 
 	controller.tryFocus(context.Background(), focusReasonMainThreadStall, errors.New("first probe missed"))
 	controller.tryFocus(context.Background(), focusReasonFinalResponseTimeout, errors.New("terminal timeout"))
@@ -382,14 +351,11 @@ func TestSendWithTransientConnectionRetryDoesNotCancelAcceptedRequestAtRetryTime
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
 	}
 
-	originalTimeout := serverConnectionRetryTimeout
+	deps := defaultConnectionRetryDeps()
 	// The retry window must be wide enough that the dial plus accepted ack always
 	// completes inside it even on a loaded CI machine, while the server delay stays
 	// well past the window so the timeout reliably fires mid-request.
-	serverConnectionRetryTimeout = 200 * time.Millisecond
-	t.Cleanup(func() {
-		serverConnectionRetryTimeout = originalTimeout
-	})
+	deps.retryTimeout = 200 * time.Millisecond
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -438,12 +404,14 @@ func TestSendWithTransientConnectionRetryDoesNotCancelAcceptedRequestAtRetryTime
 		ProjectRoot: t.TempDir(),
 	}
 
-	outcome, err := sendWithTransientConnectionRetry(
+	outcome, err := sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"compile",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 	if err != nil {
 		t.Fatalf("accepted request should not be canceled by retry timeout: %v", err)
 	}
@@ -464,14 +432,11 @@ func TestSendWithTransientConnectionRetryKeepsRetryTimeoutBeforeAcceptedAck(t *t
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
 	}
 
-	originalTimeout := serverConnectionRetryTimeout
+	deps := defaultConnectionRetryDeps()
 	// The retry window must be wide enough that the dial and request write always
 	// complete inside it even on a loaded CI machine, while the server delay stays
 	// well past the window so the pre-accept timeout reliably fires first.
-	serverConnectionRetryTimeout = 200 * time.Millisecond
-	t.Cleanup(func() {
-		serverConnectionRetryTimeout = originalTimeout
-	})
+	deps.retryTimeout = 200 * time.Millisecond
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -513,12 +478,14 @@ func TestSendWithTransientConnectionRetryKeepsRetryTimeoutBeforeAcceptedAck(t *t
 		ProjectRoot: t.TempDir(),
 	}
 
-	outcome, err := sendWithTransientConnectionRetry(
+	outcome, err := sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"compile",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 	if err == nil {
 		t.Fatalf("expected retry timeout before accepted ack, got result %s", outcome.Result)
 	}
@@ -539,27 +506,20 @@ func TestSendWithTransientConnectionRetryKeepsUnityFocusedAfterPreAcceptTimeout(
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
 	}
 
-	originalFinder := findRunningUnityProcessForConnectionRetry
-	originalFocus := focusUnityProcessForConnectionRetry
-	originalTimeout := serverConnectionRetryTimeout
+	deps := defaultConnectionRetryDeps()
 	focusCallCount := 0
 	restoreCallCount := 0
-	findRunningUnityProcessForConnectionRetry = func(context.Context, string) (*clicore.UnityProcess, error) {
+	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
 		return &clicore.UnityProcess{Pid: 123}, nil
 	}
-	focusUnityProcessForConnectionRetry = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
+	deps.focusUnityProcess = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
 		focusCallCount++
 		return func(context.Context) error {
 			restoreCallCount++
 			return nil
 		}, nil
 	}
-	serverConnectionRetryTimeout = 100 * time.Millisecond
-	t.Cleanup(func() {
-		findRunningUnityProcessForConnectionRetry = originalFinder
-		focusUnityProcessForConnectionRetry = originalFocus
-		serverConnectionRetryTimeout = originalTimeout
-	})
+	deps.retryTimeout = 100 * time.Millisecond
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -595,12 +555,14 @@ func TestSendWithTransientConnectionRetryKeepsUnityFocusedAfterPreAcceptTimeout(
 		ProjectRoot: t.TempDir(),
 	}
 
-	_, err = sendWithTransientConnectionRetry(
+	_, err = sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"get-logs",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 
 	if err == nil {
 		t.Fatal("expected pre-accept timeout")
@@ -620,11 +582,8 @@ func TestSendWithTransientConnectionRetryRetriesBusyResponses(t *testing.T) {
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
 	}
 
-	originalPoll := serverConnectionRetryPoll
-	serverConnectionRetryPoll = 5 * time.Millisecond
-	t.Cleanup(func() {
-		serverConnectionRetryPoll = originalPoll
-	})
+	deps := defaultConnectionRetryDeps()
+	deps.retryPoll = 5 * time.Millisecond
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -659,12 +618,14 @@ func TestSendWithTransientConnectionRetryRetriesBusyResponses(t *testing.T) {
 		ProjectRoot: t.TempDir(),
 	}
 
-	outcome, err := sendWithTransientConnectionRetry(
+	outcome, err := sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"get-logs",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 	if err != nil {
 		t.Fatalf("busy response should be retried to success: %v", err)
 	}
@@ -679,29 +640,22 @@ func TestSendWithTransientConnectionRetryReturnsBusyAfterRetryWindow(t *testing.
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
 	}
 
-	originalFinder := findRunningUnityProcessForConnectionRetry
-	originalTimeout := serverConnectionRetryTimeout
-	originalPoll := serverConnectionRetryPoll
+	deps := defaultConnectionRetryDeps()
 	// The busy assertion only holds once at least one busy response lands inside the
 	// retry window. A narrow window can expire before the first dial completes on a
 	// loaded CI machine, surfacing a dial timeout instead of the busy RPC error.
-	serverConnectionRetryTimeout = 500 * time.Millisecond
-	serverConnectionRetryPoll = 5 * time.Millisecond
+	deps.retryTimeout = 500 * time.Millisecond
+	deps.retryPoll = 5 * time.Millisecond
 	// A dial cut short by the expiring window probes for a running Unity process.
 	// The dial deadline is a separate timer that can fire microseconds before
 	// retryContext reports expiry, so an instant probe would reach the busy-masking
 	// guard while retryContext.Err() is still nil and surface the dial error instead.
 	// Block until the context is done, like a real OS process scan that always
 	// outlasts those microseconds, so the busy guard sees the expired context.
-	findRunningUnityProcessForConnectionRetry = func(ctx context.Context, projectRoot string) (*clicore.UnityProcess, error) {
+	deps.findRunningUnityProcess = func(ctx context.Context, projectRoot string) (*clicore.UnityProcess, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	t.Cleanup(func() {
-		findRunningUnityProcessForConnectionRetry = originalFinder
-		serverConnectionRetryTimeout = originalTimeout
-		serverConnectionRetryPoll = originalPoll
-	})
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -739,12 +693,14 @@ func TestSendWithTransientConnectionRetryReturnsBusyAfterRetryWindow(t *testing.
 		ProjectRoot: t.TempDir(),
 	}
 
-	_, err = sendWithTransientConnectionRetry(
+	_, err = sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"get-logs",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 	if err == nil {
 		t.Fatal("expected busy error after retry window")
 	}
@@ -762,26 +718,17 @@ func TestSendWithTransientConnectionRetryExtendsWindowWhileUnityProcessRuns(t *t
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
 	}
 
-	originalFinder := findRunningUnityProcessForConnectionRetry
-	originalFocus := focusUnityProcessForConnectionRetry
-	originalTimeout := serverConnectionRetryTimeout
-	originalPoll := serverConnectionRetryPoll
-	findRunningUnityProcessForConnectionRetry = func(context.Context, string) (*clicore.UnityProcess, error) {
+	deps := defaultConnectionRetryDeps()
+	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
 		return &clicore.UnityProcess{Pid: 123}, nil
 	}
-	focusUnityProcessForConnectionRetry = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
+	deps.focusUnityProcess = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
 		return func(context.Context) error { return nil }, nil
 	}
 	// Base window expires well before the server comes up; only the extended
 	// unity-alive window (base * factor) allows the late dial to succeed.
-	serverConnectionRetryTimeout = 100 * time.Millisecond
-	serverConnectionRetryPoll = 10 * time.Millisecond
-	t.Cleanup(func() {
-		findRunningUnityProcessForConnectionRetry = originalFinder
-		focusUnityProcessForConnectionRetry = originalFocus
-		serverConnectionRetryTimeout = originalTimeout
-		serverConnectionRetryPoll = originalPoll
-	})
+	deps.retryTimeout = 100 * time.Millisecond
+	deps.retryPoll = 10 * time.Millisecond
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -832,12 +779,14 @@ func TestSendWithTransientConnectionRetryExtendsWindowWhileUnityProcessRuns(t *t
 		ProjectRoot: t.TempDir(),
 	}
 
-	outcome, err := sendWithTransientConnectionRetry(
+	outcome, err := sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"get-logs",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 	if err != nil {
 		t.Fatalf("expected success after server came back inside the extended window, got %v", err)
 	}
@@ -853,14 +802,9 @@ func TestSendWithTransientConnectionRetryKeepsBusyBoundedByBaseWindow(t *testing
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
 	}
 
-	originalTimeout := serverConnectionRetryTimeout
-	originalPoll := serverConnectionRetryPoll
-	serverConnectionRetryTimeout = 200 * time.Millisecond
-	serverConnectionRetryPoll = 10 * time.Millisecond
-	t.Cleanup(func() {
-		serverConnectionRetryTimeout = originalTimeout
-		serverConnectionRetryPoll = originalPoll
-	})
+	deps := defaultConnectionRetryDeps()
+	deps.retryTimeout = 200 * time.Millisecond
+	deps.retryPoll = 10 * time.Millisecond
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -898,12 +842,14 @@ func TestSendWithTransientConnectionRetryKeepsBusyBoundedByBaseWindow(t *testing
 	}
 
 	startedAt := time.Now()
-	_, err = sendWithTransientConnectionRetry(
+	_, err = sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"get-logs",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 	elapsed := time.Since(startedAt)
 
 	var rpcErr *unityipc.RPCError
@@ -912,7 +858,7 @@ func TestSendWithTransientConnectionRetryKeepsBusyBoundedByBaseWindow(t *testing
 	}
 	// Generous CI margin: the assertion only needs to prove busy did not run for the
 	// full extended window (base * factor = 1200ms here).
-	if elapsed >= unityAliveRetryWindow() {
+	if elapsed >= unityAliveRetryWindow(deps) {
 		t.Fatalf("busy retries ran into the extended window: %v", elapsed)
 	}
 }
@@ -924,15 +870,10 @@ func TestSendWithTransientConnectionRetrySurfacesDispatchedFailureAfterBusy(t *t
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
 	}
 
-	originalTimeout := serverConnectionRetryTimeout
-	originalPoll := serverConnectionRetryPoll
+	deps := defaultConnectionRetryDeps()
 	retryWindow := 150 * time.Millisecond
-	serverConnectionRetryTimeout = retryWindow
-	serverConnectionRetryPoll = 5 * time.Millisecond
-	t.Cleanup(func() {
-		serverConnectionRetryTimeout = originalTimeout
-		serverConnectionRetryPoll = originalPoll
-	})
+	deps.retryTimeout = retryWindow
+	deps.retryPoll = 5 * time.Millisecond
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -985,12 +926,14 @@ func TestSendWithTransientConnectionRetrySurfacesDispatchedFailureAfterBusy(t *t
 		ProjectRoot: t.TempDir(),
 	}
 
-	_, err = sendWithTransientConnectionRetry(
+	_, err = sendWithTransientConnectionRetryWithDeps(
 		context.Background(),
 		connection,
 		"get-logs",
 		map[string]any{},
-		nil)
+		nil,
+		0,
+		deps)
 	if err == nil {
 		t.Fatal("expected the dispatched failure to surface")
 	}

--- a/cli/project-runner/internal/projectrunner/run.go
+++ b/cli/project-runner/internal/projectrunner/run.go
@@ -146,6 +146,17 @@ func runExecuteDynamicCodeWithDomainReloadWait(ctx context.Context, connection u
 }
 
 func runCompileWithDomainReloadWait(ctx context.Context, connection unityipc.Connection, params map[string]any, stdout io.Writer, stderr io.Writer) int {
+	return runCompileWithDomainReloadWaitWithDeps(ctx, connection, params, stdout, stderr, defaultCompileWaitDeps())
+}
+
+func runCompileWithDomainReloadWaitWithDeps(
+	ctx context.Context,
+	connection unityipc.Connection,
+	params map[string]any,
+	stdout io.Writer,
+	stderr io.Writer,
+	compileWait compileWaitDeps,
+) int {
 	requestID, err := prepareCompileWaitParams(params)
 	if err != nil {
 		clicore.WriteClassifiedError(stderr, err, clicore.ErrorContext{
@@ -182,13 +193,13 @@ func runCompileWithDomainReloadWait(ctx context.Context, connection unityipc.Con
 	}
 
 	spinner.Update("Waiting for domain reload to complete...")
-	result, completed, waitErr := waitForCompileCompletion(ctx, compileCompletionOptions{
+	result, completed, waitErr := waitForCompileCompletionWithDeps(ctx, compileCompletionOptions{
 		connection:     connection,
 		requestID:      requestID,
 		forceRecompile: compileForceRecompileEnabled(params),
 		timeout:        compileWaitTimeout,
 		pollInterval:   compileWaitPollInterval,
-	})
+	}, compileWait)
 	if waitErr != nil {
 		spinner.Stop()
 		clicore.WriteClassifiedError(stderr, waitErr, clicore.ErrorContext{


### PR DESCRIPTION
## Summary
- Replace project-runner connection retry package seam variables with explicit retry dependencies.
- Replace compile wait status query seam with compileWaitDeps.
- Update tests to pass per-test dependencies instead of mutating package state.

## Verification
- go test ./internal/projectrunner
- go test ./internal/architecture -count=1
- scripts/check-go-cli.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

