### PR TITLE
fix: Surface startup recovery failures when no server is restored

### DIFF
--- a/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
+++ b/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
@@ -103,12 +103,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public async Task RestoreServerStateIfNeededAsync_WhenRecoveryDoesNotStartServer_ShouldFail()
         {
             // Verifies that recovery is only reported as successful after a running server instance exists.
-            _sessionFlagsRepository.SetIsServerRunning(true);
-            _sessionFlagsRepository.SetIsAfterCompile(false);
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
             TestRecoveryCoordinator recoveryCoordinator = new();
-            SessionRecoveryService service = new(
-                _domainReloadDetectionService,
-                _sessionFlagsRepository);
+            SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
 
             ValidationResult result = await service.RestoreServerStateIfNeededAsync(
                 recoveryCoordinator,
@@ -124,12 +121,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public async Task RestoreServerStateIfNeededAsync_WhenNoServerWasRunning_ShouldStillStartRecovery()
         {
             // Verifies launch-time reload recovery starts the server even when no previous bridge session existed.
-            _sessionFlagsRepository.SetIsServerRunning(false);
-            _sessionFlagsRepository.SetIsAfterCompile(false);
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
             TestRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
-            SessionRecoveryService service = new(
-                _domainReloadDetectionService,
-                _sessionFlagsRepository);
+            SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
 
             ValidationResult result = await service.RestoreServerStateIfNeededAsync(
                 recoveryCoordinator,
@@ -163,7 +157,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies the running-server branch consumes AfterCompile without starting recovery.
             InMemorySessionFlagsRepository sessionFlagsRepository = new();
             sessionFlagsRepository.SetIsAfterCompile(true);
-            PureRecoveryCoordinator recoveryCoordinator = new(currentServerRunning: true);
+            TestRecoveryCoordinator recoveryCoordinator = new(currentServerRunning: true);
             SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
 
             ValidationResult result = await service.RestoreServerStateIfNeededAsync(
@@ -181,7 +175,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies AfterCompile is cleared from storage while its original value is passed to recovery.
             InMemorySessionFlagsRepository sessionFlagsRepository = new();
             sessionFlagsRepository.SetIsAfterCompile(true);
-            PureRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
+            TestRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
             SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
 
             ValidationResult result = await service.RestoreServerStateIfNeededAsync(
@@ -201,7 +195,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             InMemorySessionFlagsRepository sessionFlagsRepository = new();
             sessionFlagsRepository.SetIsAfterCompile(true);
             sessionFlagsRepository.MarkServerManuallyStopped();
-            PureRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
+            TestRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
             SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
 
             ValidationResult result = await service.RestoreServerStateIfNeededAsync(
@@ -211,40 +205,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(result.IsValid, Is.True);
             Assert.That(sessionFlagsRepository.GetIsAfterCompile(), Is.False);
             Assert.That(recoveryCoordinator.StartRecoveryCallCount, Is.EqualTo(0));
-        }
-
-        [Test]
-        public async Task RestoreServerStateIfNeededAsync_WhenNoPersistedServerState_ShouldStartRecoveryAndSucceedWhenServerStarts()
-        {
-            // Verifies a clean startup still starts recovery instead of treating missing state as a no-op.
-            InMemorySessionFlagsRepository sessionFlagsRepository = new();
-            PureRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
-            SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
-
-            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
-                recoveryCoordinator,
-                CancellationToken.None);
-
-            Assert.That(result.IsValid, Is.True);
-            Assert.That(recoveryCoordinator.StartRecoveryCallCount, Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task RestoreServerStateIfNeededAsync_WhenRecoveryDoesNotStartServer_ShouldFailWithExactMessage()
-        {
-            // Verifies recovery is invalid when no running server exists after the recovery attempt.
-            InMemorySessionFlagsRepository sessionFlagsRepository = new();
-            PureRecoveryCoordinator recoveryCoordinator = new();
-            SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
-
-            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
-                recoveryCoordinator,
-                CancellationToken.None);
-
-            Assert.That(result.IsValid, Is.False);
-            Assert.That(
-                result.ErrorMessage,
-                Is.EqualTo("Unity CLI Loop server recovery finished, but no running server instance is available."));
         }
 
         private static DomainReloadRecoveryUseCase CreateUseCase(
@@ -425,16 +385,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// Test support type used by pure SessionRecoveryService tests.
+        /// Test support type used by editor and play mode fixtures.
         /// </summary>
-        private sealed class PureRecoveryCoordinator : IUnityCliLoopServerRecoveryCoordinator
+        private sealed class TestRecoveryCoordinator : IUnityCliLoopServerRecoveryCoordinator
         {
             private readonly bool _recoverServer;
             private readonly TestServerInstance _server = new();
 
-            public PureRecoveryCoordinator(
-                bool currentServerRunning = false,
-                bool recoverServer = false)
+            public TestRecoveryCoordinator(
+                bool recoverServer = false,
+                bool currentServerRunning = false)
             {
                 _recoverServer = recoverServer;
                 if (currentServerRunning)
@@ -453,35 +413,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 StartRecoveryCallCount++;
                 LastIsAfterCompile = isAfterCompile;
-                if (_recoverServer)
-                {
-                    _server.StartServer();
-                }
-
-                return Task.CompletedTask;
-            }
-        }
-
-        /// <summary>
-        /// Test support type used by editor and play mode fixtures.
-        /// </summary>
-        private sealed class TestRecoveryCoordinator : IUnityCliLoopServerRecoveryCoordinator
-        {
-            private readonly bool _recoverServer;
-            private readonly TestServerInstance _server = new();
-
-            public TestRecoveryCoordinator(bool recoverServer = false)
-            {
-                _recoverServer = recoverServer;
-            }
-
-            public int StartRecoveryCallCount { get; private set; }
-
-            public IUnityCliLoopServerInstance CurrentServer => _server.IsRunning ? _server : null;
-
-            public Task StartRecoveryIfNeededAsync(bool isAfterCompile, CancellationToken cancellationToken)
-            {
-                StartRecoveryCallCount++;
                 if (_recoverServer)
                 {
                     _server.StartServer();

--- a/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
+++ b/Assets/Tests/Editor/DomainReloadRecoveryUseCaseTests.cs
@@ -157,6 +157,96 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(recoveryCoordinator.StartRecoveryCallCount, Is.EqualTo(0));
         }
 
+        [Test]
+        public async Task RestoreServerStateIfNeededAsync_WhenCurrentServerIsRunningAndAfterCompile_ShouldClearAfterCompileWithoutRecovery()
+        {
+            // Verifies the running-server branch consumes AfterCompile without starting recovery.
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
+            sessionFlagsRepository.SetIsAfterCompile(true);
+            PureRecoveryCoordinator recoveryCoordinator = new(currentServerRunning: true);
+            SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
+
+            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
+                recoveryCoordinator,
+                CancellationToken.None);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(sessionFlagsRepository.GetIsAfterCompile(), Is.False);
+            Assert.That(recoveryCoordinator.StartRecoveryCallCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task RestoreServerStateIfNeededAsync_WhenAfterCompileAndServerMissing_ShouldClearFlagAndPassAfterCompileToRecovery()
+        {
+            // Verifies AfterCompile is cleared from storage while its original value is passed to recovery.
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
+            sessionFlagsRepository.SetIsAfterCompile(true);
+            PureRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
+            SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
+
+            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
+                recoveryCoordinator,
+                CancellationToken.None);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(sessionFlagsRepository.GetIsAfterCompile(), Is.False);
+            Assert.That(recoveryCoordinator.StartRecoveryCallCount, Is.EqualTo(1));
+            Assert.That(recoveryCoordinator.LastIsAfterCompile, Is.True);
+        }
+
+        [Test]
+        public async Task RestoreServerStateIfNeededAsync_WhenManuallyStoppedAndAfterCompile_ShouldClearFlagAndSkipRecovery()
+        {
+            // Verifies explicit manual stop wins after the AfterCompile flag is consumed.
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
+            sessionFlagsRepository.SetIsAfterCompile(true);
+            sessionFlagsRepository.MarkServerManuallyStopped();
+            PureRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
+            SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
+
+            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
+                recoveryCoordinator,
+                CancellationToken.None);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(sessionFlagsRepository.GetIsAfterCompile(), Is.False);
+            Assert.That(recoveryCoordinator.StartRecoveryCallCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task RestoreServerStateIfNeededAsync_WhenNoPersistedServerState_ShouldStartRecoveryAndSucceedWhenServerStarts()
+        {
+            // Verifies a clean startup still starts recovery instead of treating missing state as a no-op.
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
+            PureRecoveryCoordinator recoveryCoordinator = new(recoverServer: true);
+            SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
+
+            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
+                recoveryCoordinator,
+                CancellationToken.None);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(recoveryCoordinator.StartRecoveryCallCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task RestoreServerStateIfNeededAsync_WhenRecoveryDoesNotStartServer_ShouldFailWithExactMessage()
+        {
+            // Verifies recovery is invalid when no running server exists after the recovery attempt.
+            InMemorySessionFlagsRepository sessionFlagsRepository = new();
+            PureRecoveryCoordinator recoveryCoordinator = new();
+            SessionRecoveryService service = CreatePureSessionRecoveryService(sessionFlagsRepository);
+
+            ValidationResult result = await service.RestoreServerStateIfNeededAsync(
+                recoveryCoordinator,
+                CancellationToken.None);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(
+                result.ErrorMessage,
+                Is.EqualTo("Unity CLI Loop server recovery finished, but no running server instance is available."));
+        }
+
         private static DomainReloadRecoveryUseCase CreateUseCase(
             IDomainReloadDetectionService domainReloadDetectionService,
             ISessionFlagsRepository sessionFlagsRepository)
@@ -169,6 +259,207 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 sessionRecoveryService,
                 domainReloadDetectionService,
                 sessionFlagsRepository);
+        }
+
+        private static SessionRecoveryService CreatePureSessionRecoveryService(
+            ISessionFlagsRepository sessionFlagsRepository)
+        {
+            return new SessionRecoveryService(
+                new NoOpDomainReloadDetectionService(),
+                sessionFlagsRepository);
+        }
+
+        /// <summary>
+        /// Test support type used by pure SessionRecoveryService tests.
+        /// </summary>
+        private sealed class NoOpDomainReloadDetectionService : IDomainReloadDetectionService
+        {
+            public void RegisterForEditorStartup()
+            {
+            }
+
+            public void StartDomainReload(string correlationId, bool serverIsRunning)
+            {
+            }
+
+            public void CompleteDomainReload(string correlationId)
+            {
+            }
+
+            public void RollbackDomainReloadStart(string correlationId)
+            {
+            }
+
+            public bool ShouldShowReconnectingUI()
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Test support type used by pure SessionRecoveryService tests.
+        /// </summary>
+        private sealed class InMemorySessionFlagsRepository : ISessionFlagsRepository
+        {
+            private bool _isServerRunning;
+            private bool _isServerManuallyStopped;
+            private bool _isAfterCompile;
+            private bool _isDomainReloadInProgress;
+            private bool _isReconnecting;
+            private bool _showReconnectingUI;
+            private bool _showPostCompileReconnectingUI;
+            private bool _shouldAutoScanThirdPartyToolMigration;
+
+            public bool GetIsServerRunning()
+            {
+                return _isServerRunning;
+            }
+
+            public bool GetIsServerManuallyStopped()
+            {
+                return _isServerManuallyStopped;
+            }
+
+            public bool GetIsAfterCompile()
+            {
+                return _isAfterCompile;
+            }
+
+            public bool GetIsDomainReloadInProgress()
+            {
+                return _isDomainReloadInProgress;
+            }
+
+            public bool GetShowReconnectingUI()
+            {
+                return _showReconnectingUI;
+            }
+
+            public void SetIsAfterCompile(bool isAfterCompile)
+            {
+                _isAfterCompile = isAfterCompile;
+            }
+
+            public void SetIsDomainReloadInProgress(bool isDomainReloadInProgress)
+            {
+                _isDomainReloadInProgress = isDomainReloadInProgress;
+            }
+
+            public void SetIsReconnecting(bool isReconnecting)
+            {
+                _isReconnecting = isReconnecting;
+            }
+
+            public void SetShowReconnectingUI(bool showReconnectingUI)
+            {
+                _showReconnectingUI = showReconnectingUI;
+            }
+
+            public void SetShowPostCompileReconnectingUI(bool showPostCompileReconnectingUI)
+            {
+                _showPostCompileReconnectingUI = showPostCompileReconnectingUI;
+            }
+
+            public void SetShouldAutoScanThirdPartyToolMigration(bool shouldAutoScanThirdPartyToolMigration)
+            {
+                _shouldAutoScanThirdPartyToolMigration = shouldAutoScanThirdPartyToolMigration;
+            }
+
+            public bool ConsumeShouldAutoScanThirdPartyToolMigration()
+            {
+                if (!_shouldAutoScanThirdPartyToolMigration)
+                {
+                    return false;
+                }
+
+                _shouldAutoScanThirdPartyToolMigration = false;
+                return true;
+            }
+
+            public void MarkServerStarted()
+            {
+                _isServerRunning = true;
+                _isServerManuallyStopped = false;
+            }
+
+            public void MarkServerManuallyStopped()
+            {
+                ClearServerSession();
+                _isServerManuallyStopped = true;
+            }
+
+            public void ClearServerSession()
+            {
+                _isServerRunning = false;
+            }
+
+            public void ClearAfterCompileFlag()
+            {
+                _isAfterCompile = false;
+            }
+
+            public void ClearReconnectingFlags()
+            {
+                _isReconnecting = false;
+                _showReconnectingUI = false;
+            }
+
+            public void ClearPostCompileReconnectingUI()
+            {
+                _showPostCompileReconnectingUI = false;
+            }
+
+            public void ClearDomainReloadFlag()
+            {
+                _isDomainReloadInProgress = false;
+            }
+
+            public void ClearDomainReloadRecoveryFlags()
+            {
+                _isDomainReloadInProgress = false;
+                _isAfterCompile = false;
+                _isReconnecting = false;
+                _showReconnectingUI = false;
+                _showPostCompileReconnectingUI = false;
+            }
+        }
+
+        /// <summary>
+        /// Test support type used by pure SessionRecoveryService tests.
+        /// </summary>
+        private sealed class PureRecoveryCoordinator : IUnityCliLoopServerRecoveryCoordinator
+        {
+            private readonly bool _recoverServer;
+            private readonly TestServerInstance _server = new();
+
+            public PureRecoveryCoordinator(
+                bool currentServerRunning = false,
+                bool recoverServer = false)
+            {
+                _recoverServer = recoverServer;
+                if (currentServerRunning)
+                {
+                    _server.StartServer();
+                }
+            }
+
+            public int StartRecoveryCallCount { get; private set; }
+
+            public bool? LastIsAfterCompile { get; private set; }
+
+            public IUnityCliLoopServerInstance CurrentServer => _server.IsRunning ? _server : null;
+
+            public Task StartRecoveryIfNeededAsync(bool isAfterCompile, CancellationToken cancellationToken)
+            {
+                StartRecoveryCallCount++;
+                LastIsAfterCompile = isAfterCompile;
+                if (_recoverServer)
+                {
+                    _server.StartServer();
+                }
+
+                return Task.CompletedTask;
+            }
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
@@ -448,6 +448,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _sessionFlagsRepository,
                 initializationUseCase,
                 shutdownUseCase,
+                sessionRecoveryService,
                 domainReloadRecoveryUseCase,
                 readinessService,
                 effectiveStartupProtectionService,

--- a/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
@@ -65,6 +65,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ScheduleStartupRecovery_WhenRecoveryThrowsSynchronously_FaultsTaskAndClearsRecoveryTask()
         {
             // Tests that synchronous startup recovery failures fault and clear the tracked task.
+            UnityEngine.TestTools.LogAssert.Expect(
+                UnityEngine.LogType.Error,
+                "[UnityCliLoop] Failed to restore server: restore failed");
             System.Action scheduledAction = null;
             UnityCliLoopServerRecoveryTrackingService service = CreateRecoveryTrackingService();
 

--- a/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
@@ -323,9 +323,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public async Task RestoreServerStateIfNeeded_WhenStartupProtectionActiveWithoutServer_ShouldCompleteWithoutRecovery()
+        public void RestoreServerStateIfNeeded_WhenStartupProtectionActiveWithoutServer_ShouldSurfaceRecoveryFailure()
         {
-            // Tests the current startup-only gap where protection suppresses recovery without surfacing failure.
+            // Tests that startup recovery reports failure when protection suppresses recovery without a server.
             TestServerInstanceFactory serverInstanceFactory = new();
             UnityCliLoopServerStartupProtectionService startupProtectionService = new();
             startupProtectionService.ActivateStartupProtection(60000);
@@ -333,8 +333,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 serverInstanceFactory: serverInstanceFactory,
                 startupProtectionService: startupProtectionService);
 
-            await service.RestoreServerStateIfNeeded();
+            System.InvalidOperationException exception =
+                Assert.ThrowsAsync<System.InvalidOperationException>(
+                    async () => await service.RestoreServerStateIfNeeded());
 
+            Assert.That(
+                exception.Message,
+                Is.EqualTo("Unity CLI Loop server recovery finished, but no running server instance is available."));
             Assert.That(serverInstanceFactory.LastCreated, Is.Null);
         }
 

--- a/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
@@ -323,6 +323,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task RestoreServerStateIfNeeded_WhenStartupProtectionActiveWithoutServer_ShouldCompleteWithoutRecovery()
+        {
+            // Tests the current startup-only gap where protection suppresses recovery without surfacing failure.
+            TestServerInstanceFactory serverInstanceFactory = new();
+            UnityCliLoopServerStartupProtectionService startupProtectionService = new();
+            startupProtectionService.ActivateStartupProtection(60000);
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                serverInstanceFactory: serverInstanceFactory,
+                startupProtectionService: startupProtectionService);
+
+            await service.RestoreServerStateIfNeeded();
+
+            Assert.That(serverInstanceFactory.LastCreated, Is.Null);
+        }
+
+        [Test]
         public async Task StopServerWithUseCaseAsync_WhenStoppedByUser_ShouldMarkManualStop()
         {
             // Tests that the manual Stop Server path records explicit user stop intent.
@@ -391,7 +407,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopServerLifecycleRegistryService lifecycleRegistry = null,
             System.Func<bool> isReadinessProbeBlocked = null,
             System.Func<int, CancellationToken, Task> waitBeforeReadinessRetryAsync = null,
-            int readinessIdleTimeoutMilliseconds = UnityCliLoopServerConfig.READINESS_PROBE_TIMEOUT_MS)
+            int readinessIdleTimeoutMilliseconds = UnityCliLoopServerConfig.READINESS_PROBE_TIMEOUT_MS,
+            UnityCliLoopServerStartupProtectionService startupProtectionService = null)
         {
             TestServerInstanceFactory effectiveServerInstanceFactory =
                 serverInstanceFactory ?? new TestServerInstanceFactory();
@@ -420,7 +437,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isReadinessProbeBlocked,
                 waitBeforeReadinessRetryAsync,
                 readinessIdleTimeoutMilliseconds);
-            UnityCliLoopServerStartupProtectionService startupProtectionService = new();
+            UnityCliLoopServerStartupProtectionService effectiveStartupProtectionService =
+                startupProtectionService ?? new UnityCliLoopServerStartupProtectionService();
             UnityCliLoopServerRecoveryTrackingService recoveryTrackingService = CreateRecoveryTrackingService(
                 waitBeforeRecoveryRetryAsync);
             return new UnityCliLoopServerControllerService(
@@ -432,7 +450,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 shutdownUseCase,
                 domainReloadRecoveryUseCase,
                 readinessService,
-                startupProtectionService,
+                effectiveStartupProtectionService,
                 recoveryTrackingService,
                 new TestDomainReloadLifecycle());
         }

--- a/Assets/Tests/Editor/UnityCliLoopServerStartupProtectionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerStartupProtectionTests.cs
@@ -135,6 +135,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 _sessionFlagsRepository,
                 initializationUseCase,
                 shutdownUseCase,
+                sessionRecoveryService,
                 domainReloadRecoveryUseCase,
                 readinessService,
                 startupProtectionService ?? new UnityCliLoopServerStartupProtectionService(),

--- a/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
+++ b/Packages/src/Editor/CompositionRoot/UnityCliLoopApplicationRegistration.cs
@@ -87,6 +87,7 @@ namespace io.github.hatayama.UnityCliLoop.CompositionRoot
                 sessionFlagsRepository,
                 serverInitializationUseCase,
                 serverShutdownUseCase,
+                sessionRecoveryService,
                 domainReloadRecoveryUseCase,
                 serverReadinessService,
                 startupProtectionService,

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -31,6 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly ISessionFlagsRepository _sessionFlagsRepository;
         private readonly UnityCliLoopServerInitializationUseCase _initializationUseCase;
         private readonly UnityCliLoopServerShutdownUseCase _shutdownUseCase;
+        private readonly SessionRecoveryService _sessionRecoveryService;
         private readonly DomainReloadRecoveryUseCase _domainReloadRecoveryUseCase;
         private readonly UnityCliLoopServerReadinessService _readinessService;
         private readonly UnityCliLoopServerStartupProtectionService _startupProtectionService;
@@ -46,6 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             ISessionFlagsRepository sessionFlagsRepository,
             UnityCliLoopServerInitializationUseCase initializationUseCase,
             UnityCliLoopServerShutdownUseCase shutdownUseCase,
+            SessionRecoveryService sessionRecoveryService,
             DomainReloadRecoveryUseCase domainReloadRecoveryUseCase,
             UnityCliLoopServerReadinessService readinessService,
             UnityCliLoopServerStartupProtectionService startupProtectionService,
@@ -58,6 +60,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             System.Diagnostics.Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
             System.Diagnostics.Debug.Assert(initializationUseCase != null, "initializationUseCase must not be null");
             System.Diagnostics.Debug.Assert(shutdownUseCase != null, "shutdownUseCase must not be null");
+            System.Diagnostics.Debug.Assert(sessionRecoveryService != null, "sessionRecoveryService must not be null");
             System.Diagnostics.Debug.Assert(domainReloadRecoveryUseCase != null, "domainReloadRecoveryUseCase must not be null");
             System.Diagnostics.Debug.Assert(readinessService != null, "readinessService must not be null");
             System.Diagnostics.Debug.Assert(startupProtectionService != null, "startupProtectionService must not be null");
@@ -70,6 +73,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             _sessionFlagsRepository = sessionFlagsRepository ?? throw new ArgumentNullException(nameof(sessionFlagsRepository));
             _initializationUseCase = initializationUseCase ?? throw new ArgumentNullException(nameof(initializationUseCase));
             _shutdownUseCase = shutdownUseCase ?? throw new ArgumentNullException(nameof(shutdownUseCase));
+            _sessionRecoveryService = sessionRecoveryService ?? throw new ArgumentNullException(nameof(sessionRecoveryService));
             _domainReloadRecoveryUseCase = domainReloadRecoveryUseCase ?? throw new ArgumentNullException(nameof(domainReloadRecoveryUseCase));
             _readinessService = readinessService ?? throw new ArgumentNullException(nameof(readinessService));
             _startupProtectionService = startupProtectionService ?? throw new ArgumentNullException(nameof(startupProtectionService));
@@ -296,29 +300,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return;
             }
 
-            bool isAfterCompile = _sessionFlagsRepository.GetIsAfterCompile();
-
-            if (_bridgeServer?.IsRunning == true)
+            ValidationResult restoreResult =
+                await _sessionRecoveryService.RestoreServerStateIfNeededAsync(
+                    this,
+                    CancellationToken.None);
+            if (!restoreResult.IsValid)
             {
-                if (isAfterCompile)
-                {
-                    _sessionFlagsRepository.ClearAfterCompileFlag();
-                }
-
-                return;
+                throw new InvalidOperationException(restoreResult.ErrorMessage);
             }
-
-            if (isAfterCompile)
-            {
-                _sessionFlagsRepository.ClearAfterCompileFlag();
-            }
-
-            if (_sessionFlagsRepository.GetIsServerManuallyStopped())
-            {
-                return;
-            }
-
-            await StartRecoveryIfNeededAsync(isAfterCompile, CancellationToken.None);
         }
 
         /// <summary>

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryTrackingService.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryTrackingService.cs
@@ -87,8 +87,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (restoreTask.IsFaulted)
             {
+                string message = $"Failed to restore server: {restoreTask.Exception?.GetBaseException().Message}";
+                // Why: startup restore failures are awaited by UI-facing paths and must be visible
+                // in normal user builds where VibeLogger is compiled out without ULOOP_DEBUG.
+                Debug.LogError($"[{UnityCliLoopConstants.PROJECT_NAME}] {message}");
                 VibeLogger.LogError("server_startup_restore_failed",
-                    $"Failed to restore server: {restoreTask.Exception?.GetBaseException().Message}");
+                    message);
                 scheduledRecoveryCompletionSource.SetException(restoreTask.Exception.GetBaseException());
                 return;
             }


### PR DESCRIPTION
## Summary
- Startup recovery now reports a failure when recovery finishes without a running server.
- Clean editor startup still starts the server automatically, matching the existing reload recovery behavior.

## User Impact
- Before this change, startup protection could suppress startup recovery with no current server and leave the failure silent.
- After this change, the same missing-server condition is surfaced as a startup recovery failure instead of looking successful.

## Changes
- Route editor-startup restoration through the same session recovery decision service used after domain reload.
- Keep the controller-owned background-process guard before the shared recovery decision.
- Add pure C# decision-tree pins for session recovery and update the startup protection gap expectation.
- Emit a normal-build `UnityEngine.Debug.LogError` when startup restore faults, matching the tracked recovery path.
- Consolidate the recovery coordinator test fake and fold duplicate success/failure-message scenarios into the existing service tests.
- Leave recovery task arbitration, in-flight recovery scheduling, duplicate startup-protection clearing, and the SettingsWindow RecoveryTask exception-handling gap for separate follow-up PRs.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "(DomainReloadRecoveryUseCaseTests|UnityCliLoopServerControllerRecoveryTests|UnityCliLoopServerControllerStartupLockTests|UnityCliLoopServerStartupProtectionTests|UnityCliLoopBridgeServerShutdownTests|JsonRpcHeartbeatTests|UnityCliLoopServerLifecycleRegistryServiceTests|ServerLifecycleContractTests|UnityCliLoopFirstPartyServerLifecycleBindingTests|JsonRpcProcessorCliVersionGateTests|OnionAssemblyDependencyTests)"` -> 145/145 passed
