### PR TITLE
chore: Extract server recovery tracking from controller

### DIFF
--- a/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that deferred startup recovery exposes its pending task before execution.
             System.Action scheduledAction = null;
             bool recoveryExecuted = false;
-            UnityCliLoopServerControllerService service = CreateControllerService();
+            UnityCliLoopServerRecoveryTrackingService service = CreateRecoveryTrackingService();
 
             Task recoveryTask = service.ScheduleStartupRecovery(
                 action => scheduledAction = action,
@@ -66,7 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Tests that synchronous startup recovery failures fault and clear the tracked task.
             System.Action scheduledAction = null;
-            UnityCliLoopServerControllerService service = CreateControllerService();
+            UnityCliLoopServerRecoveryTrackingService service = CreateRecoveryTrackingService();
 
             Task recoveryTask = service.ScheduleStartupRecovery(
                 action => scheduledAction = action,
@@ -85,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that asynchronous startup recovery remains pending until its restore task completes.
             System.Action scheduledAction = null;
             TaskCompletionSource<bool> recoveryCompletionSource = new();
-            UnityCliLoopServerControllerService service = CreateControllerService();
+            UnityCliLoopServerRecoveryTrackingService service = CreateRecoveryTrackingService();
 
             Task recoveryTask = service.ScheduleStartupRecovery(
                 action => scheduledAction = action,
@@ -225,8 +225,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // is retried with backoff instead of leaving the server down until the next domain reload.
             System.Collections.Generic.List<int> recordedWaits = new();
             int recoveryAttempts = 0;
-            UnityCliLoopServerControllerService service = CreateControllerService(
-                new TestReadinessProbe(),
+            UnityCliLoopServerRecoveryTrackingService service = CreateRecoveryTrackingService(
                 (delayMilliseconds, ct) =>
                 {
                     recordedWaits.Add(delayMilliseconds);
@@ -259,8 +258,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _sessionFlagsRepository.MarkServerStarted();
             System.Collections.Generic.List<int> recordedWaits = new();
             int recoveryAttempts = 0;
-            UnityCliLoopServerControllerService service = CreateControllerService(
-                new TestReadinessProbe(),
+            UnityCliLoopServerRecoveryTrackingService service = CreateRecoveryTrackingService(
                 (delayMilliseconds, ct) =>
                 {
                     recordedWaits.Add(delayMilliseconds);
@@ -291,8 +289,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Tests that an explicit Stop Server during the retry backoff wins over automatic recovery.
             int recoveryAttempts = 0;
-            UnityCliLoopServerControllerService service = CreateControllerService(
-                new TestReadinessProbe(),
+            UnityCliLoopServerRecoveryTrackingService service = CreateRecoveryTrackingService(
                 (delayMilliseconds, ct) =>
                 {
                     _sessionFlagsRepository.MarkServerManuallyStopped();
@@ -424,6 +421,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 waitBeforeReadinessRetryAsync,
                 readinessIdleTimeoutMilliseconds);
             UnityCliLoopServerStartupProtectionService startupProtectionService = new();
+            UnityCliLoopServerRecoveryTrackingService recoveryTrackingService = CreateRecoveryTrackingService(
+                waitBeforeRecoveryRetryAsync);
             return new UnityCliLoopServerControllerService(
                 effectiveServerInstanceFactory,
                 effectiveLifecycleRegistry,
@@ -434,7 +433,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 domainReloadRecoveryUseCase,
                 readinessService,
                 startupProtectionService,
-                new TestDomainReloadLifecycle(),
+                recoveryTrackingService,
+                new TestDomainReloadLifecycle());
+        }
+
+        private UnityCliLoopServerRecoveryTrackingService CreateRecoveryTrackingService(
+            System.Func<int, CancellationToken, Task> waitBeforeRecoveryRetryAsync = null)
+        {
+            return new UnityCliLoopServerRecoveryTrackingService(
+                _sessionFlagsRepository,
                 waitBeforeRecoveryRetryAsync);
         }
 

--- a/Assets/Tests/Editor/UnityCliLoopServerStartupProtectionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerStartupProtectionTests.cs
@@ -127,6 +127,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopServerReadinessService readinessService = new(
                 lifecycleRegistry,
                 new TestReadinessProbe());
+            UnityCliLoopServerRecoveryTrackingService recoveryTrackingService = new(_sessionFlagsRepository);
             return new UnityCliLoopServerControllerService(
                 serverInstanceFactory,
                 lifecycleRegistry,
@@ -137,6 +138,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 domainReloadRecoveryUseCase,
                 readinessService,
                 startupProtectionService ?? new UnityCliLoopServerStartupProtectionService(),
+                recoveryTrackingService,
                 domainReloadLifecycle ?? new TestDomainReloadLifecycle());
         }
 

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -79,6 +79,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
                 lifecycleRegistry,
                 firstPartyServerLifecycle);
             UnityCliLoopServerStartupProtectionService startupProtectionService = new();
+            UnityCliLoopServerRecoveryTrackingService recoveryTrackingService = new(sessionFlagsRepository);
             UnityCliLoopServerControllerService controllerService = new(
                 serverFactory,
                 lifecycleRegistry,
@@ -89,6 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
                 domainReloadRecoveryUseCase,
                 serverReadinessService,
                 startupProtectionService,
+                recoveryTrackingService,
                 firstPartyServerLifecycle);
             UnityCliLoopServerApplicationService applicationService = new(controllerService);
             UnityCliLoopServerApplicationFacade.RegisterService(applicationService);

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -34,11 +34,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly DomainReloadRecoveryUseCase _domainReloadRecoveryUseCase;
         private readonly UnityCliLoopServerReadinessService _readinessService;
         private readonly UnityCliLoopServerStartupProtectionService _startupProtectionService;
+        private readonly UnityCliLoopServerRecoveryTrackingService _recoveryTrackingService;
         private readonly IUnityCliLoopServerDomainReloadLifecycle _domainReloadLifecycle;
-        private readonly Func<int, CancellationToken, Task> _waitBeforeRecoveryRetryAsync;
         private IUnityCliLoopServerInstance _bridgeServer;
         private readonly SemaphoreSlim _startupSemaphore = new SemaphoreSlim(1, 1);
-        private Task _currentRecoveryTask;
 
         internal UnityCliLoopServerControllerService(
             IUnityCliLoopServerInstanceFactory serverInstanceFactory,
@@ -50,8 +49,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             DomainReloadRecoveryUseCase domainReloadRecoveryUseCase,
             UnityCliLoopServerReadinessService readinessService,
             UnityCliLoopServerStartupProtectionService startupProtectionService,
-            IUnityCliLoopServerDomainReloadLifecycle domainReloadLifecycle,
-            Func<int, CancellationToken, Task> waitBeforeRecoveryRetryAsync = null)
+            UnityCliLoopServerRecoveryTrackingService recoveryTrackingService,
+            IUnityCliLoopServerDomainReloadLifecycle domainReloadLifecycle)
         {
             System.Diagnostics.Debug.Assert(serverInstanceFactory != null, "serverInstanceFactory must not be null");
             System.Diagnostics.Debug.Assert(serverLifecycleRegistry != null, "serverLifecycleRegistry must not be null");
@@ -62,6 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             System.Diagnostics.Debug.Assert(domainReloadRecoveryUseCase != null, "domainReloadRecoveryUseCase must not be null");
             System.Diagnostics.Debug.Assert(readinessService != null, "readinessService must not be null");
             System.Diagnostics.Debug.Assert(startupProtectionService != null, "startupProtectionService must not be null");
+            System.Diagnostics.Debug.Assert(recoveryTrackingService != null, "recoveryTrackingService must not be null");
             System.Diagnostics.Debug.Assert(domainReloadLifecycle != null, "domainReloadLifecycle must not be null");
 
             _serverInstanceFactory = serverInstanceFactory ?? throw new ArgumentNullException(nameof(serverInstanceFactory));
@@ -73,8 +73,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             _domainReloadRecoveryUseCase = domainReloadRecoveryUseCase ?? throw new ArgumentNullException(nameof(domainReloadRecoveryUseCase));
             _readinessService = readinessService ?? throw new ArgumentNullException(nameof(readinessService));
             _startupProtectionService = startupProtectionService ?? throw new ArgumentNullException(nameof(startupProtectionService));
+            _recoveryTrackingService = recoveryTrackingService ?? throw new ArgumentNullException(nameof(recoveryTrackingService));
             _domainReloadLifecycle = domainReloadLifecycle ?? throw new ArgumentNullException(nameof(domainReloadLifecycle));
-            _waitBeforeRecoveryRetryAsync = waitBeforeRecoveryRetryAsync ?? TimerDelay.Wait;
         }
 
         private bool IsBackgroundUnityProcess()
@@ -104,7 +104,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         /// <summary>
         /// Current recovery task. Can be awaited by other components to ensure recovery completes first.
         /// </summary>
-        public Task RecoveryTask => _currentRecoveryTask;
+        public Task RecoveryTask => _recoveryTrackingService.RecoveryTask;
 
         public void InitializeForEditorStartup()
         {
@@ -132,73 +132,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             // Recovery binds the project IPC endpoint and may touch config files, so keep it off the
             // synchronous Editor startup path while preserving automatic startup.
-            ScheduleStartupRecovery(
+            _recoveryTrackingService.ScheduleStartupRecovery(
                 action => EditorApplication.delayCall += () => action(),
                 RestoreServerStateIfNeeded);
-        }
-
-        internal Task ScheduleStartupRecovery(
-            Action<Action> scheduleDelayCall,
-            Func<Task> restoreServerState)
-        {
-            Debug.Assert(scheduleDelayCall != null, "scheduleDelayCall must not be null");
-            Debug.Assert(restoreServerState != null, "restoreServerState must not be null");
-
-            TaskCompletionSource<bool> scheduledRecoveryCompletionSource = new();
-            _currentRecoveryTask = scheduledRecoveryCompletionSource.Task;
-
-            scheduleDelayCall(() =>
-            {
-                Task restoreTask;
-                try
-                {
-                    restoreTask = restoreServerState();
-                }
-                catch (Exception ex)
-                {
-                    CompleteScheduledStartupRecovery(Task.FromException(ex), scheduledRecoveryCompletionSource);
-                    return;
-                }
-
-                if (restoreTask.IsCompleted)
-                {
-                    CompleteScheduledStartupRecovery(restoreTask, scheduledRecoveryCompletionSource);
-                    return;
-                }
-
-                _ = restoreTask.ContinueWith(task =>
-                {
-                    CompleteScheduledStartupRecovery(task, scheduledRecoveryCompletionSource);
-                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.FromCurrentSynchronizationContext());
-            });
-
-            return scheduledRecoveryCompletionSource.Task;
-        }
-
-        private void CompleteScheduledStartupRecovery(
-            Task restoreTask,
-            TaskCompletionSource<bool> scheduledRecoveryCompletionSource)
-        {
-            if (ReferenceEquals(_currentRecoveryTask, scheduledRecoveryCompletionSource.Task))
-            {
-                _currentRecoveryTask = null;
-            }
-
-            if (restoreTask.IsCanceled)
-            {
-                scheduledRecoveryCompletionSource.SetCanceled();
-                return;
-            }
-
-            if (restoreTask.IsFaulted)
-            {
-                VibeLogger.LogError("server_startup_restore_failed",
-                    $"Failed to restore server: {restoreTask.Exception?.GetBaseException().Message}");
-                scheduledRecoveryCompletionSource.SetException(restoreTask.Exception.GetBaseException());
-                return;
-            }
-
-            scheduledRecoveryCompletionSource.SetResult(true);
         }
 
         public void StartServer()
@@ -335,7 +271,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         /// </summary>
         private void OnAfterAssemblyReload()
         {
-            ScheduleTrackedRecovery(() => ExecuteAfterDomainReloadRecoveryAsync(CancellationToken.None));
+            _recoveryTrackingService.ScheduleTrackedRecovery(() => ExecuteAfterDomainReloadRecoveryAsync(CancellationToken.None));
         }
 
         private async Task ExecuteAfterDomainReloadRecoveryAsync(CancellationToken cancellationToken)
@@ -430,88 +366,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 // within the 5-second protection window after a successful start
                 _startupProtectionService.ClearStartupProtection();
 
-                ScheduleTrackedRecovery(() => StartRecoveryIfNeededAsync(false, CancellationToken.None));
+                _recoveryTrackingService.ScheduleTrackedRecovery(() => StartRecoveryIfNeededAsync(false, CancellationToken.None));
             };
-        }
-
-        private Task ScheduleTrackedRecovery(Func<Task> recoveryAction)
-        {
-            Debug.Assert(recoveryAction != null, "recoveryAction must not be null");
-
-            Task recoveryTask = ExecuteTrackedRecoveryAsync(recoveryAction);
-            _currentRecoveryTask = recoveryTask;
-            _ = ClearTrackedRecoveryWhenCompleteAsync(recoveryTask);
-            return recoveryTask;
-        }
-
-        /// <summary>
-        /// Runs a recovery action, retrying with backoff so one transient failure
-        /// (e.g. readiness timeout during a heavy import) does not leave the server
-        /// down until the next domain reload.
-        /// </summary>
-        internal async Task ExecuteTrackedRecoveryAsync(Func<Task> recoveryAction)
-        {
-            Debug.Assert(recoveryAction != null, "recoveryAction must not be null");
-
-            int failedAttemptCount = 0;
-            while (true)
-            {
-                try
-                {
-                    await recoveryAction();
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    if (failedAttemptCount >= UnityCliLoopServerConfig.RECOVERY_RETRY_DELAYS_MS.Length)
-                    {
-                        string message = $"Unity CLI Loop server recovery failed before the bridge became ready. {ex.GetBaseException().Message}";
-                        // Why: the thrown exception ends in an unobserved task and VibeLogger is
-                        // compiled out without ULOOP_DEBUG, so without this console entry an
-                        // unrecoverable server (uloop unreachable) would be completely silent.
-                        Debug.LogError($"[{UnityCliLoopConstants.PROJECT_NAME}] {message}");
-                        VibeLogger.LogError(
-                            "server_recovery_failed",
-                            message);
-                        _sessionFlagsRepository.ClearServerSession();
-                        throw new InvalidOperationException(message, ex);
-                    }
-
-                    int delayMilliseconds = UnityCliLoopServerConfig.RECOVERY_RETRY_DELAYS_MS[failedAttemptCount];
-                    failedAttemptCount++;
-                    VibeLogger.LogWarning(
-                        "server_recovery_retry_scheduled",
-                        $"Recovery attempt {failedAttemptCount} failed; retrying in {delayMilliseconds}ms. {ex.GetBaseException().Message}");
-                    await _waitBeforeRecoveryRetryAsync(delayMilliseconds, CancellationToken.None);
-
-                    // Why: an explicit Stop Server issued during the backoff must win over
-                    // automatic recovery, otherwise the retry would silently restart the server.
-                    if (_sessionFlagsRepository.GetIsServerManuallyStopped())
-                    {
-                        VibeLogger.LogInfo(
-                            "server_recovery_retry_abandoned",
-                            "Recovery retry abandoned because the server was manually stopped.");
-                        return;
-                    }
-                }
-            }
-        }
-
-        private async Task ClearTrackedRecoveryWhenCompleteAsync(Task recoveryTask)
-        {
-            Debug.Assert(recoveryTask != null, "recoveryTask must not be null");
-
-            try
-            {
-                await recoveryTask;
-            }
-            finally
-            {
-                if (ReferenceEquals(_currentRecoveryTask, recoveryTask))
-                {
-                    _currentRecoveryTask = null;
-                }
-            }
         }
 
         /// <summary>

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryTrackingService.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryTrackingService.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Tracks active server recovery tasks and applies retry backoff for transient recovery failures.
+    /// </summary>
+    internal sealed class UnityCliLoopServerRecoveryTrackingService
+    {
+        private readonly ISessionFlagsRepository _sessionFlagsRepository;
+        private readonly Func<int, CancellationToken, Task> _waitBeforeRecoveryRetryAsync;
+        private Task _currentRecoveryTask;
+
+        internal UnityCliLoopServerRecoveryTrackingService(
+            ISessionFlagsRepository sessionFlagsRepository,
+            Func<int, CancellationToken, Task> waitBeforeRecoveryRetryAsync = null)
+        {
+            Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
+
+            _sessionFlagsRepository = sessionFlagsRepository ?? throw new ArgumentNullException(nameof(sessionFlagsRepository));
+            _waitBeforeRecoveryRetryAsync = waitBeforeRecoveryRetryAsync ?? TimerDelay.Wait;
+        }
+
+        /// <summary>
+        /// Current recovery task. Can be awaited by other components to ensure recovery completes first.
+        /// </summary>
+        internal Task RecoveryTask => _currentRecoveryTask;
+
+        internal Task ScheduleStartupRecovery(
+            Action<Action> scheduleDelayCall,
+            Func<Task> restoreServerState)
+        {
+            Debug.Assert(scheduleDelayCall != null, "scheduleDelayCall must not be null");
+            Debug.Assert(restoreServerState != null, "restoreServerState must not be null");
+
+            TaskCompletionSource<bool> scheduledRecoveryCompletionSource = new();
+            _currentRecoveryTask = scheduledRecoveryCompletionSource.Task;
+
+            scheduleDelayCall(() =>
+            {
+                Task restoreTask;
+                try
+                {
+                    restoreTask = restoreServerState();
+                }
+                catch (Exception ex)
+                {
+                    CompleteScheduledStartupRecovery(Task.FromException(ex), scheduledRecoveryCompletionSource);
+                    return;
+                }
+
+                if (restoreTask.IsCompleted)
+                {
+                    CompleteScheduledStartupRecovery(restoreTask, scheduledRecoveryCompletionSource);
+                    return;
+                }
+
+                _ = restoreTask.ContinueWith(task =>
+                {
+                    CompleteScheduledStartupRecovery(task, scheduledRecoveryCompletionSource);
+                }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.FromCurrentSynchronizationContext());
+            });
+
+            return scheduledRecoveryCompletionSource.Task;
+        }
+
+        private void CompleteScheduledStartupRecovery(
+            Task restoreTask,
+            TaskCompletionSource<bool> scheduledRecoveryCompletionSource)
+        {
+            if (ReferenceEquals(_currentRecoveryTask, scheduledRecoveryCompletionSource.Task))
+            {
+                _currentRecoveryTask = null;
+            }
+
+            if (restoreTask.IsCanceled)
+            {
+                scheduledRecoveryCompletionSource.SetCanceled();
+                return;
+            }
+
+            if (restoreTask.IsFaulted)
+            {
+                VibeLogger.LogError("server_startup_restore_failed",
+                    $"Failed to restore server: {restoreTask.Exception?.GetBaseException().Message}");
+                scheduledRecoveryCompletionSource.SetException(restoreTask.Exception.GetBaseException());
+                return;
+            }
+
+            scheduledRecoveryCompletionSource.SetResult(true);
+        }
+
+        internal Task ScheduleTrackedRecovery(Func<Task> recoveryAction)
+        {
+            Debug.Assert(recoveryAction != null, "recoveryAction must not be null");
+
+            Task recoveryTask = ExecuteTrackedRecoveryAsync(recoveryAction);
+            _currentRecoveryTask = recoveryTask;
+            _ = ClearTrackedRecoveryWhenCompleteAsync(recoveryTask);
+            return recoveryTask;
+        }
+
+        /// <summary>
+        /// Runs a recovery action, retrying with backoff so one transient failure
+        /// (e.g. readiness timeout during a heavy import) does not leave the server
+        /// down until the next domain reload.
+        /// </summary>
+        internal async Task ExecuteTrackedRecoveryAsync(Func<Task> recoveryAction)
+        {
+            Debug.Assert(recoveryAction != null, "recoveryAction must not be null");
+
+            int failedAttemptCount = 0;
+            while (true)
+            {
+                try
+                {
+                    await recoveryAction();
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    if (failedAttemptCount >= UnityCliLoopServerConfig.RECOVERY_RETRY_DELAYS_MS.Length)
+                    {
+                        string message = $"Unity CLI Loop server recovery failed before the bridge became ready. {ex.GetBaseException().Message}";
+                        // Why: the thrown exception ends in an unobserved task and VibeLogger is
+                        // compiled out without ULOOP_DEBUG, so without this console entry an
+                        // unrecoverable server (uloop unreachable) would be completely silent.
+                        Debug.LogError($"[{UnityCliLoopConstants.PROJECT_NAME}] {message}");
+                        VibeLogger.LogError(
+                            "server_recovery_failed",
+                            message);
+                        _sessionFlagsRepository.ClearServerSession();
+                        throw new InvalidOperationException(message, ex);
+                    }
+
+                    int delayMilliseconds = UnityCliLoopServerConfig.RECOVERY_RETRY_DELAYS_MS[failedAttemptCount];
+                    failedAttemptCount++;
+                    VibeLogger.LogWarning(
+                        "server_recovery_retry_scheduled",
+                        $"Recovery attempt {failedAttemptCount} failed; retrying in {delayMilliseconds}ms. {ex.GetBaseException().Message}");
+                    await _waitBeforeRecoveryRetryAsync(delayMilliseconds, CancellationToken.None);
+
+                    // Why: an explicit Stop Server issued during the backoff must win over
+                    // automatic recovery, otherwise the retry would silently restart the server.
+                    if (_sessionFlagsRepository.GetIsServerManuallyStopped())
+                    {
+                        VibeLogger.LogInfo(
+                            "server_recovery_retry_abandoned",
+                            "Recovery retry abandoned because the server was manually stopped.");
+                        return;
+                    }
+                }
+            }
+        }
+
+        private async Task ClearTrackedRecoveryWhenCompleteAsync(Task recoveryTask)
+        {
+            Debug.Assert(recoveryTask != null, "recoveryTask must not be null");
+
+            try
+            {
+                await recoveryTask;
+            }
+            finally
+            {
+                if (ReferenceEquals(_currentRecoveryTask, recoveryTask))
+                {
+                    _currentRecoveryTask = null;
+                }
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryTrackingService.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryTrackingService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88018a714b234101b66f17dc78ed67e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Preserve server recovery behavior while moving recovery task tracking out of the controller.
- Keep the public recovery task surface available for existing UI and facade consumers.

## User Impact
- No user-facing behavior is intended to change in this PR.
- Recovery retry/backoff behavior remains the same, including retry delay order and the give-up error path.

## Changes
- Add an Infrastructure recovery tracking service for startup recovery task tracking and retry/backoff execution.
- Keep Unity main-thread scheduling, bridge server mutation, readiness binding, and recovery start orchestration in the controller.
- Preserve the duplicate startup protection clearing shape for the next recovery-unification preflight, as requested by review.
- Retarget recovery tracking tests to exercise the extracted service directly without adding a new wrapper seam test.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex "(DomainReloadRecoveryUseCaseTests|UnityCliLoopServerControllerRecoveryTests|UnityCliLoopServerStartupProtectionTests|UnityCliLoopBridgeServerShutdownTests|JsonRpcHeartbeatTests|UnityCliLoopServerLifecycleRegistryServiceTests|ServerLifecycleContractTests|UnityCliLoopFirstPartyServerLifecycleBindingTests|JsonRpcProcessorCliVersionGateTests|OnionAssemblyDependencyTests)"` -> 141/141 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

