### PR TITLE
fix: execute-dynamic-code no longer hides internal errors behind a generic failure message

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -28,15 +28,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ExecuteDynamicCodeSchema parameters,
             CancellationToken cancellationToken)
         {
-            string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
-            DynamicCodeDomainReloadWaitSignal domainReloadWaitSignal = DynamicCodeDomainReloadWaitSignal.Start(parameters);
+            using DynamicCodeDomainReloadWaitSignal domainReloadWaitSignal =
+                DynamicCodeDomainReloadWaitSignal.Start(parameters);
 
             try
             {
                 object[] parametersArray = ConvertParameters(parameters.Parameters);
                 string originalCode = parameters.Code ?? string.Empty;
 
-                LogExecutionStart(parameters, correlationId);
+                LogExecutionStart(parameters, UnityCliLoopConstants.GenerateCorrelationId());
 
                 DynamicCodeExecutionRequest request = CreateExecutionRequest(
                     originalCode,
@@ -84,17 +84,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ExecuteDynamicCodeResponse response = CreateCancelledResponse();
                 response.EmitTimingsInJsonResponse = parameters?.IncludeTimings ?? false;
                 return response;
-            }
-            catch (Exception ex)
-            {
-                LogExecutionException(ex, correlationId);
-                ExecuteDynamicCodeResponse response = CreateExceptionResponse(ex);
-                response.EmitTimingsInJsonResponse = parameters?.IncludeTimings ?? false;
-                return response;
-            }
-            finally
-            {
-                domainReloadWaitSignal.Dispose();
             }
         }
 
@@ -335,38 +324,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     StringComparison.Ordinal);
         }
 
-        private ExecuteDynamicCodeResponse CreateExceptionResponse(Exception ex)
-        {
-            return new ExecuteDynamicCodeResponse
-            {
-                Success = false,
-                Result = string.Empty,
-                Logs = new List<string> { $"Original Error: {ex.Message}" },
-                CompilationErrors = new List<CompilationErrorDto>(),
-                ErrorMessage = CreateFriendlyExceptionMessage(ex)
-            };
-        }
-
-        private static string CreateFriendlyExceptionMessage(Exception ex)
-        {
-            if (ex == null)
-            {
-                return "Unknown error occurred";
-            }
-
-            if (ex is TimeoutException)
-            {
-                return "Request timeout";
-            }
-
-            if (ex is ArgumentException)
-            {
-                return "Invalid request parameters";
-            }
-
-            return ex.Message ?? "Unknown error occurred";
-        }
-
         private static ExecuteDynamicCodeResponse CreateCancelledResponse()
         {
             return new ExecuteDynamicCodeResponse
@@ -377,22 +334,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 CompilationErrors = new List<CompilationErrorDto>(),
                 ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED
             };
-        }
-
-        private static void LogExecutionException(Exception ex, string correlationId)
-        {
-            VibeLogger.LogError(
-                "execute_dynamic_code_error",
-                "Dynamic code execution failed with exception",
-                new
-                {
-                    correlationId,
-                    error = ex.Message,
-                    stackTrace = ex.StackTrace
-                },
-                correlationId,
-                "Unexpected error during dynamic code execution",
-                "Investigate error cause and improve error handling");
         }
 
         private ExecuteDynamicCodeResponse ConvertExecutionResultToResponse(ExecutionResult result)


### PR DESCRIPTION
## Summary
- When execute-dynamic-code hits an unexpected internal error, the CLI now reports the real error instead of wrapping it in a generic failure response

## User Impact
- Before: unexpected internal failures came back as a normal-looking failure response with vague text like "Request timeout" or "Invalid request parameters", hiding the real cause
- After: those failures surface as a proper CLI error with the original message; compile errors and runtime exceptions in the user's own code still return the same structured response as before, and cancellation still returns the same cancelled response

## Changes
- Kept the cancellation catch (the structured cancelled response is part of the wire contract); removed the generic catch-all and its friendly-message helpers
- Replaced the try/finally dispose of the domain-reload wait signal with a using declaration

## Verification
- dist/darwin-arm64/uloop compile: 0 errors / 0 warnings
- dist/darwin-arm64/uloop run-tests (regex ".*ExecuteDynamicCode.*|.*DynamicCode.*"): 140 passed / 0 failed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

