### PR TITLE
chore: Load CLI contract metadata explicitly

### DIFF
--- a/cli/common/clicontract/contract.go
+++ b/cli/common/clicontract/contract.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"sync"
 )
 
 const (
@@ -13,6 +14,12 @@ const (
 
 //go:embed contract.json
 var contractFiles embed.FS
+
+var (
+	contractLoadOnce sync.Once
+	loadedContract   Contract
+	loadContractErr  error
+)
 
 type Contract struct {
 	SchemaVersion int `json:"schemaVersion"`
@@ -24,6 +31,13 @@ type Contract struct {
 
 // Load reads and validates the embedded CLI contract.
 func Load() (Contract, error) {
+	contractLoadOnce.Do(func() {
+		loadedContract, loadContractErr = loadEmbeddedContract()
+	})
+	return loadedContract, loadContractErr
+}
+
+func loadEmbeddedContract() (Contract, error) {
 	content, err := contractFiles.ReadFile(contractFileName)
 	if err != nil {
 		return Contract{}, fmt.Errorf("CLI contract is not embedded: %w", err)

--- a/cli/common/clicontract/contract.go
+++ b/cli/common/clicontract/contract.go
@@ -14,8 +14,6 @@ const (
 //go:embed contract.json
 var contractFiles embed.FS
 
-var Current = mustLoadContract()
-
 type Contract struct {
 	SchemaVersion int `json:"schemaVersion"`
 	// ProtocolVersion is the C# IPC contract generation this binary speaks. It moves only
@@ -24,28 +22,54 @@ type Contract struct {
 	ProjectRunnerVersion string `json:"projectRunnerVersion"`
 }
 
-func mustLoadContract() Contract {
+// Load reads and validates the embedded CLI contract.
+func Load() (Contract, error) {
 	content, err := contractFiles.ReadFile(contractFileName)
 	if err != nil {
-		panic(fmt.Sprintf("CLI contract is not embedded: %v", err))
+		return Contract{}, fmt.Errorf("CLI contract is not embedded: %w", err)
 	}
 
+	return parseContract(content)
+}
+
+// ProjectRunnerVersion returns the project runner release version from the CLI contract.
+func ProjectRunnerVersion() string {
+	return mustLoadContract().ProjectRunnerVersion
+}
+
+// ProtocolVersion returns the IPC protocol generation from the CLI contract.
+func ProtocolVersion() int {
+	return mustLoadContract().ProtocolVersion
+}
+
+func parseContract(content []byte) (Contract, error) {
 	var contract Contract
 	if err := json.Unmarshal(content, &contract); err != nil {
-		panic(fmt.Sprintf("CLI contract is invalid JSON: %v", err))
+		return Contract{}, fmt.Errorf("CLI contract is invalid JSON: %w", err)
 	}
 	if contract.SchemaVersion != schemaVersion {
-		panic(fmt.Sprintf("CLI contract schema version mismatch: %d", contract.SchemaVersion))
+		return Contract{}, fmt.Errorf("CLI contract schema version mismatch: %d", contract.SchemaVersion)
 	}
-	requireString(contract.ProjectRunnerVersion, "projectRunnerVersion")
+	if err := requireString(contract.ProjectRunnerVersion, "projectRunnerVersion"); err != nil {
+		return Contract{}, err
+	}
 	if contract.ProtocolVersion < 1 {
-		panic(fmt.Sprintf("CLI contract protocolVersion must be at least 1, got %d", contract.ProtocolVersion))
+		return Contract{}, fmt.Errorf("CLI contract protocolVersion must be at least 1, got %d", contract.ProtocolVersion)
+	}
+	return contract, nil
+}
+
+func mustLoadContract() Contract {
+	contract, err := Load()
+	if err != nil {
+		panic(err)
 	}
 	return contract
 }
 
-func requireString(value string, key string) {
+func requireString(value string, key string) error {
 	if value == "" {
-		panic(fmt.Sprintf("contract field %s must not be empty", key))
+		return fmt.Errorf("contract field %s must not be empty", key)
 	}
+	return nil
 }

--- a/cli/common/clicontract/contract_test.go
+++ b/cli/common/clicontract/contract_test.go
@@ -8,13 +8,33 @@ import (
 
 func TestCliContractProvidesRuntimeVersion(t *testing.T) {
 	// Verifies that the project runner owns its runtime version from the single CLI module.
-	clitest.RequireValidContractVersion(t, "projectRunnerVersion", Current.ProjectRunnerVersion)
+	clitest.RequireValidContractVersion(t, "projectRunnerVersion", ProjectRunnerVersion())
 }
 
 func TestCliContractProvidesProtocolVersion(t *testing.T) {
 	// Verifies that the contract declares which C#-side IPC protocol the binary speaks.
-	if Current.ProtocolVersion < 1 {
-		t.Fatalf("protocolVersion must be at least 1, got %d", Current.ProtocolVersion)
+	if ProtocolVersion() < 1 {
+		t.Fatalf("protocolVersion must be at least 1, got %d", ProtocolVersion())
+	}
+}
+
+func TestLoadReturnsEmbeddedContract(t *testing.T) {
+	// Verifies callers can explicitly load the embedded CLI contract.
+	contract, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	clitest.RequireValidContractVersion(t, "projectRunnerVersion", contract.ProjectRunnerVersion)
+	if contract.ProtocolVersion < 1 {
+		t.Fatalf("protocolVersion must be at least 1, got %d", contract.ProtocolVersion)
+	}
+}
+
+func TestParseContractReturnsErrorForInvalidJSON(t *testing.T) {
+	// Verifies malformed contract data is reported as an error instead of panicking during package init.
+	_, err := parseContract([]byte("{"))
+	if err == nil {
+		t.Fatal("expected invalid JSON error")
 	}
 }
 

--- a/cli/common/clicontract/protocol_version_consistency_test.go
+++ b/cli/common/clicontract/protocol_version_consistency_test.go
@@ -45,11 +45,12 @@ type unityPackageCliPin struct {
 // its own package. This check is deterministic and needs no git diff or release numbering.
 func TestProtocolVersionMatchesUnityPackage(t *testing.T) {
 	unityProtocolVersion := readUnityRequiredProtocolVersion(t)
-	if Current.ProtocolVersion != unityProtocolVersion {
+	cliProtocolVersion := ProtocolVersion()
+	if cliProtocolVersion != unityProtocolVersion {
 		t.Fatalf(
 			"protocol version mismatch: cli/contract.json declares %d but %s requires %d; "+
 				"bump both together on a breaking IPC change",
-			Current.ProtocolVersion, unityProtocolConstantPath, unityProtocolVersion)
+			cliProtocolVersion, unityProtocolConstantPath, unityProtocolVersion)
 	}
 }
 
@@ -69,11 +70,11 @@ func TestUnityPackageCliPinMatchesReleaseContracts(t *testing.T) {
 	if pin.PackageVersion != manifest.Version {
 		t.Fatalf("expected %s packageVersion to match %s version: %q != %q", unityPackageCliPinPath, unityPackageManifestPath, pin.PackageVersion, manifest.Version)
 	}
-	if pin.ProjectRunnerVersion != Current.ProjectRunnerVersion {
-		t.Fatalf("expected %s projectRunnerVersion to match cli/contract.json projectRunnerVersion: %q != %q", unityPackageCliPinPath, pin.ProjectRunnerVersion, Current.ProjectRunnerVersion)
+	if pin.ProjectRunnerVersion != ProjectRunnerVersion() {
+		t.Fatalf("expected %s projectRunnerVersion to match cli/contract.json projectRunnerVersion: %q != %q", unityPackageCliPinPath, pin.ProjectRunnerVersion, ProjectRunnerVersion())
 	}
-	if pin.RequiredProtocolVersion != Current.ProtocolVersion {
-		t.Fatalf("expected %s requiredProtocolVersion to match cli/contract.json protocolVersion: %d != %d", unityPackageCliPinPath, pin.RequiredProtocolVersion, Current.ProtocolVersion)
+	if pin.RequiredProtocolVersion != ProtocolVersion() {
+		t.Fatalf("expected %s requiredProtocolVersion to match cli/contract.json protocolVersion: %d != %d", unityPackageCliPinPath, pin.RequiredProtocolVersion, ProtocolVersion())
 	}
 	if pin.RequiredProtocolVersion != readUnityRequiredProtocolVersion(t) {
 		t.Fatalf("expected %s requiredProtocolVersion to match %s", unityPackageCliPinPath, unityProtocolConstantPath)

--- a/cli/common/clicore/runner_version.go
+++ b/cli/common/clicore/runner_version.go
@@ -7,15 +7,20 @@ import (
 	clicontract "github.com/hatayama/unity-cli-loop/common/clicontract"
 )
 
-var (
-	Version         = clicontract.Current.ProjectRunnerVersion
-	ProtocolVersion = clicontract.Current.ProtocolVersion
-)
+// Version returns the project runner release version advertised by CLI commands.
+func Version() string {
+	return clicontract.ProjectRunnerVersion()
+}
+
+// ProtocolVersion returns the IPC protocol generation advertised by CLI commands.
+func ProtocolVersion() int {
+	return clicontract.ProtocolVersion()
+}
 
 func WriteVersionJSON(stdout io.Writer) {
 	content, err := json.Marshal(map[string]any{
-		"ProjectRunnerVersion": Version,
-		"ProtocolVersion":      ProtocolVersion,
+		"ProjectRunnerVersion": Version(),
+		"ProtocolVersion":      ProtocolVersion(),
 	})
 	if err != nil {
 		panic(err)

--- a/cli/common/clicore/tool_readiness.go
+++ b/cli/common/clicore/tool_readiness.go
@@ -132,11 +132,11 @@ func probeToolReadiness(ctx context.Context, projectRoot string, executeDynamicC
 	}
 
 	if !executeDynamicCodeAvailable {
-		_, err := unityipc.NewClient(connection, Version).Send(probeContext, "get-version", map[string]any{})
+		_, err := unityipc.NewClient(connection, Version()).Send(probeContext, "get-version", map[string]any{})
 		return err
 	}
 
-	response, err := unityipc.NewClient(connection, Version).Send(probeContext, "execute-dynamic-code", executeDynamicCodeReadinessProbeParams())
+	response, err := unityipc.NewClient(connection, Version()).Send(probeContext, "execute-dynamic-code", executeDynamicCodeReadinessProbeParams())
 	if err != nil {
 		return err
 	}

--- a/cli/common/unityipc/client.go
+++ b/cli/common/unityipc/client.go
@@ -199,7 +199,7 @@ func (client *Client) SendWithProgressOutcomeAcceptContext(
 		Params:  params,
 		ULoop: rpcClientMetadata{
 			ProjectRunnerVersion: client.clientVersion,
-			ProtocolVersion:      clicontract.Current.ProtocolVersion,
+			ProtocolVersion:      clicontract.ProtocolVersion(),
 			AcceptsDispatchAck:   true,
 			AcceptsHeartbeat:     true,
 		},

--- a/cli/common/unityipc/client_test.go
+++ b/cli/common/unityipc/client_test.go
@@ -251,7 +251,7 @@ func assertClientMetadataRequest(t *testing.T, request map[string]any) {
 	if metadata["projectRunnerVersion"] != "3.0.0-beta.6" {
 		t.Fatalf("project runner version metadata mismatch: %#v", metadata)
 	}
-	if metadata["protocolVersion"] != float64(clicontract.Current.ProtocolVersion) {
+	if metadata["protocolVersion"] != float64(clicontract.ProtocolVersion()) {
 		t.Fatalf("protocol version metadata mismatch: %#v", metadata)
 	}
 	if metadata["acceptsDispatchAck"] != true {

--- a/cli/dispatcher/internal/dispatcher/dispatcher_download.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_download.go
@@ -47,7 +47,7 @@ func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin, stderr io.
 }
 
 func dispatcherSiblingRealCLIPath(pin dispatcherPin) (string, bool) {
-	if pin.ProjectRunnerVersion != clicore.Version {
+	if pin.ProjectRunnerVersion != clicore.Version() {
 		return "", false
 	}
 	executablePath, err := os.Executable()

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -37,8 +37,8 @@ func TestRunDispatcherUsesProjectPinAndCachedRealCLI(t *testing.T) {
 	// Verifies dispatcher reads the project pin and executes the cached real CLI.
 	projectRoot := createDispatcherUnityProject(t)
 	cacheRoot := t.TempDir()
-	writeDispatcherProjectPin(t, projectRoot, clicore.Version)
-	expectedCLIPath := writeCachedDispatcherRealCLI(t, cacheRoot, clicore.Version)
+	writeDispatcherProjectPin(t, projectRoot, clicore.Version())
+	expectedCLIPath := writeCachedDispatcherRealCLI(t, cacheRoot, clicore.Version())
 	t.Setenv(nativepath.CacheDirEnvName, cacheRoot)
 	t.Setenv(dispatcherDisableSelfUpdateEnvName, "1")
 	t.Chdir(projectRoot)
@@ -72,8 +72,8 @@ func TestRunDispatcherPreservesExplicitProjectPathForRealCLI(t *testing.T) {
 	// Verifies dispatcher accepts trailing --project-path and passes the original arguments onward.
 	projectRoot := createDispatcherUnityProject(t)
 	cacheRoot := t.TempDir()
-	writeDispatcherProjectPin(t, projectRoot, clicore.Version)
-	writeCachedDispatcherRealCLI(t, cacheRoot, clicore.Version)
+	writeDispatcherProjectPin(t, projectRoot, clicore.Version())
+	writeCachedDispatcherRealCLI(t, cacheRoot, clicore.Version())
 	t.Setenv(nativepath.CacheDirEnvName, cacheRoot)
 	t.Setenv(dispatcherDisableSelfUpdateEnvName, "1")
 	t.Chdir(t.TempDir())
@@ -99,8 +99,8 @@ func TestRunDispatcherForwardsProjectScopedVersionToPinnedRunner(t *testing.T) {
 	// Verifies --project-path --version is forwarded so the pinned runner reports its own version.
 	projectRoot := createDispatcherUnityProject(t)
 	cacheRoot := t.TempDir()
-	writeDispatcherProjectPin(t, projectRoot, clicore.Version)
-	writeCachedDispatcherRealCLI(t, cacheRoot, clicore.Version)
+	writeDispatcherProjectPin(t, projectRoot, clicore.Version())
+	writeCachedDispatcherRealCLI(t, cacheRoot, clicore.Version())
 	t.Setenv(nativepath.CacheDirEnvName, cacheRoot)
 	t.Setenv(dispatcherDisableSelfUpdateEnvName, "1")
 	t.Chdir(t.TempDir())
@@ -129,8 +129,8 @@ func TestRunDispatcherForwardsProjectScopedVersionJSONToPinnedRunner(t *testing.
 	// Verifies --project-path --version --json is forwarded so the pinned runner reports its own version payload.
 	projectRoot := createDispatcherUnityProject(t)
 	cacheRoot := t.TempDir()
-	writeDispatcherProjectPin(t, projectRoot, clicore.Version)
-	writeCachedDispatcherRealCLI(t, cacheRoot, clicore.Version)
+	writeDispatcherProjectPin(t, projectRoot, clicore.Version())
+	writeCachedDispatcherRealCLI(t, cacheRoot, clicore.Version())
 	t.Setenv(nativepath.CacheDirEnvName, cacheRoot)
 	t.Setenv(dispatcherDisableSelfUpdateEnvName, "1")
 	t.Chdir(t.TempDir())

--- a/cli/dispatcher/internal/dispatcher/run_help.go
+++ b/cli/dispatcher/internal/dispatcher/run_help.go
@@ -17,7 +17,7 @@ const (
 func printHelp(stdout io.Writer) {
 	printMainHelp(
 		stdout,
-		clicore.Version,
+		clicore.Version(),
 		nativeCLIDescription,
 		clicore.ToolsCache{},
 		false)
@@ -37,7 +37,7 @@ func printHelpForResolvedProject(stdout io.Writer, explicitProjectPath string) {
 	}
 
 	cache, ok := clicore.LoadProjectToolCache(connection.ProjectRoot)
-	printMainHelp(stdout, clicore.Version, nativeCLIDescription, cache, ok)
+	printMainHelp(stdout, clicore.Version(), nativeCLIDescription, cache, ok)
 }
 
 func printLauncherHelp(stdout io.Writer) {

--- a/cli/project-runner/internal/projectrunner/compile_wait.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait.go
@@ -159,7 +159,7 @@ func queryCompileStatusFromUnity(ctx context.Context, connection unityipc.Connec
 	probeContext, cancel := context.WithTimeout(ctx, compileStatusProbeTimeout)
 	defer cancel()
 
-	response, err := unityipc.NewClient(connection, clicore.Version).Send(
+	response, err := unityipc.NewClient(connection, clicore.Version()).Send(
 		probeContext,
 		compileStatusCommandName,
 		map[string]any{compileRequestIDParam: requestID},
@@ -202,7 +202,7 @@ func logCliDebugModeResolved(connection unityipc.Connection, command string) {
 			"debug_enabled":    true,
 			"debug_source":     "env",
 			"project_identity": clicore.ProjectIdentity(connection.ProjectRoot),
-			"cli_version":      clicore.Version,
+			"cli_version":      clicore.Version(),
 		},
 	})
 }

--- a/cli/project-runner/internal/projectrunner/connection_retry_flow.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_flow.go
@@ -13,7 +13,7 @@ func newConnectionRetryClient(
 	responseTimeout time.Duration,
 	mainThreadStallHandler func(float64),
 ) *unityipc.Client {
-	client := unityipc.NewClient(connection, clicore.Version)
+	client := unityipc.NewClient(connection, clicore.Version())
 	if responseTimeout > 0 {
 		client = client.WithResponseTimeout(responseTimeout)
 	}

--- a/cli/project-runner/internal/projectrunner/control_play_mode_wait.go
+++ b/cli/project-runner/internal/projectrunner/control_play_mode_wait.go
@@ -198,7 +198,7 @@ func requestControlPlayModeStatus(
 	probeContext, cancel := context.WithTimeout(ctx, controlPlayModeStatusTimeout)
 	defer cancel()
 
-	result, err := unityipc.NewClient(connection, clicore.Version).Send(
+	result, err := unityipc.NewClient(connection, clicore.Version()).Send(
 		probeContext,
 		controlPlayModeCommandName,
 		map[string]any{

--- a/cli/project-runner/internal/projectrunner/pause_point_logs.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_logs.go
@@ -83,7 +83,7 @@ func fetchMatchingLogsFromUnity(
 	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
 	defer cancel()
 
-	result, err := unityipc.NewClient(connection, clicore.Version).Send(
+	result, err := unityipc.NewClient(connection, clicore.Version()).Send(
 		probeContext,
 		pausePointGetLogsCommandName,
 		map[string]any{

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -424,7 +424,7 @@ func queryPausePointStatusFromUnity(
 	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
 	defer cancel()
 
-	result, err := unityipc.NewClient(connection, clicore.Version).Send(
+	result, err := unityipc.NewClient(connection, clicore.Version()).Send(
 		probeContext,
 		pausePointStatusCommandName,
 		map[string]any{"Id": id},
@@ -448,7 +448,7 @@ func clearPausePointStatusFromUnity(
 	probeContext, cancel := context.WithTimeout(ctx, pausePointStatusProbeTimeout)
 	defer cancel()
 
-	result, err := unityipc.NewClient(connection, clicore.Version).Send(
+	result, err := unityipc.NewClient(connection, clicore.Version()).Send(
 		probeContext,
 		pausePointClearStatusCommandName,
 		map[string]any{"Id": id},

--- a/cli/project-runner/internal/projectrunner/run_test.go
+++ b/cli/project-runner/internal/projectrunner/run_test.go
@@ -14,10 +14,10 @@ func TestRunProjectLocalVersionJSONIncludesProtocolVersion(t *testing.T) {
 	// Verifies Unity setup can inspect protocol compatibility without parsing human help text.
 	payload := clitest.RunVersionJSON(t, RunProjectLocal)
 
-	if payload["ProjectRunnerVersion"] != clicore.Version {
+	if payload["ProjectRunnerVersion"] != clicore.Version() {
 		t.Fatalf("projectRunnerVersion mismatch: %#v", payload)
 	}
-	if payload["ProtocolVersion"] != float64(clicore.ProtocolVersion) {
+	if payload["ProtocolVersion"] != float64(clicore.ProtocolVersion()) {
 		t.Fatalf("protocolVersion mismatch: %#v", payload)
 	}
 }

--- a/cli/project-runner/internal/projectrunner/runner_usage.go
+++ b/cli/project-runner/internal/projectrunner/runner_usage.go
@@ -20,7 +20,7 @@ func tryHandleRunnerInfoRequest(args []string, stdout io.Writer) (bool, int) {
 		return true, 0
 	}
 	if clicore.IsVersionRequest(args) {
-		clicore.WriteLine(stdout, clicore.Version)
+		clicore.WriteLine(stdout, clicore.Version())
 		return true, 0
 	}
 	return false, 0


### PR DESCRIPTION
## Summary
- CLI contract metadata is now loaded through explicit accessors instead of an eager global.
- Runtime version and protocol metadata remain read-only from callers.

## User Impact
- Normal CLI behavior is unchanged.
- Contract metadata failures are no longer tied to package import side effects.

## Changes
- Added clicontract.Load plus ProjectRunnerVersion and ProtocolVersion getters.
- Removed direct runtime use of clicontract.Current and converted clicore version metadata to getter functions.
- Added regression coverage for explicit contract loading and invalid JSON errors.

## Verification
- go test ./clicontract ./clicore ./unityipc
- go test ./internal/projectrunner
- go test ./internal/dispatcher
- scripts/check-go-cli.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

