### PR TITLE
chore: Keep native command routing in one registry

### DIFF
--- a/cli/common/clicore/command_registry.go
+++ b/cli/common/clicore/command_registry.go
@@ -22,33 +22,59 @@ const (
 type NativeCommandEntry struct {
 	Name        string
 	Description string
+	Owner       CommandOwner
 }
+
+type CommandOwner string
+
+const (
+	DispatcherOwned CommandOwner = "dispatcher"
+	RunnerOwned     CommandOwner = "runner"
+)
 
 var NativeCommands = []NativeCommandEntry{
-	{Name: LaunchCommandName, Description: "Open this Unity project with the matching Editor version"},
-	{Name: "list", Description: "Show Unity tools currently exposed by the Editor"},
-	{Name: "sync", Description: "Refresh .uloop/tools.json from the running Editor"},
-	{Name: "focus-window", Description: "Bring the Unity Editor window to the foreground"},
-	{Name: PausePointWaitCommandName, Description: "Wait until a named UloopPausePoint.Pause marker pauses Unity"},
-	{Name: PausePointStatusUserCommandName, Description: "Show the state of a named UloopPausePoint.Pause marker"},
-	{Name: SkillsCommandName, Description: "List, install, or uninstall agent skills"},
-	{Name: "completion", Description: "Print or install shell completion"},
-	{Name: InstallCommandName, Description: "Configure the global uloop launcher binary"},
-	{Name: UpdateCommandName, Description: "Update the global uloop launcher binary"},
-	{Name: UninstallCommandName, Description: "Remove the global uloop launcher binary"},
+	{Name: LaunchCommandName, Description: "Open this Unity project with the matching Editor version", Owner: DispatcherOwned},
+	{Name: "list", Description: "Show Unity tools currently exposed by the Editor", Owner: RunnerOwned},
+	{Name: "sync", Description: "Refresh .uloop/tools.json from the running Editor", Owner: RunnerOwned},
+	{Name: "focus-window", Description: "Bring the Unity Editor window to the foreground", Owner: RunnerOwned},
+	{Name: PausePointWaitCommandName, Description: "Wait until a named UloopPausePoint.Pause marker pauses Unity", Owner: RunnerOwned},
+	{Name: PausePointStatusUserCommandName, Description: "Show the state of a named UloopPausePoint.Pause marker", Owner: RunnerOwned},
+	{Name: SkillsCommandName, Description: "List, install, or uninstall agent skills", Owner: DispatcherOwned},
+	{Name: CompletionCommand, Description: "Print or install shell completion", Owner: DispatcherOwned},
+	{Name: InstallCommandName, Description: "Configure the global uloop launcher binary", Owner: DispatcherOwned},
+	{Name: UpdateCommandName, Description: "Update the global uloop launcher binary", Owner: DispatcherOwned},
+	{Name: UninstallCommandName, Description: "Remove the global uloop launcher binary", Owner: DispatcherOwned},
 }
 
-// IsDispatcherOwnedCommandName reports whether a command belongs to the global
-// launcher's bootstrap surface. This is the single source of truth for the
-// dispatcher/runner command split: the dispatcher handles these in-process,
-// and the project runner must reject them instead of executing them.
+// IsDispatcherOwnedCommandName reports whether a native command belongs to the
+// global launcher's process. This is the single source of truth for the
+// dispatcher/runner command split: the dispatcher handles these in-process, and
+// the project runner must reject them instead of executing them.
 func IsDispatcherOwnedCommandName(command string) bool {
-	switch command {
-	case LaunchCommandName, InstallCommandName, UpdateCommandName, UninstallCommandName, SkillsCommandName:
-		return true
-	default:
-		return false
+	owner, ok := NativeCommandOwner(command)
+	return ok && owner == DispatcherOwned
+}
+
+func IsRunnerOwnedCommandName(command string) bool {
+	owner, ok := NativeCommandOwner(command)
+	return ok && owner == RunnerOwned
+}
+
+func NativeCommandOwner(command string) (CommandOwner, bool) {
+	entry, ok := NativeCommand(command)
+	if !ok {
+		return "", false
 	}
+	return entry.Owner, true
+}
+
+func NativeCommand(command string) (NativeCommandEntry, bool) {
+	for _, entry := range NativeCommands {
+		if entry.Name == command {
+			return entry, true
+		}
+	}
+	return NativeCommandEntry{}, false
 }
 
 func NativeCommandNamesForCompletion() []string {

--- a/cli/common/clicore/command_registry_test.go
+++ b/cli/common/clicore/command_registry_test.go
@@ -2,6 +2,35 @@ package clicore
 
 import "testing"
 
+func TestNativeCommandEntriesDeclareOwners(t *testing.T) {
+	// Verifies native command ownership lives in the command registry.
+	expectedOwners := map[string]CommandOwner{
+		LaunchCommandName:               DispatcherOwned,
+		InstallCommandName:              DispatcherOwned,
+		UpdateCommandName:               DispatcherOwned,
+		UninstallCommandName:            DispatcherOwned,
+		SkillsCommandName:               DispatcherOwned,
+		CompletionCommand:               DispatcherOwned,
+		"list":                          RunnerOwned,
+		"sync":                          RunnerOwned,
+		"focus-window":                  RunnerOwned,
+		PausePointWaitCommandName:       RunnerOwned,
+		PausePointStatusUserCommandName: RunnerOwned,
+	}
+	if len(NativeCommands) != len(expectedOwners) {
+		t.Fatalf("native command owner fixture is stale: %#v", NativeCommands)
+	}
+	for _, command := range NativeCommands {
+		expectedOwner, ok := expectedOwners[command.Name]
+		if !ok {
+			t.Fatalf("unexpected native command in registry: %s", command.Name)
+		}
+		if command.Owner != expectedOwner {
+			t.Fatalf("%s owner mismatch: %s", command.Name, command.Owner)
+		}
+	}
+}
+
 // Verifies the dispatcher-owned command set covers exactly the bootstrap commands and nothing forwarded to a project runner.
 func TestIsDispatcherOwnedCommandName(t *testing.T) {
 	for _, command := range []string{
@@ -10,6 +39,7 @@ func TestIsDispatcherOwnedCommandName(t *testing.T) {
 		UpdateCommandName,
 		UninstallCommandName,
 		SkillsCommandName,
+		CompletionCommand,
 	} {
 		if !IsDispatcherOwnedCommandName(command) {
 			t.Fatalf("%s must be dispatcher-owned", command)
@@ -20,10 +50,40 @@ func TestIsDispatcherOwnedCommandName(t *testing.T) {
 		ExecuteDynamicCodeCommandName,
 		RunTestsCommandName,
 		"list",
+		"sync",
 		"",
 	} {
 		if IsDispatcherOwnedCommandName(command) {
 			t.Fatalf("%s must not be dispatcher-owned", command)
+		}
+	}
+}
+
+func TestIsRunnerOwnedCommandName(t *testing.T) {
+	// Verifies project-runner native command routing is derived from registry ownership.
+	for _, command := range []string{
+		"list",
+		"sync",
+		"focus-window",
+		PausePointWaitCommandName,
+		PausePointStatusUserCommandName,
+	} {
+		if !IsRunnerOwnedCommandName(command) {
+			t.Fatalf("%s must be runner-owned", command)
+		}
+	}
+	for _, command := range []string{
+		LaunchCommandName,
+		InstallCommandName,
+		UpdateCommandName,
+		UninstallCommandName,
+		SkillsCommandName,
+		CompletionCommand,
+		CompileCommandName,
+		"",
+	} {
+		if IsRunnerOwnedCommandName(command) {
+			t.Fatalf("%s must not be runner-owned", command)
 		}
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/command_help.go
+++ b/cli/dispatcher/internal/dispatcher/command_help.go
@@ -9,7 +9,7 @@ import (
 )
 
 func tryHandleCommandHelp(command string, startPath string, projectPath string, stdout io.Writer, stderr io.Writer) (bool, int) {
-	if isNativeCommandName(command) {
+	if _, ok := clicore.NativeCommand(command); ok {
 		printNativeSingleCommandHelp(command, stdout)
 		return true, 0
 	}
@@ -100,12 +100,11 @@ func printToolHelp(tool clicore.ToolDefinition, stdout io.Writer) {
 }
 
 func nativeCommandDescription(command string) (string, bool) {
-	for _, entry := range clicore.NativeCommands {
-		if entry.Name == command {
-			return entry.Description, true
-		}
+	entry, ok := clicore.NativeCommand(command)
+	if !ok {
+		return "", false
 	}
-	return "", false
+	return entry.Description, true
 }
 
 func nativeCommandUsesProject(command string) bool {

--- a/cli/dispatcher/internal/dispatcher/completion.go
+++ b/cli/dispatcher/internal/dispatcher/completion.go
@@ -233,7 +233,7 @@ func printOptionsForCommand(command string, cache clicore.ToolsCache, stdout io.
 		clicore.WriteLine(stdout, strings.Join(options, "\n"))
 		return
 	}
-	if isNativeCommandName(command) {
+	if _, ok := clicore.NativeCommand(command); ok {
 		clicore.WriteLine(stdout, "")
 		return
 	}

--- a/cli/dispatcher/internal/dispatcher/run_help.go
+++ b/cli/dispatcher/internal/dispatcher/run_help.go
@@ -96,21 +96,12 @@ func printUnityToolCommandHelp(stdout io.Writer, cache clicore.ToolsCache, hasPr
 	}
 
 	for _, tool := range cache.Tools {
-		if isNativeCommandName(tool.Name) {
+		if _, ok := clicore.NativeCommand(tool.Name); ok {
 			continue
 		}
 		clicore.WriteFormat(stdout, "  %-22s %s\n", tool.Name, commandListDescription(tool.Description))
 	}
 	clicore.WriteLine(stdout, "  Run `uloop sync` after the Editor tool set changes to refresh this list.")
-}
-
-func isNativeCommandName(name string) bool {
-	for _, entry := range clicore.NativeCommands {
-		if entry.Name == name {
-			return true
-		}
-	}
-	return false
 }
 
 func commandListDescription(description string) string {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "41296fd13945ddc99a3296a73617c64681a280a8"
+  "sharedInputsHash": "44d7588a32dcb15e862e14b1d072c8e5657afd20"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "b08986f4dc84dd1d083113374824cd2535c1075c"
+  "sharedInputsHash": "2cbd95205bef8d25a2269f01d49475346b3506a3"
 }


### PR DESCRIPTION
## Summary
- Keeps native command ownership in the shared command registry so dispatcher and runner routing use the same source of truth.
- Preserves existing help, completion, and command rejection behavior while reducing duplicated command classification.

## User Impact
- No CLI behavior change is intended.
- Future native command additions are less likely to produce mismatched dispatcher and runner routing.

## Changes
- Added native command owner metadata for dispatcher-owned and runner-owned commands.
- Replaced duplicate native command lookups in dispatcher help and completion paths with registry helpers.
- Refreshed shared release input stamps for the common clicore change.

## Verification
- cd cli/common && go test ./clicore -count=1
- cd cli/dispatcher && go test ./internal/dispatcher -count=1
- cd cli/project-runner && go test ./internal/projectrunner -count=1
- cd cli/release-automation && go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD
- scripts/check-go-cli.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

