### PR TITLE
fix: run-tests errors now show the original failure instead of a generic message

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -85,35 +85,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // 2. Test execution
             ct.ThrowIfCancellationRequested();
             SerializableTestResult result;
-
-            try
+            if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)
             {
-                if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)
-                {
-                    result = await _executionService.ExecutePlayModeTestAsync(filter, ct);
-                }
-                else
-                {
-                    result = await _executionService.ExecuteEditModeTestAsync(filter, ct);
-                }
+                result = await _executionService.ExecutePlayModeTestAsync(filter, ct);
             }
-            catch (System.OperationCanceledException)
+            else
             {
-                // Propagate cancellation exceptions
-                throw;
-            }
-            catch (System.Exception ex)
-            {
-                // Log full exception details for debugging
-                UnityEngine.Debug.LogError($"Test execution failed: {ex}");
-                VibeLogger.LogError(
-                    "test_execution_failed",
-                    "Test execution encountered an error",
-                    new { testMode = parameters.TestMode, filterType = parameters.FilterType, filterValue = parameters.FilterValue, error = ex.Message }
-                );
-
-                // Surface the failure; the tool layer converts it into an error response.
-                throw new System.InvalidOperationException("Test execution failed. Please check the logs for details.", ex);
+                result = await _executionService.ExecuteEditModeTestAsync(filter, ct);
             }
 
             await _waitForTestRunnerCleanupAsync(ct);


### PR DESCRIPTION
## Summary
- When Unity test execution fails internally, run-tests now surfaces the original error instead of a generic "check the logs" message

## User Impact
- Before: an internal failure during test execution was re-wrapped as "Test execution failed. Please check the logs for details.", forcing users to dig through Editor logs for the real cause
- After: the original exception type and message reach the CLI error output directly; error classification (stderr, exit code 1) is unchanged

## Changes
- Removed the try-catch wrapper in the RunTests use case: a no-op cancellation rethrow and a catch-all that logged and re-wrapped failures as InvalidOperationException. The JSON-RPC layer already logs and converts thrown exceptions

## Verification
- dist/darwin-arm64/uloop compile: 0 errors / 0 warnings
- dist/darwin-arm64/uloop run-tests (regex "RunTests.*"): 58 passed / 0 failed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

