### PR TITLE
chore: Drop the never-implemented required-parameter stub from schema generation

### DIFF
--- a/Packages/src/Editor/ToolContracts/UnityCliLoopToolParameterSchemaGenerator.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopToolParameterSchemaGenerator.cs
@@ -22,7 +22,6 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         {
             Type dtoType = typeof(TDto);
             Dictionary<string, ParameterInfo> properties = new();
-            List<string> required = new();
 
             // Create instance to get default values
             TDto defaultInstance = new();
@@ -51,13 +50,6 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
                 
                 // Get enum values if applicable
                 string[] enumValues = GetEnumValues(property.PropertyType);
-                
-                // Check if property is required
-                bool isRequired = IsRequired(property);
-                if (isRequired)
-                {
-                    required.Add(parameterName);
-                }
 
                 // Create parameter info
                 ParameterInfo paramInfo = new(
@@ -70,7 +62,11 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
                 properties[parameterName] = paramInfo;
             }
 
-            return new ToolParameterSchema(properties, required.ToArray());
+            // Why: generated schemas never mark parameters as required — every tool DTO
+            // carries a usable default, and neither the package nor the CLI enforces or
+            // displays required-ness. If required parameters are ever introduced, add them
+            // end-to-end (attribute + CLI enforcement) as a feature, not here.
+            return new ToolParameterSchema(properties);
         }
 
         /// <summary>
@@ -155,15 +151,5 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
             return null;
         }
 
-        /// <summary>
-        /// Check if property is required using custom Required attribute
-        /// For now, returns false as Unity doesn't support DataAnnotations
-        /// Can be extended with custom attributes if needed
-        /// </summary>
-        private static bool IsRequired(PropertyInfo property)
-        {
-            // TODO: Implement custom Required attribute if needed
-            return false;
-        }
     }
 } 


### PR DESCRIPTION
## Summary
- Resolves a long-standing TODO in the tool parameter schema generator by removing a required-parameter stub that has never done anything.

## User Impact
- No behavior change. Tool schemas sent to the CLI are byte-identical: the `required` list has always been empty because the stub unconditionally returned false, and neither the Unity package nor the CLI ever enforced or displayed required-ness.

## Changes
- `UnityCliLoopToolParameterSchemaGenerator`: deleted the always-false `IsRequired` helper (marked `TODO: Implement custom Required attribute if needed`) and the dead accumulation loop feeding it.
- `ToolParameterSchema.Required` is intentionally kept — it is extension-facing API and part of the wire schema shape; the constructor still produces the same empty array. A comment now records that required parameters, if ever needed, should be introduced end-to-end (attribute + CLI enforcement) as a feature.

## Verification
- `dist/darwin-arm64/uloop compile` → Success, 0 errors / 0 warnings
- Confirmed by grep that no C# code reads `ToolParameterSchema.Required` and the Go CLI only uses the field for schema-presence detection (`cli/common/tools/types.go`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

