### PR TITLE
fix: Native uninstall now removes stale shell PATH setup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,6 +24,7 @@ reviews:
     - "**/*.go"
     - "**/*.py"
     - "**/*.sh"
+    - "cli/dispatcher/internal/**/scripts/**/*.ps1"
     - "**/*.command"
     - "**/*.md"
     - "**/*.uss"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Test release automation shell helpers
         run: |
           sh -n cli/dispatcher/internal/install/scripts/install_darwin.sh
+          sh -n cli/dispatcher/internal/uninstall/scripts/uninstall_darwin.sh
           scripts/test-go-cli-toolchain.sh
           scripts/test-resolve-native-cli-release-target.sh
           scripts/test-resolve-dispatcher-release-target.sh
@@ -116,6 +117,8 @@ jobs:
         shell: powershell
         run: |
           $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 cli/dispatcher/internal/install/scripts/install_windows.ps1))
+          $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 cli/dispatcher/internal/uninstall/scripts/uninstall_windows_delete.ps1))
+          $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 cli/dispatcher/internal/uninstall/scripts/uninstall_windows_launch.ps1))
           $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 scripts/install.ps1))
           $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 scripts/check-release-installer.ps1))
           $null = [scriptblock]::Create((Get-Content -Raw -Encoding UTF8 scripts/test-check-release-installer.ps1))

--- a/cli/dispatcher/internal/uninstall/command.go
+++ b/cli/dispatcher/internal/uninstall/command.go
@@ -3,7 +3,7 @@ package uninstall
 import (
 	"encoding/base64"
 	"errors"
-	"fmt"
+	"strconv"
 	"strings"
 	"unicode/utf16"
 
@@ -36,10 +36,9 @@ func CommandForOS(goos string, options Options) (Command, error) {
 	switch goos {
 	case "darwin":
 		targetPath := nativepath.CommandPath(goos, options.InstallDir, PosixCommandName, WindowsCommandName)
-		script := "rm -f " + shellQuote(targetPath)
 		return Command{
 			Name:       "sh",
-			Args:       []string{"-c", script},
+			Args:       posixUninstallArgs(targetPath),
 			TargetPath: targetPath,
 		}, nil
 	case "windows":
@@ -58,12 +57,22 @@ func CommandForOS(goos string, options Options) (Command, error) {
 	}
 }
 
+func posixUninstallArgs(targetPath string) []string {
+	return []string{
+		"-c",
+		posixUninstallScript(targetPath),
+	}
+}
+
+func posixUninstallScript(targetPath string) string {
+	return strings.NewReplacer(
+		"'{{TARGET_PATH}}'", shellQuote(targetPath),
+	).Replace(uninstallScriptTemplate("scripts/uninstall_darwin.sh"))
+}
+
 func windowsUninstallArgs(targetPath string, currentPID int) []string {
 	deleteScript := windowsDeletionScript(targetPath, currentPID)
-	launchScript := fmt.Sprintf(
-		"$EncodedDeletion = '%s'\nStart-Process -FilePath 'powershell' -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-EncodedCommand',$EncodedDeletion) -WindowStyle Hidden\n",
-		encodePowerShellCommand(deleteScript),
-	)
+	launchScript := windowsLaunchScript(encodePowerShellCommand(deleteScript))
 	return []string{
 		"-NoProfile",
 		"-ExecutionPolicy",
@@ -73,38 +82,17 @@ func windowsUninstallArgs(targetPath string, currentPID int) []string {
 	}
 }
 
+func windowsLaunchScript(encodedDeletionScript string) string {
+	return strings.NewReplacer(
+		"'{{ENCODED_DELETION}}'", powerShellSingleQuote(encodedDeletionScript),
+	).Replace(uninstallScriptTemplate("scripts/uninstall_windows_launch.ps1"))
+}
+
 func windowsDeletionScript(targetPath string, currentPID int) string {
-	return fmt.Sprintf(
-		`$Target = %s
-$ParentPid = %d
-$InstallDir = Split-Path -Parent $Target
-$NormalizePath = {
-    param([string]$Path)
-    if (-not $Path) {
-        return ''
-    }
-    return $Path.Trim().Trim('"').TrimEnd([char[]]@('\','/')).Replace('/','\')
-}
-$ParentProcess = Get-Process -Id $ParentPid -ErrorAction SilentlyContinue
-if ($ParentProcess) {
-    $ParentProcess | Wait-Process -ErrorAction SilentlyContinue
-}
-$UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-if ($UserPath) {
-    $NormalizedInstallDir = & $NormalizePath $InstallDir
-    $PathEntries = $UserPath -split ';' | Where-Object { $_ -and -not [string]::Equals((& $NormalizePath $_), $NormalizedInstallDir, [System.StringComparison]::OrdinalIgnoreCase) }
-    $NewUserPath = [string]::Join(';', $PathEntries)
-    if (-not [string]::Equals($UserPath, $NewUserPath, [System.StringComparison]::Ordinal)) {
-        [Environment]::SetEnvironmentVariable('Path', $NewUserPath, 'User')
-    }
-}
-if (Test-Path -LiteralPath $Target) {
-    Remove-Item -LiteralPath $Target -Force -ErrorAction SilentlyContinue
-}
-`,
-		powerShellSingleQuote(targetPath),
-		currentPID,
-	)
+	return strings.NewReplacer(
+		"'{{TARGET_PATH}}'", powerShellSingleQuote(targetPath),
+		"{{CURRENT_PID}}", strconv.Itoa(currentPID),
+	).Replace(uninstallScriptTemplate("scripts/uninstall_windows_delete.ps1"))
 }
 
 func encodePowerShellCommand(script string) string {

--- a/cli/dispatcher/internal/uninstall/command_test.go
+++ b/cli/dispatcher/internal/uninstall/command_test.go
@@ -2,6 +2,10 @@ package uninstall
 
 import (
 	"encoding/base64"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"unicode/utf16"
@@ -83,6 +87,73 @@ func TestPosixUninstallScriptReplacesTemplateValues(t *testing.T) {
 	}
 	if !strings.Contains(uninstallScript, `TargetPath='/tmp/uloop'"'"'s bin/uloop'`) {
 		t.Fatalf("uninstall script does not quote target path correctly: %s", uninstallScript)
+	}
+}
+
+func TestPosixUninstallScriptRemovesShellPathBlocks(t *testing.T) {
+	// Verifies macOS uninstall removes only the shell PATH blocks owned by the installer.
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX uninstall script is not available on Windows")
+	}
+
+	home := t.TempDir()
+	installDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		t.Fatalf("failed to create install dir: %v", err)
+	}
+	targetPath := filepath.Join(installDir, PosixCommandName)
+	if err := os.WriteFile(targetPath, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("failed to create target binary: %v", err)
+	}
+
+	profilePaths := []string{
+		filepath.Join(home, ".bash_profile"),
+		filepath.Join(home, ".zshrc"),
+		filepath.Join(home, ".config", "fish", "config.fish"),
+	}
+	for _, profilePath := range profilePaths {
+		if err := os.MkdirAll(filepath.Dir(profilePath), 0o755); err != nil {
+			t.Fatalf("failed to create profile dir: %v", err)
+		}
+		content := "before\n# >>> uloop PATH >>>\nexport PATH='" + installDir + ":$PATH'\n# <<< uloop PATH <<<\nafter\n"
+		if err := os.WriteFile(profilePath, []byte(content), 0o600); err != nil {
+			t.Fatalf("failed to write profile: %v", err)
+		}
+	}
+
+	command, err := CommandForOS("darwin", Options{
+		InstallDir: installDir,
+		CurrentPID: 1234,
+	})
+	if err != nil {
+		t.Fatalf("CommandForOS failed: %v", err)
+	}
+
+	process := exec.Command(command.Name, command.Args...)
+	process.Env = []string{
+		"HOME=" + home,
+		"PATH=/usr/bin:/bin:/usr/sbin:/sbin",
+	}
+	output, err := process.CombinedOutput()
+	if err != nil {
+		t.Fatalf("POSIX uninstall failed: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
+		t.Fatalf("target binary should be removed, stat err=%v", err)
+	}
+
+	for _, profilePath := range profilePaths {
+		profileContent, err := os.ReadFile(profilePath)
+		if err != nil {
+			t.Fatalf("failed to read profile: %v", err)
+		}
+		content := string(profileContent)
+		if strings.Contains(content, "# >>> uloop PATH >>>") || strings.Contains(content, "# <<< uloop PATH <<<") {
+			t.Fatalf("profile still contains uloop marker block:\n%s", content)
+		}
+		if !strings.Contains(content, "before\n") || !strings.Contains(content, "after\n") {
+			t.Fatalf("profile should preserve unrelated content:\n%s", content)
+		}
 	}
 }
 

--- a/cli/dispatcher/internal/uninstall/command_test.go
+++ b/cli/dispatcher/internal/uninstall/command_test.go
@@ -1,8 +1,10 @@
 package uninstall
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
+	"unicode/utf16"
 )
 
 func TestCommandForDarwinRemovesUloopFromInstallDirectory(t *testing.T) {
@@ -88,7 +90,8 @@ func TestWindowsUninstallScriptsReplaceTemplateValues(t *testing.T) {
 	// Verifies Windows uninstall templates cannot ship with unresolved placeholders.
 	targetPath := `C:\Temp\uloop's bin\uloop.exe`
 	deletionScript := windowsDeletionScript(targetPath, 5678)
-	launchScript := windowsLaunchScript(encodePowerShellCommand(deletionScript))
+	encodedDeletionScript := encodePowerShellCommand(deletionScript)
+	launchScript := windowsLaunchScript(encodedDeletionScript)
 
 	for _, script := range []string{deletionScript, launchScript} {
 		if strings.Contains(script, "{{") {
@@ -104,6 +107,28 @@ func TestWindowsUninstallScriptsReplaceTemplateValues(t *testing.T) {
 	if !strings.Contains(launchScript, "$EncodedDeletion = '") {
 		t.Fatalf("launch script does not assign encoded deletion command: %s", launchScript)
 	}
+	decodedDeletionScript := decodePowerShellCommandForTest(t, encodedDeletionScript)
+	if !strings.Contains(decodedDeletionScript, `$Target = 'C:\Temp\uloop''s bin\uloop.exe'`) {
+		t.Fatalf("encoded deletion script does not contain replaced target path: %s", decodedDeletionScript)
+	}
+}
+
+func decodePowerShellCommandForTest(t *testing.T, encodedCommand string) string {
+	t.Helper()
+
+	encodedBytes, err := base64.StdEncoding.DecodeString(encodedCommand)
+	if err != nil {
+		t.Fatalf("failed to decode PowerShell command: %v", err)
+	}
+	if len(encodedBytes)%2 != 0 {
+		t.Fatalf("encoded PowerShell command byte length must be even: %d", len(encodedBytes))
+	}
+
+	utf16Values := make([]uint16, 0, len(encodedBytes)/2)
+	for index := 0; index < len(encodedBytes); index += 2 {
+		utf16Values = append(utf16Values, uint16(encodedBytes[index])|uint16(encodedBytes[index+1])<<8)
+	}
+	return string(utf16.Decode(utf16Values))
 }
 
 func TestCommandForWindowsRemovesUserPathBeforeDeletingLauncher(t *testing.T) {

--- a/cli/dispatcher/internal/uninstall/command_test.go
+++ b/cli/dispatcher/internal/uninstall/command_test.go
@@ -25,6 +25,10 @@ func TestCommandForDarwinRemovesUloopFromInstallDirectory(t *testing.T) {
 	if !strings.Contains(joinedArgs, "rm -f") {
 		t.Fatalf("remove command missing: %s", joinedArgs)
 	}
+	uninstallScript := posixUninstallScript(command.TargetPath)
+	if !strings.Contains(uninstallScript, `TargetPath='/Users/ExampleUser/.local/bin/uloop'`) {
+		t.Fatalf("target path assignment missing: %s", uninstallScript)
+	}
 	if command.TargetPath != "/Users/ExampleUser/.local/bin/uloop" {
 		t.Fatalf("target path mismatch: %s", command.TargetPath)
 	}
@@ -51,7 +55,7 @@ func TestCommandForWindowsSchedulesRemovalAfterCurrentProcessExits(t *testing.T)
 	for _, expected := range []string{
 		"Get-Process -Id $ParentPid",
 		"$ParentProcess | Wait-Process",
-		"$ParentPid = 5678",
+		"$ParentPid = [int]'5678'",
 		`return $Path.Trim().Trim('"').TrimEnd([char[]]@('\','/')).Replace('/','\')`,
 		"[Environment]::SetEnvironmentVariable('Path', $NewUserPath, 'User')",
 	} {
@@ -64,6 +68,41 @@ func TestCommandForWindowsSchedulesRemovalAfterCurrentProcessExits(t *testing.T)
 	}
 	if command.TargetPath != `C:\Users\ExampleUser\AppData\Local\Programs\uloop\bin\uloop.exe` {
 		t.Fatalf("target path mismatch: %s", command.TargetPath)
+	}
+}
+
+func TestPosixUninstallScriptReplacesTemplateValues(t *testing.T) {
+	// Verifies POSIX uninstall templates cannot ship with unresolved placeholders.
+	targetPath := "/tmp/uloop's bin/uloop"
+	uninstallScript := posixUninstallScript(targetPath)
+
+	if strings.Contains(uninstallScript, "{{") {
+		t.Fatalf("uninstall script contains unresolved template placeholder: %s", uninstallScript)
+	}
+	if !strings.Contains(uninstallScript, `TargetPath='/tmp/uloop'"'"'s bin/uloop'`) {
+		t.Fatalf("uninstall script does not quote target path correctly: %s", uninstallScript)
+	}
+}
+
+func TestWindowsUninstallScriptsReplaceTemplateValues(t *testing.T) {
+	// Verifies Windows uninstall templates cannot ship with unresolved placeholders.
+	targetPath := `C:\Temp\uloop's bin\uloop.exe`
+	deletionScript := windowsDeletionScript(targetPath, 5678)
+	launchScript := windowsLaunchScript(encodePowerShellCommand(deletionScript))
+
+	for _, script := range []string{deletionScript, launchScript} {
+		if strings.Contains(script, "{{") {
+			t.Fatalf("uninstall script contains unresolved template placeholder: %s", script)
+		}
+	}
+	if !strings.Contains(deletionScript, `$Target = 'C:\Temp\uloop''s bin\uloop.exe'`) {
+		t.Fatalf("deletion script does not quote target path correctly: %s", deletionScript)
+	}
+	if !strings.Contains(deletionScript, `$ParentPid = [int]'5678'`) {
+		t.Fatalf("deletion script does not quote parent pid correctly: %s", deletionScript)
+	}
+	if !strings.Contains(launchScript, "$EncodedDeletion = '") {
+		t.Fatalf("launch script does not assign encoded deletion command: %s", launchScript)
 	}
 }
 

--- a/cli/dispatcher/internal/uninstall/scripts.go
+++ b/cli/dispatcher/internal/uninstall/scripts.go
@@ -1,0 +1,14 @@
+package uninstall
+
+import "embed"
+
+//go:embed scripts/uninstall_darwin.sh scripts/uninstall_windows_delete.ps1 scripts/uninstall_windows_launch.ps1
+var uninstallScriptFiles embed.FS
+
+func uninstallScriptTemplate(name string) string {
+	content, err := uninstallScriptFiles.ReadFile(name)
+	if err != nil {
+		panic(err)
+	}
+	return string(content)
+}

--- a/cli/dispatcher/internal/uninstall/scripts/uninstall_darwin.sh
+++ b/cli/dispatcher/internal/uninstall/scripts/uninstall_darwin.sh
@@ -1,4 +1,104 @@
 #!/bin/sh
 TargetPath='{{TARGET_PATH}}'
+PathBlockStart="# >>> uloop PATH >>>"
+PathBlockEnd="# <<< uloop PATH <<<"
+
+resolve_profile_write_path() {
+    profile_path=$1
+    if [ ! -L "$profile_path" ]; then
+        echo "$profile_path"
+        return
+    fi
+
+    link_target=$(readlink "$profile_path" 2>/dev/null || true)
+    if [ -z "$link_target" ]; then
+        echo "$profile_path"
+        return
+    fi
+
+    case "$link_target" in
+        /*)
+            echo "$link_target"
+            ;;
+        *)
+            profile_dir=${profile_path%/*}
+            if [ "$profile_dir" = "$profile_path" ]; then
+                echo "$link_target"
+                return
+            fi
+            echo "$profile_dir/$link_target"
+            ;;
+    esac
+}
+
+remove_path_block() {
+    profile_path=$1
+    profile_write_path=$(resolve_profile_write_path "$profile_path")
+    if [ ! -f "$profile_write_path" ]; then
+        return 0
+    fi
+
+    case "$profile_write_path" in
+        */*)
+            profile_dir=${profile_write_path%/*}
+            [ -n "$profile_dir" ] || profile_dir=/
+            ;;
+        *)
+            profile_dir=.
+            ;;
+    esac
+
+    tmp_path=$(mktemp "$profile_dir/.uloop_path.XXXXXX" 2>/dev/null || true)
+    if [ -z "$tmp_path" ]; then
+        echo "Could not create a temporary file for PATH cleanup." >&2
+        return 1
+    fi
+
+    awk -v start="$PathBlockStart" -v end="$PathBlockEnd" '
+        $0 == start { skipping = 1; changed = 1; next }
+        $0 == end { skipping = 0; next }
+        !skipping { print }
+        END { if (changed) exit 0; exit 2 }
+    ' "$profile_write_path" > "$tmp_path"
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        rm -f "$tmp_path"
+        if [ "$status" -eq 2 ]; then
+            return 0
+        fi
+        echo "Could not read shell profile for PATH cleanup: $profile_path" >&2
+        return 1
+    fi
+
+    if mv "$tmp_path" "$profile_write_path"; then
+        echo "Removed uloop PATH block from $profile_path."
+        return 0
+    fi
+
+    echo "Could not update shell profile for PATH cleanup: $profile_path" >&2
+    rm -f "$tmp_path"
+    return 1
+}
+
+cleanup_shell_path_blocks() {
+    if [ -z "${HOME:-}" ]; then
+        return 0
+    fi
+
+    remove_path_block "$HOME/.bash_profile" || return 1
+    remove_path_block "$HOME/.bash_login" || return 1
+    remove_path_block "$HOME/.profile" || return 1
+
+    if [ -n "${ZDOTDIR:-}" ]; then
+        remove_path_block "$ZDOTDIR/.zshrc" || return 1
+    fi
+    remove_path_block "$HOME/.zshrc" || return 1
+
+    if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+        remove_path_block "$XDG_CONFIG_HOME/fish/config.fish" || return 1
+    fi
+    remove_path_block "$HOME/.config/fish/config.fish" || return 1
+}
 
 rm -f "$TargetPath"
+cleanup_shell_path_blocks

--- a/cli/dispatcher/internal/uninstall/scripts/uninstall_darwin.sh
+++ b/cli/dispatcher/internal/uninstall/scripts/uninstall_darwin.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+TargetPath='{{TARGET_PATH}}'
+
+rm -f "$TargetPath"

--- a/cli/dispatcher/internal/uninstall/scripts/uninstall_windows_delete.ps1
+++ b/cli/dispatcher/internal/uninstall/scripts/uninstall_windows_delete.ps1
@@ -1,0 +1,26 @@
+$Target = '{{TARGET_PATH}}'
+$ParentPid = [int]'{{CURRENT_PID}}'
+$InstallDir = Split-Path -Parent $Target
+$NormalizePath = {
+    param([string]$Path)
+    if (-not $Path) {
+        return ''
+    }
+    return $Path.Trim().Trim('"').TrimEnd([char[]]@('\','/')).Replace('/','\')
+}
+$ParentProcess = Get-Process -Id $ParentPid -ErrorAction SilentlyContinue
+if ($ParentProcess) {
+    $ParentProcess | Wait-Process -ErrorAction SilentlyContinue
+}
+$UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($UserPath) {
+    $NormalizedInstallDir = & $NormalizePath $InstallDir
+    $PathEntries = $UserPath -split ';' | Where-Object { $_ -and -not [string]::Equals((& $NormalizePath $_), $NormalizedInstallDir, [System.StringComparison]::OrdinalIgnoreCase) }
+    $NewUserPath = [string]::Join(';', $PathEntries)
+    if (-not [string]::Equals($UserPath, $NewUserPath, [System.StringComparison]::Ordinal)) {
+        [Environment]::SetEnvironmentVariable('Path', $NewUserPath, 'User')
+    }
+}
+if (Test-Path -LiteralPath $Target) {
+    Remove-Item -LiteralPath $Target -Force -ErrorAction SilentlyContinue
+}

--- a/cli/dispatcher/internal/uninstall/scripts/uninstall_windows_launch.ps1
+++ b/cli/dispatcher/internal/uninstall/scripts/uninstall_windows_launch.ps1
@@ -1,0 +1,2 @@
+$EncodedDeletion = '{{ENCODED_DELETION}}'
+Start-Process -FilePath 'powershell' -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-EncodedCommand',$EncodedDeletion) -WindowStyle Hidden

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "66b1dc77ad37dfb66266577bd7fc013db954e304"
+  "sharedInputsHash": "53be2808987ea6b968d22112258b077a6e900868"
 }

--- a/cli/release-automation/internal/automation/release_trigger_guard.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard.go
@@ -24,7 +24,7 @@ type releaseTriggerRule struct {
 //
 // These rules are re-encoded as shell in scripts/stamp-release-inputs.sh
 // (list_shared_common_inputs / list_dispatcher_only_common_inputs /
-// list_installer_inputs); update both together. scripts/test-stamp-release-inputs.sh
+// list_dispatcher_script_inputs); update both together. scripts/test-stamp-release-inputs.sh
 // covers the same shared, dispatcher-only, installer, and ignored input cases.
 var releaseTriggerRules = []releaseTriggerRule{
 	{
@@ -38,8 +38,8 @@ var releaseTriggerRules = []releaseTriggerRule{
 		triggerRoots:     []string{"cli/dispatcher/"},
 	},
 	{
-		inputDescription: "installer scripts shipped as dispatcher release assets",
-		matchesInput:     isDispatcherInstallerScript,
+		inputDescription: "dispatcher installer and uninstaller script inputs",
+		matchesInput:     isDispatcherScriptInput,
 		triggerRoots:     []string{"cli/dispatcher/"},
 	},
 }
@@ -199,10 +199,11 @@ func isCommonGoSourceUnderPackageRoots(file string, packageRoots []string) bool 
 	return false
 }
 
-func isDispatcherInstallerScript(file string) bool {
+func isDispatcherScriptInput(file string) bool {
 	return file == "scripts/install.sh" ||
 		file == "scripts/install.ps1" ||
-		strings.HasPrefix(file, "cli/dispatcher/internal/install/scripts/")
+		strings.HasPrefix(file, "cli/dispatcher/internal/install/scripts/") ||
+		strings.HasPrefix(file, "cli/dispatcher/internal/uninstall/scripts/")
 }
 
 func anyFileUnderRoot(files []string, root string) bool {

--- a/cli/release-automation/internal/automation/release_trigger_guard_test.go
+++ b/cli/release-automation/internal/automation/release_trigger_guard_test.go
@@ -180,14 +180,17 @@ func TestReleaseTriggerGuardRequiresDispatcherTriggerForInstallerChanges(t *test
 	}
 }
 
-// Verifies embedded installer templates are classified as dispatcher installer inputs.
-func TestReleaseTriggerGuardMatchesEmbeddedInstallerScripts(t *testing.T) {
+// Verifies embedded dispatcher script templates are classified as dispatcher inputs.
+func TestReleaseTriggerGuardMatchesEmbeddedDispatcherScripts(t *testing.T) {
 	for _, file := range []string{
 		"cli/dispatcher/internal/install/scripts/install_darwin.sh",
 		"cli/dispatcher/internal/install/scripts/install_windows.ps1",
+		"cli/dispatcher/internal/uninstall/scripts/uninstall_darwin.sh",
+		"cli/dispatcher/internal/uninstall/scripts/uninstall_windows_delete.ps1",
+		"cli/dispatcher/internal/uninstall/scripts/uninstall_windows_launch.ps1",
 	} {
-		if !isDispatcherInstallerScript(file) {
-			t.Fatalf("expected embedded installer script to match: %s", file)
+		if !isDispatcherScriptInput(file) {
+			t.Fatalf("expected embedded dispatcher script to match: %s", file)
 		}
 	}
 }

--- a/scripts/stamp-release-inputs.sh
+++ b/scripts/stamp-release-inputs.sh
@@ -39,11 +39,12 @@ list_dispatcher_only_common_inputs() {
     grep -v '_test\.go$' || true
 }
 
-list_installer_inputs() {
+list_dispatcher_script_inputs() {
   git ls-files -- \
     scripts/install.sh \
     scripts/install.ps1 \
-    'cli/dispatcher/internal/install/scripts/'
+    'cli/dispatcher/internal/install/scripts/' \
+    'cli/dispatcher/internal/uninstall/scripts/'
 }
 
 # Hashes path/content pairs so renames change the stamp as well. Only tracked
@@ -75,7 +76,7 @@ write_stamp() {
 }
 
 common_hash=$(list_shared_common_inputs | hash_input_list)
-dispatcher_hash=$({ list_shared_common_inputs; list_dispatcher_only_common_inputs; list_installer_inputs; } | hash_input_list)
+dispatcher_hash=$({ list_shared_common_inputs; list_dispatcher_only_common_inputs; list_dispatcher_script_inputs; } | hash_input_list)
 
 write_stamp cli/project-runner/shared-inputs-stamp.json "$common_hash"
 write_stamp cli/dispatcher/shared-inputs-stamp.json "$dispatcher_hash"

--- a/scripts/test-stamp-release-inputs.sh
+++ b/scripts/test-stamp-release-inputs.sh
@@ -21,7 +21,7 @@ create_fixture_repo() {
     git config user.email "test@example.com"
     git config user.name "Test User"
 
-    mkdir -p cli/common/clicore/subpkg cli/common/clitest cli/common/version/subpkg cli/dispatcher/internal/install/scripts cli/project-runner scripts
+    mkdir -p cli/common/clicore/subpkg cli/common/clitest cli/common/version/subpkg cli/dispatcher/internal/install/scripts cli/dispatcher/internal/uninstall/scripts cli/project-runner scripts
     printf 'package clicore\n' > cli/common/clicore/core.go
     printf 'package subpkg\n' > cli/common/clicore/subpkg/core.go
     printf 'package clicore\n\n// test-only content\n' > cli/common/clicore/core_test.go
@@ -34,6 +34,9 @@ create_fixture_repo() {
     printf 'Write-Host install\n' > scripts/install.ps1
     printf 'echo embedded install\n' > cli/dispatcher/internal/install/scripts/install_darwin.sh
     printf 'Write-Host embedded install\n' > cli/dispatcher/internal/install/scripts/install_windows.ps1
+    printf 'echo embedded uninstall\n' > cli/dispatcher/internal/uninstall/scripts/uninstall_darwin.sh
+    printf 'Write-Host embedded uninstall\n' > cli/dispatcher/internal/uninstall/scripts/uninstall_windows_delete.ps1
+    printf 'Write-Host embedded uninstall launch\n' > cli/dispatcher/internal/uninstall/scripts/uninstall_windows_launch.ps1
     printf '{}\n' > cli/dispatcher/shared-inputs-stamp.json
     printf '{}\n' > cli/project-runner/shared-inputs-stamp.json
     git add .
@@ -182,8 +185,23 @@ if [ "$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)" = "$dis
   exit 1
 fi
 
-# Verifies a dispatcher-only common package change moves only the dispatcher stamp.
+# Verifies an embedded uninstaller template change also moves only the dispatcher stamp.
 commit_fixture_change "$work_dir" "embedded installer change"
+runner_hash_after_embedded_installer=$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)
+dispatcher_hash_after_embedded_installer=$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)
+printf 'Write-Host embedded uninstall v2\n' > "$work_dir/cli/dispatcher/internal/uninstall/scripts/uninstall_windows_delete.ps1"
+run_stamp "$work_dir"
+if [ "$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)" != "$runner_hash_after_embedded_installer" ]; then
+  echo "Expected an embedded uninstaller change to keep the project-runner stamp." >&2
+  exit 1
+fi
+if [ "$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)" = "$dispatcher_hash_after_embedded_installer" ]; then
+  echo "Expected an embedded uninstaller change to move the dispatcher stamp." >&2
+  exit 1
+fi
+
+# Verifies a dispatcher-only common package change moves only the dispatcher stamp.
+commit_fixture_change "$work_dir" "embedded uninstaller change"
 runner_hash_before_dispatcher_only=$(stamp_hash "$work_dir" cli/project-runner/shared-inputs-stamp.json)
 dispatcher_hash_before_dispatcher_only=$(stamp_hash "$work_dir" cli/dispatcher/shared-inputs-stamp.json)
 printf 'package version\n\nconst changed = true\n' > "$work_dir/cli/common/version/compare.go"


### PR DESCRIPTION
## Summary
- Native uninstall now removes the shell profile PATH block that the macOS installer adds.
- Native uninstall scripts are stored as standalone embedded resources and checked by CI.

## User Impact
- After uninstalling on macOS, new terminals no longer keep the uloop-managed PATH block pointing at the removed install directory.
- Future uninstall script changes are easier to review and are covered by script linting before release.

## Changes
- Extracted macOS and Windows uninstall script bodies into embedded files under cli/dispatcher/internal/uninstall/scripts.
- Added placeholder replacement coverage for POSIX and Windows uninstall templates, including decoding the deferred Windows deletion command to ensure replacement happens before encoding.
- Added macOS uninstall cleanup for uloop-managed shell profile marker blocks while preserving unrelated profile content.
- Extended dispatcher release input stamping and release-trigger detection to include embedded uninstall templates.
- Included embedded dispatcher PowerShell templates in CodeRabbit review coverage without opening review for every repository PowerShell helper.

## Verification
- sh -n cli/dispatcher/internal/uninstall/scripts/uninstall_darwin.sh && sh -n cli/dispatcher/internal/install/scripts/install_darwin.sh
- cd cli/dispatcher && go test ./internal/uninstall -count=1
- cd cli/release-automation && go test ./internal/automation -run 'TestReleaseTriggerGuardMatchesEmbeddedDispatcherScripts|TestReleaseTriggerGuardRequiresDispatcherTriggerForInstallerChanges' -count=1
- scripts/test-stamp-release-inputs.sh
- cd cli/release-automation && go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD
- scripts/check-go-cli.sh