### PR TITLE
chore: Extract server readiness policies from controller

### DIFF
--- a/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
@@ -197,7 +197,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Tests that readiness probing fails fast instead of leaving startup state stuck forever.
             TestReadinessProbe readinessProbe = new(neverCompletes: true);
-            UnityCliLoopServerControllerService service = CreateControllerService(readinessProbe);
+            UnityCliLoopServerLifecycleRegistryService lifecycleRegistry =
+                new UnityCliLoopServerLifecycleRegistryService();
+            UnityCliLoopServerReadinessService service = new(
+                lifecycleRegistry,
+                readinessProbe);
 
             System.TimeoutException exception = null;
             try
@@ -412,6 +416,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 sessionRecoveryService,
                 domainReloadDetectionService,
                 _sessionFlagsRepository);
+            TestReadinessProbe effectiveReadinessProbe = readinessProbe ?? new TestReadinessProbe();
+            UnityCliLoopServerReadinessService readinessService = new(
+                effectiveLifecycleRegistry,
+                effectiveReadinessProbe,
+                isReadinessProbeBlocked,
+                waitBeforeReadinessRetryAsync,
+                readinessIdleTimeoutMilliseconds);
+            UnityCliLoopServerStartupProtectionService startupProtectionService = new();
             return new UnityCliLoopServerControllerService(
                 effectiveServerInstanceFactory,
                 effectiveLifecycleRegistry,
@@ -420,12 +432,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 initializationUseCase,
                 shutdownUseCase,
                 domainReloadRecoveryUseCase,
-                readinessProbe ?? new TestReadinessProbe(),
+                readinessService,
+                startupProtectionService,
                 new TestDomainReloadLifecycle(),
-                isReadinessProbeBlocked,
-                waitBeforeReadinessRetryAsync,
-                waitBeforeRecoveryRetryAsync,
-                readinessIdleTimeoutMilliseconds);
+                waitBeforeRecoveryRetryAsync);
         }
 
         private DomainReloadDetectionFileService CreateDomainReloadDetectionService()

--- a/Assets/Tests/Editor/UnityCliLoopServerStartupProtectionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerStartupProtectionTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System.Threading.Tasks;
 
 using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.Domain;
@@ -34,7 +35,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ClearStartupProtection_ResetsProtectionWindow()
         {
             // Tests that the startup protection window can be cleared by recovery code.
-            UnityCliLoopServerControllerService service = CreateControllerService();
+            UnityCliLoopServerStartupProtectionService service = new();
 
             service.ActivateStartupProtection(60000);
 
@@ -49,16 +50,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void OnBeforeAssemblyReload_ShouldClearStartupProtectionBeforeRecovery()
         {
             // Tests that assembly-reload recovery clears the startup protection window before shutdown.
-            UnityCliLoopServerControllerService service = CreateControllerService();
+            UnityCliLoopServerStartupProtectionService startupProtectionService = new();
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                startupProtectionService: startupProtectionService);
             service.RegisterRecoveredServer(new TestServerInstance());
-            service.ActivateStartupProtection(60000);
+            startupProtectionService.ActivateStartupProtection(60000);
 
-            Assert.IsTrue(service.IsStartupProtectionActive(), "Startup protection should be active before reload");
+            Assert.IsTrue(startupProtectionService.IsStartupProtectionActive(), "Startup protection should be active before reload");
 
             service.OnBeforeAssemblyReload();
 
             Assert.IsFalse(
-                service.IsStartupProtectionActive(),
+                startupProtectionService.IsStartupProtectionActive(),
                 "Assembly reload recovery should clear startup protection so the server can restart"
             );
         }
@@ -76,29 +79,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void PrepareForServerShutdown_ShouldClearStartupProtectionBeforeShutdown()
+        public async Task StopServerWithUseCaseAsync_ShouldClearStartupProtectionBeforeShutdown()
         {
             // Tests that explicit shutdown clears the startup protection window before stopping.
-            UnityCliLoopServerControllerService service = CreateControllerService();
+            UnityCliLoopServerStartupProtectionService startupProtectionService = new();
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                startupProtectionService: startupProtectionService);
 
-            service.ActivateStartupProtection(60000);
+            startupProtectionService.ActivateStartupProtection(60000);
 
-            Assert.IsTrue(service.IsStartupProtectionActive(), "Startup protection should be active before shutdown");
+            Assert.IsTrue(startupProtectionService.IsStartupProtectionActive(), "Startup protection should be active before shutdown");
 
-            service.PrepareForServerShutdown();
+            await service.StopServerWithUseCaseAsync();
 
             Assert.IsFalse(
-                service.IsStartupProtectionActive(),
+                startupProtectionService.IsStartupProtectionActive(),
                 "Shutdown path should clear startup protection so recovery can restart the server"
             );
         }
 
-        private UnityCliLoopServerControllerService CreateControllerService()
-        {
-            return CreateControllerService(new TestDomainReloadLifecycle());
-        }
-
-        private UnityCliLoopServerControllerService CreateControllerService(TestDomainReloadLifecycle domainReloadLifecycle)
+        private UnityCliLoopServerControllerService CreateControllerService(
+            TestDomainReloadLifecycle domainReloadLifecycle = null,
+            UnityCliLoopServerStartupProtectionService startupProtectionService = null)
         {
             TestServerInstanceFactory serverInstanceFactory = new();
             UnityCliLoopServerLifecycleRegistryService lifecycleRegistry =
@@ -122,6 +124,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 sessionRecoveryService,
                 domainReloadDetectionService,
                 _sessionFlagsRepository);
+            UnityCliLoopServerReadinessService readinessService = new(
+                lifecycleRegistry,
+                new TestReadinessProbe());
             return new UnityCliLoopServerControllerService(
                 serverInstanceFactory,
                 lifecycleRegistry,
@@ -130,8 +135,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 initializationUseCase,
                 shutdownUseCase,
                 domainReloadRecoveryUseCase,
-                new TestReadinessProbe(),
-                domainReloadLifecycle);
+                readinessService,
+                startupProtectionService ?? new UnityCliLoopServerStartupProtectionService(),
+                domainReloadLifecycle ?? new TestDomainReloadLifecycle());
         }
 
         /// <summary>

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -75,6 +75,10 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
                 sessionRecoveryService,
                 domainReloadDetectionService,
                 sessionFlagsRepository);
+            UnityCliLoopServerReadinessService serverReadinessService = new(
+                lifecycleRegistry,
+                firstPartyServerLifecycle);
+            UnityCliLoopServerStartupProtectionService startupProtectionService = new();
             UnityCliLoopServerControllerService controllerService = new(
                 serverFactory,
                 lifecycleRegistry,
@@ -83,7 +87,8 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
                 serverInitializationUseCase,
                 serverShutdownUseCase,
                 domainReloadRecoveryUseCase,
-                firstPartyServerLifecycle,
+                serverReadinessService,
+                startupProtectionService,
                 firstPartyServerLifecycle);
             UnityCliLoopServerApplicationService applicationService = new(controllerService);
             UnityCliLoopServerApplicationFacade.RegisterService(applicationService);

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -25,8 +25,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             RestartCleanup,
         }
 
-        private const int READINESS_IDLE_POLL_INTERVAL_MS = 250;
-
         private readonly IUnityCliLoopServerInstanceFactory _serverInstanceFactory;
         private readonly UnityCliLoopServerLifecycleRegistryService _serverLifecycleRegistry;
         private readonly IDomainReloadDetectionService _domainReloadDetectionService;
@@ -34,15 +32,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly UnityCliLoopServerInitializationUseCase _initializationUseCase;
         private readonly UnityCliLoopServerShutdownUseCase _shutdownUseCase;
         private readonly DomainReloadRecoveryUseCase _domainReloadRecoveryUseCase;
-        private readonly IUnityCliLoopServerReadinessProbe _readinessProbe;
+        private readonly UnityCliLoopServerReadinessService _readinessService;
+        private readonly UnityCliLoopServerStartupProtectionService _startupProtectionService;
         private readonly IUnityCliLoopServerDomainReloadLifecycle _domainReloadLifecycle;
-        private readonly Func<bool> _isReadinessProbeBlocked;
-        private readonly Func<int, CancellationToken, Task> _waitBeforeReadinessRetryAsync;
         private readonly Func<int, CancellationToken, Task> _waitBeforeRecoveryRetryAsync;
-        private readonly int _readinessIdleTimeoutMilliseconds;
         private IUnityCliLoopServerInstance _bridgeServer;
         private readonly SemaphoreSlim _startupSemaphore = new SemaphoreSlim(1, 1);
-        private long _startupProtectionUntilTicks = 0;
         private Task _currentRecoveryTask;
 
         internal UnityCliLoopServerControllerService(
@@ -53,12 +48,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             UnityCliLoopServerInitializationUseCase initializationUseCase,
             UnityCliLoopServerShutdownUseCase shutdownUseCase,
             DomainReloadRecoveryUseCase domainReloadRecoveryUseCase,
-            IUnityCliLoopServerReadinessProbe readinessProbe,
+            UnityCliLoopServerReadinessService readinessService,
+            UnityCliLoopServerStartupProtectionService startupProtectionService,
             IUnityCliLoopServerDomainReloadLifecycle domainReloadLifecycle,
-            Func<bool> isReadinessProbeBlocked = null,
-            Func<int, CancellationToken, Task> waitBeforeReadinessRetryAsync = null,
-            Func<int, CancellationToken, Task> waitBeforeRecoveryRetryAsync = null,
-            int readinessIdleTimeoutMilliseconds = UnityCliLoopServerConfig.READINESS_PROBE_TIMEOUT_MS)
+            Func<int, CancellationToken, Task> waitBeforeRecoveryRetryAsync = null)
         {
             System.Diagnostics.Debug.Assert(serverInstanceFactory != null, "serverInstanceFactory must not be null");
             System.Diagnostics.Debug.Assert(serverLifecycleRegistry != null, "serverLifecycleRegistry must not be null");
@@ -67,9 +60,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             System.Diagnostics.Debug.Assert(initializationUseCase != null, "initializationUseCase must not be null");
             System.Diagnostics.Debug.Assert(shutdownUseCase != null, "shutdownUseCase must not be null");
             System.Diagnostics.Debug.Assert(domainReloadRecoveryUseCase != null, "domainReloadRecoveryUseCase must not be null");
-            System.Diagnostics.Debug.Assert(readinessProbe != null, "readinessProbe must not be null");
+            System.Diagnostics.Debug.Assert(readinessService != null, "readinessService must not be null");
+            System.Diagnostics.Debug.Assert(startupProtectionService != null, "startupProtectionService must not be null");
             System.Diagnostics.Debug.Assert(domainReloadLifecycle != null, "domainReloadLifecycle must not be null");
-            System.Diagnostics.Debug.Assert(readinessIdleTimeoutMilliseconds > 0, "readinessIdleTimeoutMilliseconds must be positive");
 
             _serverInstanceFactory = serverInstanceFactory ?? throw new ArgumentNullException(nameof(serverInstanceFactory));
             _serverLifecycleRegistry = serverLifecycleRegistry ?? throw new ArgumentNullException(nameof(serverLifecycleRegistry));
@@ -78,19 +71,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             _initializationUseCase = initializationUseCase ?? throw new ArgumentNullException(nameof(initializationUseCase));
             _shutdownUseCase = shutdownUseCase ?? throw new ArgumentNullException(nameof(shutdownUseCase));
             _domainReloadRecoveryUseCase = domainReloadRecoveryUseCase ?? throw new ArgumentNullException(nameof(domainReloadRecoveryUseCase));
-            _readinessProbe = readinessProbe ?? throw new ArgumentNullException(nameof(readinessProbe));
+            _readinessService = readinessService ?? throw new ArgumentNullException(nameof(readinessService));
+            _startupProtectionService = startupProtectionService ?? throw new ArgumentNullException(nameof(startupProtectionService));
             _domainReloadLifecycle = domainReloadLifecycle ?? throw new ArgumentNullException(nameof(domainReloadLifecycle));
-            _isReadinessProbeBlocked = isReadinessProbeBlocked ?? IsEditorBusyForReadinessProbe;
-            _waitBeforeReadinessRetryAsync = waitBeforeReadinessRetryAsync ?? TimerDelay.Wait;
             _waitBeforeRecoveryRetryAsync = waitBeforeRecoveryRetryAsync ?? TimerDelay.Wait;
-            _readinessIdleTimeoutMilliseconds = readinessIdleTimeoutMilliseconds;
-        }
-
-        private static bool IsEditorBusyForReadinessProbe()
-        {
-            return EditorApplication.isCompiling ||
-                   EditorApplication.isUpdating ||
-                   DomainReloadStateRegistry.IsDomainReloadInProgress();
         }
 
         private bool IsBackgroundUnityProcess()
@@ -263,7 +247,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             _bridgeServer = result.ServerInstance;
 
             ApplicationRegistrar.WarmupRegistry();
-            await MarkServerReadyAsync("manual-start", cancellationToken);
+            await _readinessService.MarkServerReadyAsync("manual-start", cancellationToken);
         }
 
         /// <summary>
@@ -300,7 +284,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             _serverLifecycleRegistry.PublishServerStopping();
-            PrepareForServerShutdown();
+            _startupProtectionService.ClearStartupProtection();
 
             ServerShutdownResult result = await _shutdownUseCase.ExecuteAsync(_bridgeServer, ct);
 
@@ -333,7 +317,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         /// </summary>
         internal void OnBeforeAssemblyReload()
         {
-            ClearStartupProtection();
+            _startupProtectionService.ClearStartupProtection();
             _domainReloadLifecycle.PrepareForDomainReload();
 
             ServiceResult<string> result = _domainReloadRecoveryUseCase.ExecuteBeforeDomainReload(_bridgeServer);
@@ -431,7 +415,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             // OnServerLoopExited fires from thread pool — marshal to main thread for Unity API safety
             EditorApplication.delayCall += () =>
             {
-                ClearStartupProtection();
+                _startupProtectionService.ClearStartupProtection();
 
                 VibeLogger.LogWarning(
                     "server_loop_exit_detected",
@@ -444,7 +428,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 // The server just crashed — startup protection blocks recovery if the crash happens
                 // within the 5-second protection window after a successful start
-                System.Threading.Volatile.Write(ref _startupProtectionUntilTicks, 0L);
+                _startupProtectionService.ClearStartupProtection();
 
                 ScheduleTrackedRecovery(() => StartRecoveryIfNeededAsync(false, CancellationToken.None));
             };
@@ -530,32 +514,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        public bool IsStartupProtectionActive()
-        {
-            long nowTicks = DateTime.UtcNow.Ticks;
-            return nowTicks < System.Threading.Volatile.Read(ref _startupProtectionUntilTicks);
-        }
-
-        internal void ActivateStartupProtection(int milliseconds)
-        {
-            long untilTicks = DateTime.UtcNow.AddMilliseconds(milliseconds).Ticks;
-            System.Threading.Volatile.Write(ref _startupProtectionUntilTicks, untilTicks);
-            VibeLogger.LogInfo("startup_protection_active", $"window={milliseconds}ms");
-        }
-
-        internal void PrepareForServerShutdown()
-        {
-            ClearStartupProtection();
-        }
-
-        /// <summary>
-        /// Clears startup protection so recovery paths can restart the server immediately.
-        /// </summary>
-        internal void ClearStartupProtection()
-        {
-            System.Threading.Volatile.Write(ref _startupProtectionUntilTicks, 0L);
-        }
-
         /// <summary>
         /// Centralized, coalesced recovery start.
         /// Attempts recovery on the project IPC endpoint for up to 5 seconds.
@@ -568,12 +526,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return;
             }
 
-            if (IsStartupProtectionActive())
+            if (_startupProtectionService.IsStartupProtectionActive())
             {
                 VibeLogger.LogInfo("server_start_ignored", "startup_protection_active");
                 if (_bridgeServer?.IsRunning == true)
                 {
-                    await MarkServerReadyAsync("startup-protection-active", cancellationToken);
+                    await _readinessService.MarkServerReadyAsync("startup-protection-active", cancellationToken);
                     return;
                 }
 
@@ -589,7 +547,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 if (_bridgeServer != null && _bridgeServer.IsRunning)
                 {
                     VibeLogger.LogInfo("server_start_ignored", $"already_running endpoint={_bridgeServer.Endpoint}");
-                    await MarkServerReadyAsync("already-running", cancellationToken);
+                    await _readinessService.MarkServerReadyAsync("already-running", cancellationToken);
                     return;
                 }
 
@@ -633,9 +591,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 _sessionFlagsRepository.ClearReconnectingFlags();
                 _sessionFlagsRepository.ClearPostCompileReconnectingUI();
                 ApplicationRegistrar.WarmupRegistry();
-                await MarkServerReadyAsync("server-recovery", cancellationToken);
+                await _readinessService.MarkServerReadyAsync("server-recovery", cancellationToken);
 
-                ActivateStartupProtection(5000);
+                _startupProtectionService.ActivateStartupProtection(5000);
             }
             finally
             {
@@ -717,93 +675,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private void SaveRunningServerState()
         {
             _sessionFlagsRepository.MarkServerStarted();
-        }
-
-        private async Task MarkServerReadyAsync(
-            string reason,
-            CancellationToken cancellationToken)
-        {
-            try
-            {
-                await WaitForEditorIdleBeforeReadinessProbeAsync(
-                    cancellationToken,
-                    _readinessIdleTimeoutMilliseconds);
-                await ProbeReadinessWithTimeoutAsync(cancellationToken, UnityCliLoopServerConfig.READINESS_PROBE_TIMEOUT_MS);
-            }
-            catch (Exception ex)
-            {
-                string message = $"Unity CLI Loop server bound its project IPC endpoint, but readiness probe failed during {reason}. {ex.GetBaseException().Message}";
-                throw new InvalidOperationException(message, ex);
-            }
-
-            _serverLifecycleRegistry.PublishServerStarted();
-        }
-
-        /// <summary>
-        /// Waits until Unity is ready for a main-thread IPC readiness probe.
-        /// </summary>
-        private async Task WaitForEditorIdleBeforeReadinessProbeAsync(
-            CancellationToken cancellationToken,
-            int timeoutMilliseconds)
-        {
-            Debug.Assert(timeoutMilliseconds > 0, "timeoutMilliseconds must be positive");
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            int remainingMilliseconds = timeoutMilliseconds;
-            while (_isReadinessProbeBlocked())
-            {
-                if (remainingMilliseconds <= 0)
-                {
-                    throw new TimeoutException(
-                        $"Readiness probe timed out after {timeoutMilliseconds}ms while waiting for Unity editor idle.");
-                }
-
-                int delayMilliseconds = Math.Min(READINESS_IDLE_POLL_INTERVAL_MS, remainingMilliseconds);
-                // Why: compile, import, and domain reload work can hold the editor thread after the
-                // endpoint is bound, so readiness timeout must start only after Unity can answer IPC.
-                await _waitBeforeReadinessRetryAsync(
-                    delayMilliseconds,
-                    cancellationToken);
-                remainingMilliseconds -= delayMilliseconds;
-                cancellationToken.ThrowIfCancellationRequested();
-            }
-        }
-
-        internal async Task ProbeReadinessWithTimeoutAsync(
-            CancellationToken cancellationToken,
-            int timeoutMilliseconds)
-        {
-            Debug.Assert(timeoutMilliseconds > 0, "timeoutMilliseconds must be positive");
-
-            using (CancellationTokenSource probeCancellation =
-                   CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
-            {
-                Task probeTask = _readinessProbe.ProbeAsync(probeCancellation.Token);
-                Task timeoutTask = TimerDelay.Wait(timeoutMilliseconds, cancellationToken);
-                Task completedTask = await Task.WhenAny(probeTask, timeoutTask).ConfigureAwait(false);
-                if (completedTask == probeTask)
-                {
-                    await probeTask.ConfigureAwait(false);
-                    return;
-                }
-
-                probeCancellation.Cancel();
-                ObserveTimedOutReadinessProbe(probeTask);
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
-            throw new TimeoutException(
-                $"Readiness probe timed out after {timeoutMilliseconds}ms while waiting for project IPC warmup.");
-        }
-
-        private static void ObserveTimedOutReadinessProbe(Task probeTask)
-        {
-            _ = probeTask.ContinueWith(
-                completedTask => _ = completedTask.Exception,
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted,
-                TaskScheduler.Default);
         }
 
         public void AddServerStateChangedHandler(Action handler)

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerReadinessService.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerReadinessService.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Verifies that the project IPC bridge is ready before the server is published as started.
+    /// </summary>
+    internal sealed class UnityCliLoopServerReadinessService
+    {
+        private const int READINESS_IDLE_POLL_INTERVAL_MS = 250;
+
+        private readonly UnityCliLoopServerLifecycleRegistryService _serverLifecycleRegistry;
+        private readonly IUnityCliLoopServerReadinessProbe _readinessProbe;
+        private readonly Func<bool> _isReadinessProbeBlocked;
+        private readonly Func<int, CancellationToken, Task> _waitBeforeReadinessRetryAsync;
+        private readonly int _readinessIdleTimeoutMilliseconds;
+
+        internal UnityCliLoopServerReadinessService(
+            UnityCliLoopServerLifecycleRegistryService serverLifecycleRegistry,
+            IUnityCliLoopServerReadinessProbe readinessProbe,
+            Func<bool> isReadinessProbeBlocked = null,
+            Func<int, CancellationToken, Task> waitBeforeReadinessRetryAsync = null,
+            int readinessIdleTimeoutMilliseconds = UnityCliLoopServerConfig.READINESS_PROBE_TIMEOUT_MS)
+        {
+            Debug.Assert(serverLifecycleRegistry != null, "serverLifecycleRegistry must not be null");
+            Debug.Assert(readinessProbe != null, "readinessProbe must not be null");
+            Debug.Assert(readinessIdleTimeoutMilliseconds > 0, "readinessIdleTimeoutMilliseconds must be positive");
+
+            _serverLifecycleRegistry = serverLifecycleRegistry ?? throw new ArgumentNullException(nameof(serverLifecycleRegistry));
+            _readinessProbe = readinessProbe ?? throw new ArgumentNullException(nameof(readinessProbe));
+            _isReadinessProbeBlocked = isReadinessProbeBlocked ?? IsEditorBusyForReadinessProbe;
+            _waitBeforeReadinessRetryAsync = waitBeforeReadinessRetryAsync ?? TimerDelay.Wait;
+            _readinessIdleTimeoutMilliseconds = readinessIdleTimeoutMilliseconds;
+        }
+
+        private static bool IsEditorBusyForReadinessProbe()
+        {
+            return EditorApplication.isCompiling ||
+                   EditorApplication.isUpdating ||
+                   DomainReloadStateRegistry.IsDomainReloadInProgress();
+        }
+
+        internal async Task MarkServerReadyAsync(
+            string reason,
+            CancellationToken ct)
+        {
+            try
+            {
+                await WaitForEditorIdleBeforeReadinessProbeAsync(
+                    ct,
+                    _readinessIdleTimeoutMilliseconds);
+                await ProbeReadinessWithTimeoutAsync(ct, UnityCliLoopServerConfig.READINESS_PROBE_TIMEOUT_MS);
+            }
+            catch (Exception ex)
+            {
+                string message = $"Unity CLI Loop server bound its project IPC endpoint, but readiness probe failed during {reason}. {ex.GetBaseException().Message}";
+                throw new InvalidOperationException(message, ex);
+            }
+
+            _serverLifecycleRegistry.PublishServerStarted();
+        }
+
+        /// <summary>
+        /// Waits until Unity is ready for a main-thread IPC readiness probe.
+        /// </summary>
+        private async Task WaitForEditorIdleBeforeReadinessProbeAsync(
+            CancellationToken ct,
+            int timeoutMilliseconds)
+        {
+            Debug.Assert(timeoutMilliseconds > 0, "timeoutMilliseconds must be positive");
+
+            ct.ThrowIfCancellationRequested();
+
+            int remainingMilliseconds = timeoutMilliseconds;
+            while (_isReadinessProbeBlocked())
+            {
+                if (remainingMilliseconds <= 0)
+                {
+                    throw new TimeoutException(
+                        $"Readiness probe timed out after {timeoutMilliseconds}ms while waiting for Unity editor idle.");
+                }
+
+                int delayMilliseconds = Math.Min(READINESS_IDLE_POLL_INTERVAL_MS, remainingMilliseconds);
+                // Why: compile, import, and domain reload work can hold the editor thread after the
+                // endpoint is bound, so readiness timeout must start only after Unity can answer IPC.
+                await _waitBeforeReadinessRetryAsync(
+                    delayMilliseconds,
+                    ct);
+                remainingMilliseconds -= delayMilliseconds;
+                ct.ThrowIfCancellationRequested();
+            }
+        }
+
+        internal async Task ProbeReadinessWithTimeoutAsync(
+            CancellationToken ct,
+            int timeoutMilliseconds)
+        {
+            Debug.Assert(timeoutMilliseconds > 0, "timeoutMilliseconds must be positive");
+
+            using (CancellationTokenSource probeCancellation =
+                   CancellationTokenSource.CreateLinkedTokenSource(ct))
+            {
+                Task probeTask = _readinessProbe.ProbeAsync(probeCancellation.Token);
+                Task timeoutTask = TimerDelay.Wait(timeoutMilliseconds, ct);
+                Task completedTask = await Task.WhenAny(probeTask, timeoutTask).ConfigureAwait(false);
+                if (completedTask == probeTask)
+                {
+                    await probeTask.ConfigureAwait(false);
+                    return;
+                }
+
+                probeCancellation.Cancel();
+                ObserveTimedOutReadinessProbe(probeTask);
+            }
+
+            ct.ThrowIfCancellationRequested();
+            throw new TimeoutException(
+                $"Readiness probe timed out after {timeoutMilliseconds}ms while waiting for project IPC warmup.");
+        }
+
+        private static void ObserveTimedOutReadinessProbe(Task probeTask)
+        {
+            _ = probeTask.ContinueWith(
+                completedTask => _ = completedTask.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerReadinessService.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerReadinessService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: abc61b2739e4417cb18b09c27c464d2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerStartupProtectionService.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerStartupProtectionService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Tracks the short recovery suppression window after a successful server startup.
+    /// </summary>
+    internal sealed class UnityCliLoopServerStartupProtectionService
+    {
+        private long _startupProtectionUntilTicks = 0;
+
+        internal bool IsStartupProtectionActive()
+        {
+            long nowTicks = DateTime.UtcNow.Ticks;
+            return nowTicks < Volatile.Read(ref _startupProtectionUntilTicks);
+        }
+
+        internal void ActivateStartupProtection(int milliseconds)
+        {
+            long untilTicks = DateTime.UtcNow.AddMilliseconds(milliseconds).Ticks;
+            Volatile.Write(ref _startupProtectionUntilTicks, untilTicks);
+            VibeLogger.LogInfo("startup_protection_active", $"window={milliseconds}ms");
+        }
+
+        /// <summary>
+        /// Clears startup protection so recovery paths can restart the server immediately.
+        /// </summary>
+        internal void ClearStartupProtection()
+        {
+            Volatile.Write(ref _startupProtectionUntilTicks, 0L);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerStartupProtectionService.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerStartupProtectionService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 886ecbbd85b142b990f429d5ded6ebb3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Keep server startup readiness and short startup protection behavior unchanged while moving their policies out of the controller.
- Narrow the controller toward orchestration so later recovery extraction can review a smaller surface.

## User Impact
- No user-facing behavior change is intended.
- Server startup, readiness publishing, and recovery suppression should behave the same as before.

## Changes
- Added Infrastructure services for readiness probing and startup protection state, then inject them from the composition root.
- Removed Controller readiness wrappers; production controller paths call the injected readiness service, and the readiness timeout test now constructs that service directly with the same never-completing probe and 1ms timeout.
- Removed Controller startup-protection wrappers because neither IUnityCliLoopServerController nor other production code requires them; tests now target the startup-protection service directly for service-only behavior and keep the shutdown seam covered through StopServerWithUseCaseAsync.
- Replaced the unexpected-loop direct Volatile.Write with ClearStartupProtection because the moved method body is the same write with no extra logging or branching.
- Removed the service-level PrepareForServerShutdown pass-through; StopServerForIntent now calls ClearStartupProtection directly.
- Left StartRecoveryIfNeededAsync, tracked recovery, and TryBindWithWaitAsync in the controller for the next PR boundary.

## Verification
- dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT> (0 errors, 0 warnings)
- dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex "(DomainReloadRecoveryUseCaseTests|UnityCliLoopServerControllerRecoveryTests|UnityCliLoopServerStartupProtectionTests|UnityCliLoopBridgeServerShutdownTests|JsonRpcHeartbeatTests|UnityCliLoopServerLifecycleRegistryServiceTests|ServerLifecycleContractTests|UnityCliLoopFirstPartyServerLifecycleBindingTests|JsonRpcProcessorCliVersionGateTests|OnionAssemblyDependencyTests)" (141/141 passed)