### PR TITLE
chore: Collapse the input-simulation tools' redundant intermediate DTO layer

### DIFF
--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -429,31 +429,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void InputSimulationTypes_WhenLoaded_CompileUnderFirstPartyToolsAssembly()
-        {
-            // Tests that bundled input simulation implementation types stay inside the first-party tool assembly.
-            string keyboardServiceAssemblyName = typeof(IUnityCliLoopKeyboardSimulationService).Assembly.GetName().Name;
-            string keyboardRequestAssemblyName = typeof(UnityCliLoopKeyboardSimulationRequest).Assembly.GetName().Name;
-            string keyboardResultAssemblyName = typeof(UnityCliLoopKeyboardSimulationResult).Assembly.GetName().Name;
-            string mouseServiceAssemblyName = typeof(IUnityCliLoopMouseInputSimulationService).Assembly.GetName().Name;
-            string mouseRequestAssemblyName = typeof(UnityCliLoopMouseInputSimulationRequest).Assembly.GetName().Name;
-            string mouseResultAssemblyName = typeof(UnityCliLoopMouseInputSimulationResult).Assembly.GetName().Name;
-            string mouseUiServiceAssemblyName = typeof(IUnityCliLoopMouseUiSimulationService).Assembly.GetName().Name;
-            string mouseUiRequestAssemblyName = typeof(UnityCliLoopMouseUiSimulationRequest).Assembly.GetName().Name;
-            string mouseUiResultAssemblyName = typeof(UnityCliLoopMouseUiSimulationResult).Assembly.GetName().Name;
-
-            Assert.That(keyboardServiceAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(keyboardRequestAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(keyboardResultAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(mouseServiceAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(mouseRequestAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(mouseResultAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(mouseUiServiceAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(mouseUiRequestAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-            Assert.That(mouseUiResultAssemblyName, Does.StartWith(FirstPartyToolsAssemblyNamePrefix));
-        }
-
-        [Test]
         public void InputSimulationUseCases_WhenLoaded_CompileUnderApplicationAssembly()
         {
             // Tests that the bundled tools own the keyboard and mouse input simulation implementations.

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/UnityCliLoopInputSimulationTypes.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/UnityCliLoopInputSimulationTypes.cs
@@ -1,40 +1,5 @@
-#nullable enable
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
-    /// <summary>
-    /// Defines the Unity CLI Loop Keyboard Simulation operations required by the owning workflow.
-    /// </summary>
-    public interface IUnityCliLoopKeyboardSimulationService
-    {
-        Task<UnityCliLoopKeyboardSimulationResult> SimulateKeyboardAsync(
-            UnityCliLoopKeyboardSimulationRequest request,
-            CancellationToken ct);
-    }
-
-    /// <summary>
-    /// Defines the Unity CLI Loop Mouse Input Simulation operations required by the owning workflow.
-    /// </summary>
-    public interface IUnityCliLoopMouseInputSimulationService
-    {
-        Task<UnityCliLoopMouseInputSimulationResult> SimulateMouseInputAsync(
-            UnityCliLoopMouseInputSimulationRequest request,
-            CancellationToken ct);
-    }
-
-    /// <summary>
-    /// Defines the Unity CLI Loop Mouse UI Simulation operations required by the owning workflow.
-    /// </summary>
-    public interface IUnityCliLoopMouseUiSimulationService
-    {
-        Task<UnityCliLoopMouseUiSimulationResult> SimulateMouseUiAsync(
-            UnityCliLoopMouseUiSimulationRequest request,
-            CancellationToken ct);
-    }
-
     public enum UnityCliLoopKeyboardAction
     {
         Press = 0,
@@ -69,22 +34,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     }
 
     /// <summary>
-    /// Provides Unity CLI Loop Input Simulation Defaults behavior for Unity CLI Loop.
+    /// Default values shared between the CLI schemas and the input simulation pipeline.
     /// </summary>
     public static class UnityCliLoopInputSimulationDefaults
     {
         public const float MouseUiDragSpeed = 2000f;
         public const float MouseUiDuration = 0.5f;
-    }
-
-    /// <summary>
-    /// Carries the request data needed for Unity CLI Loop Keyboard Simulation behavior.
-    /// </summary>
-    public sealed class UnityCliLoopKeyboardSimulationRequest
-    {
-        public UnityCliLoopKeyboardAction Action { get; set; } = UnityCliLoopKeyboardAction.Press;
-        public string Key { get; set; } = "";
-        public float Duration { get; set; }
     }
 
     /// <summary>
@@ -94,87 +49,5 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public string Id { get; set; } = "";
         public int HitCount { get; set; }
-    }
-
-    /// <summary>
-    /// Carries the result data produced by Unity CLI Loop Keyboard Simulation behavior.
-    /// </summary>
-    public sealed class UnityCliLoopKeyboardSimulationResult
-    {
-        public bool Success { get; set; }
-        public string Message { get; set; } = "";
-        public string Action { get; set; } = "";
-        public string? KeyName { get; set; }
-        public bool InterruptedByPausePoint { get; set; }
-        public string? PausePointId { get; set; }
-        public int? PausePointHitCount { get; set; }
-        public List<UnityCliLoopPausePointHit>? PausePointHits { get; set; }
-        public bool? PressEdgeObserved { get; set; }
-    }
-
-    /// <summary>
-    /// Carries the request data needed for Unity CLI Loop Mouse Input Simulation behavior.
-    /// </summary>
-    public sealed class UnityCliLoopMouseInputSimulationRequest
-    {
-        public UnityCliLoopMouseInputAction Action { get; set; } = UnityCliLoopMouseInputAction.Click;
-        public float X { get; set; }
-        public float Y { get; set; }
-        public UnityCliLoopMouseButton Button { get; set; } = UnityCliLoopMouseButton.Left;
-        public float Duration { get; set; }
-        public float DeltaX { get; set; }
-        public float DeltaY { get; set; }
-        public float ScrollX { get; set; }
-        public float ScrollY { get; set; }
-    }
-
-    /// <summary>
-    /// Carries the result data produced by Unity CLI Loop Mouse Input Simulation behavior.
-    /// </summary>
-    public sealed class UnityCliLoopMouseInputSimulationResult
-    {
-        public bool Success { get; set; }
-        public string Message { get; set; } = "";
-        public string Action { get; set; } = "";
-        public string? Button { get; set; }
-        public float? PositionX { get; set; }
-        public float? PositionY { get; set; }
-        public bool InterruptedByPausePoint { get; set; }
-        public string? PausePointId { get; set; }
-        public int? PausePointHitCount { get; set; }
-        public List<UnityCliLoopPausePointHit>? PausePointHits { get; set; }
-    }
-
-    /// <summary>
-    /// Carries the request data needed for Unity CLI Loop Mouse UI Simulation behavior.
-    /// </summary>
-    public sealed class UnityCliLoopMouseUiSimulationRequest
-    {
-        public UnityCliLoopMouseUiAction Action { get; set; } = UnityCliLoopMouseUiAction.Click;
-        public float X { get; set; }
-        public float Y { get; set; }
-        public float FromX { get; set; }
-        public float FromY { get; set; }
-        public float DragSpeed { get; set; } = UnityCliLoopInputSimulationDefaults.MouseUiDragSpeed;
-        public float Duration { get; set; } = UnityCliLoopInputSimulationDefaults.MouseUiDuration;
-        public UnityCliLoopMouseButton Button { get; set; } = UnityCliLoopMouseButton.Left;
-        public bool BypassRaycast { get; set; }
-        public string TargetPath { get; set; } = "";
-        public string DropTargetPath { get; set; } = "";
-    }
-
-    /// <summary>
-    /// Carries the result data produced by Unity CLI Loop Mouse UI Simulation behavior.
-    /// </summary>
-    public sealed class UnityCliLoopMouseUiSimulationResult
-    {
-        public bool Success { get; set; }
-        public string Message { get; set; } = "";
-        public string Action { get; set; } = "";
-        public string? HitGameObjectName { get; set; }
-        public float PositionX { get; set; }
-        public float PositionY { get; set; }
-        public float? EndPositionX { get; set; }
-        public float? EndPositionY { get; set; }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardTool.cs
@@ -16,44 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         protected override async Task<SimulateKeyboardResponse> ExecuteAsync(SimulateKeyboardSchema parameters, CancellationToken ct)
         {
             SimulateKeyboardUseCase useCase = new();
-            UnityCliLoopKeyboardSimulationResult result = await useCase.SimulateKeyboardAsync(ToRequest(parameters), ct);
-            return ToResponse(result);
-        }
-
-        private static UnityCliLoopKeyboardSimulationRequest ToRequest(SimulateKeyboardSchema parameters)
-        {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
-            return new UnityCliLoopKeyboardSimulationRequest
-            {
-                Action = parameters.Action,
-                Key = parameters.Key,
-                Duration = parameters.Duration,
-            };
-        }
-
-        private static SimulateKeyboardResponse ToResponse(UnityCliLoopKeyboardSimulationResult result)
-        {
-            if (result == null)
-            {
-                throw new System.ArgumentNullException(nameof(result));
-            }
-
-            return new SimulateKeyboardResponse
-            {
-                Success = result.Success,
-                Message = result.Message,
-                Action = result.Action,
-                KeyName = result.KeyName,
-                InterruptedByPausePoint = result.InterruptedByPausePoint,
-                PausePointId = result.PausePointId,
-                PausePointHitCount = result.PausePointHitCount,
-                PausePointHits = result.PausePointHits,
-                PressEdgeObserved = result.PressEdgeObserved,
-            };
+            return await useCase.ExecuteAsync(parameters, ct);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -17,79 +17,84 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// <summary>
     /// Coordinates Input System keyboard simulation for the bundled simulate-keyboard tool.
     /// </summary>
-    public class SimulateKeyboardUseCase : IUnityCliLoopKeyboardSimulationService
+    public class SimulateKeyboardUseCase
     {
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning disable CS1998
 #endif
-        public async Task<UnityCliLoopKeyboardSimulationResult> SimulateKeyboardAsync(
-            UnityCliLoopKeyboardSimulationRequest request,
+        public async Task<SimulateKeyboardResponse> ExecuteAsync(
+            SimulateKeyboardSchema parameters,
             CancellationToken ct)
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning restore CS1998
 #endif
         {
+            if (parameters == null)
+            {
+                throw new System.ArgumentNullException(nameof(parameters));
+            }
+
             ct.ThrowIfCancellationRequested();
 
 #if !ULOOP_HAS_INPUT_SYSTEM
-            return new UnityCliLoopKeyboardSimulationResult
+            return new SimulateKeyboardResponse
             {
                 Success = false,
                 Message = "simulate-keyboard requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.",
-                Action = request.Action.ToString()
+                Action = parameters.Action.ToString()
             };
 #else
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
             if (!EditorApplication.isPlaying)
             {
-                return new UnityCliLoopKeyboardSimulationResult
+                return new SimulateKeyboardResponse
                 {
                     Success = false,
                     Message = "PlayMode is not active. Use control-play-mode tool to start PlayMode first.",
-                    Action = request.Action.ToString()
+                    Action = parameters.Action.ToString()
                 };
             }
 
             if (EditorApplication.isPaused)
             {
-                return new UnityCliLoopKeyboardSimulationResult
+                return new SimulateKeyboardResponse
                 {
                     Success = false,
                     Message = "PlayMode is paused. Resume PlayMode before simulating keyboard input.",
-                    Action = request.Action.ToString()
+                    Action = parameters.Action.ToString()
                 };
             }
 
-            if (string.IsNullOrEmpty(request.Key))
+            if (string.IsNullOrEmpty(parameters.Key))
             {
-                return new UnityCliLoopKeyboardSimulationResult
+                return new SimulateKeyboardResponse
                 {
                     Success = false,
                     Message = "Key parameter is required. Examples: \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\".",
-                    Action = request.Action.ToString()
+                    Action = parameters.Action.ToString()
                 };
             }
 
-            string normalizedKey = NormalizeKeyName(request.Key);
+            string normalizedKey = NormalizeKeyName(parameters.Key);
             if (!Enum.TryParse<Key>(normalizedKey, ignoreCase: true, out Key key) || key == Key.None)
             {
-                return new UnityCliLoopKeyboardSimulationResult
+                return new SimulateKeyboardResponse
                 {
                     Success = false,
-                    Message = $"Invalid key name: \"{request.Key}\". Use Input System Key enum names (e.g. \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\").",
-                    Action = request.Action.ToString()
+                    Message = $"Invalid key name: \"{parameters.Key}\". Use Input System Key enum names (e.g. \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\").",
+                    Action = parameters.Action.ToString()
                 };
             }
 
             Keyboard keyboard = Keyboard.current;
             if (keyboard == null)
             {
-                return new UnityCliLoopKeyboardSimulationResult
+                return new SimulateKeyboardResponse
                 {
                     Success = false,
                     Message = "No keyboard device found in Input System. Ensure the Input System package is properly configured.",
-                    Action = request.Action.ToString()
+                    Action = parameters.Action.ToString()
                 };
             }
 
@@ -98,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             VibeLogger.LogInfo(
                 "simulate_keyboard_start",
                 "Keyboard simulation started",
-                new { Action = request.Action.ToString(), Key = request.Key },
+                new { Action = parameters.Action.ToString(), Key = parameters.Key },
                 correlationId: correlationId
             );
 
@@ -106,12 +111,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             EnsureOverlayExists();
 
-            UnityCliLoopKeyboardSimulationResult response;
+            SimulateKeyboardResponse response;
 
-            switch (request.Action)
+            switch (parameters.Action)
             {
                 case UnityCliLoopKeyboardAction.Press:
-                    response = await ExecutePress(keyboard, key, request.Duration, ct);
+                    response = await ExecutePress(keyboard, key, parameters.Duration, ct);
                     break;
 
                 case UnityCliLoopKeyboardAction.KeyDown:
@@ -123,13 +128,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     break;
 
                 default:
-                    throw new ArgumentException($"Unknown keyboard action: {request.Action}");
+                    throw new ArgumentException($"Unknown keyboard action: {parameters.Action}");
             }
 
             VibeLogger.LogInfo(
                 "simulate_keyboard_complete",
                 $"Keyboard simulation completed: {response.Message}",
-                new { Action = request.Action.ToString(), Success = response.Success },
+                new { Action = parameters.Action.ToString(), Success = response.Success },
                 correlationId: correlationId
             );
 
@@ -143,12 +148,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             OverlayCanvasFactory.EnsureExists();
         }
 
-        private async Task<UnityCliLoopKeyboardSimulationResult> ExecutePress(
+        private async Task<SimulateKeyboardResponse> ExecutePress(
             Keyboard keyboard, Key key, float duration, CancellationToken ct)
         {
             if (duration < 0f || float.IsNaN(duration) || float.IsInfinity(duration))
             {
-                return new UnityCliLoopKeyboardSimulationResult
+                return new SimulateKeyboardResponse
                 {
                     Success = false,
                     Message = $"Duration must be non-negative, got: {duration}",
@@ -160,7 +165,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string keyName = key.ToString();
             if (KeyboardKeyState.IsKeyHeld(key))
             {
-                return new UnityCliLoopKeyboardSimulationResult
+                return new SimulateKeyboardResponse
                 {
                     Success = false,
                     Message = $"Key '{keyName}' is already held down. Call KeyUp first.",
@@ -243,7 +248,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string edgeText = pressEdgeObserved
                 ? ""
                 : " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it, so retry or verify with a focused log)";
-            return new UnityCliLoopKeyboardSimulationResult
+            return new SimulateKeyboardResponse
             {
                 Success = true,
                 Message = $"Pressed '{keyName}'{durationText}{edgeText}",
@@ -253,13 +258,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private async Task<UnityCliLoopKeyboardSimulationResult> ExecuteKeyDown(Keyboard keyboard, Key key, CancellationToken ct)
+        private async Task<SimulateKeyboardResponse> ExecuteKeyDown(Keyboard keyboard, Key key, CancellationToken ct)
         {
             string keyName = key.ToString();
 
             if (KeyboardKeyState.IsKeyHeld(key))
             {
-                return new UnityCliLoopKeyboardSimulationResult
+                return new SimulateKeyboardResponse
                 {
                     Success = false,
                     Message = $"Key '{keyName}' is already held down. Call KeyUp first.",
@@ -325,7 +330,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string keyDownEdgeText = pressEdgeObserved
                 ? ""
                 : " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it)";
-            return new UnityCliLoopKeyboardSimulationResult
+            return new SimulateKeyboardResponse
             {
                 Success = true,
                 Message = $"Key '{keyName}' held down{keyDownEdgeText}",
@@ -335,13 +340,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private async Task<UnityCliLoopKeyboardSimulationResult> ExecuteKeyUp(Keyboard keyboard, Key key, CancellationToken ct)
+        private async Task<SimulateKeyboardResponse> ExecuteKeyUp(Keyboard keyboard, Key key, CancellationToken ct)
         {
             string keyName = key.ToString();
 
             if (!KeyboardKeyState.IsKeyHeld(key))
             {
-                return new UnityCliLoopKeyboardSimulationResult
+                return new SimulateKeyboardResponse
                 {
                     Success = false,
                     Message = $"Key '{keyName}' is not currently held. Call KeyDown first.",
@@ -375,7 +380,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return TimedOutKeyResult(UnityCliLoopKeyboardAction.KeyUp, keyName);
             }
 
-            return new UnityCliLoopKeyboardSimulationResult
+            return new SimulateKeyboardResponse
             {
                 Success = true,
                 Message = $"Key '{keyName}' released",
@@ -396,12 +401,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // pressEdgeObserved stays nullable because KeyUp has no press edge to report;
         // Press/KeyDown must pass their observation so pause-point interruptions (the
         // most common E2E path) do not silently drop the field.
-        private static UnityCliLoopKeyboardSimulationResult InterruptedKeyResult(
+        private static SimulateKeyboardResponse InterruptedKeyResult(
             UnityCliLoopKeyboardAction action,
             string keyName,
             bool? pressEdgeObserved)
         {
-            UnityCliLoopKeyboardSimulationResult result = new()
+            SimulateKeyboardResponse result = new()
             {
                 Success = true,
                 Message = $"Keyboard input stopped because Unity paused during Pause Point inspection. Key '{keyName}' was released from Unity CLI Loop bookkeeping.",
@@ -414,11 +419,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return result;
         }
 
-        private static UnityCliLoopKeyboardSimulationResult TimedOutKeyResult(
+        private static SimulateKeyboardResponse TimedOutKeyResult(
             UnityCliLoopKeyboardAction action,
             string keyName)
         {
-            return new UnityCliLoopKeyboardSimulationResult
+            return new SimulateKeyboardResponse
             {
                 Success = false,
                 Message = $"Keyboard input timed out while waiting for Unity Editor update. Key '{keyName}' cleanup is queued for the next Editor tick.",
@@ -427,7 +432,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static void AttachPausePointHit(UnityCliLoopKeyboardSimulationResult result)
+        private static void AttachPausePointHit(SimulateKeyboardResponse result)
         {
             if (result == null)
             {

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputTool.cs
@@ -16,52 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         protected override async Task<SimulateMouseInputResponse> ExecuteAsync(SimulateMouseInputSchema parameters, CancellationToken ct)
         {
             SimulateMouseInputUseCase useCase = new();
-            UnityCliLoopMouseInputSimulationResult result =
-                await useCase.SimulateMouseInputAsync(ToRequest(parameters), ct);
-            return ToResponse(result);
-        }
-
-        private static UnityCliLoopMouseInputSimulationRequest ToRequest(SimulateMouseInputSchema parameters)
-        {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
-            return new UnityCliLoopMouseInputSimulationRequest
-            {
-                Action = parameters.Action,
-                X = parameters.X,
-                Y = parameters.Y,
-                Button = parameters.Button,
-                Duration = parameters.Duration,
-                DeltaX = parameters.DeltaX,
-                DeltaY = parameters.DeltaY,
-                ScrollX = parameters.ScrollX,
-                ScrollY = parameters.ScrollY,
-            };
-        }
-
-        private static SimulateMouseInputResponse ToResponse(UnityCliLoopMouseInputSimulationResult result)
-        {
-            if (result == null)
-            {
-                throw new System.ArgumentNullException(nameof(result));
-            }
-
-            return new SimulateMouseInputResponse
-            {
-                Success = result.Success,
-                Message = result.Message,
-                Action = result.Action,
-                Button = result.Button,
-                PositionX = result.PositionX,
-                PositionY = result.PositionY,
-                InterruptedByPausePoint = result.InterruptedByPausePoint,
-                PausePointId = result.PausePointId,
-                PausePointHitCount = result.PausePointHitCount,
-                PausePointHits = result.PausePointHits,
-            };
+            return await useCase.ExecuteAsync(parameters, ct);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -18,22 +18,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// <summary>
     /// Coordinates Input System mouse simulation for the bundled simulate-mouse-input tool.
     /// </summary>
-    public class SimulateMouseInputUseCase : IUnityCliLoopMouseInputSimulationService
+    public class SimulateMouseInputUseCase
     {
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning disable CS1998
 #endif
-        public async Task<UnityCliLoopMouseInputSimulationResult> SimulateMouseInputAsync(
-            UnityCliLoopMouseInputSimulationRequest request,
+        public async Task<SimulateMouseInputResponse> ExecuteAsync(
+            SimulateMouseInputSchema request,
             CancellationToken ct)
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning restore CS1998
 #endif
         {
+            if (request == null)
+            {
+                throw new System.ArgumentNullException(nameof(request));
+            }
+
             ct.ThrowIfCancellationRequested();
 
 #if !ULOOP_HAS_INPUT_SYSTEM
-            return new UnityCliLoopMouseInputSimulationResult
+            return new SimulateMouseInputResponse
             {
                 Success = false,
                 Message = "simulate-mouse-input requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.",
@@ -44,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (!EditorApplication.isPlaying)
             {
-                return new UnityCliLoopMouseInputSimulationResult
+                return new SimulateMouseInputResponse
                 {
                     Success = false,
                     Message = "PlayMode is not active. Use control-play-mode tool to start PlayMode first.",
@@ -54,7 +59,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (EditorApplication.isPaused)
             {
-                return new UnityCliLoopMouseInputSimulationResult
+                return new SimulateMouseInputResponse
                 {
                     Success = false,
                     Message = "PlayMode is paused. Resume PlayMode before simulating mouse input.",
@@ -64,7 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (!System.Enum.IsDefined(typeof(UnityCliLoopMouseInputAction), request.Action))
             {
-                return new UnityCliLoopMouseInputSimulationResult
+                return new SimulateMouseInputResponse
                 {
                     Success = false,
                     Message = $"Invalid Action value: {(int)request.Action}. Use Click, LongPress, MoveDelta, Scroll, or SmoothDelta.",
@@ -74,7 +79,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (!System.Enum.IsDefined(typeof(UnityCliLoopMouseButton), request.Button))
             {
-                return new UnityCliLoopMouseInputSimulationResult
+                return new SimulateMouseInputResponse
                 {
                     Success = false,
                     Message = $"Invalid Button value: {(int)request.Button}. Use Left, Right, or Middle.",
@@ -85,7 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Mouse? mouse = Mouse.current;
             if (mouse == null)
             {
-                return new UnityCliLoopMouseInputSimulationResult
+                return new SimulateMouseInputResponse
                 {
                     Success = false,
                     Message = "No mouse device found in Input System. Ensure the Input System package is properly configured.",
@@ -106,7 +111,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             EnsureOverlayExists();
 
-            UnityCliLoopMouseInputSimulationResult response;
+            SimulateMouseInputResponse response;
 
             switch (request.Action)
             {
@@ -159,12 +164,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new Vector2(inputPos.x, Screen.height - inputPos.y);
         }
 
-        private async Task<UnityCliLoopMouseInputSimulationResult> ExecuteClick(
-            Mouse mouse, UnityCliLoopMouseInputSimulationRequest request, CancellationToken ct)
+        private async Task<SimulateMouseInputResponse> ExecuteClick(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
         {
             if (request.Duration < 0f || float.IsNaN(request.Duration) || float.IsInfinity(request.Duration))
             {
-                return new UnityCliLoopMouseInputSimulationResult
+                return new SimulateMouseInputResponse
                 {
                     Success = false,
                     Message = $"Duration must be non-negative, got: {request.Duration}",
@@ -258,7 +263,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string durationText = request.Duration > 0f ? $" for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s" : "";
-            return new UnityCliLoopMouseInputSimulationResult
+            return new SimulateMouseInputResponse
             {
                 Success = true,
                 Message = $"Clicked {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}){durationText}",
@@ -269,12 +274,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private async Task<UnityCliLoopMouseInputSimulationResult> ExecuteLongPress(
-            Mouse mouse, UnityCliLoopMouseInputSimulationRequest request, CancellationToken ct)
+        private async Task<SimulateMouseInputResponse> ExecuteLongPress(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
         {
             if (request.Duration <= 0f || float.IsNaN(request.Duration) || float.IsInfinity(request.Duration))
             {
-                return new UnityCliLoopMouseInputSimulationResult
+                return new SimulateMouseInputResponse
                 {
                     Success = false,
                     Message = $"Duration must be positive for LongPress, got: {request.Duration}",
@@ -370,7 +375,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return TimedOutButtonResult(UnityCliLoopMouseInputAction.LongPress, buttonName, inputPos);
             }
 
-            return new UnityCliLoopMouseInputSimulationResult
+            return new SimulateMouseInputResponse
             {
                 Success = true,
                 Message = $"Long-pressed {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}) for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s",
@@ -381,8 +386,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private async Task<UnityCliLoopMouseInputSimulationResult> ExecuteMoveDelta(
-            Mouse mouse, UnityCliLoopMouseInputSimulationRequest request, CancellationToken ct)
+        private async Task<SimulateMouseInputResponse> ExecuteMoveDelta(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
         {
             Vector2 delta = new(request.DeltaX, request.DeltaY);
             SimulateMouseInputOverlayState.SetMoveDelta(delta);
@@ -410,7 +415,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return TimedOutActionResult(UnityCliLoopMouseInputAction.MoveDelta);
             }
 
-            return new UnityCliLoopMouseInputSimulationResult
+            return new SimulateMouseInputResponse
             {
                 Success = true,
                 Message = $"Mouse delta injected: ({request.DeltaX:F1}, {request.DeltaY:F1})",
@@ -418,8 +423,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private async Task<UnityCliLoopMouseInputSimulationResult> ExecuteScroll(
-            Mouse mouse, UnityCliLoopMouseInputSimulationRequest request, CancellationToken ct)
+        private async Task<SimulateMouseInputResponse> ExecuteScroll(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
         {
             Vector2 scroll = new(request.ScrollX, request.ScrollY);
 
@@ -449,7 +454,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return TimedOutActionResult(UnityCliLoopMouseInputAction.Scroll);
             }
 
-            return new UnityCliLoopMouseInputSimulationResult
+            return new SimulateMouseInputResponse
             {
                 Success = true,
                 Message = $"Scroll injected: ({request.ScrollX:F1}, {request.ScrollY:F1})",
@@ -460,12 +465,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Distributes totalDelta across frames over duration for human-like smooth movement.
         // Uses ApplyOnNextConfiguredUpdate per frame so the delta is visible to game code
         // in the same Input System update cycle. Resets delta to zero only after the final frame.
-        private async Task<UnityCliLoopMouseInputSimulationResult> ExecuteSmoothDelta(
-            Mouse mouse, UnityCliLoopMouseInputSimulationRequest request, CancellationToken ct)
+        private async Task<SimulateMouseInputResponse> ExecuteSmoothDelta(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
         {
             if (request.Duration <= 0f || float.IsNaN(request.Duration) || float.IsInfinity(request.Duration))
             {
-                return new UnityCliLoopMouseInputSimulationResult
+                return new SimulateMouseInputResponse
                 {
                     Success = false,
                     Message = $"Duration must be positive for SmoothDelta, got: {request.Duration}",
@@ -529,7 +534,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return TimedOutActionResult(UnityCliLoopMouseInputAction.SmoothDelta);
             }
 
-            return new UnityCliLoopMouseInputSimulationResult
+            return new SimulateMouseInputResponse
             {
                 Success = true,
                 Message = $"Smooth delta ({request.DeltaX:F1}, {request.DeltaY:F1}) over {duration:F2}s",
@@ -537,22 +542,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static UnityCliLoopMouseInputSimulationResult InterruptedButtonResult(
+        private static SimulateMouseInputResponse InterruptedButtonResult(
             UnityCliLoopMouseInputAction action,
             string buttonName,
             Vector2 inputPos)
         {
-            UnityCliLoopMouseInputSimulationResult result = InterruptedActionResult(action);
+            SimulateMouseInputResponse result = InterruptedActionResult(action);
             result.Button = buttonName;
             result.PositionX = inputPos.x;
             result.PositionY = inputPos.y;
             return result;
         }
 
-        private static UnityCliLoopMouseInputSimulationResult InterruptedActionResult(
+        private static SimulateMouseInputResponse InterruptedActionResult(
             UnityCliLoopMouseInputAction action)
         {
-            UnityCliLoopMouseInputSimulationResult result = new()
+            SimulateMouseInputResponse result = new()
             {
                 Success = true,
                 Message = "Mouse input stopped because Unity paused during Pause Point inspection. Unity CLI Loop released its held input bookkeeping.",
@@ -563,22 +568,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return result;
         }
 
-        private static UnityCliLoopMouseInputSimulationResult TimedOutButtonResult(
+        private static SimulateMouseInputResponse TimedOutButtonResult(
             UnityCliLoopMouseInputAction action,
             string buttonName,
             Vector2 inputPos)
         {
-            UnityCliLoopMouseInputSimulationResult result = TimedOutActionResult(action);
+            SimulateMouseInputResponse result = TimedOutActionResult(action);
             result.Button = buttonName;
             result.PositionX = inputPos.x;
             result.PositionY = inputPos.y;
             return result;
         }
 
-        private static UnityCliLoopMouseInputSimulationResult TimedOutActionResult(
+        private static SimulateMouseInputResponse TimedOutActionResult(
             UnityCliLoopMouseInputAction action)
         {
-            return new UnityCliLoopMouseInputSimulationResult
+            return new SimulateMouseInputResponse
             {
                 Success = false,
                 Message = "Mouse input timed out while waiting for Unity Editor update. Cleanup is queued for the next Editor tick.",
@@ -586,7 +591,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static void AttachPausePointHit(UnityCliLoopMouseInputSimulationResult result)
+        private static void AttachPausePointHit(SimulateMouseInputResponse result)
         {
             if (result == null)
             {

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -24,15 +24,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 #pragma warning disable CS1998
 #endif
         public async Task<SimulateMouseInputResponse> ExecuteAsync(
-            SimulateMouseInputSchema request,
+            SimulateMouseInputSchema parameters,
             CancellationToken ct)
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning restore CS1998
 #endif
         {
-            if (request == null)
+            if (parameters == null)
             {
-                throw new System.ArgumentNullException(nameof(request));
+                throw new System.ArgumentNullException(nameof(parameters));
             }
 
             ct.ThrowIfCancellationRequested();
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 Success = false,
                 Message = "simulate-mouse-input requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.",
-                Action = request.Action.ToString()
+                Action = parameters.Action.ToString()
             };
 #else
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
@@ -53,7 +53,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = false,
                     Message = "PlayMode is not active. Use control-play-mode tool to start PlayMode first.",
-                    Action = request.Action.ToString()
+                    Action = parameters.Action.ToString()
                 };
             }
 
@@ -63,27 +63,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = false,
                     Message = "PlayMode is paused. Resume PlayMode before simulating mouse input.",
-                    Action = request.Action.ToString()
+                    Action = parameters.Action.ToString()
                 };
             }
 
-            if (!System.Enum.IsDefined(typeof(UnityCliLoopMouseInputAction), request.Action))
+            if (!System.Enum.IsDefined(typeof(UnityCliLoopMouseInputAction), parameters.Action))
             {
                 return new SimulateMouseInputResponse
                 {
                     Success = false,
-                    Message = $"Invalid Action value: {(int)request.Action}. Use Click, LongPress, MoveDelta, Scroll, or SmoothDelta.",
-                    Action = request.Action.ToString()
+                    Message = $"Invalid Action value: {(int)parameters.Action}. Use Click, LongPress, MoveDelta, Scroll, or SmoothDelta.",
+                    Action = parameters.Action.ToString()
                 };
             }
 
-            if (!System.Enum.IsDefined(typeof(UnityCliLoopMouseButton), request.Button))
+            if (!System.Enum.IsDefined(typeof(UnityCliLoopMouseButton), parameters.Button))
             {
                 return new SimulateMouseInputResponse
                 {
                     Success = false,
-                    Message = $"Invalid Button value: {(int)request.Button}. Use Left, Right, or Middle.",
-                    Action = request.Action.ToString()
+                    Message = $"Invalid Button value: {(int)parameters.Button}. Use Left, Right, or Middle.",
+                    Action = parameters.Action.ToString()
                 };
             }
 
@@ -94,7 +94,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     Success = false,
                     Message = "No mouse device found in Input System. Ensure the Input System package is properly configured.",
-                    Action = request.Action.ToString()
+                    Action = parameters.Action.ToString()
                 };
             }
 
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             VibeLogger.LogInfo(
                 "simulate_mouse_input_start",
                 "Mouse input simulation started",
-                new { Action = request.Action.ToString(), Button = request.Button.ToString() },
+                new { Action = parameters.Action.ToString(), Button = parameters.Button.ToString() },
                 correlationId: correlationId
             );
 
@@ -113,36 +113,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             SimulateMouseInputResponse response;
 
-            switch (request.Action)
+            switch (parameters.Action)
             {
                 case UnityCliLoopMouseInputAction.Click:
-                    response = await ExecuteClick(mouse, request, ct);
+                    response = await ExecuteClick(mouse, parameters, ct);
                     break;
 
                 case UnityCliLoopMouseInputAction.LongPress:
-                    response = await ExecuteLongPress(mouse, request, ct);
+                    response = await ExecuteLongPress(mouse, parameters, ct);
                     break;
 
                 case UnityCliLoopMouseInputAction.MoveDelta:
-                    response = await ExecuteMoveDelta(mouse, request, ct);
+                    response = await ExecuteMoveDelta(mouse, parameters, ct);
                     break;
 
                 case UnityCliLoopMouseInputAction.Scroll:
-                    response = await ExecuteScroll(mouse, request, ct);
+                    response = await ExecuteScroll(mouse, parameters, ct);
                     break;
 
                 case UnityCliLoopMouseInputAction.SmoothDelta:
-                    response = await ExecuteSmoothDelta(mouse, request, ct);
+                    response = await ExecuteSmoothDelta(mouse, parameters, ct);
                     break;
 
                 default:
-                    throw new ArgumentException($"Unknown mouse input action: {request.Action}");
+                    throw new ArgumentException($"Unknown mouse input action: {parameters.Action}");
             }
 
             VibeLogger.LogInfo(
                 "simulate_mouse_input_complete",
                 $"Mouse input simulation completed: {response.Message}",
-                new { Action = request.Action.ToString(), Success = response.Success },
+                new { Action = parameters.Action.ToString(), Success = response.Success },
                 correlationId: correlationId
             );
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiTool.cs
@@ -16,52 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         protected override async Task<SimulateMouseUiResponse> ExecuteAsync(SimulateMouseUiSchema parameters, CancellationToken ct)
         {
             SimulateMouseUiUseCase useCase = new();
-            UnityCliLoopMouseUiSimulationResult result =
-                await useCase.SimulateMouseUiAsync(ToRequest(parameters), ct).ConfigureAwait(false);
-            return ToResponse(result);
-        }
-
-        private static UnityCliLoopMouseUiSimulationRequest ToRequest(SimulateMouseUiSchema parameters)
-        {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
-            return new UnityCliLoopMouseUiSimulationRequest
-            {
-                Action = parameters.Action,
-                X = parameters.X,
-                Y = parameters.Y,
-                FromX = parameters.FromX,
-                FromY = parameters.FromY,
-                DragSpeed = parameters.DragSpeed,
-                Duration = parameters.Duration,
-                Button = parameters.Button,
-                BypassRaycast = parameters.BypassRaycast,
-                TargetPath = parameters.TargetPath,
-                DropTargetPath = parameters.DropTargetPath,
-            };
-        }
-
-        private static SimulateMouseUiResponse ToResponse(UnityCliLoopMouseUiSimulationResult result)
-        {
-            if (result == null)
-            {
-                throw new System.ArgumentNullException(nameof(result));
-            }
-
-            return new SimulateMouseUiResponse
-            {
-                Success = result.Success,
-                Message = result.Message,
-                Action = result.Action,
-                HitGameObjectName = result.HitGameObjectName,
-                PositionX = result.PositionX,
-                PositionY = result.PositionY,
-                EndPositionX = result.EndPositionX,
-                EndPositionY = result.EndPositionY,
-            };
+            return await useCase.ExecuteAsync(parameters, ct).ConfigureAwait(false);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiTool.cs
@@ -16,7 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         protected override async Task<SimulateMouseUiResponse> ExecuteAsync(SimulateMouseUiSchema parameters, CancellationToken ct)
         {
             SimulateMouseUiUseCase useCase = new();
-            return await useCase.ExecuteAsync(parameters, ct).ConfigureAwait(false);
+            return await useCase.ExecuteAsync(parameters, ct);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -16,25 +16,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// <summary>
     /// Coordinates EventSystem mouse simulation for the bundled simulate-mouse-ui tool.
     /// </summary>
-    public class SimulateMouseUiUseCase : IUnityCliLoopMouseUiSimulationService
+    public class SimulateMouseUiUseCase
     {
         private const float EXPAND_DURATION = SimulateMouseUiAnimationConstants.EXPAND_DURATION;
         private const float EXPAND_START_SCALE = SimulateMouseUiAnimationConstants.EXPAND_START_SCALE;
         private const float DISSIPATE_DURATION = SimulateMouseUiAnimationConstants.DISSIPATE_DURATION;
         private SynchronizationContext? _mainThreadContext;
 
-        public async Task<UnityCliLoopMouseUiSimulationResult> SimulateMouseUiAsync(
-            UnityCliLoopMouseUiSimulationRequest request,
+        public async Task<SimulateMouseUiResponse> ExecuteAsync(
+            SimulateMouseUiSchema request,
             CancellationToken ct)
         {
+            if (request == null)
+            {
+                throw new System.ArgumentNullException(nameof(request));
+            }
+
             ct.ThrowIfCancellationRequested();
             CaptureMainThreadContext();
-            MouseUiSimulationCommand parameters = MouseUiSimulationCommand.FromRequest(request);
+            MouseUiSimulationCommand parameters = MouseUiSimulationCommand.FromSchema(request);
 
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
             EventSystem? eventSystem = EventSystem.current;
-            UnityCliLoopMouseUiSimulationResult? validationFailure = ValidateSimulationStart(parameters, eventSystem);
+            SimulateMouseUiResponse? validationFailure = ValidateSimulationStart(parameters, eventSystem);
             if (validationFailure != null)
             {
                 return validationFailure;
@@ -45,20 +50,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             LogSimulationStart(parameters, correlationId);
             EnsureOverlayExists();
 
-            UnityCliLoopMouseUiSimulationResult? dragStateFailure = ValidateActiveDragState(parameters);
+            SimulateMouseUiResponse? dragStateFailure = ValidateActiveDragState(parameters);
             if (dragStateFailure != null)
             {
                 return dragStateFailure;
             }
 
-            UnityCliLoopMouseUiSimulationResult response =
+            SimulateMouseUiResponse response =
                 await ExecuteMouseAction(parameters, activeEventSystem, ct).ConfigureAwait(false);
             LogSimulationComplete(parameters, response, correlationId);
 
             return response;
         }
 
-        private static UnityCliLoopMouseUiSimulationResult? ValidateSimulationStart(
+        private static SimulateMouseUiResponse? ValidateSimulationStart(
             MouseUiSimulationCommand parameters,
             EventSystem? eventSystem)
         {
@@ -79,7 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ValidateSimulationRequestOptions(parameters);
         }
 
-        private static UnityCliLoopMouseUiSimulationResult? ValidateSimulationRequestOptions(
+        private static SimulateMouseUiResponse? ValidateSimulationRequestOptions(
             MouseUiSimulationCommand parameters)
         {
             if (parameters.Action != MouseAction.Click && parameters.Action != MouseAction.LongPress && parameters.DragSpeed < 0f)
@@ -118,7 +123,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        private static UnityCliLoopMouseUiSimulationResult? ValidateActiveDragState(MouseUiSimulationCommand parameters)
+        private static SimulateMouseUiResponse? ValidateActiveDragState(MouseUiSimulationCommand parameters)
         {
             if (!MouseDragState.IsDragging || !RequiresIdlePointer(parameters.Action))
             {
@@ -135,11 +140,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return action == MouseAction.Click || action == MouseAction.Drag || action == MouseAction.LongPress;
         }
 
-        private static UnityCliLoopMouseUiSimulationResult CreateFailure(
+        private static SimulateMouseUiResponse CreateFailure(
             MouseUiSimulationCommand parameters,
             string message)
         {
-            return new UnityCliLoopMouseUiSimulationResult
+            return new SimulateMouseUiResponse
             {
                 Success = false,
                 Message = message,
@@ -167,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void LogSimulationComplete(
             MouseUiSimulationCommand parameters,
-            UnityCliLoopMouseUiSimulationResult response,
+            SimulateMouseUiResponse response,
             string correlationId)
         {
             VibeLogger.LogInfo(
@@ -178,7 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             );
         }
 
-        private async Task<UnityCliLoopMouseUiSimulationResult> ExecuteMouseAction(
+        private async Task<SimulateMouseUiResponse> ExecuteMouseAction(
             MouseUiSimulationCommand parameters,
             EventSystem eventSystem,
             CancellationToken ct)
@@ -241,7 +246,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new Vector2(screenPos.x, targetHeight - screenPos.y);
         }
 
-        private async Task<UnityCliLoopMouseUiSimulationResult> ExecuteClick(
+        private async Task<SimulateMouseUiResponse> ExecuteClick(
             MouseUiSimulationCommand parameters, EventSystem eventSystem, CancellationToken ct)
         {
             Vector2 inputPos = new(parameters.X, parameters.Y);
@@ -256,7 +261,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (parameters.BypassRaycast && resolvedTargets.Target == null)
             {
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = $"TargetPath '{parameters.TargetPath}' has no pointer click or pointer down handler.",
@@ -294,12 +299,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return CreateClickResult(parameters, inputPos, targetName, hitTarget);
         }
 
-        private async Task<UnityCliLoopMouseUiSimulationResult> ExecuteLongPress(
+        private async Task<SimulateMouseUiResponse> ExecuteLongPress(
             MouseUiSimulationCommand parameters, EventSystem eventSystem, CancellationToken ct)
         {
             if (parameters.Duration <= 0f || float.IsNaN(parameters.Duration) || float.IsInfinity(parameters.Duration))
             {
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = $"Duration must be positive, got: {parameters.Duration}",
@@ -319,7 +324,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (parameters.BypassRaycast && resolvedTargets.Target == null)
             {
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = $"TargetPath '{parameters.TargetPath}' has no pointer down or pointer click handler.",
@@ -433,7 +438,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 action,
                 inputPos,
                 out GameObject? rawTarget,
-                out UnityCliLoopMouseUiSimulationResult? failureResponse))
+                out SimulateMouseUiResponse? failureResponse))
             {
                 return ResolvedPointerTargets.Failure(failureResponse);
             }
@@ -551,7 +556,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return pointerData;
         }
 
-        private async Task<UnityCliLoopMouseUiSimulationResult> ExecuteDragOneShot(
+        private async Task<SimulateMouseUiResponse> ExecuteDragOneShot(
             MouseUiSimulationCommand parameters, EventSystem eventSystem, CancellationToken ct)
         {
             Vector2 inputStart = new(parameters.FromX, parameters.FromY);
@@ -570,7 +575,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     MouseAction.Drag,
                     inputStart,
                     out rawTarget,
-                    out UnityCliLoopMouseUiSimulationResult? failureResponse))
+                    out SimulateMouseUiResponse? failureResponse))
                 {
                     return failureResponse!;
                 }
@@ -589,7 +594,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 MouseAction.Drag,
                 inputEnd,
                 out explicitDropTarget,
-                out UnityCliLoopMouseUiSimulationResult? dropFailureResponse))
+                out SimulateMouseUiResponse? dropFailureResponse))
             {
                 return dropFailureResponse!;
             }
@@ -619,7 +624,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = parameters.BypassRaycast
@@ -782,12 +787,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
-        private async Task<UnityCliLoopMouseUiSimulationResult> ExecuteDragStart(
+        private async Task<SimulateMouseUiResponse> ExecuteDragStart(
             MouseUiSimulationCommand parameters, EventSystem eventSystem, CancellationToken ct)
         {
             if (MouseDragState.IsDragging)
             {
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = "A drag is already in progress. Call DragEnd first.",
@@ -811,7 +816,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     MouseAction.DragStart,
                     inputPos,
                     out rawTarget,
-                    out UnityCliLoopMouseUiSimulationResult? failureResponse))
+                    out SimulateMouseUiResponse? failureResponse))
                 {
                     return failureResponse!;
                 }
@@ -848,7 +853,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = parameters.BypassRaycast
@@ -896,7 +901,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
             }
 
-            return new UnityCliLoopMouseUiSimulationResult
+            return new SimulateMouseUiResponse
             {
                 Success = true,
                 Message = $"Drag started on '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1})",
@@ -907,12 +912,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private async Task<UnityCliLoopMouseUiSimulationResult> ExecuteDragMove(
+        private async Task<SimulateMouseUiResponse> ExecuteDragMove(
             MouseUiSimulationCommand parameters, CancellationToken ct)
         {
             if (!MouseDragState.IsDragging)
             {
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = "No drag in progress. Call DragStart first.",
@@ -925,7 +930,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(MouseDragState.Target != null, "Target must not be null when IsDragging is true");
             Debug.Assert(MouseDragState.PointerData != null, "PointerData must not be null when IsDragging is true");
 
-            UnityCliLoopMouseUiSimulationResult? invalidResponse = ValidateDragStillActive(parameters.Action);
+            SimulateMouseUiResponse? invalidResponse = ValidateDragStillActive(parameters.Action);
             if (invalidResponse != null)
             {
                 return invalidResponse;
@@ -956,7 +961,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             SimulateMouseUiOverlayState.AddWaypoint(inputEnd);
 
-            return new UnityCliLoopMouseUiSimulationResult
+            return new SimulateMouseUiResponse
             {
                 Success = true,
                 Message = $"Drag moved on '{targetName}' to ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s",
@@ -967,12 +972,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private async Task<UnityCliLoopMouseUiSimulationResult> ExecuteDragEnd(
+        private async Task<SimulateMouseUiResponse> ExecuteDragEnd(
             MouseUiSimulationCommand parameters, CancellationToken ct)
         {
             if (!MouseDragState.IsDragging)
             {
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = "No drag in progress. Call DragStart first.",
@@ -985,7 +990,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(MouseDragState.Target != null, "Target must not be null when IsDragging is true");
             Debug.Assert(MouseDragState.PointerData != null, "PointerData must not be null when IsDragging is true");
 
-            UnityCliLoopMouseUiSimulationResult? invalidResponse = ValidateDragStillActive(parameters.Action);
+            SimulateMouseUiResponse? invalidResponse = ValidateDragStillActive(parameters.Action);
             if (invalidResponse != null)
             {
                 return invalidResponse;
@@ -1003,7 +1008,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 MouseAction.DragEnd,
                 inputEnd,
                 out explicitDropTarget,
-                out UnityCliLoopMouseUiSimulationResult? dropFailureResponse))
+                out SimulateMouseUiResponse? dropFailureResponse))
             {
                 return dropFailureResponse!;
             }
@@ -1059,13 +1064,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // User input during a CLI drag can cause Unity's StandaloneInputModule to
         // release or reassign the drag, leaving MouseDragState stale.
-        private UnityCliLoopMouseUiSimulationResult? ValidateDragStillActive(MouseAction action)
+        private SimulateMouseUiResponse? ValidateDragStillActive(MouseAction action)
         {
             if (!MouseDragState.Target!.activeInHierarchy)
             {
                 MouseDragState.Clear();
                 SimulateMouseUiOverlayState.Clear();
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = "Drag target was destroyed or deactivated during drag.",
@@ -1078,7 +1083,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 MouseDragState.Clear();
                 SimulateMouseUiOverlayState.Clear();
-                return new UnityCliLoopMouseUiSimulationResult
+                return new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = "Drag was interrupted by user input or system event.",
@@ -1190,13 +1195,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             context.Post(_ => cleanup(), null);
         }
 
-        private static UnityCliLoopMouseUiSimulationResult CreateFrameTimeoutResult(
+        private static SimulateMouseUiResponse CreateFrameTimeoutResult(
             MouseAction action,
             Vector2 position,
             Vector2? endPosition,
             string? hitGameObjectName)
         {
-            return new UnityCliLoopMouseUiSimulationResult
+            return new SimulateMouseUiResponse
             {
                 Success = false,
                 Message = $"Timed out after {UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS}ms while waiting for an editor frame.",
@@ -1209,13 +1214,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static UnityCliLoopMouseUiSimulationResult CreateClickResult(
+        private static SimulateMouseUiResponse CreateClickResult(
             MouseUiSimulationCommand parameters,
             Vector2 inputPos,
             string? targetName,
             bool hitTarget)
         {
-            return new UnityCliLoopMouseUiSimulationResult
+            return new SimulateMouseUiResponse
             {
                 Success = true,
                 Message = hitTarget
@@ -1230,13 +1235,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static UnityCliLoopMouseUiSimulationResult CreateLongPressResult(
+        private static SimulateMouseUiResponse CreateLongPressResult(
             MouseUiSimulationCommand parameters,
             Vector2 inputPos,
             string? targetName,
             bool hitTarget)
         {
-            return new UnityCliLoopMouseUiSimulationResult
+            return new SimulateMouseUiResponse
             {
                 Success = true,
                 Message = hitTarget
@@ -1251,13 +1256,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static UnityCliLoopMouseUiSimulationResult CreateDragResult(
+        private static SimulateMouseUiResponse CreateDragResult(
             MouseUiSimulationCommand parameters,
             Vector2 inputStart,
             Vector2 inputEnd,
             string targetName)
         {
-            return new UnityCliLoopMouseUiSimulationResult
+            return new SimulateMouseUiResponse
             {
                 Success = true,
                 Message = parameters.BypassRaycast
@@ -1272,12 +1277,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static UnityCliLoopMouseUiSimulationResult CreateDragEndResult(
+        private static SimulateMouseUiResponse CreateDragEndResult(
             MouseUiSimulationCommand parameters,
             Vector2 inputEnd,
             string targetName)
         {
-            return new UnityCliLoopMouseUiSimulationResult
+            return new SimulateMouseUiResponse
             {
                 Success = true,
                 Message = $"Drag ended on '{targetName}' at ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s",
@@ -1314,7 +1319,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MouseAction action,
             Vector2 inputPosition,
             out GameObject? target,
-            out UnityCliLoopMouseUiSimulationResult? failureResponse)
+            out SimulateMouseUiResponse? failureResponse)
         {
             TargetPathLookupResult lookupResult = FindActiveGameObjectByPath(targetPath);
             target = lookupResult.Target;
@@ -1328,7 +1333,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ? $"{parameterName} '{targetPath}' was not found."
                 : $"{parameterName} '{targetPath}' matched {lookupResult.MatchCount} active GameObjects. Use a unique hierarchy path.";
 
-            failureResponse = new UnityCliLoopMouseUiSimulationResult
+            failureResponse = new SimulateMouseUiResponse
             {
                 Success = false,
                 Message = message,
@@ -1344,7 +1349,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MouseAction action,
             Vector2 inputPosition,
             out GameObject? dropTarget,
-            out UnityCliLoopMouseUiSimulationResult? failureResponse)
+            out SimulateMouseUiResponse? failureResponse)
         {
             dropTarget = null;
             failureResponse = null;
@@ -1368,7 +1373,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             GameObject? dropHandler = ExecuteEvents.GetEventHandler<IDropHandler>(rawDropTarget!);
             if (dropHandler == null)
             {
-                failureResponse = new UnityCliLoopMouseUiSimulationResult
+                failureResponse = new SimulateMouseUiResponse
                 {
                     Success = false,
                     Message = $"DropTargetPath '{parameters.DropTargetPath}' has no drop handler.",
@@ -1427,7 +1432,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         private sealed class MouseUiSimulationCommand
         {
-            private MouseUiSimulationCommand(UnityCliLoopMouseUiSimulationRequest request)
+            private MouseUiSimulationCommand(SimulateMouseUiSchema request)
             {
                 if (request == null)
                 {
@@ -1459,7 +1464,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public string TargetPath { get; }
             public string DropTargetPath { get; }
 
-            public static MouseUiSimulationCommand FromRequest(UnityCliLoopMouseUiSimulationRequest request)
+            public static MouseUiSimulationCommand FromSchema(SimulateMouseUiSchema request)
             {
                 return new MouseUiSimulationCommand(request);
             }
@@ -1518,7 +1523,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 GameObject? pressTarget,
                 GameObject? clickTarget,
                 GameObject? target,
-                UnityCliLoopMouseUiSimulationResult? failureResponse)
+                SimulateMouseUiResponse? failureResponse)
             {
                 RawTarget = rawTarget;
                 PressTarget = pressTarget;
@@ -1534,7 +1539,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public GameObject? PressTarget { get; }
             public GameObject? ClickTarget { get; }
             public GameObject? Target { get; }
-            public UnityCliLoopMouseUiSimulationResult? FailureResponse { get; }
+            public SimulateMouseUiResponse? FailureResponse { get; }
 
             public static ResolvedPointerTargets Success(
                 GameObject rawTarget,
@@ -1546,7 +1551,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             public static ResolvedPointerTargets Failure(
-                UnityCliLoopMouseUiSimulationResult? failureResponse)
+                SimulateMouseUiResponse? failureResponse)
             {
                 Debug.Assert(failureResponse != null, "Failure response must exist when target resolution fails.");
                 return new ResolvedPointerTargets(null, null, null, null, failureResponse);


### PR DESCRIPTION
## Summary
- Removes the intermediate DTO layer shared by the three input-simulation tools (SimulateKeyboard, SimulateMouseInput, SimulateMouseUi): the three `IUnityCliLoop*SimulationService` interfaces and six `UnityCliLoop*SimulationRequest`/`Result` classes, which only performed field-by-field copies. Third PR in the series after #1514 (Compile) and #1515 (RunTests).

## User Impact
- No user-visible change. All three tool responses stay identical.

## Changes
- Each use case now takes its wire Schema and returns its wire Response directly; the tools' ToRequest/ToResponse mapping helpers are deleted.
- The shared types file keeps the real domain vocabulary (the four action/button enums, `UnityCliLoopInputSimulationDefaults`, `UnityCliLoopPausePointHit`) — those are consumed by the wire DTOs themselves.
- Explicit ArgumentNullException guards sit at each use-case entry, matching the precedent set in the earlier collapses.
- No SessionState or persistence path exists for these results, so there is no stored-shape compatibility constraint. Repo-wide grep confirms zero remaining references to the nine deleted types.
- The assembly-boundary guard test that referenced the deleted types is removed; sibling guards remain.

## Verification
- `dist/darwin-arm64/uloop compile` → 0 errors, 0 warnings.
- `dist/darwin-arm64/uloop run-tests --filter-type regex --filter-value "(Simulate|StaticFacadeStateGuard|OnionAssemblyDependency).*Tests"` → 93 passed, 0 failed, 0 skipped.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

