### PR TITLE
fix: Shared IPC clients assign request IDs safely

### DIFF
--- a/cli/common/unityipc/client.go
+++ b/cli/common/unityipc/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 	"time"
 
 	clicontract "github.com/hatayama/unity-cli-loop/common/clicontract"
@@ -36,15 +37,11 @@ const defaultMainThreadStallLimit = 5 * time.Minute
 const mainThreadStallProgressThresholdSeconds = 30
 
 type Client struct {
-	connection      Connection
-	requestID       int
-	clientVersion   string
-	acceptTimeout   time.Duration
-	responseTimeout time.Duration
-	// Test seams: zero means "use the derived/default values".
-	heartbeatSilenceOverride time.Duration
-	mainThreadStallLimit     time.Duration
-	mainThreadStallHandler   func(float64)
+	connection    Connection
+	requestIDMu   sync.Mutex
+	requestID     int
+	clientVersion string
+	options       ClientOptions
 }
 
 type ProgressFunc = func(message string)
@@ -128,18 +125,30 @@ func (err *RPCError) Error() string {
 	return fmt.Sprintf("unity error: %s", err.Message)
 }
 
-func NewClient(connection Connection, clientVersion string) *Client {
-	return &Client{connection: connection, clientVersion: clientVersion}
+func NewClient(connection Connection, clientVersion string, options ...ClientOption) *Client {
+	clientOptions := ClientOptions{}
+	for _, option := range options {
+		option(&clientOptions)
+	}
+	return &Client{connection: connection, clientVersion: clientVersion, options: clientOptions}
 }
 
 func (client *Client) WithResponseTimeout(timeout time.Duration) *Client {
-	client.responseTimeout = timeout
-	return client
+	return client.withOption(WithResponseTimeout(timeout))
 }
 
 func (client *Client) WithMainThreadStallHandler(handler func(float64)) *Client {
-	client.mainThreadStallHandler = handler
-	return client
+	return client.withOption(WithMainThreadStallHandler(handler))
+}
+
+func (client *Client) withOption(option ClientOption) *Client {
+	clientOptions := client.options
+	option(&clientOptions)
+	return &Client{
+		connection:    client.connection,
+		clientVersion: client.clientVersion,
+		options:       clientOptions,
+	}
 }
 
 func (client *Client) Send(ctx context.Context, method string, params map[string]any) (json.RawMessage, error) {
@@ -183,7 +192,7 @@ func (client *Client) SendWithProgressOutcomeAcceptContext(
 		progress(ProgressEventConnected)
 	}
 
-	client.requestID++
+	requestID := client.nextRequestID()
 	request := rpcRequest{
 		JSONRPC: "2.0",
 		Method:  method,
@@ -194,7 +203,7 @@ func (client *Client) SendWithProgressOutcomeAcceptContext(
 			AcceptsDispatchAck:   true,
 			AcceptsHeartbeat:     true,
 		},
-		ID: client.requestID,
+		ID: requestID,
 	}
 
 	payload, err := json.Marshal(request)
@@ -346,8 +355,8 @@ func (client *Client) handleHeartbeatResponse(
 }
 
 func (client *Client) reportMainThreadStall(stallSeconds float64, progress ProgressFunc) {
-	if client.mainThreadStallHandler != nil {
-		client.mainThreadStallHandler(stallSeconds)
+	if client.options.mainThreadStallHandler != nil {
+		client.options.mainThreadStallHandler(stallSeconds)
 	}
 	if progress != nil {
 		progress(fmt.Sprintf(
@@ -391,15 +400,15 @@ func finishOutcomeWithError(
 }
 
 func (client *Client) getAcceptTimeout() time.Duration {
-	if client.acceptTimeout > 0 {
-		return client.acceptTimeout
+	if client.options.acceptTimeout > 0 {
+		return client.options.acceptTimeout
 	}
 	return requestTimeout
 }
 
 func (client *Client) getResponseTimeout() time.Duration {
-	if client.responseTimeout > 0 {
-		return client.responseTimeout
+	if client.options.responseTimeout > 0 {
+		return client.options.responseTimeout
 	}
 	return finalResponseTimeout
 }
@@ -409,23 +418,30 @@ func (client *Client) getResponseTimeout() time.Duration {
 // to status polling) must stay an absolute deadline, and servers that did not
 // negotiate heartbeats keep the legacy absolute deadline too.
 func (client *Client) getHeartbeatSilence(heartbeatIntervalSeconds int) time.Duration {
-	if client.responseTimeout > 0 {
+	if client.options.responseTimeout > 0 {
 		return 0
 	}
 	if heartbeatIntervalSeconds <= 0 {
 		return 0
 	}
-	if client.heartbeatSilenceOverride > 0 {
-		return client.heartbeatSilenceOverride
+	if client.options.heartbeatSilenceOverride > 0 {
+		return client.options.heartbeatSilenceOverride
 	}
 	return time.Duration(heartbeatIntervalSeconds) * time.Second * heartbeatSilenceGraceFactor
 }
 
 func (client *Client) getMainThreadStallLimit() time.Duration {
-	if client.mainThreadStallLimit > 0 {
-		return client.mainThreadStallLimit
+	if client.options.mainThreadStallLimit > 0 {
+		return client.options.mainThreadStallLimit
 	}
 	return defaultMainThreadStallLimit
+}
+
+func (client *Client) nextRequestID() int {
+	client.requestIDMu.Lock()
+	defer client.requestIDMu.Unlock()
+	client.requestID++
+	return client.requestID
 }
 
 // Reports whether the error is a connection deadline expiry. go-winio's named pipe

--- a/cli/common/unityipc/client.go
+++ b/cli/common/unityipc/client.go
@@ -399,51 +399,6 @@ func finishOutcomeWithError(
 	return outcome, err
 }
 
-func (client *Client) getAcceptTimeout() time.Duration {
-	if client.options.acceptTimeout > 0 {
-		return client.options.acceptTimeout
-	}
-	return requestTimeout
-}
-
-func (client *Client) getResponseTimeout() time.Duration {
-	if client.options.responseTimeout > 0 {
-		return client.options.responseTimeout
-	}
-	return finalResponseTimeout
-}
-
-// Derives the sliding silence window for a negotiated heartbeat connection.
-// Zero disables sliding: an explicit response timeout (e.g. compile's quick fallback
-// to status polling) must stay an absolute deadline, and servers that did not
-// negotiate heartbeats keep the legacy absolute deadline too.
-func (client *Client) getHeartbeatSilence(heartbeatIntervalSeconds int) time.Duration {
-	if client.options.responseTimeout > 0 {
-		return 0
-	}
-	if heartbeatIntervalSeconds <= 0 {
-		return 0
-	}
-	if client.options.heartbeatSilenceOverride > 0 {
-		return client.options.heartbeatSilenceOverride
-	}
-	return time.Duration(heartbeatIntervalSeconds) * time.Second * heartbeatSilenceGraceFactor
-}
-
-func (client *Client) getMainThreadStallLimit() time.Duration {
-	if client.options.mainThreadStallLimit > 0 {
-		return client.options.mainThreadStallLimit
-	}
-	return defaultMainThreadStallLimit
-}
-
-func (client *Client) nextRequestID() int {
-	client.requestIDMu.Lock()
-	defer client.requestIDMu.Unlock()
-	client.requestID++
-	return client.requestID
-}
-
 // Reports whether the error is a connection deadline expiry. go-winio's named pipe
 // deadline error is not os.ErrDeadlineExceeded, so a Timeout() probe through the
 // unwrap chain is required for Windows.

--- a/cli/common/unityipc/client_heartbeat_test.go
+++ b/cli/common/unityipc/client_heartbeat_test.go
@@ -126,8 +126,7 @@ func TestSendKeepsWaitingWhileHeartbeatsArrive(t *testing.T) {
 		writeFrame(t, conn, `{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`)
 	})
 
-	client := NewClient(connection, "9.9.9")
-	client.heartbeatSilenceOverride = 200 * time.Millisecond
+	client := NewClient(connection, "9.9.9", withHeartbeatSilenceOverrideForTest(200*time.Millisecond))
 
 	outcome, err := client.SendWithProgressOutcome(context.Background(), "run-tests", map[string]any{}, nil)
 	if err != nil {
@@ -151,10 +150,14 @@ func TestSendReportsMainThreadStallToHandler(t *testing.T) {
 	})
 
 	stallReports := []float64{}
-	client := NewClient(connection, "9.9.9").WithMainThreadStallHandler(func(stallSeconds float64) {
-		stallReports = append(stallReports, stallSeconds)
-	})
-	client.heartbeatSilenceOverride = 5 * time.Second
+	client := NewClient(
+		connection,
+		"9.9.9",
+		WithMainThreadStallHandler(func(stallSeconds float64) {
+			stallReports = append(stallReports, stallSeconds)
+		}),
+		withHeartbeatSilenceOverrideForTest(5*time.Second),
+	)
 
 	outcome, err := client.SendWithProgressOutcome(context.Background(), "run-tests", map[string]any{}, nil)
 	if err != nil {
@@ -178,8 +181,7 @@ func TestSendReportsMainThreadStallProgressWithModalHint(t *testing.T) {
 	})
 
 	progressMessages := []string{}
-	client := NewClient(connection, "9.9.9")
-	client.heartbeatSilenceOverride = 5 * time.Second
+	client := NewClient(connection, "9.9.9", withHeartbeatSilenceOverrideForTest(5*time.Second))
 
 	_, err := client.SendWithProgressOutcome(
 		context.Background(),
@@ -214,8 +216,7 @@ func TestSendFailsWithDiagnosisWhenHeartbeatsStop(t *testing.T) {
 	})
 	defer close(done)
 
-	client := NewClient(connection, "9.9.9")
-	client.heartbeatSilenceOverride = 150 * time.Millisecond
+	client := NewClient(connection, "9.9.9", withHeartbeatSilenceOverrideForTest(150*time.Millisecond))
 
 	startedAt := time.Now()
 	_, err := client.SendWithProgressOutcome(context.Background(), "run-tests", map[string]any{}, nil)
@@ -245,9 +246,12 @@ func TestSendFailsWhenMainThreadStallExceedsLimit(t *testing.T) {
 	})
 	defer close(done)
 
-	client := NewClient(connection, "9.9.9")
-	client.heartbeatSilenceOverride = 5 * time.Second
-	client.mainThreadStallLimit = 2 * time.Second
+	client := NewClient(
+		connection,
+		"9.9.9",
+		withHeartbeatSilenceOverrideForTest(5*time.Second),
+		withMainThreadStallLimitForTest(2*time.Second),
+	)
 
 	_, err := client.SendWithProgressOutcome(context.Background(), "run-tests", map[string]any{}, nil)
 	var unresponsiveErr *EditorUnresponsiveError

--- a/cli/common/unityipc/client_options.go
+++ b/cli/common/unityipc/client_options.go
@@ -45,3 +45,48 @@ func withMainThreadStallLimitForTest(timeout time.Duration) ClientOption {
 		options.mainThreadStallLimit = timeout
 	}
 }
+
+func (client *Client) getAcceptTimeout() time.Duration {
+	if client.options.acceptTimeout > 0 {
+		return client.options.acceptTimeout
+	}
+	return requestTimeout
+}
+
+func (client *Client) getResponseTimeout() time.Duration {
+	if client.options.responseTimeout > 0 {
+		return client.options.responseTimeout
+	}
+	return finalResponseTimeout
+}
+
+// Derives the sliding silence window for a negotiated heartbeat connection.
+// Zero disables sliding: an explicit response timeout (e.g. compile's quick fallback
+// to status polling) must stay an absolute deadline, and servers that did not
+// negotiate heartbeats keep the legacy absolute deadline too.
+func (client *Client) getHeartbeatSilence(heartbeatIntervalSeconds int) time.Duration {
+	if client.options.responseTimeout > 0 {
+		return 0
+	}
+	if heartbeatIntervalSeconds <= 0 {
+		return 0
+	}
+	if client.options.heartbeatSilenceOverride > 0 {
+		return client.options.heartbeatSilenceOverride
+	}
+	return time.Duration(heartbeatIntervalSeconds) * time.Second * heartbeatSilenceGraceFactor
+}
+
+func (client *Client) getMainThreadStallLimit() time.Duration {
+	if client.options.mainThreadStallLimit > 0 {
+		return client.options.mainThreadStallLimit
+	}
+	return defaultMainThreadStallLimit
+}
+
+func (client *Client) nextRequestID() int {
+	client.requestIDMu.Lock()
+	defer client.requestIDMu.Unlock()
+	client.requestID++
+	return client.requestID
+}

--- a/cli/common/unityipc/client_options.go
+++ b/cli/common/unityipc/client_options.go
@@ -1,0 +1,47 @@
+package unityipc
+
+import "time"
+
+// ClientOptions configures optional IPC client timing and progress behavior.
+type ClientOptions struct {
+	acceptTimeout            time.Duration
+	responseTimeout          time.Duration
+	heartbeatSilenceOverride time.Duration
+	mainThreadStallLimit     time.Duration
+	mainThreadStallHandler   func(float64)
+}
+
+// ClientOption applies one optional IPC client setting.
+type ClientOption func(*ClientOptions)
+
+// WithResponseTimeout configures the post-accept response deadline.
+func WithResponseTimeout(timeout time.Duration) ClientOption {
+	return func(options *ClientOptions) {
+		options.responseTimeout = timeout
+	}
+}
+
+// WithMainThreadStallHandler configures a callback for heartbeat stall reports.
+func WithMainThreadStallHandler(handler func(float64)) ClientOption {
+	return func(options *ClientOptions) {
+		options.mainThreadStallHandler = handler
+	}
+}
+
+func withAcceptTimeoutForTest(timeout time.Duration) ClientOption {
+	return func(options *ClientOptions) {
+		options.acceptTimeout = timeout
+	}
+}
+
+func withHeartbeatSilenceOverrideForTest(timeout time.Duration) ClientOption {
+	return func(options *ClientOptions) {
+		options.heartbeatSilenceOverride = timeout
+	}
+}
+
+func withMainThreadStallLimitForTest(timeout time.Duration) ClientOption {
+	return func(options *ClientOptions) {
+		options.mainThreadStallLimit = timeout
+	}
+}

--- a/cli/common/unityipc/client_test.go
+++ b/cli/common/unityipc/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -37,6 +38,21 @@ func TestFormatConnectionAttemptErrorExplainsDialFailureWithoutDisconnectClaim(t
 	}
 	if connectionErr.Unwrap().Error() != "dial unix /tmp/uloop/UnityCliLoop-sample.sock: connect: no such file or directory" {
 		t.Fatalf("cause mismatch: %v", connectionErr.Unwrap())
+	}
+}
+
+func TestWithResponseTimeoutReturnsConfiguredCopy(t *testing.T) {
+	// Verifies that builder-style timeout configuration does not mutate the original client.
+	connection := Connection{ProjectRoot: t.TempDir()}
+	client := NewClient(connection, "3.0.0-beta.6")
+
+	configuredClient := client.WithResponseTimeout(250 * time.Millisecond)
+
+	if client.getResponseTimeout() != finalResponseTimeout {
+		t.Fatalf("original client response timeout was mutated: %s", client.getResponseTimeout())
+	}
+	if configuredClient.getResponseTimeout() != 250*time.Millisecond {
+		t.Fatalf("configured client response timeout mismatch: %s", configuredClient.getResponseTimeout())
 	}
 }
 
@@ -76,6 +92,116 @@ func TestSendIncludesProjectRunnerVersionWithoutProjectIdentityMetadata(t *testi
 	case request := <-captured:
 		assertClientMetadataRequest(t, request)
 	}
+}
+
+func TestSendAssignsUniqueRequestIDsConcurrently(t *testing.T) {
+	// Verifies that a shared Client can assign request IDs safely during concurrent sends.
+	if runtime.GOOS == "windows" {
+		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
+	}
+
+	requestCount := 32
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	capturedIDs := make(chan int, requestCount)
+	serverErr := make(chan error, requestCount)
+	go captureConcurrentRequestIDs(listener, requestCount, capturedIDs, serverErr)
+
+	connection := Connection{
+		Endpoint: Endpoint{
+			Network: "tcp",
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: "/tmp/MyProject",
+	}
+	client := NewClient(connection, "3.0.0-beta.6")
+
+	start := make(chan struct{})
+	clientErrs := make(chan error, requestCount)
+	wg := sync.WaitGroup{}
+	for i := 0; i < requestCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, sendErr := client.Send(context.Background(), "get-version", map[string]any{})
+			clientErrs <- sendErr
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(clientErrs)
+
+	for sendErr := range clientErrs {
+		if sendErr != nil {
+			t.Fatalf("Send failed: %v", sendErr)
+		}
+	}
+
+	seenIDs := map[int]bool{}
+	for i := 0; i < requestCount; i++ {
+		select {
+		case serverErrValue := <-serverErr:
+			t.Fatalf("server failed: %v", serverErrValue)
+		case requestID := <-capturedIDs:
+			if seenIDs[requestID] {
+				t.Fatalf("duplicate request ID captured: %d", requestID)
+			}
+			seenIDs[requestID] = true
+		}
+	}
+	if len(seenIDs) != requestCount {
+		t.Fatalf("request ID count mismatch: %d", len(seenIDs))
+	}
+}
+
+func captureConcurrentRequestIDs(
+	listener net.Listener,
+	requestCount int,
+	capturedIDs chan<- int,
+	serverErr chan<- error,
+) {
+	wg := sync.WaitGroup{}
+	for i := 0; i < requestCount; i++ {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		wg.Add(1)
+		go func(conn net.Conn) {
+			defer wg.Done()
+			defer func() {
+				_ = conn.Close()
+			}()
+
+			payload, readErr := Read(bufio.NewReader(conn))
+			if readErr != nil {
+				serverErr <- readErr
+				return
+			}
+
+			request := rpcRequest{}
+			if decodeErr := json.Unmarshal(payload, &request); decodeErr != nil {
+				serverErr <- decodeErr
+				return
+			}
+			capturedIDs <- request.ID
+
+			response := []byte(`{"jsonrpc":"2.0","result":{"ok":true},"id":1}`)
+			if writeErr := Write(conn, response); writeErr != nil {
+				serverErr <- writeErr
+				return
+			}
+		}(conn)
+	}
+	wg.Wait()
 }
 
 func captureClientMetadataRequest(
@@ -255,11 +381,10 @@ func TestSendWithProgressOutcomeWaitsForFinalResponseAfterDispatchAckWithoutAcce
 		},
 		ProjectRoot: "/tmp/MyProject",
 	}
-	client := NewClient(connection, "3.0.0-beta.6")
 	// The accept timeout must be wide enough that the accepted ack always arrives
 	// inside it even on a loaded CI machine, while the server delays the final
 	// response well past it to prove accepted requests outlive the accept timeout.
-	client.acceptTimeout = 250 * time.Millisecond
+	client := NewClient(connection, "3.0.0-beta.6", withAcceptTimeoutForTest(250*time.Millisecond))
 
 	outcome, err := client.SendWithProgressOutcome(context.Background(), "execute-dynamic-code", map[string]any{}, nil)
 	if err != nil {
@@ -324,9 +449,12 @@ func TestSendWithProgressOutcomeTimesOutFinalResponseAfterDispatchAck(t *testing
 		},
 		ProjectRoot: "/tmp/MyProject",
 	}
-	client := NewClient(connection, "3.0.0-beta.6")
-	client.acceptTimeout = time.Second
-	client.responseTimeout = 50 * time.Millisecond
+	client := NewClient(
+		connection,
+		"3.0.0-beta.6",
+		withAcceptTimeoutForTest(time.Second),
+		WithResponseTimeout(50*time.Millisecond),
+	)
 
 	outcome, err := client.SendWithProgressOutcome(context.Background(), "execute-dynamic-code", map[string]any{}, nil)
 	if err == nil || !strings.Contains(err.Error(), "i/o timeout") {
@@ -388,8 +516,7 @@ func TestSendWithProgressOutcomeStillHonorsParentCancellationAfterDispatchAck(t 
 		},
 		ProjectRoot: "/tmp/MyProject",
 	}
-	client := NewClient(connection, "3.0.0-beta.6")
-	client.acceptTimeout = time.Second
+	client := NewClient(connection, "3.0.0-beta.6", withAcceptTimeoutForTest(time.Second))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()

--- a/cli/common/unityipc/client_windows_test.go
+++ b/cli/common/unityipc/client_windows_test.go
@@ -73,8 +73,7 @@ func TestPipeSendKeepsWaitingWhileHeartbeatsArrive(t *testing.T) {
 		writeFrame(t, conn, `{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`)
 	})
 
-	client := NewClient(connection, "9.9.9")
-	client.heartbeatSilenceOverride = 200 * time.Millisecond
+	client := NewClient(connection, "9.9.9", withHeartbeatSilenceOverrideForTest(200*time.Millisecond))
 
 	outcome, err := client.SendWithProgressOutcome(context.Background(), "run-tests", map[string]any{}, nil)
 	if err != nil {
@@ -96,8 +95,7 @@ func TestPipeSendFailsWithDiagnosisWhenHeartbeatsStop(t *testing.T) {
 	})
 	defer close(done)
 
-	client := NewClient(connection, "9.9.9")
-	client.heartbeatSilenceOverride = 150 * time.Millisecond
+	client := NewClient(connection, "9.9.9", withHeartbeatSilenceOverrideForTest(150*time.Millisecond))
 
 	_, err := client.SendWithProgressOutcome(context.Background(), "run-tests", map[string]any{}, nil)
 	if err == nil {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "a556368434de848422cb045b2e5290c07d1a919f"
+  "sharedInputsHash": "b58452f9c0f12c73da40ccdda7b87ee77e64b99a"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "89c6319df7684d530be31c15b3e324efcbea09f4"
+  "sharedInputsHash": "bdaecfb852b88de8634ae849eddd5e1b0c0f064e"
 }


### PR DESCRIPTION
## Summary
- Shared IPC clients now assign request IDs safely during concurrent sends.
- Client timing and heartbeat test seams are configured through options instead of mutating client internals.

## User Impact
- Concurrent IPC requests are less likely to corrupt request/response correlation.
- Timeout and heartbeat behavior remains unchanged for normal CLI use.

## Changes
- Added ClientOptions and function options for response timeout and main-thread stall callbacks.
- Moved accept timeout, heartbeat silence, and stall-limit test seams behind unexported test options.
- Protected request ID assignment with a mutex and added a race-tested concurrent send regression test.

## Verification
- go test ./unityipc
- go test -race ./unityipc -run TestSendAssignsUniqueRequestIDsConcurrently -count=1
- go test ./... in cli/common
- scripts/check-go-cli.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

