### PR TITLE
chore: Compile result session state uses a dedicated repository

### DIFF
--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -221,6 +221,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void CompileResultSessionRepositoryPort_WhenLoaded_CompilesUnderDomainAssembly()
+        {
+            // Tests that compile-result session persistence stays behind a domain-owned repository port.
+            string repositoryAssemblyName = typeof(ICompileResultSessionRepository).Assembly.GetName().Name;
+
+            Assert.That(repositoryAssemblyName, Is.EqualTo(DomainAssemblyName));
+        }
+
+        [Test]
         public void ToolCorePolicy_WhenLoaded_CompilesUnderDomainAssembly()
         {
             // Tests that tool catalog and assembly classification rules stay in the domain layer.

--- a/Assets/Tests/Editor/UnityCliLoopEditorSessionStateRepositoryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSessionStateRepositoryTests.cs
@@ -141,21 +141,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetCompileResult_WhenLegacySingleSlotExists_ReturnsLegacyResult()
         {
             // Verifies an in-flight compile that started on the old storage key can finish after this assembly reloads.
-            UnityCliLoopEditorSessionStateRepository repository = new UnityCliLoopEditorSessionStateRepository();
             DateTime completedAtUtc = new DateTime(2026, 5, 30, 0, 0, 0, DateTimeKind.Utc);
-            repository.SetLegacyCompileResultRequestId("compile_legacy_request");
-            repository.SetLegacyCompileResultForceRecompile(false);
-            repository.SetLegacyCompileResultJson("{\"Success\":true}");
-            repository.SetLegacyCompileResultCompletedAtUtcTicks(completedAtUtc.Ticks.ToString());
+            UnityCliLoopCompileResultSessionRepository.SetLegacyCompileResultRequestId("compile_legacy_request");
+            UnityCliLoopCompileResultSessionRepository.SetLegacyCompileResultForceRecompile(false);
+            UnityCliLoopCompileResultSessionRepository.SetLegacyCompileResultJson("{\"Success\":true}");
+            UnityCliLoopCompileResultSessionRepository.SetLegacyCompileResultCompletedAtUtcTicks(
+                completedAtUtc.Ticks.ToString());
             UnityCliLoopEditorSessionStateService recreatedService =
-                new UnityCliLoopEditorSessionStateService(repository);
+                UnityCliLoopEditorSessionStateTestFactory.CreateService();
 
             UnityCliLoopStoredCompileResult storedResult =
                 recreatedService.GetCompileResult("compile_legacy_request");
 
             Assert.That(storedResult.HasResult, Is.True);
             Assert.That(storedResult.ResultJson, Is.EqualTo("{\"Success\":true}"));
-            Assert.That(repository.GetLegacyCompileResultRequestId(), Is.Empty);
+            Assert.That(UnityCliLoopCompileResultSessionRepository.GetLegacyCompileResultRequestId(), Is.Empty);
         }
 
         [Test]
@@ -216,7 +216,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             repository.SetLegacyPendingCompileExpiresAtUtcTicks(expiresAtUtc.Ticks.ToString());
             repository.SetLegacyPendingCompileReloadObserved(true);
             UnityCliLoopEditorSessionStateService recreatedService =
-                new UnityCliLoopEditorSessionStateService(repository);
+                new UnityCliLoopEditorSessionStateService(
+                    repository,
+                    new UnityCliLoopCompileResultSessionRepository());
 
             UnityCliLoopPendingCompileRequest pendingRequest =
                 recreatedService.GetPendingCompileRequestForRequestId("compile_legacy_request");
@@ -280,13 +282,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetStoredCompileResult_WhenCompletedTicksAreMalformed_ClearsSessionValue()
         {
             // Verifies malformed stored compile results self-heal instead of breaking status polling.
-            UnityCliLoopEditorSessionStateRepository repository = new UnityCliLoopEditorSessionStateRepository();
-            repository.SetCompileResultRequestIds("compile_test_request");
-            repository.SetCompileResultForceRecompile("compile_test_request", false);
-            repository.SetCompileResultJson("compile_test_request", "{\"Success\":true}");
-            repository.SetCompileResultCompletedAtUtcTicks("compile_test_request", "not_ticks");
+            UnityCliLoopCompileResultSessionRepository.SetCompileResultRequestIds("compile_test_request");
+            UnityCliLoopCompileResultSessionRepository.SetCompileResultForceRecompile("compile_test_request", false);
+            UnityCliLoopCompileResultSessionRepository.SetCompileResultJson("compile_test_request", "{\"Success\":true}");
+            UnityCliLoopCompileResultSessionRepository.SetCompileResultCompletedAtUtcTicks(
+                "compile_test_request",
+                "not_ticks");
             UnityCliLoopEditorSessionStateService recreatedService =
-                new UnityCliLoopEditorSessionStateService(repository);
+                UnityCliLoopEditorSessionStateTestFactory.CreateService();
 
             UnityCliLoopStoredCompileResult storedResult =
                 recreatedService.GetStoredCompileResult();
@@ -299,19 +302,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetCompileResult_WhenLegacyCompletedTicksAreOutOfRange_ClearsLegacySessionValue()
         {
             // Verifies legacy compile result migration rejects ticks that cannot become a UTC DateTime.
-            UnityCliLoopEditorSessionStateRepository repository = new UnityCliLoopEditorSessionStateRepository();
-            repository.SetLegacyCompileResultRequestId("compile_legacy_request");
-            repository.SetLegacyCompileResultForceRecompile(false);
-            repository.SetLegacyCompileResultJson("{\"Success\":true}");
-            repository.SetLegacyCompileResultCompletedAtUtcTicks(long.MaxValue.ToString());
+            UnityCliLoopCompileResultSessionRepository.SetLegacyCompileResultRequestId("compile_legacy_request");
+            UnityCliLoopCompileResultSessionRepository.SetLegacyCompileResultForceRecompile(false);
+            UnityCliLoopCompileResultSessionRepository.SetLegacyCompileResultJson("{\"Success\":true}");
+            UnityCliLoopCompileResultSessionRepository.SetLegacyCompileResultCompletedAtUtcTicks(long.MaxValue.ToString());
             UnityCliLoopEditorSessionStateService recreatedService =
-                new UnityCliLoopEditorSessionStateService(repository);
+                UnityCliLoopEditorSessionStateTestFactory.CreateService();
 
             UnityCliLoopStoredCompileResult storedResult =
                 recreatedService.GetCompileResult("compile_legacy_request");
 
             Assert.That(storedResult.HasResult, Is.False);
-            Assert.That(repository.GetLegacyCompileResultRequestId(), Is.Empty);
+            Assert.That(UnityCliLoopCompileResultSessionRepository.GetLegacyCompileResultRequestId(), Is.Empty);
         }
 
         [Test]

--- a/Assets/Tests/Editor/UnityCliLoopEditorSessionStateTestFactory.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSessionStateTestFactory.cs
@@ -10,7 +10,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     {
         internal static UnityCliLoopEditorSessionStateService CreateService()
         {
-            return new UnityCliLoopEditorSessionStateService(new UnityCliLoopEditorSessionStateRepository());
+            return new UnityCliLoopEditorSessionStateService(
+                new UnityCliLoopEditorSessionStateRepository(),
+                new UnityCliLoopCompileResultSessionRepository());
         }
 
         internal static UnityCliLoopEditorSessionStateSnapshot CaptureSnapshot(

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -18,7 +18,11 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             IToolSettingsPort toolSettingsPort = new ToolSettingsRepository();
             IUnityCliLoopEditorSettingsPort editorSettingsPort = new UnityCliLoopEditorSettingsRepository();
             UnityCliLoopEditorSessionStateRepository sessionStateRepository = new();
-            UnityCliLoopEditorSessionStateService sessionStateService = new(sessionStateRepository);
+            ICompileResultSessionRepository compileResultSessionRepository =
+                new UnityCliLoopCompileResultSessionRepository();
+            UnityCliLoopEditorSessionStateService sessionStateService = new(
+                sessionStateRepository,
+                compileResultSessionRepository);
             UnityCliLoopEditorSessionStateFacade.RegisterService(sessionStateService);
             UnityCliLoopFirstPartyServerLifecycleBinding firstPartyServerLifecycle = new(new ProjectIpcWarmupClient());
             DomainReloadDetectionFileService domainReloadDetectionService = new(

--- a/Packages/src/Editor/Domain/ICompileResultSessionRepository.cs
+++ b/Packages/src/Editor/Domain/ICompileResultSessionRepository.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Persists compile results that must survive Unity Editor Domain Reload within the current session.
+    /// </summary>
+    public interface ICompileResultSessionRepository
+    {
+        void StoreCompileResult(
+            string requestId,
+            bool forceRecompile,
+            string resultJson,
+            DateTime completedAtUtc);
+
+        UnityCliLoopStoredCompileResult GetCompileResult(string requestId);
+        UnityCliLoopStoredCompileResult GetStoredCompileResult();
+        UnityCliLoopStoredCompileResult[] GetStoredCompileResults();
+        void ClearCompileResult();
+        bool ClearExpiredCompileResult(DateTime utcNow, TimeSpan lifetime);
+    }
+}

--- a/Packages/src/Editor/Domain/ICompileResultSessionRepository.cs.meta
+++ b/Packages/src/Editor/Domain/ICompileResultSessionRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96bbab4a1a804a2d881e3e1259ddf504
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateService.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateService.cs
@@ -22,22 +22,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         void SetShowPostCompileReconnectingUI(bool showPostCompileReconnectingUI);
         bool GetShouldAutoScanThirdPartyToolMigration();
         void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration);
-        string GetCompileResultRequestIds();
-        void SetCompileResultRequestIds(string compileResultRequestIds);
-        string GetLegacyCompileResultRequestId();
-        void SetLegacyCompileResultRequestId(string compileResultRequestId);
-        bool GetLegacyCompileResultForceRecompile();
-        void SetLegacyCompileResultForceRecompile(bool compileResultForceRecompile);
-        string GetLegacyCompileResultJson();
-        void SetLegacyCompileResultJson(string compileResultJson);
-        string GetLegacyCompileResultCompletedAtUtcTicks();
-        void SetLegacyCompileResultCompletedAtUtcTicks(string compileResultCompletedAtUtcTicks);
-        bool GetCompileResultForceRecompile(string requestId);
-        void SetCompileResultForceRecompile(string requestId, bool compileResultForceRecompile);
-        string GetCompileResultJson(string requestId);
-        void SetCompileResultJson(string requestId, string compileResultJson);
-        string GetCompileResultCompletedAtUtcTicks(string requestId);
-        void SetCompileResultCompletedAtUtcTicks(string requestId, string compileResultCompletedAtUtcTicks);
         string GetPendingCompileRequestIds();
         void SetPendingCompileRequestIds(string pendingCompileRequestIds);
         string GetLegacyPendingCompileRequestId();
@@ -188,12 +172,18 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     {
         private static readonly TimeSpan CompileResultLifetime = TimeSpan.FromMinutes(32);
         private readonly IUnityCliLoopEditorSessionStatePort _sessionStatePort;
+        private readonly ICompileResultSessionRepository _compileResultSessionRepository;
 
-        public UnityCliLoopEditorSessionStateService(IUnityCliLoopEditorSessionStatePort sessionStatePort)
+        public UnityCliLoopEditorSessionStateService(
+            IUnityCliLoopEditorSessionStatePort sessionStatePort,
+            ICompileResultSessionRepository compileResultSessionRepository)
         {
             Debug.Assert(sessionStatePort != null, "sessionStatePort must not be null");
+            Debug.Assert(compileResultSessionRepository != null, "compileResultSessionRepository must not be null");
 
             _sessionStatePort = sessionStatePort ?? throw new ArgumentNullException(nameof(sessionStatePort));
+            _compileResultSessionRepository = compileResultSessionRepository ??
+                throw new ArgumentNullException(nameof(compileResultSessionRepository));
         }
 
         public bool GetIsServerRunning()
@@ -377,209 +367,38 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             string resultJson,
             DateTime completedAtUtc)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-            Debug.Assert(!string.IsNullOrWhiteSpace(resultJson), "resultJson must not be null or whitespace");
-            Debug.Assert(completedAtUtc.Kind == DateTimeKind.Utc, "completedAtUtc must be UTC");
-
-            _sessionStatePort.SetCompileResultRequestIds(
-                AddRequestIdToIndex(_sessionStatePort.GetCompileResultRequestIds(), requestId));
-            _sessionStatePort.SetCompileResultForceRecompile(requestId, forceRecompile);
-            _sessionStatePort.SetCompileResultJson(requestId, resultJson);
-            _sessionStatePort.SetCompileResultCompletedAtUtcTicks(requestId, completedAtUtc.Ticks.ToString());
+            _compileResultSessionRepository.StoreCompileResult(
+                requestId,
+                forceRecompile,
+                resultJson,
+                completedAtUtc);
         }
 
         public UnityCliLoopStoredCompileResult GetCompileResult(string requestId)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            string resultJson = _sessionStatePort.GetCompileResultJson(requestId);
-            if (string.IsNullOrWhiteSpace(resultJson))
-            {
-                UnityCliLoopStoredCompileResult legacyResult =
-                    GetLegacyCompileResultForRequestId(requestId);
-                if (legacyResult.HasResult)
-                {
-                    return legacyResult;
-                }
-
-                ClearCompileResultForRequestId(requestId);
-                return UnityCliLoopStoredCompileResult.None();
-            }
-
-            string completedAtUtcTicksText = _sessionStatePort.GetCompileResultCompletedAtUtcTicks(requestId);
-            (bool isValid, long completedAtUtcTicks) =
-                ParseUtcTicks(completedAtUtcTicksText);
-            if (!isValid || completedAtUtcTicks <= 0)
-            {
-                ClearCompileResultForRequestId(requestId);
-                return UnityCliLoopStoredCompileResult.None();
-            }
-
-            return UnityCliLoopStoredCompileResult.Create(
-                requestId,
-                _sessionStatePort.GetCompileResultForceRecompile(requestId),
-                resultJson,
-                completedAtUtcTicks);
+            return _compileResultSessionRepository.GetCompileResult(requestId);
         }
 
         public UnityCliLoopStoredCompileResult GetStoredCompileResult()
         {
-            UnityCliLoopStoredCompileResult[] storedResults = GetStoredCompileResults();
-            if (storedResults.Length == 0)
-            {
-                return UnityCliLoopStoredCompileResult.None();
-            }
-
-            return storedResults[0];
+            return _compileResultSessionRepository.GetStoredCompileResult();
         }
 
         public UnityCliLoopStoredCompileResult[] GetStoredCompileResults()
         {
-            string[] requestIds = ParseRequestIdIndex(_sessionStatePort.GetCompileResultRequestIds());
-            List<UnityCliLoopStoredCompileResult> storedResults =
-                new List<UnityCliLoopStoredCompileResult>();
-            foreach (string requestId in requestIds)
-            {
-                UnityCliLoopStoredCompileResult storedResult = GetCompileResult(requestId);
-                if (storedResult.HasResult)
-                {
-                    storedResults.Add(storedResult);
-                }
-            }
-
-            UnityCliLoopStoredCompileResult legacyResult = GetLegacyCompileResult();
-            if (legacyResult.HasResult && !ContainsCompileResult(storedResults, legacyResult.RequestId))
-            {
-                storedResults.Add(legacyResult);
-            }
-
-            return storedResults.ToArray();
+            return _compileResultSessionRepository.GetStoredCompileResults();
         }
 
         public void ClearCompileResult()
         {
-            foreach (string requestId in ParseRequestIdIndex(_sessionStatePort.GetCompileResultRequestIds()))
-            {
-                ClearCompileResultValues(requestId);
-            }
-
-            _sessionStatePort.SetCompileResultRequestIds("");
-            ClearLegacyCompileResult();
-        }
-
-        private void ClearCompileResultForRequestId(string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            ClearCompileResultValues(requestId);
-            _sessionStatePort.SetCompileResultRequestIds(
-                RemoveRequestIdFromIndex(_sessionStatePort.GetCompileResultRequestIds(), requestId));
-        }
-
-        private void ClearCompileResultValues(string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            _sessionStatePort.SetCompileResultForceRecompile(requestId, false);
-            _sessionStatePort.SetCompileResultJson(requestId, "");
-            _sessionStatePort.SetCompileResultCompletedAtUtcTicks(requestId, "");
-        }
-
-        private static bool ContainsCompileResult(
-            List<UnityCliLoopStoredCompileResult> storedResults,
-            string requestId)
-        {
-            Debug.Assert(storedResults != null, "storedResults must not be null");
-
-            foreach (UnityCliLoopStoredCompileResult storedResult in storedResults)
-            {
-                if (storedResult.RequestId == requestId)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private UnityCliLoopStoredCompileResult GetLegacyCompileResult()
-        {
-            string requestId = _sessionStatePort.GetLegacyCompileResultRequestId();
-            if (string.IsNullOrWhiteSpace(requestId))
-            {
-                return UnityCliLoopStoredCompileResult.None();
-            }
-
-            return GetLegacyCompileResultForRequestId(requestId);
-        }
-
-        private UnityCliLoopStoredCompileResult GetLegacyCompileResultForRequestId(string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            string legacyRequestId = _sessionStatePort.GetLegacyCompileResultRequestId();
-            if (legacyRequestId != requestId)
-            {
-                return UnityCliLoopStoredCompileResult.None();
-            }
-
-            string resultJson = _sessionStatePort.GetLegacyCompileResultJson();
-            if (string.IsNullOrWhiteSpace(resultJson))
-            {
-                ClearLegacyCompileResult();
-                return UnityCliLoopStoredCompileResult.None();
-            }
-
-            string completedAtUtcTicksText =
-                _sessionStatePort.GetLegacyCompileResultCompletedAtUtcTicks();
-            (bool isValid, long completedAtUtcTicks) =
-                ParseUtcTicks(completedAtUtcTicksText);
-            if (!isValid || completedAtUtcTicks <= 0)
-            {
-                ClearLegacyCompileResult();
-                return UnityCliLoopStoredCompileResult.None();
-            }
-
-            bool forceRecompile = _sessionStatePort.GetLegacyCompileResultForceRecompile();
-            StoreCompileResult(
-                requestId,
-                forceRecompile,
-                resultJson,
-                new DateTime(completedAtUtcTicks, DateTimeKind.Utc));
-            ClearLegacyCompileResult();
-            return UnityCliLoopStoredCompileResult.Create(
-                requestId,
-                forceRecompile,
-                resultJson,
-                completedAtUtcTicks);
-        }
-
-        private void ClearLegacyCompileResult()
-        {
-            _sessionStatePort.SetLegacyCompileResultRequestId("");
-            _sessionStatePort.SetLegacyCompileResultForceRecompile(false);
-            _sessionStatePort.SetLegacyCompileResultJson("");
-            _sessionStatePort.SetLegacyCompileResultCompletedAtUtcTicks("");
+            _compileResultSessionRepository.ClearCompileResult();
         }
 
         public bool ClearExpiredCompileResult(DateTime utcNow)
         {
             Debug.Assert(utcNow.Kind == DateTimeKind.Utc, "utcNow must be UTC");
 
-            bool cleared = false;
-            UnityCliLoopStoredCompileResult[] storedResults = GetStoredCompileResults();
-            foreach (UnityCliLoopStoredCompileResult storedResult in storedResults)
-            {
-                if (!storedResult.IsExpiredAt(utcNow, CompileResultLifetime))
-                {
-                    continue;
-                }
-
-                ClearCompileResultForRequestId(storedResult.RequestId);
-                cleared = true;
-            }
-
-            return cleared;
+            return _compileResultSessionRepository.ClearExpiredCompileResult(utcNow, CompileResultLifetime);
         }
 
         public void MarkPendingCompileRequest(

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopCompileResultSessionRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopCompileResultSessionRepository.cs
@@ -1,0 +1,452 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Stores compile-result session records in Unity SessionState.
+    /// </summary>
+    public sealed class UnityCliLoopCompileResultSessionRepository : ICompileResultSessionRepository
+    {
+        private const string KeyPrefix = "io.github.hatayama.uloopmcp.editorSession.";
+        private const string CompileResultRequestIdsKey = KeyPrefix + "compileResultRequestIds";
+        private const string LegacyCompileResultRequestIdKey = KeyPrefix + "compileResultRequestId";
+        private const string LegacyCompileResultForceRecompileKey = KeyPrefix + "compileResultForceRecompile";
+        private const string LegacyCompileResultJsonKey = KeyPrefix + "compileResultJson";
+        private const string LegacyCompileResultCompletedAtUtcTicksKey =
+            KeyPrefix + "compileResultCompletedAtUtcTicks";
+        private const string CompileResultKeyPrefix = KeyPrefix + "compileResult.";
+        private const string CompileResultForceRecompileKeySuffix = ".forceRecompile";
+        private const string CompileResultJsonKeySuffix = ".json";
+        private const string CompileResultCompletedAtUtcTicksKeySuffix = ".completedAtUtcTicks";
+
+        public void StoreCompileResult(
+            string requestId,
+            bool forceRecompile,
+            string resultJson,
+            DateTime completedAtUtc)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+            Debug.Assert(!string.IsNullOrWhiteSpace(resultJson), "resultJson must not be null or whitespace");
+            Debug.Assert(completedAtUtc.Kind == DateTimeKind.Utc, "completedAtUtc must be UTC");
+
+            SetCompileResultRequestIds(AddRequestIdToIndex(GetCompileResultRequestIds(), requestId));
+            SetCompileResultForceRecompile(requestId, forceRecompile);
+            SetCompileResultJson(requestId, resultJson);
+            SetCompileResultCompletedAtUtcTicks(requestId, completedAtUtc.Ticks.ToString());
+        }
+
+        public UnityCliLoopStoredCompileResult GetCompileResult(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            string resultJson = GetCompileResultJson(requestId);
+            if (string.IsNullOrWhiteSpace(resultJson))
+            {
+                UnityCliLoopStoredCompileResult legacyResult =
+                    GetLegacyCompileResultForRequestId(requestId);
+                if (legacyResult.HasResult)
+                {
+                    return legacyResult;
+                }
+
+                ClearCompileResultForRequestId(requestId);
+                return UnityCliLoopStoredCompileResult.None();
+            }
+
+            string completedAtUtcTicksText = GetCompileResultCompletedAtUtcTicks(requestId);
+            (bool isValid, long completedAtUtcTicks) =
+                ParseUtcTicks(completedAtUtcTicksText);
+            if (!isValid || completedAtUtcTicks <= 0)
+            {
+                ClearCompileResultForRequestId(requestId);
+                return UnityCliLoopStoredCompileResult.None();
+            }
+
+            return UnityCliLoopStoredCompileResult.Create(
+                requestId,
+                GetCompileResultForceRecompile(requestId),
+                resultJson,
+                completedAtUtcTicks);
+        }
+
+        public UnityCliLoopStoredCompileResult GetStoredCompileResult()
+        {
+            UnityCliLoopStoredCompileResult[] storedResults = GetStoredCompileResults();
+            if (storedResults.Length == 0)
+            {
+                return UnityCliLoopStoredCompileResult.None();
+            }
+
+            return storedResults[0];
+        }
+
+        public UnityCliLoopStoredCompileResult[] GetStoredCompileResults()
+        {
+            string[] requestIds = ParseRequestIdIndex(GetCompileResultRequestIds());
+            List<UnityCliLoopStoredCompileResult> storedResults =
+                new List<UnityCliLoopStoredCompileResult>();
+            foreach (string requestId in requestIds)
+            {
+                UnityCliLoopStoredCompileResult storedResult = GetCompileResult(requestId);
+                if (storedResult.HasResult)
+                {
+                    storedResults.Add(storedResult);
+                }
+            }
+
+            UnityCliLoopStoredCompileResult legacyResult = GetLegacyCompileResult();
+            if (legacyResult.HasResult && !ContainsCompileResult(storedResults, legacyResult.RequestId))
+            {
+                storedResults.Add(legacyResult);
+            }
+
+            return storedResults.ToArray();
+        }
+
+        public void ClearCompileResult()
+        {
+            foreach (string requestId in ParseRequestIdIndex(GetCompileResultRequestIds()))
+            {
+                ClearCompileResultValues(requestId);
+            }
+
+            SetCompileResultRequestIds("");
+            ClearLegacyCompileResult();
+        }
+
+        public bool ClearExpiredCompileResult(DateTime utcNow, TimeSpan lifetime)
+        {
+            Debug.Assert(utcNow.Kind == DateTimeKind.Utc, "utcNow must be UTC");
+            Debug.Assert(lifetime > TimeSpan.Zero, "lifetime must be positive");
+
+            bool cleared = false;
+            UnityCliLoopStoredCompileResult[] storedResults = GetStoredCompileResults();
+            foreach (UnityCliLoopStoredCompileResult storedResult in storedResults)
+            {
+                if (!storedResult.IsExpiredAt(utcNow, lifetime))
+                {
+                    continue;
+                }
+
+                ClearCompileResultForRequestId(storedResult.RequestId);
+                cleared = true;
+            }
+
+            return cleared;
+        }
+
+        // Tests seed pre-refactor and corrupt values through these helpers without widening the aggregate port.
+        internal static void SetLegacyCompileResultRequestId(string compileResultRequestId)
+        {
+            SetString(LegacyCompileResultRequestIdKey, compileResultRequestId);
+        }
+
+        internal static string GetLegacyCompileResultRequestId()
+        {
+            return GetString(LegacyCompileResultRequestIdKey);
+        }
+
+        internal static void SetLegacyCompileResultForceRecompile(bool compileResultForceRecompile)
+        {
+            SetBool(LegacyCompileResultForceRecompileKey, compileResultForceRecompile);
+        }
+
+        internal static void SetLegacyCompileResultJson(string compileResultJson)
+        {
+            SetString(LegacyCompileResultJsonKey, compileResultJson);
+        }
+
+        internal static void SetLegacyCompileResultCompletedAtUtcTicks(string compileResultCompletedAtUtcTicks)
+        {
+            SetString(LegacyCompileResultCompletedAtUtcTicksKey, compileResultCompletedAtUtcTicks);
+        }
+
+        internal static void SetCompileResultRequestIds(string compileResultRequestIds)
+        {
+            SetString(CompileResultRequestIdsKey, compileResultRequestIds);
+        }
+
+        internal static void SetCompileResultForceRecompile(string requestId, bool compileResultForceRecompile)
+        {
+            SetBool(CreateCompileResultKey(requestId, CompileResultForceRecompileKeySuffix), compileResultForceRecompile);
+        }
+
+        internal static void SetCompileResultJson(string requestId, string compileResultJson)
+        {
+            SetString(CreateCompileResultKey(requestId, CompileResultJsonKeySuffix), compileResultJson);
+        }
+
+        internal static void SetCompileResultCompletedAtUtcTicks(string requestId, string compileResultCompletedAtUtcTicks)
+        {
+            SetString(CreateCompileResultKey(requestId, CompileResultCompletedAtUtcTicksKeySuffix), compileResultCompletedAtUtcTicks);
+        }
+
+        private static string GetCompileResultRequestIds()
+        {
+            return GetString(CompileResultRequestIdsKey);
+        }
+
+        private static bool GetLegacyCompileResultForceRecompile()
+        {
+            return GetBool(LegacyCompileResultForceRecompileKey);
+        }
+
+        private static string GetLegacyCompileResultJson()
+        {
+            return GetString(LegacyCompileResultJsonKey);
+        }
+
+        private static string GetLegacyCompileResultCompletedAtUtcTicks()
+        {
+            return GetString(LegacyCompileResultCompletedAtUtcTicksKey);
+        }
+
+        private static bool GetCompileResultForceRecompile(string requestId)
+        {
+            return GetBool(CreateCompileResultKey(requestId, CompileResultForceRecompileKeySuffix));
+        }
+
+        private static string GetCompileResultJson(string requestId)
+        {
+            return GetString(CreateCompileResultKey(requestId, CompileResultJsonKeySuffix));
+        }
+
+        private static string GetCompileResultCompletedAtUtcTicks(string requestId)
+        {
+            return GetString(CreateCompileResultKey(requestId, CompileResultCompletedAtUtcTicksKeySuffix));
+        }
+
+        private static void ClearCompileResultForRequestId(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            ClearCompileResultValues(requestId);
+            SetCompileResultRequestIds(
+                RemoveRequestIdFromIndex(GetCompileResultRequestIds(), requestId));
+        }
+
+        private static void ClearCompileResultValues(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            SetCompileResultForceRecompile(requestId, false);
+            SetCompileResultJson(requestId, "");
+            SetCompileResultCompletedAtUtcTicks(requestId, "");
+        }
+
+        private static bool ContainsCompileResult(
+            List<UnityCliLoopStoredCompileResult> storedResults,
+            string requestId)
+        {
+            Debug.Assert(storedResults != null, "storedResults must not be null");
+
+            foreach (UnityCliLoopStoredCompileResult storedResult in storedResults)
+            {
+                if (storedResult.RequestId == requestId)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static UnityCliLoopStoredCompileResult GetLegacyCompileResult()
+        {
+            string requestId = GetLegacyCompileResultRequestId();
+            if (string.IsNullOrWhiteSpace(requestId))
+            {
+                return UnityCliLoopStoredCompileResult.None();
+            }
+
+            return GetLegacyCompileResultForRequestId(requestId);
+        }
+
+        private static UnityCliLoopStoredCompileResult GetLegacyCompileResultForRequestId(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            string legacyRequestId = GetLegacyCompileResultRequestId();
+            if (legacyRequestId != requestId)
+            {
+                return UnityCliLoopStoredCompileResult.None();
+            }
+
+            string resultJson = GetLegacyCompileResultJson();
+            if (string.IsNullOrWhiteSpace(resultJson))
+            {
+                ClearLegacyCompileResult();
+                return UnityCliLoopStoredCompileResult.None();
+            }
+
+            string completedAtUtcTicksText =
+                GetLegacyCompileResultCompletedAtUtcTicks();
+            (bool isValid, long completedAtUtcTicks) =
+                ParseUtcTicks(completedAtUtcTicksText);
+            if (!isValid || completedAtUtcTicks <= 0)
+            {
+                ClearLegacyCompileResult();
+                return UnityCliLoopStoredCompileResult.None();
+            }
+
+            bool forceRecompile = GetLegacyCompileResultForceRecompile();
+            StoreMigratedCompileResult(
+                requestId,
+                forceRecompile,
+                resultJson,
+                new DateTime(completedAtUtcTicks, DateTimeKind.Utc));
+            ClearLegacyCompileResult();
+            return UnityCliLoopStoredCompileResult.Create(
+                requestId,
+                forceRecompile,
+                resultJson,
+                completedAtUtcTicks);
+        }
+
+        private static void StoreMigratedCompileResult(
+            string requestId,
+            bool forceRecompile,
+            string resultJson,
+            DateTime completedAtUtc)
+        {
+            SetCompileResultRequestIds(AddRequestIdToIndex(GetCompileResultRequestIds(), requestId));
+            SetCompileResultForceRecompile(requestId, forceRecompile);
+            SetCompileResultJson(requestId, resultJson);
+            SetCompileResultCompletedAtUtcTicks(requestId, completedAtUtc.Ticks.ToString());
+        }
+
+        private static void ClearLegacyCompileResult()
+        {
+            SetLegacyCompileResultRequestId("");
+            SetBool(LegacyCompileResultForceRecompileKey, false);
+            SetString(LegacyCompileResultJsonKey, "");
+            SetString(LegacyCompileResultCompletedAtUtcTicksKey, "");
+        }
+
+        private static (bool IsValid, long Value) ParseUtcTicks(string utcTicksText)
+        {
+            if (string.IsNullOrWhiteSpace(utcTicksText))
+            {
+                return (true, 0);
+            }
+
+            string trimmedText = utcTicksText.Trim();
+            long value = 0;
+            foreach (char character in trimmedText)
+            {
+                if (character < '0' || character > '9')
+                {
+                    return (false, 0);
+                }
+
+                int digit = character - '0';
+                if (value > (long.MaxValue - digit) / 10)
+                {
+                    return (false, 0);
+                }
+
+                value = value * 10 + digit;
+            }
+
+            if (value > DateTime.MaxValue.Ticks)
+            {
+                return (false, 0);
+            }
+
+            return (true, value);
+        }
+
+        private static string[] ParseRequestIdIndex(string requestIdIndex)
+        {
+            if (string.IsNullOrWhiteSpace(requestIdIndex))
+            {
+                return Array.Empty<string>();
+            }
+
+            string[] rawRequestIds = requestIdIndex.Split(
+                new[] { '\n' },
+                StringSplitOptions.RemoveEmptyEntries);
+            List<string> requestIds = new List<string>();
+            foreach (string rawRequestId in rawRequestIds)
+            {
+                string requestId = rawRequestId.Trim();
+                if (string.IsNullOrWhiteSpace(requestId) || requestIds.Contains(requestId))
+                {
+                    continue;
+                }
+
+                requestIds.Add(requestId);
+            }
+
+            return requestIds.ToArray();
+        }
+
+        private static string FormatRequestIdIndex(List<string> requestIds)
+        {
+            Debug.Assert(requestIds != null, "requestIds must not be null");
+            return string.Join("\n", requestIds.ToArray());
+        }
+
+        private static string AddRequestIdToIndex(string requestIdIndex, string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            List<string> requestIds = new List<string>(ParseRequestIdIndex(requestIdIndex));
+            if (!requestIds.Contains(requestId))
+            {
+                requestIds.Add(requestId);
+            }
+
+            return FormatRequestIdIndex(requestIds);
+        }
+
+        private static string RemoveRequestIdFromIndex(string requestIdIndex, string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            List<string> requestIds = new List<string>();
+            foreach (string indexedRequestId in ParseRequestIdIndex(requestIdIndex))
+            {
+                if (indexedRequestId == requestId)
+                {
+                    continue;
+                }
+
+                requestIds.Add(indexedRequestId);
+            }
+
+            return FormatRequestIdIndex(requestIds);
+        }
+
+        private static string CreateCompileResultKey(string requestId, string suffix)
+        {
+            return CompileResultKeyPrefix + requestId + suffix;
+        }
+
+        private static bool GetBool(string key)
+        {
+            return SessionState.GetBool(key, false);
+        }
+
+        private static void SetBool(string key, bool value)
+        {
+            SessionState.SetBool(key, value);
+        }
+
+        private static string GetString(string key)
+        {
+            return SessionState.GetString(key, "");
+        }
+
+        private static void SetString(string key, string value)
+        {
+            SessionState.SetString(key, value ?? "");
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopCompileResultSessionRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopCompileResultSessionRepository.cs
@@ -141,7 +141,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return cleared;
         }
 
-        // Tests seed pre-refactor and corrupt values through these helpers without widening the aggregate port.
+        // Tests and legacy migration use these helpers without widening the aggregate port.
         internal static void SetLegacyCompileResultRequestId(string compileResultRequestId)
         {
             SetString(LegacyCompileResultRequestIdKey, compileResultRequestId);
@@ -257,7 +257,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return false;
         }
 
-        private static UnityCliLoopStoredCompileResult GetLegacyCompileResult()
+        private UnityCliLoopStoredCompileResult GetLegacyCompileResult()
         {
             string requestId = GetLegacyCompileResultRequestId();
             if (string.IsNullOrWhiteSpace(requestId))
@@ -268,7 +268,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return GetLegacyCompileResultForRequestId(requestId);
         }
 
-        private static UnityCliLoopStoredCompileResult GetLegacyCompileResultForRequestId(string requestId)
+        private UnityCliLoopStoredCompileResult GetLegacyCompileResultForRequestId(string requestId)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
 
@@ -296,7 +296,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             bool forceRecompile = GetLegacyCompileResultForceRecompile();
-            StoreMigratedCompileResult(
+            StoreCompileResult(
                 requestId,
                 forceRecompile,
                 resultJson,
@@ -309,24 +309,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 completedAtUtcTicks);
         }
 
-        private static void StoreMigratedCompileResult(
-            string requestId,
-            bool forceRecompile,
-            string resultJson,
-            DateTime completedAtUtc)
-        {
-            SetCompileResultRequestIds(AddRequestIdToIndex(GetCompileResultRequestIds(), requestId));
-            SetCompileResultForceRecompile(requestId, forceRecompile);
-            SetCompileResultJson(requestId, resultJson);
-            SetCompileResultCompletedAtUtcTicks(requestId, completedAtUtc.Ticks.ToString());
-        }
-
         private static void ClearLegacyCompileResult()
         {
             SetLegacyCompileResultRequestId("");
-            SetBool(LegacyCompileResultForceRecompileKey, false);
-            SetString(LegacyCompileResultJsonKey, "");
-            SetString(LegacyCompileResultCompletedAtUtcTicksKey, "");
+            SetLegacyCompileResultForceRecompile(false);
+            SetLegacyCompileResultJson("");
+            SetLegacyCompileResultCompletedAtUtcTicks("");
         }
 
         private static (bool IsValid, long Value) ParseUtcTicks(string utcTicksText)

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopCompileResultSessionRepository.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopCompileResultSessionRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 695e6bce8df3422e9f4bfeb384008f87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateRepository.cs
@@ -5,7 +5,7 @@ using io.github.hatayama.UnityCliLoop.Domain;
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
     /// <summary>
-    /// Stores Unity CLI Loop runtime flags in Unity SessionState for the current Editor session.
+    /// Stores Unity CLI Loop runtime flags and pending compile markers for the current Editor session.
     /// </summary>
     public sealed class UnityCliLoopEditorSessionStateRepository : IUnityCliLoopEditorSessionStatePort
     {
@@ -19,16 +19,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string ShowPostCompileReconnectingUIKey = KeyPrefix + "showPostCompileReconnectingUI";
         private const string ShouldAutoScanThirdPartyToolMigrationKey =
             KeyPrefix + "shouldAutoScanThirdPartyToolMigration";
-        private const string CompileResultRequestIdsKey = KeyPrefix + "compileResultRequestIds";
-        private const string LegacyCompileResultRequestIdKey = KeyPrefix + "compileResultRequestId";
-        private const string LegacyCompileResultForceRecompileKey = KeyPrefix + "compileResultForceRecompile";
-        private const string LegacyCompileResultJsonKey = KeyPrefix + "compileResultJson";
-        private const string LegacyCompileResultCompletedAtUtcTicksKey =
-            KeyPrefix + "compileResultCompletedAtUtcTicks";
-        private const string CompileResultKeyPrefix = KeyPrefix + "compileResult.";
-        private const string CompileResultForceRecompileKeySuffix = ".forceRecompile";
-        private const string CompileResultJsonKeySuffix = ".json";
-        private const string CompileResultCompletedAtUtcTicksKeySuffix = ".completedAtUtcTicks";
         private const string PendingCompileRequestIdsKey = KeyPrefix + "pendingCompileRequestIds";
         private const string LegacyPendingCompileRequestIdKey = KeyPrefix + "pendingCompileRequestId";
         private const string LegacyPendingCompileForceRecompileKey = KeyPrefix + "pendingCompileForceRecompile";
@@ -120,86 +110,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             SetBool(ShouldAutoScanThirdPartyToolMigrationKey, shouldAutoScanThirdPartyToolMigration);
         }
 
-        public string GetCompileResultRequestIds()
-        {
-            return GetString(CompileResultRequestIdsKey);
-        }
-
-        public void SetCompileResultRequestIds(string compileResultRequestIds)
-        {
-            SetString(CompileResultRequestIdsKey, compileResultRequestIds);
-        }
-
-        public string GetLegacyCompileResultRequestId()
-        {
-            return GetString(LegacyCompileResultRequestIdKey);
-        }
-
-        public void SetLegacyCompileResultRequestId(string compileResultRequestId)
-        {
-            SetString(LegacyCompileResultRequestIdKey, compileResultRequestId);
-        }
-
-        public bool GetLegacyCompileResultForceRecompile()
-        {
-            return GetBool(LegacyCompileResultForceRecompileKey);
-        }
-
-        public void SetLegacyCompileResultForceRecompile(bool compileResultForceRecompile)
-        {
-            SetBool(LegacyCompileResultForceRecompileKey, compileResultForceRecompile);
-        }
-
-        public string GetLegacyCompileResultJson()
-        {
-            return GetString(LegacyCompileResultJsonKey);
-        }
-
-        public void SetLegacyCompileResultJson(string compileResultJson)
-        {
-            SetString(LegacyCompileResultJsonKey, compileResultJson);
-        }
-
-        public string GetLegacyCompileResultCompletedAtUtcTicks()
-        {
-            return GetString(LegacyCompileResultCompletedAtUtcTicksKey);
-        }
-
-        public void SetLegacyCompileResultCompletedAtUtcTicks(string compileResultCompletedAtUtcTicks)
-        {
-            SetString(LegacyCompileResultCompletedAtUtcTicksKey, compileResultCompletedAtUtcTicks);
-        }
-
-        public bool GetCompileResultForceRecompile(string requestId)
-        {
-            return GetBool(CreateCompileResultKey(requestId, CompileResultForceRecompileKeySuffix));
-        }
-
-        public void SetCompileResultForceRecompile(string requestId, bool compileResultForceRecompile)
-        {
-            SetBool(CreateCompileResultKey(requestId, CompileResultForceRecompileKeySuffix), compileResultForceRecompile);
-        }
-
-        public string GetCompileResultJson(string requestId)
-        {
-            return GetString(CreateCompileResultKey(requestId, CompileResultJsonKeySuffix));
-        }
-
-        public void SetCompileResultJson(string requestId, string compileResultJson)
-        {
-            SetString(CreateCompileResultKey(requestId, CompileResultJsonKeySuffix), compileResultJson);
-        }
-
-        public string GetCompileResultCompletedAtUtcTicks(string requestId)
-        {
-            return GetString(CreateCompileResultKey(requestId, CompileResultCompletedAtUtcTicksKeySuffix));
-        }
-
-        public void SetCompileResultCompletedAtUtcTicks(string requestId, string compileResultCompletedAtUtcTicks)
-        {
-            SetString(CreateCompileResultKey(requestId, CompileResultCompletedAtUtcTicksKeySuffix), compileResultCompletedAtUtcTicks);
-        }
-
         public string GetPendingCompileRequestIds()
         {
             return GetString(PendingCompileRequestIdsKey);
@@ -278,11 +188,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public void SetPendingCompileReloadObserved(string requestId, bool pendingCompileReloadObserved)
         {
             SetBool(CreatePendingCompileKey(requestId, PendingCompileReloadObservedKeySuffix), pendingCompileReloadObserved);
-        }
-
-        private static string CreateCompileResultKey(string requestId, string suffix)
-        {
-            return CompileResultKeyPrefix + requestId + suffix;
         }
 
         private static string CreatePendingCompileKey(string requestId, string suffix)


### PR DESCRIPTION
## Summary
- Split compile-result session persistence out of the broad editor SessionState port.
- Keep existing compile-result behavior unchanged while preparing the remaining PendingCompile and SessionFlags splits.

## User Impact
- No user-facing behavior change is intended.
- Compile result recovery after Domain Reload keeps the same keyed storage, legacy migration, malformed tick cleanup, and expiry behavior.

## Changes
- Added a domain-owned compile-result session repository port and a Unity SessionState-backed infrastructure implementation.
- Removed the compile-result raw KV methods from the broad editor session-state port.
- Kept UnityCliLoopEditorSessionStateService as a transitional delegate for this series; service delegation is transitional and will be removed in the final PR of this series.
- Updated session-state tests and onion guard coverage for the new repository port.

## Verification
- dist/darwin-arm64/uloop compile --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" (0 errors, 0 warnings)
- dist/darwin-arm64/uloop run-tests --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" --test-mode EditMode --filter-type regex --filter-value "(UnityCliLoopEditorSessionStateRepositoryTests|CompileStatusBridgeCommandTests|CompileSessionResultServiceTests|OnionAssemblyDependencyTests|StaticFacadeStateGuardTests)" (127 passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

