### PR TITLE
chore: Remove the version field from default-tools.json

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -40,6 +40,6 @@ reviews:
 
         The compatibility gate is an exact protocol match, not a release-semver range. If a change makes a CLI/package from the previous protocol generation unable to interoperate, require both `cli/common/clicontract/contract.json` `protocolVersion` and `CliConstants.REQUIRED_CLI_PROTOCOL_VERSION` to be incremented in the same PR.
 
-        Do not request a protocol bump for ordinary CLI features, bug fixes, UI changes, documentation, or additive wire-format changes that older counterparts can safely ignore. `projectRunnerVersion` and `default-tools.json` `version` are release-please managed release metadata. If a PR bumps `CliConstants.REQUIRED_CLI_PROTOCOL_VERSION`, require a matching update to `CliConstants.MINIMUM_REQUIRED_PROJECT_RUNNER_VERSION` after the corresponding published project runner release tag is available, because setup must install a project runner release that advertises the required protocol.
+        Do not request a protocol bump for ordinary CLI features, bug fixes, UI changes, documentation, or additive wire-format changes that older counterparts can safely ignore. `projectRunnerVersion` is release-please managed release metadata. If a PR bumps `CliConstants.REQUIRED_CLI_PROTOCOL_VERSION`, require a matching update to `CliConstants.MINIMUM_REQUIRED_PROJECT_RUNNER_VERSION` after the corresponding published project runner release tag is available, because setup must install a project runner release that advertises the required protocol.
 chat:
   auto_reply: true

--- a/cli/common/tools/catalog_test.go
+++ b/cli/common/tools/catalog_test.go
@@ -9,7 +9,7 @@ import (
 // Tests that callers can explicitly prefer embedded definitions without tools knowing command names.
 func TestFindForCommandUsesEmbeddedDefinitionWhenRequested(t *testing.T) {
 	projectRoot := t.TempDir()
-	writeToolCache(t, projectRoot, `{"version":"test","tools":[]}`)
+	writeToolCache(t, projectRoot, `{"tools":[]}`)
 
 	tool, _, ok, err := FindForCommand(projectRoot, "execute-dynamic-code", map[string]bool{}, true)
 	if err != nil {
@@ -28,7 +28,6 @@ func TestFindForCommandUsesEmbeddedDefinitionWhenRequested(t *testing.T) {
 func TestFindForCommandUsesProjectCacheWhenEmbeddedPreferenceIsFalse(t *testing.T) {
 	projectRoot := t.TempDir()
 	writeToolCache(t, projectRoot, `{
-  "version": "test",
   "tools": [
     {
       "name": "execute-dynamic-code",

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -1,5 +1,4 @@
 {
-  "version": "3.0.0-beta.46",
   "tools": [
     {
       "name": "compile",

--- a/cli/common/tools/types.go
+++ b/cli/common/tools/types.go
@@ -1,7 +1,6 @@
 package tools
 
 type ToolCatalog struct {
-	Version       string           `json:"version"`
 	ServerVersion string           `json:"serverVersion,omitempty"`
 	UpdatedAt     string           `json:"updatedAt,omitempty"`
 	Tools         []ToolDefinition `json:"tools"`

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "9af384d70ef14c3600cb092b48ff3646a00d16b9"
+  "sharedInputsHash": "3f3307c144a2772e20885a3dd1b8643746991312"
 }

--- a/cli/project-runner/internal/projectrunner/list_output.go
+++ b/cli/project-runner/internal/projectrunner/list_output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"sort"
 
+	"github.com/hatayama/unity-cli-loop/common/clicontract"
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 )
 
@@ -47,8 +48,10 @@ func newListCatalog(cache clicore.ToolsCache) listCatalog {
 		tools = append(tools, newListTool(tool))
 	}
 
+	// Sourced from the embedded CLI contract because the tool catalog no longer
+	// carries a release-please-stamped version field of its own.
 	return listCatalog{
-		Version:       cache.Version,
+		Version:       clicontract.ProjectRunnerVersion(),
 		ServerVersion: cache.ServerVersion,
 		UpdatedAt:     cache.UpdatedAt,
 		Tools:         tools,

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "96a846581558cb16f2e478e59199ccef16642f0a"
+  "sharedInputsHash": "814737cf4b61d82fe9cb2f4fc99c198f4c3fae12"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,11 +47,6 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "/cli/common/tools/default-tools.json",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "json",
           "path": "/cli/common/clicontract/contract.json",
           "jsonpath": "$.projectRunnerVersion"
         },

--- a/scripts/test-release-please-config.sh
+++ b/scripts/test-release-please-config.sh
@@ -139,13 +139,13 @@ assert_json_value '.packages["cli/project-runner"].["changelog-path"]' 'CHANGELO
 # so there is nothing left under cli/project-runner to exclude from
 # uloop-project-runner releases.
 assert_json_value '.packages["cli/project-runner"] | has("exclude-paths")' 'false'
-assert_json_value '.packages["cli/project-runner"]["extra-files"] | length' '4'
-assert_json_value '.packages["cli/project-runner"]["extra-files"][0].path' '/cli/common/tools/default-tools.json'
-assert_json_value '.packages["cli/project-runner"]["extra-files"][1].path' '/cli/common/clicontract/contract.json'
-assert_json_value '.packages["cli/project-runner"]["extra-files"][2].path' '/Packages/src/project-runner-pin.json'
+assert_json_value '.packages["cli/project-runner"]["extra-files"] | length' '3'
+assert_json_value '.packages["cli/project-runner"]["extra-files"][0].path' '/cli/common/clicontract/contract.json'
+assert_json_value '.packages["cli/project-runner"]["extra-files"][0].jsonpath' '$.projectRunnerVersion'
+assert_json_value '.packages["cli/project-runner"]["extra-files"][1].path' '/Packages/src/project-runner-pin.json'
+assert_json_value '.packages["cli/project-runner"]["extra-files"][1].jsonpath' '$.projectRunnerVersion'
+assert_json_value '.packages["cli/project-runner"]["extra-files"][2].path' '/.uloop/project-runner-pin.json'
 assert_json_value '.packages["cli/project-runner"]["extra-files"][2].jsonpath' '$.projectRunnerVersion'
-assert_json_value '.packages["cli/project-runner"]["extra-files"][3].path' '/.uloop/project-runner-pin.json'
-assert_json_value '.packages["cli/project-runner"]["extra-files"][3].jsonpath' '$.projectRunnerVersion'
 
 # The dispatcher tag format must stay dispatcher-v<version> to continue the
 # existing tag sequence started before release-please management.


### PR DESCRIPTION
## Summary

Part 4 of the version-gate consolidation (G4), following #1501/#1503/#1504. The stamped `version` in `cli/common/tools/default-tools.json` had zero gates or guards; its only consumer was the `Version` field in `uloop list` output. That display now reads the embedded contract's `projectRunnerVersion`, which release-please stamps to the same value, so the output is unchanged while one release-please extra-file entry and one value-to-keep-consistent disappear.

- Remove `version` from `default-tools.json` and the `Version` field from `ToolCatalog`
- `uloop list` renders `clicontract.ProjectRunnerVersion()` (same key, same position, same value at release time)
- Drop the corresponding `release-please-config.json` extra-files entry and update the config test
- Refresh shared-inputs stamps (`cli/common/tools/types.go` is a shared common input)

## Validation

- `scripts/check-go-cli.sh`, `scripts/test-release-please-config.sh`, `scripts/test-stamp-release-inputs.sh`
- `check-release-triggers`: passed
- `uloop list` output verified identical before/after

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

