### PR TITLE
feat: 3D raycast annotations report hit layers

### DIFF
--- a/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
+++ b/Assets/Tests/Editor/RaycastGridAnnotatorTests.cs
@@ -298,6 +298,92 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
             }
         }
 
+        [Test]
+        public void CreateLayerSummaries_ShouldCountHitsByLayerAndSortByHitCount()
+        {
+            List<RaycastGridPointInfo> points = new List<RaycastGridPointInfo>
+            {
+                CreateLayerHitPoint("Default", 0, "CubeA"),
+                CreateLayerHitPoint("Clickable", 8, "Button"),
+                CreateLayerHitPoint("Clickable", 8, "Button"),
+                CreateLayerHitPoint("Default", 0, "CubeB"),
+                CreateLayerHitPoint("Clickable", 8, "Button")
+            };
+
+            List<RaycastLayerSummaryInfo> summaries = RaycastGridAnnotator.CreateLayerSummaries(points);
+
+            Assert.That(summaries.Count, Is.EqualTo(2));
+            Assert.That(summaries[0].Layer, Is.EqualTo("Clickable"));
+            Assert.That(summaries[0].LayerIndex, Is.EqualTo(8));
+            Assert.That(summaries[0].HitCount, Is.EqualTo(3));
+            Assert.That(summaries[0].RepresentativeObjectPath, Is.EqualTo("Button"));
+            Assert.That(summaries[1].Layer, Is.EqualTo("Default"));
+            Assert.That(summaries[1].LayerIndex, Is.EqualTo(0));
+            Assert.That(summaries[1].HitCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void CreateLayerSummaries_WhenLayerCountsTie_ShouldSortByLayerIndex()
+        {
+            List<RaycastGridPointInfo> points = new List<RaycastGridPointInfo>
+            {
+                CreateLayerHitPoint("Clickable", 8, "Button"),
+                CreateLayerHitPoint("Default", 0, "Cube")
+            };
+
+            List<RaycastLayerSummaryInfo> summaries = RaycastGridAnnotator.CreateLayerSummaries(points);
+
+            Assert.That(summaries[0].LayerIndex, Is.EqualTo(0));
+            Assert.That(summaries[1].LayerIndex, Is.EqualTo(8));
+        }
+
+        [Test]
+        public void CreateLayerSummaries_ShouldUseMostFrequentObjectPathAsRepresentative()
+        {
+            List<RaycastGridPointInfo> points = new List<RaycastGridPointInfo>
+            {
+                CreateLayerHitPoint("Default", 0, "CubeA"),
+                CreateLayerHitPoint("Default", 0, "CubeB"),
+                CreateLayerHitPoint("Default", 0, "CubeB"),
+                CreateLayerHitPoint("Default", 0, "CubeA"),
+                CreateLayerHitPoint("Default", 0, "CubeA")
+            };
+
+            List<RaycastLayerSummaryInfo> summaries = RaycastGridAnnotator.CreateLayerSummaries(points);
+
+            Assert.That(summaries[0].RepresentativeObjectPath, Is.EqualTo("CubeA"));
+        }
+
+        [Test]
+        public void CreateLayerSummaries_WhenObjectCountsTie_ShouldUseAlphabeticalPath()
+        {
+            List<RaycastGridPointInfo> points = new List<RaycastGridPointInfo>
+            {
+                CreateLayerHitPoint("Default", 0, "CubeB"),
+                CreateLayerHitPoint("Default", 0, "CubeA")
+            };
+
+            List<RaycastLayerSummaryInfo> summaries = RaycastGridAnnotator.CreateLayerSummaries(points);
+
+            Assert.That(summaries[0].RepresentativeObjectPath, Is.EqualTo("CubeA"));
+        }
+
+        [Test]
+        public void CreateLayerSummaries_WhenNoHits_ShouldReturnEmptyList()
+        {
+            List<RaycastGridPointInfo> points = new List<RaycastGridPointInfo>
+            {
+                new RaycastGridPointInfo
+                {
+                    Hit = false
+                }
+            };
+
+            List<RaycastLayerSummaryInfo> summaries = RaycastGridAnnotator.CreateLayerSummaries(points);
+
+            Assert.That(summaries, Is.Empty);
+        }
+
         private static RaycastClusterSample CreateSample(int clusterKey, float inputX, float inputY)
         {
             return new RaycastClusterSample
@@ -305,6 +391,20 @@ namespace io.github.hatayama.uLoopMCP.Tests.Editor
                 ClusterKey = clusterKey,
                 InputX = inputX,
                 InputY = inputY
+            };
+        }
+
+        private static RaycastGridPointInfo CreateLayerHitPoint(
+            string layer,
+            int layerIndex,
+            string objectPath)
+        {
+            return new RaycastGridPointInfo
+            {
+                Hit = true,
+                HitLayer = layer,
+                HitLayerIndex = layerIndex,
+                HitGameObjectPath = objectPath
             };
         }
     }

--- a/Packages/src/Editor/Api/McpTools/Screenshot/RaycastGridPointInfo.cs
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/RaycastGridPointInfo.cs
@@ -12,6 +12,8 @@ namespace io.github.hatayama.uLoopMCP
         public float InjectedUnityPositionY { get; set; }
         public string? HitGameObjectName { get; set; }
         public string? HitGameObjectPath { get; set; }
+        public string? HitLayer { get; set; }
+        public int? HitLayerIndex { get; set; }
         public float? Distance { get; set; }
     }
 }

--- a/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotResponse.cs
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotResponse.cs
@@ -19,6 +19,7 @@ namespace io.github.hatayama.uLoopMCP
         public string UnityInputFormula { get; set; } = "";
         public List<UIElementInfo> AnnotatedElements { get; set; } = new();
         public List<RaycastGridPointInfo> RaycastGridPoints { get; set; } = new();
+        public List<RaycastLayerSummaryInfo> RaycastLayerSummaries { get; set; } = new();
 
         public ScreenshotInfo(string imagePath, long fileSizeBytes, int width, int height,
             string imageCoordinateSystem = McpConstants.COORDINATE_SYSTEM_TOP_LEFT_WINDOW,
@@ -35,6 +36,14 @@ namespace io.github.hatayama.uLoopMCP
         public ScreenshotInfo()
         {
         }
+    }
+
+    public class RaycastLayerSummaryInfo
+    {
+        public string Layer { get; set; } = "";
+        public int LayerIndex { get; set; }
+        public int HitCount { get; set; }
+        public string RepresentativeObjectPath { get; set; } = "";
     }
 
     public class ScreenshotResponse : BaseToolResponse

--- a/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotTool.cs
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/ScreenshotTool.cs
@@ -59,6 +59,7 @@ namespace io.github.hatayama.uLoopMCP
             List<UIElementInfo> physicsColliderElements = new List<UIElementInfo>();
             Vector2 gameViewSize = GameViewCoordinateUtility.GetMainGameViewSize();
             List<RaycastGridPointInfo> raycastGridPoints = new List<RaycastGridPointInfo>();
+            List<RaycastLayerSummaryInfo> raycastLayerSummaries = new List<RaycastLayerSummaryInfo>();
             List<UIElementInfo> raycastGridOverlayElements = new List<UIElementInfo>();
             GameRenderingImageInfo? raycastGridRenderingInfo = null;
 
@@ -89,6 +90,9 @@ namespace io.github.hatayama.uLoopMCP
                     raycastGridPoints = RaycastGridAnnotator.CollectRaycastGridPoints(
                         renderingImageInfo.RenderingImageSize,
                         renderingImageInfo.ImageToInputOffsetY);
+                    raycastLayerSummaries = RaycastGridAnnotator.CollectRaycastLayerSummaries(
+                        renderingImageInfo.RenderingImageSize,
+                        renderingImageInfo.ImageToInputOffsetY);
                     raycastGridOverlayElements = RaycastGridAnnotator.CreateOverlayElements(raycastGridPoints);
                 }
             }
@@ -104,6 +108,7 @@ namespace io.github.hatayama.uLoopMCP
                 ApplyRenderingCoordinateMetadata(elementsOnlyInfo, gameViewSize, imageToInputOffsetY);
                 elementsOnlyInfo.AnnotatedElements = elementsOnlyAnnotatedElements;
                 elementsOnlyInfo.RaycastGridPoints = raycastGridPoints;
+                elementsOnlyInfo.RaycastLayerSummaries = raycastLayerSummaries;
                 return new ScreenshotResponse(new List<ScreenshotInfo> { elementsOnlyInfo });
             }
 
@@ -171,6 +176,7 @@ namespace io.github.hatayama.uLoopMCP
                     captureRenderingInfo.ImageToInputOffsetY);
                 info.AnnotatedElements = responseAnnotatedElements;
                 info.RaycastGridPoints = raycastGridPoints;
+                info.RaycastLayerSummaries = raycastLayerSummaries;
                 screenshots.Add(info);
             }
             catch (Exception ex)

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/SKILL.md
@@ -60,6 +60,10 @@ uloop screenshot --capture-mode rendering --annotate-elements
 # Annotate 3D physics raycast candidate points
 uloop screenshot --capture-mode rendering --annotate-raycast-grid
 
+# Inspect hit layers, then rerun with the layer used by game input
+uloop screenshot --capture-mode rendering --annotate-raycast-grid --elements-only
+uloop screenshot --capture-mode rendering --annotate-raycast-grid --raycast-layer-mask Default --elements-only
+
 # Annotate clustered 3D collider candidates on selected layers
 uloop screenshot --capture-mode rendering --annotate-raycast-grid --raycast-layer-mask Ground,Clickable
 
@@ -99,6 +103,7 @@ Returns JSON with:
   - `UnityInputFormula`: Formula used internally by mouse input tools to inject `Mouse.current.position`
   - `AnnotatedElements`: Array of annotated UI element metadata. Also includes clustered `PhysicsCollider` entries when `--annotate-raycast-grid --raycast-layer-mask <layers>` is used.
   - `RaycastGridPoints`: Array of coarse 3D raycast candidate metadata. Empty unless `--annotate-raycast-grid` is used without `--raycast-layer-mask`.
+  - `RaycastLayerSummaries`: Dense raycast hit counts by layer when `--annotate-raycast-grid` is used without `--raycast-layer-mask`. Empty when a mask is provided.
 
 For `AnnotatedElements` fields and Game View coordinates, read [references/annotated-elements.md](references/annotated-elements.md) before using screenshot coordinates with mouse simulation tools.
 
@@ -111,6 +116,7 @@ When multiple windows match (e.g., multiple Inspector windows or when using `con
 - Window name matching is always case-insensitive
 - Use `--capture-mode rendering` for coordinates that should be passed to `simulate-mouse-input`, `simulate-mouse-ui`, or `raycast`.
 - Use `ScreenshotToInputFormula` before passing raw image pixels to mouse tools. `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` are already mouse-input coordinates.
+- To discover a useful physics layer, first run `--annotate-raycast-grid` without `--raycast-layer-mask`, inspect `RaycastLayerSummaries`, then rerun with `--raycast-layer-mask <Layer>`.
 - Use `--raycast-layer-mask` with layer names from `find-game-objects` or project code when the game input code raycasts only specific layers. Layers hidden by Camera.main.cullingMask are not reported because they are not visible to the screenshot camera.
 - Clustered `PhysicsCollider` entries avoid points where the frontmost EventSystem hit comes from a `GraphicRaycaster` UI element, including world-space Canvas UI. PhysicsRaycaster and other non-uGUI hits are not treated as UI occlusion. If the centroid-nearest sample is covered, the nearest uncovered sampled hit is used; if every sampled hit in the cluster is covered, that collider is omitted.
 - Do not use `window` captures as mouse-input coordinates because they include Unity Editor chrome.

--- a/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
+++ b/Packages/src/Editor/Api/McpTools/Screenshot/Skill/references/annotated-elements.md
@@ -18,6 +18,17 @@ Read this when using `uloop screenshot --capture-mode rendering --annotate-eleme
 - `SortingOrder`: Canvas sorting order. Higher values are in front.
 - `SiblingIndex`: Transform sibling index under the element's direct parent. Do not use it as a reliable z-order signal across nested UI hierarchies.
 
+## RaycastLayerSummaries Fields
+
+`RaycastLayerSummaries` is populated when `--annotate-raycast-grid` is used without `--raycast-layer-mask`. It is built from dense raycast samples, while `RaycastGridPoints` remains the coarse 5x5 annotated grid.
+
+- `Layer`: Physics layer name to pass to `--raycast-layer-mask`
+- `LayerIndex`: Unity physics layer index
+- `HitCount`: Dense raycast hit count for the layer
+- `RepresentativeObjectPath`: Hierarchy path for the object with the most hits on that layer. Ties are resolved alphabetically by path.
+
+Entries are sorted by `HitCount` descending, then `LayerIndex` ascending.
+
 ## Coordinate Conversion
 
 When `ImageCoordinateSystem` is `"top-left-game-view"`, convert raw image pixel coordinates from `screenshot --capture-mode rendering` with the formula returned in `ScreenshotToInputFormula`:

--- a/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
+++ b/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
@@ -21,18 +21,45 @@ namespace io.github.hatayama.uLoopMCP
             Vector2 renderingImageSize,
             int imageToInputOffsetY)
         {
+            return CollectRaycastGridPointsForGrid(
+                renderingImageSize,
+                imageToInputOffsetY,
+                GRID_ROWS,
+                GRID_COLUMNS);
+        }
+
+        internal static List<RaycastLayerSummaryInfo> CollectRaycastLayerSummaries(
+            Vector2 renderingImageSize,
+            int imageToInputOffsetY)
+        {
+            List<RaycastGridPointInfo> points = CollectRaycastGridPointsForGrid(
+                renderingImageSize,
+                imageToInputOffsetY,
+                CLUSTERED_GRID_ROWS,
+                CLUSTERED_GRID_COLUMNS);
+            return CreateLayerSummaries(points);
+        }
+
+        private static List<RaycastGridPointInfo> CollectRaycastGridPointsForGrid(
+            Vector2 renderingImageSize,
+            int imageToInputOffsetY,
+            int rowCount,
+            int columnCount)
+        {
             List<RaycastGridPointInfo> points = new List<RaycastGridPointInfo>();
             int labelIndex = 1;
             // Sync once for the whole grid; each candidate raycast then reads the same current physics state.
             Physics.SyncTransforms();
 
-            for (int row = 1; row <= GRID_ROWS; row++)
+            for (int row = 1; row <= rowCount; row++)
             {
-                for (int column = 1; column <= GRID_COLUMNS; column++)
+                for (int column = 1; column <= columnCount; column++)
                 {
-                    Vector2 inputPosition = CalculateGridInputPosition(
+                    Vector2 inputPosition = CalculateGridInputPositionForGrid(
                         renderingImageSize,
                         imageToInputOffsetY,
+                        rowCount,
+                        columnCount,
                         row,
                         column);
                     GameViewRaycastResult raycastResult = GameViewRaycastUtility.RaycastFromInputPosition(
@@ -175,8 +202,117 @@ namespace io.github.hatayama.uLoopMCP
             RaycastHit hit = raycastResult.Hits[0];
             pointInfo.HitGameObjectName = hit.collider.gameObject.name;
             pointInfo.HitGameObjectPath = GameObjectPathUtility.GetFullPath(hit.collider.gameObject);
+            pointInfo.HitLayerIndex = hit.collider.gameObject.layer;
+            pointInfo.HitLayer = LayerMask.LayerToName(hit.collider.gameObject.layer);
             pointInfo.Distance = hit.distance;
             return pointInfo;
+        }
+
+        internal static List<RaycastLayerSummaryInfo> CreateLayerSummaries(List<RaycastGridPointInfo> points)
+        {
+            Dictionary<int, RaycastLayerSummaryAccumulator> accumulatorsByLayerIndex =
+                new Dictionary<int, RaycastLayerSummaryAccumulator>();
+
+            foreach (RaycastGridPointInfo point in points)
+            {
+                if (!point.Hit || point.HitLayerIndex == null)
+                {
+                    continue;
+                }
+
+                int layerIndex = point.HitLayerIndex.Value;
+                if (!accumulatorsByLayerIndex.ContainsKey(layerIndex))
+                {
+                    accumulatorsByLayerIndex.Add(
+                        layerIndex,
+                        new RaycastLayerSummaryAccumulator(point.HitLayer ?? "", layerIndex));
+                }
+
+                RaycastLayerSummaryAccumulator accumulator = accumulatorsByLayerIndex[layerIndex];
+                accumulator.AddHit(point.HitGameObjectPath ?? "");
+            }
+
+            List<RaycastLayerSummaryInfo> summaries = new List<RaycastLayerSummaryInfo>();
+            foreach (RaycastLayerSummaryAccumulator accumulator in accumulatorsByLayerIndex.Values)
+            {
+                summaries.Add(accumulator.CreateSummary());
+            }
+
+            summaries.Sort(CompareLayerSummaries);
+            return summaries;
+        }
+
+        private static int CompareLayerSummaries(
+            RaycastLayerSummaryInfo left,
+            RaycastLayerSummaryInfo right)
+        {
+            int hitCountComparison = right.HitCount.CompareTo(left.HitCount);
+            if (hitCountComparison != 0)
+            {
+                return hitCountComparison;
+            }
+
+            return left.LayerIndex.CompareTo(right.LayerIndex);
+        }
+
+        private sealed class RaycastLayerSummaryAccumulator
+        {
+            private readonly Dictionary<string, int> _objectHitCounts = new Dictionary<string, int>();
+            private string _representativeObjectPath = "";
+            private int _representativeObjectHitCount;
+
+            public string Layer { get; }
+            public int LayerIndex { get; }
+            public int HitCount { get; private set; }
+
+            public RaycastLayerSummaryAccumulator(string layer, int layerIndex)
+            {
+                Layer = layer;
+                LayerIndex = layerIndex;
+            }
+
+            public void AddHit(string objectPath)
+            {
+                HitCount++;
+                int objectHitCount = 1;
+                if (_objectHitCounts.ContainsKey(objectPath))
+                {
+                    objectHitCount = _objectHitCounts[objectPath] + 1;
+                }
+
+                _objectHitCounts[objectPath] = objectHitCount;
+                if (ShouldUseAsRepresentative(objectPath, objectHitCount))
+                {
+                    _representativeObjectPath = objectPath;
+                    _representativeObjectHitCount = objectHitCount;
+                }
+            }
+
+            public RaycastLayerSummaryInfo CreateSummary()
+            {
+                return new RaycastLayerSummaryInfo
+                {
+                    Layer = Layer,
+                    LayerIndex = LayerIndex,
+                    HitCount = HitCount,
+                    RepresentativeObjectPath = _representativeObjectPath
+                };
+            }
+
+            private bool ShouldUseAsRepresentative(string objectPath, int objectHitCount)
+            {
+                if (objectHitCount > _representativeObjectHitCount)
+                {
+                    return true;
+                }
+
+                if (objectHitCount < _representativeObjectHitCount)
+                {
+                    return false;
+                }
+
+                return string.CompareOrdinal(objectPath, _representativeObjectPath) < 0;
+            }
         }
 
         private static RaycastClusterCollection CollectClusterSamples(


### PR DESCRIPTION
## Summary
- Screenshot raycast grid output now reports dense hit summaries by physics layer when no layer mask is provided.
- Agents can inspect `RaycastLayerSummaries`, choose a likely layer, then rerun with `--raycast-layer-mask` to get clustered 3D click targets.

## User Impact
- Before this change, agents had to infer the correct physics layer from code or coarse grid hits before using `--raycast-layer-mask`.
- After this change, the screenshot response directly shows layer names, hit counts, and a representative object path for each hit layer.

## Changes
- Add `RaycastLayerSummaries` to `ScreenshotInfo` for unmasked `--annotate-raycast-grid` runs.
- Populate `HitLayer` and `HitLayerIndex` on coarse `RaycastGridPoints`.
- Build summaries from dense samples while keeping the visible grid annotation at the existing 5x5 density.
- Document the discover-summary-then-rerun workflow.

## Verification
- `uloop compile --force-recompile true --wait-for-domain-reload true` -> 0 errors, 0 warnings
- `uloop run-tests --test-mode EditMode --filter-type regex --filter-value "io\\.github\\.hatayama\\.uLoopMCP\\.Tests\\.Editor\\.RaycastGridAnnotatorTests.*"` -> 19 passed
- `npm run lint` -> 0 errors, existing warnings only
- `npm run build`
- PlayMode check: unmasked raycast grid returned `RaycastLayerSummaries` with `Default`, then rerunning with `--raycast-layer-mask Default` returned a clustered `PhysicsCollider`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

