### PR TITLE
chore: Remove shadowed compile controller validation

### DIFF
--- a/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
+++ b/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Dev
 {
@@ -21,6 +22,11 @@ namespace io.github.hatayama.UnityCliLoop.Dev
 
             try
             {
+                if (!ValidateCompilationStateBeforeControllerExecution())
+                {
+                    return;
+                }
+
                 // How Masamichi requested to use it
                 CompileResult result = await compileController.TryCompileAsync();
                 CompilerMessage[] err = result.Errors;
@@ -57,6 +63,11 @@ namespace io.github.hatayama.UnityCliLoop.Dev
 
             try
             {
+                if (!ValidateCompilationStateBeforeControllerExecution())
+                {
+                    return;
+                }
+
                 // Example of forced re-compilation
                 CompileResult result = await compileController.TryCompileAsync(forceRecompile: true);
                 CompilerMessage[] err = result.Errors;
@@ -69,6 +80,19 @@ namespace io.github.hatayama.UnityCliLoop.Dev
             {
                 compileController.Dispose();
             }
+        }
+
+        private static bool ValidateCompilationStateBeforeControllerExecution()
+        {
+            CompilationStateValidationService validationService = new();
+            ValidationResult validation = validationService.ValidateCompilationState();
+            if (validation.IsValid)
+            {
+                return true;
+            }
+
+            Debug.LogWarning(validation.ErrorMessage);
+            return false;
         }
     }
 }

--- a/Assets/Editor/CompileCheckWindow/CompileEditorWindow.cs
+++ b/Assets/Editor/CompileCheckWindow/CompileEditorWindow.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Compilation;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -129,6 +130,11 @@ namespace io.github.hatayama.UnityCliLoop.Dev
 
         private async Task ExecuteCompileAsync()
         {
+            if (!ValidateCompilationStateBeforeControllerExecution())
+            {
+                return;
+            }
+
             CompileResult result = await _compileController.TryCompileAsync(_forceRecompile, CancellationToken.None);
             if (ShouldRunExecuteDynamicCodeReadinessAfterCompile(result))
             {
@@ -159,6 +165,31 @@ namespace io.github.hatayama.UnityCliLoop.Dev
             }
 
             UnityEngine.Debug.Log(logMessage);
+        }
+
+        private bool ValidateCompilationStateBeforeControllerExecution()
+        {
+            CompilationStateValidationService validationService = new();
+            ValidationResult validation = validationService.ValidateCompilationState();
+            if (validation.IsValid)
+            {
+                return true;
+            }
+
+            CompileResult result = new CompileResult(
+                success: false,
+                errorCount: 0,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: new CompilerMessage[0],
+                errors: new CompilerMessage[0],
+                warnings: new CompilerMessage[0],
+                isIndeterminate: true,
+                message: validation.ErrorMessage);
+            _logDisplay.AppendCompletionMessage(result);
+            Repaint();
+            UnityEngine.Debug.LogWarning(validation.ErrorMessage);
+            return false;
         }
 
         private static bool ShouldRunExecuteDynamicCodeReadinessAfterCompile(CompileResult result)

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -86,11 +86,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <param name="forceRecompile">Whether to force a recompile.</param>
         /// <returns>The compilation result.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the task is not found during compilation.</exception>
+        /// <remarks>
+        /// Callers must validate editor compilation state before invoking compile execution;
+        /// the production pipeline does this in CompileUseCase.
+        /// </remarks>
         public async Task<CompileResult> TryCompileAsync(bool forceRecompile = false)
         {
             return await TryCompileAsync(forceRecompile, CancellationToken.None);
         }
 
+        /// <summary>
+        /// Executes compilation asynchronously.
+        /// </summary>
+        /// <param name="forceRecompile">Whether to force a recompile.</param>
+        /// <param name="ct">Cancellation token for the compile execution.</param>
+        /// <returns>The compilation result.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the task is not found during compilation.</exception>
+        /// <remarks>
+        /// Callers must validate editor compilation state before invoking compile execution;
+        /// the production pipeline does this in CompileUseCase.
+        /// </remarks>
         public async Task<CompileResult> TryCompileAsync(bool forceRecompile, CancellationToken ct)
         {
             if (_isCompiling)
@@ -108,34 +123,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return await _currentCompileTask.Task;
                 }
                 throw new InvalidOperationException("Compilation is in progress, but the task could not be found.");
-            }
-
-            CompilationStateValidationService validationService = new();
-            ValidationResult validation = validationService.ValidateCompilationState();
-            if (!validation.IsValid)
-            {
-                VibeLogger.LogWarning(
-                    "compile_controller_validation_failed",
-                    validation.ErrorMessage,
-                    new { force_recompile = forceRecompile });
-                CompileResult result = new CompileResult(
-                    success: false,
-                    errorCount: 0,
-                    warningCount: 0,
-                    completedAt: DateTime.Now,
-                    messages: new CompilerMessage[0],
-                    errors: new CompilerMessage[0],
-                    warnings: new CompilerMessage[0],
-                    isIndeterminate: true,
-                    message: validation.ErrorMessage
-                );
-                RecordCompileResultIfNeeded(
-                    result,
-                    BuildCompileControllerStateContext(new Dictionary<string, object>
-                    {
-                        ["validation_failed_before_request"] = true
-                    }));
-                return result;
             }
 
             (bool CanProceed, string Message, string[] ScenePaths) sceneChangeResult =


### PR DESCRIPTION
## Summary
- remove the compile-state validation branch from CompileController because the production path is prevalidated by CompileUseCase
- keep external scene-change handling in CompileController unchanged
- document the prevalidated-state contract at the controller boundary
- add caller-side validation to the two direct dev sample callers so they follow the new controller contract

## Behavior
- User-visible validation failures remain owned by CompileUseCase and keep the existing detailed response shape: Success=false, ErrorCount=1, Errors populated, Message=null.
- The removed Controller branch was shadowed on the production route: CompileTool -> CompileUseCase -> CompilationExecutionService -> CompileController.
- The direct dev sample callers now validate before invoking CompileController, preserving their polite early-out behavior during editor compiling/updating states.
- No protocol or wire shape changes are intended.

## Verification
- dist/darwin-arm64/uloop compile --project-path "<PROJECT_ROOT>" (0 errors / 0 warnings)
- dist/darwin-arm64/uloop run-tests --project-path "<PROJECT_ROOT>" --test-mode EditMode --filter-type regex --filter-value "(CompileUseCaseTests|CompileResultSessionRecorderTests|CompileSessionResultStoreTests|CompileResponseFactoryTests|CompileStatusBridgeCommandTests|CompileLifecycleWatchdogTests)" (26/26 passed)
