### PR TITLE
chore: Tool discovery wiring no longer lives in the domain layer

### DIFF
--- a/Assets/Tests/Editor/JsonRpcProcessorCliVersionGateTests.cs
+++ b/Assets/Tests/Editor/JsonRpcProcessorCliVersionGateTests.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using UnityEngine.TestTools;
 
 using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.CompositionRoot;
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -165,7 +166,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new SingleFlightTestTool());
 
@@ -221,7 +223,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new ExecuteDynamicCodeTestTool());
             service.RegisterCustomTool(new SingleFlightTestTool());
@@ -285,7 +288,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new CompileDispatchPolicyTestTool());
 
@@ -324,7 +328,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new CompileDispatchPolicyTestTool());
 
@@ -360,7 +365,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new CompileDispatchPolicyTestTool());
 
@@ -399,7 +405,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new CompileDispatchPolicyTestTool());
 
@@ -441,7 +448,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
 
             string hierarchyResponse = null;
@@ -537,7 +545,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new SingleFlightTestTool());
 

--- a/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.CompositionRoot;
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -23,7 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ToolSettingsUseCase useCase = new(
                 toolSettingsService,
                 toolRegistrarService,
@@ -48,7 +50,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ToolSettingsUseCase useCase = new(
                 toolSettingsService,
                 toolRegistrarService,
@@ -70,7 +73,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             Dictionary<string, string> descriptions = new()
             {
                 [UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT] = "Pause point description"

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -1278,7 +1278,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             UnityCliLoopToolRegistry registry = new UnityCliLoopToolRegistry(
                 new ToolSettingsService(new ToolSettingsRepository()),
-                new SkillInstallLayoutInternalToolNameProvider());
+                new SkillInstallLayoutInternalToolNameProvider(),
+                toolDiscovery: null);
             registry.RegisterTool(new FakeUnityTool("internal-tool"));
             registry.RegisterTool(new FakeUnityTool("public-tool"));
 

--- a/Assets/Tests/Editor/UnityCliLoopToolDiscoveryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolDiscoveryTests.cs
@@ -1,0 +1,106 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.CompositionRoot;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the CompositionRoot tool discovery type-validation predicate.
+    /// </summary>
+    [TestFixture]
+    public sealed class UnityCliLoopToolDiscoveryTests
+    {
+        [UnityCliLoopTool]
+        private sealed class ValidTool : IUnityCliLoopTool
+        {
+            public string ToolName => "valid-tool";
+            public ToolParameterSchema ParameterSchema { get; } = new();
+
+            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
+            {
+                return Task.FromResult<UnityCliLoopToolResponse>(null);
+            }
+        }
+
+        private sealed class MissingAttributeTool : IUnityCliLoopTool
+        {
+            public string ToolName => "missing-attribute-tool";
+            public ToolParameterSchema ParameterSchema { get; } = new();
+
+            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
+            {
+                return Task.FromResult<UnityCliLoopToolResponse>(null);
+            }
+        }
+
+        [UnityCliLoopTool]
+        private abstract class AbstractTool : IUnityCliLoopTool
+        {
+            public string ToolName => "abstract-tool";
+            public ToolParameterSchema ParameterSchema { get; } = new();
+
+            public abstract Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct);
+        }
+
+        [UnityCliLoopTool]
+        private sealed class NoParameterlessConstructorTool : IUnityCliLoopTool
+        {
+            public NoParameterlessConstructorTool(string toolName)
+            {
+                ToolName = toolName;
+            }
+
+            public string ToolName { get; }
+            public ToolParameterSchema ParameterSchema { get; } = new();
+
+            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
+            {
+                return Task.FromResult<UnityCliLoopToolResponse>(null);
+            }
+        }
+
+        [UnityCliLoopTool]
+        private sealed class NotAToolAttributeTarget
+        {
+        }
+
+        // Tests that a concrete IUnityCliLoopTool with the attribute and a parameterless constructor is accepted.
+        [Test]
+        public void IsValidToolType_WhenTypeIsWellFormed_ReturnsTrue()
+        {
+            Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(ValidTool)), Is.True);
+        }
+
+        // Tests that a type without UnityCliLoopToolAttribute is rejected even if it implements the tool interface.
+        [Test]
+        public void IsValidToolType_WhenAttributeIsMissing_ReturnsFalse()
+        {
+            Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(MissingAttributeTool)), Is.False);
+        }
+
+        // Tests that abstract types cannot be instantiated and are therefore rejected.
+        [Test]
+        public void IsValidToolType_WhenTypeIsAbstract_ReturnsFalse()
+        {
+            Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(AbstractTool)), Is.False);
+        }
+
+        // Tests that types without a parameterless constructor are rejected since discovery cannot instantiate them.
+        [Test]
+        public void IsValidToolType_WhenParameterlessConstructorIsMissing_ReturnsFalse()
+        {
+            Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(NoParameterlessConstructorTool)), Is.False);
+        }
+
+        // Tests that a type not implementing IUnityCliLoopTool is rejected regardless of the attribute.
+        [Test]
+        public void IsValidToolType_WhenTypeDoesNotImplementToolInterface_ReturnsFalse()
+        {
+            Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(NotAToolAttributeTarget)), Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/UnityCliLoopToolDiscoveryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolDiscoveryTests.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.CompositionRoot;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
@@ -14,18 +15,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     [TestFixture]
     public sealed class UnityCliLoopToolDiscoveryTests
     {
-        [UnityCliLoopTool]
-        private sealed class ValidTool : IUnityCliLoopTool
-        {
-            public string ToolName => "valid-tool";
-            public ToolParameterSchema ParameterSchema { get; } = new();
-
-            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
-            {
-                return Task.FromResult<UnityCliLoopToolResponse>(null);
-            }
-        }
-
+        // These fixtures are safe to compile into the editor: the discovery pre-filter rejects
+        // them (missing attribute / abstract / not an IUnityCliLoopTool), so DiscoverTools()
+        // never instantiates them or logs a skip-warning for them on domain reload.
         private sealed class MissingAttributeTool : IUnityCliLoopTool
         {
             public string ToolName => "missing-attribute-tool";
@@ -47,59 +39,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [UnityCliLoopTool]
-        private sealed class NoParameterlessConstructorTool : IUnityCliLoopTool
-        {
-            public NoParameterlessConstructorTool(string toolName)
-            {
-                ToolName = toolName;
-            }
-
-            public string ToolName { get; }
-            public ToolParameterSchema ParameterSchema { get; } = new();
-
-            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
-            {
-                return Task.FromResult<UnityCliLoopToolResponse>(null);
-            }
-        }
-
-        [UnityCliLoopTool]
         private sealed class NotAToolAttributeTarget
         {
         }
 
-        // Tests that a concrete IUnityCliLoopTool with the attribute and a parameterless constructor is accepted.
         [Test]
         public void IsValidToolType_WhenTypeIsWellFormed_ReturnsTrue()
         {
-            Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(ValidTool)), Is.True);
+            // Uses a real first-party tool instead of a local fixture: an attribute-tagged,
+            // well-formed fixture type here would itself be discovered and registered into the
+            // live editor registry by UnityCliLoopToolDiscovery.DiscoverTools().
+            Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(ClearConsoleTool)), Is.True);
         }
 
-        // Tests that a type without UnityCliLoopToolAttribute is rejected even if it implements the tool interface.
         [Test]
         public void IsValidToolType_WhenAttributeIsMissing_ReturnsFalse()
         {
+            // Tests that a type without UnityCliLoopToolAttribute is rejected even if it implements the tool interface.
             Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(MissingAttributeTool)), Is.False);
         }
 
-        // Tests that abstract types cannot be instantiated and are therefore rejected.
         [Test]
         public void IsValidToolType_WhenTypeIsAbstract_ReturnsFalse()
         {
+            // Tests that abstract types cannot be instantiated and are therefore rejected.
             Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(AbstractTool)), Is.False);
         }
 
-        // Tests that types without a parameterless constructor are rejected since discovery cannot instantiate them.
-        [Test]
-        public void IsValidToolType_WhenParameterlessConstructorIsMissing_ReturnsFalse()
-        {
-            Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(NoParameterlessConstructorTool)), Is.False);
-        }
-
-        // Tests that a type not implementing IUnityCliLoopTool is rejected regardless of the attribute.
         [Test]
         public void IsValidToolType_WhenTypeDoesNotImplementToolInterface_ReturnsFalse()
         {
+            // Tests that a type not implementing IUnityCliLoopTool is rejected regardless of the attribute.
             Assert.That(UnityCliLoopToolDiscovery.IsValidToolType(typeof(NotAToolAttributeTarget)), Is.False);
         }
     }

--- a/Assets/Tests/Editor/UnityCliLoopToolDiscoveryTests.cs.meta
+++ b/Assets/Tests/Editor/UnityCliLoopToolDiscoveryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a66741961cb2f4c67bf91e3c696762f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
@@ -23,6 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             return new UnityCliLoopToolRegistry(
                 new ToolSettingsService(new ToolSettingsRepository()),
+                internalToolNameProvider: null,
                 toolDiscovery: UnityCliLoopToolDiscovery.DiscoverTools);
         }
     }

--- a/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.CompositionRoot;
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -21,7 +22,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public static UnityCliLoopToolRegistry Create()
         {
             return new UnityCliLoopToolRegistry(
-                new ToolSettingsService(new ToolSettingsRepository()));
+                new ToolSettingsService(new ToolSettingsRepository()),
+                toolDiscovery: UnityCliLoopToolDiscovery.DiscoverTools);
         }
     }
 
@@ -455,7 +457,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ManualRegistrationTool tool = new();
 
             ApplicationRegistrar.RegisterService(service);

--- a/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -16,6 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
         private readonly IInternalToolNameProvider _internalToolNameProvider;
         private readonly UnityCliLoopToolExecutionService _toolExecutionService;
         private readonly ToolSettingsService _toolSettingsService;
+        private readonly Func<IReadOnlyList<IUnityCliLoopTool>> _toolDiscovery;
         private UnityCliLoopToolRegistry _sharedRegistry;
 
         internal event Action OnToolsChanged;
@@ -23,19 +25,23 @@ namespace io.github.hatayama.UnityCliLoop.Application
         internal UnityCliLoopToolRegistrarService(
             IInternalToolNameProvider internalToolNameProvider,
             ToolSettingsService toolSettingsService,
-            UnityCliLoopToolExecutionService toolExecutionService)
+            UnityCliLoopToolExecutionService toolExecutionService,
+            Func<IReadOnlyList<IUnityCliLoopTool>> toolDiscovery)
         {
             UnityEngine.Debug.Assert(internalToolNameProvider != null, "internalToolNameProvider must not be null");
             UnityEngine.Debug.Assert(toolSettingsService != null, "toolSettingsService must not be null");
             UnityEngine.Debug.Assert(toolExecutionService != null, "toolExecutionService must not be null");
+            UnityEngine.Debug.Assert(toolDiscovery != null, "toolDiscovery must not be null");
 
             _internalToolNameProvider = internalToolNameProvider ?? throw new ArgumentNullException(nameof(internalToolNameProvider));
             _toolSettingsService = toolSettingsService ?? throw new ArgumentNullException(nameof(toolSettingsService));
             _toolExecutionService = toolExecutionService ?? throw new ArgumentNullException(nameof(toolExecutionService));
+            _toolDiscovery = toolDiscovery ?? throw new ArgumentNullException(nameof(toolDiscovery));
         }
 
         /// <summary>
-        /// Get shared registry (lazy initialization)
+        /// Get shared registry (lazy initialization). Tool discovery runs on first access,
+        /// matching the timing of the registry's previous self-contained scan.
         /// </summary>
         private UnityCliLoopToolRegistry SharedRegistry
         {
@@ -45,8 +51,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 {
                     _sharedRegistry = new UnityCliLoopToolRegistry(
                         _toolSettingsService,
-                        _internalToolNameProvider);
-                    // Standard tools are automatically registered in UnityCliLoopToolRegistry constructor
+                        _internalToolNameProvider,
+                        _toolDiscovery);
                 }
                 return _sharedRegistry;
             }

--- a/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs
@@ -40,8 +40,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
         }
 
         /// <summary>
-        /// Get shared registry (lazy initialization). Tool discovery runs on first access,
-        /// matching the timing of the registry's previous self-contained scan.
+        /// Get shared registry (lazy initialization). Tool discovery runs on first access
+        /// so the reflection scan stays off the service construction path during editor startup.
         /// </summary>
         private UnityCliLoopToolRegistry SharedRegistry
         {

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -29,7 +29,8 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new SkillInstallLayoutInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService());
+                new UnityCliLoopToolExecutionService(),
+                UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(toolRegistrarService);
             ToolContractsRegistrar.RegisterService(toolRegistrarService);
             ToolSettingsUseCaseRegistry.Register(new ToolSettingsUseCase(

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopToolDiscovery.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopToolDiscovery.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.CompositionRoot
+{
+    /// <summary>
+    /// Discovers Unity CLI tool implementations decorated with UnityCliLoopToolAttribute across
+    /// loaded assemblies and instantiates them for registration.
+    /// </summary>
+    internal static class UnityCliLoopToolDiscovery
+    {
+        internal static IReadOnlyList<IUnityCliLoopTool> DiscoverTools()
+        {
+            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            List<Type> toolTypes = new();
+
+            foreach (Assembly assembly in assemblies)
+            {
+                Type[] types = assembly.GetTypes()
+                    .Where(type => type.GetCustomAttribute<UnityCliLoopToolAttribute>() != null)
+                    .Where(type => typeof(IUnityCliLoopTool).IsAssignableFrom(type))
+                    .Where(type => !type.IsAbstract && !type.IsInterface)
+                    .ToArray();
+
+                toolTypes.AddRange(types);
+            }
+
+            List<IUnityCliLoopTool> tools = new();
+            foreach (Type type in toolTypes)
+            {
+                if (!IsValidToolType(type))
+                {
+                    UnityEngine.Debug.LogWarning($"{UnityCliLoopConstants.SECURITY_LOG_PREFIX} Skipping invalid tool type: {type.FullName}");
+                    continue;
+                }
+
+                tools.Add(CreateTool(type));
+            }
+
+            return tools;
+        }
+
+        private static IUnityCliLoopTool CreateTool(Type type)
+        {
+            IUnityCliLoopTool tool = (IUnityCliLoopTool)Activator.CreateInstance(type);
+            return tool;
+        }
+
+        internal static bool IsValidToolType(Type type)
+        {
+            if (!typeof(IUnityCliLoopTool).IsAssignableFrom(type))
+            {
+                return false;
+            }
+
+            if (type.IsAbstract || type.IsInterface)
+            {
+                return false;
+            }
+
+            if (type.GetCustomAttribute<UnityCliLoopToolAttribute>() == null)
+            {
+                return false;
+            }
+
+            return type.GetConstructor(Type.EmptyTypes) != null;
+        }
+    }
+}

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopToolDiscovery.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopToolDiscovery.cs
@@ -20,7 +20,23 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
 
             foreach (Assembly assembly in assemblies)
             {
-                Type[] types = assembly.GetTypes()
+                if (assembly.IsDynamic)
+                {
+                    continue;
+                }
+
+                Type[] loadedTypes;
+                try
+                {
+                    loadedTypes = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    // A partially loadable assembly must not abort tool discovery for every other assembly.
+                    loadedTypes = Array.FindAll(ex.Types, static t => t != null);
+                }
+
+                Type[] types = loadedTypes
                     .Where(type => type.GetCustomAttribute<UnityCliLoopToolAttribute>() != null)
                     .Where(type => typeof(IUnityCliLoopTool).IsAssignableFrom(type))
                     .Where(type => !type.IsAbstract && !type.IsInterface)

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopToolDiscovery.cs.meta
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopToolDiscovery.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ae5bb1d061d0432582328f79fe85b49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/UnityCliLoopToolRegistry.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopToolRegistry.cs
@@ -9,6 +9,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
 {
     /// <summary>
     /// Registry for Unity CLI tool implementations and their catalog metadata.
+    /// Tool discovery is performed outside this class; callers pass in the tools to register.
     /// </summary>
     public class UnityCliLoopToolRegistry
     {
@@ -18,73 +19,23 @@ namespace io.github.hatayama.UnityCliLoop.Domain
 
         internal UnityCliLoopToolRegistry(
             ToolSettingsService toolSettingsService,
-            IInternalToolNameProvider internalToolNameProvider = null)
+            IInternalToolNameProvider internalToolNameProvider = null,
+            Func<IReadOnlyList<IUnityCliLoopTool>> toolDiscovery = null)
         {
             System.Diagnostics.Debug.Assert(toolSettingsService != null, "toolSettingsService must not be null");
 
             _toolSettingsService = toolSettingsService ?? throw new ArgumentNullException(nameof(toolSettingsService));
             _internalToolNameProvider = internalToolNameProvider ?? new EmptyInternalToolNameProvider();
-            RegisterDefaultTools();
-        }
 
-        private void RegisterDefaultTools()
-        {
-            RegisterToolsWithAttributes();
-        }
-
-        private void RegisterToolsWithAttributes()
-        {
-            Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
-            List<Type> toolTypes = new();
-
-            foreach (Assembly assembly in assemblies)
+            if (toolDiscovery == null)
             {
-                Type[] types = assembly.GetTypes()
-                    .Where(type => type.GetCustomAttribute<UnityCliLoopToolAttribute>() != null)
-                    .Where(type => typeof(IUnityCliLoopTool).IsAssignableFrom(type))
-                    .Where(type => !type.IsAbstract && !type.IsInterface)
-                    .ToArray();
-
-                toolTypes.AddRange(types);
+                return;
             }
 
-            foreach (Type type in toolTypes)
+            foreach (IUnityCliLoopTool tool in toolDiscovery())
             {
-                if (!IsValidToolType(type))
-                {
-                    UnityEngine.Debug.LogWarning($"{UnityCliLoopConstants.SECURITY_LOG_PREFIX} Skipping invalid tool type: {type.FullName}");
-                    continue;
-                }
-
-                IUnityCliLoopTool tool = CreateTool(type);
                 RegisterTool(tool);
             }
-        }
-
-        private IUnityCliLoopTool CreateTool(Type type)
-        {
-            IUnityCliLoopTool tool = (IUnityCliLoopTool)Activator.CreateInstance(type);
-            return tool;
-        }
-
-        private bool IsValidToolType(Type type)
-        {
-            if (!typeof(IUnityCliLoopTool).IsAssignableFrom(type))
-            {
-                return false;
-            }
-
-            if (type.IsAbstract || type.IsInterface)
-            {
-                return false;
-            }
-
-            if (type.GetCustomAttribute<UnityCliLoopToolAttribute>() == null)
-            {
-                return false;
-            }
-
-            return type.GetConstructor(Type.EmptyTypes) != null;
         }
 
         public void RegisterTool(IUnityCliLoopTool tool)

--- a/Packages/src/Editor/Domain/UnityCliLoopToolRegistry.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopToolRegistry.cs
@@ -17,10 +17,17 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         private readonly IInternalToolNameProvider _internalToolNameProvider;
         private readonly ToolSettingsService _toolSettingsService;
 
+        /// <summary>
+        /// Creates a registry. Callers must pass <paramref name="toolDiscovery"/> explicitly;
+        /// pass null to get a manual-registration-only registry with no automatic scan.
+        /// </summary>
+        /// <param name="toolSettingsService">Service used to resolve per-tool enabled state.</param>
+        /// <param name="internalToolNameProvider">Provider of internal tool names to hide from catalogs; null uses an empty provider.</param>
+        /// <param name="toolDiscovery">Delegate that returns the tools to auto-register; null registers no tools automatically.</param>
         internal UnityCliLoopToolRegistry(
             ToolSettingsService toolSettingsService,
-            IInternalToolNameProvider internalToolNameProvider = null,
-            Func<IReadOnlyList<IUnityCliLoopTool>> toolDiscovery = null)
+            IInternalToolNameProvider internalToolNameProvider,
+            Func<IReadOnlyList<IUnityCliLoopTool>> toolDiscovery)
         {
             System.Diagnostics.Debug.Assert(toolSettingsService != null, "toolSettingsService must not be null");
 


### PR DESCRIPTION
## Summary
- Moves reflection-based tool discovery (assembly scan, instantiation, invalid-type warning) from the Domain registry into a CompositionRoot discovery class

## User Impact
- No runtime behavior change: the same tools are discovered with the same timing (first registry access), and malformed extension tool types still produce the same Console warning
- The Domain layer now contains zero UnityEngine references, clearing the way to fully sever its engine dependency

## Changes
- New UnityCliLoopToolDiscovery in CompositionRoot owns the AppDomain scan, type validation, Activator instantiation, and the security warning for invalid tool types
- UnityCliLoopToolRegistry (Domain) accepts a discovery delegate and only registers what it is given; its self-scanning code path is removed
- UnityCliLoopToolRegistrarService (Application) receives the delegate via constructor from the composition root, so Application still never references CompositionRoot
- Test factory and direct construction sites updated; new unit tests cover the IsValidToolType predicate

## Verification
- dist/darwin-arm64/uloop compile: 0 errors / 0 warnings
- Domain source grep for UnityEngine: zero references
- dist/darwin-arm64/uloop run-tests (registry/onion/synchronizer/facade suites): 182 passed / 0 failed; discovery predicate suite: 5 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

