### PR TITLE
chore: Clean up unused assembly references and legacy compile result aliases

### DIFF
--- a/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
+++ b/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
@@ -1,4 +1,5 @@
 using UnityEditor;
+using UnityEditor.Compilation;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -19,8 +20,8 @@ namespace io.github.hatayama.UnityCliLoop.Dev
             {
                 // How Masamichi requested to use it
                 CompileResult result = await compileController.TryCompileAsync();
-                var err = result.error;
-                var warning = result.warning;
+                CompilerMessage[] err = result.Errors;
+                CompilerMessage[] warning = result.Warnings;
 
                 Debug.Log($"Compilation result: Success={result.Success}");
                 Debug.Log($"Number of errors: {err.Length}");
@@ -53,8 +54,8 @@ namespace io.github.hatayama.UnityCliLoop.Dev
             {
                 // Example of forced re-compilation
                 CompileResult result = await compileController.TryCompileAsync(forceRecompile: true);
-                var err = result.error;
-                var warning = result.warning;
+                CompilerMessage[] err = result.Errors;
+                CompilerMessage[] warning = result.Warnings;
 
                 Debug.Log($"Forced compilation result: Success={result.Success}");
                 Debug.Log($"Number of errors: {err.Length}, Number of warnings: {warning.Length}");

--- a/Assets/Editor/CompileCheckWindow/CompileEditorWindow.cs
+++ b/Assets/Editor/CompileCheckWindow/CompileEditorWindow.cs
@@ -147,7 +147,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
             bool displaySuccess = result.Success ?? false;
             bool shouldWarn = result.Success == false;
             string logMessage =
-                $"Compilation finished: Success={displaySuccess}, Indeterminate={result.IsIndeterminate}, Errors={result.error.Length}, Warnings={result.warning.Length}, Message={message}";
+                $"Compilation finished: Success={displaySuccess}, Indeterminate={result.IsIndeterminate}, Errors={result.Errors.Length}, Warnings={result.Warnings.Length}, Message={message}";
 
             if (shouldWarn)
             {

--- a/Packages/src/Editor/Application/UnityCLILoop.Application.asmdef
+++ b/Packages/src/Editor/Application/UnityCLILoop.Application.asmdef
@@ -2,11 +2,8 @@
     "name": "UnityCLILoop.Application",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.Application",
     "references": [
-        "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
         "GUID:5c4588558a3624eacbce0f50007cf1eb",
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
-        "GUID:c956a21f824994ef087b6de566690b3d",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
     ],
     "includePlatforms": [
         "Editor"
@@ -17,12 +14,6 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "com.unity.inputsystem",
-            "expression": "",
-            "define": "ULOOP_HAS_INPUT_SYSTEM"
-        }
-    ],
+    "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -868,16 +868,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal bool PreserveDetailsWhenForceRecompile { get; }
 
         /// <summary>
-        /// Alias for error messages (for backward compatibility).
-        /// </summary>
-        public CompilerMessage[] error => Errors;
-        
-        /// <summary>
-        /// Alias for warning messages (for backward compatibility).
-        /// </summary>
-        public CompilerMessage[] warning => Warnings;
-
-        /// <summary>
         /// Initializes the compilation result.
         /// </summary>
         /// <param name="success">The compilation success flag. Null indicates indeterminate status.</param>


### PR DESCRIPTION
## Summary
- Removes assembly references that the Application layer declares but never uses, and deletes the deprecated lowercase compile-result aliases.

## User Impact
- No runtime behavior change. This is internal cleanup that keeps the layered architecture boundaries honest: the Application assembly no longer claims dependencies on the internal API bridge, the runtime assembly, or the Input System.

## Changes
- `UnityCLILoop.Application.asmdef`: dropped the InternalAPIBridge, Runtime, and Unity.InputSystem references (grep confirmed zero usages) and the now-unneeded `ULOOP_HAS_INPUT_SYSTEM` version define, leaving only Domain and ToolContracts.
- `CompileController`: removed the backward-compatibility `error`/`warning` alias properties on `CompileResult`; the sample editor windows under `Assets/Editor/CompileCheckWindow` now use `Errors`/`Warnings` directly.

## Verification
- `dist/darwin-arm64/uloop compile` → Success, 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "Compile(SessionResultService|LifecycleWatchdog|StatusBridgeCommand)Tests"` → 22/22 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

