### PR TITLE
chore: Move compile disconnect policy into Domain

### DIFF
--- a/Assets/Tests/Editor/JsonRpcAcceptedRequestCancellationPolicyTests.cs
+++ b/Assets/Tests/Editor/JsonRpcAcceptedRequestCancellationPolicyTests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests accepted-request cancellation decisions before infrastructure parses transport details.
+    /// </summary>
+    public sealed class JsonRpcAcceptedRequestCancellationPolicyTests
+    {
+        [Test]
+        public void ShouldCancelOnClientDisconnect_WhenMethodIsNotCompile_ReturnsTrue()
+        {
+            // Verifies non-compile accepted work is tied to the CLI connection lifetime.
+            bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
+                UnityCliLoopConstants.TOOL_NAME_GET_LOGS,
+                true);
+
+            Assert.That(shouldCancel, Is.True);
+        }
+
+        [Test]
+        public void ShouldCancelOnClientDisconnect_WhenCompileWaitsForDomainReload_ReturnsFalse()
+        {
+            // Verifies long compile requests can persist after the CLI connection closes.
+            bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
+                UnityCliLoopConstants.TOOL_NAME_COMPILE,
+                true);
+
+            Assert.That(shouldCancel, Is.False);
+        }
+
+        [Test]
+        public void ShouldCancelOnClientDisconnect_WhenCompileDoesNotWaitForDomainReload_ReturnsTrue()
+        {
+            // Verifies fire-and-forget compile requests keep the usual disconnect cancellation behavior.
+            bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
+                UnityCliLoopConstants.TOOL_NAME_COMPILE,
+                false);
+
+            Assert.That(shouldCancel, Is.True);
+        }
+
+        [Test]
+        public void ShouldCancelOnClientDisconnect_WhenCompileWaitPreferenceIsUnknown_ReturnsFalse()
+        {
+            // Verifies missing, null, or non-boolean transport values preserve the compile default wait contract.
+            bool shouldCancel = JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
+                UnityCliLoopConstants.TOOL_NAME_COMPILE,
+                null);
+
+            Assert.That(shouldCancel, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/JsonRpcAcceptedRequestCancellationPolicyTests.cs.meta
+++ b/Assets/Tests/Editor/JsonRpcAcceptedRequestCancellationPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7416db6e9cbd47a4b9b0c866195774e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/JsonRpcProcessorCliVersionGateTests.cs
+++ b/Assets/Tests/Editor/JsonRpcProcessorCliVersionGateTests.cs
@@ -357,6 +357,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task ProcessRequest_WhenCompileReloadWaitIsNotBoolean_KeepsAcceptedRequestAliveAfterDisconnect()
+        {
+            // Verifies malformed compile reload-wait params preserve the default wait contract.
+            UnityCliLoopToolRegistrarService previousService = ApplicationRegistrar.Service;
+            IToolSettingsPort toolSettingsPort = new ToolSettingsRepository();
+            UnityCliLoopToolRegistrarService service = new(
+                new EmptyInternalToolNameProvider(),
+                toolSettingsPort,
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
+                UnityCliLoopToolDiscovery.DiscoverTools);
+            ApplicationRegistrar.RegisterService(service);
+            service.RegisterCustomTool(new CompileDispatchPolicyTestTool());
+
+            bool cancelOnClientDisconnect = true;
+            try
+            {
+                string response = await JsonRpcProcessor.ProcessRequestWithEarlyResponseAsync(
+                    BuildToolRequestWithParams(
+                        UnityCliLoopConstants.TOOL_NAME_COMPILE,
+                        "{\"WaitForDomainReload\":\"false\"}",
+                        1),
+                    CancellationToken.None,
+                    (_, shouldCancelOnClientDisconnect, _) =>
+                    {
+                        cancelOnClientDisconnect = shouldCancelOnClientDisconnect;
+                        return Task.CompletedTask;
+                    });
+                JObject parsed = JObject.Parse(response);
+
+                Assert.That(parsed["error"], Is.Null);
+                Assert.That(parsed["result"], Is.Not.Null);
+                Assert.That(cancelOnClientDisconnect, Is.False);
+            }
+            finally
+            {
+                ApplicationRegistrar.RegisterService(previousService);
+            }
+        }
+
+        [Test]
         public async Task ProcessRequest_WhenCompileDoesNotWaitForDomainReload_CancelsOnClientDisconnect()
         {
             // Verifies fire-and-forget compile requests still cancel when the CLI connection goes away.

--- a/Packages/src/Editor/Domain/JsonRpcAcceptedRequestCancellationPolicy.cs
+++ b/Packages/src/Editor/Domain/JsonRpcAcceptedRequestCancellationPolicy.cs
@@ -1,0 +1,27 @@
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Decides whether accepted JSON-RPC work should be canceled when the CLI disconnects.
+    /// </summary>
+    public static class JsonRpcAcceptedRequestCancellationPolicy
+    {
+        public static bool ShouldCancelOnClientDisconnect(
+            string methodName,
+            bool? compileWaitsForDomainReload)
+        {
+            if (methodName != UnityCliLoopConstants.TOOL_NAME_COMPILE)
+            {
+                return true;
+            }
+
+            return !CompileRequestWaitsForDomainReload(compileWaitsForDomainReload);
+        }
+
+        private static bool CompileRequestWaitsForDomainReload(bool? compileWaitsForDomainReload)
+        {
+            return compileWaitsForDomainReload ?? true;
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/JsonRpcAcceptedRequestCancellationPolicy.cs.meta
+++ b/Packages/src/Editor/Domain/JsonRpcAcceptedRequestCancellationPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a6bb389836e49ddb1652ffe0cf17e65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcProcessor.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcProcessor.cs
@@ -283,31 +283,29 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             System.Diagnostics.Debug.Assert(request != null, "request must not be null");
 
-            if (request.Method != UnityCliLoopConstants.TOOL_NAME_COMPILE)
-            {
-                return true;
-            }
-
-            return !CompileRequestWaitsForDomainReload(request.Params);
+            bool? compileWaitsForDomainReload = ReadCompileRequestWaitsForDomainReload(request.Params);
+            return JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
+                request.Method,
+                compileWaitsForDomainReload);
         }
 
-        private static bool CompileRequestWaitsForDomainReload(JToken paramsToken)
+        private static bool? ReadCompileRequestWaitsForDomainReload(JToken paramsToken)
         {
             if (paramsToken is not JObject paramsObject)
             {
-                return true;
+                return null;
             }
 
             JToken waitForDomainReloadToken =
                 paramsObject.GetValue(WaitForDomainReloadParamName, StringComparison.OrdinalIgnoreCase);
             if (waitForDomainReloadToken == null)
             {
-                return true;
+                return null;
             }
 
             if (waitForDomainReloadToken.Type != JTokenType.Boolean)
             {
-                return true;
+                return null;
             }
 
             return waitForDomainReloadToken.Value<bool>();


### PR DESCRIPTION
## Summary
- Moves the accepted-request disconnect decision for compile requests into a pure Domain policy.
- Keeps JSON-RPC parameter extraction in the infrastructure layer.

## User Impact
- No intended behavior change: compile requests that wait for domain reload still stay alive after client disconnect, while fire-and-forget compile requests still cancel.

## Changes
- Added JsonRpcAcceptedRequestCancellationPolicy in Domain with signature ShouldCancelOnClientDisconnect(string methodName, bool? compileWaitsForDomainReload).
- Updated JsonRpcProcessor to read WaitForDomainReload from JToken as a nullable bool and delegate the decision to Domain.
- Added unit coverage for non-compile, compile wait=true, compile wait=false, and unknown wait preference defaults.
- Added JSON-RPC coverage for non-boolean WaitForDomainReload preserving the default wait=true behavior.

## Verification
- dist/darwin-arm64/uloop compile --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" (0 errors, 0 warnings)
- dist/darwin-arm64/uloop run-tests --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" --test-mode EditMode --filter-type regex --filter-value "io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.(JsonRpcAcceptedRequestCancellationPolicyTests|JsonRpcProcessorCliVersionGateTests).*" (21/21 passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

