### PR TITLE
chore: Keep server lifecycle wiring in composition root

### DIFF
--- a/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
+++ b/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
@@ -107,11 +107,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _sessionFlagsRepository.SetIsAfterCompile(false);
             TestRecoveryCoordinator recoveryCoordinator = new();
             SessionRecoveryService service = new(
-                recoveryCoordinator,
                 _domainReloadDetectionService,
                 _sessionFlagsRepository);
 
-            ValidationResult result = await service.RestoreServerStateIfNeededAsync(CancellationToken.None);
+            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
+                recoveryCoordinator,
+                CancellationToken.None);
 
             Assert.That(result.IsValid, Is.False);
             Assert.That(
@@ -127,11 +128,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _sessionFlagsRepository.SetIsAfterCompile(false);
             TestRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
             SessionRecoveryService service = new(
-                recoveryCoordinator,
                 _domainReloadDetectionService,
                 _sessionFlagsRepository);
 
-            ValidationResult result = await service.RestoreServerStateIfNeededAsync(CancellationToken.None);
+            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
+                recoveryCoordinator,
+                CancellationToken.None);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(recoveryCoordinator.StartRecoveryCallCount, Is.EqualTo(1));
@@ -144,11 +146,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _sessionFlagsRepository.MarkServerManuallyStopped();
             TestRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
             SessionRecoveryService service = new(
-                recoveryCoordinator,
                 _domainReloadDetectionService,
                 _sessionFlagsRepository);
 
-            ValidationResult result = await service.RestoreServerStateIfNeededAsync(CancellationToken.None);
+            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
+                recoveryCoordinator,
+                CancellationToken.None);
 
             Assert.That(result.IsValid, Is.True);
             Assert.That(recoveryCoordinator.StartRecoveryCallCount, Is.EqualTo(0));
@@ -158,10 +161,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             IDomainReloadDetectionService domainReloadDetectionService,
             ISessionFlagsRepository sessionFlagsRepository)
         {
-            TestRecoveryCoordinator recoveryCoordinator = new();
             SessionRecoveryService sessionRecoveryService =
                 new SessionRecoveryService(
-                    recoveryCoordinator,
                     domainReloadDetectionService,
                     sessionFlagsRepository);
             return new DomainReloadRecoveryUseCase(

--- a/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
@@ -113,13 +113,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             TestReadinessProbe readinessProbe = new();
             int serverStartedCount = 0;
             lifecycleRegistry.ServerStarted += () => serverStartedCount++;
-            UnityCliLoopServerControllerService service = new(
-                serverInstanceFactory,
-                lifecycleRegistry,
-                CreateDomainReloadDetectionService(),
-                _sessionFlagsRepository,
-                readinessProbe,
-                new TestDomainReloadLifecycle());
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                readinessProbe: readinessProbe,
+                serverInstanceFactory: serverInstanceFactory,
+                lifecycleRegistry: lifecycleRegistry,
+                isReadinessProbeBlocked: () => false);
 
             await service.StartRecoveryIfNeededAsync(isAfterCompile: false, CancellationToken.None);
 
@@ -139,15 +137,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             TestReadinessProbe readinessProbe = new();
             int serverStartedCount = 0;
             lifecycleRegistry.ServerStarted += () => serverStartedCount++;
-            UnityCliLoopServerControllerService service = new(
-                serverInstanceFactory,
-                lifecycleRegistry,
-                CreateDomainReloadDetectionService(),
-                _sessionFlagsRepository,
-                readinessProbe,
-                new TestDomainReloadLifecycle(),
-                () => editorIsBusy,
-                (delayMilliseconds, ct) =>
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                readinessProbe: readinessProbe,
+                serverInstanceFactory: serverInstanceFactory,
+                lifecycleRegistry: lifecycleRegistry,
+                isReadinessProbeBlocked: () => editorIsBusy,
+                waitBeforeReadinessRetryAsync: (delayMilliseconds, ct) =>
                 {
                     delayCallCount++;
                     Assert.That(readinessProbe.CallCount, Is.EqualTo(0));
@@ -173,15 +168,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             TestReadinessProbe readinessProbe = new();
             int serverStartedCount = 0;
             lifecycleRegistry.ServerStarted += () => serverStartedCount++;
-            UnityCliLoopServerControllerService service = new(
-                serverInstanceFactory,
-                lifecycleRegistry,
-                CreateDomainReloadDetectionService(),
-                _sessionFlagsRepository,
-                readinessProbe,
-                new TestDomainReloadLifecycle(),
-                () => true,
-                (delayMilliseconds, ct) =>
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                readinessProbe: readinessProbe,
+                serverInstanceFactory: serverInstanceFactory,
+                lifecycleRegistry: lifecycleRegistry,
+                isReadinessProbeBlocked: () => true,
+                waitBeforeReadinessRetryAsync: (delayMilliseconds, ct) =>
                 {
                     delayCallCount++;
                     return Task.CompletedTask;
@@ -270,6 +262,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     recordedWaits.Add(delayMilliseconds);
                     return Task.CompletedTask;
                 });
+            UnityEngine.TestTools.LogAssert.Expect(
+                UnityEngine.LogType.Error,
+                "[UnityCliLoop] Unity CLI Loop server recovery failed before the bridge became ready. readiness probe timed out");
 
             System.InvalidOperationException exception =
                 Assert.ThrowsAsync<System.InvalidOperationException>(async () =>
@@ -317,13 +312,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             TestServerInstanceFactory serverInstanceFactory = new();
             UnityCliLoopServerLifecycleRegistryService lifecycleRegistry =
                 new UnityCliLoopServerLifecycleRegistryService();
-            UnityCliLoopServerControllerService service = new(
-                serverInstanceFactory,
-                lifecycleRegistry,
-                CreateDomainReloadDetectionService(),
-                _sessionFlagsRepository,
-                new TestReadinessProbe(),
-                new TestDomainReloadLifecycle());
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                serverInstanceFactory: serverInstanceFactory,
+                lifecycleRegistry: lifecycleRegistry);
 
             await service.RestoreServerStateIfNeeded();
 
@@ -355,13 +346,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             TestServerInstanceFactory serverInstanceFactory = new(throwOnCreate: true);
             UnityCliLoopServerLifecycleRegistryService lifecycleRegistry =
                 new UnityCliLoopServerLifecycleRegistryService();
-            UnityCliLoopServerControllerService service = new(
-                serverInstanceFactory,
-                lifecycleRegistry,
-                CreateDomainReloadDetectionService(),
-                _sessionFlagsRepository,
-                new TestReadinessProbe(),
-                new TestDomainReloadLifecycle());
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                serverInstanceFactory: serverInstanceFactory,
+                lifecycleRegistry: lifecycleRegistry);
             TestServerInstance runningServer = new();
             runningServer.StartServer();
             service.RegisterRecoveredServer(runningServer);
@@ -382,13 +369,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             TestServerInstanceFactory serverInstanceFactory = new();
             UnityCliLoopServerLifecycleRegistryService lifecycleRegistry =
                 new UnityCliLoopServerLifecycleRegistryService();
-            UnityCliLoopServerControllerService service = new(
-                serverInstanceFactory,
-                lifecycleRegistry,
-                CreateDomainReloadDetectionService(),
-                _sessionFlagsRepository,
-                new TestReadinessProbe(),
-                new TestDomainReloadLifecycle());
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                serverInstanceFactory: serverInstanceFactory,
+                lifecycleRegistry: lifecycleRegistry);
             TestServerInstance runningServer = new(throwOnDispose: true);
             runningServer.StartServer();
             service.RegisterRecoveredServer(runningServer);
@@ -402,19 +385,47 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private UnityCliLoopServerControllerService CreateControllerService(
             TestReadinessProbe readinessProbe = null,
-            System.Func<int, CancellationToken, Task> waitBeforeRecoveryRetryAsync = null)
+            System.Func<int, CancellationToken, Task> waitBeforeRecoveryRetryAsync = null,
+            TestServerInstanceFactory serverInstanceFactory = null,
+            UnityCliLoopServerLifecycleRegistryService lifecycleRegistry = null,
+            System.Func<bool> isReadinessProbeBlocked = null,
+            System.Func<int, CancellationToken, Task> waitBeforeReadinessRetryAsync = null,
+            int readinessIdleTimeoutMilliseconds = UnityCliLoopServerConfig.READINESS_PROBE_TIMEOUT_MS)
         {
-            TestServerInstanceFactory serverInstanceFactory = new();
-            UnityCliLoopServerLifecycleRegistryService lifecycleRegistry =
-                new UnityCliLoopServerLifecycleRegistryService();
+            TestServerInstanceFactory effectiveServerInstanceFactory =
+                serverInstanceFactory ?? new TestServerInstanceFactory();
+            UnityCliLoopServerLifecycleRegistryService effectiveLifecycleRegistry =
+                lifecycleRegistry ?? new UnityCliLoopServerLifecycleRegistryService();
+            DomainReloadDetectionFileService domainReloadDetectionService =
+                CreateDomainReloadDetectionService();
+            UnityCliLoopServerStartupService startupService = new(
+                effectiveServerInstanceFactory,
+                _sessionFlagsRepository);
+            UnityCliLoopServerInitializationUseCase initializationUseCase = new(
+                new EditorSecurityValidationService(),
+                startupService);
+            UnityCliLoopServerShutdownUseCase shutdownUseCase = new(startupService);
+            SessionRecoveryService sessionRecoveryService = new(
+                domainReloadDetectionService,
+                _sessionFlagsRepository);
+            DomainReloadRecoveryUseCase domainReloadRecoveryUseCase = new(
+                sessionRecoveryService,
+                domainReloadDetectionService,
+                _sessionFlagsRepository);
             return new UnityCliLoopServerControllerService(
-                serverInstanceFactory,
-                lifecycleRegistry,
-                CreateDomainReloadDetectionService(),
+                effectiveServerInstanceFactory,
+                effectiveLifecycleRegistry,
+                domainReloadDetectionService,
                 _sessionFlagsRepository,
+                initializationUseCase,
+                shutdownUseCase,
+                domainReloadRecoveryUseCase,
                 readinessProbe ?? new TestReadinessProbe(),
                 new TestDomainReloadLifecycle(),
-                waitBeforeRecoveryRetryAsync: waitBeforeRecoveryRetryAsync);
+                isReadinessProbeBlocked,
+                waitBeforeReadinessRetryAsync,
+                waitBeforeRecoveryRetryAsync,
+                readinessIdleTimeoutMilliseconds);
         }
 
         private DomainReloadDetectionFileService CreateDomainReloadDetectionService()

--- a/Assets/Tests/Editor/UnityCliLoopServerStartupProtectionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerStartupProtectionTests.cs
@@ -103,14 +103,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             TestServerInstanceFactory serverInstanceFactory = new();
             UnityCliLoopServerLifecycleRegistryService lifecycleRegistry =
                 new UnityCliLoopServerLifecycleRegistryService();
-            return new UnityCliLoopServerControllerService(
-                serverInstanceFactory,
-                lifecycleRegistry,
+            DomainReloadDetectionFileService domainReloadDetectionService =
                 new DomainReloadDetectionFileService(
                     _sessionFlagsRepository,
                     new UnityCliLoopPendingCompileSessionRepository(),
-                    _sessionStateService),
+                    _sessionStateService);
+            UnityCliLoopServerStartupService startupService = new(
+                serverInstanceFactory,
+                _sessionFlagsRepository);
+            UnityCliLoopServerInitializationUseCase initializationUseCase = new(
+                new EditorSecurityValidationService(),
+                startupService);
+            UnityCliLoopServerShutdownUseCase shutdownUseCase = new(startupService);
+            SessionRecoveryService sessionRecoveryService = new(
+                domainReloadDetectionService,
+                _sessionFlagsRepository);
+            DomainReloadRecoveryUseCase domainReloadRecoveryUseCase = new(
+                sessionRecoveryService,
+                domainReloadDetectionService,
+                _sessionFlagsRepository);
+            return new UnityCliLoopServerControllerService(
+                serverInstanceFactory,
+                lifecycleRegistry,
+                domainReloadDetectionService,
                 _sessionFlagsRepository,
+                initializationUseCase,
+                shutdownUseCase,
+                domainReloadRecoveryUseCase,
                 new TestReadinessProbe(),
                 domainReloadLifecycle);
         }

--- a/Packages/src/Editor/Application/SessionRecoveryService.cs
+++ b/Packages/src/Editor/Application/SessionRecoveryService.cs
@@ -21,34 +21,31 @@ namespace io.github.hatayama.UnityCliLoop.Application
     /// </summary>
     public sealed class SessionRecoveryService
     {
-        private readonly IUnityCliLoopServerRecoveryCoordinator _recoveryCoordinator;
         private readonly IDomainReloadDetectionService _domainReloadDetectionService;
         private readonly ISessionFlagsRepository _sessionFlagsRepository;
 
         public SessionRecoveryService(
-            IUnityCliLoopServerRecoveryCoordinator recoveryCoordinator,
             IDomainReloadDetectionService domainReloadDetectionService,
             ISessionFlagsRepository sessionFlagsRepository)
         {
-            System.Diagnostics.Debug.Assert(recoveryCoordinator != null, "recoveryCoordinator must not be null");
             System.Diagnostics.Debug.Assert(domainReloadDetectionService != null, "domainReloadDetectionService must not be null");
             System.Diagnostics.Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
 
-            _recoveryCoordinator = recoveryCoordinator
-                ?? throw new System.ArgumentNullException(nameof(recoveryCoordinator));
             _domainReloadDetectionService = domainReloadDetectionService
                 ?? throw new System.ArgumentNullException(nameof(domainReloadDetectionService));
             _sessionFlagsRepository = sessionFlagsRepository
                 ?? throw new System.ArgumentNullException(nameof(sessionFlagsRepository));
         }
 
-        public async Task<ValidationResult> RestoreServerStateIfNeededAsync(CancellationToken ct)
+        public async Task<ValidationResult> RestoreServerStateIfNeededAsync(
+            IUnityCliLoopServerRecoveryCoordinator recoveryCoordinator,
+            CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
 
             bool isAfterCompile = _sessionFlagsRepository.GetIsAfterCompile();
 
-            IUnityCliLoopServerInstance currentServer = _recoveryCoordinator.CurrentServer;
+            IUnityCliLoopServerInstance currentServer = recoveryCoordinator.CurrentServer;
             if (currentServer?.IsRunning == true)
             {
                 if (isAfterCompile)
@@ -68,8 +65,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 return ValidationResult.Success();
             }
 
-            await _recoveryCoordinator.StartRecoveryIfNeededAsync(isAfterCompile, ct);
-            IUnityCliLoopServerInstance recoveredServer = _recoveryCoordinator.CurrentServer;
+            await recoveryCoordinator.StartRecoveryIfNeededAsync(isAfterCompile, ct);
+            IUnityCliLoopServerInstance recoveredServer = recoveryCoordinator.CurrentServer;
             if (recoveredServer?.IsRunning != true)
             {
                 return ValidationResult.Failure(

--- a/Packages/src/Editor/Application/UseCases/DomainReloadRecoveryUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/DomainReloadRecoveryUseCase.cs
@@ -95,7 +95,9 @@ namespace io.github.hatayama.UnityCliLoop.Application
         /// Execute recovery processing after Domain Reload completion
         /// </summary>
         /// <returns>Processing result</returns>
-        public async Task<ServiceResult<string>> ExecuteAfterDomainReloadAsync(CancellationToken cancellationToken = default)
+        public async Task<ServiceResult<string>> ExecuteAfterDomainReloadAsync(
+            IUnityCliLoopServerRecoveryCoordinator recoveryCoordinator,
+            CancellationToken ct = default)
         {
             // 1. Generate tracking ID for related operations
             string correlationId = VibeLogger.GenerateCorrelationId();
@@ -106,12 +108,14 @@ namespace io.github.hatayama.UnityCliLoop.Application
             // 3. Start timeout for reconnection UI display if needed
             if (_domainReloadDetectionService.ShouldShowReconnectingUI())
             {
-                _sessionRecoveryService.StartReconnectionUITimeoutAsync(cancellationToken).Forget();
+                _sessionRecoveryService.StartReconnectionUITimeoutAsync(ct).Forget();
             }
 
             // 4. Restore server state
             ValidationResult restoreResult =
-                await _sessionRecoveryService.RestoreServerStateIfNeededAsync(cancellationToken);
+                await _sessionRecoveryService.RestoreServerStateIfNeededAsync(
+                    recoveryCoordinator,
+                    ct);
             if (!restoreResult.IsValid)
             {
                 return ServiceResult<string>.FailureResult($"Server restoration failed: {restoreResult.ErrorMessage}");

--- a/Packages/src/Editor/Application/UseCases/UnityCliLoopServerShutdownUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/UnityCliLoopServerShutdownUseCase.cs
@@ -7,34 +7,23 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.Application
 {
     /// <summary>
-    /// Defines read access to Unity CLI Loop Server State state for callers that should not own it.
-    /// </summary>
-    public interface IUnityCliLoopServerStateReader
-    {
-        IUnityCliLoopServerInstance CurrentServer { get; }
-    }
-
-    /// <summary>
     /// Coordinates server shutdown while leaving lifecycle result semantics to the domain layer.
     /// </summary>
     public class UnityCliLoopServerShutdownUseCase
     {
         private readonly UnityCliLoopServerStartupService _startupService;
-        private readonly IUnityCliLoopServerStateReader _serverStateReader;
 
-        public UnityCliLoopServerShutdownUseCase(
-            UnityCliLoopServerStartupService startupService,
-            IUnityCliLoopServerStateReader serverStateReader)
+        public UnityCliLoopServerShutdownUseCase(UnityCliLoopServerStartupService startupService)
         {
             _startupService = startupService ?? throw new System.ArgumentNullException(nameof(startupService));
-            _serverStateReader = serverStateReader ?? throw new System.ArgumentNullException(nameof(serverStateReader));
         }
 
-        public Task<ServerShutdownResult> ExecuteAsync(CancellationToken ct)
+        public Task<ServerShutdownResult> ExecuteAsync(
+            IUnityCliLoopServerInstance currentServer,
+            CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
 
-            IUnityCliLoopServerInstance currentServer = _serverStateReader.CurrentServer;
             if (currentServer == null)
             {
                 return Task.FromResult(ServerShutdownResult.AlreadyStopped());

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -61,11 +61,28 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
             UnityCliLoopBridgeServerInstanceFactory serverFactory = new(domainReloadDetectionService);
             UnityCliLoopServerLifecycleRegistryService lifecycleRegistry = new();
             lifecycleRegistry.RegisterSource(serverFactory);
+            UnityCliLoopServerStartupService serverStartupService = new(
+                serverFactory,
+                sessionFlagsRepository);
+            UnityCliLoopServerInitializationUseCase serverInitializationUseCase = new(
+                new EditorSecurityValidationService(),
+                serverStartupService);
+            UnityCliLoopServerShutdownUseCase serverShutdownUseCase = new(serverStartupService);
+            SessionRecoveryService sessionRecoveryService = new(
+                domainReloadDetectionService,
+                sessionFlagsRepository);
+            DomainReloadRecoveryUseCase domainReloadRecoveryUseCase = new(
+                sessionRecoveryService,
+                domainReloadDetectionService,
+                sessionFlagsRepository);
             UnityCliLoopServerControllerService controllerService = new(
                 serverFactory,
                 lifecycleRegistry,
                 domainReloadDetectionService,
                 sessionFlagsRepository,
+                serverInitializationUseCase,
+                serverShutdownUseCase,
+                domainReloadRecoveryUseCase,
                 firstPartyServerLifecycle,
                 firstPartyServerLifecycle);
             UnityCliLoopServerApplicationService applicationService = new(controllerService);

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -17,8 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class UnityCliLoopServerControllerService :
         IUnityCliLoopServerController,
-        IUnityCliLoopServerRecoveryCoordinator,
-        IUnityCliLoopServerStateReader
+        IUnityCliLoopServerRecoveryCoordinator
     {
         private enum ServerStopIntent
         {
@@ -32,7 +31,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly UnityCliLoopServerLifecycleRegistryService _serverLifecycleRegistry;
         private readonly IDomainReloadDetectionService _domainReloadDetectionService;
         private readonly ISessionFlagsRepository _sessionFlagsRepository;
-        private readonly SessionRecoveryService _sessionRecoveryService;
+        private readonly UnityCliLoopServerInitializationUseCase _initializationUseCase;
+        private readonly UnityCliLoopServerShutdownUseCase _shutdownUseCase;
+        private readonly DomainReloadRecoveryUseCase _domainReloadRecoveryUseCase;
         private readonly IUnityCliLoopServerReadinessProbe _readinessProbe;
         private readonly IUnityCliLoopServerDomainReloadLifecycle _domainReloadLifecycle;
         private readonly Func<bool> _isReadinessProbeBlocked;
@@ -49,6 +50,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             UnityCliLoopServerLifecycleRegistryService serverLifecycleRegistry,
             IDomainReloadDetectionService domainReloadDetectionService,
             ISessionFlagsRepository sessionFlagsRepository,
+            UnityCliLoopServerInitializationUseCase initializationUseCase,
+            UnityCliLoopServerShutdownUseCase shutdownUseCase,
+            DomainReloadRecoveryUseCase domainReloadRecoveryUseCase,
             IUnityCliLoopServerReadinessProbe readinessProbe,
             IUnityCliLoopServerDomainReloadLifecycle domainReloadLifecycle,
             Func<bool> isReadinessProbeBlocked = null,
@@ -60,6 +64,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             System.Diagnostics.Debug.Assert(serverLifecycleRegistry != null, "serverLifecycleRegistry must not be null");
             System.Diagnostics.Debug.Assert(domainReloadDetectionService != null, "domainReloadDetectionService must not be null");
             System.Diagnostics.Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
+            System.Diagnostics.Debug.Assert(initializationUseCase != null, "initializationUseCase must not be null");
+            System.Diagnostics.Debug.Assert(shutdownUseCase != null, "shutdownUseCase must not be null");
+            System.Diagnostics.Debug.Assert(domainReloadRecoveryUseCase != null, "domainReloadRecoveryUseCase must not be null");
             System.Diagnostics.Debug.Assert(readinessProbe != null, "readinessProbe must not be null");
             System.Diagnostics.Debug.Assert(domainReloadLifecycle != null, "domainReloadLifecycle must not be null");
             System.Diagnostics.Debug.Assert(readinessIdleTimeoutMilliseconds > 0, "readinessIdleTimeoutMilliseconds must be positive");
@@ -68,16 +75,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             _serverLifecycleRegistry = serverLifecycleRegistry ?? throw new ArgumentNullException(nameof(serverLifecycleRegistry));
             _domainReloadDetectionService = domainReloadDetectionService ?? throw new ArgumentNullException(nameof(domainReloadDetectionService));
             _sessionFlagsRepository = sessionFlagsRepository ?? throw new ArgumentNullException(nameof(sessionFlagsRepository));
+            _initializationUseCase = initializationUseCase ?? throw new ArgumentNullException(nameof(initializationUseCase));
+            _shutdownUseCase = shutdownUseCase ?? throw new ArgumentNullException(nameof(shutdownUseCase));
+            _domainReloadRecoveryUseCase = domainReloadRecoveryUseCase ?? throw new ArgumentNullException(nameof(domainReloadRecoveryUseCase));
             _readinessProbe = readinessProbe ?? throw new ArgumentNullException(nameof(readinessProbe));
             _domainReloadLifecycle = domainReloadLifecycle ?? throw new ArgumentNullException(nameof(domainReloadLifecycle));
             _isReadinessProbeBlocked = isReadinessProbeBlocked ?? IsEditorBusyForReadinessProbe;
             _waitBeforeReadinessRetryAsync = waitBeforeReadinessRetryAsync ?? TimerDelay.Wait;
             _waitBeforeRecoveryRetryAsync = waitBeforeRecoveryRetryAsync ?? TimerDelay.Wait;
             _readinessIdleTimeoutMilliseconds = readinessIdleTimeoutMilliseconds;
-            _sessionRecoveryService = new SessionRecoveryService(
-                this,
-                _domainReloadDetectionService,
-                _sessionFlagsRepository);
         }
 
         private static bool IsEditorBusyForReadinessProbe()
@@ -240,16 +246,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
             }
 
-            UnityCliLoopServerStartupService startupService =
-                new UnityCliLoopServerStartupService(_serverInstanceFactory, _sessionFlagsRepository);
-            UnityCliLoopServerInitializationUseCase useCase =
-                new UnityCliLoopServerInitializationUseCase(
-                    new EditorSecurityValidationService(),
-                    startupService);
             System.Threading.CancellationToken cancellationToken = System.Threading.CancellationToken.None;
 
             ServerInitializationResult<IUnityCliLoopServerInstance> result =
-                await useCase.ExecuteAsync(cancellationToken);
+                await _initializationUseCase.ExecuteAsync(cancellationToken);
 
             if (!result.Success)
             {
@@ -302,12 +302,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             _serverLifecycleRegistry.PublishServerStopping();
             PrepareForServerShutdown();
 
-            UnityCliLoopServerStartupService startupService =
-                new UnityCliLoopServerStartupService(_serverInstanceFactory, _sessionFlagsRepository);
-            UnityCliLoopServerShutdownUseCase useCase =
-                new UnityCliLoopServerShutdownUseCase(startupService, this);
-
-            ServerShutdownResult result = await useCase.ExecuteAsync(ct);
+            ServerShutdownResult result = await _shutdownUseCase.ExecuteAsync(_bridgeServer, ct);
 
             if (result.Success)
             {
@@ -341,12 +336,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             ClearStartupProtection();
             _domainReloadLifecycle.PrepareForDomainReload();
 
-            DomainReloadRecoveryUseCase useCase =
-                new DomainReloadRecoveryUseCase(
-                    _sessionRecoveryService,
-                    _domainReloadDetectionService,
-                    _sessionFlagsRepository);
-            ServiceResult<string> result = useCase.ExecuteBeforeDomainReload(_bridgeServer);
+            ServiceResult<string> result = _domainReloadRecoveryUseCase.ExecuteBeforeDomainReload(_bridgeServer);
             
             // Clear instance if server shutdown succeeded
             if (result.Success)
@@ -366,13 +356,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private async Task ExecuteAfterDomainReloadRecoveryAsync(CancellationToken cancellationToken)
         {
-            DomainReloadRecoveryUseCase useCase =
-                new DomainReloadRecoveryUseCase(
-                    _sessionRecoveryService,
-                    _domainReloadDetectionService,
-                    _sessionFlagsRepository);
             ServiceResult<string> result =
-                await useCase.ExecuteAfterDomainReloadAsync(cancellationToken);
+                await _domainReloadRecoveryUseCase.ExecuteAfterDomainReloadAsync(this, cancellationToken);
             if (!result.Success)
             {
                 string message = $"Domain reload recovery failed after Unity finished reloading assemblies. {result.ErrorMessage}";


### PR DESCRIPTION
## Summary
- Moves server lifecycle use case wiring into the composition root so the controller no longer constructs those use cases during lifecycle callbacks.
- Keeps startup, shutdown, and domain reload recovery behavior unchanged while making the injected use cases stateless.

## User Impact
- No direct user-facing behavior change is intended.
- This narrows the controller's responsibilities, which makes later server recovery and readiness refactors easier to review safely.

## Changes
- Injects initialization, shutdown, and domain reload recovery use cases into the server controller.
- Passes the live server instance or recovery coordinator at execution time to avoid construction cycles without adding factories.
- Updates related EditMode fixtures to construct the same use case graph and records the pre-existing deterministic recovery failure log expectation.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value "(DomainReloadRecoveryUseCaseTests|UnityCliLoopServerControllerRecoveryTests|UnityCliLoopServerStartupProtectionTests|UnityCliLoopBridgeServerShutdownTests|JsonRpcHeartbeatTests|UnityCliLoopServerLifecycleRegistryServiceTests|ServerLifecycleContractTests|UnityCliLoopFirstPartyServerLifecycleBindingTests|JsonRpcProcessorCliVersionGateTests|OnionAssemblyDependencyTests)"` -> 141 passed