### PR TITLE
chore: Move skill scanning helpers into common package

### DIFF
--- a/cli/common/clicore/skillscan_aliases.go
+++ b/cli/common/clicore/skillscan_aliases.go
@@ -1,0 +1,36 @@
+package clicore
+
+import "github.com/hatayama/unity-cli-loop/common/skillscan"
+
+const (
+	SkillFileName       = skillscan.SkillFileName
+	SkillSearchMaxDepth = skillscan.SkillSearchMaxDepth
+)
+
+var ExcludedSkillSearchDirs = skillscan.ExcludedSkillSearchDirs
+
+type SkillSourceRoot = skillscan.SkillSourceRoot
+
+func collectInternalSkillToolNames(projectRoot string) map[string]bool {
+	return skillscan.CollectInternalSkillToolNames(projectRoot)
+}
+
+func FindEditorFolders(basePath string, maxDepth int) []string {
+	return skillscan.FindEditorFolders(basePath, maxDepth)
+}
+
+func ResolvePackageRoot(projectRoot string) string {
+	return skillscan.ResolvePackageRoot(projectRoot)
+}
+
+func EnumerateSkillSourceRoots(projectRoot string) []SkillSourceRoot {
+	return skillscan.EnumerateSkillSourceRoots(projectRoot)
+}
+
+func FallbackSkillName(skillDirectory string) string {
+	return skillscan.FallbackSkillName(skillDirectory)
+}
+
+func ParseSkillFrontmatter(content string) map[string]string {
+	return skillscan.ParseSkillFrontmatter(content)
+}

--- a/cli/common/skillscan/cli_source.go
+++ b/cli/common/skillscan/cli_source.go
@@ -1,4 +1,4 @@
-package skills
+package skillscan
 
 import "path/filepath"
 

--- a/cli/common/skillscan/packages.go
+++ b/cli/common/skillscan/packages.go
@@ -1,4 +1,4 @@
-package clicore
+package skillscan
 
 import (
 	"encoding/json"

--- a/cli/common/skillscan/packages_test.go
+++ b/cli/common/skillscan/packages_test.go
@@ -1,4 +1,4 @@
-package clicore
+package skillscan
 
 import (
 	"os"

--- a/cli/common/skillscan/sources.go
+++ b/cli/common/skillscan/sources.go
@@ -1,11 +1,9 @@
-package clicore
+package skillscan
 
 import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/hatayama/unity-cli-loop/common/skills"
 )
 
 const (
@@ -31,7 +29,7 @@ type SkillSourceRoot struct {
 	CLIOnly bool
 }
 
-func collectInternalSkillToolNames(projectRoot string) map[string]bool {
+func CollectInternalSkillToolNames(projectRoot string) map[string]bool {
 	toolNames := map[string]bool{}
 	for _, sourceRoot := range EnumerateSkillSourceRoots(projectRoot) {
 		for _, toolName := range scanInternalSkillToolNames(sourceRoot) {
@@ -56,7 +54,7 @@ func EnumerateSkillSourceRoots(projectRoot string) []SkillSourceRoot {
 		sourceRoots = append(sourceRoots, SkillSourceRoot{Path: absolutePath, CLIOnly: cliOnly})
 	}
 
-	addSourceRoot(skills.CliOnlySourceRoot(projectRoot), true)
+	addSourceRoot(CliOnlySourceRoot(projectRoot), true)
 	addSourceRoot(filepath.Join(projectRoot, "Assets"), false)
 	for _, packageRoot := range enumerateDirectProjectPackageRoots(projectRoot) {
 		addSourceRoot(packageRoot, false)

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "06b6f9bf6cbdd8b02f1213905048a3eb6e4e5ef7"
+  "sharedInputsHash": "082863cc8aea15881939e1101990acab8e535b36"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "082863cc8aea15881939e1101990acab8e535b36"
+  "sharedInputsHash": "d5b7782a709e8025d43352b1746d8fb84fcf261c"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "4d69c805f009f427144ecab4a78119d537e99c97"
+  "sharedInputsHash": "4927bc05b4c84ecfb1b01ff3d80974f20b12d8d0"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "4927bc05b4c84ecfb1b01ff3d80974f20b12d8d0"
+  "sharedInputsHash": "9d71859ae23baf04af3d6dc4241dae5ca798d7ad"
 }

--- a/cli/release-automation/internal/automation/release_trigger_guard.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard.go
@@ -154,7 +154,7 @@ var sharedCommonPackageRoots = []string{
 	"cli/common/clicore/",
 	"cli/common/errors/",
 	"cli/common/project/",
-	"cli/common/skills/",
+	"cli/common/skillscan/",
 	"cli/common/tools/",
 	"cli/common/unityipc/",
 	"cli/common/unityprocess/",

--- a/scripts/stamp-release-inputs.sh
+++ b/scripts/stamp-release-inputs.sh
@@ -21,7 +21,7 @@ list_shared_common_inputs() {
     'cli/common/clicore/' \
     'cli/common/errors/' \
     'cli/common/project/' \
-    'cli/common/skills/' \
+    'cli/common/skillscan/' \
     'cli/common/tools/' \
     'cli/common/unityipc/' \
     'cli/common/unityprocess/' |


### PR DESCRIPTION
## Summary
- Move skill source scanning and package-root discovery helpers into `common/skillscan`.
- Keep existing `clicore` entry points as thin compatibility wrappers so behavior stays unchanged.

## User Impact
- No CLI behavior or output schema is intended to change.
- This prepares the next skill/package identity cleanup PR by isolating the current scanning implementation first.

## Changes
- Moved skill package discovery, source root enumeration, frontmatter parsing, and the CLI-only skill root helper into `common/skillscan`.
- Removed the tiny standalone `common/skills` package by absorbing its source-root helper into `skillscan`.
- Updated release trigger whitelist and dispatcher/project-runner shared input stamps for the new shared package root.

## Verification
- `cd cli/common && go test ./skillscan ./clicore`
- `cd cli/dispatcher && go test ./internal/dispatcher`
- `cd cli/release-automation && go test ./internal/automation -run TestReleaseTriggerGuardCommonPackageWhitelistsMatchGoDependencies -count=1`
- `scripts/check-go-cli.sh`
- `cd cli/release-automation && go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

