### PR TITLE
chore: The domain layer now stays engine-free by compiler enforcement

### DIFF
--- a/Packages/src/Editor/Domain/UnityCLILoop.Domain.asmdef
+++ b/Packages/src/Editor/Domain/UnityCLILoop.Domain.asmdef
@@ -20,5 +20,5 @@
             "define": "ULOOP_HAS_TEST_FRAMEWORK"
         }
     ],
-    "noEngineReferences": false
+    "noEngineReferences": true
 }


### PR DESCRIPTION
## Summary
- The Domain assembly is now compiled with noEngineReferences, so any future UnityEngine/UnityEditor dependency in domain code fails the build immediately.

## User Impact
- No runtime behavior change. This hardens the architecture boundary established in #1523/#1524: the engine-free rule for the domain layer is now enforced by the compiler rather than by review or guard tests alone.

## Changes
- Flip noEngineReferences from false to true in the Domain asmdef (one line). PR #1524 already removed the last UnityEngine usage from this assembly.

## Verification
- uloop compile: 0 errors, 0 warnings
- OnionAssemblyDependencyTests: 77/77 passed
- Grep confirms no UnityEngine/UnityEditor references remain in Packages/src/Editor/Domain, including inside #if ULOOP_HAS_TEST_FRAMEWORK blocks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

