### PR TITLE
fix: Retry incomplete project runner downloads

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_download.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_download.go
@@ -23,7 +23,12 @@ import (
 	sharedupdate "github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
 )
 
-var dispatcherHTTPClient = &http.Client{Timeout: 2 * time.Minute}
+var (
+	dispatcherHTTPClient = &http.Client{Timeout: 2 * time.Minute}
+	dispatcherRename     = os.Rename
+)
+
+const dispatcherRealCLIReadyFileName = "READY"
 
 func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin, stderr io.Writer) (string, error) {
 	pin.ProjectRunnerVersion = strings.TrimSpace(pin.ProjectRunnerVersion)
@@ -39,7 +44,7 @@ func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin, stderr io.
 		return "", err
 	}
 	realCLIPath := dispatcherCachedRealCLIPath(cacheRoot, pin.ProjectRunnerVersion, runtime.GOOS, runtime.GOARCH)
-	if isExecutableFile(realCLIPath) {
+	if isReadyDispatcherRealCLI(realCLIPath) {
 		return realCLIPath, nil
 	}
 
@@ -99,6 +104,19 @@ func isExecutableFile(filePath string) bool {
 	return info.Mode()&0o111 != 0
 }
 
+func isReadyDispatcherRealCLI(filePath string) bool {
+	return isExecutableFile(filePath) && fileExists(dispatcherRealCLIReadyPath(filePath))
+}
+
+func fileExists(filePath string) bool {
+	_, err := os.Stat(filePath)
+	return err == nil
+}
+
+func dispatcherRealCLIReadyPath(realCLIPath string) string {
+	return filepath.Join(filepath.Dir(realCLIPath), dispatcherRealCLIReadyFileName)
+}
+
 func downloadDispatcherRealCLIForPin(ctx context.Context, cacheRoot string, pin dispatcherPin, goos string, goarch string, stderr io.Writer) (string, error) {
 	assetName, err := dispatcherReleaseAssetName(goos, goarch)
 	if err != nil {
@@ -142,22 +160,40 @@ func downloadDispatcherRealCLIForPin(ctx context.Context, cacheRoot string, pin 
 }
 
 func installDownloadedDispatcherRealCLI(tempRealCLIPath string, realCLIPath string) (string, error) {
-	if isExecutableFile(realCLIPath) {
+	if isReadyDispatcherRealCLI(realCLIPath) {
 		return realCLIPath, nil
 	}
-	if err := os.Rename(tempRealCLIPath, realCLIPath); err == nil {
+	if err := dispatcherRename(tempRealCLIPath, realCLIPath); err == nil {
+		return markDispatcherRealCLIReady(realCLIPath)
+	}
+	if isReadyDispatcherRealCLI(realCLIPath) {
 		return realCLIPath, nil
 	}
-	if isExecutableFile(realCLIPath) {
-		return realCLIPath, nil
+	if err := removeDispatcherRealCLIReady(realCLIPath); err != nil {
+		return "", err
 	}
 	if err := os.Remove(realCLIPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return "", err
 	}
-	if err := os.Rename(tempRealCLIPath, realCLIPath); err != nil {
+	if err := dispatcherRename(tempRealCLIPath, realCLIPath); err != nil {
+		return "", err
+	}
+	return markDispatcherRealCLIReady(realCLIPath)
+}
+
+func markDispatcherRealCLIReady(realCLIPath string) (string, error) {
+	if err := os.WriteFile(dispatcherRealCLIReadyPath(realCLIPath), []byte("ready\n"), 0o644); err != nil {
 		return "", err
 	}
 	return realCLIPath, nil
+}
+
+func removeDispatcherRealCLIReady(realCLIPath string) error {
+	err := os.Remove(dispatcherRealCLIReadyPath(realCLIPath))
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 func dispatcherReleaseAssetName(goos string, goarch string) (string, error) {

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -505,10 +505,87 @@ func TestDownloadDispatcherRealCLIWritesDownloadStatus(t *testing.T) {
 		t.Fatalf("download status mismatch: %q", stderr.String())
 	}
 	assertFileContent(t, realCLIPath, "real")
+	assertFileContent(t, dispatcherRealCLIReadyPath(realCLIPath), "ready\n")
 }
 
 func TestInstallDownloadedDispatcherRealCLIKeepsExistingExecutable(t *testing.T) {
-	// Verifies concurrent downloads do not delete an executable another dispatcher already cached.
+	// Verifies concurrent downloads do not delete a ready executable another dispatcher already cached.
+	tempDir := t.TempDir()
+	realCLIPath := filepath.Join(tempDir, dispatcherRealCLIFileName(runtime.GOOS))
+	tempRealCLIPath := filepath.Join(tempDir, "downloaded-"+dispatcherRealCLIFileName(runtime.GOOS))
+	if err := os.WriteFile(realCLIPath, []byte("existing"), 0o755); err != nil {
+		t.Fatalf("failed to write existing real CLI: %v", err)
+	}
+	if err := os.WriteFile(dispatcherRealCLIReadyPath(realCLIPath), []byte("ready\n"), 0o644); err != nil {
+		t.Fatalf("failed to write ready marker: %v", err)
+	}
+	if err := os.WriteFile(tempRealCLIPath, []byte("downloaded"), 0o755); err != nil {
+		t.Fatalf("failed to write temp real CLI: %v", err)
+	}
+
+	path, err := installDownloadedDispatcherRealCLI(tempRealCLIPath, realCLIPath)
+	if err != nil {
+		t.Fatalf("installDownloadedDispatcherRealCLI failed: %v", err)
+	}
+	if path != realCLIPath {
+		t.Fatalf("real CLI path mismatch: %s", path)
+	}
+	assertFileContent(t, realCLIPath, "existing")
+}
+
+func TestInstallDownloadedDispatcherRealCLIKeepsReadyExecutableAfterRenameFailure(t *testing.T) {
+	// Verifies a cache entry that becomes ready during install is reused instead of replaced.
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support the POSIX executable-bit setup this race regression uses.")
+	}
+	tempDir := t.TempDir()
+	realCLIPath := filepath.Join(tempDir, dispatcherRealCLIFileName(runtime.GOOS))
+	tempRealCLIPath := filepath.Join(tempDir, "downloaded-"+dispatcherRealCLIFileName(runtime.GOOS))
+	if err := os.WriteFile(realCLIPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("failed to write existing real CLI: %v", err)
+	}
+	if err := os.WriteFile(dispatcherRealCLIReadyPath(realCLIPath), []byte("ready\n"), 0o644); err != nil {
+		t.Fatalf("failed to write ready marker: %v", err)
+	}
+	if err := os.WriteFile(tempRealCLIPath, []byte("downloaded"), 0o755); err != nil {
+		t.Fatalf("failed to write temp real CLI: %v", err)
+	}
+
+	previousRename := dispatcherRename
+	defer func() {
+		dispatcherRename = previousRename
+	}()
+	renameCalls := 0
+	dispatcherRename = func(oldPath string, newPath string) error {
+		renameCalls++
+		if oldPath != tempRealCLIPath || newPath != realCLIPath {
+			t.Fatalf("rename paths mismatch: %s -> %s", oldPath, newPath)
+		}
+		if renameCalls == 1 {
+			if err := os.Chmod(realCLIPath, 0o755); err != nil {
+				t.Fatalf("failed to mark existing real CLI executable: %v", err)
+			}
+			return errors.New("destination exists")
+		}
+		return previousRename(oldPath, newPath)
+	}
+
+	path, err := installDownloadedDispatcherRealCLI(tempRealCLIPath, realCLIPath)
+	if err != nil {
+		t.Fatalf("installDownloadedDispatcherRealCLI failed: %v", err)
+	}
+	if path != realCLIPath {
+		t.Fatalf("real CLI path mismatch: %s", path)
+	}
+	if renameCalls != 1 {
+		t.Fatalf("rename call count mismatch: %d", renameCalls)
+	}
+	assertFileContent(t, realCLIPath, "existing")
+	assertFileContent(t, dispatcherRealCLIReadyPath(realCLIPath), "ready\n")
+}
+
+func TestInstallDownloadedDispatcherRealCLIReplacesExecutableWithoutReady(t *testing.T) {
+	// Verifies executable files without READY are treated as incomplete cache entries.
 	tempDir := t.TempDir()
 	realCLIPath := filepath.Join(tempDir, dispatcherRealCLIFileName(runtime.GOOS))
 	tempRealCLIPath := filepath.Join(tempDir, "downloaded-"+dispatcherRealCLIFileName(runtime.GOOS))
@@ -526,7 +603,8 @@ func TestInstallDownloadedDispatcherRealCLIKeepsExistingExecutable(t *testing.T)
 	if path != realCLIPath {
 		t.Fatalf("real CLI path mismatch: %s", path)
 	}
-	assertFileContent(t, realCLIPath, "existing")
+	assertFileContent(t, realCLIPath, "downloaded")
+	assertFileContent(t, dispatcherRealCLIReadyPath(realCLIPath), "ready\n")
 }
 
 func TestLoadDispatcherPinFallsBackToPackagePin(t *testing.T) {
@@ -728,6 +806,9 @@ func writeCachedDispatcherRealCLI(t *testing.T, cacheRoot string, projectRunnerV
 	}
 	if err := os.WriteFile(realCLIPath, []byte("cached real cli"), 0o755); err != nil {
 		t.Fatalf("failed to write cached CLI: %v", err)
+	}
+	if err := os.WriteFile(dispatcherRealCLIReadyPath(realCLIPath), []byte("ready\n"), 0o644); err != nil {
+		t.Fatalf("failed to write cached CLI ready marker: %v", err)
 	}
 	return realCLIPath
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "058dfc6153eecc5bd339def577253f792fa486de"
+  "sharedInputsHash": "41296fd13945ddc99a3296a73617c64681a280a8"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "8a15e5515c0c9df68396cc71e34c4df10d3f8546"
+  "sharedInputsHash": "b08986f4dc84dd1d083113374824cd2535c1075c"
 }


### PR DESCRIPTION
## Summary
- Cached downloaded project runner binaries now require a READY marker before reuse.
- Interrupted downloads that leave only an executable file are treated as incomplete and replaced.

## User Impact
- The dispatcher no longer reuses partially installed project runner downloads after an interrupted cache write.
- Successful downloads still reuse the cached binary without another network request.

## Changes
- Write a READY marker after installing the downloaded project runner binary.
- Require both an executable file and the READY marker for cached downloaded project runners.
- Replace executable cache entries that are missing READY.
- Bump dispatcherVersion from 3.0.1-beta.12 to 3.0.1-beta.13 because dispatcher release inputs changed.

## Verification
- cd cli/dispatcher && go test ./dispatchercontract ./internal/dispatcher
- cd cli/release-automation && go test ./internal/automation -run 'Test(ReleaseTriggerGuard|Dispatcher|ReleaseTriggerGuardCommonPackageWhitelistsMatchGoDependencies)' -count=1
- cd cli/release-automation && go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD
- scripts/check-go-cli.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

