### PR TITLE
chore: Server lifecycle events now fire through a single delivery path

### DIFF
--- a/Assets/Tests/Editor/UnityCliLoopServerLifecycleRegistryServiceTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerLifecycleRegistryServiceTests.cs
@@ -1,0 +1,133 @@
+using System;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Application;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the server lifecycle registry delivery paths:
+    /// ServerStarted/ServerStopping via manual publish, ServerLoopExited via the registered source.
+    /// </summary>
+    public class UnityCliLoopServerLifecycleRegistryServiceTests
+    {
+        /// <summary>
+        /// Fake lifecycle source that lets tests raise ServerLoopExited on demand.
+        /// </summary>
+        private sealed class FakeLifecycleSource : IUnityCliLoopServerLifecycleSource
+        {
+            public event Action ServerLoopExited;
+
+            public void RaiseServerLoopExited()
+            {
+                ServerLoopExited?.Invoke();
+            }
+
+            public bool HasServerLoopExitedSubscribers => ServerLoopExited != null;
+        }
+
+        [Test]
+        public void PublishServerStarted_WithAddedHandler_InvokesHandler()
+        {
+            // Verifies that ServerStarted handlers fire through the manual publish path.
+            UnityCliLoopServerLifecycleRegistryService registry = new();
+            int invocationCount = 0;
+            registry.ServerStarted += () => invocationCount++;
+
+            registry.PublishServerStarted();
+
+            Assert.That(invocationCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void PublishServerStarted_AfterHandlerRemoved_DoesNotInvokeHandler()
+        {
+            // Verifies that removed ServerStarted handlers no longer receive publishes.
+            UnityCliLoopServerLifecycleRegistryService registry = new();
+            int invocationCount = 0;
+            Action handler = () => invocationCount++;
+            registry.ServerStarted += handler;
+            registry.ServerStarted -= handler;
+
+            registry.PublishServerStarted();
+
+            Assert.That(invocationCount, Is.Zero);
+        }
+
+        [Test]
+        public void PublishServerStopping_WithAddedHandler_InvokesHandler()
+        {
+            // Verifies that ServerStopping handlers fire through the manual publish path.
+            UnityCliLoopServerLifecycleRegistryService registry = new();
+            int invocationCount = 0;
+            registry.ServerStopping += () => invocationCount++;
+
+            registry.PublishServerStopping();
+
+            Assert.That(invocationCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ServerStateChanged_OnStartedAndStoppingPublishes_InvokesHandlerForEach()
+        {
+            // Verifies that ServerStateChanged aggregates both started and stopping publishes.
+            UnityCliLoopServerLifecycleRegistryService registry = new();
+            int invocationCount = 0;
+            registry.ServerStateChanged += () => invocationCount++;
+
+            registry.PublishServerStarted();
+            registry.PublishServerStopping();
+
+            Assert.That(invocationCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void ServerLoopExited_WhenHandlerAddedBeforeRegisterSource_InvokesHandlerOnSourceRaise()
+        {
+            // Verifies that handlers added before source registration are wired onto the source.
+            UnityCliLoopServerLifecycleRegistryService registry = new();
+            FakeLifecycleSource source = new();
+            int invocationCount = 0;
+            registry.ServerLoopExited += () => invocationCount++;
+
+            registry.RegisterSource(source);
+            source.RaiseServerLoopExited();
+
+            Assert.That(invocationCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ServerLoopExited_WhenHandlerAddedAfterRegisterSource_InvokesHandlerOnSourceRaise()
+        {
+            // Verifies that handlers added after source registration are wired onto the source.
+            UnityCliLoopServerLifecycleRegistryService registry = new();
+            FakeLifecycleSource source = new();
+            registry.RegisterSource(source);
+            int invocationCount = 0;
+
+            registry.ServerLoopExited += () => invocationCount++;
+            source.RaiseServerLoopExited();
+
+            Assert.That(invocationCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void RegisterSource_WhenReplacingSource_UnwiresHandlersFromOldSource()
+        {
+            // Verifies that replacing the source moves ServerLoopExited wiring to the new source.
+            UnityCliLoopServerLifecycleRegistryService registry = new();
+            FakeLifecycleSource oldSource = new();
+            FakeLifecycleSource newSource = new();
+            int invocationCount = 0;
+            registry.ServerLoopExited += () => invocationCount++;
+            registry.RegisterSource(oldSource);
+
+            registry.RegisterSource(newSource);
+
+            Assert.That(oldSource.HasServerLoopExitedSubscribers, Is.False);
+            oldSource.RaiseServerLoopExited();
+            newSource.RaiseServerLoopExited();
+            Assert.That(invocationCount, Is.EqualTo(1));
+        }
+    }
+}

--- a/Assets/Tests/Editor/UnityCliLoopServerLifecycleRegistryServiceTests.cs.meta
+++ b/Assets/Tests/Editor/UnityCliLoopServerLifecycleRegistryServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43a3c7df62ffc4ffcbced98f2013fb0a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Application/UnityCliLoopServerApplicationService.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopServerApplicationService.cs
@@ -28,13 +28,12 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
     /// <summary>
     /// Defines the event source used to observe Unity CLI Loop server lifecycle behavior.
+    /// Why only ServerLoopExited: it is the one lifecycle signal raised by the server itself
+    /// (from the thread pool when the accept loop dies). ServerStarted/ServerStopping describe
+    /// controller-level readiness and are published manually via the lifecycle registry.
     /// </summary>
     public interface IUnityCliLoopServerLifecycleSource
     {
-        event Action ServerStarted;
-
-        event Action ServerStopping;
-
         event Action ServerLoopExited;
     }
 
@@ -70,6 +69,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
     /// <summary>
     /// Provides Unity CLI Loop Server Lifecycle Registry operations for its owning module.
+    /// ServerStarted/ServerStopping are delivered only through the Publish* methods;
+    /// ServerLoopExited is delivered only by the registered lifecycle source.
     /// </summary>
     public sealed class UnityCliLoopServerLifecycleRegistryService
     {
@@ -97,11 +98,17 @@ namespace io.github.hatayama.UnityCliLoop.Application
         {
             add
             {
-                AddHandler(ref _serverStartedHandlers, value, source => source.ServerStarted += value);
+                lock (_syncRoot)
+                {
+                    _serverStartedHandlers += value;
+                }
             }
             remove
             {
-                RemoveHandler(ref _serverStartedHandlers, value, source => source.ServerStarted -= value);
+                lock (_syncRoot)
+                {
+                    _serverStartedHandlers -= value;
+                }
             }
         }
 
@@ -109,11 +116,17 @@ namespace io.github.hatayama.UnityCliLoop.Application
         {
             add
             {
-                AddHandler(ref _serverStoppingHandlers, value, source => source.ServerStopping += value);
+                lock (_syncRoot)
+                {
+                    _serverStoppingHandlers += value;
+                }
             }
             remove
             {
-                RemoveHandler(ref _serverStoppingHandlers, value, source => source.ServerStopping -= value);
+                lock (_syncRoot)
+                {
+                    _serverStoppingHandlers -= value;
+                }
             }
         }
 
@@ -121,11 +134,25 @@ namespace io.github.hatayama.UnityCliLoop.Application
         {
             add
             {
-                AddHandler(ref _serverLoopExitedHandlers, value, source => source.ServerLoopExited += value);
+                lock (_syncRoot)
+                {
+                    _serverLoopExitedHandlers += value;
+                    if (_source != null)
+                    {
+                        _source.ServerLoopExited += value;
+                    }
+                }
             }
             remove
             {
-                RemoveHandler(ref _serverLoopExitedHandlers, value, source => source.ServerLoopExited -= value);
+                lock (_syncRoot)
+                {
+                    _serverLoopExitedHandlers -= value;
+                    if (_source != null)
+                    {
+                        _source.ServerLoopExited -= value;
+                    }
+                }
             }
         }
 
@@ -135,13 +162,16 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
             lock (_syncRoot)
             {
-                if (_source != null)
+                if (_source != null && _serverLoopExitedHandlers != null)
                 {
-                    UnwireHandlers(_source);
+                    _source.ServerLoopExited -= _serverLoopExitedHandlers;
                 }
 
                 _source = source;
-                WireHandlers(_source);
+                if (_serverLoopExitedHandlers != null)
+                {
+                    _source.ServerLoopExited += _serverLoopExitedHandlers;
+                }
             }
         }
 
@@ -165,78 +195,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
             }
 
             handlers?.Invoke();
-        }
-
-        private void AddHandler(
-            ref Action handlers,
-            Action value,
-            Action<IUnityCliLoopServerLifecycleSource> wireHandler)
-        {
-            System.Diagnostics.Debug.Assert(value != null, "value must not be null");
-            System.Diagnostics.Debug.Assert(wireHandler != null, "wireHandler must not be null");
-
-            lock (_syncRoot)
-            {
-                handlers += value;
-                if (_source != null)
-                {
-                    wireHandler(_source);
-                }
-            }
-        }
-
-        private void RemoveHandler(
-            ref Action handlers,
-            Action value,
-            Action<IUnityCliLoopServerLifecycleSource> unwireHandler)
-        {
-            System.Diagnostics.Debug.Assert(value != null, "value must not be null");
-            System.Diagnostics.Debug.Assert(unwireHandler != null, "unwireHandler must not be null");
-
-            lock (_syncRoot)
-            {
-                handlers -= value;
-                if (_source != null)
-                {
-                    unwireHandler(_source);
-                }
-            }
-        }
-
-        private void WireHandlers(IUnityCliLoopServerLifecycleSource source)
-        {
-            if (_serverStartedHandlers != null)
-            {
-                source.ServerStarted += _serverStartedHandlers;
-            }
-
-            if (_serverStoppingHandlers != null)
-            {
-                source.ServerStopping += _serverStoppingHandlers;
-            }
-
-            if (_serverLoopExitedHandlers != null)
-            {
-                source.ServerLoopExited += _serverLoopExitedHandlers;
-            }
-        }
-
-        private void UnwireHandlers(IUnityCliLoopServerLifecycleSource source)
-        {
-            if (_serverStartedHandlers != null)
-            {
-                source.ServerStarted -= _serverStartedHandlers;
-            }
-
-            if (_serverStoppingHandlers != null)
-            {
-                source.ServerStopping -= _serverStoppingHandlers;
-            }
-
-            if (_serverLoopExitedHandlers != null)
-            {
-                source.ServerLoopExited -= _serverLoopExitedHandlers;
-            }
         }
     }
 

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
@@ -22,17 +22,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         IUnityCliLoopServerInstanceFactory,
         IUnityCliLoopServerLifecycleSource
     {
-        public event Action ServerStarted
-        {
-            add { }
-            remove { }
-        }
-
-        public event Action ServerStopping
-        {
-            add { }
-            remove { }
-        }
         public event Action ServerLoopExited;
         private readonly IDomainReloadDetectionService _domainReloadDetectionService;
 
@@ -69,9 +58,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public class UnityCliLoopBridgeServer : IUnityCliLoopServerInstance
     {
-        public event Action ServerStopping;
-        public event Action ServerStarted;
-
         // Fired from thread pool when ServerLoopAsync exits while _isRunning is still true.
         // Subscribers must marshal to main thread before accessing Unity APIs.
         public event Action ServerLoopExited;
@@ -152,9 +138,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         );
                     }
                 }, TaskScheduler.Default);
-
-                ServerStarted?.Invoke();
-                
             }
             catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressAlreadyInUse)
             {
@@ -178,9 +161,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 return;
             }
-
-            // Notify that server is stopping
-            ServerStopping?.Invoke();
 
             _isRunning = false;
 


### PR DESCRIPTION
## Summary
- Removes the dead half of the server lifecycle event plumbing so each lifecycle signal has exactly one delivery mechanism.

## User Impact
- No behavior change. Every event keeps firing exactly when it fired before; what changes is that the codebase no longer carries a second, permanently silent delivery path for the same events, which previously made it unclear which mechanism actually runs.

## Changes
- `ServerStarted` / `ServerStopping` are now publish-only: they describe controller-level readiness and were only ever delivered by the controller's `PublishServerStarted` / `PublishServerStopping` calls. The parallel source-wired path was intentionally neutered (empty `add {} remove {}` stubs on the factory) and the bridge server's own `ServerStarted` / `ServerStopping` events had zero subscribers — all of that is deleted.
- `ServerLoopExited` stays source-wired: it is the one signal the server itself raises (from the thread pool when the accept loop dies), and its wiring through `IUnityCliLoopServerLifecycleSource` is unchanged.
- `IUnityCliLoopServerLifecycleSource` shrinks to `ServerLoopExited` only; the lifecycle registry loses its now-unneeded generic wire/unwire helpers.
- New pure C# EditMode tests pin both delivery paths, including handler add/remove and source replacement rewiring.
- This unification is a prerequisite for the planned `ServerController` split (the next refactor phase needs one unambiguous publish path to relocate).

## Verification
- `dist/darwin-arm64/uloop compile` → Success, 0 errors / 0 warnings
- `uloop run-tests` over the lifecycle/startup/recovery suites → 24/25 passed; the single failure (`ExecuteTrackedRecoveryAsync_WhenRecoveryKeepsFailing_GivesUpAfterAllRetriesAndClearsSession`) fails identically on a clean `origin/v3-beta` checkout in this environment (readiness-probe timeout, environment-dependent) and is unrelated to this change

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

