### PR TITLE
fix: Invalid tool parameters now return a readable error result instead of an RPC failure

### DIFF
--- a/Assets/Tests/Editor/InputActionValidationTests.cs
+++ b/Assets/Tests/Editor/InputActionValidationTests.cs
@@ -1,0 +1,54 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies that out-of-range action enum values reaching record/replay use cases
+    /// surface as Success=false responses rather than JSON-RPC errors.
+    /// </summary>
+    [TestFixture]
+    public sealed class InputActionValidationTests
+    {
+        [Test]
+        public async Task ReplayInputAsync_WithUnknownAction_ReturnsValidationFailureResponse()
+        {
+            // Verifies invalid replay-input action enum values do not escape as an exception.
+            ReplayInputUseCase useCase = new();
+            UnityCliLoopReplayInputRequest request = new()
+            {
+                Action = (ReplayInputAction)999
+            };
+
+            UnityCliLoopReplayInputResult result =
+                await useCase.ReplayInputAsync(request, CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Message, Does.Contain("Unknown replay-input action"));
+            Assert.That(result.Action, Is.EqualTo(request.Action.ToString()));
+        }
+
+        [Test]
+        public async Task RecordInputAsync_WithUnknownAction_ReturnsValidationFailureResponse()
+        {
+            // Verifies invalid record-input action enum values do not escape as an exception.
+            RecordInputUseCase useCase = new();
+            UnityCliLoopRecordInputRequest request = new()
+            {
+                Action = (RecordInputAction)999
+            };
+
+            UnityCliLoopRecordInputResult result =
+                await useCase.RecordInputAsync(request, CancellationToken.None);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Message, Does.Contain("Unknown record-input action"));
+            Assert.That(result.Action, Is.EqualTo(request.Action.ToString()));
+        }
+    }
+}
+#endif

--- a/Assets/Tests/Editor/InputActionValidationTests.cs.meta
+++ b/Assets/Tests/Editor/InputActionValidationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30f73b0bb830c4d99ae6797b3ddb32fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -328,6 +328,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task Enable_WhenIdIsEmpty_ReturnsValidationFailureResponse()
+        {
+            // Verifies empty id surfaces as a Success=false response instead of a JSON-RPC error.
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = string.Empty,
+                ["timeoutSeconds"] = 30
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("Id must not be null or empty."));
+        }
+
+        [Test]
+        public async Task Enable_WhenTimeoutSecondsIsZero_ReturnsValidationFailureResponse()
+        {
+            // Verifies non-positive TimeoutSeconds surface as a Success=false response instead of a JSON-RPC error.
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["timeoutSeconds"] = 0
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("TimeoutSeconds must be greater than zero."));
+        }
+
+        [Test]
+        public async Task Clear_WhenIdIsEmptyAndAllIsFalse_ReturnsValidationFailureResponse()
+        {
+            // Verifies empty id on clear-pause-point surfaces as a Success=false response.
+            ClearPausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = string.Empty,
+                ["all"] = false
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("Id must not be null or empty."));
+        }
+
+        [Test]
         public void PauseMethod_WhenSourceIsScanned_UsesUnityEditorConditionalWithoutDebugBreak()
         {
             // Verifies the public marker follows Unity's conditional call-site removal pattern.

--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -51,10 +51,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Test for filter creation via service.
         /// </summary>
         [Test]
-        public void CreateFilter_WithRegexType_ShouldReturnRegexFilter()
+        public void TryCreateFilter_WithRegexType_ShouldReturnRegexFilter()
         {
-            TestExecutionFilter result = filterService.CreateFilter(TestFilterType.regex, "TestClass");
+            // Verifies regex filter type is mapped to a class-name filter with the caller's value.
+            (TestExecutionFilter result, string errorMessage) = filterService.TryCreateFilter(TestFilterType.regex, "TestClass");
 
+            Assert.That(errorMessage, Is.Null);
             Assert.That(result.FilterType, Is.EqualTo(TestExecutionFilterType.Regex));
             Assert.That(result.FilterValue, Is.EqualTo("TestClass"));
         }
@@ -63,10 +65,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Test for creating exact filter.
         /// </summary>
         [Test]
-        public void CreateFilter_WithExactType_ShouldReturnExactFilter()
+        public void TryCreateFilter_WithExactType_ShouldReturnExactFilter()
         {
-            TestExecutionFilter result = filterService.CreateFilter(TestFilterType.exact, "io.github.Test");
+            // Verifies exact filter type is mapped to a test-name filter with the caller's value.
+            (TestExecutionFilter result, string errorMessage) = filterService.TryCreateFilter(TestFilterType.exact, "io.github.Test");
 
+            Assert.That(errorMessage, Is.Null);
             Assert.That(result.FilterType, Is.EqualTo(TestExecutionFilterType.Exact));
             Assert.That(result.FilterValue, Is.EqualTo("io.github.Test"));
         }
@@ -75,12 +79,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Test for unsupported filter types.
         /// </summary>
         [Test]
-        public void CreateFilter_WithUnsupportedType_ShouldThrowException()
+        public void TryCreateFilter_WithUnsupportedType_ShouldReturnErrorMessage()
         {
-            Assert.Throws<System.ArgumentException>(() =>
-            {
-                filterService.CreateFilter((TestFilterType)999, "value");
-            });
+            // Verifies out-of-range enum values surface as an error message rather than an exception.
+            (TestExecutionFilter result, string errorMessage) = filterService.TryCreateFilter((TestFilterType)999, "value");
+
+            Assert.That(result, Is.Null);
+            Assert.That(errorMessage, Does.Contain("Unsupported filter type"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -177,6 +177,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task ExecuteAsync_WithUnsupportedFilterType_ShouldFailFastWithoutRunningTests()
+        {
+            // Verifies invalid filter-type enum values surface as a Success=false response instead of a JSON-RPC error.
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                NoCleanupWait
+            );
+            RunTestsSchema parameters = new()
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = (TestFilterType)999,
+                FilterValue = "value"
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.ExecutionFailed));
+            Assert.That(response.Message, Does.Contain("Unsupported filter type"));
+            Assert.That(executionService.WasCalled, Is.False);
+        }
+
+        [Test]
         public async Task ExecuteAsync_AfterTestExecution_ShouldWaitForCleanup()
         {
             // Verifies run-tests waits for Unity Test Runner cleanup before responding.

--- a/Assets/Tests/Editor/SimulateMouseUiActionValidationTests.cs
+++ b/Assets/Tests/Editor/SimulateMouseUiActionValidationTests.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies that out-of-range mouse UI action enum values surface as a Success=false
+    /// response through SimulateMouseUiUseCase's TryFromSchema entry point instead of a throw.
+    /// </summary>
+    [TestFixture]
+    public sealed class SimulateMouseUiActionValidationTests
+    {
+        [Test]
+        public async Task ExecuteAsync_WithUnknownMouseUiAction_ReturnsValidationFailureResponse()
+        {
+            // Verifies TryFromSchema rejects an integer-cast enum value with the exact wire-visible message.
+            SimulateMouseUiUseCase useCase = new();
+            UnityCliLoopMouseUiAction invalidAction = (UnityCliLoopMouseUiAction)999;
+            SimulateMouseUiSchema request = new()
+            {
+                Action = invalidAction
+            };
+
+            SimulateMouseUiResponse response = await useCase.ExecuteAsync(request, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo($"Unknown mouse UI action: {invalidAction}"));
+            Assert.That(response.Action, Is.EqualTo(invalidAction.ToString()));
+        }
+    }
+}

--- a/Assets/Tests/Editor/SimulateMouseUiActionValidationTests.cs.meta
+++ b/Assets/Tests/Editor/SimulateMouseUiActionValidationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae2650d25a8114714881208d115a1c86
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -33,6 +33,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class PausePointResponse : UnityCliLoopToolResponse
     {
+        // Defaults to true so existing snapshot/clear paths keep their prior semantics.
+        // Only explicit validation failures set this to false.
+        public bool Success { get; set; } = true;
         public string Id { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
         public bool IsEnabled { get; set; }
@@ -174,10 +177,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            string id = RequireId(parameters.Id);
+            (string id, string idError) = TryRequireId(parameters.Id);
+            if (idError != null)
+            {
+                return CreateValidationFailure(idError);
+            }
+
             if (parameters.TimeoutSeconds <= 0)
             {
-                throw new UnityCliLoopToolParameterValidationException("TimeoutSeconds must be greater than zero.");
+                return CreateValidationFailure("TimeoutSeconds must be greater than zero.");
             }
 
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(id, parameters.TimeoutSeconds);
@@ -199,19 +207,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return PausePointResponse.FromClearAll(clearAllResult);
             }
 
-            string id = RequireId(parameters.Id);
+            (string id, string idError) = TryRequireId(parameters.Id);
+            if (idError != null)
+            {
+                return CreateValidationFailure(idError);
+            }
+
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(id);
             return PausePointResponse.FromSnapshot(snapshot);
         }
 
-        private static string RequireId(string id)
+        // Returns (id, error). error is non-null when the caller-supplied id fails validation.
+        private static (string id, string errorMessage) TryRequireId(string id)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
-                throw new UnityCliLoopToolParameterValidationException("Id must not be null or empty.");
+                return (null, "Id must not be null or empty.");
             }
 
-            return id;
+            return (id, null);
+        }
+
+        private static PausePointResponse CreateValidationFailure(string message)
+        {
+            return new PausePointResponse
+            {
+                Success = false,
+                Message = message
+            };
         }
 
         private static string CreateEnableWarning()

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -177,7 +177,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 throw new ArgumentNullException(nameof(parameters));
             }
 
-            (string id, string idError) = TryRequireId(parameters.Id);
+            string idError = ValidateId(parameters.Id);
             if (idError != null)
             {
                 return CreateValidationFailure(idError);
@@ -188,7 +188,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return CreateValidationFailure("TimeoutSeconds must be greater than zero.");
             }
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(id, parameters.TimeoutSeconds);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(parameters.Id, parameters.TimeoutSeconds);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.Warning = CreateEnableWarning();
             return response;
@@ -207,25 +207,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return PausePointResponse.FromClearAll(clearAllResult);
             }
 
-            (string id, string idError) = TryRequireId(parameters.Id);
+            string idError = ValidateId(parameters.Id);
             if (idError != null)
             {
                 return CreateValidationFailure(idError);
             }
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(id);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(parameters.Id);
             return PausePointResponse.FromSnapshot(snapshot);
         }
 
-        // Returns (id, error). error is non-null when the caller-supplied id fails validation.
-        private static (string id, string errorMessage) TryRequireId(string id)
+        // Returns an error message when id fails validation, or null when it is valid.
+        private static string ValidateId(string id)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
-                return (null, "Id must not be null or empty.");
+                return "Id must not be null or empty.";
             }
 
-            return (id, null);
+            return null;
         }
 
         private static PausePointResponse CreateValidationFailure(string message)

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -70,7 +69,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     break;
 
                 default:
-                    throw new ArgumentException($"Unknown record-input action: {request.Action}");
+                    // Only reachable when an out-of-range enum value is cast from an integer;
+                    // surface as a Success=false response so the CLI treats it as a validation failure.
+                    response = new UnityCliLoopRecordInputResult
+                    {
+                        Success = false,
+                        Message = $"Unknown record-input action: {request.Action}",
+                        Action = request.Action.ToString()
+                    };
+                    break;
             }
 
             VibeLogger.LogInfo(

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -69,7 +68,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     break;
 
                 default:
-                    throw new ArgumentException($"Unknown replay-input action: {request.Action}");
+                    // Only reachable when an out-of-range enum value is cast from an integer;
+                    // surface as a Success=false response so the CLI treats it as a validation failure.
+                    response = new UnityCliLoopReplayInputResult
+                    {
+                        Success = false,
+                        Message = $"Unknown replay-input action: {request.Action}",
+                        Action = request.Action.ToString()
+                    };
+                    break;
             }
 
             VibeLogger.LogInfo(

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -79,7 +79,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TestExecutionFilter filter = null;
             if (parameters.FilterType != TestFilterType.all)
             {
-                filter = _filterService.CreateFilter(parameters.FilterType, parameters.FilterValue);
+                (TestExecutionFilter createdFilter, string filterError) = _filterService.TryCreateFilter(parameters.FilterType, parameters.FilterValue);
+                if (filterError != null)
+                {
+                    return CreateFailureResponse(filterError);
+                }
+                filter = createdFilter;
             }
 
             // 2. Test execution

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFilterCreationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFilterCreationService.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -10,21 +8,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class TestFilterCreationService
     {
         /// <summary>
-        /// Create test execution filter
+        /// Create test execution filter. Returns (filter, errorMessage); errorMessage is non-null
+        /// only when the caller supplied an out-of-range enum value cast from an integer.
         /// </summary>
         /// <param name="filterType">Filter type</param>
         /// <param name="filterValue">Filter value</param>
-        /// <returns>Test execution filter</returns>
-        public TestExecutionFilter CreateFilter(TestFilterType filterType, string filterValue)
+        /// <returns>Test execution filter or an error message describing an invalid filter type</returns>
+        public (TestExecutionFilter filter, string errorMessage) TryCreateFilter(TestFilterType filterType, string filterValue)
         {
-            return filterType switch
+            switch (filterType)
             {
-                TestFilterType.all => TestExecutionFilter.All(),
-                TestFilterType.exact => TestExecutionFilter.ByTestName(filterValue),
-                TestFilterType.regex => TestExecutionFilter.ByClassName(filterValue),
-                TestFilterType.assembly => TestExecutionFilter.ByAssemblyName(filterValue),
-                _ => throw new ArgumentException($"Unsupported filter type: {filterType}")
-            };
+                case TestFilterType.all:
+                    return (TestExecutionFilter.All(), null);
+                case TestFilterType.exact:
+                    return (TestExecutionFilter.ByTestName(filterValue), null);
+                case TestFilterType.regex:
+                    return (TestExecutionFilter.ByClassName(filterValue), null);
+                case TestFilterType.assembly:
+                    return (TestExecutionFilter.ByAssemblyName(filterValue), null);
+                default:
+                    return (null, $"Unsupported filter type: {filterType}");
+            }
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -122,7 +122,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     break;
 
                 default:
-                    throw new ArgumentException($"Unknown keyboard action: {parameters.Action}");
+                    // Only reachable when an out-of-range enum value is cast from an integer;
+                    // surface as a Success=false response so the CLI treats it as a normal validation failure.
+                    return new SimulateKeyboardResponse
+                    {
+                        Success = false,
+                        Message = $"Unknown keyboard action: {parameters.Action}",
+                        Action = parameters.Action.ToString()
+                    };
             }
 
             VibeLogger.LogInfo(

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -37,7 +37,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             ct.ThrowIfCancellationRequested();
             CaptureMainThreadContext();
-            MouseUiSimulationCommand parameters = MouseUiSimulationCommand.FromSchema(request);
+
+            (MouseUiSimulationCommand? parameters, string? actionError) = MouseUiSimulationCommand.TryFromSchema(request);
+            if (parameters == null)
+            {
+                return new SimulateMouseUiResponse
+                {
+                    Success = false,
+                    Message = actionError ?? "Invalid mouse UI request.",
+                    Action = request.Action.ToString()
+                };
+            }
 
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
 
@@ -211,7 +221,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return await ExecuteLongPress(parameters, eventSystem, ct).ConfigureAwait(false);
 
                 default:
-                    throw new ArgumentException($"Unknown mouse action: {parameters.Action}");
+                    // Unreachable when TryFromSchema succeeds; kept as a defensive Success=false response
+                    // instead of a throw so any future MouseAction addition surfaces as a validation failure.
+                    return new SimulateMouseUiResponse
+                    {
+                        Success = false,
+                        Message = $"Unknown mouse action: {parameters.Action}",
+                        Action = parameters.Action.ToString()
+                    };
             }
         }
 
@@ -1434,14 +1451,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         private sealed class MouseUiSimulationCommand
         {
-            private MouseUiSimulationCommand(SimulateMouseUiSchema request)
+            private MouseUiSimulationCommand(SimulateMouseUiSchema request, MouseAction action)
             {
-                if (request == null)
-                {
-                    throw new ArgumentNullException(nameof(request));
-                }
-
-                Action = ToRuntimeMouseAction(request.Action);
+                Action = action;
                 X = request.X;
                 Y = request.Y;
                 FromX = request.FromX;
@@ -1466,29 +1478,41 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public string TargetPath { get; }
             public string DropTargetPath { get; }
 
-            public static MouseUiSimulationCommand FromSchema(SimulateMouseUiSchema request)
+            // Returns (command, error). Error is non-null iff the caller supplied an out-of-range enum value.
+            public static (MouseUiSimulationCommand? command, string? errorMessage) TryFromSchema(SimulateMouseUiSchema request)
             {
-                return new MouseUiSimulationCommand(request);
+                if (request == null)
+                {
+                    throw new ArgumentNullException(nameof(request));
+                }
+
+                (bool ok, MouseAction action) = TryConvertMouseAction(request.Action);
+                if (!ok)
+                {
+                    return (null, $"Unknown mouse UI action: {request.Action}");
+                }
+
+                return (new MouseUiSimulationCommand(request, action), null);
             }
 
-            private static MouseAction ToRuntimeMouseAction(UnityCliLoopMouseUiAction action)
+            private static (bool ok, MouseAction action) TryConvertMouseAction(UnityCliLoopMouseUiAction action)
             {
                 switch (action)
                 {
                     case UnityCliLoopMouseUiAction.Click:
-                        return MouseAction.Click;
+                        return (true, MouseAction.Click);
                     case UnityCliLoopMouseUiAction.Drag:
-                        return MouseAction.Drag;
+                        return (true, MouseAction.Drag);
                     case UnityCliLoopMouseUiAction.DragStart:
-                        return MouseAction.DragStart;
+                        return (true, MouseAction.DragStart);
                     case UnityCliLoopMouseUiAction.DragMove:
-                        return MouseAction.DragMove;
+                        return (true, MouseAction.DragMove);
                     case UnityCliLoopMouseUiAction.DragEnd:
-                        return MouseAction.DragEnd;
+                        return (true, MouseAction.DragEnd);
                     case UnityCliLoopMouseUiAction.LongPress:
-                        return MouseAction.LongPress;
+                        return (true, MouseAction.LongPress);
                     default:
-                        throw new ArgumentException($"Unknown mouse UI action: {action}");
+                        return (false, default);
                 }
             }
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -41,10 +41,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             (MouseUiSimulationCommand? parameters, string? actionError) = MouseUiSimulationCommand.TryFromSchema(request);
             if (parameters == null)
             {
+                // TryFromSchema guarantees actionError is non-null when command is null.
                 return new SimulateMouseUiResponse
                 {
                     Success = false,
-                    Message = actionError ?? "Invalid mouse UI request.",
+                    Message = actionError!,
                     Action = request.Action.ToString()
                 };
             }
@@ -223,12 +224,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 default:
                     // Unreachable when TryFromSchema succeeds; kept as a defensive Success=false response
                     // instead of a throw so any future MouseAction addition surfaces as a validation failure.
-                    return new SimulateMouseUiResponse
-                    {
-                        Success = false,
-                        Message = $"Unknown mouse action: {parameters.Action}",
-                        Action = parameters.Action.ToString()
-                    };
+                    return CreateFailure(parameters, $"Unknown mouse action: {parameters.Action}");
             }
         }
 
@@ -1486,33 +1482,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     throw new ArgumentNullException(nameof(request));
                 }
 
-                (bool ok, MouseAction action) = TryConvertMouseAction(request.Action);
-                if (!ok)
+                MouseAction? action = TryConvertMouseAction(request.Action);
+                if (action == null)
                 {
                     return (null, $"Unknown mouse UI action: {request.Action}");
                 }
 
-                return (new MouseUiSimulationCommand(request, action), null);
+                return (new MouseUiSimulationCommand(request, action.Value), null);
             }
 
-            private static (bool ok, MouseAction action) TryConvertMouseAction(UnityCliLoopMouseUiAction action)
+            private static MouseAction? TryConvertMouseAction(UnityCliLoopMouseUiAction action)
             {
                 switch (action)
                 {
                     case UnityCliLoopMouseUiAction.Click:
-                        return (true, MouseAction.Click);
+                        return MouseAction.Click;
                     case UnityCliLoopMouseUiAction.Drag:
-                        return (true, MouseAction.Drag);
+                        return MouseAction.Drag;
                     case UnityCliLoopMouseUiAction.DragStart:
-                        return (true, MouseAction.DragStart);
+                        return MouseAction.DragStart;
                     case UnityCliLoopMouseUiAction.DragMove:
-                        return (true, MouseAction.DragMove);
+                        return MouseAction.DragMove;
                     case UnityCliLoopMouseUiAction.DragEnd:
-                        return (true, MouseAction.DragEnd);
+                        return MouseAction.DragEnd;
                     case UnityCliLoopMouseUiAction.LongPress:
-                        return (true, MouseAction.LongPress);
+                        return MouseAction.LongPress;
                     default:
-                        return (false, default);
+                        return null;
                 }
             }
 


### PR DESCRIPTION
## Summary
- Invalid tool parameters (unknown action values, empty pause-point ids, non-positive timeouts, unsupported test filter types) now come back as a normal result with Success=false and a clear message, instead of a generic RPC error

## User Impact
- Before: passing an invalid parameter to record-input, replay-input, simulate-keyboard, simulate-mouse-ui, run-tests, or the pause-point tools surfaced as "UNITY_RPC_ERROR" on stderr with exit code 1, hiding the actual problem
- After: the tool returns Success=false with a message naming the invalid value (e.g. "Unknown keyboard action: 999"), readable directly from the result JSON

## Changes
- Converted user-input validation throws to Success=false responses across the affected use cases; contract guards for null parameters remain exceptions
- TestFilterCreationService and the mouse UI command factory now return (value, errorMessage) tuples instead of throwing on out-of-range enum values
- PausePointResponse gains a Success field (defaults to true), matching the other tool responses
- Added tests covering each converted validation path

## Verification
- dist/darwin-arm64/uloop compile: 0 errors / 0 warnings
- dist/darwin-arm64/uloop run-tests (regex over the affected suites): 88 passed / 0 failed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

