### PR TITLE
chore: Compile session state now flows from a single composition-root instance

### DIFF
--- a/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
+++ b/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
@@ -2,6 +2,7 @@ using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
 namespace io.github.hatayama.UnityCliLoop.Dev
@@ -14,7 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
         [MenuItem("UnityCliLoop/Debug/Compile Tests/Compile Checker Usage Example")]
         public static async void TestCompileChecker()
         {
-            CompileController compileController = new();
+            CompileController compileController = new(UnityCliLoopEditorSessionStateFacade.Service);
             
             try
             {
@@ -48,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
         [MenuItem("UnityCliLoop/Debug/Compile Tests/Force Compile Checker Usage Example")]
         public static async void TestForceCompileChecker()
         {
-            CompileController compileController = new();
+            CompileController compileController = new(UnityCliLoopEditorSessionStateFacade.Service);
             
             try
             {

--- a/Assets/Editor/CompileCheckWindow/CompileEditorWindow.cs
+++ b/Assets/Editor/CompileCheckWindow/CompileEditorWindow.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
+using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -36,7 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.Dev
             // Create instances only if they don't exist yet
             if (_compileController == null || _logDisplay == null)
             {
-                _compileController = new CompileController();
+                _compileController = new CompileController(UnityCliLoopEditorSessionStateFacade.Service);
                 _logDisplay = new CompileLogDisplay();
 
                 // Subscribe to events

--- a/Assets/Editor/UnityCLILoop.Dev.asmdef
+++ b/Assets/Editor/UnityCLILoop.Dev.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "io.github.hatayama.UnityCliLoop.Dev",
     "references": [
         "GUID:214998e563c124e8a88199b2dd1f522d",
+        "GUID:5c4588558a3624eacbce0f50007cf1eb",
         "GUID:01082d2dd8b5b41d487dcc154c017098",
         "GUID:aa8dd8c09aac9487db2e0b50381920dc",
         "GUID:e5952ef560e1641f68b2687e6045bf5b",

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -21,6 +21,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             UnityCliLoopEditorSettingsService editorSettingsService = new(editorSettingsRepository);
             UnityCliLoopEditorSessionStateRepository sessionStateRepository = new();
             UnityCliLoopEditorSessionStateService sessionStateService = new(sessionStateRepository);
+            UnityCliLoopEditorSessionStateFacade.RegisterService(sessionStateService);
             UnityCliLoopFirstPartyServerLifecycleBinding firstPartyServerLifecycle = new(new ProjectIpcWarmupClient());
             DomainReloadDetectionFileService domainReloadDetectionService = new(
                 sessionStateService);

--- a/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateFacade.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateFacade.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Exposes the CompositionRoot-owned UnityCliLoopEditorSessionStateService to call sites
+    /// that cannot receive it through constructor injection.
+    /// Why: static bridge command handlers (dispatched by IPC routers) and Activator.CreateInstance
+    /// -built tools have no injection seam, so they need to read the shared service without
+    /// rebuilding an ad hoc instance that would diverge from the CompositionRoot wiring.
+    /// </summary>
+    public static class UnityCliLoopEditorSessionStateFacade
+    {
+        private static UnityCliLoopEditorSessionStateService ServiceValue;
+
+        internal static void RegisterService(UnityCliLoopEditorSessionStateService service)
+        {
+            Debug.Assert(service != null, "service must not be null");
+
+            ServiceValue = service ?? throw new ArgumentNullException(nameof(service));
+        }
+
+        public static UnityCliLoopEditorSessionStateService Service
+        {
+            get
+            {
+                if (ServiceValue == null)
+                {
+                    throw new InvalidOperationException(
+                        "Unity CLI Loop editor session state service is not registered.");
+                }
+
+                return ServiceValue;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateFacade.cs.meta
+++ b/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateFacade.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1457db5797c475288ca7d06454184be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
@@ -1,5 +1,9 @@
+using System;
 using System.Threading.Tasks;
 using System.Threading;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Domain;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -10,6 +14,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class CompilationExecutionService
     {
+        private readonly UnityCliLoopEditorSessionStateService _sessionStateService;
+
+        public CompilationExecutionService(UnityCliLoopEditorSessionStateService sessionStateService)
+        {
+            Debug.Assert(sessionStateService != null, "sessionStateService must not be null");
+
+            _sessionStateService =
+                sessionStateService ?? throw new ArgumentNullException(nameof(sessionStateService));
+        }
+
         /// <summary>
         /// Execute compilation asynchronously
         /// </summary>
@@ -22,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new System.ArgumentNullException(nameof(request));
             }
 
-            using CompileController compileController = new();
+            using CompileController compileController = new(_sessionStateService);
             compileController.SetResultRecordingContext(CompileResultRecordingContext.Create(request));
             compileController.SetExternalSceneChangePolicy(request.ReloadExternalSceneChanges);
             return await compileController.TryCompileAsync(request.ForceRecompile, ct);

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Threading;
 
 using io.github.hatayama.UnityCliLoop.Domain;
-using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -18,6 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class CompileController : IDisposable
     {
+        private readonly UnityCliLoopEditorSessionStateService _sessionStateService;
         private bool _isCompiling = false;
         private List<CompilerMessage> _compileMessages = new();
         private TaskCompletionSource<CompileResult> _currentCompileTask;
@@ -25,6 +25,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private bool _reloadExternalSceneChanges = true;
         private CompileResultRecordingContext _resultRecordingContext = CompileResultRecordingContext.Disabled();
         private DateTime _compileStartedAtUtc = DateTime.MinValue;
+
+        public CompileController(UnityCliLoopEditorSessionStateService sessionStateService)
+        {
+            UnityEngine.Debug.Assert(sessionStateService != null, "sessionStateService must not be null");
+
+            _sessionStateService =
+                sessionStateService ?? throw new ArgumentNullException(nameof(sessionStateService));
+        }
 
         /// <summary>
         /// Event that occurs when compilation is complete.
@@ -508,12 +516,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            UnityCliLoopEditorSessionStateService sessionStateService =
-                new UnityCliLoopEditorSessionStateService(new UnityCliLoopEditorSessionStateRepository());
             UnityCliLoopCompileResult response =
                 CompileSessionResultService.CreateCompileResult(result, _resultRecordingContext.ForceRecompile);
             CompileSessionResultService.StoreCompileResult(
-                sessionStateService,
+                _sessionStateService,
                 _resultRecordingContext.RequestId,
                 _resultRecordingContext.ForceRecompile,
                 response,

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileTool.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -17,7 +18,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         protected override async Task<CompileResponse> ExecuteAsync(CompileSchema parameters, CancellationToken ct)
         {
-            CompileUseCase useCase = new();
+            // Why: CompileTool is created via Activator.CreateInstance by the tool registry and cannot
+            // receive CompositionRoot-owned services through its own constructor, so the shared
+            // session state service is fetched from the facade here and threaded through the pipeline.
+            UnityCliLoopEditorSessionStateService sessionStateService =
+                UnityCliLoopEditorSessionStateFacade.Service;
+            CompileUseCase useCase = new(sessionStateService);
             UnityCliLoopCompileResult result = await useCase.CompileAsync(ToRequest(parameters), ct);
             return ToResponse(result);
         }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -5,7 +5,6 @@ using UnityEditor;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Domain;
-using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -21,10 +20,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const int POLL_INTERVAL_MS = 50;
         private readonly UnityCliLoopEditorSessionStateService _sessionStateService;
 
-        public CompileUseCase()
+        public CompileUseCase(UnityCliLoopEditorSessionStateService sessionStateService)
         {
+            Debug.Assert(sessionStateService != null, "sessionStateService must not be null");
+
             _sessionStateService =
-                new UnityCliLoopEditorSessionStateService(new UnityCliLoopEditorSessionStateRepository());
+                sessionStateService ?? throw new ArgumentNullException(nameof(sessionStateService));
         }
 
         /// <summary>
@@ -130,7 +131,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // 3. Compilation execution
             ct.ThrowIfCancellationRequested();
-            CompilationExecutionService executionService = new();
+            CompilationExecutionService executionService = new(_sessionStateService);
             CompileResult result = await executionService.ExecuteCompilationAsync(request, ct);
 
             // 4. Result formatting

--- a/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
@@ -23,7 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             string requestId = ReadRequestId(paramsToken);
             UnityCliLoopEditorSessionStateService sessionStateService =
-                new UnityCliLoopEditorSessionStateService(new UnityCliLoopEditorSessionStateRepository());
+                UnityCliLoopEditorSessionStateFacade.Service;
             sessionStateService.ClearExpiredCompileResult(DateTime.UtcNow);
             bool isCompiling = EditorApplication.isCompiling;
             bool isUpdating = EditorApplication.isUpdating;

--- a/Packages/src/Editor/Infrastructure/Server/DomainReloadDetectionFileService.cs
+++ b/Packages/src/Editor/Infrastructure/Server/DomainReloadDetectionFileService.cs
@@ -15,11 +15,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly UnityCliLoopEditorSessionStateService _sessionStateService;
         private readonly IUnityCliLoopEditorLegacySessionStateReader _legacySessionStateReader;
 
-        public DomainReloadDetectionFileService()
-            : this(new UnityCliLoopEditorSessionStateService(new UnityCliLoopEditorSessionStateRepository()))
-        {
-        }
-
         internal DomainReloadDetectionFileService(
             UnityCliLoopEditorSessionStateService sessionStateService,
             IUnityCliLoopEditorLegacySessionStateReader legacySessionStateReader = null)

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
@@ -25,11 +25,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public event Action ServerLoopExited;
         private readonly IDomainReloadDetectionService _domainReloadDetectionService;
 
-        public UnityCliLoopBridgeServerInstanceFactory()
-            : this(new DomainReloadDetectionFileService())
-        {
-        }
-
         internal UnityCliLoopBridgeServerInstanceFactory(IDomainReloadDetectionService domainReloadDetectionService)
         {
             System.Diagnostics.Debug.Assert(domainReloadDetectionService != null, "domainReloadDetectionService must not be null");
@@ -85,11 +80,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly ConcurrentDictionary<int, Task> _clientTasks = new();
         private int _nextClientTaskId;
         private const int ClientDisconnectMonitorPollMilliseconds = 100;
-
-        public UnityCliLoopBridgeServer()
-            : this(new DomainReloadDetectionFileService())
-        {
-        }
 
         internal UnityCliLoopBridgeServer(IDomainReloadDetectionService domainReloadDetectionService)
         {


### PR DESCRIPTION
## Summary
- Stops four production code paths from hand-building their own session state service and routes them all to the single instance the composition root already constructs.

## User Impact
- No behavior change (the underlying storage is Unity's `SessionState`, so all instances always read the same data). The gain is structural: session state now has one owner, so future changes to its wiring happen in one place instead of five.

## Changes
- New `UnityCliLoopEditorSessionStateFacade` (Domain): exposes the composition-root-owned service to call sites that have no injection seam — static IPC bridge command handlers and tools instantiated via `Activator.CreateInstance`. Follows the existing facade pattern (`RegisterService` + `ServiceValue` + throw-if-unregistered accessor) enforced by `StaticFacadeStateGuardTests`. Placed in Domain because the compile tool and Infrastructure assemblies reference Domain but not Application.
- Compile pipeline (`CompileTool` → `CompileUseCase` → `CompilationExecutionService` → `CompileController`): the tool reads the facade once and threads the service down through constructors; the ad hoc constructions inside `CompileUseCase` and `CompileController` are gone.
- `CompileStatusBridgeCommand.Execute`: reads the facade instead of newing a service per request.
- Deleted the parameterless convenience constructors on `DomainReloadDetectionFileService`, `UnityCliLoopBridgeServer`, and `UnityCliLoopBridgeServerInstanceFactory` (grep confirmed no callers; the composition root always used the injected overloads).
- Dev-only compile window/example under `Assets/Editor` now pass the facade service explicitly (Dev asmdef gains a Domain reference).

## Verification
- `dist/darwin-arm64/uloop compile` → Success, 0 errors / 0 warnings
- `uloop run-tests` over compile/session-state/server-startup/facade-guard/onion-dependency suites → 122 tests, 119 passed; the 3 failures (`MigratedFacadeFiles_WhenScanned_DoNotOwnMutableStaticState`, `EditorUiFiles_WhenLoaded_DoNotReferenceFacadeInternalsDirectly`, `SimulateMouseUiUseCase_WhenReturningAfterTimeout_UsesCapturedUnityObjectState`) reproduce identically on a clean `origin/v3-beta` checkout and are unrelated to this change
- grep confirms no `new UnityCliLoopEditorSessionStateService(` remains in `Packages/src` outside the composition root

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

