### PR TITLE
chore: Keep spinner progress independent from IPC internals

### DIFF
--- a/cli/common/clicore/ui_aliases.go
+++ b/cli/common/clicore/ui_aliases.go
@@ -3,8 +3,8 @@ package clicore
 import (
 	"io"
 
+	"github.com/hatayama/unity-cli-loop/common/progress"
 	"github.com/hatayama/unity-cli-loop/common/ui"
-	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
 type TerminalSpinner = ui.TerminalSpinner
@@ -17,7 +17,7 @@ func NewLaunchSpinner(stdout io.Writer, stderr io.Writer) *TerminalSpinner {
 	return ui.NewLaunchSpinner(stdout, stderr)
 }
 
-func NewSpinnerProgressFunc(spinner *TerminalSpinner, executingMessage string) unityipc.ProgressFunc {
+func NewSpinnerProgressFunc(spinner *TerminalSpinner, executingMessage string) progress.Func {
 	return ui.NewSpinnerProgressFunc(spinner, executingMessage)
 }
 

--- a/cli/common/progress/progress.go
+++ b/cli/common/progress/progress.go
@@ -1,0 +1,24 @@
+package progress
+
+// Stage identifies which phase produced a progress event.
+type Stage string
+
+const (
+	// StageConnected means the client reached the Unity IPC endpoint.
+	StageConnected Stage = "connected"
+
+	// StageAccepted means Unity accepted the request and may stream heartbeats.
+	StageAccepted Stage = "accepted"
+
+	// StageMessage carries display-ready progress text.
+	StageMessage Stage = "message"
+)
+
+// Event reports structured progress without tying UI packages to IPC details.
+type Event struct {
+	Stage   Stage
+	Message string
+}
+
+// Func receives structured progress events.
+type Func func(Event)

--- a/cli/common/ui/spinner.go
+++ b/cli/common/ui/spinner.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hatayama/unity-cli-loop/common/unityipc"
+	"github.com/hatayama/unity-cli-loop/common/progress"
 )
 
 const (
@@ -42,13 +42,13 @@ func NewLaunchSpinner(stdout io.Writer, stderr io.Writer) *TerminalSpinner {
 // and passes display-ready payloads (such as the heartbeat main-thread stall
 // notice) through to the spinner verbatim. Without this mapping the stall
 // diagnosis built by the IPC client would never reach the user.
-func NewSpinnerProgressFunc(spinner *TerminalSpinner, executingMessage string) unityipc.ProgressFunc {
-	return func(message string) {
-		if message == unityipc.ProgressEventConnected || message == unityipc.ProgressEventAccepted {
+func NewSpinnerProgressFunc(spinner *TerminalSpinner, executingMessage string) progress.Func {
+	return func(event progress.Event) {
+		if event.Stage == progress.StageConnected || event.Stage == progress.StageAccepted {
 			spinner.Update(executingMessage)
 			return
 		}
-		spinner.Update(message)
+		spinner.Update(event.Message)
 	}
 }
 

--- a/cli/common/ui/spinner_test.go
+++ b/cli/common/ui/spinner_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hatayama/unity-cli-loop/common/unityipc"
+	"github.com/hatayama/unity-cli-loop/common/progress"
 )
 
 func TestSpinnerDoesNotWriteWhenDisabled(t *testing.T) {
@@ -56,9 +56,12 @@ func TestSpinnerProgressFuncShowsStallMessageVerbatim(t *testing.T) {
 	// Verifies that heartbeat stall payloads reach the spinner verbatim.
 	var stderr bytes.Buffer
 	spinner := newSpinner(&stderr, true, "Connecting to Unity...")
-	progress := NewSpinnerProgressFunc(spinner, "Executing get-logs...")
+	progressFunc := NewSpinnerProgressFunc(spinner, "Executing get-logs...")
 
-	progress("unity editor main thread busy for 38s...")
+	progressFunc(progress.Event{
+		Stage:   progress.StageMessage,
+		Message: "unity editor main thread busy for 38s...",
+	})
 	spinner.Stop()
 
 	if !strings.Contains(stderr.String(), "unity editor main thread busy for 38s...") {
@@ -71,17 +74,17 @@ func TestSpinnerProgressFuncMapsConnectionEventsToExecutingMessage(t *testing.T)
 	// instead of the raw event token.
 	var stderr bytes.Buffer
 	spinner := newSpinner(&stderr, true, "Connecting to Unity...")
-	progress := NewSpinnerProgressFunc(spinner, "Executing get-logs...")
+	progressFunc := NewSpinnerProgressFunc(spinner, "Executing get-logs...")
 
-	progress(unityipc.ProgressEventConnected)
-	progress(unityipc.ProgressEventAccepted)
+	progressFunc(progress.Event{Stage: progress.StageConnected})
+	progressFunc(progress.Event{Stage: progress.StageAccepted})
 	spinner.Stop()
 
 	output := stderr.String()
 	if !strings.Contains(output, "Executing get-logs...") {
 		t.Fatalf("spinner output did not include executing message: %q", output)
 	}
-	if strings.Contains(output, unityipc.ProgressEventConnected) || strings.Contains(output, unityipc.ProgressEventAccepted) {
+	if strings.Contains(output, string(progress.StageConnected)) || strings.Contains(output, string(progress.StageAccepted)) {
 		t.Fatalf("spinner output leaked a raw progress event token: %q", output)
 	}
 }

--- a/cli/common/unityipc/client.go
+++ b/cli/common/unityipc/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	clicontract "github.com/hatayama/unity-cli-loop/common/clicontract"
+	cliprogress "github.com/hatayama/unity-cli-loop/common/progress"
 )
 
 const (
@@ -44,15 +45,7 @@ type Client struct {
 	options       ClientOptions
 }
 
-type ProgressFunc = func(message string)
-
-// Connection-stage progress events. Consumers map these tokens to their own
-// contextual message; any other progress payload is display-ready text such
-// as the main-thread stall notice.
-const (
-	ProgressEventConnected = "connected"
-	ProgressEventAccepted  = "accepted"
-)
+type ProgressFunc = cliprogress.Func
 
 type rpcRequest struct {
 	JSONRPC string            `json:"jsonrpc"`
@@ -189,7 +182,7 @@ func (client *Client) SendWithProgressOutcomeAcceptContext(
 	}()
 
 	if progress != nil {
-		progress(ProgressEventConnected)
+		progress(cliprogress.Event{Stage: cliprogress.StageConnected})
 	}
 
 	requestID := client.nextRequestID()
@@ -235,7 +228,7 @@ func (client *Client) SendWithProgressOutcomeAcceptContext(
 	if response.ULoop.Phase == rpcResponsePhaseAccepted {
 		outcome.RequestAccepted = true
 		if progress != nil {
-			progress(ProgressEventAccepted)
+			progress(cliprogress.Event{Stage: cliprogress.StageAccepted})
 		}
 
 		return client.readAcceptedResponse(
@@ -359,9 +352,12 @@ func (client *Client) reportMainThreadStall(stallSeconds float64, progress Progr
 		client.options.mainThreadStallHandler(stallSeconds)
 	}
 	if progress != nil {
-		progress(fmt.Sprintf(
-			"Unity main thread stuck %.0fs; check modal/long operation...",
-			stallSeconds))
+		progress(cliprogress.Event{
+			Stage: cliprogress.StageMessage,
+			Message: fmt.Sprintf(
+				"Unity main thread stuck %.0fs; check modal/long operation...",
+				stallSeconds),
+		})
 	}
 }
 

--- a/cli/common/unityipc/client_heartbeat_test.go
+++ b/cli/common/unityipc/client_heartbeat_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hatayama/unity-cli-loop/common/progress"
 )
 
 // Test support server that acks with heartbeat negotiation and then runs the given
@@ -187,8 +189,8 @@ func TestSendReportsMainThreadStallProgressWithModalHint(t *testing.T) {
 		context.Background(),
 		"run-tests",
 		map[string]any{},
-		func(message string) {
-			progressMessages = append(progressMessages, message)
+		func(event progress.Event) {
+			progressMessages = append(progressMessages, event.Message)
 		},
 	)
 	if err != nil {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "aa413fd0ffbaeefef9a79b0ab303e99a6e1d49e9"
+  "sharedInputsHash": "77cffafbf3305c46db9ed84f3d01fd2361b4ee80"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "f5fa84f303962f5155cfa758ae2014e6676bc0ed"
+  "sharedInputsHash": "c9e0d7eba3162ef745996e864439558561eae796"
 }

--- a/cli/release-automation/internal/automation/release_trigger_guard.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard.go
@@ -153,6 +153,7 @@ var sharedCommonPackageRoots = []string{
 	"cli/common/clicontract/",
 	"cli/common/clicore/",
 	"cli/common/errors/",
+	"cli/common/progress/",
 	"cli/common/project/",
 	"cli/common/skillscan/",
 	"cli/common/tooldocs/",

--- a/scripts/stamp-release-inputs.sh
+++ b/scripts/stamp-release-inputs.sh
@@ -20,6 +20,7 @@ list_shared_common_inputs() {
     'cli/common/clicontract/' \
     'cli/common/clicore/' \
     'cli/common/errors/' \
+    'cli/common/progress/' \
     'cli/common/project/' \
     'cli/common/skillscan/' \
     'cli/common/tooldocs/' \


### PR DESCRIPTION
## Summary
- Keep command progress output behavior unchanged while removing the spinner package dependency on IPC internals.
- Report connection progress as structured events instead of raw string tokens.

## User Impact
- Tool progress messages continue to show the contextual executing text and main-thread stall hints.
- This reduces coupling between shared CLI UI code and Unity IPC implementation details.

## Changes
- Add a neutral common progress package with typed progress stages and events.
- Make unityipc emit structured progress events and make UI map stages to spinner text.
- Add the new shared package to release input stamping and guard whitelists.

## Verification
- cd cli/common && go test ./progress ./unityipc ./ui ./clicore
- cd cli/dispatcher && go test ./internal/dispatcher
- cd cli/project-runner && go test ./internal/projectrunner
- cd cli/release-automation && go test ./internal/automation -run TestReleaseTriggerGuardCommonPackageWhitelistsMatchGoDependencies -count=1
- scripts/check-go-cli.sh
- cd cli/release-automation && go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

