### PR TITLE
fix: 3D click targets avoid overlay UI

### DIFF
--- a/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
+++ b/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
@@ -176,6 +176,48 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
         }
 
         [Test]
+        public void SelectReachableRepresentativeSample_WhenNearestSampleIsOccluded_ShouldPromoteNextNearestSample()
+        {
+            RaycastClusterSample leftSample = CreateSample(1, 0f, 0f);
+            RaycastClusterSample nearestSample = CreateSample(1, 5f, 0f);
+            RaycastClusterSample farSample = CreateSample(1, 20f, 0f);
+            List<RaycastClusterSample> samples = new List<RaycastClusterSample>
+            {
+                leftSample,
+                nearestSample,
+                farSample
+            };
+            HashSet<RaycastClusterSample> occludedSamples = new HashSet<RaycastClusterSample>
+            {
+                nearestSample
+            };
+
+            RaycastClusterSample representative = RaycastHitClusterer.SelectReachableRepresentativeSample(
+                samples,
+                (RaycastClusterSample sample) => occludedSamples.Contains(sample));
+
+            Assert.That(representative, Is.SameAs(leftSample));
+        }
+
+        [Test]
+        public void SelectReachableRepresentativeSample_WhenAllSamplesAreOccluded_ShouldReturnNull()
+        {
+            List<RaycastClusterSample> samples = new List<RaycastClusterSample>
+            {
+                CreateSample(1, 0f, 0f),
+                CreateSample(1, 5f, 0f),
+                CreateSample(1, 20f, 0f)
+            };
+            HashSet<RaycastClusterSample> occludedSamples = new HashSet<RaycastClusterSample>(samples);
+
+            RaycastClusterSample representative = RaycastHitClusterer.SelectReachableRepresentativeSample(
+                samples,
+                (RaycastClusterSample sample) => occludedSamples.Contains(sample));
+
+            Assert.That(representative, Is.Null);
+        }
+
+        [Test]
         public void CreatePhysicsColliderElement_ShouldKeepBoundsInTopLeftInputSpace()
         {
             RaycastClusterInfo cluster = new RaycastClusterInfo

--- a/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
+++ b/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
 namespace io.github.hatayama.uLoopMCP.Tests.Editor
 {
@@ -249,6 +251,51 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             Assert.That(element.BoundsMaxY, Is.EqualTo(209f));
             Assert.That(element.SimX, Is.InRange(element.BoundsMinX, element.BoundsMaxX));
             Assert.That(element.SimY, Is.InRange(element.BoundsMinY, element.BoundsMaxY));
+        }
+
+        [Test]
+        public void IsUiOcclusionRaycastResult_WhenGraphicRaycasterHit_ShouldReturnTrue()
+        {
+            GameObject canvasObject = new GameObject("GraphicRaycasterOcclusionTest");
+            try
+            {
+                GraphicRaycaster graphicRaycaster = canvasObject.AddComponent<GraphicRaycaster>();
+                RaycastResult raycastResult = new RaycastResult
+                {
+                    module = graphicRaycaster
+                };
+
+                bool isOccluded = RaycastGridAnnotator.IsUiOcclusionRaycastResult(raycastResult);
+
+                Assert.That(isOccluded, Is.True);
+            }
+            finally
+            {
+                Object.DestroyImmediate(canvasObject);
+            }
+        }
+
+        [Test]
+        public void IsUiOcclusionRaycastResult_WhenPhysicsRaycasterHit_ShouldReturnFalse()
+        {
+            GameObject cameraObject = new GameObject("PhysicsRaycasterOcclusionTest");
+            try
+            {
+                cameraObject.AddComponent<Camera>();
+                PhysicsRaycaster physicsRaycaster = cameraObject.AddComponent<PhysicsRaycaster>();
+                RaycastResult raycastResult = new RaycastResult
+                {
+                    module = physicsRaycaster
+                };
+
+                bool isOccluded = RaycastGridAnnotator.IsUiOcclusionRaycastResult(raycastResult);
+
+                Assert.That(isOccluded, Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(cameraObject);
+            }
         }
 
         private static RaycastClusterSample CreateSample(int clusterKey, float inputX, float inputY)

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
@@ -24,7 +24,7 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 | `--output-directory` | string | `""` | Output directory path for saving screenshots. When empty, uses default path (.uloop/outputs/Screenshots/). Accepts absolute paths. |
 | `--annotate-elements` | boolean | `false` | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
 | `--annotate-raycast-grid` | boolean | `false` | Annotate 3D physics raycast candidate points (R1, R2, ...). Only works with `--capture-mode rendering`; uses Camera.main and its culling mask. |
-| `--raycast-layer-mask` | string | `""` | Comma-separated physics layer names for `--annotate-raycast-grid`. Hits are limited to layers also visible to Camera.main.cullingMask. When set, dense raycast samples are clustered by collider and returned as `Type="PhysicsCollider"` entries in `AnnotatedElements`; samples blocked by EventSystem UI Raycast are skipped. |
+| `--raycast-layer-mask` | string | `""` | Comma-separated physics layer names for `--annotate-raycast-grid`. Hits are limited to layers also visible to Camera.main.cullingMask. When set, dense raycast samples are clustered by collider and returned as `Type="PhysicsCollider"` entries in `AnnotatedElements`; samples blocked by EventSystem `GraphicRaycaster` UI hits are skipped. |
 | `--elements-only` | boolean | `false` | Return only annotation JSON without capturing a screenshot image. Requires `--annotate-elements` or `--annotate-raycast-grid`, and `--capture-mode rendering` in PlayMode. |
 
 ## Match Modes
@@ -112,5 +112,5 @@ When multiple windows match (e.g., multiple Inspector windows or when using `con
 - Use `--capture-mode rendering` for coordinates that should be passed to `simulate-mouse-input`, `simulate-mouse-ui`, or `raycast`.
 - Use `ScreenshotToInputFormula` before passing raw image pixels to mouse tools. `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` are already mouse-input coordinates.
 - Use `--raycast-layer-mask` with layer names from `find-game-objects` or project code when the game input code raycasts only specific layers. Layers hidden by Camera.main.cullingMask are not reported because they are not visible to the screenshot camera.
-- Clustered `PhysicsCollider` entries avoid points covered by UI that appears in EventSystem Raycast results. If the centroid-nearest sample is covered, the nearest uncovered sampled hit is used; if every sampled hit in the cluster is covered, that collider is omitted.
+- Clustered `PhysicsCollider` entries avoid points where the frontmost EventSystem hit comes from a `GraphicRaycaster` UI element, including world-space Canvas UI. PhysicsRaycaster and other non-uGUI hits are not treated as UI occlusion. If the centroid-nearest sample is covered, the nearest uncovered sampled hit is used; if every sampled hit in the cluster is covered, that collider is omitted.
 - Do not use `window` captures as mouse-input coordinates because they include Unity Editor chrome.

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
@@ -24,7 +24,7 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 | `--output-directory` | string | `""` | Output directory path for saving screenshots. When empty, uses default path (.uloop/outputs/Screenshots/). Accepts absolute paths. |
 | `--annotate-elements` | boolean | `false` | Annotate interactive UI elements with index labels and interaction hints (A / CLICK, B / DRAG, ...). Only works with `--capture-mode rendering` in PlayMode. |
 | `--annotate-raycast-grid` | boolean | `false` | Annotate 3D physics raycast candidate points (R1, R2, ...). Only works with `--capture-mode rendering`; uses Camera.main and its culling mask. |
-| `--raycast-layer-mask` | string | `""` | Comma-separated physics layer names for `--annotate-raycast-grid`. Hits are limited to layers also visible to Camera.main.cullingMask. When set, dense raycast samples are clustered by collider and returned as `Type="PhysicsCollider"` entries in `AnnotatedElements`. |
+| `--raycast-layer-mask` | string | `""` | Comma-separated physics layer names for `--annotate-raycast-grid`. Hits are limited to layers also visible to Camera.main.cullingMask. When set, dense raycast samples are clustered by collider and returned as `Type="PhysicsCollider"` entries in `AnnotatedElements`; samples blocked by EventSystem UI Raycast are skipped. |
 | `--elements-only` | boolean | `false` | Return only annotation JSON without capturing a screenshot image. Requires `--annotate-elements` or `--annotate-raycast-grid`, and `--capture-mode rendering` in PlayMode. |
 
 ## Match Modes
@@ -112,4 +112,5 @@ When multiple windows match (e.g., multiple Inspector windows or when using `con
 - Use `--capture-mode rendering` for coordinates that should be passed to `simulate-mouse-input`, `simulate-mouse-ui`, or `raycast`.
 - Use `ScreenshotToInputFormula` before passing raw image pixels to mouse tools. `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` are already mouse-input coordinates.
 - Use `--raycast-layer-mask` with layer names from `find-game-objects` or project code when the game input code raycasts only specific layers. Layers hidden by Camera.main.cullingMask are not reported because they are not visible to the screenshot camera.
+- Clustered `PhysicsCollider` entries avoid points covered by UI that appears in EventSystem Raycast results. If the centroid-nearest sample is covered, the nearest uncovered sampled hit is used; if every sampled hit in the cluster is covered, that collider is omitted.
 - Do not use `window` captures as mouse-input coordinates because they include Unity Editor chrome.

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
@@ -33,6 +33,8 @@ For `PhysicsCollider` entries, `SimX/SimY` is a real sampled raycast hit nearest
 
 `--raycast-layer-mask` filters by the requested physics layers and Camera.main.cullingMask. A layer that is requested but hidden from the active camera is treated as not visible and will not produce `PhysicsCollider` entries.
 
+For clustered `PhysicsCollider` entries, points hit by EventSystem UI Raycast are treated as covered by UI. When the centroid-nearest sample is covered, the annotator promotes the nearest uncovered sampled hit; if every sampled hit in that collider cluster is covered, the collider is omitted from `AnnotatedElements`.
+
 The mouse input tools convert internally to Unity Input System coordinates:
 
 ```text

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
@@ -33,7 +33,7 @@ For `PhysicsCollider` entries, `SimX/SimY` is a real sampled raycast hit nearest
 
 `--raycast-layer-mask` filters by the requested physics layers and Camera.main.cullingMask. A layer that is requested but hidden from the active camera is treated as not visible and will not produce `PhysicsCollider` entries.
 
-For clustered `PhysicsCollider` entries, points hit by EventSystem UI Raycast are treated as covered by UI. When the centroid-nearest sample is covered, the annotator promotes the nearest uncovered sampled hit; if every sampled hit in that collider cluster is covered, the collider is omitted from `AnnotatedElements`.
+For clustered `PhysicsCollider` entries, points where the frontmost EventSystem hit comes from a `GraphicRaycaster` UI element are treated as covered by UI. This includes world-space Canvas UI. PhysicsRaycaster and other non-uGUI hits are not treated as UI occlusion. When the centroid-nearest sample is covered, the annotator promotes the nearest uncovered sampled hit; if every sampled hit in that collider cluster is covered, the collider is omitted from `AnnotatedElements`.
 
 The mouse input tools convert internally to Unity Input System coordinates:
 

--- a/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
+++ b/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 namespace io.github.hatayama.uLoopMCP
 {
@@ -94,12 +95,24 @@ namespace io.github.hatayama.uLoopMCP
                 layerMask);
             List<RaycastClusterInfo> clusters = RaycastHitClusterer.CreateClusters(clusterCollection.Samples);
             List<UIElementInfo> elements = new List<UIElementInfo>();
+            UiRaycastHelper.RaycastContext? uiRaycastContext = CreateUiRaycastContext();
+            Vector2 gameViewSize = GameViewCoordinateUtility.GetMainGameViewSize();
 
             for (int i = 0; i < clusters.Count; i++)
             {
+                RaycastClusterSample? representative = SelectUnoccludedRepresentative(
+                    clusters[i],
+                    uiRaycastContext,
+                    gameViewSize);
+                if (representative == null)
+                {
+                    continue;
+                }
+
+                clusters[i].Representative = representative;
                 RaycastColliderMetadata metadata =
-                    clusterCollection.MetadataByClusterKey[clusters[i].Representative.ClusterKey];
-                elements.Add(CreatePhysicsColliderElement($"R{i + 1}", clusters[i], metadata));
+                    clusterCollection.MetadataByClusterKey[representative.ClusterKey];
+                elements.Add(CreatePhysicsColliderElement($"R{elements.Count + 1}", clusters[i], metadata));
             }
 
             return elements;
@@ -271,6 +284,43 @@ namespace io.github.hatayama.uLoopMCP
                 element.SimY <= element.BoundsMaxY,
                 "Physics collider bounds must use the same top-left input coordinate space as SimX/SimY.");
             return element;
+        }
+
+        private static UiRaycastHelper.RaycastContext? CreateUiRaycastContext()
+        {
+            EventSystem currentEventSystem = EventSystem.current;
+            if (currentEventSystem == null || !currentEventSystem.isActiveAndEnabled)
+            {
+                return null;
+            }
+
+            return new UiRaycastHelper.RaycastContext(currentEventSystem);
+        }
+
+        private static RaycastClusterSample? SelectUnoccludedRepresentative(
+            RaycastClusterInfo cluster,
+            UiRaycastHelper.RaycastContext? uiRaycastContext,
+            Vector2 gameViewSize)
+        {
+            if (uiRaycastContext == null)
+            {
+                return cluster.Representative;
+            }
+
+            return RaycastHitClusterer.SelectReachableRepresentativeSample(
+                cluster.Samples,
+                (RaycastClusterSample sample) => IsSampleOccludedByUi(sample, uiRaycastContext, gameViewSize));
+        }
+
+        private static bool IsSampleOccludedByUi(
+            RaycastClusterSample sample,
+            UiRaycastHelper.RaycastContext uiRaycastContext,
+            Vector2 gameViewSize)
+        {
+            Vector2 inputPosition = new Vector2(sample.InputX, sample.InputY);
+            GameViewCoordinateConversion conversion =
+                GameViewCoordinateUtility.ConvertInputToUnity(inputPosition, gameViewSize);
+            return uiRaycastContext.Raycast(conversion.InjectedUnityPosition) != null;
         }
 
         private static List<string> GetRelevantComponentTypeNames(GameObject hitObject)

--- a/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
+++ b/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
 namespace io.github.hatayama.uLoopMCP
 {
@@ -320,7 +321,12 @@ namespace io.github.hatayama.uLoopMCP
             Vector2 inputPosition = new Vector2(sample.InputX, sample.InputY);
             GameViewCoordinateConversion conversion =
                 GameViewCoordinateUtility.ConvertInputToUnity(inputPosition, gameViewSize);
-            return uiRaycastContext.Raycast(conversion.InjectedUnityPosition) != null;
+            return IsUiOcclusionRaycastResult(uiRaycastContext.Raycast(conversion.InjectedUnityPosition));
+        }
+
+        internal static bool IsUiOcclusionRaycastResult(RaycastResult? raycastResult)
+        {
+            return raycastResult != null && raycastResult.Value.module is GraphicRaycaster;
         }
 
         private static List<string> GetRelevantComponentTypeNames(GameObject hitObject)

--- a/Packages/src/Editor/Utils/RaycastHitClusterer.cs
+++ b/Packages/src/Editor/Utils/RaycastHitClusterer.cs
@@ -35,7 +35,8 @@ namespace io.github.hatayama.uLoopMCP
                 clusters.Add(new RaycastClusterInfo
                 {
                     Representative = SelectRepresentativeSample(clusterSamples),
-                    SampleCount = clusterSamples.Count
+                    SampleCount = clusterSamples.Count,
+                    Samples = new List<RaycastClusterSample>(clusterSamples)
                 });
             }
 
@@ -68,6 +69,30 @@ namespace io.github.hatayama.uLoopMCP
             return representative;
         }
 
+        internal static RaycastClusterSample? SelectReachableRepresentativeSample(
+            List<RaycastClusterSample> samples,
+            RaycastClusterSampleOcclusionCheck isOccluded)
+        {
+            System.Diagnostics.Debug.Assert(samples != null, "Raycast samples must not be null.");
+            System.Diagnostics.Debug.Assert(isOccluded != null, "Raycast sample occlusion check must not be null.");
+            List<RaycastClusterSample> validSamples = samples!;
+            RaycastClusterSampleOcclusionCheck validIsOccluded = isOccluded!;
+            System.Diagnostics.Debug.Assert(validSamples.Count > 0, "At least one raycast sample is required.");
+
+            List<RaycastClusterSample> candidates = CreateSamplesOrderedByCentroidDistance(validSamples);
+            foreach (RaycastClusterSample candidate in candidates)
+            {
+                if (validIsOccluded(candidate))
+                {
+                    continue;
+                }
+
+                return candidate;
+            }
+
+            return null;
+        }
+
         private static Vector2Like CalculateCentroid(List<RaycastClusterSample> samples)
         {
             float sumX = 0f;
@@ -90,6 +115,51 @@ namespace io.github.hatayama.uLoopMCP
             float deltaX = sample.InputX - point.X;
             float deltaY = sample.InputY - point.Y;
             return deltaX * deltaX + deltaY * deltaY;
+        }
+
+        private static List<RaycastClusterSample> CreateSamplesOrderedByCentroidDistance(
+            List<RaycastClusterSample> samples)
+        {
+            Vector2Like centroid = CalculateCentroid(samples);
+            List<RankedRaycastClusterSample> rankedSamples = new List<RankedRaycastClusterSample>();
+            for (int i = 0; i < samples.Count; i++)
+            {
+                RaycastClusterSample sample = samples[i];
+                rankedSamples.Add(new RankedRaycastClusterSample
+                {
+                    Sample = sample,
+                    OriginalIndex = i,
+                    SquaredDistance = CalculateSquaredDistance(sample, centroid)
+                });
+            }
+
+            rankedSamples.Sort(CompareRankedSamples);
+
+            List<RaycastClusterSample> orderedSamples = new List<RaycastClusterSample>();
+            foreach (RankedRaycastClusterSample rankedSample in rankedSamples)
+            {
+                orderedSamples.Add(rankedSample.Sample);
+            }
+
+            return orderedSamples;
+        }
+
+        private static int CompareRankedSamples(RankedRaycastClusterSample left, RankedRaycastClusterSample right)
+        {
+            int distanceComparison = left.SquaredDistance.CompareTo(right.SquaredDistance);
+            if (distanceComparison != 0)
+            {
+                return distanceComparison;
+            }
+
+            return left.OriginalIndex.CompareTo(right.OriginalIndex);
+        }
+
+        private struct RankedRaycastClusterSample
+        {
+            public RaycastClusterSample Sample { get; set; }
+            public int OriginalIndex { get; set; }
+            public float SquaredDistance { get; set; }
         }
 
         private struct Vector2Like
@@ -116,7 +186,13 @@ namespace io.github.hatayama.uLoopMCP
     {
         public RaycastClusterSample Representative { get; set; } = new RaycastClusterSample();
         public int SampleCount { get; set; }
+        public List<RaycastClusterSample> Samples { get; set; } = new List<RaycastClusterSample>();
     }
+
+    /// <summary>
+    /// Reports whether a raycast sample cannot be used as a click target.
+    /// </summary>
+    internal delegate bool RaycastClusterSampleOcclusionCheck(RaycastClusterSample sample);
 
     /// <summary>
     /// Carries GameObject metadata for one clustered collider.


### PR DESCRIPTION
## Summary
- 3D physics click annotations now avoid sampled points covered by EventSystem UI.
- If the centroid-nearest collider sample is covered by overlay UI, the annotator promotes the nearest uncovered sampled hit instead of returning an unreachable click target.

## User Impact
- Before this change, a visible 3D collider could be annotated at a point hidden behind HUD or overlay UI, causing agents to click a coordinate that the game UI intercepts.
- After this change, clustered `PhysicsCollider` entries only report click candidates that are not covered by EventSystem UI raycast results. Fully covered collider clusters are omitted.

## Changes
- Add representative promotion logic for clustered physics raycast samples.
- Apply UI occlusion checks only to dense clustered `PhysicsCollider` annotations, preserving the legacy 5x5 raycast grid behavior.
- Treat only frontmost EventSystem hits from `GraphicRaycaster` as UI occlusion so `PhysicsRaycaster` hits do not hide reachable 3D colliders.
- Document the EventSystem UI raycast heuristic and add focused unit coverage for promotion and full-occlusion cases.

## Verification
- `uloop compile --force-recompile true --wait-for-domain-reload true` -> 0 errors, 0 warnings
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "io\\.github\\.hatayama\\.uLoopMCP\\.Tests\\.Editor\\.RaycastGridAnnotatorTests.*"` -> 14 passed
- `npm run lint` -> 0 errors, existing warnings only
- `npm run build`
- PlayMode check with a temporary cube behind overlay UI: center UI raycast hit, promoted annotation coordinate had 0 UI hits and still raycast-hit the cube
- PlayMode check with a temporary cube and Camera `PhysicsRaycaster`: EventSystem first hit was `PhysicsRaycaster`, and the `PhysicsCollider` annotation remained visible
