### PR TITLE
chore: Stabilize settings CLI action version tests

### DIFF
--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -1,7 +1,9 @@
 using NUnit.Framework;
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.Presentation;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
@@ -11,6 +13,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public class UnityCliLoopSettingsWindowCliActionTests
     {
+        private const string TestProjectRunnerVersion = "3.0.0";
+        private const string TestMinimumDispatcherVersion = "3.0.0";
+
+        [SetUp]
+        public void SetUp()
+        {
+            RegisterCliSetupService(new TestCliPinReader(TestMinimumDispatcherVersion));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            CliPinReaderService cliPinReaderService = new();
+            RegisterCliSetupService(cliPinReaderService);
+        }
+
         [TestCase(null, false, true, false)]
         [TestCase("2.9.0", false, true, false)]
         [TestCase("3.0.0", false, true, false)]
@@ -166,6 +184,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             return (CliSetupPrimaryAction)
                 System.Enum.Parse(typeof(CliSetupPrimaryAction), action);
+        }
+
+        private static void RegisterCliSetupService(ICliPinReader cliPinReader)
+        {
+            CliSetupApplicationFacade.RegisterService(new CliSetupApplicationService(
+                new CliInstallationDetector(cliPinReader),
+                new NativeCliInstallerService(),
+                cliPinReader));
+        }
+
+        private sealed class TestCliPinReader : ICliPinReader
+        {
+            private readonly string _minimumDispatcherVersion;
+
+            public TestCliPinReader(string minimumDispatcherVersion)
+            {
+                _minimumDispatcherVersion = minimumDispatcherVersion;
+            }
+
+            public CliPinLoadResult LoadPackagePin()
+            {
+                return CliPinLoadResult.FromSuccess(
+                    new CliPin(TestProjectRunnerVersion, _minimumDispatcherVersion));
+            }
+
+            public string LoadMinimumDispatcherVersionOrThrow()
+            {
+                return _minimumDispatcherVersion;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- register a synthetic CLI pin reader in `UnityCliLoopSettingsWindowCliActionTests` so dispatcher-version boundary expectations are independent from the checked-in package pin
- keep the existing boundary table at synthetic minimum dispatcher version `3.0.0`, covering below, equal, and above cases
- restore the production-style CLI setup service after each test

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- related EditMode: `UnityCliLoopSettingsWindowCliActionTests` -> 40/40 passed
- full EditMode: 1570 total, 1563 passed, 0 failed, 7 skipped


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

