### PR TITLE
fix: Simulating UI input now fails clearly when PlayMode is paused

### DIFF
--- a/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
+++ b/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
@@ -77,5 +77,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 PlayModeToolPreflightService.FormatPausedMessage(SimulateMouseInputUseCase.PausedActionDescription),
                 Is.EqualTo("PlayMode is paused. Resume PlayMode before simulating mouse input."));
         }
+
+        [Test]
+        public void FormatPausedMessage_WithSimulateMouseUiSuffix_ReturnsExpectedWireString()
+        {
+            // Verifies SimulateMouseUi's paused preflight message stays byte-identical, including the suffix the use case actually passes.
+            Assert.That(
+                PlayModeToolPreflightService.FormatPausedMessage(SimulateMouseUiUseCase.PausedActionDescription),
+                Is.EqualTo("PlayMode is paused. Resume PlayMode before simulating UI input."));
+        }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -18,6 +18,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class SimulateMouseUiUseCase
     {
+        // Wire-visible fragment of the paused preflight message; tests pin the composed string.
+        public const string PausedActionDescription = "simulating UI input";
+
         private const float EXPAND_DURATION = SimulateMouseUiAnimationConstants.EXPAND_DURATION;
         private const float EXPAND_START_SCALE = SimulateMouseUiAnimationConstants.EXPAND_START_SCALE;
         private const float DISSIPATE_DURATION = SimulateMouseUiAnimationConstants.DISSIPATE_DURATION;
@@ -67,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MouseUiSimulationCommand parameters,
             EventSystem? eventSystem)
         {
-            ValidationResult playModeResult = PlayModeToolPreflightService.RequireActive();
+            ValidationResult playModeResult = PlayModeToolPreflightService.RequireActiveAndNotPaused(PausedActionDescription);
             if (!playModeResult.IsValid)
             {
                 return CreateFailure(parameters, playModeResult.ErrorMessage);


### PR DESCRIPTION
## Summary
- simulate-mouse-ui now rejects requests while PlayMode is paused, matching the other input-simulation tools

## User Impact
- Before: UI clicks fired while PlayMode was paused executed the immediate event, but follow-up frame updates and coroutines stayed frozen, leaving the scene inconsistent with no warning
- After: the tool fails fast with "PlayMode is paused. Resume PlayMode before simulating UI input." — the same guidance the sibling input tools give

## Changes
- SimulateMouseUiUseCase preflight now uses the shared RequireActiveAndNotPaused check with its own paused-action description
- Added a test pinning the exact wire-visible paused message

## Verification
- dist/darwin-arm64/uloop compile: 0 errors / 0 warnings
- dist/darwin-arm64/uloop run-tests (regex ".*(PlayModeToolPreflight|SimulateMouseUi).*"): 10 passed / 0 failed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

