### PR TITLE
chore: Collapse the RunTests tool's redundant intermediate DTO layer

### DIFF
--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -338,19 +338,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void TestExecutionTypes_WhenLoaded_CompileUnderFirstPartyToolsAssembly()
-        {
-            // Tests that bundled test-runner implementation types stay inside the first-party tool assembly.
-            string serviceAssemblyName = typeof(IUnityCliLoopTestExecutionService).Assembly.GetName().Name;
-            string requestAssemblyName = typeof(UnityCliLoopTestExecutionRequest).Assembly.GetName().Name;
-            string resultAssemblyName = typeof(UnityCliLoopTestExecutionResult).Assembly.GetName().Name;
-
-            Assert.That(serviceAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(requestAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(resultAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-        }
-
-        [Test]
         public void RunTestsUseCase_WhenLoaded_CompilesUnderApplicationAssembly()
         {
             // Tests that the bundled tool owns the test execution implementation.

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -25,13 +25,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 validationService,
                 NoCleanupWait
             );
-            UnityCliLoopTestExecutionRequest parameters = new()
+            RunTestsSchema parameters = new()
             {
                 TestMode = UnityCliLoopTestMode.EditMode,
                 SaveBeforeRun = true
             };
 
-            UnityCliLoopTestExecutionResult response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.ExecutionFailed));
@@ -60,12 +60,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 validationService,
                 NoCleanupWait
             );
-            UnityCliLoopTestExecutionRequest parameters = new()
+            RunTestsSchema parameters = new()
             {
                 TestMode = (UnityCliLoopTestMode)999
             };
 
-            UnityCliLoopTestExecutionResult response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.Message, Does.Contain("Unsupported test mode"));
@@ -85,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 validationService,
                 NoCleanupWait
             );
-            UnityCliLoopTestExecutionRequest parameters = new();
+            RunTestsSchema parameters = new();
 
             await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
@@ -109,13 +109,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 validationService,
                 NoCleanupWait
             );
-            UnityCliLoopTestExecutionRequest parameters = new()
+            RunTestsSchema parameters = new()
             {
                 TestMode = UnityCliLoopTestMode.PlayMode,
                 SaveBeforeRun = true
             };
 
-            UnityCliLoopTestExecutionResult response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.ExecutionFailed));
@@ -157,14 +157,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 validationService,
                 NoCleanupWait
             );
-            UnityCliLoopTestExecutionRequest parameters = new()
+            RunTestsSchema parameters = new()
             {
                 TestMode = UnityCliLoopTestMode.PlayMode,
                 FilterType = TestFilterType.exact,
                 FilterValue = "MissingTest"
             };
 
-            UnityCliLoopTestExecutionResult response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.NoTestsFound));
@@ -194,7 +194,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     return Task.CompletedTask;
                 }
             );
-            UnityCliLoopTestExecutionRequest parameters = new();
+            RunTestsSchema parameters = new();
 
             await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
@@ -221,7 +221,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     return Task.CompletedTask;
                 }
             );
-            UnityCliLoopTestExecutionRequest parameters = new();
+            RunTestsSchema parameters = new();
 
             await useCase.ExecuteAsync(parameters, CancellationToken.None);
 
@@ -250,7 +250,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     return Task.CompletedTask;
                 }
             );
-            UnityCliLoopTestExecutionRequest parameters = new();
+            RunTestsSchema parameters = new();
 
             await useCase.ExecuteAsync(parameters, CancellationToken.None);
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTool.cs
@@ -16,46 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         protected override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken ct)
         {
             RunTestsUseCase useCase = new();
-            UnityCliLoopTestExecutionResult result = await useCase.RunTestsAsync(ToRequest(parameters), ct);
-            return ToResponse(result);
-        }
-
-        private static UnityCliLoopTestExecutionRequest ToRequest(RunTestsSchema parameters)
-        {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
-            return new UnityCliLoopTestExecutionRequest
-            {
-                TestMode = parameters.TestMode,
-                FilterType = parameters.FilterType,
-                FilterValue = parameters.FilterValue,
-                SaveBeforeRun = parameters.SaveBeforeRun,
-            };
-        }
-
-        private static RunTestsResponse ToResponse(UnityCliLoopTestExecutionResult result)
-        {
-            if (result == null)
-            {
-                throw new System.ArgumentNullException(nameof(result));
-            }
-
-            return new RunTestsResponse(
-                success: result.Success,
-                message: result.Message,
-                completedAt: result.CompletedAt,
-                testCount: result.TestCount,
-                passedCount: result.PassedCount,
-                failedCount: result.FailedCount,
-                skippedCount: result.SkippedCount,
-                xmlPath: result.XmlPath,
-                status: result.Status,
-                hasFailures: result.HasFailures,
-                noTestsFound: result.NoTestsFound,
-                noTestsFoundExplanation: result.NoTestsFoundExplanation);
+            return await useCase.RunTestsAsync(parameters, ct);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsTool.cs
@@ -16,7 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         protected override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken ct)
         {
             RunTestsUseCase useCase = new();
-            return await useCase.RunTestsAsync(parameters, ct);
+            return await useCase.ExecuteAsync(parameters, ct);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -142,11 +142,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return response;
         }
 
-        public Task<RunTestsResponse> RunTestsAsync(RunTestsSchema request, CancellationToken ct)
-        {
-            return ExecuteAsync(request, ct);
-        }
-
         private static bool IsSupportedTestMode(UnityCliLoopTestMode testMode)
         {
             return Enum.IsDefined(typeof(UnityCliLoopTestMode), testMode);

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -12,7 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// Processing sequence: 1. Test filter creation, 2. Test execution, 3. Result processing
     /// Related classes: RunTestsTool, TestFilterCreationService, TestExecutionService
     /// </summary>
-    public class RunTestsUseCase : IUnityCliLoopTestExecutionService
+    public class RunTestsUseCase
     {
         private readonly TestFilterCreationService _filterService;
         private readonly TestExecutionService _executionService;
@@ -51,8 +51,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <param name="parameters">Test execution parameters</param>
         /// <param name="ct">Cancellation control token</param>
         /// <returns>Test execution result</returns>
-        public async Task<UnityCliLoopTestExecutionResult> ExecuteAsync(UnityCliLoopTestExecutionRequest parameters, CancellationToken ct)
+        public async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken ct)
         {
+            Debug.Assert(parameters != null, "parameters must not be null");
+
             if (!IsSupportedTestMode(parameters.TestMode))
             {
                 return CreateFailureResponse("Unsupported test mode: " + parameters.TestMode);
@@ -76,11 +78,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 filter = _filterService.CreateFilter(parameters.FilterType, parameters.FilterValue);
             }
-            
+
             // 2. Test execution
             ct.ThrowIfCancellationRequested();
             SerializableTestResult result;
-            
+
             try
             {
                 if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)
@@ -102,33 +104,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Log full exception details for debugging
                 UnityEngine.Debug.LogError($"Test execution failed: {ex}");
                 VibeLogger.LogError(
-                    "test_execution_failed", 
-                    "Test execution encountered an error", 
+                    "test_execution_failed",
+                    "Test execution encountered an error",
                     new { testMode = parameters.TestMode, filterType = parameters.FilterType, filterValue = parameters.FilterValue, error = ex.Message }
                 );
-                
+
                 // Create a minimal error result
                 throw new System.InvalidOperationException("Test execution failed. Please check the logs for details.", ex);
             }
 
             await _waitForTestRunnerCleanupAsync(ct);
-            
-            // 3. Response creation
-            UnityCliLoopTestExecutionResult response = new UnityCliLoopTestExecutionResult
-            {
-                Success = result.success,
-                Status = result.status,
-                HasFailures = result.hasFailures,
-                NoTestsFound = result.noTestsFound,
-                NoTestsFoundExplanation = result.noTestsFoundExplanation,
-                Message = result.message,
-                CompletedAt = result.completedAt,
-                TestCount = result.testCount,
-                PassedCount = result.passedCount,
-                FailedCount = result.failedCount,
-                SkippedCount = result.skippedCount,
-                XmlPath = result.xmlPath
-            };
+
+            // 3. Response creation.
+            // Why: pass every derived field explicitly so RunTestsResponse's derivation branches stay skipped
+            // and the wire output matches the pre-collapse pipeline byte-for-byte.
+            RunTestsResponse response = new(
+                success: result.success,
+                message: result.message,
+                completedAt: result.completedAt,
+                testCount: result.testCount,
+                passedCount: result.passedCount,
+                failedCount: result.failedCount,
+                skippedCount: result.skippedCount,
+                xmlPath: result.xmlPath,
+                status: result.status,
+                hasFailures: result.hasFailures,
+                noTestsFound: result.noTestsFound,
+                noTestsFoundExplanation: result.noTestsFoundExplanation);
             response.Message = RunTestsNoTestsDiagnosticService.AppendDiagnosticsOrOriginalMessage(
                 response.Message,
                 () => _noTestsDiagnosticService.AppendDiagnosticsIfNeeded(
@@ -140,7 +142,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return response;
         }
 
-        public Task<UnityCliLoopTestExecutionResult> RunTestsAsync(UnityCliLoopTestExecutionRequest request, CancellationToken ct)
+        public Task<RunTestsResponse> RunTestsAsync(RunTestsSchema request, CancellationToken ct)
         {
             return ExecuteAsync(request, ct);
         }
@@ -150,28 +152,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return Enum.IsDefined(typeof(UnityCliLoopTestMode), testMode);
         }
 
-        private static UnityCliLoopTestExecutionResult CreateTestFrameworkUnavailableResponse()
+        private static RunTestsResponse CreateTestFrameworkUnavailableResponse()
         {
             return CreateFailureResponse(RunTestsResponse.TestFrameworkUnavailableMessage);
         }
 
-        private static UnityCliLoopTestExecutionResult CreateFailureResponse(string message)
+        private static RunTestsResponse CreateFailureResponse(string message)
         {
-            return new UnityCliLoopTestExecutionResult
-            {
-                Success = false,
-                Status = RunTestsExecutionStatus.ExecutionFailed,
-                HasFailures = false,
-                NoTestsFound = false,
-                NoTestsFoundExplanation = string.Empty,
-                Message = message,
-                CompletedAt = DateTime.UtcNow.ToString("o"),
-                TestCount = 0,
-                PassedCount = 0,
-                FailedCount = 0,
-                SkippedCount = 0,
-                XmlPath = null
-            };
+            // Why: supply every optional argument so RunTestsResponse skips its derivation branches
+            // and returns the same explicit failure shape the intermediate DTO used to build.
+            return new RunTestsResponse(
+                success: false,
+                message: message,
+                completedAt: DateTime.UtcNow.ToString("o"),
+                testCount: 0,
+                passedCount: 0,
+                failedCount: 0,
+                skippedCount: 0,
+                xmlPath: null,
+                status: RunTestsExecutionStatus.ExecutionFailed,
+                hasFailures: false,
+                noTestsFound: false,
+                noTestsFoundExplanation: string.Empty);
         }
 
         private static async Task WaitForTestRunnerCleanupAsync(CancellationToken ct)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -53,7 +53,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <returns>Test execution result</returns>
         public async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters, CancellationToken ct)
         {
-            Debug.Assert(parameters != null, "parameters must not be null");
+            if (parameters == null)
+            {
+                throw new System.ArgumentNullException(nameof(parameters));
+            }
 
             if (!IsSupportedTestMode(parameters.TestMode))
             {
@@ -63,7 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ct.ThrowIfCancellationRequested();
             if (!_executionService.IsTestFrameworkAvailable)
             {
-                return CreateTestFrameworkUnavailableResponse();
+                return RunTestsResponse.CreateTestFrameworkUnavailable();
             }
 
             ValidationResult validation = _validationService.Validate(parameters.TestMode, parameters.SaveBeforeRun);
@@ -109,15 +112,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     new { testMode = parameters.TestMode, filterType = parameters.FilterType, filterValue = parameters.FilterValue, error = ex.Message }
                 );
 
-                // Create a minimal error result
+                // Surface the failure; the tool layer converts it into an error response.
                 throw new System.InvalidOperationException("Test execution failed. Please check the logs for details.", ex);
             }
 
             await _waitForTestRunnerCleanupAsync(ct);
 
             // 3. Response creation.
-            // Why: pass every derived field explicitly so RunTestsResponse's derivation branches stay skipped
-            // and the wire output matches the pre-collapse pipeline byte-for-byte.
+            // Why: pass the derived fields explicitly so the constructor does not re-derive them;
+            // the null-triggered derivation exists only as a source-compat fallback for callers
+            // that omit the optional arguments.
             RunTestsResponse response = new(
                 success: result.success,
                 message: result.message,
@@ -147,15 +151,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return Enum.IsDefined(typeof(UnityCliLoopTestMode), testMode);
         }
 
-        private static RunTestsResponse CreateTestFrameworkUnavailableResponse()
-        {
-            return CreateFailureResponse(RunTestsResponse.TestFrameworkUnavailableMessage);
-        }
-
         private static RunTestsResponse CreateFailureResponse(string message)
         {
-            // Why: supply every optional argument so RunTestsResponse skips its derivation branches
-            // and returns the same explicit failure shape the intermediate DTO used to build.
+            // Why: supply every optional argument so the constructor does not re-derive
+            // status or explanation fields from the failure message.
             return new RunTestsResponse(
                 success: false,
                 message: message,

--- a/Packages/src/Editor/FirstPartyTools/RunTests/UnityCliLoopTestExecutionTypes.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/UnityCliLoopTestExecutionTypes.cs
@@ -1,22 +1,17 @@
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Defines the Unity CLI Loop Test Execution operations required by the owning workflow.
+    /// Test mode selector shared between the CLI schema and the run-tests pipeline.
     /// </summary>
-    public interface IUnityCliLoopTestExecutionService
-    {
-        Task<UnityCliLoopTestExecutionResult> RunTestsAsync(UnityCliLoopTestExecutionRequest request, CancellationToken ct);
-    }
-
     public enum UnityCliLoopTestMode
     {
         EditMode = 0,
         PlayMode = 1
     }
 
+    /// <summary>
+    /// Filter strategy that determines how the run-tests filter value is interpreted.
+    /// </summary>
     public enum TestFilterType
     {
         all = 0,
@@ -34,35 +29,5 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string Failed = "Failed";
         public const string NoTestsFound = "NoTestsFound";
         public const string ExecutionFailed = "ExecutionFailed";
-    }
-
-    /// <summary>
-    /// Carries the request data needed for Unity CLI Loop Test Execution behavior.
-    /// </summary>
-    public sealed class UnityCliLoopTestExecutionRequest
-    {
-        public UnityCliLoopTestMode TestMode { get; set; } = UnityCliLoopTestMode.EditMode;
-        public TestFilterType FilterType { get; set; } = TestFilterType.all;
-        public string FilterValue { get; set; } = "";
-        public bool SaveBeforeRun { get; set; } = true;
-    }
-
-    /// <summary>
-    /// Carries the result data produced by Unity CLI Loop Test Execution behavior.
-    /// </summary>
-    public sealed class UnityCliLoopTestExecutionResult
-    {
-        public bool Success { get; set; }
-        public string Status { get; set; } = "";
-        public bool HasFailures { get; set; }
-        public bool NoTestsFound { get; set; }
-        public string NoTestsFoundExplanation { get; set; } = "";
-        public string Message { get; set; } = "";
-        public string CompletedAt { get; set; } = "";
-        public int TestCount { get; set; }
-        public int PassedCount { get; set; }
-        public int FailedCount { get; set; }
-        public int SkippedCount { get; set; }
-        public string XmlPath { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- Removes the RunTests tool's intermediate DTO layer (`IUnityCliLoopTestExecutionService`, `UnityCliLoopTestExecutionRequest`, `UnityCliLoopTestExecutionResult`), which only performed field-by-field copies between the wire DTOs and the test-execution pipeline. Follows the same collapse applied to the Compile tool in #1514.

## User Impact
- No user-visible change. The run-tests tool response stays identical.

## Changes
- `RunTestsUseCase` now takes `RunTestsSchema` and returns `RunTestsResponse` directly; `RunTestsTool` no longer needs its ToRequest/ToResponse mapping helpers.
- The response is constructed with every derived field passed explicitly (named arguments), so `RunTestsResponse`'s null-triggered derivation branches stay skipped exactly as before — output is unchanged.
- The domain enums (`UnityCliLoopTestMode`, `TestFilterType`, `RunTestsExecutionStatus`) stay in place: they are the real shared vocabulary, not mapping artifacts.
- The `RunTestsAsync` pass-through (which only existed to satisfy the deleted interface) is removed; `ExecuteAsync` is the single entry point.
- Unit tests retyped to the wire DTOs; the assembly-boundary guard test for the deleted types is removed (the sibling `RunTestsUseCase` guard remains). Repo-wide grep confirms no remaining references, including non-C# files.

## Verification
- `dist/darwin-arm64/uloop compile` → 0 errors, 0 warnings.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "(RunTests|OnionAssemblyDependency).*Tests"` → 124 passed, 0 failed, 0 skipped.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

