### PR TITLE
chore: Domain layer can no longer link against Unity engine modules

### DIFF
--- a/Packages/src/Editor/Domain/UnityCLILoop.Domain.asmdef
+++ b/Packages/src/Editor/Domain/UnityCLILoop.Domain.asmdef
@@ -20,5 +20,5 @@
             "define": "ULOOP_HAS_TEST_FRAMEWORK"
         }
     ],
-    "noEngineReferences": false
+    "noEngineReferences": true
 }


### PR DESCRIPTION
## Summary
- The Domain assembly now declares `noEngineReferences: true`, so the compiler enforces what #1523 and #1524 achieved: no UnityEngine/UnityEditor dependency in the domain layer.

## User Impact
- No runtime behavior change. This is an architectural guardrail: any future attempt to use a UnityEngine API from Domain fails at compile time instead of slipping through review.

## Changes
- Flip `noEngineReferences` from `false` to `true` in `UnityCLILoop.Domain.asmdef` (single-line change).

## Verification
- `dist/darwin-arm64/uloop compile`: 0 errors, 0 warnings
- `uloop run-tests` (OnionAssemblyDependencyTests): 77/77 passed
- Grep confirmed zero `UnityEngine`/`UnityEditor` references remain in Domain sources

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

