### PR TITLE
chore: CLI pin reading now goes through an injectable boundary instead of static file IO

### DIFF
--- a/Assets/Tests/Editor/CliPathSetupFlowTests.cs
+++ b/Assets/Tests/Editor/CliPathSetupFlowTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -21,7 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             FakeNativeCliInstaller installer = new FakeNativeCliInstaller(
                 CreateSupportedPlan(),
                 CreateAppliedResult());
-            CliSetupApplicationService service = new(detector, installer);
+            CliSetupApplicationService service = new(detector, installer, new CliPinReaderService());
 
             CliPathSetupFlowResult result = await service.EnsureCliVisibleFromShellAsync(
                 RuntimePlatform.OSXEditor,
@@ -39,7 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             FakeNativeCliInstaller installer = new FakeNativeCliInstaller(
                 CreateSupportedPlan(),
                 CreateAppliedResult());
-            CliSetupApplicationService service = new(detector, installer);
+            CliSetupApplicationService service = new(detector, installer, new CliPinReaderService());
 
             CliPathSetupFlowResult result = await service.EnsureCliVisibleFromShellAsync(
                 RuntimePlatform.OSXEditor,
@@ -58,7 +59,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             FakeNativeCliInstaller installer = new FakeNativeCliInstaller(
                 CreateUnsupportedPlan(),
                 CreateAppliedResult());
-            CliSetupApplicationService service = new(detector, installer);
+            CliSetupApplicationService service = new(detector, installer, new CliPinReaderService());
 
             CliPathSetupFlowResult result = await service.EnsureCliVisibleFromShellAsync(
                 RuntimePlatform.OSXEditor,
@@ -78,7 +79,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 CliPathSetupApplyStatus.Failed,
                 "profile is read-only");
             FakeNativeCliInstaller installer = new FakeNativeCliInstaller(CreateSupportedPlan(), applyResult);
-            CliSetupApplicationService service = new CliSetupApplicationService(detector, installer);
+            CliSetupApplicationService service = new CliSetupApplicationService(
+                detector,
+                installer,
+                new CliPinReaderService());
 
             CliPathSetupFlowResult result = await service.EnsureCliVisibleFromShellAsync(
                 RuntimePlatform.OSXEditor,

--- a/Assets/Tests/Editor/CliPinReaderServiceTests.cs
+++ b/Assets/Tests/Editor/CliPinReaderServiceTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies CLI pin reader service file IO behavior.
+    /// </summary>
+    public sealed class CliPinReaderServiceTests
+    {
+        [Test]
+        public void LoadPinFromPath_WhenPinFileIsValid_ReturnsBothVersions()
+        {
+            // Tests that a well-formed pin file yields the project runner and dispatcher versions.
+            string root = CreateTestRoot();
+            string pinPath = Path.Combine(root, "project-runner-pin.json");
+
+            try
+            {
+                Directory.CreateDirectory(root);
+                File.WriteAllText(
+                    pinPath,
+                    "{\"projectRunnerVersion\":\"3.0.0\",\"minimumDispatcherVersion\":\"3.0.1\"}");
+
+                CliPinLoadResult result = CliPinReaderService.LoadPinFromPath(pinPath);
+
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Pin.ProjectRunnerVersion, Is.EqualTo("3.0.0"));
+                Assert.That(result.Pin.MinimumDispatcherVersion, Is.EqualTo("3.0.1"));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public void LoadPinFromPath_WhenFileIsMissing_ReturnsFailureWithNotFoundMessage()
+        {
+            // Tests that a missing pin file fails with the exact "not found" message.
+            string root = CreateTestRoot();
+            string pinPath = Path.Combine(root, "project-runner-pin.json");
+
+            CliPinLoadResult result = CliPinReaderService.LoadPinFromPath(pinPath);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo($"Unity CLI Loop pin file not found at {pinPath}."));
+        }
+
+        [Test]
+        public void LoadPinFromPath_WhenFileIsEmpty_ReturnsFailureWithEmptyMessage()
+        {
+            // Tests that an empty pin file fails with the exact "is empty" message.
+            string root = CreateTestRoot();
+            string pinPath = Path.Combine(root, "project-runner-pin.json");
+
+            try
+            {
+                Directory.CreateDirectory(root);
+                File.WriteAllText(pinPath, "");
+
+                CliPinLoadResult result = CliPinReaderService.LoadPinFromPath(pinPath);
+
+                Assert.That(result.Success, Is.False);
+                Assert.That(result.ErrorMessage, Is.EqualTo($"Unity CLI Loop pin file at {pinPath} is empty."));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public void LoadPinFromPath_WhenProjectRunnerVersionKeyIsMissing_ReturnsFailureWithMissingKeyMessage()
+        {
+            // Tests that a pin file without projectRunnerVersion fails with the exact missing-key message.
+            string root = CreateTestRoot();
+            string pinPath = Path.Combine(root, "project-runner-pin.json");
+
+            try
+            {
+                Directory.CreateDirectory(root);
+                File.WriteAllText(pinPath, "{\"minimumDispatcherVersion\":\"3.0.1\"}");
+
+                CliPinLoadResult result = CliPinReaderService.LoadPinFromPath(pinPath);
+
+                Assert.That(result.Success, Is.False);
+                Assert.That(
+                    result.ErrorMessage,
+                    Is.EqualTo($"Unity CLI Loop pin file at {pinPath} is missing projectRunnerVersion."));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public void LoadPinFromPath_WhenMinimumDispatcherVersionKeyIsMissing_ReturnsFailureWithMissingKeyMessage()
+        {
+            // Tests that a pin file without minimumDispatcherVersion fails with the exact missing-key message.
+            string root = CreateTestRoot();
+            string pinPath = Path.Combine(root, "project-runner-pin.json");
+
+            try
+            {
+                Directory.CreateDirectory(root);
+                File.WriteAllText(pinPath, "{\"projectRunnerVersion\":\"3.0.0\"}");
+
+                CliPinLoadResult result = CliPinReaderService.LoadPinFromPath(pinPath);
+
+                Assert.That(result.Success, Is.False);
+                Assert.That(
+                    result.ErrorMessage,
+                    Is.EqualTo($"Unity CLI Loop pin file at {pinPath} is missing minimumDispatcherVersion."));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        private static string CreateTestRoot()
+        {
+            return Path.Combine(
+                Path.GetTempPath(),
+                "unity-cli-loop-tests",
+                Guid.NewGuid().ToString("N"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/CliPinReaderServiceTests.cs
+++ b/Assets/Tests/Editor/CliPinReaderServiceTests.cs
@@ -35,7 +35,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                Directory.Delete(root, recursive: true);
+                // Why: guard so a failure before directory creation does not mask the original
+                // exception with a DirectoryNotFoundException from cleanup.
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
             }
         }
 
@@ -71,7 +76,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                Directory.Delete(root, recursive: true);
+                // Why: guard so a failure before directory creation does not mask the original
+                // exception with a DirectoryNotFoundException from cleanup.
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
             }
         }
 
@@ -96,7 +106,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                Directory.Delete(root, recursive: true);
+                // Why: guard so a failure before directory creation does not mask the original
+                // exception with a DirectoryNotFoundException from cleanup.
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
             }
         }
 
@@ -121,7 +136,43 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
             finally
             {
-                Directory.Delete(root, recursive: true);
+                // Why: guard so a failure before directory creation does not mask the original
+                // exception with a DirectoryNotFoundException from cleanup.
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+            }
+        }
+
+        [Test]
+        public void LoadPinFromPath_WhenFileIsInvalidJson_ReturnsFailureWithInvalidJsonMessage()
+        {
+            // Tests that a pin file with malformed JSON fails with a message naming the pin path
+            // instead of letting the JsonReaderException escape.
+            string root = CreateTestRoot();
+            string pinPath = Path.Combine(root, "project-runner-pin.json");
+
+            try
+            {
+                Directory.CreateDirectory(root);
+                File.WriteAllText(pinPath, "{\"projectRunnerVersion\":");
+
+                CliPinLoadResult result = CliPinReaderService.LoadPinFromPath(pinPath);
+
+                Assert.That(result.Success, Is.False);
+                Assert.That(
+                    result.ErrorMessage,
+                    Does.StartWith($"Unity CLI Loop pin file at {pinPath} contains invalid JSON:"));
+            }
+            finally
+            {
+                // Why: guard so a failure before directory creation does not mask the original
+                // exception with a DirectoryNotFoundException from cleanup.
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
             }
         }
 

--- a/Assets/Tests/Editor/CliPinReaderServiceTests.cs.meta
+++ b/Assets/Tests/Editor/CliPinReaderServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52ccf95db8d754def9878110a5abbdef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
+++ b/Assets/Tests/Editor/CliSetupApplicationServiceTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -20,7 +21,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             FakeNativeCliInstaller nativeCliInstaller = new();
             CliSetupApplicationService service = new(
                 new FakeCliInstallationDetector(new string[] { null }),
-                nativeCliInstaller);
+                nativeCliInstaller,
+                new CliPinReaderService());
 
             await service.InstallGlobalCliAsync(RuntimePlatform.OSXEditor, CancellationToken.None);
 
@@ -35,7 +37,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies setup reads the minimum dispatcher version from the package pin JSON.
             CliSetupApplicationService service = new(
                 new FakeCliInstallationDetector(new string[] { null }),
-                new FakeNativeCliInstaller());
+                new FakeNativeCliInstaller(),
+                new CliPinReaderService());
 
             Assert.That(service.GetMinimumRequiredCliVersion(), Is.EqualTo(ExpectedMinimumDispatcherVersion()));
         }
@@ -46,7 +49,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies setup derives the prefixed release tag from the package pin instead of a duplicated constant.
             CliSetupApplicationService service = new(
                 new FakeCliInstallationDetector(new string[] { null }),
-                new FakeNativeCliInstaller());
+                new FakeNativeCliInstaller(),
+                new CliPinReaderService());
 
             Assert.That(service.GetMinimumRequiredCliReleaseTag(), Is.EqualTo(ExpectedDispatcherReleaseTag()));
         }
@@ -58,7 +62,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             FakeNativeCliInstaller nativeCliInstaller = new();
             CliSetupApplicationService service = new(
                 new FakeCliInstallationDetector(new string[] { null }),
-                nativeCliInstaller);
+                nativeCliInstaller,
+                new CliPinReaderService());
 
             NativeCliInstallCommand command = service.GetGlobalCliInstallCommand(
                 RuntimePlatform.OSXEditor,
@@ -71,7 +76,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private static string ExpectedMinimumDispatcherVersion()
         {
-            CliPinLoadResult result = CliPinReader.LoadPackagePin();
+            CliPinLoadResult result = new CliPinReaderService().LoadPackagePin();
             Assert.That(result.Success, Is.True, result.ErrorMessage);
             return result.Pin.MinimumDispatcherVersion;
         }

--- a/Packages/src/Editor/Application/CliPinReader.cs
+++ b/Packages/src/Editor/Application/CliPinReader.cs
@@ -1,10 +1,4 @@
-using System;
-using System.IO;
-
-using Newtonsoft.Json.Linq;
-
 using io.github.hatayama.UnityCliLoop.Domain;
-using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Application
 {
@@ -51,80 +45,24 @@ namespace io.github.hatayama.UnityCliLoop.Application
     }
 
     /// <summary>
-    /// Reads the CLI pin JSON that ships with the Unity package so callers can
-    /// consult a single source of truth for minimum-version requirements.
+    /// Defines how the CLI pin JSON shipped with the Unity package is read, so Application code can
+    /// consult a single source of truth for minimum-version requirements without depending on file IO.
+    /// </summary>
+    public interface ICliPinReader
+    {
+        CliPinLoadResult LoadPackagePin();
+        string LoadMinimumDispatcherVersionOrThrow();
+    }
+
+    /// <summary>
+    /// Builds derived values from the CLI pin JSON that ships with the Unity package.
     /// </summary>
     public static class CliPinReader
     {
-        // Why: keep pin JSON keys named in one place so callers do not spread string literals.
-        private const string PIN_JSON_PROJECT_RUNNER_VERSION_KEY = "projectRunnerVersion";
-        private const string PIN_JSON_MINIMUM_DISPATCHER_VERSION_KEY = "minimumDispatcherVersion";
-
-        public static CliPinLoadResult LoadPackagePin()
-        {
-            string pinPath = Path.Combine(
-                UnityCliLoopConstants.PackageResolvedPath,
-                UnityCliLoopConstants.ULOOP_PROJECT_RUNNER_PIN_FILE_NAME);
-            return LoadPinFromPath(pinPath);
-        }
-
-        // Why: exposed so tests and edge-case callers can point at an alternate pin file layout.
-        public static CliPinLoadResult LoadPinFromPath(string pinPath)
-        {
-            if (string.IsNullOrWhiteSpace(pinPath))
-            {
-                return CliPinLoadResult.FromFailure("Unity CLI Loop pin file path is empty.");
-            }
-
-            if (!File.Exists(pinPath))
-            {
-                return CliPinLoadResult.FromFailure(
-                    $"Unity CLI Loop pin file not found at {pinPath}.");
-            }
-
-            string content = File.ReadAllText(pinPath);
-            if (string.IsNullOrWhiteSpace(content))
-            {
-                return CliPinLoadResult.FromFailure(
-                    $"Unity CLI Loop pin file at {pinPath} is empty.");
-            }
-
-            JObject parsed = JObject.Parse(content);
-            string projectRunnerVersion = parsed[PIN_JSON_PROJECT_RUNNER_VERSION_KEY]?.ToString();
-            string minimumDispatcherVersion = parsed[PIN_JSON_MINIMUM_DISPATCHER_VERSION_KEY]?.ToString();
-            if (string.IsNullOrWhiteSpace(projectRunnerVersion))
-            {
-                return CliPinLoadResult.FromFailure(
-                    $"Unity CLI Loop pin file at {pinPath} is missing {PIN_JSON_PROJECT_RUNNER_VERSION_KEY}.");
-            }
-            if (string.IsNullOrWhiteSpace(minimumDispatcherVersion))
-            {
-                return CliPinLoadResult.FromFailure(
-                    $"Unity CLI Loop pin file at {pinPath} is missing {PIN_JSON_MINIMUM_DISPATCHER_VERSION_KEY}.");
-            }
-
-            return CliPinLoadResult.FromSuccess(
-                new CliPin(projectRunnerVersion, minimumDispatcherVersion));
-        }
-
         // Why: composes the dispatcher release tag from the pin so callers do not have to know the prefix.
         public static string BuildDispatcherReleaseTag(string minimumDispatcherVersion)
         {
             return CliConstants.DISPATCHER_RELEASE_TAG_PREFIX + minimumDispatcherVersion;
-        }
-
-        // Why: setup/detection paths must fail closed when the pin is unreadable rather than defaulting
-        // to "compatible", so both call sites share one Fail-Fast helper instead of duplicating it.
-        public static string LoadMinimumDispatcherVersionOrThrow()
-        {
-            CliPinLoadResult pinResult = LoadPackagePin();
-            if (!pinResult.Success)
-            {
-                throw new InvalidOperationException(
-                    "Unity CLI Loop cannot resolve minimum dispatcher version from the package pin: "
-                    + pinResult.ErrorMessage);
-            }
-            return pinResult.Pin.MinimumDispatcherVersion;
         }
     }
 }

--- a/Packages/src/Editor/Application/CliSetupApplicationService.cs
+++ b/Packages/src/Editor/Application/CliSetupApplicationService.cs
@@ -66,16 +66,20 @@ namespace io.github.hatayama.UnityCliLoop.Application
     {
         private readonly ICliInstallationDetector _cliInstallationDetector;
         private readonly INativeCliInstaller _nativeCliInstaller;
+        private readonly ICliPinReader _cliPinReader;
 
         public CliSetupApplicationService(
             ICliInstallationDetector cliInstallationDetector,
-            INativeCliInstaller nativeCliInstaller)
+            INativeCliInstaller nativeCliInstaller,
+            ICliPinReader cliPinReader)
         {
             Debug.Assert(cliInstallationDetector != null, "cliInstallationDetector must not be null");
             Debug.Assert(nativeCliInstaller != null, "nativeCliInstaller must not be null");
+            Debug.Assert(cliPinReader != null, "cliPinReader must not be null");
 
-            _cliInstallationDetector = cliInstallationDetector;
-            _nativeCliInstaller = nativeCliInstaller;
+            _cliInstallationDetector = cliInstallationDetector ?? throw new ArgumentNullException(nameof(cliInstallationDetector));
+            _nativeCliInstaller = nativeCliInstaller ?? throw new ArgumentNullException(nameof(nativeCliInstaller));
+            _cliPinReader = cliPinReader ?? throw new ArgumentNullException(nameof(cliPinReader));
         }
 
         public bool IsCliCheckCompleted()
@@ -127,14 +131,14 @@ namespace io.github.hatayama.UnityCliLoop.Application
         {
             // Why: v3 setup installs the global dispatcher and reads the minimum from the package pin JSON
             // so that the single source of truth stays consistent with the dispatcher installation flow.
-            return CliPinReader.LoadMinimumDispatcherVersionOrThrow();
+            return _cliPinReader.LoadMinimumDispatcherVersionOrThrow();
         }
 
         public string GetMinimumRequiredCliReleaseTag()
         {
             // Why: v3 setup installs the global dispatcher, and the release tag is derived from the pin so it
             // cannot drift from the version reported by GetMinimumRequiredCliVersion.
-            return CliPinReader.BuildDispatcherReleaseTag(CliPinReader.LoadMinimumDispatcherVersionOrThrow());
+            return CliPinReader.BuildDispatcherReleaseTag(_cliPinReader.LoadMinimumDispatcherVersionOrThrow());
         }
 
         public bool IsPackageOwnedCurrentUserInstallPath(

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -41,9 +41,11 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             SkillSetupUseCaseRegistry.Register(skillSetupUseCase);
             ThirdPartyToolMigrationUseCaseRegistry.Register(
                 new ThirdPartyToolMigrationUseCase(new ThirdPartyToolMigrationFileService()));
+            CliPinReaderService cliPinReaderService = new();
             CliSetupApplicationFacade.RegisterService(new CliSetupApplicationService(
-                new CliInstallationDetector(),
-                new NativeCliInstallerService()));
+                new CliInstallationDetector(cliPinReaderService),
+                new NativeCliInstallerService(),
+                cliPinReaderService));
             UnityCliLoopBridgeServerInstanceFactory serverFactory = new(domainReloadDetectionService);
             UnityCliLoopServerLifecycleRegistryService lifecycleRegistry = new();
             lifecycleRegistry.RegisterSource(serverFactory);

--- a/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
@@ -49,11 +49,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string VERSION_JSON_LEGACY_CLI_VERSION_PROPERTY = "CliVersion";
         private const string VERSION_JSON_DISPATCHER_VERSION_PROPERTY = "DispatcherVersion";
 
+        private readonly ICliPinReader _cliPinReader;
+
         private string _cachedCliVersion;
         private bool _cachedCliIsDispatcher;
         private string _cachedCliExecutablePath;
         private bool _cacheInitialized;
         private bool _isRefreshing;
+
+        public CliInstallationDetector(ICliPinReader cliPinReader)
+        {
+            UnityEngine.Debug.Assert(cliPinReader != null, "cliPinReader must not be null");
+
+            _cliPinReader = cliPinReader ?? throw new ArgumentNullException(nameof(cliPinReader));
+        }
 
         public bool IsCliInstalled()
         {
@@ -120,7 +129,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             // Why: resolve the minimum dispatcher version once on the caller thread so the background
             // detection task does not perform Unity package IO from a worker thread.
-            string minimumDispatcherVersion = CliPinReader.LoadMinimumDispatcherVersionOrThrow();
+            string minimumDispatcherVersion = _cliPinReader.LoadMinimumDispatcherVersionOrThrow();
 
             return Task.Run(
                 () =>

--- a/Packages/src/Editor/Infrastructure/CLI/CliPinReaderService.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliPinReaderService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 using io.github.hatayama.UnityCliLoop.Application;
@@ -61,7 +62,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     $"Unity CLI Loop pin file at {pinPath} is empty.");
             }
 
-            JObject parsed = JObject.Parse(content);
+            // Why: a corrupt pin must surface as a structured failure like every other unreadable-pin
+            // case, not as a raw parse exception; mirrors the JsonReaderException handling in
+            // JsonRpcProcessor and keeps LoadMinimumDispatcherVersionOrThrow's fail-closed message useful.
+            JObject parsed;
+            try
+            {
+                parsed = JObject.Parse(content);
+            }
+            catch (JsonReaderException ex)
+            {
+                return CliPinLoadResult.FromFailure(
+                    $"Unity CLI Loop pin file at {pinPath} contains invalid JSON: {ex.Message}");
+            }
+
             string projectRunnerVersion = parsed[PIN_JSON_PROJECT_RUNNER_VERSION_KEY]?.ToString();
             string minimumDispatcherVersion = parsed[PIN_JSON_MINIMUM_DISPATCHER_VERSION_KEY]?.ToString();
             if (string.IsNullOrWhiteSpace(projectRunnerVersion))

--- a/Packages/src/Editor/Infrastructure/CLI/CliPinReaderService.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliPinReaderService.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+
+using Newtonsoft.Json.Linq;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Reads the CLI pin JSON that ships with the Unity package from disk.
+    /// </summary>
+    public sealed class CliPinReaderService : ICliPinReader
+    {
+        // Why: keep pin JSON keys named in one place so callers do not spread string literals.
+        private const string PIN_JSON_PROJECT_RUNNER_VERSION_KEY = "projectRunnerVersion";
+        private const string PIN_JSON_MINIMUM_DISPATCHER_VERSION_KEY = "minimumDispatcherVersion";
+
+        public CliPinLoadResult LoadPackagePin()
+        {
+            string pinPath = Path.Combine(
+                UnityCliLoopConstants.PackageResolvedPath,
+                UnityCliLoopConstants.ULOOP_PROJECT_RUNNER_PIN_FILE_NAME);
+            return LoadPinFromPath(pinPath);
+        }
+
+        // Why: setup/detection paths must fail closed when the pin is unreadable rather than defaulting
+        // to "compatible", so both call sites share one Fail-Fast helper instead of duplicating it.
+        public string LoadMinimumDispatcherVersionOrThrow()
+        {
+            CliPinLoadResult pinResult = LoadPackagePin();
+            if (!pinResult.Success)
+            {
+                throw new InvalidOperationException(
+                    "Unity CLI Loop cannot resolve minimum dispatcher version from the package pin: "
+                    + pinResult.ErrorMessage);
+            }
+            return pinResult.Pin.MinimumDispatcherVersion;
+        }
+
+        // Why: internal so tests can point at an alternate pin file layout without exposing path-based
+        // loading on the public ICliPinReader surface.
+        internal static CliPinLoadResult LoadPinFromPath(string pinPath)
+        {
+            if (string.IsNullOrWhiteSpace(pinPath))
+            {
+                return CliPinLoadResult.FromFailure("Unity CLI Loop pin file path is empty.");
+            }
+
+            if (!File.Exists(pinPath))
+            {
+                return CliPinLoadResult.FromFailure(
+                    $"Unity CLI Loop pin file not found at {pinPath}.");
+            }
+
+            string content = File.ReadAllText(pinPath);
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return CliPinLoadResult.FromFailure(
+                    $"Unity CLI Loop pin file at {pinPath} is empty.");
+            }
+
+            JObject parsed = JObject.Parse(content);
+            string projectRunnerVersion = parsed[PIN_JSON_PROJECT_RUNNER_VERSION_KEY]?.ToString();
+            string minimumDispatcherVersion = parsed[PIN_JSON_MINIMUM_DISPATCHER_VERSION_KEY]?.ToString();
+            if (string.IsNullOrWhiteSpace(projectRunnerVersion))
+            {
+                return CliPinLoadResult.FromFailure(
+                    $"Unity CLI Loop pin file at {pinPath} is missing {PIN_JSON_PROJECT_RUNNER_VERSION_KEY}.");
+            }
+            if (string.IsNullOrWhiteSpace(minimumDispatcherVersion))
+            {
+                return CliPinLoadResult.FromFailure(
+                    $"Unity CLI Loop pin file at {pinPath} is missing {PIN_JSON_MINIMUM_DISPATCHER_VERSION_KEY}.");
+            }
+
+            return CliPinLoadResult.FromSuccess(
+                new CliPin(projectRunnerVersion, minimumDispatcherVersion));
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/CLI/CliPinReaderService.cs.meta
+++ b/Packages/src/Editor/Infrastructure/CLI/CliPinReaderService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a6bdf61389344c71a0a07f54be3f735
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- The CLI version pin (project-runner-pin.json) is now read through an ICliPinReader port implemented in Infrastructure, instead of static file IO calls inside the Application layer.

## User Impact
- No behavior change. Setup and installation checks read the same pin file with identical validation and error messages. This removes a hidden file-system dependency from the Application layer and makes pin-dependent flows testable without touching disk.

## Changes
- ICliPinReader declared in Application; CliPinReader static class retains only the pure BuildDispatcherReleaseTag helper
- New CliPinReaderService in Infrastructure/CLI carries the IO, parsing, and validation logic unchanged
- CliSetupApplicationService and CliInstallationDetector take the reader via constructor injection, wired in UnityCliLoopApplicationRegistration; CliInstallationDetector still resolves the pin on the caller thread before Task.Run
- CliPinSynchronizer (the pin writer) is untouched; pin format and protocol version are unaffected

## Verification
- uloop compile: 0 errors, 0 warnings
- uloop run-tests (CliPinReaderServiceTests, CliSetupApplicationServiceTests, CliInstallationDetectorTests, CliPathSetupFlowTests, OnionAssemblyDependencyTests, StaticFacadeStateGuardTests): 121/121 passed
- New CliPinReaderServiceTests cover valid pin, missing file, empty file, and each missing-key branch with exact message assertions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

