### PR TITLE
chore: Simplify bridge heartbeat and disconnect handling

### DIFF
--- a/Assets/Tests/Editor/JsonRpcHeartbeatTests.cs
+++ b/Assets/Tests/Editor/JsonRpcHeartbeatTests.cs
@@ -55,8 +55,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // without leaving background work behind.
             int writtenFrameCount = 0;
             using CancellationTokenSource cancellationSource = new();
+            UnityCliLoopBridgeHeartbeatService heartbeatService = new();
 
-            Task heartbeatTask = UnityCliLoopBridgeServer.SendHeartbeatsAsync(
+            Task heartbeatTask = heartbeatService.SendHeartbeatsAsync(
                 () => "{}",
                 _ =>
                 {
@@ -79,8 +80,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that a broken connection ends the heartbeat loop silently; teardown is
             // owned by the read loop, not the heartbeat writer.
             using CancellationTokenSource cancellationSource = new();
+            UnityCliLoopBridgeHeartbeatService heartbeatService = new();
 
-            Task heartbeatTask = UnityCliLoopBridgeServer.SendHeartbeatsAsync(
+            Task heartbeatTask = heartbeatService.SendHeartbeatsAsync(
                 () => "{}",
                 _ => throw new System.IO.IOException("broken pipe"),
                 TimeSpan.FromMilliseconds(1),

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Cancels accepted project IPC requests when their client connection disappears.
+    /// </summary>
+    internal sealed class UnityCliLoopBridgeClientDisconnectMonitor
+    {
+        private const int ClientDisconnectMonitorPollMilliseconds = 100;
+
+        internal async Task MonitorClientDisconnectAsync(
+            BridgeClientConnection client,
+            CancellationTokenSource requestCancellationTokenSource)
+        {
+            while (!requestCancellationTokenSource.IsCancellationRequested)
+            {
+                if (!client.IsConnected)
+                {
+                    requestCancellationTokenSource.Cancel();
+                    return;
+                }
+
+                try
+                {
+                    await Task.Delay(ClientDisconnectMonitorPollMilliseconds, requestCancellationTokenSource.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Cancellation is the normal stop signal from StopClientDisconnectMonitorAsync.
+                    // Without the token the delay always ran to completion, adding one poll
+                    // interval of tail latency to every request teardown and server shutdown.
+                    return;
+                }
+            }
+        }
+
+        internal async Task StopClientDisconnectMonitorAsync(
+            Task clientDisconnectMonitorTask,
+            CancellationTokenSource requestCancellationTokenSource)
+        {
+            if (clientDisconnectMonitorTask == null)
+            {
+                return;
+            }
+
+            requestCancellationTokenSource.Cancel();
+            await clientDisconnectMonitorTask;
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs
@@ -11,6 +11,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         private const int ClientDisconnectMonitorPollMilliseconds = 100;
 
+        /// <summary>
+        /// Monitors an accepted client connection and cancels the request token source when the client disconnects.
+        /// </summary>
         internal async Task MonitorClientDisconnectAsync(
             BridgeClientConnection client,
             CancellationTokenSource requestCancellationTokenSource)

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs.meta
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3331ed1250b74839a192452fa1298bd8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeHeartbeatService.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeHeartbeatService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Sends and stops project IPC heartbeat frames for an accepted client request.
+    /// </summary>
+    internal sealed class UnityCliLoopBridgeHeartbeatService
+    {
+        internal async Task SendHeartbeatsAsync(
+            Func<string> createHeartbeatJson,
+            Func<string, Task> writeFrameAsync,
+            TimeSpan interval,
+            CancellationToken ct)
+        {
+            while (true)
+            {
+                try
+                {
+                    await Task.Delay(interval, ct);
+                    await writeFrameAsync(createHeartbeatJson());
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (IOException)
+                {
+                    return;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+            }
+        }
+
+        internal async Task StopHeartbeatsAsync(
+            Task heartbeatTask,
+            CancellationTokenSource heartbeatCancellationSource)
+        {
+            if (heartbeatTask == null)
+            {
+                return;
+            }
+
+            heartbeatCancellationSource?.Cancel();
+            await heartbeatTask;
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeHeartbeatService.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeHeartbeatService.cs
@@ -10,6 +10,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     internal sealed class UnityCliLoopBridgeHeartbeatService
     {
+        /// <summary>
+        /// Sends heartbeat frames at the given interval until cancelled. Write failures end
+        /// the loop silently because the connection teardown is owned by the read loop.
+        /// </summary>
         internal async Task SendHeartbeatsAsync(
             Func<string> createHeartbeatJson,
             Func<string, Task> writeFrameAsync,

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeHeartbeatService.cs.meta
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeHeartbeatService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 535bfd8a9aaa4ffbb3544b4aa611fb80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
@@ -35,7 +35,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         public IUnityCliLoopServerInstance Create()
         {
-            UnityCliLoopBridgeServer server = new(_domainReloadDetectionService);
+            UnityCliLoopBridgeHeartbeatService heartbeatService = new();
+            UnityCliLoopBridgeClientDisconnectMonitor clientDisconnectMonitor = new();
+            UnityCliLoopBridgeServer server = new(
+                _domainReloadDetectionService,
+                heartbeatService,
+                clientDisconnectMonitor);
             server.ServerLoopExited += NotifyServerLoopExited;
 
             return server;
@@ -57,6 +62,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         // Subscribers must marshal to main thread before accessing Unity APIs.
         public event Action ServerLoopExited;
         private readonly IDomainReloadDetectionService _domainReloadDetectionService;
+        private readonly UnityCliLoopBridgeHeartbeatService _heartbeatService;
+        private readonly UnityCliLoopBridgeClientDisconnectMonitor _clientDisconnectMonitor;
         
         // HResult error codes for normal disconnection detection
         private static readonly HashSet<int> NormalDisconnectionHResults = new()
@@ -79,14 +86,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly ConcurrentDictionary<string, Stream> _clientStreams = new();
         private readonly ConcurrentDictionary<int, Task> _clientTasks = new();
         private int _nextClientTaskId;
-        private const int ClientDisconnectMonitorPollMilliseconds = 100;
 
-        internal UnityCliLoopBridgeServer(IDomainReloadDetectionService domainReloadDetectionService)
+        internal UnityCliLoopBridgeServer(
+            IDomainReloadDetectionService domainReloadDetectionService,
+            UnityCliLoopBridgeHeartbeatService heartbeatService,
+            UnityCliLoopBridgeClientDisconnectMonitor clientDisconnectMonitor)
         {
             System.Diagnostics.Debug.Assert(domainReloadDetectionService != null, "domainReloadDetectionService must not be null");
+            System.Diagnostics.Debug.Assert(heartbeatService != null, "heartbeatService must not be null");
+            System.Diagnostics.Debug.Assert(clientDisconnectMonitor != null, "clientDisconnectMonitor must not be null");
 
             _domainReloadDetectionService = domainReloadDetectionService
                 ?? throw new ArgumentNullException(nameof(domainReloadDetectionService));
+            _heartbeatService = heartbeatService
+                ?? throw new ArgumentNullException(nameof(heartbeatService));
+            _clientDisconnectMonitor = clientDisconnectMonitor
+                ?? throw new ArgumentNullException(nameof(clientDisconnectMonitor));
         }
         
         /// <summary>
@@ -616,7 +631,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                                 // server token an in-flight write could ignore StopHeartbeatsAsync
                                 // and stall the final response behind a slow client.
                                 CancellationToken heartbeatToken = heartbeatCancellationSource.Token;
-                                heartbeatTask = SendHeartbeatsAsync(
+                                heartbeatTask = _heartbeatService.SendHeartbeatsAsync(
                                     createHeartbeatJson,
                                     heartbeatJson => WriteJsonResponseLockedAsync(
                                         stream, streamWriteLock, heartbeatJson, heartbeatToken),
@@ -630,70 +645,27 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                             }
 
                             clientDisconnectMonitorTask =
-                                MonitorClientDisconnectAsync(client, requestCancellationTokenSource);
+                                _clientDisconnectMonitor.MonitorClientDisconnectAsync(
+                                    client,
+                                    requestCancellationTokenSource);
                         });
 
                     // Stop heartbeats before the final response so no heartbeat frame can be
                     // queued after the response the CLI stops reading at.
-                    await StopHeartbeatsAsync(heartbeatTask, heartbeatCancellationSource);
+                    await _heartbeatService.StopHeartbeatsAsync(heartbeatTask, heartbeatCancellationSource);
                     heartbeatTask = null;
 
                     await WriteJsonResponseLockedAsync(stream, streamWriteLock, responseJson, serverCancellationToken);
                 }
                 finally
                 {
-                    await StopHeartbeatsAsync(heartbeatTask, heartbeatCancellationSource);
+                    await _heartbeatService.StopHeartbeatsAsync(heartbeatTask, heartbeatCancellationSource);
                     heartbeatCancellationSource?.Dispose();
-                    await StopClientDisconnectMonitorAsync(
+                    await _clientDisconnectMonitor.StopClientDisconnectMonitorAsync(
                         clientDisconnectMonitorTask,
                         requestCancellationTokenSource);
                 }
             }
-        }
-
-        /// <summary>
-        /// Sends heartbeat frames at the given interval until cancelled. Write failures end
-        /// the loop silently because the connection teardown is owned by the read loop.
-        /// </summary>
-        internal static async Task SendHeartbeatsAsync(
-            Func<string> createHeartbeatJson,
-            Func<string, Task> writeFrameAsync,
-            TimeSpan interval,
-            CancellationToken ct)
-        {
-            while (true)
-            {
-                try
-                {
-                    await Task.Delay(interval, ct);
-                    await writeFrameAsync(createHeartbeatJson());
-                }
-                catch (OperationCanceledException)
-                {
-                    return;
-                }
-                catch (IOException)
-                {
-                    return;
-                }
-                catch (ObjectDisposedException)
-                {
-                    return;
-                }
-            }
-        }
-
-        private static async Task StopHeartbeatsAsync(
-            Task heartbeatTask,
-            CancellationTokenSource heartbeatCancellationSource)
-        {
-            if (heartbeatTask == null)
-            {
-                return;
-            }
-
-            heartbeatCancellationSource?.Cancel();
-            await heartbeatTask;
         }
 
         private async Task WriteJsonResponseLockedAsync(
@@ -714,45 +686,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 streamWriteLock.Release();
             }
-        }
-
-        private static async Task MonitorClientDisconnectAsync(
-            BridgeClientConnection client,
-            CancellationTokenSource requestCancellationTokenSource)
-        {
-            while (!requestCancellationTokenSource.IsCancellationRequested)
-            {
-                if (!client.IsConnected)
-                {
-                    requestCancellationTokenSource.Cancel();
-                    return;
-                }
-
-                try
-                {
-                    await Task.Delay(ClientDisconnectMonitorPollMilliseconds, requestCancellationTokenSource.Token);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Cancellation is the normal stop signal from StopClientDisconnectMonitorAsync.
-                    // Without the token the delay always ran to completion, adding one poll
-                    // interval of tail latency to every request teardown and server shutdown.
-                    return;
-                }
-            }
-        }
-
-        private static async Task StopClientDisconnectMonitorAsync(
-            Task clientDisconnectMonitorTask,
-            CancellationTokenSource requestCancellationTokenSource)
-        {
-            if (clientDisconnectMonitorTask == null)
-            {
-                return;
-            }
-
-            requestCancellationTokenSource.Cancel();
-            await clientDisconnectMonitorTask;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Keep project IPC heartbeat and client-disconnect monitoring behavior unchanged while moving those loops out of the bridge server body.
- Preserve the existing shutdown, request cancellation, and per-client write-lock ownership.

## User Impact
- No runtime behavior change is intended.
- This reduces the bridge server surface area so follow-up server refactors can review concurrency ownership more clearly.

## Changes
- Add stateless infrastructure services for heartbeat sending/stopping and client-disconnect monitoring.
- Inject those services from the bridge server instance factory.
- Retarget the existing heartbeat tests without changing their timing structure.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "(JsonRpcHeartbeatTests|UnityCliLoopBridgeServerShutdownTests|UnityCliLoopServerControllerRecoveryTests|JsonRpcProcessorCliVersionGateTests|OnionAssemblyDependencyTests)"` -> 122/122 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

