### PR TITLE
chore: Keep compile storage independent from infrastructure

### DIFF
--- a/Assets/Tests/Editor/JsonRpcResponseSerializerTests.cs
+++ b/Assets/Tests/Editor/JsonRpcResponseSerializerTests.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests JSON-RPC serializer settings compatibility with the shared CLI wire contract.
+    /// </summary>
+    [TestFixture]
+    public sealed class JsonRpcResponseSerializerTests
+    {
+        [Test]
+        public void Settings_WhenReadFromInfrastructure_UsesSharedWireContractInstance()
+        {
+            // Tests that JSON-RPC responses and stored compile results cannot drift into separate serializer shapes.
+            Assert.That(JsonRpcResponseSerializer.Settings, Is.SameAs(UnityCliLoopJsonResponseSerializerSettings.Settings));
+        }
+    }
+}

--- a/Assets/Tests/Editor/JsonRpcResponseSerializerTests.cs.meta
+++ b/Assets/Tests/Editor/JsonRpcResponseSerializerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41b95515ed1347029e84436c71797cb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -541,6 +541,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void CompileToolAsmdef_WhenLoaded_DoesNotReferenceInfrastructure()
+        {
+            // Tests that compile result storage keeps its wire serializer contract without depending on infrastructure.
+            string[] references = ReadResolvedReferences("Packages/src/Editor/FirstPartyTools/Compile/UnityCLILoop.FirstPartyTools.Compile.Editor.asmdef");
+
+            Assert.That(references, Does.Not.Contain(InfrastructureAssemblyName));
+        }
+
+        [Test]
         public void ApplicationToolSources_WhenLoaded_DoNotDeclarePublicToolEntryPoints()
         {
             // Tests that bundled tool entry points stay outside the application layer.

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultStore.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileSessionResultStore.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using Newtonsoft.Json;
 
 using io.github.hatayama.UnityCliLoop.Domain;
-using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -34,7 +33,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string resultJson = JsonConvert.SerializeObject(
                 result,
                 Formatting.None,
-                JsonRpcResponseSerializer.Settings);
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
             UnityCliLoopStoredCompileResult previousResult =
                 compileResultRepository.GetCompileResult(requestId);
             UnityCliLoopPendingCompileRequest pendingRequest =

--- a/Packages/src/Editor/FirstPartyTools/Compile/UnityCLILoop.FirstPartyTools.Compile.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Compile/UnityCLILoop.FirstPartyTools.Compile.Editor.asmdef
@@ -3,7 +3,6 @@
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
         "GUID:5c4588558a3624eacbce0f50007cf1eb",
-        "GUID:18e6dd30a99d14f32a045f79a2956f46",
         "GUID:e5952ef560e1641f68b2687e6045bf5b",
         "GUID:d427b32aad9cb44fc8e962437c9dbcd8",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b"

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseSerializer.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseSerializer.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
@@ -8,10 +7,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public static class JsonRpcResponseSerializer
     {
-        public static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
-        {
-            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-            MaxDepth = UnityCliLoopServerConfig.DEFAULT_JSON_MAX_DEPTH
-        };
+        public static readonly Newtonsoft.Json.JsonSerializerSettings Settings =
+            UnityCliLoopJsonResponseSerializerSettings.Settings;
     }
 }

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopJsonResponseSerializerSettings.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopJsonResponseSerializerSettings.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace io.github.hatayama.UnityCliLoop.ToolContracts
+{
+    /// <summary>
+    /// Single source for the JSON shape shared by JSON-RPC responses and stored compile results as the Go CLI wire contract.
+    /// </summary>
+    public static class UnityCliLoopJsonResponseSerializerSettings
+    {
+        public static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        {
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            MaxDepth = UnityCliLoopServerConfig.DEFAULT_JSON_MAX_DEPTH
+        };
+    }
+}

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopJsonResponseSerializerSettings.cs.meta
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopJsonResponseSerializerSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9f1b833fdc049719e6c3408780d3421
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Keep stored compile-result JSON and JSON-RPC responses on the same serializer settings instance.
- Remove the compile tool assembly's direct Infrastructure reference used only for serializer settings.

## User Impact
- No runtime behavior change is intended.
- Delayed compile polling keeps the same PascalCase JSON wire shape consumed by the native CLI.

## Changes
- Add a ToolContracts serializer settings seam as the single source for response JSON shape.
- Keep the existing Infrastructure serializer API as a delegating wrapper to preserve public identifiers.
- Switch compile result storage to the shared settings and remove the compile asmdef Infrastructure reference.
- Add regression tests for the shared instance and compile asmdef boundary.

## Verification
- dist/darwin-arm64/uloop compile --project-path "<PROJECT_ROOT>"
- dist/darwin-arm64/uloop run-tests --project-path "<PROJECT_ROOT>" --test-mode EditMode --filter-type regex --filter-value "(JsonRpcResponseSerializerTests|CompileSessionResultStoreTests|CompileStatusBridgeCommandTests|ExecuteDynamicCodeUseCaseTests|JsonRpcHeartbeatTests|JsonRpcProcessorCliVersionGateTests|OnionAssemblyDependencyTests)"