### PR TITLE
chore: Fix runtime source editor-only test scope

### DIFF
--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
@@ -194,9 +195,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void RuntimeSources_WhenScanned_AreEditorOnly()
         {
-            // Verifies that Runtime assembly sources cannot compile into Player assemblies.
+            // Verifies that root UnityCLILoop.Runtime sources cannot compile into Player assemblies.
             string runtimeSourceDirectory = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), RuntimeSourceDirectoryPath);
-            string[] runtimeSourcePaths = Directory.GetFiles(runtimeSourceDirectory, "*.cs", SearchOption.AllDirectories);
+            string[] runtimeSourcePaths = GetRootRuntimeAssemblySourcePaths(runtimeSourceDirectory);
             System.Array.Sort(runtimeSourcePaths);
 
             for (int pathIndex = 0; pathIndex < runtimeSourcePaths.Length; pathIndex++)
@@ -208,6 +209,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     Does.StartWith("#if UNITY_EDITOR"),
                     runtimeSourcePaths[pathIndex]);
             }
+        }
+
+        private static string[] GetRootRuntimeAssemblySourcePaths(string runtimeSourceDirectory)
+        {
+            string[] runtimeSourcePaths = Directory.GetFiles(runtimeSourceDirectory, "*.cs", SearchOption.AllDirectories);
+            string[] assemblyDefinitionPaths = Directory.GetFiles(runtimeSourceDirectory, "*.asmdef", SearchOption.AllDirectories);
+            HashSet<string> nestedAssemblyDirectories = new();
+
+            for (int pathIndex = 0; pathIndex < assemblyDefinitionPaths.Length; pathIndex++)
+            {
+                string assemblyDefinitionDirectory = Path.GetDirectoryName(assemblyDefinitionPaths[pathIndex]);
+                if (assemblyDefinitionDirectory == runtimeSourceDirectory)
+                {
+                    continue;
+                }
+
+                nestedAssemblyDirectories.Add(assemblyDefinitionDirectory);
+            }
+
+            List<string> rootRuntimeSourcePaths = new();
+            for (int pathIndex = 0; pathIndex < runtimeSourcePaths.Length; pathIndex++)
+            {
+                if (IsUnderNestedAssemblyDirectory(runtimeSourcePaths[pathIndex], nestedAssemblyDirectories))
+                {
+                    continue;
+                }
+
+                rootRuntimeSourcePaths.Add(runtimeSourcePaths[pathIndex]);
+            }
+
+            return rootRuntimeSourcePaths.ToArray();
+        }
+
+        private static bool IsUnderNestedAssemblyDirectory(
+            string sourcePath,
+            HashSet<string> nestedAssemblyDirectories)
+        {
+            foreach (string nestedAssemblyDirectory in nestedAssemblyDirectories)
+            {
+                string nestedAssemblyPrefix = nestedAssemblyDirectory + Path.DirectorySeparatorChar;
+                if (sourcePath.StartsWith(nestedAssemblyPrefix, System.StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void AssertEditorOnlyTags(GameObject root, string prefabPath)

--- a/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
+++ b/Assets/Tests/Editor/InputVisualizationCanvasPrefabTests.cs
@@ -22,6 +22,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Runtime/UnityCLILoop.Runtime.asmdef";
         private const string RuntimeSourceDirectoryPath =
             "Packages/src/Runtime";
+        private static readonly string[] PlayerVisibleNestedRuntimeAssemblyDefinitionPaths =
+        {
+            "Packages/src/Runtime/PausePoints/UnityCLILoop.PausePoints.Runtime.asmdef"
+        };
         private static readonly string[] OverlayPrefabPaths =
         {
             "Packages/io.github.hatayama.uloopmcp/Runtime/Common/InputVisualizationCanvas.prefab",
@@ -193,12 +197,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void RuntimeSources_WhenScanned_AreEditorOnly()
+        public void RootRuntimeSources_WhenScanned_AreEditorOnly()
         {
             // Verifies that root UnityCLILoop.Runtime sources cannot compile into Player assemblies.
-            string runtimeSourceDirectory = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), RuntimeSourceDirectoryPath);
-            string[] runtimeSourcePaths = GetRootRuntimeAssemblySourcePaths(runtimeSourceDirectory);
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string runtimeSourceDirectory = Path.Combine(projectRoot, RuntimeSourceDirectoryPath);
+            string[] runtimeSourcePaths = GetRootRuntimeAssemblySourcePaths(projectRoot, runtimeSourceDirectory);
             System.Array.Sort(runtimeSourcePaths);
+
+            Assert.That(runtimeSourcePaths, Is.Not.Empty);
 
             for (int pathIndex = 0; pathIndex < runtimeSourcePaths.Length; pathIndex++)
             {
@@ -211,19 +218,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
         }
 
-        private static string[] GetRootRuntimeAssemblySourcePaths(string runtimeSourceDirectory)
+        private static string[] GetRootRuntimeAssemblySourcePaths(
+            string projectRoot,
+            string runtimeSourceDirectory)
         {
             string[] runtimeSourcePaths = Directory.GetFiles(runtimeSourceDirectory, "*.cs", SearchOption.AllDirectories);
             string[] assemblyDefinitionPaths = Directory.GetFiles(runtimeSourceDirectory, "*.asmdef", SearchOption.AllDirectories);
+            HashSet<string> allowedNestedAssemblyDefinitionPaths =
+                GetAllowedNestedRuntimeAssemblyDefinitionPaths(projectRoot);
             HashSet<string> nestedAssemblyDirectories = new();
 
             for (int pathIndex = 0; pathIndex < assemblyDefinitionPaths.Length; pathIndex++)
             {
+                string assemblyDefinitionPath = Path.GetFullPath(assemblyDefinitionPaths[pathIndex]);
                 string assemblyDefinitionDirectory = Path.GetDirectoryName(assemblyDefinitionPaths[pathIndex]);
                 if (assemblyDefinitionDirectory == runtimeSourceDirectory)
                 {
                     continue;
                 }
+
+                Assert.That(
+                    allowedNestedAssemblyDefinitionPaths,
+                    Does.Contain(assemblyDefinitionPath),
+                    $"{assemblyDefinitionPath} is a nested Runtime asmdef. Guard its sources with #if UNITY_EDITOR, " +
+                    "or add it to PlayerVisibleNestedRuntimeAssemblyDefinitionPaths when the nested assembly is intentionally player-visible.");
 
                 nestedAssemblyDirectories.Add(assemblyDefinitionDirectory);
             }
@@ -240,6 +258,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
 
             return rootRuntimeSourcePaths.ToArray();
+        }
+
+        private static HashSet<string> GetAllowedNestedRuntimeAssemblyDefinitionPaths(string projectRoot)
+        {
+            HashSet<string> allowedAssemblyDefinitionPaths = new();
+            for (int pathIndex = 0; pathIndex < PlayerVisibleNestedRuntimeAssemblyDefinitionPaths.Length; pathIndex++)
+            {
+                string assemblyDefinitionPath = Path.GetFullPath(
+                    Path.Combine(projectRoot, PlayerVisibleNestedRuntimeAssemblyDefinitionPaths[pathIndex]));
+                allowedAssemblyDefinitionPaths.Add(assemblyDefinitionPath);
+            }
+
+            return allowedAssemblyDefinitionPaths;
         }
 
         private static bool IsUnderNestedAssemblyDirectory(


### PR DESCRIPTION
## Summary
- limit `InputVisualizationCanvasPrefabTests.RootRuntimeSources_WhenScanned_AreEditorOnly` to sources owned by the root `UnityCLILoop.Runtime` asmdef
- pin the allowed player-visible nested runtime asmdef so future nested runtime asmdefs require an explicit test update
- keep `UloopPausePoint` player-visible: `UnityCLILoop.PausePoints.Runtime.asmdef` is intentionally player-compiled and `UloopPausePoint.Pause` uses `[Conditional("UNITY_EDITOR")]` so user runtime scripts can compile in player builds

## Notes
- `Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs` already starts with `#if UNITY_EDITOR`; no production source changes were needed.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- exact EditMode: `InputVisualizationCanvasPrefabTests.RootRuntimeSources_WhenScanned_AreEditorOnly` -> 1/1 passed
- related EditMode: `InputVisualizationCanvasPrefabTests` -> 7/7 passed
- full EditMode: 1570 total, 1559 passed, 4 failed, 7 skipped; remaining failures are the known `UnityCliLoopSettingsWindowCliActionTests` dispatcher-version boundary drift cases planned for the next PR
