### PR TITLE
chore: Application layer no longer reads Unity editor state directly

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParameterValidationTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeParameterValidationTests.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 
 using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Tests.Editor;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
@@ -20,7 +21,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             // Verifies that a string Parameters value is rejected with a clear validation error before any compilation starts.
             // Arrange
             UnityCliLoopToolRegistry registry = ToolRegistryTestFactory.Create();
-            UnityCliLoopToolExecutionService executionService = new();
+            UnityCliLoopToolExecutionService executionService = new(new NoOpEditorRuntimeStatePort());
             JObject paramsToken = new()            {
                 ["Code"] = "return \"ok\";",
                 ["Parameters"] = "{}", // invalid: string instead of object

--- a/Assets/Tests/Editor/JsonRpcProcessorCliVersionGateTests.cs
+++ b/Assets/Tests/Editor/JsonRpcProcessorCliVersionGateTests.cs
@@ -166,7 +166,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new SingleFlightTestTool());
@@ -223,7 +223,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new ExecuteDynamicCodeTestTool());
@@ -288,7 +288,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new CompileDispatchPolicyTestTool());
@@ -328,7 +328,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new CompileDispatchPolicyTestTool());
@@ -365,7 +365,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new CompileDispatchPolicyTestTool());
@@ -405,7 +405,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new CompileDispatchPolicyTestTool());
@@ -448,7 +448,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
 
@@ -545,7 +545,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(service);
             service.RegisterCustomTool(new SingleFlightTestTool());

--- a/Assets/Tests/Editor/NoOpEditorRuntimeStatePort.cs
+++ b/Assets/Tests/Editor/NoOpEditorRuntimeStatePort.cs
@@ -1,0 +1,16 @@
+using io.github.hatayama.UnityCliLoop.Application;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Reports every Editor runtime state as false. Used by tests that construct
+    /// UnityCliLoopToolExecutionService but never exercise its compile/update/play-mode guarded paths.
+    /// </summary>
+    internal sealed class NoOpEditorRuntimeStatePort : IEditorRuntimeStatePort
+    {
+        public bool IsCompiling => false;
+        public bool IsUpdating => false;
+        public bool IsPlaying => false;
+        public bool IsPaused => false;
+    }
+}

--- a/Assets/Tests/Editor/NoOpEditorRuntimeStatePort.cs.meta
+++ b/Assets/Tests/Editor/NoOpEditorRuntimeStatePort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27632efcae2ca40679fb844088f32c7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -651,6 +651,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void ApplicationSources_WhenLoaded_DoNotReferenceUnityEditor()
+        {
+            // Tests that Application code stays free of UnityEditor so it can compile without the Editor platform.
+            string[] offendingReferences = ReadApplicationSourcePaths()
+                .SelectMany(path => FindForbiddenReferences(path, new[] { "UnityEditor" }))
+                .OrderBy(reference => reference)
+                .ToArray();
+
+            Assert.That(offendingReferences, Is.Empty);
+        }
+
+        [Test]
         public void ProjectIpcInfrastructure_WhenLoaded_CompilesUnderInfrastructureAssembly()
         {
             // Tests that project IPC transport implementation is owned by infrastructure.

--- a/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
@@ -24,7 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ToolSettingsUseCase useCase = new(
                 toolSettingsService,
@@ -50,7 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ToolSettingsUseCase useCase = new(
                 toolSettingsService,
@@ -73,7 +73,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             Dictionary<string, string> descriptions = new()
             {

--- a/Assets/Tests/Editor/UnityCliLoopEditorStateGuardTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorStateGuardTests.cs
@@ -13,9 +13,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that compile-time editor state is reported as retryable tool busy.
             UnityCliLoopToolBusyException exception = Assert.Throws<UnityCliLoopToolBusyException>(
                 () => UnityCliLoopEditorStateGuard.ValidateForState(
-                    UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE,
-                    true,
-                    false));
+                    toolName: UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE,
+                    isCompiling: true,
+                    isUpdating: false,
+                    isPlaying: false,
+                    isPaused: false));
 
             Assert.That(exception.RunningToolName, Is.Not.Empty);
             Assert.That(exception.RequestedToolName, Is.EqualTo(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE));
@@ -27,9 +29,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that asset-update editor state is reported as retryable tool busy.
             UnityCliLoopToolBusyException exception = Assert.Throws<UnityCliLoopToolBusyException>(
                 () => UnityCliLoopEditorStateGuard.ValidateForState(
-                    UnityCliLoopConstants.TOOL_NAME_CONTROL_PLAY_MODE,
-                    false,
-                    true));
+                    toolName: UnityCliLoopConstants.TOOL_NAME_CONTROL_PLAY_MODE,
+                    isCompiling: false,
+                    isUpdating: true,
+                    isPlaying: false,
+                    isPaused: false));
 
             Assert.That(exception.RunningToolName, Is.Not.Empty);
             Assert.That(exception.RequestedToolName, Is.EqualTo(UnityCliLoopConstants.TOOL_NAME_CONTROL_PLAY_MODE));
@@ -41,9 +45,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that read-only tools bypass state guards that only protect mutating commands.
             Assert.DoesNotThrow(
                 () => UnityCliLoopEditorStateGuard.ValidateForState(
-                    "get-logs",
-                    true,
-                    true));
+                    toolName: "get-logs",
+                    isCompiling: true,
+                    isUpdating: true,
+                    isPlaying: false,
+                    isPaused: false));
         }
     }
 }

--- a/Assets/Tests/Editor/UnityCliLoopToolExecutionServiceTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolExecutionServiceTests.cs
@@ -30,7 +30,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             try
             {
                 UnityCliLoopToolBusyException exception =
-                    UnityCliLoopToolExecutionService.CreateBusyException("running-tool", "requested-tool");
+                    UnityCliLoopToolExecutionService.CreateBusyException(
+                        "running-tool",
+                        "requested-tool",
+                        new NoOpEditorRuntimeStatePort());
 
                 Assert.That(exception.RunningToolName, Is.EqualTo("running-tool"));
                 Assert.That(exception.RequestedToolName, Is.EqualTo("requested-tool"));
@@ -51,7 +54,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistry registry = ToolRegistryTestFactory.Create();
             PendingTypedTool pendingTool = new PendingTypedTool();
             registry.RegisterTool(pendingTool);
-            UnityCliLoopToolExecutionService executionService = new UnityCliLoopToolExecutionService();
+            UnityCliLoopToolExecutionService executionService =
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort());
             ImmediateMainThreadDispatcher dispatcher = new ImmediateMainThreadDispatcher();
             MainThreadSwitcher.RegisterService(dispatcher);
             BlockingSynchronizationContext blockedContext = new BlockingSynchronizationContext();

--- a/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
@@ -388,7 +388,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Tests that third-party sample tools deserialize camelCase JSON into typed schema values.
             UnityCliLoopToolRegistry registry = ToolRegistryTestFactory.Create();
-            UnityCliLoopToolExecutionService executionService = new();
+            UnityCliLoopToolExecutionService executionService = new(new NoOpEditorRuntimeStatePort());
             JObject parameters = JObject.FromObject(new
             {
                 name = "<USER_NAME>",
@@ -413,7 +413,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Tests that tool execution may omit params and still use schema defaults.
             UnityCliLoopToolRegistry registry = ToolRegistryTestFactory.Create();
-            UnityCliLoopToolExecutionService executionService = new();
+            UnityCliLoopToolExecutionService executionService = new(new NoOpEditorRuntimeStatePort());
 
             UnityCliLoopToolResponse response = await executionService.ExecuteToolAsync(
                 registry,
@@ -431,7 +431,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Tests that tool responses do not carry obsolete per-response protocol version metadata.
             UnityCliLoopToolRegistry registry = ToolRegistryTestFactory.Create();
-            UnityCliLoopToolExecutionService executionService = new();
+            UnityCliLoopToolExecutionService executionService = new(new NoOpEditorRuntimeStatePort());
             JObject parameters = JObject.FromObject(new
             {
                 name = "Masamichi",
@@ -458,7 +458,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopToolRegistrarService service = new(
                 new EmptyInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ManualRegistrationTool tool = new();
 

--- a/Packages/src/Editor/Application/ApplicationEditorStartup.cs
+++ b/Packages/src/Editor/Application/ApplicationEditorStartup.cs
@@ -17,7 +17,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
             UnityCliLoopEditorDomainReloadStateRegistration.RegisterForEditorStartup();
             MainThreadSwitcher.InitializeForEditorStartup();
-            UnityCliLoopEditorStateSnapshot.InitializeForEditorStartup();
             EditorFrameWaiter.InitializeForEditorStartup();
             domainReloadDetectionService.RegisterForEditorStartup();
         }

--- a/Packages/src/Editor/Application/EditorRuntimeStatePort.cs
+++ b/Packages/src/Editor/Application/EditorRuntimeStatePort.cs
@@ -1,0 +1,14 @@
+namespace io.github.hatayama.UnityCliLoop.Application
+{
+    /// <summary>
+    /// Reads live Unity Editor runtime state so Application code can consult compile/update/play-mode
+    /// state without depending on Editor platform types directly.
+    /// </summary>
+    public interface IEditorRuntimeStatePort
+    {
+        bool IsCompiling { get; }
+        bool IsUpdating { get; }
+        bool IsPlaying { get; }
+        bool IsPaused { get; }
+    }
+}

--- a/Packages/src/Editor/Application/EditorRuntimeStatePort.cs.meta
+++ b/Packages/src/Editor/Application/EditorRuntimeStatePort.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa6b0ff6fa7d242e78b05bd2a290cccb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Application/UnityCliLoopEditorStateGuard.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopEditorStateGuard.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using UnityEditor;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -22,15 +21,24 @@ namespace io.github.hatayama.UnityCliLoop.Application
             NotUpdating = 2,
         }
 
-        public static void Validate(string toolName)
+        public static void Validate(string toolName, IEditorRuntimeStatePort editorRuntimeStatePort)
         {
+            Debug.Assert(editorRuntimeStatePort != null, "editorRuntimeStatePort must not be null");
+
             ValidateForState(
-                toolName,
-                EditorApplication.isCompiling,
-                EditorApplication.isUpdating);
+                toolName: toolName,
+                isCompiling: editorRuntimeStatePort.IsCompiling,
+                isUpdating: editorRuntimeStatePort.IsUpdating,
+                isPlaying: editorRuntimeStatePort.IsPlaying,
+                isPaused: editorRuntimeStatePort.IsPaused);
         }
 
-        internal static void ValidateForState(string toolName, bool isCompiling, bool isUpdating)
+        internal static void ValidateForState(
+            string toolName,
+            bool isCompiling,
+            bool isUpdating,
+            bool isPlaying,
+            bool isPaused)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(toolName), "toolName must not be null or whitespace");
 
@@ -45,8 +53,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 throw new UnityCliLoopToolBusyException(
                     UnityCompileOperationName,
                     toolName,
-                    EditorApplication.isPlaying,
-                    EditorApplication.isPaused);
+                    isPlaying,
+                    isPaused);
             }
 
             if ((condition & GuardCondition.NotUpdating) != 0 && isUpdating)
@@ -54,8 +62,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 throw new UnityCliLoopToolBusyException(
                     UnityAssetDatabaseUpdateOperationName,
                     toolName,
-                    EditorApplication.isPlaying,
-                    EditorApplication.isPaused);
+                    isPlaying,
+                    isPaused);
             }
         }
 

--- a/Packages/src/Editor/Application/UnityCliLoopEditorStateSnapshot.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopEditorStateSnapshot.cs
@@ -1,9 +1,9 @@
-using UnityEditor;
-
 namespace io.github.hatayama.UnityCliLoop.Application
 {
     /// <summary>
     /// Stores the latest Unity play state for error responses created outside the main thread.
+    /// Infrastructure keeps this cache fresh by subscribing to Editor update/play-mode events and calling
+    /// <see cref="SetPlayState"/>; this class holds no Editor platform dependency itself.
     /// </summary>
     internal static class UnityCliLoopEditorStateSnapshot
     {
@@ -11,15 +11,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
         private static bool _hasPlayState;
         private static bool _isPlaying;
         private static bool _isPaused;
-
-        internal static void InitializeForEditorStartup()
-        {
-            EditorApplication.update -= RefreshFromEditor;
-            EditorApplication.update += RefreshFromEditor;
-            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
-            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
-            RefreshFromEditor();
-        }
 
         internal static (bool HasValue, bool IsPlaying, bool IsPaused) GetPlayState()
         {
@@ -29,6 +20,18 @@ namespace io.github.hatayama.UnityCliLoop.Application
                     HasValue: _hasPlayState,
                     IsPlaying: _isPlaying,
                     IsPaused: _isPaused);
+            }
+        }
+
+        // Why: Infrastructure's Editor update/play-mode subscriber is the only production caller;
+        // internal (not private) so it can refresh this cache without Application depending on the Editor platform.
+        internal static void SetPlayState(bool isPlaying, bool isPaused)
+        {
+            lock (StateLock)
+            {
+                _hasPlayState = true;
+                _isPlaying = isPlaying;
+                _isPaused = isPaused;
             }
         }
 
@@ -44,28 +47,6 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 _hasPlayState = false;
                 _isPlaying = false;
                 _isPaused = false;
-            }
-        }
-
-        private static void OnPlayModeStateChanged(PlayModeStateChange state)
-        {
-            RefreshFromEditor();
-        }
-
-        private static void RefreshFromEditor()
-        {
-            SetPlayState(
-                EditorApplication.isPlaying,
-                EditorApplication.isPaused);
-        }
-
-        private static void SetPlayState(bool isPlaying, bool isPaused)
-        {
-            lock (StateLock)
-            {
-                _hasPlayState = true;
-                _isPlaying = isPlaying;
-                _isPaused = isPaused;
             }
         }
     }

--- a/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using UnityEditor;
 
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -17,9 +16,17 @@ namespace io.github.hatayama.UnityCliLoop.Application
     {
         private const string UnknownToolName = "unknown";
 
+        private readonly IEditorRuntimeStatePort _editorRuntimeStatePort;
         private readonly object _executionStateLock = new();
         private string _runningToolName;
         private int _runningExecutionCount;
+
+        internal UnityCliLoopToolExecutionService(IEditorRuntimeStatePort editorRuntimeStatePort)
+        {
+            Debug.Assert(editorRuntimeStatePort != null, "editorRuntimeStatePort must not be null");
+
+            _editorRuntimeStatePort = editorRuntimeStatePort ?? throw new ArgumentNullException(nameof(editorRuntimeStatePort));
+        }
 
         internal async Task<UnityCliLoopToolResponse> ExecuteToolAsync(
             UnityCliLoopToolRegistry registry,
@@ -50,14 +57,14 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
             if (!TryEnterExecution(toolName, out string runningToolName))
             {
-                throw CreateBusyException(runningToolName, toolName);
+                throw CreateBusyException(runningToolName, toolName, _editorRuntimeStatePort);
             }
 
             try
             {
                 await MainThreadSwitcher.SwitchToMainThread(ct);
                 ct.ThrowIfCancellationRequested();
-                UnityCliLoopEditorStateGuard.Validate(toolName);
+                UnityCliLoopEditorStateGuard.Validate(toolName, _editorRuntimeStatePort);
 
                 UnityCliLoopToolResponse response = await tool.ExecuteAsync(paramsToken, ct).ConfigureAwait(false);
                 if (response == null)
@@ -120,18 +127,20 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
         internal static UnityCliLoopToolBusyException CreateBusyException(
             string runningToolName,
-            string requestedToolName)
+            string requestedToolName,
+            IEditorRuntimeStatePort editorRuntimeStatePort)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(runningToolName), "runningToolName must not be null or whitespace");
             Debug.Assert(!string.IsNullOrWhiteSpace(requestedToolName), "requestedToolName must not be null or whitespace");
+            Debug.Assert(editorRuntimeStatePort != null, "editorRuntimeStatePort must not be null");
 
             if (MainThreadSwitcher.IsMainThread)
             {
                 return new UnityCliLoopToolBusyException(
                     runningToolName,
                     requestedToolName,
-                    EditorApplication.isPlaying,
-                    EditorApplication.isPaused);
+                    editorRuntimeStatePort.IsPlaying,
+                    editorRuntimeStatePort.IsPaused);
             }
 
             (bool HasValue, bool IsPlaying, bool IsPaused) playState =

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -26,10 +26,11 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             DomainReloadDetectionFileService domainReloadDetectionService = new(
                 sessionStateService);
             MainThreadSwitcher.RegisterService(new EditorMainThreadDispatcher());
+            EditorRuntimeStateService editorRuntimeStateService = new();
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new SkillInstallLayoutInternalToolNameProvider(),
                 toolSettingsService,
-                new UnityCliLoopToolExecutionService(),
+                new UnityCliLoopToolExecutionService(editorRuntimeStateService),
                 UnityCliLoopToolDiscovery.DiscoverTools);
             ApplicationRegistrar.RegisterService(toolRegistrarService);
             ToolContractsRegistrar.RegisterService(toolRegistrarService);

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopEditorBootstrapper.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopEditorBootstrapper.cs
@@ -26,6 +26,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             _ = CliPinSynchronizer.SyncCurrentProjectPin();
             UnityCliLoopApplicationServices applicationServices = _applicationRegistration.Register();
             ApplicationEditorStartup.Initialize(applicationServices.DomainReloadDetectionService);
+            EditorRuntimeStateSnapshotSubscriber.InitializeForEditorStartup();
             FirstPartyToolsEditorStartup.Initialize();
             InfrastructureEditorStartup.Initialize(applicationServices.EditorSettingsService);
             PresentationEditorStartup.Initialize(

--- a/Packages/src/Editor/Infrastructure/EditorState.meta
+++ b/Packages/src/Editor/Infrastructure/EditorState.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52e701d20de4f4c0f8e6f6c03b50118a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/EditorState/EditorRuntimeStateService.cs
+++ b/Packages/src/Editor/Infrastructure/EditorState/EditorRuntimeStateService.cs
@@ -1,0 +1,17 @@
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.Application;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Reads live Unity Editor runtime state directly from EditorApplication.
+    /// </summary>
+    public sealed class EditorRuntimeStateService : IEditorRuntimeStatePort
+    {
+        public bool IsCompiling => EditorApplication.isCompiling;
+        public bool IsUpdating => EditorApplication.isUpdating;
+        public bool IsPlaying => EditorApplication.isPlaying;
+        public bool IsPaused => EditorApplication.isPaused;
+    }
+}

--- a/Packages/src/Editor/Infrastructure/EditorState/EditorRuntimeStateService.cs.meta
+++ b/Packages/src/Editor/Infrastructure/EditorState/EditorRuntimeStateService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4ad8fafeda8c47188605863bb0b4d96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/EditorState/EditorRuntimeStateSnapshotSubscriber.cs
+++ b/Packages/src/Editor/Infrastructure/EditorState/EditorRuntimeStateSnapshotSubscriber.cs
@@ -1,0 +1,35 @@
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.Application;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    // Owns the EditorApplication event subscriptions that used to live in Application, so Application
+    // stays free of UnityEditor while UnityCliLoopEditorStateSnapshot keeps caching the latest play state.
+    /// <summary>
+    /// Keeps <see cref="UnityCliLoopEditorStateSnapshot"/> refreshed from Editor update and play-mode events.
+    /// </summary>
+    internal static class EditorRuntimeStateSnapshotSubscriber
+    {
+        internal static void InitializeForEditorStartup()
+        {
+            EditorApplication.update -= RefreshFromEditor;
+            EditorApplication.update += RefreshFromEditor;
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+            RefreshFromEditor();
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            RefreshFromEditor();
+        }
+
+        private static void RefreshFromEditor()
+        {
+            UnityCliLoopEditorStateSnapshot.SetPlayState(
+                EditorApplication.isPlaying,
+                EditorApplication.isPaused);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/EditorState/EditorRuntimeStateSnapshotSubscriber.cs.meta
+++ b/Packages/src/Editor/Infrastructure/EditorState/EditorRuntimeStateSnapshotSubscriber.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6c40818746874db5bfdcd78ac1086e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- The Application layer no longer touches `UnityEditor` APIs. Editor runtime state (compiling / updating / playing / paused) now flows through an `IEditorRuntimeStatePort` owned by Application and implemented in Infrastructure, following the same pattern as the CLI pin reader port (#1527).

## User Impact
- No runtime behavior change. Busy/guard error messages, state-refresh timing, and domain-reload subscription behavior are unchanged; only where the values are read from moved.

## Changes
- New `IEditorRuntimeStatePort` (Application) + `EditorRuntimeStateService` (Infrastructure) reading `EditorApplication` state.
- The `EditorApplication.update`/`playModeStateChanged` subscription moved from the Application-side snapshot into an Infrastructure subscriber, initialized at the same bootstrap position.
- `UnityCliLoopEditorStateGuard.ValidateForState` now receives all four state booleans explicitly (named arguments at every call site) instead of reading two of them from `EditorApplication` inside its throw branches.
- `UnityCliLoopToolExecutionService` takes the port via constructor injection from the composition root.
- New source-scan guard test `ApplicationSources_WhenLoaded_DoNotReferenceUnityEditor` pins the Application layer as UnityEditor-free (no compiler-level gate exists for UnityEditor usage).

## Verification
- `dist/darwin-arm64/uloop compile`: 0 errors, 0 warnings
- `uloop run-tests` (state guard, tool execution service, onion dependency, JSON-RPC version gate, tool registry, tool settings suites): 135/135 passed
- `grep -rn "UnityEditor" Packages/src/Editor/Application/`: zero matches

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

