### PR TITLE
chore: restore migration result move-only behavior

### DIFF
--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleData.cs
@@ -93,7 +93,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 removedPlayerLoopTimingSignatures != null,
                 "removedPlayerLoopTimingSignatures must not be null");
 
-            Content = content;
+            Content = content ?? string.Empty;
             ReplacementCount = replacementCount;
             RemovedPlayerLoopTimingSignatures =
                 removedPlayerLoopTimingSignatures ??


### PR DESCRIPTION
## Summary
- Restore `ThirdPartyToolMigrationContentResult` to the pre-C4-11 move-only null-content behavior.
- Keep fail-fast policy alignment out of the C4-11 move PR; it belongs in a focused follow-up if needed.

## Rationale
C4-11 was approved as a behavior-preserving move. The previous null-content edit responded to a bot suggestion but changed pre-existing behavior after the move-only review had already approved the DTO as verbatim.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value ThirdPartyToolMigrationRulesTests` -> 160 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

