### PR TITLE
chore: Replace stale architecture comments with a project glossary

### DIFF
--- a/Packages/src/Editor/Infrastructure/Api/UnityApiHandler.cs
+++ b/Packages/src/Editor/Infrastructure/Api/UnityApiHandler.cs
@@ -11,25 +11,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
 
     /// <summary>
-    /// Class specialized in handling Unity API calls
-    /// Supports new command-based structure
-    /// 
-    /// Design document reference: Packages/src/Editor/ARCHITECTURE.md
-    /// 
-    /// Related classes:
-    /// - UnityCommandRegistry: Registry that manages all available Unity commands
-    /// - CustomCommandManager: Provides access to the command registry singleton
-    /// - JsonRpcProcessor: Receives JSON-RPC requests and delegates to this handler
-    /// - IUnityCommand: Interface implemented by all command classes
-    /// - AbstractUnityCommand: Base class for all Unity commands
-    /// - BaseCommandResponse: Base response type for all commands
-    /// - MainThreadSwitcher: Ensures command execution on Unity's main thread
-    /// 
-    /// Command execution flow:
-    /// 1. JsonRpcProcessor receives request from the CLI client
-    /// 2. Delegates to ExecuteCommand method with command name and parameters
-    /// 3. Looks up command in registry and executes asynchronously
-    /// 4. Returns command response or error information
+    /// Routes JSON-RPC execution requests received by JsonRpcProcessor to either the
+    /// internal bridge command router or the registered tools in the Application layer.
+    /// Terminology for "tool" vs "internal bridge command" is defined in docs/glossary.md.
     /// </summary>
     public static class UnityApiHandler
     {

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,86 @@
+# Glossary
+
+Ubiquitous language for Unity CLI Loop. Code identifiers, docs, commit messages, and reviews
+should use these terms with the meanings defined here.
+
+## Naming policy
+
+Public package, assembly, and extension API identifiers are never renamed as part of
+terminology cleanup (see the repository guidelines). When an internal identifier conflicts
+with this glossary, prefer renaming the internal identifier; when a public identifier
+conflicts, keep the identifier and document the mismatch here instead.
+
+## Terms
+
+### Tool
+
+A unit of Unity-side functionality exposed to the CLI, implemented as an
+`IUnityCliLoopTool` and registered in the tool registry. Each tool maps to one CLI command
+an agent can run (for example `compile`, `get-logs`, `run-tests`). Tool names use
+`UnityCliLoopConstants.TOOL_NAME_*` constants.
+
+### Internal bridge command
+
+A CLI-only request handled inside the Unity package that must not appear in the
+extension-facing tool registry (for example `get-version`, `get-compile-status`).
+Routed by `InternalBridgeCommandRouter`; names use `UnityCliLoopConstants.COMMAND_NAME_*`
+constants. Anything an end user or third-party extension should call is a tool, not an
+internal bridge command.
+
+### Server
+
+The TCP IPC endpoint hosted inside the Unity Editor by the package
+(`UnityCliLoopBridgeServer`). It accepts short-lived sessions from the CLI, dispatches
+JSON-RPC requests to tools and internal bridge commands, and reports editor readiness.
+
+### CLI
+
+The `uloop` command-line interface as a whole — the user-facing entry point that talks to
+the server over TCP. Physically it consists of two Go binaries: the dispatcher and the
+project runner.
+
+### Dispatcher
+
+The globally installed `uloop` binary. It resolves the target Unity project, ensures the
+pinned project runner release is installed (downloading it when needed), keeps itself
+up to date against the pin's `minimumDispatcherVersion`, and delegates command execution
+to the project runner. Released via release-please from `cli/dispatcher/`.
+
+### Project runner
+
+The per-project CLI binary that implements the actual commands and speaks the IPC protocol
+with the Unity package. Its release is selected by the pin's `projectRunnerVersion`, so a
+project always runs the runner generation its package was built against. Released via
+release-please from `cli/project-runner/`.
+
+### Pin
+
+`Packages/src/project-runner-pin.json` (mirrored byte-identically to
+`.uloop/project-runner-pin.json`), the single source for cross-component version
+requirements: `projectRunnerVersion` (stamped by release-please) and
+`minimumDispatcherVersion` (the manually maintained dispatcher floor). The pin evolves
+additively only — existing fields are never deleted or renamed.
+
+### Protocol version
+
+The integer IPC contract generation declared on both sides: `protocolVersion` in
+`cli/common/clicontract/contract.json` and `CliConstants.REQUIRED_CLI_PROTOCOL_VERSION`
+in the package. The runtime gate requires exact equality; both are bumped together only
+when the wire format breaks compatibility.
+
+### Skill
+
+A generated instruction document that teaches an AI agent how to use a `uloop` command.
+Skill sources live in the package; the copies under `.agents/` and `.claude/` are
+generated and must not be edited directly.
+
+### Skill target
+
+A destination agent environment into which skills are installed (for example Claude Code,
+Cursor). Each target defines where its skill copies live and which folder layout it uses.
+
+### UseCase
+
+An Application-layer orchestration class that coordinates one tool execution flow across
+domain services and infrastructure ports. UseCases contain no UI and no direct Unity
+editor state access; they are the only layer that sequences multi-step tool work.


### PR DESCRIPTION
## Summary
- Removes a misleading class comment that referenced deleted types and a deleted design document, and adds a project glossary that pins down the terminology used across the codebase.

## User Impact
- No runtime behavior change. Readers of the Unity-side entry point no longer get pointed at classes and documents that no longer exist, and contributors now have a single reference (`docs/glossary.md`) for what tool, internal bridge command, server, dispatcher, project runner, pin, skill, and UseCase mean.

## Changes
- `UnityApiHandler`: replaced the fossil XML documentation (references to `UnityCommandRegistry`, `CustomCommandManager`, `IUnityCommand`, `AbstractUnityCommand`, `BaseCommandResponse`, and `Packages/src/Editor/ARCHITECTURE.md`) with a short summary matching the actual routing behavior.
- `docs/glossary.md` (new): defines the ubiquitous language for the project and records the policy that public/extension API identifiers are never renamed for terminology cleanup.

## Verification
- `dist/darwin-arm64/uloop compile` → Success, 0 errors / 0 warnings (docs-only change plus one XML comment)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

