### PR TITLE
chore: Keep embedded tool selection in CLI core

### DIFF
--- a/cli/common/clicore/tool_catalog.go
+++ b/cli/common/clicore/tool_catalog.go
@@ -38,12 +38,17 @@ func FindDefaultTool(name string) (ToolDefinition, bool) {
 }
 
 func FindToolForCommand(projectRoot string, command string) (ToolDefinition, ToolsCache, bool, error) {
-	return findToolForCommandWithInternalToolNames(projectRoot, command, skillscan.CollectInternalSkillToolNames)
+	return findToolForCommandWithInternalToolNames(
+		projectRoot,
+		command,
+		shouldPreferEmbeddedToolDefinition(command),
+		skillscan.CollectInternalSkillToolNames)
 }
 
 func findToolForCommandWithInternalToolNames(
 	projectRoot string,
 	command string,
+	preferEmbedded bool,
 	collectInternalToolNames func(string) map[string]bool,
 ) (ToolDefinition, ToolsCache, bool, error) {
 	defaultCache := LoadDefaultTools()
@@ -51,5 +56,9 @@ func findToolForCommandWithInternalToolNames(
 		return tool, defaultCache, true, nil
 	}
 
-	return tools.FindForCommand(projectRoot, command, collectInternalToolNames(projectRoot))
+	return tools.FindForCommand(projectRoot, command, collectInternalToolNames(projectRoot), preferEmbedded)
+}
+
+func shouldPreferEmbeddedToolDefinition(command string) bool {
+	return command == ExecuteDynamicCodeCommandName
 }

--- a/cli/common/clicore/tool_catalog_test.go
+++ b/cli/common/clicore/tool_catalog_test.go
@@ -187,6 +187,7 @@ func TestFindToolForCommandSkipsInternalSkillScanForExecuteDynamicCode(t *testin
 	tool, _, ok, err := findToolForCommandWithInternalToolNames(
 		t.TempDir(),
 		ExecuteDynamicCodeCommandName,
+		shouldPreferEmbeddedToolDefinition(ExecuteDynamicCodeCommandName),
 		func(string) map[string]bool {
 			collectorCalled = true
 			return map[string]bool{}

--- a/cli/common/tools/catalog.go
+++ b/cli/common/tools/catalog.go
@@ -69,8 +69,13 @@ func Find(cache ToolCatalog, name string) (ToolDefinition, bool) {
 	return ToolDefinition{}, false
 }
 
-func FindForCommand(projectRoot string, command string, internalToolNames map[string]bool) (ToolDefinition, ToolCatalog, bool, error) {
-	if command == "execute-dynamic-code" {
+func FindForCommand(
+	projectRoot string,
+	command string,
+	internalToolNames map[string]bool,
+	preferEmbedded bool,
+) (ToolDefinition, ToolCatalog, bool, error) {
+	if preferEmbedded {
 		cache := LoadDefault()
 		tool, ok := Find(cache, command)
 		return tool, cache, ok, nil

--- a/cli/common/tools/catalog_test.go
+++ b/cli/common/tools/catalog_test.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Tests that callers can explicitly prefer embedded definitions without tools knowing command names.
+func TestFindForCommandUsesEmbeddedDefinitionWhenRequested(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeToolCache(t, projectRoot, `{"version":"test","tools":[]}`)
+
+	tool, _, ok, err := FindForCommand(projectRoot, "execute-dynamic-code", map[string]bool{}, true)
+	if err != nil {
+		t.Fatalf("FindForCommand failed: %v", err)
+	}
+
+	if !ok {
+		t.Fatal("embedded tool should be found")
+	}
+	if tool.Name != "execute-dynamic-code" {
+		t.Fatalf("tool name mismatch: %s", tool.Name)
+	}
+}
+
+// Tests that project caches are used when callers do not request embedded preference.
+func TestFindForCommandUsesProjectCacheWhenEmbeddedPreferenceIsFalse(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeToolCache(t, projectRoot, `{
+  "version": "test",
+  "tools": [
+    {
+      "name": "execute-dynamic-code",
+      "description": "cached definition",
+      "inputSchema": {"type": "object", "properties": {}}
+    }
+  ]
+}`)
+
+	tool, _, ok, err := FindForCommand(projectRoot, "execute-dynamic-code", map[string]bool{}, false)
+	if err != nil {
+		t.Fatalf("FindForCommand failed: %v", err)
+	}
+
+	if !ok {
+		t.Fatal("project cache tool should be found")
+	}
+	if tool.Description != "cached definition" {
+		t.Fatalf("project cache definition was not used: %s", tool.Description)
+	}
+}
+
+func writeToolCache(t *testing.T, projectRoot string, content string) {
+	t.Helper()
+	cacheDir := filepath.Join(projectRoot, CacheDirectoryName)
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("failed to create tool cache dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, CacheFileName), []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write tool cache: %v", err)
+	}
+}

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "1d28b9b0722bb9c7908f235151e307936d1ef054"
+  "sharedInputsHash": "aa413fd0ffbaeefef9a79b0ab303e99a6e1d49e9"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "b68505047708ceedd9b13fdb5f74176482b41e62"
+  "sharedInputsHash": "f5fa84f303962f5155cfa758ae2014e6676bc0ed"
 }


### PR DESCRIPTION
## Summary
- Keep tool lookup behavior unchanged while removing command-specific routing from common/tools.
- Make embedded-definition preference an explicit caller decision.

## User Impact
- No CLI output, tool schema, or IPC behavior changes are intended.
- execute-dynamic-code still uses the embedded hot-path definition, including when project tool caches are stale.

## Changes
- Added a preferEmbedded flag to common/tools FindForCommand.
- Moved the execute-dynamic-code embedded preference decision into clicore.
- Added common/tools tests that prove embedded preference is controlled by the caller rather than a hardcoded command branch.
- Refreshed shared release input stamps.

## Verification
- cd cli/common && go test ./tools ./clicore
- cd cli/dispatcher && go test ./internal/dispatcher
- cd cli/project-runner && go test ./internal/projectrunner
- cd cli/release-automation && go test ./internal/automation -run TestReleaseTriggerGuardCommonPackageWhitelistsMatchGoDependencies -count=1
- scripts/check-go-cli.sh
- cd cli/release-automation && go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

