### PR TITLE
chore: Pending compile session state uses a dedicated repository

### DIFF
--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -230,6 +230,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void PendingCompileSessionRepositoryPort_WhenLoaded_CompilesUnderDomainAssembly()
+        {
+            // Tests that pending compile session persistence stays behind a domain-owned repository port.
+            string repositoryAssemblyName = typeof(IPendingCompileSessionRepository).Assembly.GetName().Name;
+
+            Assert.That(repositoryAssemblyName, Is.EqualTo(DomainAssemblyName));
+        }
+
+        [Test]
         public void ToolCorePolicy_WhenLoaded_CompilesUnderDomainAssembly()
         {
             // Tests that tool catalog and assembly classification rules stay in the domain layer.

--- a/Assets/Tests/Editor/UnityCliLoopEditorSessionStateRepositoryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSessionStateRepositoryTests.cs
@@ -209,16 +209,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetPendingCompileRequestForRequestId_WhenLegacySingleSlotExists_ReturnsLegacyRequest()
         {
             // Verifies pending compile recovery can see a request marked before this assembly reloads.
-            UnityCliLoopEditorSessionStateRepository repository = new UnityCliLoopEditorSessionStateRepository();
             DateTime expiresAtUtc = new DateTime(2026, 5, 30, 0, 32, 0, DateTimeKind.Utc);
-            repository.SetLegacyPendingCompileRequestId("compile_legacy_request");
-            repository.SetLegacyPendingCompileForceRecompile(true);
-            repository.SetLegacyPendingCompileExpiresAtUtcTicks(expiresAtUtc.Ticks.ToString());
-            repository.SetLegacyPendingCompileReloadObserved(true);
+            UnityCliLoopPendingCompileSessionRepository.SetLegacyPendingCompileRequestId("compile_legacy_request");
+            UnityCliLoopPendingCompileSessionRepository.SetLegacyPendingCompileForceRecompile(true);
+            UnityCliLoopPendingCompileSessionRepository.SetLegacyPendingCompileExpiresAtUtcTicks(
+                expiresAtUtc.Ticks.ToString());
+            UnityCliLoopPendingCompileSessionRepository.SetLegacyPendingCompileReloadObserved(true);
             UnityCliLoopEditorSessionStateService recreatedService =
                 new UnityCliLoopEditorSessionStateService(
-                    repository,
-                    new UnityCliLoopCompileResultSessionRepository());
+                    new UnityCliLoopEditorSessionStateRepository(),
+                    new UnityCliLoopCompileResultSessionRepository(),
+                    new UnityCliLoopPendingCompileSessionRepository());
 
             UnityCliLoopPendingCompileRequest pendingRequest =
                 recreatedService.GetPendingCompileRequestForRequestId("compile_legacy_request");
@@ -226,7 +227,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(pendingRequest.HasRequest, Is.True);
             Assert.That(pendingRequest.ForceRecompile, Is.True);
             Assert.That(pendingRequest.ReloadObserved, Is.True);
-            Assert.That(repository.GetLegacyPendingCompileRequestId(), Is.Empty);
+            Assert.That(UnityCliLoopPendingCompileSessionRepository.GetLegacyPendingCompileRequestId(), Is.Empty);
         }
 
         [Test]

--- a/Assets/Tests/Editor/UnityCliLoopEditorSessionStateTestFactory.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSessionStateTestFactory.cs
@@ -12,7 +12,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             return new UnityCliLoopEditorSessionStateService(
                 new UnityCliLoopEditorSessionStateRepository(),
-                new UnityCliLoopCompileResultSessionRepository());
+                new UnityCliLoopCompileResultSessionRepository(),
+                new UnityCliLoopPendingCompileSessionRepository());
         }
 
         internal static UnityCliLoopEditorSessionStateSnapshot CaptureSnapshot(

--- a/Assets/Tests/Editor/UnityCliLoopEditorSessionStateTestFactory.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSessionStateTestFactory.cs
@@ -85,7 +85,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 service.StorePendingCompileRequest(
                     pendingCompileRequest.RequestId,
                     pendingCompileRequest.ForceRecompile,
-                    pendingCompileRequest.ExpiresAtUtcTicks,
+                    new System.DateTime(
+                        pendingCompileRequest.ExpiresAtUtcTicks,
+                        System.DateTimeKind.Utc),
                     pendingCompileRequest.ReloadObserved);
             }
         }

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -20,9 +20,12 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             UnityCliLoopEditorSessionStateRepository sessionStateRepository = new();
             ICompileResultSessionRepository compileResultSessionRepository =
                 new UnityCliLoopCompileResultSessionRepository();
+            IPendingCompileSessionRepository pendingCompileSessionRepository =
+                new UnityCliLoopPendingCompileSessionRepository();
             UnityCliLoopEditorSessionStateService sessionStateService = new(
                 sessionStateRepository,
-                compileResultSessionRepository);
+                compileResultSessionRepository,
+                pendingCompileSessionRepository);
             UnityCliLoopEditorSessionStateFacade.RegisterService(sessionStateService);
             UnityCliLoopFirstPartyServerLifecycleBinding firstPartyServerLifecycle = new(new ProjectIpcWarmupClient());
             DomainReloadDetectionFileService domainReloadDetectionService = new(

--- a/Packages/src/Editor/Domain/IPendingCompileSessionRepository.cs
+++ b/Packages/src/Editor/Domain/IPendingCompileSessionRepository.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Stores pending compile recovery requests for the current Unity Editor session.
+    /// </summary>
+    public interface IPendingCompileSessionRepository
+    {
+        void StorePendingCompileRequest(
+            string requestId,
+            bool forceRecompile,
+            long expiresAtUtcTicks,
+            bool reloadObserved);
+
+        UnityCliLoopPendingCompileRequest GetPendingCompileRequest();
+        UnityCliLoopPendingCompileRequest[] GetPendingCompileRequests();
+        bool MarkPendingCompileRequestReloadObserved();
+        UnityCliLoopPendingCompileRequest GetPendingCompileRequestForRequestId(string requestId);
+        void ClearPendingCompileRequest();
+        bool ClearPendingCompileRequestIfMatches(string requestId);
+        bool ClearExpiredPendingCompileRequest(DateTime utcNow);
+    }
+}

--- a/Packages/src/Editor/Domain/IPendingCompileSessionRepository.cs
+++ b/Packages/src/Editor/Domain/IPendingCompileSessionRepository.cs
@@ -10,10 +10,9 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         void StorePendingCompileRequest(
             string requestId,
             bool forceRecompile,
-            long expiresAtUtcTicks,
+            DateTime expiresAtUtc,
             bool reloadObserved);
 
-        UnityCliLoopPendingCompileRequest GetPendingCompileRequest();
         UnityCliLoopPendingCompileRequest[] GetPendingCompileRequests();
         bool MarkPendingCompileRequestReloadObserved();
         UnityCliLoopPendingCompileRequest GetPendingCompileRequestForRequestId(string requestId);

--- a/Packages/src/Editor/Domain/IPendingCompileSessionRepository.cs.meta
+++ b/Packages/src/Editor/Domain/IPendingCompileSessionRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f1b0d96cf2243c38a60436a7bbf34be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateService.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace io.github.hatayama.UnityCliLoop.Domain
@@ -22,22 +21,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         void SetShowPostCompileReconnectingUI(bool showPostCompileReconnectingUI);
         bool GetShouldAutoScanThirdPartyToolMigration();
         void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration);
-        string GetPendingCompileRequestIds();
-        void SetPendingCompileRequestIds(string pendingCompileRequestIds);
-        string GetLegacyPendingCompileRequestId();
-        void SetLegacyPendingCompileRequestId(string pendingCompileRequestId);
-        bool GetLegacyPendingCompileForceRecompile();
-        void SetLegacyPendingCompileForceRecompile(bool pendingCompileForceRecompile);
-        string GetLegacyPendingCompileExpiresAtUtcTicks();
-        void SetLegacyPendingCompileExpiresAtUtcTicks(string pendingCompileExpiresAtUtcTicks);
-        bool GetLegacyPendingCompileReloadObserved();
-        void SetLegacyPendingCompileReloadObserved(bool pendingCompileReloadObserved);
-        bool GetPendingCompileForceRecompile(string requestId);
-        void SetPendingCompileForceRecompile(string requestId, bool pendingCompileForceRecompile);
-        string GetPendingCompileExpiresAtUtcTicks(string requestId);
-        void SetPendingCompileExpiresAtUtcTicks(string requestId, string pendingCompileExpiresAtUtcTicks);
-        bool GetPendingCompileReloadObserved(string requestId);
-        void SetPendingCompileReloadObserved(string requestId, bool pendingCompileReloadObserved);
     }
 
     /// <summary>
@@ -173,17 +156,22 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         private static readonly TimeSpan CompileResultLifetime = TimeSpan.FromMinutes(32);
         private readonly IUnityCliLoopEditorSessionStatePort _sessionStatePort;
         private readonly ICompileResultSessionRepository _compileResultSessionRepository;
+        private readonly IPendingCompileSessionRepository _pendingCompileSessionRepository;
 
         public UnityCliLoopEditorSessionStateService(
             IUnityCliLoopEditorSessionStatePort sessionStatePort,
-            ICompileResultSessionRepository compileResultSessionRepository)
+            ICompileResultSessionRepository compileResultSessionRepository,
+            IPendingCompileSessionRepository pendingCompileSessionRepository)
         {
             Debug.Assert(sessionStatePort != null, "sessionStatePort must not be null");
             Debug.Assert(compileResultSessionRepository != null, "compileResultSessionRepository must not be null");
+            Debug.Assert(pendingCompileSessionRepository != null, "pendingCompileSessionRepository must not be null");
 
             _sessionStatePort = sessionStatePort ?? throw new ArgumentNullException(nameof(sessionStatePort));
             _compileResultSessionRepository = compileResultSessionRepository ??
                 throw new ArgumentNullException(nameof(compileResultSessionRepository));
+            _pendingCompileSessionRepository = pendingCompileSessionRepository ??
+                throw new ArgumentNullException(nameof(pendingCompileSessionRepository));
         }
 
         public bool GetIsServerRunning()
@@ -266,101 +254,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             _sessionStatePort.SetShouldAutoScanThirdPartyToolMigration(shouldAutoScanThirdPartyToolMigration);
         }
 
-        private static (bool IsValid, long Value) ParseUtcTicks(string utcTicksText)
-        {
-            if (string.IsNullOrWhiteSpace(utcTicksText))
-            {
-                return (true, 0);
-            }
-
-            string trimmedText = utcTicksText.Trim();
-            long value = 0;
-            foreach (char character in trimmedText)
-            {
-                if (character < '0' || character > '9')
-                {
-                    return (false, 0);
-                }
-
-                int digit = character - '0';
-                if (value > (long.MaxValue - digit) / 10)
-                {
-                    return (false, 0);
-                }
-
-                value = value * 10 + digit;
-            }
-
-            if (value > DateTime.MaxValue.Ticks)
-            {
-                return (false, 0);
-            }
-
-            return (true, value);
-        }
-
-        private static string[] ParseRequestIdIndex(string requestIdIndex)
-        {
-            if (string.IsNullOrWhiteSpace(requestIdIndex))
-            {
-                return Array.Empty<string>();
-            }
-
-            string[] rawRequestIds = requestIdIndex.Split(
-                new[] { '\n' },
-                StringSplitOptions.RemoveEmptyEntries);
-            List<string> requestIds = new List<string>();
-            foreach (string rawRequestId in rawRequestIds)
-            {
-                string requestId = rawRequestId.Trim();
-                if (string.IsNullOrWhiteSpace(requestId) || requestIds.Contains(requestId))
-                {
-                    continue;
-                }
-
-                requestIds.Add(requestId);
-            }
-
-            return requestIds.ToArray();
-        }
-
-        private static string FormatRequestIdIndex(List<string> requestIds)
-        {
-            Debug.Assert(requestIds != null, "requestIds must not be null");
-            return string.Join("\n", requestIds.ToArray());
-        }
-
-        private static string AddRequestIdToIndex(string requestIdIndex, string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            List<string> requestIds = new List<string>(ParseRequestIdIndex(requestIdIndex));
-            if (!requestIds.Contains(requestId))
-            {
-                requestIds.Add(requestId);
-            }
-
-            return FormatRequestIdIndex(requestIds);
-        }
-
-        private static string RemoveRequestIdFromIndex(string requestIdIndex, string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            List<string> requestIds = new List<string>();
-            foreach (string indexedRequestId in ParseRequestIdIndex(requestIdIndex))
-            {
-                if (indexedRequestId == requestId)
-                {
-                    continue;
-                }
-
-                requestIds.Add(indexedRequestId);
-            }
-
-            return FormatRequestIdIndex(requestIds);
-        }
-
         public void StoreCompileResult(
             string requestId,
             bool forceRecompile,
@@ -422,231 +315,48 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             long expiresAtUtcTicks,
             bool reloadObserved)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-            Debug.Assert(expiresAtUtcTicks > 0, "expiresAtUtcTicks must be positive");
-
-            _sessionStatePort.SetPendingCompileRequestIds(
-                AddRequestIdToIndex(_sessionStatePort.GetPendingCompileRequestIds(), requestId));
-            _sessionStatePort.SetPendingCompileForceRecompile(requestId, forceRecompile);
-            _sessionStatePort.SetPendingCompileExpiresAtUtcTicks(requestId, expiresAtUtcTicks.ToString());
-            _sessionStatePort.SetPendingCompileReloadObserved(requestId, reloadObserved);
+            _pendingCompileSessionRepository.StorePendingCompileRequest(
+                requestId,
+                forceRecompile,
+                expiresAtUtcTicks,
+                reloadObserved);
         }
 
         public UnityCliLoopPendingCompileRequest GetPendingCompileRequest()
         {
-            UnityCliLoopPendingCompileRequest[] pendingRequests = GetPendingCompileRequests();
-            if (pendingRequests.Length == 0)
-            {
-                return UnityCliLoopPendingCompileRequest.None();
-            }
-
-            return pendingRequests[0];
+            return _pendingCompileSessionRepository.GetPendingCompileRequest();
         }
 
         public UnityCliLoopPendingCompileRequest[] GetPendingCompileRequests()
         {
-            string[] requestIds = ParseRequestIdIndex(_sessionStatePort.GetPendingCompileRequestIds());
-            List<UnityCliLoopPendingCompileRequest> pendingRequests =
-                new List<UnityCliLoopPendingCompileRequest>();
-            foreach (string requestId in requestIds)
-            {
-                UnityCliLoopPendingCompileRequest pendingRequest =
-                    GetPendingCompileRequestForRequestId(requestId);
-                if (pendingRequest.HasRequest)
-                {
-                    pendingRequests.Add(pendingRequest);
-                }
-            }
-
-            UnityCliLoopPendingCompileRequest legacyRequest = GetLegacyPendingCompileRequest();
-            if (legacyRequest.HasRequest && !ContainsPendingCompileRequest(pendingRequests, legacyRequest.RequestId))
-            {
-                pendingRequests.Add(legacyRequest);
-            }
-
-            return pendingRequests.ToArray();
+            return _pendingCompileSessionRepository.GetPendingCompileRequests();
         }
 
         public bool MarkPendingCompileRequestReloadObserved()
         {
-            UnityCliLoopPendingCompileRequest[] pendingRequests = GetPendingCompileRequests();
-            if (pendingRequests.Length == 0)
-            {
-                return false;
-            }
-
-            foreach (UnityCliLoopPendingCompileRequest pendingRequest in pendingRequests)
-            {
-                StorePendingCompileRequest(
-                    pendingRequest.RequestId,
-                    pendingRequest.ForceRecompile,
-                    pendingRequest.ExpiresAtUtcTicks,
-                    reloadObserved: true);
-            }
-
-            return true;
+            return _pendingCompileSessionRepository.MarkPendingCompileRequestReloadObserved();
         }
 
         public UnityCliLoopPendingCompileRequest GetPendingCompileRequestForRequestId(string requestId)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            string expiresAtUtcTicksText = _sessionStatePort.GetPendingCompileExpiresAtUtcTicks(requestId);
-            (bool isValid, long expiresAtUtcTicks) =
-                ParseUtcTicks(expiresAtUtcTicksText);
-            if (!isValid || expiresAtUtcTicks <= 0)
-            {
-                UnityCliLoopPendingCompileRequest legacyRequest =
-                    GetLegacyPendingCompileRequestForRequestId(requestId);
-                if (legacyRequest.HasRequest)
-                {
-                    return legacyRequest;
-                }
-
-                ClearPendingCompileRequestForRequestId(requestId);
-                return UnityCliLoopPendingCompileRequest.None();
-            }
-
-            return UnityCliLoopPendingCompileRequest.Create(
-                requestId,
-                _sessionStatePort.GetPendingCompileForceRecompile(requestId),
-                expiresAtUtcTicks,
-                _sessionStatePort.GetPendingCompileReloadObserved(requestId));
+            return _pendingCompileSessionRepository.GetPendingCompileRequestForRequestId(requestId);
         }
 
         public void ClearPendingCompileRequest()
         {
-            foreach (string requestId in ParseRequestIdIndex(_sessionStatePort.GetPendingCompileRequestIds()))
-            {
-                ClearPendingCompileRequestValues(requestId);
-            }
-
-            _sessionStatePort.SetPendingCompileRequestIds("");
-            ClearLegacyPendingCompileRequest();
-        }
-
-        private void ClearPendingCompileRequestForRequestId(string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            ClearPendingCompileRequestValues(requestId);
-            _sessionStatePort.SetPendingCompileRequestIds(
-                RemoveRequestIdFromIndex(_sessionStatePort.GetPendingCompileRequestIds(), requestId));
-        }
-
-        private void ClearPendingCompileRequestValues(string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            _sessionStatePort.SetPendingCompileForceRecompile(requestId, false);
-            _sessionStatePort.SetPendingCompileExpiresAtUtcTicks(requestId, "");
-            _sessionStatePort.SetPendingCompileReloadObserved(requestId, false);
-        }
-
-        private static bool ContainsPendingCompileRequest(
-            List<UnityCliLoopPendingCompileRequest> pendingRequests,
-            string requestId)
-        {
-            Debug.Assert(pendingRequests != null, "pendingRequests must not be null");
-
-            foreach (UnityCliLoopPendingCompileRequest pendingRequest in pendingRequests)
-            {
-                if (pendingRequest.RequestId == requestId)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private UnityCliLoopPendingCompileRequest GetLegacyPendingCompileRequest()
-        {
-            string requestId = _sessionStatePort.GetLegacyPendingCompileRequestId();
-            if (string.IsNullOrWhiteSpace(requestId))
-            {
-                return UnityCliLoopPendingCompileRequest.None();
-            }
-
-            return GetLegacyPendingCompileRequestForRequestId(requestId);
-        }
-
-        private UnityCliLoopPendingCompileRequest GetLegacyPendingCompileRequestForRequestId(string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            string legacyRequestId = _sessionStatePort.GetLegacyPendingCompileRequestId();
-            if (legacyRequestId != requestId)
-            {
-                return UnityCliLoopPendingCompileRequest.None();
-            }
-
-            string expiresAtUtcTicksText =
-                _sessionStatePort.GetLegacyPendingCompileExpiresAtUtcTicks();
-            (bool isValid, long expiresAtUtcTicks) =
-                ParseUtcTicks(expiresAtUtcTicksText);
-            if (!isValid || expiresAtUtcTicks <= 0)
-            {
-                ClearLegacyPendingCompileRequest();
-                return UnityCliLoopPendingCompileRequest.None();
-            }
-
-            bool forceRecompile = _sessionStatePort.GetLegacyPendingCompileForceRecompile();
-            bool reloadObserved = _sessionStatePort.GetLegacyPendingCompileReloadObserved();
-            StorePendingCompileRequest(
-                requestId,
-                forceRecompile,
-                expiresAtUtcTicks,
-                reloadObserved);
-            ClearLegacyPendingCompileRequest();
-            return UnityCliLoopPendingCompileRequest.Create(
-                requestId,
-                forceRecompile,
-                expiresAtUtcTicks,
-                reloadObserved);
-        }
-
-        private void ClearLegacyPendingCompileRequest()
-        {
-            _sessionStatePort.SetLegacyPendingCompileRequestId("");
-            _sessionStatePort.SetLegacyPendingCompileForceRecompile(false);
-            _sessionStatePort.SetLegacyPendingCompileExpiresAtUtcTicks("");
-            _sessionStatePort.SetLegacyPendingCompileReloadObserved(false);
+            _pendingCompileSessionRepository.ClearPendingCompileRequest();
         }
 
         public bool ClearPendingCompileRequestIfMatches(string requestId)
         {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            UnityCliLoopPendingCompileRequest pendingRequest =
-                GetPendingCompileRequestForRequestId(requestId);
-            if (!pendingRequest.HasRequest)
-            {
-                return false;
-            }
-
-            ClearPendingCompileRequestForRequestId(requestId);
-            return true;
+            return _pendingCompileSessionRepository.ClearPendingCompileRequestIfMatches(requestId);
         }
 
         public bool ClearExpiredPendingCompileRequest(DateTime utcNow)
         {
             Debug.Assert(utcNow.Kind == DateTimeKind.Utc, "utcNow must be UTC");
 
-            bool cleared = false;
-            UnityCliLoopPendingCompileRequest[] pendingRequests = GetPendingCompileRequests();
-            foreach (UnityCliLoopPendingCompileRequest pendingRequest in pendingRequests)
-            {
-                if (!pendingRequest.IsExpiredAt(utcNow))
-                {
-                    continue;
-                }
-
-                ClearPendingCompileRequestForRequestId(pendingRequest.RequestId);
-                cleared = true;
-            }
-
-            return cleared;
+            return _pendingCompileSessionRepository.ClearExpiredPendingCompileRequest(utcNow);
         }
 
         public bool ConsumeShouldAutoScanThirdPartyToolMigration()

--- a/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateService.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopEditorSessionStateService.cs
@@ -305,26 +305,33 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             StorePendingCompileRequest(
                 requestId,
                 forceRecompile,
-                markedAtUtc.Add(CompileResultLifetime).Ticks,
+                markedAtUtc.Add(CompileResultLifetime),
                 reloadObserved: false);
         }
 
         public void StorePendingCompileRequest(
             string requestId,
             bool forceRecompile,
-            long expiresAtUtcTicks,
+            DateTime expiresAtUtc,
             bool reloadObserved)
         {
             _pendingCompileSessionRepository.StorePendingCompileRequest(
                 requestId,
                 forceRecompile,
-                expiresAtUtcTicks,
+                expiresAtUtc,
                 reloadObserved);
         }
 
         public UnityCliLoopPendingCompileRequest GetPendingCompileRequest()
         {
-            return _pendingCompileSessionRepository.GetPendingCompileRequest();
+            UnityCliLoopPendingCompileRequest[] pendingRequests =
+                _pendingCompileSessionRepository.GetPendingCompileRequests();
+            if (pendingRequests.Length == 0)
+            {
+                return UnityCliLoopPendingCompileRequest.None();
+            }
+
+            return pendingRequests[0];
         }
 
         public UnityCliLoopPendingCompileRequest[] GetPendingCompileRequests()

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopCompileResultSessionRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopCompileResultSessionRepository.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
-using UnityEditor;
-
 using io.github.hatayama.UnityCliLoop.Domain;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
@@ -13,14 +11,18 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class UnityCliLoopCompileResultSessionRepository : ICompileResultSessionRepository
     {
-        private const string KeyPrefix = "io.github.hatayama.uloopmcp.editorSession.";
-        private const string CompileResultRequestIdsKey = KeyPrefix + "compileResultRequestIds";
-        private const string LegacyCompileResultRequestIdKey = KeyPrefix + "compileResultRequestId";
-        private const string LegacyCompileResultForceRecompileKey = KeyPrefix + "compileResultForceRecompile";
-        private const string LegacyCompileResultJsonKey = KeyPrefix + "compileResultJson";
+        private const string CompileResultRequestIdsKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "compileResultRequestIds";
+        private const string LegacyCompileResultRequestIdKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "compileResultRequestId";
+        private const string LegacyCompileResultForceRecompileKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "compileResultForceRecompile";
+        private const string LegacyCompileResultJsonKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "compileResultJson";
         private const string LegacyCompileResultCompletedAtUtcTicksKey =
-            KeyPrefix + "compileResultCompletedAtUtcTicks";
-        private const string CompileResultKeyPrefix = KeyPrefix + "compileResult.";
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "compileResultCompletedAtUtcTicks";
+        private const string CompileResultKeyPrefix =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "compileResult.";
         private const string CompileResultForceRecompileKeySuffix = ".forceRecompile";
         private const string CompileResultJsonKeySuffix = ".json";
         private const string CompileResultCompletedAtUtcTicksKeySuffix = ".completedAtUtcTicks";
@@ -35,7 +37,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrWhiteSpace(resultJson), "resultJson must not be null or whitespace");
             Debug.Assert(completedAtUtc.Kind == DateTimeKind.Utc, "completedAtUtc must be UTC");
 
-            SetCompileResultRequestIds(AddRequestIdToIndex(GetCompileResultRequestIds(), requestId));
+            SetCompileResultRequestIds(
+                UnityCliLoopEditorSessionStateStorage.AddRequestIdToIndex(GetCompileResultRequestIds(), requestId));
             SetCompileResultForceRecompile(requestId, forceRecompile);
             SetCompileResultJson(requestId, resultJson);
             SetCompileResultCompletedAtUtcTicks(requestId, completedAtUtc.Ticks.ToString());
@@ -61,7 +64,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             string completedAtUtcTicksText = GetCompileResultCompletedAtUtcTicks(requestId);
             (bool isValid, long completedAtUtcTicks) =
-                ParseUtcTicks(completedAtUtcTicksText);
+                UnityCliLoopEditorSessionStateStorage.ParseUtcTicks(completedAtUtcTicksText);
             if (!isValid || completedAtUtcTicks <= 0)
             {
                 ClearCompileResultForRequestId(requestId);
@@ -88,7 +91,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         public UnityCliLoopStoredCompileResult[] GetStoredCompileResults()
         {
-            string[] requestIds = ParseRequestIdIndex(GetCompileResultRequestIds());
+            string[] requestIds =
+                UnityCliLoopEditorSessionStateStorage.ParseRequestIdIndex(GetCompileResultRequestIds());
             List<UnityCliLoopStoredCompileResult> storedResults =
                 new List<UnityCliLoopStoredCompileResult>();
             foreach (string requestId in requestIds)
@@ -111,7 +115,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         public void ClearCompileResult()
         {
-            foreach (string requestId in ParseRequestIdIndex(GetCompileResultRequestIds()))
+            foreach (string requestId in UnityCliLoopEditorSessionStateStorage.ParseRequestIdIndex(
+                GetCompileResultRequestIds()))
             {
                 ClearCompileResultValues(requestId);
             }
@@ -144,82 +149,97 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         // Tests and legacy migration use these helpers without widening the aggregate port.
         internal static void SetLegacyCompileResultRequestId(string compileResultRequestId)
         {
-            SetString(LegacyCompileResultRequestIdKey, compileResultRequestId);
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                LegacyCompileResultRequestIdKey,
+                compileResultRequestId);
         }
 
         internal static string GetLegacyCompileResultRequestId()
         {
-            return GetString(LegacyCompileResultRequestIdKey);
+            return UnityCliLoopEditorSessionStateStorage.GetString(LegacyCompileResultRequestIdKey);
         }
 
         internal static void SetLegacyCompileResultForceRecompile(bool compileResultForceRecompile)
         {
-            SetBool(LegacyCompileResultForceRecompileKey, compileResultForceRecompile);
+            UnityCliLoopEditorSessionStateStorage.SetBool(
+                LegacyCompileResultForceRecompileKey,
+                compileResultForceRecompile);
         }
 
         internal static void SetLegacyCompileResultJson(string compileResultJson)
         {
-            SetString(LegacyCompileResultJsonKey, compileResultJson);
+            UnityCliLoopEditorSessionStateStorage.SetString(LegacyCompileResultJsonKey, compileResultJson);
         }
 
         internal static void SetLegacyCompileResultCompletedAtUtcTicks(string compileResultCompletedAtUtcTicks)
         {
-            SetString(LegacyCompileResultCompletedAtUtcTicksKey, compileResultCompletedAtUtcTicks);
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                LegacyCompileResultCompletedAtUtcTicksKey,
+                compileResultCompletedAtUtcTicks);
         }
 
         internal static void SetCompileResultRequestIds(string compileResultRequestIds)
         {
-            SetString(CompileResultRequestIdsKey, compileResultRequestIds);
+            UnityCliLoopEditorSessionStateStorage.SetString(CompileResultRequestIdsKey, compileResultRequestIds);
         }
 
         internal static void SetCompileResultForceRecompile(string requestId, bool compileResultForceRecompile)
         {
-            SetBool(CreateCompileResultKey(requestId, CompileResultForceRecompileKeySuffix), compileResultForceRecompile);
+            UnityCliLoopEditorSessionStateStorage.SetBool(
+                CreateCompileResultKey(requestId, CompileResultForceRecompileKeySuffix),
+                compileResultForceRecompile);
         }
 
         internal static void SetCompileResultJson(string requestId, string compileResultJson)
         {
-            SetString(CreateCompileResultKey(requestId, CompileResultJsonKeySuffix), compileResultJson);
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                CreateCompileResultKey(requestId, CompileResultJsonKeySuffix),
+                compileResultJson);
         }
 
         internal static void SetCompileResultCompletedAtUtcTicks(string requestId, string compileResultCompletedAtUtcTicks)
         {
-            SetString(CreateCompileResultKey(requestId, CompileResultCompletedAtUtcTicksKeySuffix), compileResultCompletedAtUtcTicks);
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                CreateCompileResultKey(requestId, CompileResultCompletedAtUtcTicksKeySuffix),
+                compileResultCompletedAtUtcTicks);
         }
 
         private static string GetCompileResultRequestIds()
         {
-            return GetString(CompileResultRequestIdsKey);
+            return UnityCliLoopEditorSessionStateStorage.GetString(CompileResultRequestIdsKey);
         }
 
         private static bool GetLegacyCompileResultForceRecompile()
         {
-            return GetBool(LegacyCompileResultForceRecompileKey);
+            return UnityCliLoopEditorSessionStateStorage.GetBool(LegacyCompileResultForceRecompileKey);
         }
 
         private static string GetLegacyCompileResultJson()
         {
-            return GetString(LegacyCompileResultJsonKey);
+            return UnityCliLoopEditorSessionStateStorage.GetString(LegacyCompileResultJsonKey);
         }
 
         private static string GetLegacyCompileResultCompletedAtUtcTicks()
         {
-            return GetString(LegacyCompileResultCompletedAtUtcTicksKey);
+            return UnityCliLoopEditorSessionStateStorage.GetString(LegacyCompileResultCompletedAtUtcTicksKey);
         }
 
         private static bool GetCompileResultForceRecompile(string requestId)
         {
-            return GetBool(CreateCompileResultKey(requestId, CompileResultForceRecompileKeySuffix));
+            return UnityCliLoopEditorSessionStateStorage.GetBool(
+                CreateCompileResultKey(requestId, CompileResultForceRecompileKeySuffix));
         }
 
         private static string GetCompileResultJson(string requestId)
         {
-            return GetString(CreateCompileResultKey(requestId, CompileResultJsonKeySuffix));
+            return UnityCliLoopEditorSessionStateStorage.GetString(
+                CreateCompileResultKey(requestId, CompileResultJsonKeySuffix));
         }
 
         private static string GetCompileResultCompletedAtUtcTicks(string requestId)
         {
-            return GetString(CreateCompileResultKey(requestId, CompileResultCompletedAtUtcTicksKeySuffix));
+            return UnityCliLoopEditorSessionStateStorage.GetString(
+                CreateCompileResultKey(requestId, CompileResultCompletedAtUtcTicksKeySuffix));
         }
 
         private static void ClearCompileResultForRequestId(string requestId)
@@ -228,7 +248,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             ClearCompileResultValues(requestId);
             SetCompileResultRequestIds(
-                RemoveRequestIdFromIndex(GetCompileResultRequestIds(), requestId));
+                UnityCliLoopEditorSessionStateStorage.RemoveRequestIdFromIndex(
+                    GetCompileResultRequestIds(),
+                    requestId));
         }
 
         private static void ClearCompileResultValues(string requestId)
@@ -288,7 +310,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string completedAtUtcTicksText =
                 GetLegacyCompileResultCompletedAtUtcTicks();
             (bool isValid, long completedAtUtcTicks) =
-                ParseUtcTicks(completedAtUtcTicksText);
+                UnityCliLoopEditorSessionStateStorage.ParseUtcTicks(completedAtUtcTicksText);
             if (!isValid || completedAtUtcTicks <= 0)
             {
                 ClearLegacyCompileResult();
@@ -317,124 +339,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             SetLegacyCompileResultCompletedAtUtcTicks("");
         }
 
-        private static (bool IsValid, long Value) ParseUtcTicks(string utcTicksText)
-        {
-            if (string.IsNullOrWhiteSpace(utcTicksText))
-            {
-                return (true, 0);
-            }
-
-            string trimmedText = utcTicksText.Trim();
-            long value = 0;
-            foreach (char character in trimmedText)
-            {
-                if (character < '0' || character > '9')
-                {
-                    return (false, 0);
-                }
-
-                int digit = character - '0';
-                if (value > (long.MaxValue - digit) / 10)
-                {
-                    return (false, 0);
-                }
-
-                value = value * 10 + digit;
-            }
-
-            if (value > DateTime.MaxValue.Ticks)
-            {
-                return (false, 0);
-            }
-
-            return (true, value);
-        }
-
-        private static string[] ParseRequestIdIndex(string requestIdIndex)
-        {
-            if (string.IsNullOrWhiteSpace(requestIdIndex))
-            {
-                return Array.Empty<string>();
-            }
-
-            string[] rawRequestIds = requestIdIndex.Split(
-                new[] { '\n' },
-                StringSplitOptions.RemoveEmptyEntries);
-            List<string> requestIds = new List<string>();
-            foreach (string rawRequestId in rawRequestIds)
-            {
-                string requestId = rawRequestId.Trim();
-                if (string.IsNullOrWhiteSpace(requestId) || requestIds.Contains(requestId))
-                {
-                    continue;
-                }
-
-                requestIds.Add(requestId);
-            }
-
-            return requestIds.ToArray();
-        }
-
-        private static string FormatRequestIdIndex(List<string> requestIds)
-        {
-            Debug.Assert(requestIds != null, "requestIds must not be null");
-            return string.Join("\n", requestIds.ToArray());
-        }
-
-        private static string AddRequestIdToIndex(string requestIdIndex, string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            List<string> requestIds = new List<string>(ParseRequestIdIndex(requestIdIndex));
-            if (!requestIds.Contains(requestId))
-            {
-                requestIds.Add(requestId);
-            }
-
-            return FormatRequestIdIndex(requestIds);
-        }
-
-        private static string RemoveRequestIdFromIndex(string requestIdIndex, string requestId)
-        {
-            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-
-            List<string> requestIds = new List<string>();
-            foreach (string indexedRequestId in ParseRequestIdIndex(requestIdIndex))
-            {
-                if (indexedRequestId == requestId)
-                {
-                    continue;
-                }
-
-                requestIds.Add(indexedRequestId);
-            }
-
-            return FormatRequestIdIndex(requestIds);
-        }
-
         private static string CreateCompileResultKey(string requestId, string suffix)
         {
-            return CompileResultKeyPrefix + requestId + suffix;
-        }
-
-        private static bool GetBool(string key)
-        {
-            return SessionState.GetBool(key, false);
-        }
-
-        private static void SetBool(string key, bool value)
-        {
-            SessionState.SetBool(key, value);
-        }
-
-        private static string GetString(string key)
-        {
-            return SessionState.GetString(key, "");
-        }
-
-        private static void SetString(string key, string value)
-        {
-            SessionState.SetString(key, value ?? "");
+            return UnityCliLoopEditorSessionStateStorage.CreateRequestScopedKey(
+                CompileResultKeyPrefix,
+                requestId,
+                suffix);
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateRepository.cs
@@ -9,7 +9,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class UnityCliLoopEditorSessionStateRepository : IUnityCliLoopEditorSessionStatePort
     {
-        private const string KeyPrefix = "io.github.hatayama.uloopmcp.editorSession.";
+        private const string KeyPrefix = UnityCliLoopEditorSessionStateStorage.KeyPrefix;
         private const string IsServerRunningKey = KeyPrefix + "isServerRunning";
         private const string IsServerManuallyStoppedKey = KeyPrefix + "isServerManuallyStopped";
         private const string IsAfterCompileKey = KeyPrefix + "isAfterCompile";
@@ -107,16 +107,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static void SetBool(string key, bool value)
         {
             SessionState.SetBool(key, value);
-        }
-
-        private static string GetString(string key)
-        {
-            return SessionState.GetString(key, "");
-        }
-
-        private static void SetString(string key, string value)
-        {
-            SessionState.SetString(key, value ?? "");
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateRepository.cs
@@ -5,7 +5,7 @@ using io.github.hatayama.UnityCliLoop.Domain;
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
     /// <summary>
-    /// Stores Unity CLI Loop runtime flags and pending compile markers for the current Editor session.
+    /// Stores Unity CLI Loop runtime flags for the current Editor session.
     /// </summary>
     public sealed class UnityCliLoopEditorSessionStateRepository : IUnityCliLoopEditorSessionStatePort
     {
@@ -19,17 +19,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const string ShowPostCompileReconnectingUIKey = KeyPrefix + "showPostCompileReconnectingUI";
         private const string ShouldAutoScanThirdPartyToolMigrationKey =
             KeyPrefix + "shouldAutoScanThirdPartyToolMigration";
-        private const string PendingCompileRequestIdsKey = KeyPrefix + "pendingCompileRequestIds";
-        private const string LegacyPendingCompileRequestIdKey = KeyPrefix + "pendingCompileRequestId";
-        private const string LegacyPendingCompileForceRecompileKey = KeyPrefix + "pendingCompileForceRecompile";
-        private const string LegacyPendingCompileExpiresAtUtcTicksKey =
-            KeyPrefix + "pendingCompileExpiresAtUtcTicks";
-        private const string LegacyPendingCompileReloadObservedKey = KeyPrefix + "pendingCompileReloadObserved";
-        private const string PendingCompileKeyPrefix = KeyPrefix + "pendingCompile.";
-        private const string PendingCompileForceRecompileKeySuffix = ".forceRecompile";
-        private const string PendingCompileExpiresAtUtcTicksKeySuffix = ".expiresAtUtcTicks";
-        private const string PendingCompileReloadObservedKeySuffix = ".reloadObserved";
-
         public bool GetIsServerRunning()
         {
             return GetBool(IsServerRunningKey);
@@ -108,91 +97,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration)
         {
             SetBool(ShouldAutoScanThirdPartyToolMigrationKey, shouldAutoScanThirdPartyToolMigration);
-        }
-
-        public string GetPendingCompileRequestIds()
-        {
-            return GetString(PendingCompileRequestIdsKey);
-        }
-
-        public void SetPendingCompileRequestIds(string pendingCompileRequestIds)
-        {
-            SetString(PendingCompileRequestIdsKey, pendingCompileRequestIds);
-        }
-
-        public string GetLegacyPendingCompileRequestId()
-        {
-            return GetString(LegacyPendingCompileRequestIdKey);
-        }
-
-        public void SetLegacyPendingCompileRequestId(string pendingCompileRequestId)
-        {
-            SetString(LegacyPendingCompileRequestIdKey, pendingCompileRequestId);
-        }
-
-        public bool GetLegacyPendingCompileForceRecompile()
-        {
-            return GetBool(LegacyPendingCompileForceRecompileKey);
-        }
-
-        public void SetLegacyPendingCompileForceRecompile(bool pendingCompileForceRecompile)
-        {
-            SetBool(LegacyPendingCompileForceRecompileKey, pendingCompileForceRecompile);
-        }
-
-        public string GetLegacyPendingCompileExpiresAtUtcTicks()
-        {
-            return GetString(LegacyPendingCompileExpiresAtUtcTicksKey);
-        }
-
-        public void SetLegacyPendingCompileExpiresAtUtcTicks(string pendingCompileExpiresAtUtcTicks)
-        {
-            SetString(LegacyPendingCompileExpiresAtUtcTicksKey, pendingCompileExpiresAtUtcTicks);
-        }
-
-        public bool GetLegacyPendingCompileReloadObserved()
-        {
-            return GetBool(LegacyPendingCompileReloadObservedKey);
-        }
-
-        public void SetLegacyPendingCompileReloadObserved(bool pendingCompileReloadObserved)
-        {
-            SetBool(LegacyPendingCompileReloadObservedKey, pendingCompileReloadObserved);
-        }
-
-        public bool GetPendingCompileForceRecompile(string requestId)
-        {
-            return GetBool(CreatePendingCompileKey(requestId, PendingCompileForceRecompileKeySuffix));
-        }
-
-        public void SetPendingCompileForceRecompile(string requestId, bool pendingCompileForceRecompile)
-        {
-            SetBool(CreatePendingCompileKey(requestId, PendingCompileForceRecompileKeySuffix), pendingCompileForceRecompile);
-        }
-
-        public string GetPendingCompileExpiresAtUtcTicks(string requestId)
-        {
-            return GetString(CreatePendingCompileKey(requestId, PendingCompileExpiresAtUtcTicksKeySuffix));
-        }
-
-        public void SetPendingCompileExpiresAtUtcTicks(string requestId, string pendingCompileExpiresAtUtcTicks)
-        {
-            SetString(CreatePendingCompileKey(requestId, PendingCompileExpiresAtUtcTicksKeySuffix), pendingCompileExpiresAtUtcTicks);
-        }
-
-        public bool GetPendingCompileReloadObserved(string requestId)
-        {
-            return GetBool(CreatePendingCompileKey(requestId, PendingCompileReloadObservedKeySuffix));
-        }
-
-        public void SetPendingCompileReloadObserved(string requestId, bool pendingCompileReloadObserved)
-        {
-            SetBool(CreatePendingCompileKey(requestId, PendingCompileReloadObservedKeySuffix), pendingCompileReloadObserved);
-        }
-
-        private static string CreatePendingCompileKey(string requestId, string suffix)
-        {
-            return PendingCompileKeyPrefix + requestId + suffix;
         }
 
         private static bool GetBool(string key)

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateStorage.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateStorage.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Provides shared SessionState key formatting and primitive storage helpers for editor-session repositories.
+    /// </summary>
+    internal static class UnityCliLoopEditorSessionStateStorage
+    {
+        internal const string KeyPrefix = "io.github.hatayama.uloopmcp.editorSession.";
+
+        internal static (bool IsValid, long Value) ParseUtcTicks(string utcTicksText)
+        {
+            if (string.IsNullOrWhiteSpace(utcTicksText))
+            {
+                return (true, 0);
+            }
+
+            string trimmedText = utcTicksText.Trim();
+            long value = 0;
+            foreach (char character in trimmedText)
+            {
+                if (character < '0' || character > '9')
+                {
+                    return (false, 0);
+                }
+
+                int digit = character - '0';
+                if (value > (long.MaxValue - digit) / 10)
+                {
+                    return (false, 0);
+                }
+
+                value = value * 10 + digit;
+            }
+
+            if (value > DateTime.MaxValue.Ticks)
+            {
+                return (false, 0);
+            }
+
+            return (true, value);
+        }
+
+        internal static string[] ParseRequestIdIndex(string requestIdIndex)
+        {
+            if (string.IsNullOrWhiteSpace(requestIdIndex))
+            {
+                return Array.Empty<string>();
+            }
+
+            string[] rawRequestIds = requestIdIndex.Split(
+                new[] { '\n' },
+                StringSplitOptions.RemoveEmptyEntries);
+            List<string> requestIds = new List<string>();
+            foreach (string rawRequestId in rawRequestIds)
+            {
+                string requestId = rawRequestId.Trim();
+                if (string.IsNullOrWhiteSpace(requestId) || requestIds.Contains(requestId))
+                {
+                    continue;
+                }
+
+                requestIds.Add(requestId);
+            }
+
+            return requestIds.ToArray();
+        }
+
+        internal static string AddRequestIdToIndex(string requestIdIndex, string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            List<string> requestIds = new List<string>(ParseRequestIdIndex(requestIdIndex));
+            if (!requestIds.Contains(requestId))
+            {
+                requestIds.Add(requestId);
+            }
+
+            return FormatRequestIdIndex(requestIds);
+        }
+
+        internal static string RemoveRequestIdFromIndex(string requestIdIndex, string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            List<string> requestIds = new List<string>();
+            foreach (string indexedRequestId in ParseRequestIdIndex(requestIdIndex))
+            {
+                if (indexedRequestId == requestId)
+                {
+                    continue;
+                }
+
+                requestIds.Add(indexedRequestId);
+            }
+
+            return FormatRequestIdIndex(requestIds);
+        }
+
+        internal static string CreateRequestScopedKey(string requestKeyPrefix, string requestId, string suffix)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestKeyPrefix), "requestKeyPrefix must not be null or whitespace");
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+            Debug.Assert(!string.IsNullOrWhiteSpace(suffix), "suffix must not be null or whitespace");
+
+            return requestKeyPrefix + requestId + suffix;
+        }
+
+        internal static bool GetBool(string key)
+        {
+            return SessionState.GetBool(key, false);
+        }
+
+        internal static void SetBool(string key, bool value)
+        {
+            SessionState.SetBool(key, value);
+        }
+
+        internal static string GetString(string key)
+        {
+            return SessionState.GetString(key, "");
+        }
+
+        internal static void SetString(string key, string value)
+        {
+            SessionState.SetString(key, value ?? "");
+        }
+
+        private static string FormatRequestIdIndex(List<string> requestIds)
+        {
+            Debug.Assert(requestIds != null, "requestIds must not be null");
+            return string.Join("\n", requestIds.ToArray());
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateStorage.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSessionStateStorage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d69367b96c444e769198f2f97767fc7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPendingCompileSessionRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPendingCompileSessionRepository.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Stores pending compile recovery records in Unity SessionState.
+    /// </summary>
+    public sealed class UnityCliLoopPendingCompileSessionRepository : IPendingCompileSessionRepository
+    {
+        private const string PendingCompileRequestIdsKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "pendingCompileRequestIds";
+        private const string LegacyPendingCompileRequestIdKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "pendingCompileRequestId";
+        private const string LegacyPendingCompileForceRecompileKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "pendingCompileForceRecompile";
+        private const string LegacyPendingCompileExpiresAtUtcTicksKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "pendingCompileExpiresAtUtcTicks";
+        private const string LegacyPendingCompileReloadObservedKey =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "pendingCompileReloadObserved";
+        private const string PendingCompileKeyPrefix =
+            UnityCliLoopEditorSessionStateStorage.KeyPrefix + "pendingCompile.";
+        private const string PendingCompileForceRecompileKeySuffix = ".forceRecompile";
+        private const string PendingCompileExpiresAtUtcTicksKeySuffix = ".expiresAtUtcTicks";
+        private const string PendingCompileReloadObservedKeySuffix = ".reloadObserved";
+
+        public void StorePendingCompileRequest(
+            string requestId,
+            bool forceRecompile,
+            long expiresAtUtcTicks,
+            bool reloadObserved)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+            Debug.Assert(expiresAtUtcTicks > 0, "expiresAtUtcTicks must be positive");
+
+            SetPendingCompileRequestIds(
+                UnityCliLoopEditorSessionStateStorage.AddRequestIdToIndex(
+                    GetPendingCompileRequestIds(),
+                    requestId));
+            SetPendingCompileForceRecompile(requestId, forceRecompile);
+            SetPendingCompileExpiresAtUtcTicks(requestId, expiresAtUtcTicks.ToString());
+            SetPendingCompileReloadObserved(requestId, reloadObserved);
+        }
+
+        public UnityCliLoopPendingCompileRequest GetPendingCompileRequest()
+        {
+            UnityCliLoopPendingCompileRequest[] pendingRequests = GetPendingCompileRequests();
+            if (pendingRequests.Length == 0)
+            {
+                return UnityCliLoopPendingCompileRequest.None();
+            }
+
+            return pendingRequests[0];
+        }
+
+        public UnityCliLoopPendingCompileRequest[] GetPendingCompileRequests()
+        {
+            string[] requestIds =
+                UnityCliLoopEditorSessionStateStorage.ParseRequestIdIndex(GetPendingCompileRequestIds());
+            List<UnityCliLoopPendingCompileRequest> pendingRequests =
+                new List<UnityCliLoopPendingCompileRequest>();
+            foreach (string requestId in requestIds)
+            {
+                UnityCliLoopPendingCompileRequest pendingRequest =
+                    GetPendingCompileRequestForRequestId(requestId);
+                if (pendingRequest.HasRequest)
+                {
+                    pendingRequests.Add(pendingRequest);
+                }
+            }
+
+            UnityCliLoopPendingCompileRequest legacyRequest = GetLegacyPendingCompileRequest();
+            if (legacyRequest.HasRequest && !ContainsPendingCompileRequest(pendingRequests, legacyRequest.RequestId))
+            {
+                pendingRequests.Add(legacyRequest);
+            }
+
+            return pendingRequests.ToArray();
+        }
+
+        public bool MarkPendingCompileRequestReloadObserved()
+        {
+            UnityCliLoopPendingCompileRequest[] pendingRequests = GetPendingCompileRequests();
+            if (pendingRequests.Length == 0)
+            {
+                return false;
+            }
+
+            foreach (UnityCliLoopPendingCompileRequest pendingRequest in pendingRequests)
+            {
+                StorePendingCompileRequest(
+                    pendingRequest.RequestId,
+                    pendingRequest.ForceRecompile,
+                    pendingRequest.ExpiresAtUtcTicks,
+                    reloadObserved: true);
+            }
+
+            return true;
+        }
+
+        public UnityCliLoopPendingCompileRequest GetPendingCompileRequestForRequestId(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            string expiresAtUtcTicksText = GetPendingCompileExpiresAtUtcTicks(requestId);
+            (bool isValid, long expiresAtUtcTicks) =
+                UnityCliLoopEditorSessionStateStorage.ParseUtcTicks(expiresAtUtcTicksText);
+            if (!isValid || expiresAtUtcTicks <= 0)
+            {
+                UnityCliLoopPendingCompileRequest legacyRequest =
+                    GetLegacyPendingCompileRequestForRequestId(requestId);
+                if (legacyRequest.HasRequest)
+                {
+                    return legacyRequest;
+                }
+
+                ClearPendingCompileRequestForRequestId(requestId);
+                return UnityCliLoopPendingCompileRequest.None();
+            }
+
+            return UnityCliLoopPendingCompileRequest.Create(
+                requestId,
+                GetPendingCompileForceRecompile(requestId),
+                expiresAtUtcTicks,
+                GetPendingCompileReloadObserved(requestId));
+        }
+
+        public void ClearPendingCompileRequest()
+        {
+            foreach (string requestId in UnityCliLoopEditorSessionStateStorage.ParseRequestIdIndex(
+                GetPendingCompileRequestIds()))
+            {
+                ClearPendingCompileRequestValues(requestId);
+            }
+
+            SetPendingCompileRequestIds("");
+            ClearLegacyPendingCompileRequest();
+        }
+
+        public bool ClearPendingCompileRequestIfMatches(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            UnityCliLoopPendingCompileRequest pendingRequest =
+                GetPendingCompileRequestForRequestId(requestId);
+            if (!pendingRequest.HasRequest)
+            {
+                return false;
+            }
+
+            ClearPendingCompileRequestForRequestId(requestId);
+            return true;
+        }
+
+        public bool ClearExpiredPendingCompileRequest(DateTime utcNow)
+        {
+            Debug.Assert(utcNow.Kind == DateTimeKind.Utc, "utcNow must be UTC");
+
+            bool cleared = false;
+            UnityCliLoopPendingCompileRequest[] pendingRequests = GetPendingCompileRequests();
+            foreach (UnityCliLoopPendingCompileRequest pendingRequest in pendingRequests)
+            {
+                if (!pendingRequest.IsExpiredAt(utcNow))
+                {
+                    continue;
+                }
+
+                ClearPendingCompileRequestForRequestId(pendingRequest.RequestId);
+                cleared = true;
+            }
+
+            return cleared;
+        }
+
+        // Tests and legacy migration use these helpers without widening the aggregate port.
+        internal static void SetLegacyPendingCompileRequestId(string pendingCompileRequestId)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                LegacyPendingCompileRequestIdKey,
+                pendingCompileRequestId);
+        }
+
+        internal static string GetLegacyPendingCompileRequestId()
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetString(LegacyPendingCompileRequestIdKey);
+        }
+
+        internal static void SetLegacyPendingCompileForceRecompile(bool pendingCompileForceRecompile)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetBool(
+                LegacyPendingCompileForceRecompileKey,
+                pendingCompileForceRecompile);
+        }
+
+        internal static void SetLegacyPendingCompileExpiresAtUtcTicks(string pendingCompileExpiresAtUtcTicks)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                LegacyPendingCompileExpiresAtUtcTicksKey,
+                pendingCompileExpiresAtUtcTicks);
+        }
+
+        internal static void SetLegacyPendingCompileReloadObserved(bool pendingCompileReloadObserved)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetBool(
+                LegacyPendingCompileReloadObservedKey,
+                pendingCompileReloadObserved);
+        }
+
+        internal static void SetPendingCompileRequestIds(string pendingCompileRequestIds)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(PendingCompileRequestIdsKey, pendingCompileRequestIds);
+        }
+
+        internal static void SetPendingCompileForceRecompile(string requestId, bool pendingCompileForceRecompile)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetBool(
+                CreatePendingCompileKey(requestId, PendingCompileForceRecompileKeySuffix),
+                pendingCompileForceRecompile);
+        }
+
+        internal static void SetPendingCompileExpiresAtUtcTicks(
+            string requestId,
+            string pendingCompileExpiresAtUtcTicks)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetString(
+                CreatePendingCompileKey(requestId, PendingCompileExpiresAtUtcTicksKeySuffix),
+                pendingCompileExpiresAtUtcTicks);
+        }
+
+        internal static void SetPendingCompileReloadObserved(string requestId, bool pendingCompileReloadObserved)
+        {
+            UnityCliLoopEditorSessionStateStorage.SetBool(
+                CreatePendingCompileKey(requestId, PendingCompileReloadObservedKeySuffix),
+                pendingCompileReloadObserved);
+        }
+
+        private static string GetPendingCompileRequestIds()
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetString(PendingCompileRequestIdsKey);
+        }
+
+        private static bool GetLegacyPendingCompileForceRecompile()
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetBool(LegacyPendingCompileForceRecompileKey);
+        }
+
+        private static string GetLegacyPendingCompileExpiresAtUtcTicks()
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetString(LegacyPendingCompileExpiresAtUtcTicksKey);
+        }
+
+        private static bool GetLegacyPendingCompileReloadObserved()
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetBool(LegacyPendingCompileReloadObservedKey);
+        }
+
+        private static bool GetPendingCompileForceRecompile(string requestId)
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetBool(
+                CreatePendingCompileKey(requestId, PendingCompileForceRecompileKeySuffix));
+        }
+
+        private static string GetPendingCompileExpiresAtUtcTicks(string requestId)
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetString(
+                CreatePendingCompileKey(requestId, PendingCompileExpiresAtUtcTicksKeySuffix));
+        }
+
+        private static bool GetPendingCompileReloadObserved(string requestId)
+        {
+            return UnityCliLoopEditorSessionStateStorage.GetBool(
+                CreatePendingCompileKey(requestId, PendingCompileReloadObservedKeySuffix));
+        }
+
+        private static void ClearPendingCompileRequestForRequestId(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            ClearPendingCompileRequestValues(requestId);
+            SetPendingCompileRequestIds(
+                UnityCliLoopEditorSessionStateStorage.RemoveRequestIdFromIndex(
+                    GetPendingCompileRequestIds(),
+                    requestId));
+        }
+
+        private static void ClearPendingCompileRequestValues(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            SetPendingCompileForceRecompile(requestId, false);
+            SetPendingCompileExpiresAtUtcTicks(requestId, "");
+            SetPendingCompileReloadObserved(requestId, false);
+        }
+
+        private static bool ContainsPendingCompileRequest(
+            List<UnityCliLoopPendingCompileRequest> pendingRequests,
+            string requestId)
+        {
+            Debug.Assert(pendingRequests != null, "pendingRequests must not be null");
+
+            foreach (UnityCliLoopPendingCompileRequest pendingRequest in pendingRequests)
+            {
+                if (pendingRequest.RequestId == requestId)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private UnityCliLoopPendingCompileRequest GetLegacyPendingCompileRequest()
+        {
+            string requestId = GetLegacyPendingCompileRequestId();
+            if (string.IsNullOrWhiteSpace(requestId))
+            {
+                return UnityCliLoopPendingCompileRequest.None();
+            }
+
+            return GetLegacyPendingCompileRequestForRequestId(requestId);
+        }
+
+        private UnityCliLoopPendingCompileRequest GetLegacyPendingCompileRequestForRequestId(string requestId)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
+
+            string legacyRequestId = GetLegacyPendingCompileRequestId();
+            if (legacyRequestId != requestId)
+            {
+                return UnityCliLoopPendingCompileRequest.None();
+            }
+
+            string expiresAtUtcTicksText = GetLegacyPendingCompileExpiresAtUtcTicks();
+            (bool isValid, long expiresAtUtcTicks) =
+                UnityCliLoopEditorSessionStateStorage.ParseUtcTicks(expiresAtUtcTicksText);
+            if (!isValid || expiresAtUtcTicks <= 0)
+            {
+                ClearLegacyPendingCompileRequest();
+                return UnityCliLoopPendingCompileRequest.None();
+            }
+
+            bool forceRecompile = GetLegacyPendingCompileForceRecompile();
+            bool reloadObserved = GetLegacyPendingCompileReloadObserved();
+            StorePendingCompileRequest(
+                requestId,
+                forceRecompile,
+                expiresAtUtcTicks,
+                reloadObserved);
+            ClearLegacyPendingCompileRequest();
+            return UnityCliLoopPendingCompileRequest.Create(
+                requestId,
+                forceRecompile,
+                expiresAtUtcTicks,
+                reloadObserved);
+        }
+
+        private static void ClearLegacyPendingCompileRequest()
+        {
+            SetLegacyPendingCompileRequestId("");
+            SetLegacyPendingCompileForceRecompile(false);
+            SetLegacyPendingCompileExpiresAtUtcTicks("");
+            SetLegacyPendingCompileReloadObserved(false);
+        }
+
+        private static string CreatePendingCompileKey(string requestId, string suffix)
+        {
+            return UnityCliLoopEditorSessionStateStorage.CreateRequestScopedKey(
+                PendingCompileKeyPrefix,
+                requestId,
+                suffix);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPendingCompileSessionRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPendingCompileSessionRepository.cs
@@ -30,30 +30,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public void StorePendingCompileRequest(
             string requestId,
             bool forceRecompile,
-            long expiresAtUtcTicks,
+            DateTime expiresAtUtc,
             bool reloadObserved)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(requestId), "requestId must not be null or whitespace");
-            Debug.Assert(expiresAtUtcTicks > 0, "expiresAtUtcTicks must be positive");
+            Debug.Assert(expiresAtUtc.Kind == DateTimeKind.Utc, "expiresAtUtc must be UTC");
+            Debug.Assert(expiresAtUtc.Ticks > 0, "expiresAtUtc ticks must be positive");
 
             SetPendingCompileRequestIds(
                 UnityCliLoopEditorSessionStateStorage.AddRequestIdToIndex(
                     GetPendingCompileRequestIds(),
                     requestId));
             SetPendingCompileForceRecompile(requestId, forceRecompile);
-            SetPendingCompileExpiresAtUtcTicks(requestId, expiresAtUtcTicks.ToString());
+            SetPendingCompileExpiresAtUtcTicks(requestId, expiresAtUtc.Ticks.ToString());
             SetPendingCompileReloadObserved(requestId, reloadObserved);
-        }
-
-        public UnityCliLoopPendingCompileRequest GetPendingCompileRequest()
-        {
-            UnityCliLoopPendingCompileRequest[] pendingRequests = GetPendingCompileRequests();
-            if (pendingRequests.Length == 0)
-            {
-                return UnityCliLoopPendingCompileRequest.None();
-            }
-
-            return pendingRequests[0];
         }
 
         public UnityCliLoopPendingCompileRequest[] GetPendingCompileRequests()
@@ -94,7 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 StorePendingCompileRequest(
                     pendingRequest.RequestId,
                     pendingRequest.ForceRecompile,
-                    pendingRequest.ExpiresAtUtcTicks,
+                    new DateTime(pendingRequest.ExpiresAtUtcTicks, DateTimeKind.Utc),
                     reloadObserved: true);
             }
 
@@ -347,7 +337,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             StorePendingCompileRequest(
                 requestId,
                 forceRecompile,
-                expiresAtUtcTicks,
+                new DateTime(expiresAtUtcTicks, DateTimeKind.Utc),
                 reloadObserved);
             ClearLegacyPendingCompileRequest();
             return UnityCliLoopPendingCompileRequest.Create(

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPendingCompileSessionRepository.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopPendingCompileSessionRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4a3c8a4ff7845c79688cd0dbb91364b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Pending compile recovery state is now stored behind a dedicated Domain repository port.
- Compile-result and pending-compile repositories share the SessionState key/index/ticks helper instead of duplicating a third persistence helper copy.

## Changes
- Added IPendingCompileSessionRepository and UnityCliLoopPendingCompileSessionRepository.
- Kept UnityCliLoopEditorSessionStateService public API stable by delegating pending compile methods to the new repository; service delegation is transitional and will be removed in the final PR of this C4-5d series.
- Moved shared SessionState key prefix, request-id index formatting, ticks parsing, and primitive access into an internal Infrastructure helper used by both compile-result and pending-compile repositories.
- Removed pending compile raw KV methods from IUnityCliLoopEditorSessionStatePort and UnityCliLoopEditorSessionStateRepository.
- Kept reloadObserved in the PendingCompile aggregate because it records whether a specific pending compile request has crossed Domain Reload, not an independent session flag.

## Verification
- dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT> => 0 errors / 0 warnings
- dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value "(UnityCliLoopEditorSessionStateRepositoryTests|CompileStatusBridgeCommandTests|CompileSessionResultServiceTests|OnionAssemblyDependencyTests|StaticFacadeStateGuardTests)" => 128 passed