### PR TITLE
chore: Consolidate the PlayMode preflight checks shared by input tools

### DIFF
--- a/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
+++ b/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
@@ -1,0 +1,81 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies PlayMode preflight validation shared by first-party tool use cases.
+    /// </summary>
+    public class PlayModeToolPreflightServiceTests
+    {
+        private const string ExpectedNotActiveMessage =
+            "PlayMode is not active. Use control-play-mode tool to start PlayMode first.";
+
+        [Test]
+        public void RequireActive_WhenEditModeIsNotPlaying_ReturnsNotActiveFailure()
+        {
+            // Verifies the active-only preflight fails with the exact wire-visible not-active message.
+            ValidationResult result = PlayModeToolPreflightService.RequireActive();
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo(ExpectedNotActiveMessage));
+        }
+
+        [Test]
+        public void RequireActiveAndNotPaused_WhenEditModeIsNotPlaying_ReturnsNotActiveFailure()
+        {
+            // Verifies the paused-aware preflight also fails with the exact not-active message when PlayMode is inactive.
+            ValidationResult result = PlayModeToolPreflightService.RequireActiveAndNotPaused("recording input");
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo(ExpectedNotActiveMessage));
+        }
+
+        [Test]
+        public void PlayModeNotActiveMessage_MatchesOriginalToolResponseString()
+        {
+            // Pins the not-active constant exposed to callers so any refactor keeps the wire string byte-identical.
+            Assert.That(
+                PlayModeToolPreflightService.PlayModeNotActiveMessage,
+                Is.EqualTo(ExpectedNotActiveMessage));
+        }
+
+        [Test]
+        public void FormatPausedMessage_WithRecordingInputSuffix_MatchesOriginalToolResponse()
+        {
+            // Pins RecordInput's exact wire-visible paused message.
+            Assert.That(
+                PlayModeToolPreflightService.FormatPausedMessage("recording input"),
+                Is.EqualTo("PlayMode is paused. Resume PlayMode before recording input."));
+        }
+
+        [Test]
+        public void FormatPausedMessage_WithReplayingInputSuffix_MatchesOriginalToolResponse()
+        {
+            // Pins ReplayInput's exact wire-visible paused message.
+            Assert.That(
+                PlayModeToolPreflightService.FormatPausedMessage("replaying input"),
+                Is.EqualTo("PlayMode is paused. Resume PlayMode before replaying input."));
+        }
+
+        [Test]
+        public void FormatPausedMessage_WithSimulatingKeyboardInputSuffix_MatchesOriginalToolResponse()
+        {
+            // Pins SimulateKeyboard's exact wire-visible paused message.
+            Assert.That(
+                PlayModeToolPreflightService.FormatPausedMessage("simulating keyboard input"),
+                Is.EqualTo("PlayMode is paused. Resume PlayMode before simulating keyboard input."));
+        }
+
+        [Test]
+        public void FormatPausedMessage_WithSimulatingMouseInputSuffix_MatchesOriginalToolResponse()
+        {
+            // Pins SimulateMouseInput's exact wire-visible paused message.
+            Assert.That(
+                PlayModeToolPreflightService.FormatPausedMessage("simulating mouse input"),
+                Is.EqualTo("PlayMode is paused. Resume PlayMode before simulating mouse input."));
+        }
+    }
+}

--- a/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
+++ b/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
@@ -27,14 +27,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void RequireActiveAndNotPaused_WhenEditModeIsNotPlaying_ReturnsNotActiveFailure()
         {
             // Verifies the paused-aware preflight also fails with the exact not-active message when PlayMode is inactive.
-            ValidationResult result = PlayModeToolPreflightService.RequireActiveAndNotPaused("recording input");
+            ValidationResult result = PlayModeToolPreflightService.RequireActiveAndNotPaused(RecordInputUseCase.PausedActionDescription);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(result.ErrorMessage, Is.EqualTo(ExpectedNotActiveMessage));
         }
 
         [Test]
-        public void PlayModeNotActiveMessage_MatchesOriginalToolResponseString()
+        public void PlayModeNotActiveMessage_EqualsExpectedWireString()
         {
             // Pins the not-active constant exposed to callers so any refactor keeps the wire string byte-identical.
             Assert.That(
@@ -43,38 +43,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void FormatPausedMessage_WithRecordingInputSuffix_MatchesOriginalToolResponse()
+        public void FormatPausedMessage_WithRecordInputSuffix_ReturnsExpectedWireString()
         {
-            // Pins RecordInput's exact wire-visible paused message.
+            // Verifies RecordInput's paused preflight message stays byte-identical, including the suffix the use case actually passes.
             Assert.That(
-                PlayModeToolPreflightService.FormatPausedMessage("recording input"),
+                PlayModeToolPreflightService.FormatPausedMessage(RecordInputUseCase.PausedActionDescription),
                 Is.EqualTo("PlayMode is paused. Resume PlayMode before recording input."));
         }
 
         [Test]
-        public void FormatPausedMessage_WithReplayingInputSuffix_MatchesOriginalToolResponse()
+        public void FormatPausedMessage_WithReplayInputSuffix_ReturnsExpectedWireString()
         {
-            // Pins ReplayInput's exact wire-visible paused message.
+            // Verifies ReplayInput's paused preflight message stays byte-identical, including the suffix the use case actually passes.
             Assert.That(
-                PlayModeToolPreflightService.FormatPausedMessage("replaying input"),
+                PlayModeToolPreflightService.FormatPausedMessage(ReplayInputUseCase.PausedActionDescription),
                 Is.EqualTo("PlayMode is paused. Resume PlayMode before replaying input."));
         }
 
         [Test]
-        public void FormatPausedMessage_WithSimulatingKeyboardInputSuffix_MatchesOriginalToolResponse()
+        public void FormatPausedMessage_WithSimulateKeyboardSuffix_ReturnsExpectedWireString()
         {
-            // Pins SimulateKeyboard's exact wire-visible paused message.
+            // Verifies SimulateKeyboard's paused preflight message stays byte-identical, including the suffix the use case actually passes.
             Assert.That(
-                PlayModeToolPreflightService.FormatPausedMessage("simulating keyboard input"),
+                PlayModeToolPreflightService.FormatPausedMessage(SimulateKeyboardUseCase.PausedActionDescription),
                 Is.EqualTo("PlayMode is paused. Resume PlayMode before simulating keyboard input."));
         }
 
         [Test]
-        public void FormatPausedMessage_WithSimulatingMouseInputSuffix_MatchesOriginalToolResponse()
+        public void FormatPausedMessage_WithSimulateMouseInputSuffix_ReturnsExpectedWireString()
         {
-            // Pins SimulateMouseInput's exact wire-visible paused message.
+            // Verifies SimulateMouseInput's paused preflight message stays byte-identical, including the suffix the use case actually passes.
             Assert.That(
-                PlayModeToolPreflightService.FormatPausedMessage("simulating mouse input"),
+                PlayModeToolPreflightService.FormatPausedMessage(SimulateMouseInputUseCase.PausedActionDescription),
                 Is.EqualTo("PlayMode is paused. Resume PlayMode before simulating mouse input."));
         }
     }

--- a/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs.meta
+++ b/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7866aa6f39e643ca93d7e1c96c9d15c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef
+++ b/Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef
@@ -36,7 +36,8 @@
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
-        "GUID:332048ead1ebf4658b9961338e5d68c3"
+        "GUID:332048ead1ebf4658b9961338e5d68c3",
+        "GUID:33fef506e6744f2982e8c13b1196f696"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/Common/Preflight.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/Preflight.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e2c742533f948fbb813a89bcbb9f1a2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/Common/Preflight/PlayModeToolPreflightService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/Preflight/PlayModeToolPreflightService.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Provides shared PlayMode preflight validation for first-party tools that require Unity to be in PlayMode.
+    /// </summary>
+    public static class PlayModeToolPreflightService
+    {
+        // The not-active message is a wire-visible tool response, so callers must reproduce it byte-for-byte.
+        public const string PlayModeNotActiveMessage =
+            "PlayMode is not active. Use control-play-mode tool to start PlayMode first.";
+
+        /// <summary>
+        /// Fails when PlayMode is not active. Use for tools that tolerate paused PlayMode.
+        /// </summary>
+        public static ValidationResult RequireActive()
+        {
+            if (!EditorApplication.isPlaying)
+            {
+                return ValidationResult.Failure(PlayModeNotActiveMessage);
+            }
+
+            return ValidationResult.Success();
+        }
+
+        /// <summary>
+        /// Fails when PlayMode is not active, or is active but paused. The paused-message suffix
+        /// describes the blocked action in the caller's vocabulary (for example "recording input").
+        /// </summary>
+        public static ValidationResult RequireActiveAndNotPaused(string pausedActionDescription)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(pausedActionDescription), "pausedActionDescription must not be null or empty");
+
+            if (!EditorApplication.isPlaying)
+            {
+                return ValidationResult.Failure(PlayModeNotActiveMessage);
+            }
+
+            if (EditorApplication.isPaused)
+            {
+                return ValidationResult.Failure(FormatPausedMessage(pausedActionDescription));
+            }
+
+            return ValidationResult.Success();
+        }
+
+        /// <summary>
+        /// Composes the paused-mode failure message. Exposed so tests can pin the exact
+        /// wire-visible string for each caller's action suffix.
+        /// </summary>
+        public static string FormatPausedMessage(string pausedActionDescription)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(pausedActionDescription), "pausedActionDescription must not be null or empty");
+            return $"PlayMode is paused. Resume PlayMode before {pausedActionDescription}.";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/Preflight/PlayModeToolPreflightService.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/Preflight/PlayModeToolPreflightService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7dd6e5b051c44696b11823e8d34d35f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/Common/Preflight/UnityCLILoop.FirstPartyTools.Common.Preflight.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/Preflight/UnityCLILoop.FirstPartyTools.Common.Preflight.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "UnityCLILoop.FirstPartyTools.Common.Preflight.Editor",
+    "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
+    "references": [
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/Preflight/UnityCLILoop.FirstPartyTools.Common.Preflight.Editor.asmdef.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/Preflight/UnityCLILoop.FirstPartyTools.Common.Preflight.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 33fef506e6744f2982e8c13b1196f696
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
@@ -23,6 +23,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class RecordInputUseCase : IUnityCliLoopRecordInputService
     {
+        // Wire-visible fragment of the paused preflight message; tests pin the composed string.
+        public const string PausedActionDescription = "recording input";
+
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning disable CS1998
 #endif
@@ -88,7 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityCliLoopRecordInputRequest request,
             CancellationToken ct)
         {
-            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused("recording input");
+            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused(PausedActionDescription);
             if (!preflight.IsValid)
             {
                 return new UnityCliLoopRecordInputResult

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
@@ -88,22 +88,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityCliLoopRecordInputRequest request,
             CancellationToken ct)
         {
-            if (!EditorApplication.isPlaying)
+            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused("recording input");
+            if (!preflight.IsValid)
             {
                 return new UnityCliLoopRecordInputResult
                 {
                     Success = false,
-                    Message = "PlayMode is not active. Use control-play-mode tool to start PlayMode first.",
-                    Action = RecordInputAction.Start.ToString()
-                };
-            }
-
-            if (EditorApplication.isPaused)
-            {
-                return new UnityCliLoopRecordInputResult
-                {
-                    Success = false,
-                    Message = "PlayMode is paused. Resume PlayMode before recording input.",
+                    Message = preflight.ErrorMessage,
                     Action = RecordInputAction.Start.ToString()
                 };
             }

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/UnityCLILoop.FirstPartyTools.RecordInput.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/UnityCLILoop.FirstPartyTools.RecordInput.Editor.asmdef
@@ -8,7 +8,8 @@
         "GUID:45d3617c96fa64d3e95383450e67f25a",
         "GUID:aa7cf56cc5f074e57ba35272b877e116",
         "GUID:c956a21f824994ef087b6de566690b3d",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:33fef506e6744f2982e8c13b1196f696"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using UnityEditor;
 using UnityEngine;
 #if ULOOP_HAS_INPUT_SYSTEM
 using UnityEngine.InputSystem;
@@ -85,22 +84,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 #if ULOOP_HAS_INPUT_SYSTEM
         private static UnityCliLoopReplayInputResult ExecuteStart(UnityCliLoopReplayInputRequest request)
         {
-            if (!EditorApplication.isPlaying)
+            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused("replaying input");
+            if (!preflight.IsValid)
             {
                 return new UnityCliLoopReplayInputResult
                 {
                     Success = false,
-                    Message = "PlayMode is not active. Use control-play-mode tool to start PlayMode first.",
-                    Action = ReplayInputAction.Start.ToString()
-                };
-            }
-
-            if (EditorApplication.isPaused)
-            {
-                return new UnityCliLoopReplayInputResult
-                {
-                    Success = false,
-                    Message = "PlayMode is paused. Resume PlayMode before replaying input.",
+                    Message = preflight.ErrorMessage,
                     Action = ReplayInputAction.Start.ToString()
                 };
             }

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
@@ -20,6 +20,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class ReplayInputUseCase : IUnityCliLoopReplayInputService
     {
+        // Wire-visible fragment of the paused preflight message; tests pin the composed string.
+        public const string PausedActionDescription = "replaying input";
+
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning disable CS1998
 #endif
@@ -84,7 +87,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 #if ULOOP_HAS_INPUT_SYSTEM
         private static UnityCliLoopReplayInputResult ExecuteStart(UnityCliLoopReplayInputRequest request)
         {
-            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused("replaying input");
+            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused(PausedActionDescription);
             if (!preflight.IsValid)
             {
                 return new UnityCliLoopReplayInputResult

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/UnityCLILoop.FirstPartyTools.ReplayInput.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/UnityCLILoop.FirstPartyTools.ReplayInput.Editor.asmdef
@@ -8,7 +8,8 @@
         "GUID:a2d87883023de4cf59b7d1962d5dd8aa",
         "GUID:aa7cf56cc5f074e57ba35272b877e116",
         "GUID:c956a21f824994ef087b6de566690b3d",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:33fef506e6744f2982e8c13b1196f696"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -19,6 +19,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class SimulateKeyboardUseCase
     {
+        // Wire-visible fragment of the paused preflight message; tests pin the composed string.
+        public const string PausedActionDescription = "simulating keyboard input";
+
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning disable CS1998
 #endif
@@ -46,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 #else
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
-            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused("simulating keyboard input");
+            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused(PausedActionDescription);
             if (!preflight.IsValid)
             {
                 return new SimulateKeyboardResponse

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -46,22 +46,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 #else
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
-            if (!EditorApplication.isPlaying)
+            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused("simulating keyboard input");
+            if (!preflight.IsValid)
             {
                 return new SimulateKeyboardResponse
                 {
                     Success = false,
-                    Message = "PlayMode is not active. Use control-play-mode tool to start PlayMode first.",
-                    Action = parameters.Action.ToString()
-                };
-            }
-
-            if (EditorApplication.isPaused)
-            {
-                return new SimulateKeyboardResponse
-                {
-                    Success = false,
-                    Message = "PlayMode is paused. Resume PlayMode before simulating keyboard input.",
+                    Message = preflight.ErrorMessage,
                     Action = parameters.Action.ToString()
                 };
             }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor.asmdef
@@ -8,7 +8,8 @@
         "GUID:527f26a36b5043c2bd4d4036d04cd76d",
         "GUID:aa7cf56cc5f074e57ba35272b877e116",
         "GUID:c956a21f824994ef087b6de566690b3d",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:33fef506e6744f2982e8c13b1196f696"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -47,22 +47,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 #else
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
-            if (!EditorApplication.isPlaying)
+            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused("simulating mouse input");
+            if (!preflight.IsValid)
             {
                 return new SimulateMouseInputResponse
                 {
                     Success = false,
-                    Message = "PlayMode is not active. Use control-play-mode tool to start PlayMode first.",
-                    Action = parameters.Action.ToString()
-                };
-            }
-
-            if (EditorApplication.isPaused)
-            {
-                return new SimulateMouseInputResponse
-                {
-                    Success = false,
-                    Message = "PlayMode is paused. Resume PlayMode before simulating mouse input.",
+                    Message = preflight.ErrorMessage,
                     Action = parameters.Action.ToString()
                 };
             }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -20,6 +20,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class SimulateMouseInputUseCase
     {
+        // Wire-visible fragment of the paused preflight message; tests pin the composed string.
+        public const string PausedActionDescription = "simulating mouse input";
+
 #if !ULOOP_HAS_INPUT_SYSTEM
 #pragma warning disable CS1998
 #endif
@@ -47,7 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 #else
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
-            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused("simulating mouse input");
+            ValidationResult preflight = PlayModeToolPreflightService.RequireActiveAndNotPaused(PausedActionDescription);
             if (!preflight.IsValid)
             {
                 return new SimulateMouseInputResponse

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor.asmdef
@@ -8,7 +8,8 @@
         "GUID:527f26a36b5043c2bd4d4036d04cd76d",
         "GUID:aa7cf56cc5f074e57ba35272b877e116",
         "GUID:c956a21f824994ef087b6de566690b3d",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:33fef506e6744f2982e8c13b1196f696"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -67,11 +67,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MouseUiSimulationCommand parameters,
             EventSystem? eventSystem)
         {
-            if (!EditorApplication.isPlaying)
+            ValidationResult playModeResult = PlayModeToolPreflightService.RequireActive();
+            if (!playModeResult.IsValid)
             {
-                return CreateFailure(
-                    parameters,
-                    "PlayMode is not active. Use control-play-mode tool to start PlayMode first.");
+                return CreateFailure(parameters, playModeResult.ErrorMessage);
             }
 
             if (eventSystem == null)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor.asmdef
@@ -7,7 +7,8 @@
         "GUID:f1a38fcd7e85047c5a86331a3e37ddfc",
         "GUID:a2d87883023de4cf59b7d1962d5dd8aa",
         "GUID:aa7cf56cc5f074e57ba35272b877e116",
-        "GUID:c956a21f824994ef087b6de566690b3d"
+        "GUID:c956a21f824994ef087b6de566690b3d",
+        "GUID:33fef506e6744f2982e8c13b1196f696"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
## Summary
- The five PlayMode-dependent input tools (record-input, replay-input, simulate-keyboard, simulate-mouse-input, simulate-mouse-ui) now run one shared PlayMode preflight instead of five hand-copied check blocks.

## User Impact
- No visible change. Every preflight failure message stays byte-identical: the paused-message suffix is passed per tool, and simulate-mouse-ui deliberately keeps its current behavior (no paused check) because adding one would be a behavior change.

## Changes
- Added PlayModeToolPreflightService under FirstPartyTools/Common/Preflight with its own asmdef, matching the existing Common/* layout. It exposes an active-only check and an active-and-not-paused check.
- Reused the existing ValidationResult contract for the result instead of introducing a new DTO.
- The five use cases map the shared result to their own response types; response construction stays per tool.
- New EditMode tests pin the not-active message and all four paused messages byte-for-byte.

## Verification
- uloop compile: 0 errors / 0 warnings
- EditMode suite (preflight + affected tools + architecture guards): 100/100 pass
- PlayMode suites for the simulate/replay tools: 80/80 pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

