### PR TITLE
chore: RunTests result classification no longer depends on message wording

### DIFF
--- a/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs
+++ b/Assets/Tests/Editor/RunTestsNoTestsDiagnosticServiceTests.cs
@@ -13,9 +13,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     public sealed class RunTestsNoTestsDiagnosticServiceTests
     {
         [Test]
-        public void AppendFindingsIfEligible_WhenRunWasSuccessful_DoesNotAppendFindings()
+        public void AppendFindingsIfEligible_WhenNoTestsFoundIsFalse_DoesNotAppendFindings()
         {
-            // Verifies that a normal successful result cannot receive no-test asmdef hints.
+            // Verifies that runs that did discover tests cannot receive no-test asmdef hints.
             RunTestsAsmdefDiagnosticFinding[] findings =
             {
                 new RunTestsAsmdefDiagnosticFinding("Assets/Tests/EditMode/Sample.Tests.asmdef", "sample finding")
@@ -23,8 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             string message = RunTestsNoTestsDiagnosticService.AppendFindingsIfEligible(
                 RunTestsResponse.NoTestsFoundMessage,
-                success: true,
-                testCount: 1,
+                noTestsFound: false,
                 findings);
 
             Assert.That(message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
@@ -33,32 +32,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void AppendFindingsIfEligible_WhenNoFindingsExist_DoesNotAppendGenericHint()
         {
-            // Verifies that filter-only no-discovery results stay unchanged when asmdefs look healthy.
+            // Verifies that no-discovery results stay unchanged when asmdefs look healthy.
             string message = RunTestsNoTestsDiagnosticService.AppendFindingsIfEligible(
                 RunTestsResponse.NoTestsFoundMessage,
-                success: false,
-                testCount: 0,
+                noTestsFound: true,
                 Array.Empty<RunTestsAsmdefDiagnosticFinding>());
 
             Assert.That(message, Is.EqualTo(RunTestsResponse.NoTestsFoundMessage));
         }
 
         [Test]
-        public void AppendFindingsIfEligible_WhenMessageIsNull_DoesNotAppendFindings()
+        public void AppendFindingsIfEligible_WhenNoTestsFoundIsTrueAndFindingsExist_AppendsHint()
         {
-            // Verifies unset result messages are ignored by no-test diagnostics.
+            // Verifies that asmdef hints are appended to the original message when no tests were discovered.
             RunTestsAsmdefDiagnosticFinding[] findings =
             {
                 new RunTestsAsmdefDiagnosticFinding("Assets/Tests/EditMode/Sample.Tests.asmdef", "sample finding")
             };
 
             string message = RunTestsNoTestsDiagnosticService.AppendFindingsIfEligible(
-                null,
-                success: false,
-                testCount: 0,
+                RunTestsResponse.NoTestsFoundMessage,
+                noTestsFound: true,
                 findings);
 
-            Assert.That(message, Is.Null);
+            Assert.That(message, Does.StartWith(RunTestsResponse.NoTestsFoundMessage));
+            Assert.That(message, Does.Contain("Possible asmdef issues"));
+            Assert.That(message, Does.Contain("sample finding"));
         }
 
         [Test]
@@ -87,9 +86,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies that unfiltered no-discovery results can receive asmdef diagnostics.
             bool shouldAppend = RunTestsNoTestsDiagnosticService.ShouldAppendDiagnostics(
-                RunTestsResponse.NoTestsFoundMessage,
-                success: false,
-                testCount: 0,
+                noTestsFound: true,
                 TestFilterType.all);
 
             Assert.That(shouldAppend, Is.True);
@@ -100,10 +97,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies that narrow filter misses cannot receive asmdef diagnostics.
             bool shouldAppend = RunTestsNoTestsDiagnosticService.ShouldAppendDiagnostics(
-                RunTestsResponse.NoTestsFoundMessage,
-                success: false,
-                testCount: 0,
+                noTestsFound: true,
                 TestFilterType.exact);
+
+            Assert.That(shouldAppend, Is.False);
+        }
+
+        [Test]
+        public void ShouldAppendDiagnostics_WhenNoTestsFoundIsFalse_ReturnsFalse()
+        {
+            // Verifies that runs that discovered tests are gated out even under the wide filter.
+            bool shouldAppend = RunTestsNoTestsDiagnosticService.ShouldAppendDiagnostics(
+                noTestsFound: false,
+                TestFilterType.all);
 
             Assert.That(shouldAppend, Is.False);
         }

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -104,41 +104,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void Constructor_WhenLegacySuccessfulCallerOmitsStatus_ShouldDerivePassedStatus()
+        public void Constructor_ShouldStoreEveryArgumentVerbatim()
         {
-            // Verifies source-compatible constructor calls cannot report success as execution failure.
+            // Verifies the constructor propagates every field as supplied instead of deriving any of them.
             RunTestsResponse response = new(
                 success: true,
-                message: "Test execution completed with status: Passed",
+                message: "arbitrary message",
                 completedAt: "2026-01-01T00:00:00.0000000Z",
-                testCount: 1,
-                passedCount: 1,
-                failedCount: 0,
-                skippedCount: 0);
+                testCount: 5,
+                passedCount: 3,
+                failedCount: 2,
+                skippedCount: 1,
+                xmlPath: "/tmp/results.xml",
+                status: "CustomStatus",
+                hasFailures: false,
+                noTestsFound: true,
+                noTestsFoundExplanation: "custom explanation");
 
-            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.Passed));
-            Assert.That(response.HasFailures, Is.False);
-            Assert.That(response.NoTestsFound, Is.False);
-            Assert.That(response.NoTestsFoundExplanation, Is.Empty);
-        }
-
-        [Test]
-        public void Constructor_WhenLegacyNoTestsCallerOmitsStatus_ShouldDeriveNoTestsFoundStatus()
-        {
-            // Verifies source-compatible zero-discovery responses remain distinct from execution failures.
-            RunTestsResponse response = new(
-                success: false,
-                message: RunTestsResponse.NoTestsFoundMessage,
-                completedAt: "2026-01-01T00:00:00.0000000Z",
-                testCount: 0,
-                passedCount: 0,
-                failedCount: 0,
-                skippedCount: 0);
-
-            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.NoTestsFound));
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Message, Is.EqualTo("arbitrary message"));
+            Assert.That(response.CompletedAt, Is.EqualTo("2026-01-01T00:00:00.0000000Z"));
+            Assert.That(response.TestCount, Is.EqualTo(5));
+            Assert.That(response.PassedCount, Is.EqualTo(3));
+            Assert.That(response.FailedCount, Is.EqualTo(2));
+            Assert.That(response.SkippedCount, Is.EqualTo(1));
+            Assert.That(response.XmlPath, Is.EqualTo("/tmp/results.xml"));
+            Assert.That(response.Status, Is.EqualTo("CustomStatus"));
             Assert.That(response.HasFailures, Is.False);
             Assert.That(response.NoTestsFound, Is.True);
-            Assert.That(response.NoTestsFoundExplanation, Does.Contain("not a test failure"));
+            Assert.That(response.NoTestsFoundExplanation, Is.EqualTo("custom explanation"));
         }
     }
-} 
+}

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -294,7 +294,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             public bool TestFrameworkAvailable { get; set; } = true;
             public bool WasCalled { get; private set; }
-            public SerializableTestResult NextResult { get; set; } = new();
+            // Default stub result satisfies RunTestsResponse preconditions (non-null status
+            // and noTestsFoundExplanation); individual tests override NextResult when they
+            // need a specific execution status.
+            public SerializableTestResult NextResult { get; set; } = new()
+            {
+                status = RunTestsExecutionStatus.Passed,
+                noTestsFoundExplanation = string.Empty
+            };
 
             public override bool IsTestFrameworkAvailable => TestFrameworkAvailable;
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsNoTestsDiagnosticService.cs
@@ -24,19 +24,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public string AppendDiagnosticsIfNeeded(
             string message,
-            bool success,
-            int testCount,
+            bool noTestsFound,
             UnityCliLoopTestMode testMode,
             TestFilterType filterType)
         {
-            if (!ShouldAppendDiagnostics(message, success, testCount, filterType))
+            if (!ShouldAppendDiagnostics(noTestsFound, filterType))
             {
                 return message;
             }
 
             RunTestsAsmdefInfo[] asmdefs = LoadProjectAsmdefs();
             RunTestsAsmdefDiagnosticFinding[] findings = Analyze(asmdefs, testMode);
-            return AppendFindingsIfEligible(message, success, testCount, findings);
+            return AppendFindingsIfEligible(message, noTestsFound, findings);
         }
 
         internal static string AppendDiagnosticsOrOriginalMessage(string message, Func<string> appendDiagnostics)
@@ -64,13 +63,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static string AppendFindingsIfEligible(
             string message,
-            bool success,
-            int testCount,
+            bool noTestsFound,
             IReadOnlyList<RunTestsAsmdefDiagnosticFinding> findings)
         {
             Debug.Assert(findings != null, "findings must not be null");
 
-            if (!ShouldInspect(message, success, testCount) || findings.Count == 0)
+            if (!noTestsFound || findings.Count == 0)
             {
                 return message;
             }
@@ -149,20 +147,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return findings.ToArray();
         }
 
-        internal static bool ShouldAppendDiagnostics(
-            string message,
-            bool success,
-            int testCount,
-            TestFilterType filterType)
+        internal static bool ShouldAppendDiagnostics(bool noTestsFound, TestFilterType filterType)
         {
-            return filterType == TestFilterType.all && ShouldInspect(message, success, testCount);
-        }
-
-        internal static bool ShouldInspect(string message, bool success, int testCount)
-        {
-            return !success
-                   && testCount == 0
-                   && string.Equals(message, RunTestsResponse.NoTestsFoundMessage, StringComparison.Ordinal);
+            return filterType == TestFilterType.all && noTestsFound;
         }
 
         private static RunTestsAsmdefInfo[] LoadProjectAsmdefs()

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -78,14 +78,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string XmlPath { get; set; }
 
         /// <summary>
-        /// Create a new RunTestsResponse
+        /// Create a new RunTestsResponse. Every field is required so classification decisions
+        /// stay at the call site (the Unity Test Runner adapter and use-case), not in this DTO.
         /// </summary>
-        public RunTestsResponse(bool success, string message, string completedAt, int testCount, 
-                               int passedCount, int failedCount, int skippedCount, string xmlPath = null,
-                               string status = null,
-                               bool? hasFailures = null,
-                               bool? noTestsFound = null,
-                               string noTestsFoundExplanation = null)
+        public RunTestsResponse(
+            bool success,
+            string message,
+            string completedAt,
+            int testCount,
+            int passedCount,
+            int failedCount,
+            int skippedCount,
+            string xmlPath,
+            string status,
+            bool hasFailures,
+            bool noTestsFound,
+            string noTestsFoundExplanation)
         {
             Success = success;
             Message = message;
@@ -95,12 +103,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             FailedCount = failedCount;
             SkippedCount = skippedCount;
             XmlPath = xmlPath;
-            HasFailures = hasFailures ?? failedCount > 0;
-            NoTestsFound = noTestsFound ?? IsNoTestsFound(success, message, testCount, failedCount);
-            Status = string.IsNullOrEmpty(status)
-                ? DeriveStatus(success, testCount, FailedCount, NoTestsFound)
-                : status;
-            NoTestsFoundExplanation = noTestsFoundExplanation ?? DeriveNoTestsFoundExplanation(NoTestsFound);
+            Status = status;
+            HasFailures = hasFailures;
+            NoTestsFound = noTestsFound;
+            NoTestsFoundExplanation = noTestsFoundExplanation;
         }
 
         /// <summary>
@@ -130,39 +136,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 hasFailures: false,
                 noTestsFound: false,
                 noTestsFoundExplanation: string.Empty);
-        }
-
-        private static bool IsNoTestsFound(bool success, string message, int testCount, int failedCount)
-        {
-            return !success
-                   && testCount == 0
-                   && failedCount == 0
-                   && string.Equals(message, NoTestsFoundMessage, StringComparison.Ordinal);
-        }
-
-        private static string DeriveStatus(bool success, int testCount, int failedCount, bool noTestsFound)
-        {
-            if (noTestsFound)
-            {
-                return RunTestsExecutionStatus.NoTestsFound;
-            }
-
-            if (failedCount > 0)
-            {
-                return RunTestsExecutionStatus.Failed;
-            }
-
-            if (success && testCount > 0)
-            {
-                return RunTestsExecutionStatus.Passed;
-            }
-
-            return RunTestsExecutionStatus.ExecutionFailed;
-        }
-
-        private static string DeriveNoTestsFoundExplanation(bool noTestsFound)
-        {
-            return noTestsFound ? NoTestsFoundExplanationText : string.Empty;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -95,6 +96,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool noTestsFound,
             string noTestsFoundExplanation)
         {
+            Debug.Assert(!string.IsNullOrEmpty(status), "status must be a RunTestsExecutionStatus value");
+            Debug.Assert(noTestsFoundExplanation != null, "noTestsFoundExplanation must not be null; pass string.Empty when not applicable");
+
             Success = success;
             Message = message;
             CompletedAt = completedAt;

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -119,9 +119,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await _waitForTestRunnerCleanupAsync(ct);
 
             // 3. Response creation.
-            // Why: pass the derived fields explicitly so the constructor does not re-derive them;
-            // the null-triggered derivation exists only as a source-compat fallback for callers
-            // that omit the optional arguments.
             RunTestsResponse response = new(
                 success: result.success,
                 message: result.message,
@@ -139,8 +136,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 response.Message,
                 () => _noTestsDiagnosticService.AppendDiagnosticsIfNeeded(
                     response.Message,
-                    response.Success,
-                    response.TestCount,
+                    response.NoTestsFound,
                     parameters.TestMode,
                     parameters.FilterType));
             return response;
@@ -153,8 +149,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static RunTestsResponse CreateFailureResponse(string message)
         {
-            // Why: supply every optional argument so the constructor does not re-derive
-            // status or explanation fields from the failure message.
             return new RunTestsResponse(
                 success: false,
                 message: message,


### PR DESCRIPTION
## Summary
- run-tests result classification (no-tests detection and the asmdef hint gate) now keys on the structured status and NoTestsFound fields instead of comparing message text.

## User Impact
- No visible change. Response JSON fields and message contents are identical. This removes the risk that a future message wording tweak silently breaks the NoTestsFound flag or the asmdef diagnostics.

## Changes
- RunTestsResponse's constructor requires every field and stores them verbatim; the string-match derivation paths were removed.
- RunTestsNoTestsDiagnosticService gates on the NoTestsFound flag instead of message equality.
- Tests: the derivation pins were replaced by a verbatim-storage pin, and the diagnostic-gate tests moved to the flag-based signature.

## Verification
- uloop compile: 0 errors / 0 warnings
- RunTests + SerializableTestResult suites: 46/46 pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

