### PR TITLE
feat: Return click-ready 3D collider targets from screenshots

### DIFF
--- a/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
+++ b/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
@@ -65,5 +65,159 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             Assert.That(overlayElements[0].Type, Is.EqualTo("RaycastHit"));
             Assert.That(overlayElements[0].Interaction, Is.EqualTo("Raycast"));
         }
+
+        [Test]
+        public void Resolve_WhenLayerNamesAreCommaSeparated_ShouldBuildMaskFromKnownLayers()
+        {
+            List<RaycastLayerDefinition> availableLayers = new List<RaycastLayerDefinition>
+            {
+                new RaycastLayerDefinition { Name = "Default", Index = 0 },
+                new RaycastLayerDefinition { Name = "Ground", Index = 8 },
+                new RaycastLayerDefinition { Name = "Clickable", Index = 9 }
+            };
+
+            RaycastLayerMaskResolution resolution =
+                RaycastLayerMaskResolver.Resolve("Ground, Clickable", availableLayers);
+
+            Assert.That(resolution.IsValid, Is.True);
+            Assert.That(resolution.HasLayerNames, Is.True);
+            Assert.That(resolution.Mask, Is.EqualTo((1 << 8) | (1 << 9)));
+            Assert.That(resolution.LayerNames, Is.EqualTo(new List<string> { "Ground", "Clickable" }));
+        }
+
+        [Test]
+        public void Resolve_WhenLayerNameDoesNotExist_ShouldReturnInvalidNamesAndValidNames()
+        {
+            List<RaycastLayerDefinition> availableLayers = new List<RaycastLayerDefinition>
+            {
+                new RaycastLayerDefinition { Name = "Default", Index = 0 },
+                new RaycastLayerDefinition { Name = "Ground", Index = 8 }
+            };
+
+            RaycastLayerMaskResolution resolution =
+                RaycastLayerMaskResolver.Resolve("Missing, Ground", availableLayers);
+
+            Assert.That(resolution.IsValid, Is.False);
+            Assert.That(resolution.InvalidLayerNames, Is.EqualTo(new List<string> { "Missing" }));
+            Assert.That(resolution.ValidLayerNames, Is.EqualTo(new List<string> { "Default", "Ground" }));
+        }
+
+        [Test]
+        public void CreateClusters_WhenSamplesHitSameCollider_ShouldReturnOneCluster()
+        {
+            List<RaycastClusterSample> samples = new List<RaycastClusterSample>
+            {
+                CreateSample(1, 0f, 0f),
+                CreateSample(1, 10f, 0f),
+                CreateSample(1, 0f, 10f)
+            };
+
+            List<RaycastClusterInfo> clusters = RaycastHitClusterer.CreateClusters(samples);
+
+            Assert.That(clusters.Count, Is.EqualTo(1));
+            Assert.That(clusters[0].SampleCount, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void CreateClusters_WhenSamplesHitDifferentColliders_ShouldReturnClusterPerCollider()
+        {
+            List<RaycastClusterSample> samples = new List<RaycastClusterSample>
+            {
+                CreateSample(1, 0f, 0f),
+                CreateSample(2, 10f, 0f),
+                CreateSample(1, 0f, 10f)
+            };
+
+            List<RaycastClusterInfo> clusters = RaycastHitClusterer.CreateClusters(samples);
+
+            Assert.That(clusters.Count, Is.EqualTo(2));
+            Assert.That(clusters[0].Representative.ClusterKey, Is.EqualTo(1));
+            Assert.That(clusters[1].Representative.ClusterKey, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void CreateClusters_WhenSamplesFormLShape_ShouldChooseActualHitClosestToCentroid()
+        {
+            List<RaycastClusterSample> samples = new List<RaycastClusterSample>
+            {
+                CreateSample(1, 0f, 0f),
+                CreateSample(1, 10f, 0f),
+                CreateSample(1, 0f, 10f)
+            };
+
+            List<RaycastClusterInfo> clusters = RaycastHitClusterer.CreateClusters(samples);
+
+            Assert.That(clusters[0].Representative.InputX, Is.EqualTo(0f));
+            Assert.That(clusters[0].Representative.InputY, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void CreateClusters_WhenSamplesFormDonut_ShouldNotSynthesizeCentroidPoint()
+        {
+            List<RaycastClusterSample> samples = new List<RaycastClusterSample>
+            {
+                CreateSample(1, 0f, 5f),
+                CreateSample(1, 5f, 0f),
+                CreateSample(1, 10f, 5f),
+                CreateSample(1, 5f, 10f)
+            };
+
+            List<RaycastClusterInfo> clusters = RaycastHitClusterer.CreateClusters(samples);
+
+            bool representativeIsActualSample = samples.Exists(
+                (RaycastClusterSample sample) =>
+                    sample.InputX == clusters[0].Representative.InputX &&
+                    sample.InputY == clusters[0].Representative.InputY);
+            Assert.That(representativeIsActualSample, Is.True);
+            bool representativeIsCentroid =
+                clusters[0].Representative.InputX == 5f &&
+                clusters[0].Representative.InputY == 5f;
+            Assert.That(representativeIsCentroid, Is.False);
+        }
+
+        [Test]
+        public void CreatePhysicsColliderElement_ShouldKeepSimCoordinatesInTopLeftInputSpace()
+        {
+            RaycastClusterInfo cluster = new RaycastClusterInfo
+            {
+                Representative = new RaycastClusterSample
+                {
+                    InputX = 100f,
+                    InputY = 200f,
+                    ScreenX = 100f,
+                    ScreenY = 880f,
+                    Name = "Cube",
+                    Path = "Cube",
+                    Layer = "Default",
+                    Components = new List<string> { "BoxCollider" }
+                },
+                SampleCount = 3
+            };
+
+            UIElementInfo element = RaycastGridAnnotator.CreatePhysicsColliderElement("R1", cluster);
+
+            Assert.That(element.Type, Is.EqualTo("PhysicsCollider"));
+            Assert.That(element.Interaction, Is.EqualTo("Raycast"));
+            Assert.That(element.SimX, Is.EqualTo(100f));
+            Assert.That(element.SimY, Is.EqualTo(200f));
+            Assert.That(element.BoundsMinY, Is.EqualTo(871f));
+            Assert.That(element.BoundsMaxY, Is.EqualTo(889f));
+        }
+
+        private static RaycastClusterSample CreateSample(int clusterKey, float inputX, float inputY)
+        {
+            return new RaycastClusterSample
+            {
+                ClusterKey = clusterKey,
+                InputX = inputX,
+                InputY = inputY,
+                ScreenX = inputX,
+                ScreenY = inputY,
+                Name = $"Collider{clusterKey}",
+                Path = $"Root/Collider{clusterKey}",
+                Layer = "Default",
+                Components = new List<string> { "BoxCollider" }
+            };
+        }
     }
 }

--- a/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
+++ b/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
@@ -176,32 +176,37 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
-        public void CreatePhysicsColliderElement_ShouldKeepSimCoordinatesInTopLeftInputSpace()
+        public void CreatePhysicsColliderElement_ShouldKeepBoundsInTopLeftInputSpace()
         {
             RaycastClusterInfo cluster = new RaycastClusterInfo
             {
                 Representative = new RaycastClusterSample
                 {
                     InputX = 100f,
-                    InputY = 200f,
-                    ScreenX = 100f,
-                    ScreenY = 880f,
-                    Name = "Cube",
-                    Path = "Cube",
-                    Layer = "Default",
-                    Components = new List<string> { "BoxCollider" }
+                    InputY = 200f
                 },
                 SampleCount = 3
             };
+            RaycastColliderMetadata metadata = new RaycastColliderMetadata
+            {
+                Name = "Cube",
+                Path = "Cube",
+                Layer = "Default",
+                Components = new List<string> { "BoxCollider" }
+            };
 
-            UIElementInfo element = RaycastGridAnnotator.CreatePhysicsColliderElement("R1", cluster);
+            UIElementInfo element = RaycastGridAnnotator.CreatePhysicsColliderElement("R1", cluster, metadata);
 
             Assert.That(element.Type, Is.EqualTo("PhysicsCollider"));
             Assert.That(element.Interaction, Is.EqualTo("Raycast"));
             Assert.That(element.SimX, Is.EqualTo(100f));
             Assert.That(element.SimY, Is.EqualTo(200f));
-            Assert.That(element.BoundsMinY, Is.EqualTo(871f));
-            Assert.That(element.BoundsMaxY, Is.EqualTo(889f));
+            Assert.That(element.BoundsMinX, Is.EqualTo(91f));
+            Assert.That(element.BoundsMinY, Is.EqualTo(191f));
+            Assert.That(element.BoundsMaxX, Is.EqualTo(109f));
+            Assert.That(element.BoundsMaxY, Is.EqualTo(209f));
+            Assert.That(element.SimX, Is.InRange(element.BoundsMinX, element.BoundsMaxX));
+            Assert.That(element.SimY, Is.InRange(element.BoundsMinY, element.BoundsMaxY));
         }
 
         private static RaycastClusterSample CreateSample(int clusterKey, float inputX, float inputY)
@@ -210,13 +215,7 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             {
                 ClusterKey = clusterKey,
                 InputX = inputX,
-                InputY = inputY,
-                ScreenX = inputX,
-                ScreenY = inputY,
-                Name = $"Collider{clusterKey}",
-                Path = $"Root/Collider{clusterKey}",
-                Layer = "Default",
-                Components = new List<string> { "BoxCollider" }
+                InputY = inputY
             };
         }
     }

--- a/Assets/Tests/Editor/ScreenshotToolTests.cs
+++ b/Assets/Tests/Editor/ScreenshotToolTests.cs
@@ -1,0 +1,76 @@
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP.Tests.Editor
+{
+    public class ScreenshotToolTests
+    {
+        [Test]
+        public void ExecuteAsync_WhenRaycastLayerMaskIsSetWithoutRaycastGrid_ShouldThrowValidationException()
+        {
+            ScreenshotTool tool = new ScreenshotTool();
+            JObject parameters = new JObject
+            {
+                ["RaycastLayerMask"] = "Default"
+            };
+
+            ParameterValidationException exception = Assert.ThrowsAsync<ParameterValidationException>(
+                async () => await tool.ExecuteAsync(parameters));
+
+            Assert.That(exception.Message, Does.Contain("RaycastLayerMask requires AnnotateRaycastGrid=true"));
+        }
+
+        [Test]
+        public void ExecuteAsync_WhenElementsOnlyHasNoAnnotationMode_ShouldThrowValidationException()
+        {
+            ScreenshotTool tool = new ScreenshotTool();
+            JObject parameters = new JObject
+            {
+                ["CaptureMode"] = "rendering",
+                ["ElementsOnly"] = true
+            };
+
+            ParameterValidationException exception = Assert.ThrowsAsync<ParameterValidationException>(
+                async () => await tool.ExecuteAsync(parameters));
+
+            Assert.That(
+                exception.Message,
+                Does.Contain("ElementsOnly requires AnnotateElements=true or AnnotateRaycastGrid=true"));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenElementsOnlyUsesRaycastGrid_ShouldPassValidation()
+        {
+            ScreenshotTool tool = new ScreenshotTool();
+            JObject parameters = new JObject
+            {
+                ["CaptureMode"] = "rendering",
+                ["AnnotateRaycastGrid"] = true,
+                ["ElementsOnly"] = true
+            };
+
+            BaseToolResponse response = await tool.ExecuteAsync(parameters);
+
+            Assert.That(response, Is.InstanceOf<ScreenshotResponse>());
+        }
+
+        [Test]
+        public void ExecuteAsync_WhenRaycastLayerMaskContainsUnknownLayer_ShouldThrowValidationException()
+        {
+            ScreenshotTool tool = new ScreenshotTool();
+            JObject parameters = new JObject
+            {
+                ["CaptureMode"] = "rendering",
+                ["AnnotateRaycastGrid"] = true,
+                ["RaycastLayerMask"] = "MissingLayerForTest"
+            };
+
+            ParameterValidationException exception = Assert.ThrowsAsync<ParameterValidationException>(
+                async () => await tool.ExecuteAsync(parameters));
+
+            Assert.That(exception.Message, Does.Contain("unknown layer name"));
+            Assert.That(exception.Message, Does.Contain("MissingLayerForTest"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ScreenshotToolTests.cs.meta
+++ b/Assets/Tests/Editor/ScreenshotToolTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e78451c54158e4b77b18eb729c2ead39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Cli~/src/default-tools.json
+++ b/Packages/src/Cli~/src/default-tools.json
@@ -261,13 +261,18 @@
           },
           "ElementsOnly": {
             "type": "boolean",
-            "description": "Return only annotated element JSON without capturing a screenshot image. Requires AnnotateElements=true and CaptureMode=rendering in PlayMode.",
+            "description": "Return only annotation JSON without capturing a screenshot image. Requires AnnotateElements=true or AnnotateRaycastGrid=true, and CaptureMode=rendering in PlayMode.",
             "default": false
           },
           "AnnotateRaycastGrid": {
             "type": "boolean",
             "description": "Annotate 3D physics raycast candidate points on rendering screenshots. Uses Camera.main and the same top-left Game View coordinates as simulate-mouse-input.",
             "default": false
+          },
+          "RaycastLayerMask": {
+            "type": "string",
+            "description": "Comma-separated physics layer names used by AnnotateRaycastGrid. When set, returns clustered PhysicsCollider entries in AnnotatedElements instead of the coarse grid points.",
+            "default": ""
           }
         }
       }

--- a/Packages/src/Cli~/src/default-tools.json
+++ b/Packages/src/Cli~/src/default-tools.json
@@ -266,12 +266,12 @@
           },
           "AnnotateRaycastGrid": {
             "type": "boolean",
-            "description": "Annotate 3D physics raycast candidate points on rendering screenshots. Uses Camera.main and the same top-left Game View coordinates as simulate-mouse-input.",
+            "description": "Annotate 3D physics raycast candidate points on rendering screenshots. Uses Camera.main, Camera.main.cullingMask visibility, and the same top-left Game View coordinates as simulate-mouse-input.",
             "default": false
           },
           "RaycastLayerMask": {
             "type": "string",
-            "description": "Comma-separated physics layer names used by AnnotateRaycastGrid. When set, returns clustered PhysicsCollider entries in AnnotatedElements instead of the coarse grid points.",
+            "description": "Comma-separated physics layer names used by AnnotateRaycastGrid. Hits are limited to layers also visible to Camera.main.cullingMask. When set, returns clustered PhysicsCollider entries in AnnotatedElements instead of the coarse grid points.",
             "default": ""
           }
         }

--- a/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotSchema.cs
@@ -52,10 +52,10 @@ namespace io.github.hatayama.uLoopMCP
         [Description("Return only annotation JSON without capturing a screenshot image. Requires AnnotateElements=true or AnnotateRaycastGrid=true, and CaptureMode=rendering in PlayMode.")]
         public bool ElementsOnly { get; set; } = false;
 
-        [Description("Annotate 3D physics raycast candidate points on rendering screenshots. Uses Camera.main and the same top-left Game View coordinates as simulate-mouse-input.")]
+        [Description("Annotate 3D physics raycast candidate points on rendering screenshots. Uses Camera.main, Camera.main.cullingMask visibility, and the same top-left Game View coordinates as simulate-mouse-input.")]
         public bool AnnotateRaycastGrid { get; set; } = false;
 
-        [Description("Comma-separated physics layer names used by AnnotateRaycastGrid. When set, returns clustered PhysicsCollider entries in AnnotatedElements instead of the coarse grid points.")]
+        [Description("Comma-separated physics layer names used by AnnotateRaycastGrid. Hits are limited to layers also visible to Camera.main.cullingMask. When set, returns clustered PhysicsCollider entries in AnnotatedElements instead of the coarse grid points.")]
         public string RaycastLayerMask { get; set; } = "";
     }
 }

--- a/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotSchema.cs
@@ -49,10 +49,13 @@ namespace io.github.hatayama.uLoopMCP
         [Description("Annotate interactive UI elements with names and simulate-mouse coordinates on the screenshot. Only works with CaptureMode=rendering in PlayMode.")]
         public bool AnnotateElements { get; set; } = false;
 
-        [Description("Return only annotated element JSON without capturing a screenshot image. Requires AnnotateElements=true and CaptureMode=rendering in PlayMode.")]
+        [Description("Return only annotation JSON without capturing a screenshot image. Requires AnnotateElements=true or AnnotateRaycastGrid=true, and CaptureMode=rendering in PlayMode.")]
         public bool ElementsOnly { get; set; } = false;
 
         [Description("Annotate 3D physics raycast candidate points on rendering screenshots. Uses Camera.main and the same top-left Game View coordinates as simulate-mouse-input.")]
         public bool AnnotateRaycastGrid { get; set; } = false;
+
+        [Description("Comma-separated physics layer names used by AnnotateRaycastGrid. When set, returns clustered PhysicsCollider entries in AnnotatedElements instead of the coarse grid points.")]
+        public string RaycastLayerMask { get; set; } = "";
     }
 }

--- a/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotTool.cs
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotTool.cs
@@ -56,6 +56,7 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             List<UIElementInfo> annotatedElements = new List<UIElementInfo>();
+            List<UIElementInfo> physicsColliderElements = new List<UIElementInfo>();
             Vector2 gameViewSize = GameViewCoordinateUtility.GetMainGameViewSize();
             List<RaycastGridPointInfo> raycastGridPoints = new List<RaycastGridPointInfo>();
             List<UIElementInfo> raycastGridOverlayElements = new List<UIElementInfo>();
@@ -73,20 +74,35 @@ namespace io.github.hatayama.uLoopMCP
                     await EditorWindowCaptureUtility.GetGameRenderingImageInfoAsync(ct);
                 raycastGridRenderingInfo = renderingImageInfo;
                 gameViewSize = renderingImageInfo.GameViewSize;
-                raycastGridPoints = RaycastGridAnnotator.CollectRaycastGridPoints(
-                    renderingImageInfo.RenderingImageSize,
-                    renderingImageInfo.ImageToInputOffsetY);
-                raycastGridOverlayElements = RaycastGridAnnotator.CreateOverlayElements(raycastGridPoints);
+                RaycastLayerMaskResolution raycastLayerMaskResolution =
+                    ResolveRaycastLayerMask(parameters);
+
+                if (raycastLayerMaskResolution.HasLayerNames)
+                {
+                    physicsColliderElements = RaycastGridAnnotator.CollectPhysicsColliderElements(
+                        renderingImageInfo.RenderingImageSize,
+                        renderingImageInfo.ImageToInputOffsetY,
+                        raycastLayerMaskResolution.Mask);
+                }
+                else
+                {
+                    raycastGridPoints = RaycastGridAnnotator.CollectRaycastGridPoints(
+                        renderingImageInfo.RenderingImageSize,
+                        renderingImageInfo.ImageToInputOffsetY);
+                    raycastGridOverlayElements = RaycastGridAnnotator.CreateOverlayElements(raycastGridPoints);
+                }
             }
 
             if (parameters.ElementsOnly)
             {
                 UIElementAnnotator.ConvertToSimCoordinates(annotatedElements, Mathf.RoundToInt(gameViewSize.y));
+                List<UIElementInfo> elementsOnlyAnnotatedElements =
+                    CreateResponseAnnotatedElements(annotatedElements, physicsColliderElements);
                 ScreenshotInfo elementsOnlyInfo = new ScreenshotInfo();
                 elementsOnlyInfo.ResolutionScale = parameters.ResolutionScale;
                 int imageToInputOffsetY = raycastGridRenderingInfo?.ImageToInputOffsetY ?? 0;
                 ApplyRenderingCoordinateMetadata(elementsOnlyInfo, gameViewSize, imageToInputOffsetY);
-                elementsOnlyInfo.AnnotatedElements = annotatedElements;
+                elementsOnlyInfo.AnnotatedElements = elementsOnlyAnnotatedElements;
                 elementsOnlyInfo.RaycastGridPoints = raycastGridPoints;
                 return new ScreenshotResponse(new List<ScreenshotInfo> { elementsOnlyInfo });
             }
@@ -100,6 +116,7 @@ namespace io.github.hatayama.uLoopMCP
                 {
                     List<UIElementInfo> overlayElements = new List<UIElementInfo>(annotatedElements);
                     overlayElements.AddRange(raycastGridOverlayElements);
+                    overlayElements.AddRange(physicsColliderElements);
                     annotationOverlay = UIElementAnnotator.CreateAnnotationOverlay(
                         overlayElements,
                         parameters.ResolutionScale);
@@ -119,6 +136,8 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             UIElementAnnotator.ConvertToSimCoordinates(annotatedElements, Mathf.RoundToInt(gameViewSize.y));
+            List<UIElementInfo> responseAnnotatedElements =
+                CreateResponseAnnotatedElements(annotatedElements, physicsColliderElements);
 
             if (texture == null)
             {
@@ -150,7 +169,7 @@ namespace io.github.hatayama.uLoopMCP
                     info,
                     captureRenderingInfo.GameViewSize,
                     captureRenderingInfo.ImageToInputOffsetY);
-                info.AnnotatedElements = annotatedElements;
+                info.AnnotatedElements = responseAnnotatedElements;
                 info.RaycastGridPoints = raycastGridPoints;
                 screenshots.Add(info);
             }
@@ -282,6 +301,15 @@ namespace io.github.hatayama.uLoopMCP
             info.UnityInputFormula = "";
         }
 
+        private static List<UIElementInfo> CreateResponseAnnotatedElements(
+            List<UIElementInfo> uiElements,
+            List<UIElementInfo> physicsColliderElements)
+        {
+            List<UIElementInfo> responseElements = new List<UIElementInfo>(uiElements);
+            responseElements.AddRange(physicsColliderElements);
+            return responseElements;
+        }
+
         private void ValidateParameters(ScreenshotSchema parameters)
         {
             if (parameters.CaptureMode != CaptureMode.rendering &&
@@ -315,10 +343,69 @@ namespace io.github.hatayama.uLoopMCP
                 }
             }
 
-            if (parameters.ElementsOnly && !parameters.AnnotateElements)
+            if (parameters.ElementsOnly &&
+                !parameters.AnnotateElements &&
+                !parameters.AnnotateRaycastGrid)
             {
-                throw new ParameterValidationException("ElementsOnly requires AnnotateElements=true");
+                throw new ParameterValidationException(
+                    "ElementsOnly requires AnnotateElements=true or AnnotateRaycastGrid=true");
             }
+
+            RaycastLayerMaskResolution raycastLayerMaskResolution =
+                ResolveRaycastLayerMask(parameters);
+            if (raycastLayerMaskResolution.HasLayerNames && !parameters.AnnotateRaycastGrid)
+            {
+                throw new ParameterValidationException(
+                    "RaycastLayerMask requires AnnotateRaycastGrid=true");
+            }
+
+            if (!raycastLayerMaskResolution.IsValid)
+            {
+                throw new ParameterValidationException(
+                    CreateInvalidRaycastLayerMaskMessage(raycastLayerMaskResolution));
+            }
+        }
+
+        private static RaycastLayerMaskResolution ResolveRaycastLayerMask(ScreenshotSchema parameters)
+        {
+            string raycastLayerMask = parameters.RaycastLayerMask ?? "";
+            return RaycastLayerMaskResolver.Resolve(
+                raycastLayerMask,
+                GetAvailableLayerDefinitions());
+        }
+
+        private static List<RaycastLayerDefinition> GetAvailableLayerDefinitions()
+        {
+            List<RaycastLayerDefinition> layerDefinitions = new List<RaycastLayerDefinition>();
+            for (int layerIndex = 0; layerIndex <= 31; layerIndex++)
+            {
+                string layerName = LayerMask.LayerToName(layerIndex);
+                if (string.IsNullOrEmpty(layerName))
+                {
+                    continue;
+                }
+
+                layerDefinitions.Add(new RaycastLayerDefinition
+                {
+                    Name = layerName,
+                    Index = layerIndex
+                });
+            }
+
+            return layerDefinitions;
+        }
+
+        private static string CreateInvalidRaycastLayerMaskMessage(
+            RaycastLayerMaskResolution raycastLayerMaskResolution)
+        {
+            string invalidLayerNames = string.Join(", ", raycastLayerMaskResolution.InvalidLayerNames);
+            string validLayerNames = string.Join(", ", raycastLayerMaskResolution.ValidLayerNames);
+            if (string.IsNullOrEmpty(validLayerNames))
+            {
+                validLayerNames = "(none)";
+            }
+
+            return $"RaycastLayerMask contains unknown layer name(s): {invalidLayerNames}. Valid layers: {validLayerNames}";
         }
 
         private string EnsureOutputDirectoryExists(string outputDirectory)

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
@@ -23,8 +23,8 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
 | `--output-directory` | string | `""` | Output directory path for saving screenshots. When empty, uses default path (.uloop/outputs/Screenshots/). Accepts absolute paths. |
 | `--annotate-elements` | boolean | `false` | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
-| `--annotate-raycast-grid` | boolean | `false` | Annotate 3D physics raycast candidate points (R1, R2, ...). Only works with `--capture-mode rendering`; uses Camera.main. |
-| `--raycast-layer-mask` | string | `""` | Comma-separated physics layer names for `--annotate-raycast-grid`. When set, dense raycast samples are clustered by collider and returned as `Type="PhysicsCollider"` entries in `AnnotatedElements`. |
+| `--annotate-raycast-grid` | boolean | `false` | Annotate 3D physics raycast candidate points (R1, R2, ...). Only works with `--capture-mode rendering`; uses Camera.main and its culling mask. |
+| `--raycast-layer-mask` | string | `""` | Comma-separated physics layer names for `--annotate-raycast-grid`. Hits are limited to layers also visible to Camera.main.cullingMask. When set, dense raycast samples are clustered by collider and returned as `Type="PhysicsCollider"` entries in `AnnotatedElements`. |
 | `--elements-only` | boolean | `false` | Return only annotation JSON without capturing a screenshot image. Requires `--annotate-elements` or `--annotate-raycast-grid`, and `--capture-mode rendering` in PlayMode. |
 
 ## Match Modes
@@ -111,5 +111,5 @@ When multiple windows match (e.g., multiple Inspector windows or when using `con
 - Window name matching is always case-insensitive
 - Use `--capture-mode rendering` for coordinates that should be passed to `simulate-mouse-input`, `simulate-mouse-ui`, or `raycast`.
 - Use `ScreenshotToInputFormula` before passing raw image pixels to mouse tools. `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` are already mouse-input coordinates.
-- Use `--raycast-layer-mask` with layer names from `find-game-objects` or project code when the game input code raycasts only specific layers.
+- Use `--raycast-layer-mask` with layer names from `find-game-objects` or project code when the game input code raycasts only specific layers. Layers hidden by Camera.main.cullingMask are not reported because they are not visible to the screenshot camera.
 - Do not use `window` captures as mouse-input coordinates because they include Unity Editor chrome.

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
@@ -10,7 +10,7 @@ Take a screenshot of any Unity EditorWindow by name and save as PNG.
 ## Usage
 
 ```bash
-uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mode <mode>] [--capture-mode <mode>] [--annotate-elements] [--annotate-raycast-grid] [--elements-only] [--output-directory <path>]
+uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mode <mode>] [--capture-mode <mode>] [--annotate-elements] [--annotate-raycast-grid] [--raycast-layer-mask <layers>] [--elements-only] [--output-directory <path>]
 ```
 
 ## Parameters
@@ -24,7 +24,8 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 | `--output-directory` | string | `""` | Output directory path for saving screenshots. When empty, uses default path (.uloop/outputs/Screenshots/). Accepts absolute paths. |
 | `--annotate-elements` | boolean | `false` | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
 | `--annotate-raycast-grid` | boolean | `false` | Annotate 3D physics raycast candidate points (R1, R2, ...). Only works with `--capture-mode rendering`; uses Camera.main. |
-| `--elements-only` | boolean | `false` | Return only annotated element JSON without capturing a screenshot image. Requires `--annotate-elements` and `--capture-mode rendering` in PlayMode. |
+| `--raycast-layer-mask` | string | `""` | Comma-separated physics layer names for `--annotate-raycast-grid`. When set, dense raycast samples are clustered by collider and returned as `Type="PhysicsCollider"` entries in `AnnotatedElements`. |
+| `--elements-only` | boolean | `false` | Return only annotation JSON without capturing a screenshot image. Requires `--annotate-elements` or `--annotate-raycast-grid`, and `--capture-mode rendering` in PlayMode. |
 
 ## Match Modes
 
@@ -59,8 +60,14 @@ uloop screenshot --capture-mode rendering --annotate-elements
 # Annotate 3D physics raycast candidate points
 uloop screenshot --capture-mode rendering --annotate-raycast-grid
 
+# Annotate clustered 3D collider candidates on selected layers
+uloop screenshot --capture-mode rendering --annotate-raycast-grid --raycast-layer-mask Ground,Clickable
+
 # Get UI element coordinates without capturing an image (fastest)
 uloop screenshot --capture-mode rendering --annotate-elements --elements-only
+
+# Get clustered 3D collider coordinates without capturing an image
+uloop screenshot --capture-mode rendering --annotate-raycast-grid --raycast-layer-mask Default --elements-only
 
 # Take a screenshot of Scene View
 uloop screenshot --window-name Scene
@@ -90,8 +97,8 @@ Returns JSON with:
   - `GameViewWidth` / `GameViewHeight`: Game View size used by mouse input tools
   - `ScreenshotToInputFormula`: Formula for turning image coordinates into mouse-input coordinates
   - `UnityInputFormula`: Formula used internally by mouse input tools to inject `Mouse.current.position`
-  - `AnnotatedElements`: Array of annotated UI element metadata. Empty unless `--annotate-elements` is used.
-  - `RaycastGridPoints`: Array of 3D raycast candidate metadata. Empty unless `--annotate-raycast-grid` is used.
+  - `AnnotatedElements`: Array of annotated UI element metadata. Also includes clustered `PhysicsCollider` entries when `--annotate-raycast-grid --raycast-layer-mask <layers>` is used.
+  - `RaycastGridPoints`: Array of coarse 3D raycast candidate metadata. Empty unless `--annotate-raycast-grid` is used without `--raycast-layer-mask`.
 
 For `AnnotatedElements` fields and Game View coordinates, read [references/annotated-elements.md](references/annotated-elements.md) before using screenshot coordinates with mouse simulation tools.
 
@@ -104,4 +111,5 @@ When multiple windows match (e.g., multiple Inspector windows or when using `con
 - Window name matching is always case-insensitive
 - Use `--capture-mode rendering` for coordinates that should be passed to `simulate-mouse-input`, `simulate-mouse-ui`, or `raycast`.
 - Use `ScreenshotToInputFormula` before passing raw image pixels to mouse tools. `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` are already mouse-input coordinates.
+- Use `--raycast-layer-mask` with layer names from `find-game-objects` or project code when the game input code raycasts only specific layers.
 - Do not use `window` captures as mouse-input coordinates because they include Unity Editor chrome.

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
@@ -1,16 +1,18 @@
 # Annotated Elements and Coordinates
 
-Read this when using `uloop screenshot --capture-mode rendering --annotate-elements` to find coordinates for `simulate-mouse-ui` or `simulate-mouse-input`.
+Read this when using `uloop screenshot --capture-mode rendering --annotate-elements` or clustered `--annotate-raycast-grid --raycast-layer-mask <layers>` output to find coordinates for `simulate-mouse-ui` or `simulate-mouse-input`.
 
 ## AnnotatedElements Fields
 
-`AnnotatedElements` is empty unless `--annotate-elements` is used. Entries are sorted by z-order, frontmost first. Each item contains:
+`AnnotatedElements` is empty unless `--annotate-elements` is used, or unless `--annotate-raycast-grid --raycast-layer-mask <layers>` adds clustered 3D collider candidates. UI entries are sorted by z-order, frontmost first. Each item contains:
 
 - `Label`: Index label in JSON (`A` = frontmost, `B` = next, ...). Screenshot labels also include the interaction hint, such as `A / CLICK` or `B / DRAG`.
 - `Name`: Element name
 - `Path`: Hierarchy path from the scene root, for example `Canvas/Panel/Button`. Use this as `simulate-mouse-ui --target-path` when bypassing raycast blockers.
-- `Type`: Element type (`Button`, `Toggle`, `Slider`, `Dropdown`, `InputField`, `Scrollbar`, `Draggable`, `DropTarget`, `Selectable`)
-- `Interaction`: Derived interaction category (`Click`, `Drag`, `Drop`, `Text`). Use this to choose between `simulate-mouse-ui --action Click` and drag actions.
+- `Type`: Element type (`Button`, `Toggle`, `Slider`, `Dropdown`, `InputField`, `Scrollbar`, `Draggable`, `DropTarget`, `Selectable`, `PhysicsCollider`)
+- `Interaction`: Derived interaction category (`Click`, `Drag`, `Drop`, `Text`) or `Raycast` for clustered physics collider entries. Use this to choose between `simulate-mouse-ui --action Click`, drag actions, or `simulate-mouse-input`/`raycast`.
+- `Layer`: Physics layer name for `PhysicsCollider` entries. Empty for UI entries.
+- `Components`: Collider and MonoBehaviour component type names from the hit GameObject for `PhysicsCollider` entries. Empty for UI entries.
 - `SimX`, `SimY`: Center position in top-left Game View coordinates. Use these directly with `simulate-mouse-ui --x/--y`, `simulate-mouse-input --x/--y`, or `raycast --x/--y`.
 - `BoundsMinX`, `BoundsMinY`, `BoundsMaxX`, `BoundsMaxY`: Bounding box in simulate-mouse coordinates
 - `SortingOrder`: Canvas sorting order. Higher values are in front.
@@ -26,6 +28,8 @@ input_y = image_y / resolutionScale + imageToInputOffsetY
 ```
 
 When `ResolutionScale` is `1.0` and `ImageToInputOffsetY` is `0`, raw image pixel coordinates already match mouse-input coordinates. `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` are always returned as mouse-input coordinates, so pass those values directly.
+
+For `PhysicsCollider` entries, `SimX/SimY` is a real sampled raycast hit nearest to the cluster centroid. This avoids synthetic center points that may fall into empty space for L-shaped or ring-shaped collider coverage.
 
 The mouse input tools convert internally to Unity Input System coordinates:
 

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
@@ -31,6 +31,8 @@ When `ResolutionScale` is `1.0` and `ImageToInputOffsetY` is `0`, raw image pixe
 
 For `PhysicsCollider` entries, `SimX/SimY` is a real sampled raycast hit nearest to the cluster centroid. This avoids synthetic center points that may fall into empty space for L-shaped or ring-shaped collider coverage.
 
+`--raycast-layer-mask` filters by the requested physics layers and Camera.main.cullingMask. A layer that is requested but hidden from the active camera is treated as not visible and will not produce `PhysicsCollider` entries.
+
 The mouse input tools convert internally to Unity Input System coordinates:
 
 ```text

--- a/Packages/src/Editor/Api/McpTools/Screenshot/UIElementInfo.cs
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/UIElementInfo.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace io.github.hatayama.uLoopMCP
 {
     public class UIElementInfo
@@ -6,6 +8,8 @@ namespace io.github.hatayama.uLoopMCP
         public string Path { get; set; } = "";
         public string Type { get; set; } = "";
         public string Interaction { get; set; } = "";
+        public string Layer { get; set; } = "";
+        public List<string> Components { get; set; } = new List<string>();
         public float SimX { get; set; }
         public float SimY { get; set; }
         public float BoundsMinX { get; set; }

--- a/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
+++ b/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
@@ -11,6 +11,8 @@ namespace io.github.hatayama.uLoopMCP
     {
         private const int GRID_COLUMNS = 5;
         private const int GRID_ROWS = 5;
+        private const int CLUSTERED_GRID_COLUMNS = 20;
+        private const int CLUSTERED_GRID_ROWS = 20;
         private const float MARKER_SIZE = 18f;
 
         internal static List<RaycastGridPointInfo> CollectRaycastGridPoints(
@@ -51,15 +53,54 @@ namespace io.github.hatayama.uLoopMCP
             int row,
             int column)
         {
+            return CalculateGridInputPositionForGrid(
+                renderingImageSize,
+                imageToInputOffsetY,
+                GRID_ROWS,
+                GRID_COLUMNS,
+                row,
+                column);
+        }
+
+        internal static Vector2 CalculateGridInputPositionForGrid(
+            Vector2 renderingImageSize,
+            int imageToInputOffsetY,
+            int rowCount,
+            int columnCount,
+            int row,
+            int column)
+        {
             Debug.Assert(renderingImageSize.x >= 0f, "Rendering image width must not be negative.");
             Debug.Assert(renderingImageSize.y >= 0f, "Rendering image height must not be negative.");
-            Debug.Assert(row >= 1 && row <= GRID_ROWS, "Grid row must be within the configured grid.");
-            Debug.Assert(column >= 1 && column <= GRID_COLUMNS, "Grid column must be within the configured grid.");
+            Debug.Assert(rowCount > 0, "Grid row count must be positive.");
+            Debug.Assert(columnCount > 0, "Grid column count must be positive.");
+            Debug.Assert(row >= 1 && row <= rowCount, "Grid row must be within the configured grid.");
+            Debug.Assert(column >= 1 && column <= columnCount, "Grid column must be within the configured grid.");
 
             // Grid points must be visible in the captured PNG, so sample image space before adding the input Y offset.
             return new Vector2(
-                renderingImageSize.x * column / (GRID_COLUMNS + 1f),
-                imageToInputOffsetY + renderingImageSize.y * row / (GRID_ROWS + 1f));
+                renderingImageSize.x * column / (columnCount + 1f),
+                imageToInputOffsetY + renderingImageSize.y * row / (rowCount + 1f));
+        }
+
+        internal static List<UIElementInfo> CollectPhysicsColliderElements(
+            Vector2 renderingImageSize,
+            int imageToInputOffsetY,
+            int layerMask)
+        {
+            List<RaycastClusterSample> samples = CollectClusterSamples(
+                renderingImageSize,
+                imageToInputOffsetY,
+                layerMask);
+            List<RaycastClusterInfo> clusters = RaycastHitClusterer.CreateClusters(samples);
+            List<UIElementInfo> elements = new List<UIElementInfo>();
+
+            for (int i = 0; i < clusters.Count; i++)
+            {
+                elements.Add(CreatePhysicsColliderElement($"R{i + 1}", clusters[i]));
+            }
+
+            return elements;
         }
 
         internal static List<UIElementInfo> CreateOverlayElements(List<RaycastGridPointInfo> points)
@@ -120,6 +161,125 @@ namespace io.github.hatayama.uLoopMCP
             pointInfo.HitGameObjectPath = GameObjectPathUtility.GetFullPath(hit.collider.gameObject);
             pointInfo.Distance = hit.distance;
             return pointInfo;
+        }
+
+        private static List<RaycastClusterSample> CollectClusterSamples(
+            Vector2 renderingImageSize,
+            int imageToInputOffsetY,
+            int layerMask)
+        {
+            List<RaycastClusterSample> samples = new List<RaycastClusterSample>();
+            // Sync once before the dense pass so every sample reads the same current physics state.
+            Physics.SyncTransforms();
+
+            for (int row = 1; row <= CLUSTERED_GRID_ROWS; row++)
+            {
+                for (int column = 1; column <= CLUSTERED_GRID_COLUMNS; column++)
+                {
+                    Vector2 inputPosition = CalculateGridInputPositionForGrid(
+                        renderingImageSize,
+                        imageToInputOffsetY,
+                        CLUSTERED_GRID_ROWS,
+                        CLUSTERED_GRID_COLUMNS,
+                        row,
+                        column);
+                    GameViewRaycastResult raycastResult = GameViewRaycastUtility.RaycastFromInputPosition(
+                        inputPosition,
+                        McpConstants.RAYCAST_DEFAULT_MAX_DISTANCE,
+                        layerMask,
+                        false);
+
+                    if (raycastResult.Hits.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    RaycastHit hit = raycastResult.Hits[0];
+                    samples.Add(CreateClusterSample(inputPosition, raycastResult, hit));
+                }
+            }
+
+            return samples;
+        }
+
+        private static RaycastClusterSample CreateClusterSample(
+            Vector2 inputPosition,
+            GameViewRaycastResult raycastResult,
+            RaycastHit hit)
+        {
+            Collider collider = hit.collider;
+            GameObject hitObject = collider.gameObject;
+
+            return new RaycastClusterSample
+            {
+                ClusterKey = collider.GetInstanceID(),
+                InputX = inputPosition.x,
+                InputY = inputPosition.y,
+                ScreenX = raycastResult.Conversion.InjectedUnityPosition.x,
+                ScreenY = raycastResult.Conversion.InjectedUnityPosition.y,
+                Name = hitObject.name,
+                Path = GameObjectPathUtility.GetFullPath(hitObject),
+                Layer = LayerMask.LayerToName(hitObject.layer),
+                Components = GetRelevantComponentTypeNames(hitObject)
+            };
+        }
+
+        internal static UIElementInfo CreatePhysicsColliderElement(
+            string label,
+            RaycastClusterInfo cluster)
+        {
+            RaycastClusterSample representative = cluster.Representative;
+            float halfSize = MARKER_SIZE / 2f;
+
+            return new UIElementInfo
+            {
+                Label = label,
+                Name = representative.Name,
+                Path = representative.Path,
+                Type = "PhysicsCollider",
+                Interaction = "Raycast",
+                SimX = representative.InputX,
+                SimY = representative.InputY,
+                BoundsMinX = representative.ScreenX - halfSize,
+                BoundsMinY = representative.ScreenY - halfSize,
+                BoundsMaxX = representative.ScreenX + halfSize,
+                BoundsMaxY = representative.ScreenY + halfSize,
+                SortingOrder = 0,
+                SiblingIndex = 0,
+                Layer = representative.Layer,
+                Components = new List<string>(representative.Components)
+            };
+        }
+
+        private static List<string> GetRelevantComponentTypeNames(GameObject hitObject)
+        {
+            List<string> componentTypeNames = new List<string>();
+            HashSet<string> seenTypeNames = new HashSet<string>();
+            Component[] components = hitObject.GetComponents<Component>();
+
+            foreach (Component component in components)
+            {
+                if (component == null)
+                {
+                    continue;
+                }
+
+                if (!(component is Collider) && !(component is MonoBehaviour))
+                {
+                    continue;
+                }
+
+                string typeName = component.GetType().Name;
+                if (seenTypeNames.Contains(typeName))
+                {
+                    continue;
+                }
+
+                seenTypeNames.Add(typeName);
+                componentTypeNames.Add(typeName);
+            }
+
+            return componentTypeNames;
         }
     }
 }

--- a/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
+++ b/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
@@ -88,16 +88,18 @@ namespace io.github.hatayama.uLoopMCP
             int imageToInputOffsetY,
             int layerMask)
         {
-            List<RaycastClusterSample> samples = CollectClusterSamples(
+            RaycastClusterCollection clusterCollection = CollectClusterSamples(
                 renderingImageSize,
                 imageToInputOffsetY,
                 layerMask);
-            List<RaycastClusterInfo> clusters = RaycastHitClusterer.CreateClusters(samples);
+            List<RaycastClusterInfo> clusters = RaycastHitClusterer.CreateClusters(clusterCollection.Samples);
             List<UIElementInfo> elements = new List<UIElementInfo>();
 
             for (int i = 0; i < clusters.Count; i++)
             {
-                elements.Add(CreatePhysicsColliderElement($"R{i + 1}", clusters[i]));
+                RaycastColliderMetadata metadata =
+                    clusterCollection.MetadataByClusterKey[clusters[i].Representative.ClusterKey];
+                elements.Add(CreatePhysicsColliderElement($"R{i + 1}", clusters[i], metadata));
             }
 
             return elements;
@@ -163,12 +165,12 @@ namespace io.github.hatayama.uLoopMCP
             return pointInfo;
         }
 
-        private static List<RaycastClusterSample> CollectClusterSamples(
+        private static RaycastClusterCollection CollectClusterSamples(
             Vector2 renderingImageSize,
             int imageToInputOffsetY,
             int layerMask)
         {
-            List<RaycastClusterSample> samples = new List<RaycastClusterSample>();
+            RaycastClusterCollection clusterCollection = new RaycastClusterCollection();
             // Sync once before the dense pass so every sample reads the same current physics state.
             Physics.SyncTransforms();
 
@@ -195,28 +197,39 @@ namespace io.github.hatayama.uLoopMCP
                     }
 
                     RaycastHit hit = raycastResult.Hits[0];
-                    samples.Add(CreateClusterSample(inputPosition, raycastResult, hit));
+                    Collider collider = hit.collider;
+                    int clusterKey = collider.GetInstanceID();
+                    if (!clusterCollection.MetadataByClusterKey.ContainsKey(clusterKey))
+                    {
+                        clusterCollection.MetadataByClusterKey.Add(
+                            clusterKey,
+                            CreateColliderMetadata(collider));
+                    }
+
+                    clusterCollection.Samples.Add(CreateClusterSample(inputPosition, clusterKey));
                 }
             }
 
-            return samples;
+            return clusterCollection;
         }
 
         private static RaycastClusterSample CreateClusterSample(
             Vector2 inputPosition,
-            GameViewRaycastResult raycastResult,
-            RaycastHit hit)
+            int clusterKey)
         {
-            Collider collider = hit.collider;
-            GameObject hitObject = collider.gameObject;
-
             return new RaycastClusterSample
             {
-                ClusterKey = collider.GetInstanceID(),
+                ClusterKey = clusterKey,
                 InputX = inputPosition.x,
-                InputY = inputPosition.y,
-                ScreenX = raycastResult.Conversion.InjectedUnityPosition.x,
-                ScreenY = raycastResult.Conversion.InjectedUnityPosition.y,
+                InputY = inputPosition.y
+            };
+        }
+
+        private static RaycastColliderMetadata CreateColliderMetadata(Collider collider)
+        {
+            GameObject hitObject = collider.gameObject;
+            return new RaycastColliderMetadata
+            {
                 Name = hitObject.name,
                 Path = GameObjectPathUtility.GetFullPath(hitObject),
                 Layer = LayerMask.LayerToName(hitObject.layer),
@@ -226,35 +239,44 @@ namespace io.github.hatayama.uLoopMCP
 
         internal static UIElementInfo CreatePhysicsColliderElement(
             string label,
-            RaycastClusterInfo cluster)
+            RaycastClusterInfo cluster,
+            RaycastColliderMetadata metadata)
         {
             RaycastClusterSample representative = cluster.Representative;
             float halfSize = MARKER_SIZE / 2f;
 
-            return new UIElementInfo
+            UIElementInfo element = new UIElementInfo
             {
                 Label = label,
-                Name = representative.Name,
-                Path = representative.Path,
+                Name = metadata.Name,
+                Path = metadata.Path,
                 Type = "PhysicsCollider",
                 Interaction = "Raycast",
                 SimX = representative.InputX,
                 SimY = representative.InputY,
-                BoundsMinX = representative.ScreenX - halfSize,
-                BoundsMinY = representative.ScreenY - halfSize,
-                BoundsMaxX = representative.ScreenX + halfSize,
-                BoundsMaxY = representative.ScreenY + halfSize,
+                BoundsMinX = representative.InputX - halfSize,
+                BoundsMinY = representative.InputY - halfSize,
+                BoundsMaxX = representative.InputX + halfSize,
+                BoundsMaxY = representative.InputY + halfSize,
                 SortingOrder = 0,
                 SiblingIndex = 0,
-                Layer = representative.Layer,
-                Components = new List<string>(representative.Components)
+                Layer = metadata.Layer,
+                Components = new List<string>(metadata.Components)
             };
+
+            Debug.Assert(
+                element.SimX >= element.BoundsMinX &&
+                element.SimX <= element.BoundsMaxX &&
+                element.SimY >= element.BoundsMinY &&
+                element.SimY <= element.BoundsMaxY,
+                "Physics collider bounds must use the same top-left input coordinate space as SimX/SimY.");
+            return element;
         }
 
         private static List<string> GetRelevantComponentTypeNames(GameObject hitObject)
         {
             List<string> componentTypeNames = new List<string>();
-            HashSet<string> seenTypeNames = new HashSet<string>();
+            HashSet<System.Type> seenTypes = new HashSet<System.Type>();
             Component[] components = hitObject.GetComponents<Component>();
 
             foreach (Component component in components)
@@ -269,14 +291,14 @@ namespace io.github.hatayama.uLoopMCP
                     continue;
                 }
 
-                string typeName = component.GetType().Name;
-                if (seenTypeNames.Contains(typeName))
+                System.Type componentType = component.GetType();
+                if (seenTypes.Contains(componentType))
                 {
                     continue;
                 }
 
-                seenTypeNames.Add(typeName);
-                componentTypeNames.Add(typeName);
+                seenTypes.Add(componentType);
+                componentTypeNames.Add(componentType.Name);
             }
 
             return componentTypeNames;

--- a/Packages/src/Editor/Utils/RaycastHitClusterer.cs
+++ b/Packages/src/Editor/Utils/RaycastHitClusterer.cs
@@ -1,0 +1,126 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Groups raycast samples by collider and chooses a real sampled hit as each representative.
+    /// </summary>
+    internal static class RaycastHitClusterer
+    {
+        internal static List<RaycastClusterInfo> CreateClusters(List<RaycastClusterSample> samples)
+        {
+            System.Diagnostics.Debug.Assert(samples != null, "Raycast samples must not be null.");
+            List<RaycastClusterSample> validSamples = samples!;
+
+            Dictionary<int, List<RaycastClusterSample>> samplesByClusterKey =
+                new Dictionary<int, List<RaycastClusterSample>>();
+            List<int> clusterKeys = new List<int>();
+
+            foreach (RaycastClusterSample sample in validSamples)
+            {
+                if (!samplesByClusterKey.ContainsKey(sample.ClusterKey))
+                {
+                    samplesByClusterKey.Add(sample.ClusterKey, new List<RaycastClusterSample>());
+                    clusterKeys.Add(sample.ClusterKey);
+                }
+
+                samplesByClusterKey[sample.ClusterKey].Add(sample);
+            }
+
+            List<RaycastClusterInfo> clusters = new List<RaycastClusterInfo>();
+            foreach (int clusterKey in clusterKeys)
+            {
+                List<RaycastClusterSample> clusterSamples = samplesByClusterKey[clusterKey];
+                clusters.Add(new RaycastClusterInfo
+                {
+                    Representative = SelectRepresentativeSample(clusterSamples),
+                    SampleCount = clusterSamples.Count
+                });
+            }
+
+            return clusters;
+        }
+
+        internal static RaycastClusterSample SelectRepresentativeSample(List<RaycastClusterSample> samples)
+        {
+            System.Diagnostics.Debug.Assert(samples != null, "Raycast samples must not be null.");
+            List<RaycastClusterSample> validSamples = samples!;
+            System.Diagnostics.Debug.Assert(validSamples.Count > 0, "At least one raycast sample is required.");
+
+            Vector2Like centroid = CalculateCentroid(validSamples);
+            RaycastClusterSample representative = validSamples[0];
+            float nearestSquaredDistance = CalculateSquaredDistance(representative, centroid);
+
+            for (int i = 1; i < validSamples.Count; i++)
+            {
+                RaycastClusterSample candidate = validSamples[i];
+                float candidateSquaredDistance = CalculateSquaredDistance(candidate, centroid);
+                if (candidateSquaredDistance >= nearestSquaredDistance)
+                {
+                    continue;
+                }
+
+                representative = candidate;
+                nearestSquaredDistance = candidateSquaredDistance;
+            }
+
+            return representative;
+        }
+
+        private static Vector2Like CalculateCentroid(List<RaycastClusterSample> samples)
+        {
+            float sumX = 0f;
+            float sumY = 0f;
+            foreach (RaycastClusterSample sample in samples)
+            {
+                sumX += sample.InputX;
+                sumY += sample.InputY;
+            }
+
+            return new Vector2Like
+            {
+                X = sumX / samples.Count,
+                Y = sumY / samples.Count
+            };
+        }
+
+        private static float CalculateSquaredDistance(RaycastClusterSample sample, Vector2Like point)
+        {
+            float deltaX = sample.InputX - point.X;
+            float deltaY = sample.InputY - point.Y;
+            return deltaX * deltaX + deltaY * deltaY;
+        }
+
+        private struct Vector2Like
+        {
+            public float X { get; set; }
+            public float Y { get; set; }
+        }
+    }
+
+    /// <summary>
+    /// Represents one screen-space raycast hit sample before collider clustering.
+    /// </summary>
+    internal sealed class RaycastClusterSample
+    {
+        public int ClusterKey { get; set; }
+        public float InputX { get; set; }
+        public float InputY { get; set; }
+        public float ScreenX { get; set; }
+        public float ScreenY { get; set; }
+        public string Name { get; set; } = "";
+        public string Path { get; set; } = "";
+        public string Layer { get; set; } = "";
+        public List<string> Components { get; set; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Contains one collider cluster and its selected representative hit sample.
+    /// </summary>
+    internal sealed class RaycastClusterInfo
+    {
+        public RaycastClusterSample Representative { get; set; } = new RaycastClusterSample();
+        public int SampleCount { get; set; }
+    }
+}

--- a/Packages/src/Editor/Utils/RaycastHitClusterer.cs
+++ b/Packages/src/Editor/Utils/RaycastHitClusterer.cs
@@ -107,12 +107,6 @@ namespace io.github.hatayama.uLoopMCP
         public int ClusterKey { get; set; }
         public float InputX { get; set; }
         public float InputY { get; set; }
-        public float ScreenX { get; set; }
-        public float ScreenY { get; set; }
-        public string Name { get; set; } = "";
-        public string Path { get; set; } = "";
-        public string Layer { get; set; } = "";
-        public List<string> Components { get; set; } = new List<string>();
     }
 
     /// <summary>
@@ -122,5 +116,27 @@ namespace io.github.hatayama.uLoopMCP
     {
         public RaycastClusterSample Representative { get; set; } = new RaycastClusterSample();
         public int SampleCount { get; set; }
+    }
+
+    /// <summary>
+    /// Carries GameObject metadata for one clustered collider.
+    /// </summary>
+    internal sealed class RaycastColliderMetadata
+    {
+        public string Name { get; set; } = "";
+        public string Path { get; set; } = "";
+        public string Layer { get; set; } = "";
+        public List<string> Components { get; set; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Keeps pure raycast samples separate from per-collider metadata.
+    /// </summary>
+    internal sealed class RaycastClusterCollection
+    {
+        public List<RaycastClusterSample> Samples { get; set; } = new List<RaycastClusterSample>();
+
+        public Dictionary<int, RaycastColliderMetadata> MetadataByClusterKey { get; set; } =
+            new Dictionary<int, RaycastColliderMetadata>();
     }
 }

--- a/Packages/src/Editor/Utils/RaycastHitClusterer.cs.meta
+++ b/Packages/src/Editor/Utils/RaycastHitClusterer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b0740475d6b847d69f517e95c3daf19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Utils/RaycastLayerMaskResolver.cs
+++ b/Packages/src/Editor/Utils/RaycastLayerMaskResolver.cs
@@ -1,0 +1,161 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Resolves comma-separated physics layer names into a Unity layer mask.
+    /// </summary>
+    internal static class RaycastLayerMaskResolver
+    {
+        private const int MIN_LAYER_INDEX = 0;
+        private const int MAX_LAYER_INDEX = 31;
+
+        internal static RaycastLayerMaskResolution Resolve(
+            string layerNamesText,
+            IReadOnlyList<RaycastLayerDefinition> availableLayers)
+        {
+            System.Diagnostics.Debug.Assert(layerNamesText != null, "Layer mask text must not be null.");
+            System.Diagnostics.Debug.Assert(availableLayers != null, "Available layers must not be null.");
+            string validLayerNamesText = layerNamesText!;
+            IReadOnlyList<RaycastLayerDefinition> validAvailableLayers = availableLayers!;
+
+            List<string> parsedLayerNames = ParseLayerNames(validLayerNamesText);
+            List<string> validLayerNames = CreateValidLayerNames(validAvailableLayers);
+            if (parsedLayerNames.Count == 0)
+            {
+                return new RaycastLayerMaskResolution
+                {
+                    IsValid = true,
+                    HasLayerNames = false,
+                    Mask = 0,
+                    LayerNames = parsedLayerNames,
+                    InvalidLayerNames = new List<string>(),
+                    ValidLayerNames = validLayerNames
+                };
+            }
+
+            Dictionary<string, int> layerIndexByName = CreateLayerIndexByName(validAvailableLayers);
+            List<string> resolvedLayerNames = new List<string>();
+            List<string> invalidLayerNames = new List<string>();
+            int mask = 0;
+
+            foreach (string layerName in parsedLayerNames)
+            {
+                if (!layerIndexByName.ContainsKey(layerName))
+                {
+                    invalidLayerNames.Add(layerName);
+                    continue;
+                }
+
+                int layerIndex = layerIndexByName[layerName];
+                mask |= 1 << layerIndex;
+                resolvedLayerNames.Add(layerName);
+            }
+
+            return new RaycastLayerMaskResolution
+            {
+                IsValid = invalidLayerNames.Count == 0,
+                HasLayerNames = true,
+                Mask = mask,
+                LayerNames = resolvedLayerNames,
+                InvalidLayerNames = invalidLayerNames,
+                ValidLayerNames = validLayerNames
+            };
+        }
+
+        private static List<string> ParseLayerNames(string layerNamesText)
+        {
+            List<string> layerNames = new List<string>();
+            HashSet<string> seenLayerNames = new HashSet<string>();
+            string[] parts = layerNamesText.Split(',');
+
+            foreach (string part in parts)
+            {
+                string layerName = part.Trim();
+                if (layerName.Length == 0)
+                {
+                    continue;
+                }
+
+                if (seenLayerNames.Contains(layerName))
+                {
+                    continue;
+                }
+
+                seenLayerNames.Add(layerName);
+                layerNames.Add(layerName);
+            }
+
+            return layerNames;
+        }
+
+        private static Dictionary<string, int> CreateLayerIndexByName(
+            IReadOnlyList<RaycastLayerDefinition> availableLayers)
+        {
+            Dictionary<string, int> layerIndexByName = new Dictionary<string, int>();
+            foreach (RaycastLayerDefinition layer in availableLayers)
+            {
+                if (!IsValidLayer(layer))
+                {
+                    continue;
+                }
+
+                if (layerIndexByName.ContainsKey(layer.Name))
+                {
+                    continue;
+                }
+
+                layerIndexByName.Add(layer.Name, layer.Index);
+            }
+
+            return layerIndexByName;
+        }
+
+        private static List<string> CreateValidLayerNames(
+            IReadOnlyList<RaycastLayerDefinition> availableLayers)
+        {
+            List<string> layerNames = new List<string>();
+            foreach (RaycastLayerDefinition layer in availableLayers)
+            {
+                if (!IsValidLayer(layer))
+                {
+                    continue;
+                }
+
+                layerNames.Add(layer.Name);
+            }
+
+            return layerNames;
+        }
+
+        private static bool IsValidLayer(RaycastLayerDefinition layer)
+        {
+            return !string.IsNullOrEmpty(layer.Name) &&
+                   layer.Index >= MIN_LAYER_INDEX &&
+                   layer.Index <= MAX_LAYER_INDEX;
+        }
+    }
+
+    /// <summary>
+    /// Describes one named Unity physics layer.
+    /// </summary>
+    internal sealed class RaycastLayerDefinition
+    {
+        public string Name { get; set; } = "";
+        public int Index { get; set; }
+    }
+
+    /// <summary>
+    /// Carries the result of layer-mask name resolution without throwing from pure logic.
+    /// </summary>
+    internal sealed class RaycastLayerMaskResolution
+    {
+        public bool IsValid { get; set; }
+        public bool HasLayerNames { get; set; }
+        public int Mask { get; set; }
+        public List<string> LayerNames { get; set; } = new List<string>();
+        public List<string> InvalidLayerNames { get; set; } = new List<string>();
+        public List<string> ValidLayerNames { get; set; } = new List<string>();
+    }
+}

--- a/Packages/src/Editor/Utils/RaycastLayerMaskResolver.cs.meta
+++ b/Packages/src/Editor/Utils/RaycastLayerMaskResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94bf95f96ab3a4962b0eb4db4266ecc9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Screenshots can now return fewer, click-ready 3D collider targets by filtering raycast annotations with named physics layers.
- Physics-only annotation JSON can be requested without also collecting UI elements.

## User Impact
- Agents can pass layer names from project code or scene inspection into `--raycast-layer-mask` and get clustered `PhysicsCollider` entries in `AnnotatedElements`.
- Returned `SimX` and `SimY` coordinates are representative real hit samples, so they can be used directly with raycast checks or mouse input.
- Existing coarse `RaycastGridPoints` behavior stays unchanged when no layer mask is provided.

## Changes
- Added layer-name parsing and validation for screenshot raycast annotations, including valid-layer feedback on invalid input.
- Added dense raycast sampling with collider-level clustering and nearest-real-hit representative point selection.
- Added `Layer` and `Components` metadata for annotated physics targets.
- Updated the CLI schema and screenshot skill docs for `--raycast-layer-mask`.
- Added focused EditMode coverage for parsing, clustering, coordinate behavior, and screenshot parameter validation.

## Verification
- `uloop compile --force-recompile true --wait-for-domain-reload true` returned 0 errors and 0 warnings.
- Targeted EditMode tests for raycast annotation and screenshot validation passed: 14 passed, 0 failed.
- `npm run lint` passed in the CLI package.
- `npm run build` passed in the CLI package.
- CLI sync and help output confirmed `--raycast-layer-mask` is exposed.
- SimulateMouseDemoScene E2E confirmed a temporary collider was returned as `Type="PhysicsCollider"`, the returned coordinate raycast-hit the collider, and `simulate-mouse-input` clicked that coordinate successfully.
- Full EditMode suite completed on this branch with 727 passed, 0 failed, and 11 skipped. One earlier local full-suite attempt timed out; after restarting Unity, `origin/main` completed with 716 passed, 0 failed, and 11 skipped, and this branch completed on rerun.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

