### PR TITLE
chore: Move error severity decisions into Domain

### DIFF
--- a/Assets/Tests/Editor/DefaultErrorTranslatorTests.cs
+++ b/Assets/Tests/Editor/DefaultErrorTranslatorTests.cs
@@ -132,5 +132,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.AreEqual("Internal error", result.FriendlyMessage);
         }
+
+        [Test]
+        public void ProcessException_WhenExceptionIsNull_ShouldUseHighSeverity()
+        {
+            // Verifies null exception conversion uses the same domain severity policy as formatted exceptions.
+            UserFriendlyErrorConverter converter = new();
+
+            UserFriendlyErrorDto dto = converter.ProcessException(null);
+
+            Assert.AreEqual(ErrorSeverity.High, dto.Severity);
+        }
     }
 }

--- a/Assets/Tests/Editor/DefaultErrorTranslatorTests.cs
+++ b/Assets/Tests/Editor/DefaultErrorTranslatorTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -74,6 +75,40 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             TranslationOutput translation = _translator.TranslateFromException(exception);
 
             UserFriendlyErrorDto dto = _formatter.Format(translation, exception.Message, exception);
+
+            Assert.AreEqual(ErrorSeverity.Medium, dto.Severity);
+        }
+
+        [Test]
+        public void DetermineSeverity_ParameterValidation_ShouldBeLow()
+        {
+            // Verifies parameter validation exceptions remain user-correctable low severity.
+            UnityCliLoopToolParameterValidationException exception = new("invalid params");
+            TranslationOutput translation = _translator.TranslateFromException(exception);
+
+            UserFriendlyErrorDto dto = _formatter.Format(translation, exception.Message, exception);
+
+            Assert.AreEqual(ErrorSeverity.Low, dto.Severity);
+        }
+
+        [Test]
+        public void DetermineSeverity_CompilerBlockingMessage_ShouldBeHigh()
+        {
+            // Verifies compiler messages that block execution remain high severity.
+            UserFriendlyErrorDto dto = _formatter.Format(
+                new TranslationOutput(),
+                "Top-level statements must precede namespace declarations");
+
+            Assert.AreEqual(ErrorSeverity.High, dto.Severity);
+        }
+
+        [Test]
+        public void DetermineSeverity_AmbiguousReferenceMessage_ShouldBeMedium()
+        {
+            // Verifies ambiguous reference compiler messages remain medium severity.
+            UserFriendlyErrorDto dto = _formatter.Format(
+                new TranslationOutput(),
+                "error CS0104: ambiguous reference");
 
             Assert.AreEqual(ErrorSeverity.Medium, dto.Severity);
         }

--- a/Assets/Tests/Editor/ErrorSeverityClassificationPolicyTests.cs
+++ b/Assets/Tests/Editor/ErrorSeverityClassificationPolicyTests.cs
@@ -20,6 +20,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void DetermineSeverity_WhenCategoryIsBlockingCompilerMessage_ReturnsHigh()
+        {
+            // Verifies compiler-blocking messages share the high-severity category group.
+            ErrorSeverity severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
+                ErrorSeverityCategory.BlockingCompilerMessage);
+
+            Assert.That(severity, Is.EqualTo(ErrorSeverity.High));
+        }
+
+        [Test]
+        public void DetermineSeverity_WhenCategoryIsUnknownException_ReturnsHigh()
+        {
+            // Verifies unclassified exceptions share the high-severity category group.
+            ErrorSeverity severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
+                ErrorSeverityCategory.UnknownException);
+
+            Assert.That(severity, Is.EqualTo(ErrorSeverity.High));
+        }
+
+        [Test]
         public void DetermineSeverity_WhenCategoryIsRecoverableExecutionState_ReturnsMedium()
         {
             // Verifies busy, timeout, and disabled-tool states share the recoverable severity.
@@ -30,11 +50,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void DetermineSeverity_WhenCategoryIsAmbiguousCompilerMessage_ReturnsMedium()
+        {
+            // Verifies ambiguous compiler messages share the medium-severity category group.
+            ErrorSeverity severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
+                ErrorSeverityCategory.AmbiguousCompilerMessage);
+
+            Assert.That(severity, Is.EqualTo(ErrorSeverity.Medium));
+        }
+
+        [Test]
         public void DetermineSeverity_WhenCategoryIsParameterValidation_ReturnsLow()
         {
             // Verifies user-correctable parameter issues stay at low severity.
             ErrorSeverity severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
                 ErrorSeverityCategory.ParameterValidation);
+
+            Assert.That(severity, Is.EqualTo(ErrorSeverity.Low));
+        }
+
+        [Test]
+        public void DetermineSeverity_WhenCategoryIsUserMessage_ReturnsLow()
+        {
+            // Verifies ordinary user messages share the low-severity category group.
+            ErrorSeverity severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
+                ErrorSeverityCategory.UserMessage);
 
             Assert.That(severity, Is.EqualTo(ErrorSeverity.Low));
         }

--- a/Assets/Tests/Editor/ErrorSeverityClassificationPolicyTests.cs
+++ b/Assets/Tests/Editor/ErrorSeverityClassificationPolicyTests.cs
@@ -1,0 +1,52 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests domain severity decisions after application-specific errors are categorized.
+    /// </summary>
+    public sealed class ErrorSeverityClassificationPolicyTests
+    {
+        [Test]
+        public void DetermineSeverity_WhenCategoryIsSecurityViolation_ReturnsHigh()
+        {
+            // Verifies security failures stay highly visible to users.
+            ErrorSeverity severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
+                ErrorSeverityCategory.SecurityViolation);
+
+            Assert.That(severity, Is.EqualTo(ErrorSeverity.High));
+        }
+
+        [Test]
+        public void DetermineSeverity_WhenCategoryIsRecoverableExecutionState_ReturnsMedium()
+        {
+            // Verifies busy, timeout, and disabled-tool states share the recoverable severity.
+            ErrorSeverity severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
+                ErrorSeverityCategory.RecoverableExecutionState);
+
+            Assert.That(severity, Is.EqualTo(ErrorSeverity.Medium));
+        }
+
+        [Test]
+        public void DetermineSeverity_WhenCategoryIsParameterValidation_ReturnsLow()
+        {
+            // Verifies user-correctable parameter issues stay at low severity.
+            ErrorSeverity severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
+                ErrorSeverityCategory.ParameterValidation);
+
+            Assert.That(severity, Is.EqualTo(ErrorSeverity.Low));
+        }
+
+        [Test]
+        public void DetermineSeverity_WhenCategoryIsUnknown_ReturnsHigh()
+        {
+            // Verifies unexpected categories fail closed as high severity.
+            ErrorSeverity severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
+                (ErrorSeverityCategory)999);
+
+            Assert.That(severity, Is.EqualTo(ErrorSeverity.High));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ErrorSeverityClassificationPolicyTests.cs.meta
+++ b/Assets/Tests/Editor/ErrorSeverityClassificationPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c64a496ce33148a8b92380b5ef1ec6cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Application/ImprovedErrorHandler.cs
+++ b/Packages/src/Editor/Application/ImprovedErrorHandler.cs
@@ -147,41 +147,47 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
         private ErrorSeverity DetermineSeverity(string errorMessage, Exception exception)
         {
+            ErrorSeverityCategory category = DetermineSeverityCategory(errorMessage, exception);
+            return ErrorSeverityClassificationPolicy.DetermineSeverity(category);
+        }
+
+        private ErrorSeverityCategory DetermineSeverityCategory(string errorMessage, Exception exception)
+        {
             if (exception != null)
             {
                 if (exception is UnityCliLoopSecurityException)
                 {
-                    return ErrorSeverity.High;
+                    return ErrorSeverityCategory.SecurityViolation;
                 }
                 if (exception is UnityCliLoopToolBusyException)
                 {
-                    return ErrorSeverity.Medium;
+                    return ErrorSeverityCategory.RecoverableExecutionState;
                 }
                 if (exception is TimeoutException)
                 {
-                    return ErrorSeverity.Medium;
+                    return ErrorSeverityCategory.RecoverableExecutionState;
                 }
                 if (exception is ToolDisabledException)
                 {
-                    return ErrorSeverity.Medium;
+                    return ErrorSeverityCategory.RecoverableExecutionState;
                 }
                 if (exception is UnityCliLoopToolParameterValidationException)
                 {
-                    return ErrorSeverity.Low;
+                    return ErrorSeverityCategory.ParameterValidation;
                 }
-                return ErrorSeverity.High;
+                return ErrorSeverityCategory.UnknownException;
             }
 
             string msg = errorMessage ?? string.Empty;
             if (msg.Contains("Top-level statements") || msg.Contains("not all code paths"))
             {
-                return ErrorSeverity.High;
+                return ErrorSeverityCategory.BlockingCompilerMessage;
             }
             if (msg.Contains("ambiguous reference"))
             {
-                return ErrorSeverity.Medium;
+                return ErrorSeverityCategory.AmbiguousCompilerMessage;
             }
-            return ErrorSeverity.Low;
+            return ErrorSeverityCategory.UserMessage;
         }
     }
 
@@ -237,13 +243,4 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public ErrorSeverity Severity { get; set; }
     }
 
-    /// <summary>
-    /// Error Severity
-    /// </summary>
-    public enum ErrorSeverity
-    {
-        Low,
-        Medium,
-        High
-    }
 }

--- a/Packages/src/Editor/Application/ImprovedErrorHandler.cs
+++ b/Packages/src/Editor/Application/ImprovedErrorHandler.cs
@@ -220,7 +220,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
                     Example = string.Empty,
                     SuggestedSolutions = new List<string>(),
                     LearningTips = new List<string>(),
-                    Severity = ErrorSeverity.High
+                    Severity = ErrorSeverityClassificationPolicy.DetermineSeverity(
+                        ErrorSeverityCategory.UnknownException)
                 };
             }
 

--- a/Packages/src/Editor/Domain/ErrorSeverityClassificationPolicy.cs
+++ b/Packages/src/Editor/Domain/ErrorSeverityClassificationPolicy.cs
@@ -1,0 +1,51 @@
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// User-facing severity applied to structured error responses.
+    /// </summary>
+    public enum ErrorSeverity
+    {
+        Low,
+        Medium,
+        High
+    }
+
+    /// <summary>
+    /// Domain category used to classify errors without depending on application exception types.
+    /// </summary>
+    public enum ErrorSeverityCategory
+    {
+        UserMessage,
+        BlockingCompilerMessage,
+        AmbiguousCompilerMessage,
+        SecurityViolation,
+        RecoverableExecutionState,
+        ParameterValidation,
+        UnknownException
+    }
+
+    /// <summary>
+    /// Maps domain-neutral error categories to user-facing severity.
+    /// </summary>
+    public static class ErrorSeverityClassificationPolicy
+    {
+        public static ErrorSeverity DetermineSeverity(ErrorSeverityCategory category)
+        {
+            switch (category)
+            {
+                case ErrorSeverityCategory.SecurityViolation:
+                case ErrorSeverityCategory.BlockingCompilerMessage:
+                case ErrorSeverityCategory.UnknownException:
+                    return ErrorSeverity.High;
+                case ErrorSeverityCategory.RecoverableExecutionState:
+                case ErrorSeverityCategory.AmbiguousCompilerMessage:
+                    return ErrorSeverity.Medium;
+                case ErrorSeverityCategory.ParameterValidation:
+                case ErrorSeverityCategory.UserMessage:
+                    return ErrorSeverity.Low;
+                default:
+                    return ErrorSeverity.High;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/ErrorSeverityClassificationPolicy.cs.meta
+++ b/Packages/src/Editor/Domain/ErrorSeverityClassificationPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc05b9a10c054920bdd1236a192eb8fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Moves user-facing error severity decisions into a pure Domain policy.
- Keeps application-specific exception and message mapping in the Application layer.

## User Impact
- No intended behavior change: security and unknown exceptions remain high severity, recoverable execution states remain medium, and parameter/user-correctable issues remain low.

## Changes
- Added ErrorSeverity, ErrorSeverityCategory, and ErrorSeverityClassificationPolicy in Domain.
- Domain policy signature: ErrorSeverityClassificationPolicy.DetermineSeverity(ErrorSeverityCategory category).
- Category enum values: UserMessage, BlockingCompilerMessage, AmbiguousCompilerMessage, SecurityViolation, RecoverableExecutionState, ParameterValidation, UnknownException.
- Updated DefaultErrorFormatter so Application maps exception/message details to categories, while Domain owns category grouping, defaults, and unknown-category handling.

## Verification
- dist/darwin-arm64/uloop compile --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" (0 errors, 0 warnings)
- dist/darwin-arm64/uloop run-tests --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" --test-mode EditMode --filter-type regex --filter-value "io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.(ErrorSeverityClassificationPolicyTests|DefaultErrorTranslatorTests).*" (14/14 passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

