### PR TITLE
chore: Split dispatcher update decisions from execution

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -397,6 +397,79 @@ func TestEnforceDispatcherFreshnessReportsRequiredUpdateVersionChange(t *testing
 	}
 }
 
+func TestDecideDispatcherFreshnessPlansUpdatePaths(t *testing.T) {
+	// Verifies dispatcher freshness decisions are pure and separate from update execution.
+	tests := []struct {
+		name               string
+		minimumVersion     string
+		currentVersion     string
+		selfUpdateDisabled bool
+		hasSiblingRealCLI  bool
+		updateDue          bool
+		expectedAction     dispatcherFreshnessAction
+	}{
+		{
+			name:           "no minimum",
+			currentVersion: dispatcherVersion,
+			expectedAction: dispatcherFreshnessNoop,
+		},
+		{
+			name:               "required update disabled",
+			minimumVersion:     "999.0.0",
+			currentVersion:     dispatcherVersion,
+			selfUpdateDisabled: true,
+			updateDue:          true,
+			expectedAction:     dispatcherFreshnessManualUpdateRequired,
+		},
+		{
+			name:           "required update runs immediately",
+			minimumVersion: "999.0.0",
+			currentVersion: dispatcherVersion,
+			expectedAction: dispatcherFreshnessRunRequiredUpdate,
+		},
+		{
+			name:              "optional sibling skip",
+			minimumVersion:    dispatcherVersion,
+			currentVersion:    dispatcherVersion,
+			hasSiblingRealCLI: true,
+			updateDue:         true,
+			expectedAction:    dispatcherFreshnessNoop,
+		},
+		{
+			name:           "optional due",
+			minimumVersion: dispatcherVersion,
+			currentVersion: dispatcherVersion,
+			updateDue:      true,
+			expectedAction: dispatcherFreshnessRunOptionalUpdate,
+		},
+		{
+			name:           "optional not due",
+			minimumVersion: dispatcherVersion,
+			currentVersion: dispatcherVersion,
+			expectedAction: dispatcherFreshnessNoop,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := decideDispatcherFreshness(dispatcherFreshnessInputs{
+				MinimumVersion:     tt.minimumVersion,
+				CurrentVersion:     tt.currentVersion,
+				SelfUpdateDisabled: tt.selfUpdateDisabled,
+				HasSiblingRealCLI:  tt.hasSiblingRealCLI,
+				UpdateDue:          tt.updateDue,
+			})
+
+			if plan.Action != tt.expectedAction {
+				t.Fatalf("action mismatch: %s", plan.Action)
+			}
+			if plan.MinimumVersion != strings.TrimSpace(tt.minimumVersion) {
+				t.Fatalf("minimum version mismatch: %s", plan.MinimumVersion)
+			}
+		})
+	}
+}
+
 func stubDispatcherUpdateHooks(t *testing.T, updatedVersion string) (dispatcherRunDeps, func()) {
 	t.Helper()
 	previousReader := dispatcherReadInstalledVersion

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -191,32 +191,94 @@ func enforceDispatcherFreshness(ctx context.Context, pin dispatcherPin, stderr i
 	return enforceDispatcherFreshnessWithDeps(ctx, pin, stderr, defaultDispatcherRunDeps())
 }
 
+type dispatcherFreshnessAction string
+
+const (
+	dispatcherFreshnessNoop                 dispatcherFreshnessAction = "noop"
+	dispatcherFreshnessManualUpdateRequired dispatcherFreshnessAction = "manual-update-required"
+	dispatcherFreshnessRunRequiredUpdate    dispatcherFreshnessAction = "run-required-update"
+	dispatcherFreshnessRunOptionalUpdate    dispatcherFreshnessAction = "run-optional-update"
+)
+
+type dispatcherFreshnessInputs struct {
+	MinimumVersion     string
+	CurrentVersion     string
+	SelfUpdateDisabled bool
+	HasSiblingRealCLI  bool
+	UpdateDue          bool
+}
+
+type dispatcherFreshnessPlan struct {
+	Action         dispatcherFreshnessAction
+	MinimumVersion string
+}
+
 func enforceDispatcherFreshnessWithDeps(ctx context.Context, pin dispatcherPin, stderr io.Writer, deps dispatcherRunDeps) (bool, int) {
 	minimumVersion := strings.TrimSpace(pin.MinimumDispatcherVersion)
-	if minimumVersion == "" {
-		return false, 0
-	}
-	updateRequired := sharedversion.IsLessThan(dispatcherVersion, minimumVersion)
-	if updateRequired && dispatcherSelfUpdateDisabled() {
-		writeDispatcherManualUpdateRequiredError(stderr, minimumVersion, "Automatic update is disabled.")
-		return true, 1
-	}
-	if !updateRequired {
+	selfUpdateDisabled := dispatcherSelfUpdateDisabled()
+	updateRequired := minimumVersion != "" && sharedversion.IsLessThan(dispatcherVersion, minimumVersion)
+	hasSiblingRealCLI := false
+	if minimumVersion != "" && !updateRequired {
 		if _, ok := dispatcherSiblingRealCLIPath(pin); ok {
-			return false, 0
+			hasSiblingRealCLI = true
 		}
 	}
-
-	updateDue := !dispatcherSelfUpdateDisabled() && dispatcherSelfUpdateDueWithDeps(deps)
-	if !updateRequired && !updateDue {
-		return false, 0
+	updateDue := false
+	if minimumVersion != "" && !updateRequired && !hasSiblingRealCLI && !selfUpdateDisabled {
+		updateDue = dispatcherSelfUpdateDueWithDeps(deps)
 	}
+	plan := decideDispatcherFreshness(dispatcherFreshnessInputs{
+		MinimumVersion:     minimumVersion,
+		CurrentVersion:     dispatcherVersion,
+		SelfUpdateDisabled: selfUpdateDisabled,
+		HasSiblingRealCLI:  hasSiblingRealCLI,
+		UpdateDue:          updateDue,
+	})
+	return executeDispatcherFreshnessPlan(ctx, plan, stderr, deps)
+}
 
+func decideDispatcherFreshness(inputs dispatcherFreshnessInputs) dispatcherFreshnessPlan {
+	minimumVersion := strings.TrimSpace(inputs.MinimumVersion)
+	if minimumVersion == "" {
+		return dispatcherFreshnessPlan{Action: dispatcherFreshnessNoop}
+	}
+	updateRequired := sharedversion.IsLessThan(inputs.CurrentVersion, minimumVersion)
+	if updateRequired && inputs.SelfUpdateDisabled {
+		return dispatcherFreshnessPlan{Action: dispatcherFreshnessManualUpdateRequired, MinimumVersion: minimumVersion}
+	}
+	if updateRequired {
+		return dispatcherFreshnessPlan{Action: dispatcherFreshnessRunRequiredUpdate, MinimumVersion: minimumVersion}
+	}
+	if inputs.HasSiblingRealCLI || !inputs.UpdateDue {
+		return dispatcherFreshnessPlan{Action: dispatcherFreshnessNoop, MinimumVersion: minimumVersion}
+	}
+	return dispatcherFreshnessPlan{Action: dispatcherFreshnessRunOptionalUpdate, MinimumVersion: minimumVersion}
+}
+
+func executeDispatcherFreshnessPlan(ctx context.Context, plan dispatcherFreshnessPlan, stderr io.Writer, deps dispatcherRunDeps) (bool, int) {
+	switch plan.Action {
+	case dispatcherFreshnessNoop:
+		return false, 0
+	case dispatcherFreshnessManualUpdateRequired:
+		writeDispatcherManualUpdateRequiredError(stderr, plan.MinimumVersion, "Automatic update is disabled.")
+		return true, 1
+	case dispatcherFreshnessRunRequiredUpdate, dispatcherFreshnessRunOptionalUpdate:
+		return runDispatcherFreshnessUpdate(ctx, plan, stderr, deps)
+	default:
+		clicore.WriteErrorEnvelope(stderr, clicore.InternalCLIError(
+			"Dispatcher freshness routing bug: unknown action: "+string(plan.Action),
+			clicore.ErrorContext{},
+		))
+		return true, 1
+	}
+}
+
+func runDispatcherFreshnessUpdate(ctx context.Context, plan dispatcherFreshnessPlan, stderr io.Writer, deps dispatcherRunDeps) (bool, int) {
 	err := deps.runUpdate(ctx)
 	if err == nil {
 		markDispatcherSelfUpdateCheckedWithDeps(deps)
 		updatedVersion := dispatcherInstalledVersionOrEmpty(ctx)
-		if updateRequired {
+		if plan.Action == dispatcherFreshnessRunRequiredUpdate {
 			writeDispatcherSelfUpdateRequiredError(stderr, updatedVersion)
 			return true, 1
 		}
@@ -224,8 +286,8 @@ func enforceDispatcherFreshnessWithDeps(ctx context.Context, pin dispatcherPin, 
 		return false, 0
 	}
 
-	if updateRequired {
-		writeDispatcherManualUpdateRequiredError(stderr, minimumVersion, "Automatic update failed: "+err.Error())
+	if plan.Action == dispatcherFreshnessRunRequiredUpdate {
+		writeDispatcherManualUpdateRequiredError(stderr, plan.MinimumVersion, "Automatic update failed: "+err.Error())
 		return true, 1
 	}
 


### PR DESCRIPTION
## Summary
- Separates dispatcher self-update decision-making from update execution.
- Keeps existing required update, optional update, and sibling runner behavior covered by focused tests.

## User Impact
- No CLI behavior change is intended.
- Future dispatcher update changes should be easier to review without accidentally changing state marking or retry behavior.

## Changes
- Added a pure freshness decision step that returns a small update plan.
- Moved update execution, user output, and update-state marking into a separate plan execution path.
- Added table coverage for required update, optional update, disabled update, sibling runner, and no-op decisions.

## Verification
- cd cli/dispatcher && go test ./internal/dispatcher -run 'Test(DecideDispatcherFreshnessPlansUpdatePaths|EnforceDispatcherFreshness)' -count=1
- scripts/check-go-cli.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

