### PR TITLE
chore: Simplify setup wizard resizing

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -352,7 +352,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 contentSize = new(350f, 280f);
             Vector2 frameSize = new(18f, 28f);
 
-            Rect resizedRect = SetupWizardWindow.WithContentSize(initialRect, contentSize, frameSize);
+            Rect resizedRect = SetupWizardWindowResizer.WithContentSize(initialRect, contentSize, frameSize);
 
             Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
             Assert.That(resizedRect.size, Is.EqualTo(new Vector2(368f, 380f)));
@@ -365,7 +365,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 contentSize = new(120f, 140f);
             Vector2 frameSize = new(18f, 28f);
 
-            Rect resizedRect = SetupWizardWindow.WithContentSize(initialRect, contentSize, frameSize);
+            Rect resizedRect = SetupWizardWindowResizer.WithContentSize(initialRect, contentSize, frameSize);
 
             Assert.That(resizedRect.center, Is.EqualTo(initialRect.center));
             Assert.That(resizedRect.size, Is.EqualTo(new Vector2(360f, 380f)));
@@ -377,7 +377,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Rect bounds = new(100f, 200f, 900f, 700f);
             Vector2 size = new(300f, 250f);
 
-            Rect centeredRect = SetupWizardWindow.CreateCenteredRect(bounds, size);
+            Rect centeredRect = SetupWizardWindowResizer.CreateCenteredRect(bounds, size);
 
             Assert.That(centeredRect.center, Is.EqualTo(bounds.center));
             Assert.That(centeredRect.size, Is.EqualTo(size));
@@ -857,7 +857,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void EstimateWrappedLineCount_WithPositiveHeight_ReturnsRoundedLineCount()
         {
-            int lineCount = SetupWizardWindow.EstimateWrappedLineCount(35f, 12f);
+            int lineCount = SetupWizardWindowResizer.EstimateWrappedLineCount(35f, 12f);
 
             Assert.That(lineCount, Is.EqualTo(3));
         }
@@ -865,7 +865,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void SelectPreferredTextWidth_WhenWrappedAcrossManyLines_UsesTwoLineTarget()
         {
-            float preferredWidth = SetupWizardWindow.SelectPreferredTextWidth(120f, 320f, 4, WhiteSpace.Normal);
+            float preferredWidth = SetupWizardWindowResizer.SelectPreferredTextWidth(120f, 320f, 4, WhiteSpace.Normal);
 
             Assert.That(preferredWidth, Is.EqualTo(160f));
         }
@@ -873,7 +873,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void SelectPreferredTextWidth_WhenWrappedAcrossTwoLines_KeepsLaidOutWidth()
         {
-            float preferredWidth = SetupWizardWindow.SelectPreferredTextWidth(180f, 320f, 2, WhiteSpace.Normal);
+            float preferredWidth = SetupWizardWindowResizer.SelectPreferredTextWidth(180f, 320f, 2, WhiteSpace.Normal);
 
             Assert.That(preferredWidth, Is.EqualTo(180f));
         }
@@ -881,7 +881,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void SelectPreferredTextWidth_WhenShorterTextFitsWithinCurrentWidth_ShrinksToMeasuredWidth()
         {
-            float preferredWidth = SetupWizardWindow.SelectPreferredTextWidth(420f, 180f, 1, WhiteSpace.Normal);
+            float preferredWidth = SetupWizardWindowResizer.SelectPreferredTextWidth(420f, 180f, 1, WhiteSpace.Normal);
 
             Assert.That(preferredWidth, Is.EqualTo(180f));
         }
@@ -889,7 +889,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void SelectPreferredTextWidth_WhenTextDoesNotWrap_UsesMeasuredWidth()
         {
-            float preferredWidth = SetupWizardWindow.SelectPreferredTextWidth(180f, 320f, 1, WhiteSpace.NoWrap);
+            float preferredWidth = SetupWizardWindowResizer.SelectPreferredTextWidth(180f, 320f, 1, WhiteSpace.NoWrap);
 
             Assert.That(preferredWidth, Is.EqualTo(320f));
         }
@@ -897,7 +897,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void HasFiniteSize_WhenVectorContainsNaN_ReturnsFalse()
         {
-            bool hasFiniteSize = SetupWizardWindow.HasFiniteSize(new Vector2(float.NaN, 120f));
+            bool hasFiniteSize = SetupWizardWindowResizer.HasFiniteSize(new Vector2(float.NaN, 120f));
 
             Assert.That(hasFiniteSize, Is.False);
         }
@@ -905,7 +905,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void HasFiniteSize_WhenVectorContainsFiniteValues_ReturnsTrue()
         {
-            bool hasFiniteSize = SetupWizardWindow.HasFiniteSize(new Vector2(240f, 120f));
+            bool hasFiniteSize = SetupWizardWindowResizer.HasFiniteSize(new Vector2(240f, 120f));
 
             Assert.That(hasFiniteSize, Is.True);
         }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -24,10 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string UXML_RELATIVE_PATH = "Editor/Presentation/Setup/SetupWizardWindow.uxml";
         private const string USS_RELATIVE_PATH = "Editor/Presentation/Setup/SetupWizardWindow.uss";
         private const string GITHUB_ICON_RELATIVE_PATH = "Editor/Presentation/Setup/GitHub_Invertocat_White.png";
-        private const int PreferredWrappedTextLineCount = 2;
         private const bool ForceFlatSkillInstall = true;
         private static readonly char[] VersionMajorSeparators = { '.', '-' };
-        private static readonly Vector2 MinimumWindowSize = new(360f, 380f);
         private static IUnityCliLoopEditorSettingsPort RegisteredEditorSettingsPort;
         private static ISessionFlagsRepository RegisteredSessionFlagsRepository;
         private static CliSetupApplicationService RegisteredCliSetupApplicationService;
@@ -302,7 +300,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             string lastSeenSetupWizardVersionBeforeOpen =
                 GetEditorSettingsPort().GetLastSeenSetupWizardVersion();
-            Rect windowPosition = CreateCenteredRect(EditorGUIUtility.GetMainWindowPosition(), MinimumWindowSize);
+            Rect windowPosition = SetupWizardWindowResizer.CreateCenteredRect(
+                EditorGUIUtility.GetMainWindowPosition(),
+                SetupWizardWindowResizer.MinimumWindowSize);
             SetupWizardWindow window = CreateInstance<SetupWizardWindow>();
             PrepareForOpen(
                 window,
@@ -312,21 +312,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 shouldRecordVersion);
             window.ShowUtility();
             window.ScheduleResizeToContent();
-        }
-
-        internal static Rect WithContentSize(Rect currentRect, Vector2 contentSize, Vector2 frameSize)
-        {
-            Vector2 measuredSize = contentSize + frameSize;
-            Vector2 targetSize = new(
-                Mathf.Max(measuredSize.x, MinimumWindowSize.x),
-                Mathf.Max(measuredSize.y, MinimumWindowSize.y));
-            return CreateCenteredRect(currentRect, targetSize);
-        }
-
-        internal static Rect CreateCenteredRect(Rect bounds, Vector2 size)
-        {
-            Vector2 centeredPosition = bounds.center - (size * 0.5f);
-            return new Rect(centeredPosition, size);
         }
 
         internal static string GetGitHubRepositoryUrl()
@@ -477,7 +462,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private bool _isInstallingCli;
         private bool _isInstallingSkills;
         private bool _needsCliPathSetup;
-        private bool _isApplyingContentSize;
         private bool _isSkillsTargetFieldInitialized;
         private bool _shouldUseFirstInstallSkillsUi;
         private bool _installSkillsFlat;
@@ -486,12 +470,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         [SerializeField]
         private bool _shouldRecordLastSeenVersionAfterCreateGui;
         private IVisualElementScheduledItem _initialRefreshScheduledItem;
-        private IVisualElementScheduledItem _resizeScheduledItem;
         private CancellationTokenSource _skillInstallStateRefreshCts;
         private SkillsTarget _skillsTarget = SkillsTarget.Claude;
         private SkillSetupUseCase _skillSetupUseCase;
         private IUnityCliLoopEditorSettingsPort _editorSettingsPort;
         private CliSetupApplicationService _cliSetupApplicationService;
+        private SetupWizardWindowResizer _resizer;
 
         private void CreateGUI()
         {
@@ -499,6 +483,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             InitializeFirstInstallSkillsUiState();
             LoadLayout();
             BindElements();
+            _resizer = new SetupWizardWindowResizer(this, _mainScrollView);
             BindEvents();
             BindSizeUpdates();
             ApplyInitialCheckingState();
@@ -532,6 +517,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void OnDisable()
         {
             _initialRefreshScheduledItem?.Pause();
+            _resizer?.Pause();
             CancelSkillInstallStateRefresh();
         }
 
@@ -641,11 +627,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void BindSizeUpdates()
         {
-            rootVisualElement.RegisterCallback<GeometryChangedEvent>(_ =>
-            {
-                if (_isApplyingContentSize) return;
-                ScheduleResizeToContent();
-            });
+            _resizer.BindSizeUpdates();
         }
 
         private void RefreshAutoShowToggle()
@@ -1450,158 +1432,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void ScheduleResizeToContent()
         {
-            _resizeScheduledItem?.Pause();
-            _resizeScheduledItem = rootVisualElement.schedule.Execute(ResizeToContent).StartingIn(0);
-        }
-
-        private void ResizeToContent()
-        {
-            ScrollView mainContainer = rootVisualElement.Q<ScrollView>();
-            if (mainContainer == null) return;
-            if (rootVisualElement.layout.width <= 0f || rootVisualElement.layout.height <= 0f) return;
-
-            Vector2 contentSize = MeasureContentSize(mainContainer);
-            if (!HasFiniteSize(contentSize)) return;
-            if (contentSize.x <= 0f || contentSize.y <= 0f) return;
-
-            Vector2 frameSize = position.size - rootVisualElement.layout.size;
-            if (!HasFiniteSize(frameSize)) return;
-            Rect targetRect = WithContentSize(position, contentSize, frameSize);
-            if (!HasFiniteSize(targetRect.size)) return;
-            if (Approximately(position.size, targetRect.size))
-            {
-                minSize = targetRect.size;
-                maxSize = targetRect.size;
-                return;
-            }
-
-            _isApplyingContentSize = true;
-            minSize = targetRect.size;
-            maxSize = targetRect.size;
-            position = targetRect;
-            _isApplyingContentSize = false;
-        }
-
-        private static Vector2 MeasureContentSize(ScrollView mainContainer)
-        {
-            VisualElement contentContainer = mainContainer.contentContainer;
-            float width = MeasurePreferredContentWidth(mainContainer, contentContainer);
-            float height = MeasurePreferredContentHeight(mainContainer, contentContainer);
-            return new Vector2(width, height);
-        }
-
-        private static float MeasurePreferredContentWidth(VisualElement mainContainer, VisualElement contentContainer)
-        {
-            float maxRight = 0f;
-            foreach (TextElement textElement in contentContainer.Query<TextElement>().Build())
-            {
-                if (!textElement.visible) continue;
-                if (string.IsNullOrEmpty(textElement.text)) continue;
-                if (!HasFiniteRect(textElement.worldBound)) continue;
-
-                float left = textElement.worldBound.xMin - contentContainer.worldBound.xMin;
-                float horizontalChrome =
-                    textElement.resolvedStyle.paddingLeft
-                    + textElement.resolvedStyle.paddingRight
-                    + textElement.resolvedStyle.borderLeftWidth
-                    + textElement.resolvedStyle.borderRightWidth;
-                float verticalChrome =
-                    textElement.resolvedStyle.paddingTop
-                    + textElement.resolvedStyle.paddingBottom
-                    + textElement.resolvedStyle.borderTopWidth
-                    + textElement.resolvedStyle.borderBottomWidth;
-                float laidOutWidth = textElement.worldBound.width;
-                Vector2 measuredTextSize = textElement.MeasureTextSize(
-                    textElement.text,
-                    0f,
-                    VisualElement.MeasureMode.Undefined,
-                    0f,
-                    VisualElement.MeasureMode.Undefined);
-                if (!IsFinite(left)) continue;
-                if (!IsFinite(horizontalChrome) || !IsFinite(verticalChrome)) continue;
-                if (!HasFiniteSize(measuredTextSize)) continue;
-                if (!IsFinite(laidOutWidth)) continue;
-                float measuredWidth = measuredTextSize.x + horizontalChrome;
-                int lineCount = EstimateWrappedLineCount(
-                    textElement.worldBound.height - verticalChrome,
-                    measuredTextSize.y);
-                float preferredWidth = SelectPreferredTextWidth(
-                    laidOutWidth,
-                    measuredWidth,
-                    lineCount,
-                    textElement.resolvedStyle.whiteSpace);
-                if (!IsFinite(preferredWidth)) continue;
-                float right = left + preferredWidth;
-                maxRight = Mathf.Max(maxRight, right);
-            }
-
-            float width =
-                mainContainer.resolvedStyle.paddingLeft
-                + maxRight
-                + mainContainer.resolvedStyle.paddingRight;
-            return IsFinite(width) ? Mathf.Ceil(width) : 0f;
-        }
-
-        internal static int EstimateWrappedLineCount(float laidOutTextHeight, float singleLineTextHeight)
-        {
-            if (singleLineTextHeight <= 0f) return 1;
-
-            return Mathf.Max(1, Mathf.RoundToInt(laidOutTextHeight / singleLineTextHeight));
-        }
-
-        internal static float SelectPreferredTextWidth(
-            float laidOutWidth,
-            float measuredWidth,
-            int lineCount,
-            WhiteSpace whiteSpace)
-        {
-            if (whiteSpace != WhiteSpace.Normal) return measuredWidth;
-            if (lineCount <= PreferredWrappedTextLineCount) return Mathf.Min(laidOutWidth, measuredWidth);
-
-            return Mathf.Max(laidOutWidth, measuredWidth / PreferredWrappedTextLineCount);
-        }
-
-        private static float MeasurePreferredContentHeight(VisualElement mainContainer, VisualElement contentContainer)
-        {
-            float maxBottom = 0f;
-            foreach (VisualElement child in contentContainer.Children())
-            {
-                if (!child.visible) continue;
-                if (!HasFiniteRect(child.worldBound)) continue;
-                float bottom = child.worldBound.yMax - contentContainer.worldBound.yMin;
-                if (!IsFinite(bottom)) continue;
-                maxBottom = Mathf.Max(maxBottom, bottom);
-            }
-
-            float height =
-                mainContainer.resolvedStyle.paddingTop
-                + maxBottom
-                + mainContainer.resolvedStyle.paddingBottom;
-            return IsFinite(height) ? Mathf.Ceil(height) : 0f;
-        }
-
-        private static bool Approximately(Vector2 left, Vector2 right)
-        {
-            const float Tolerance = 0.5f;
-            return Mathf.Abs(left.x - right.x) < Tolerance && Mathf.Abs(left.y - right.y) < Tolerance;
-        }
-
-        internal static bool HasFiniteSize(Vector2 size)
-        {
-            return IsFinite(size.x) && IsFinite(size.y);
-        }
-
-        private static bool HasFiniteRect(Rect rect)
-        {
-            return IsFinite(rect.xMin)
-                && IsFinite(rect.xMax)
-                && IsFinite(rect.yMin)
-                && IsFinite(rect.yMax);
-        }
-
-        private static bool IsFinite(float value)
-        {
-            return !float.IsNaN(value) && !float.IsInfinity(value);
+            _resizer?.ScheduleResizeToContent();
         }
 
     }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindowResizer.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindowResizer.cs
@@ -1,0 +1,218 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Measures UI Toolkit content and resizes the setup wizard window around it.
+    /// </summary>
+    internal sealed class SetupWizardWindowResizer
+    {
+        internal static readonly Vector2 MinimumWindowSize = new Vector2(360f, 380f);
+
+        private const int PreferredWrappedTextLineCount = 2;
+
+        private readonly EditorWindow _window;
+        private readonly VisualElement _root;
+        private readonly ScrollView _mainScrollView;
+        private bool _isApplyingContentSize;
+        private IVisualElementScheduledItem _resizeScheduledItem;
+
+        internal SetupWizardWindowResizer(EditorWindow window, ScrollView mainScrollView)
+        {
+            Debug.Assert(window != null, "window must not be null");
+            Debug.Assert(mainScrollView != null, "mainScrollView must not be null");
+
+            _window = window ?? throw new System.ArgumentNullException(nameof(window));
+            _root = window.rootVisualElement;
+            _mainScrollView = mainScrollView ?? throw new System.ArgumentNullException(nameof(mainScrollView));
+        }
+
+        internal static Rect WithContentSize(Rect currentRect, Vector2 contentSize, Vector2 frameSize)
+        {
+            Vector2 measuredSize = contentSize + frameSize;
+            Vector2 targetSize = new(
+                Mathf.Max(measuredSize.x, MinimumWindowSize.x),
+                Mathf.Max(measuredSize.y, MinimumWindowSize.y));
+            return CreateCenteredRect(currentRect, targetSize);
+        }
+
+        internal static Rect CreateCenteredRect(Rect bounds, Vector2 size)
+        {
+            Vector2 centeredPosition = bounds.center - (size * 0.5f);
+            return new Rect(centeredPosition, size);
+        }
+
+        internal static int EstimateWrappedLineCount(float laidOutTextHeight, float singleLineTextHeight)
+        {
+            if (singleLineTextHeight <= 0f) return 1;
+
+            return Mathf.Max(1, Mathf.RoundToInt(laidOutTextHeight / singleLineTextHeight));
+        }
+
+        internal static float SelectPreferredTextWidth(
+            float laidOutWidth,
+            float measuredWidth,
+            int lineCount,
+            WhiteSpace whiteSpace)
+        {
+            if (whiteSpace != WhiteSpace.Normal) return measuredWidth;
+            if (lineCount <= PreferredWrappedTextLineCount) return Mathf.Min(laidOutWidth, measuredWidth);
+
+            return Mathf.Max(laidOutWidth, measuredWidth / PreferredWrappedTextLineCount);
+        }
+
+        internal static bool HasFiniteSize(Vector2 size)
+        {
+            return IsFinite(size.x) && IsFinite(size.y);
+        }
+
+        internal void BindSizeUpdates()
+        {
+            _root.RegisterCallback<GeometryChangedEvent>(HandleGeometryChanged);
+        }
+
+        internal void ScheduleResizeToContent()
+        {
+            _resizeScheduledItem?.Pause();
+            _resizeScheduledItem = _root.schedule.Execute(ResizeToContent).StartingIn(0);
+        }
+
+        internal void Pause()
+        {
+            _resizeScheduledItem?.Pause();
+        }
+
+        private static Vector2 MeasureContentSize(ScrollView mainContainer)
+        {
+            VisualElement contentContainer = mainContainer.contentContainer;
+            float width = MeasurePreferredContentWidth(mainContainer, contentContainer);
+            float height = MeasurePreferredContentHeight(mainContainer, contentContainer);
+            return new Vector2(width, height);
+        }
+
+        private static float MeasurePreferredContentWidth(VisualElement mainContainer, VisualElement contentContainer)
+        {
+            float maxRight = 0f;
+            foreach (TextElement textElement in contentContainer.Query<TextElement>().Build())
+            {
+                if (!textElement.visible) continue;
+                if (string.IsNullOrEmpty(textElement.text)) continue;
+                if (!HasFiniteRect(textElement.worldBound)) continue;
+
+                float left = textElement.worldBound.xMin - contentContainer.worldBound.xMin;
+                float horizontalChrome =
+                    textElement.resolvedStyle.paddingLeft
+                    + textElement.resolvedStyle.paddingRight
+                    + textElement.resolvedStyle.borderLeftWidth
+                    + textElement.resolvedStyle.borderRightWidth;
+                float verticalChrome =
+                    textElement.resolvedStyle.paddingTop
+                    + textElement.resolvedStyle.paddingBottom
+                    + textElement.resolvedStyle.borderTopWidth
+                    + textElement.resolvedStyle.borderBottomWidth;
+                float laidOutWidth = textElement.worldBound.width;
+                Vector2 measuredTextSize = textElement.MeasureTextSize(
+                    textElement.text,
+                    0f,
+                    VisualElement.MeasureMode.Undefined,
+                    0f,
+                    VisualElement.MeasureMode.Undefined);
+                if (!IsFinite(left)) continue;
+                if (!IsFinite(horizontalChrome) || !IsFinite(verticalChrome)) continue;
+                if (!HasFiniteSize(measuredTextSize)) continue;
+                if (!IsFinite(laidOutWidth)) continue;
+                float measuredWidth = measuredTextSize.x + horizontalChrome;
+                int lineCount = EstimateWrappedLineCount(
+                    textElement.worldBound.height - verticalChrome,
+                    measuredTextSize.y);
+                float preferredWidth = SelectPreferredTextWidth(
+                    laidOutWidth,
+                    measuredWidth,
+                    lineCount,
+                    textElement.resolvedStyle.whiteSpace);
+                if (!IsFinite(preferredWidth)) continue;
+                float right = left + preferredWidth;
+                maxRight = Mathf.Max(maxRight, right);
+            }
+
+            float width =
+                mainContainer.resolvedStyle.paddingLeft
+                + maxRight
+                + mainContainer.resolvedStyle.paddingRight;
+            return IsFinite(width) ? Mathf.Ceil(width) : 0f;
+        }
+
+        private static float MeasurePreferredContentHeight(VisualElement mainContainer, VisualElement contentContainer)
+        {
+            float maxBottom = 0f;
+            foreach (VisualElement child in contentContainer.Children())
+            {
+                if (!child.visible) continue;
+                if (!HasFiniteRect(child.worldBound)) continue;
+                float bottom = child.worldBound.yMax - contentContainer.worldBound.yMin;
+                if (!IsFinite(bottom)) continue;
+                maxBottom = Mathf.Max(maxBottom, bottom);
+            }
+
+            float height =
+                mainContainer.resolvedStyle.paddingTop
+                + maxBottom
+                + mainContainer.resolvedStyle.paddingBottom;
+            return IsFinite(height) ? Mathf.Ceil(height) : 0f;
+        }
+
+        private static bool Approximately(Vector2 left, Vector2 right)
+        {
+            const float Tolerance = 0.5f;
+            return Mathf.Abs(left.x - right.x) < Tolerance && Mathf.Abs(left.y - right.y) < Tolerance;
+        }
+
+        private static bool HasFiniteRect(Rect rect)
+        {
+            return IsFinite(rect.xMin)
+                && IsFinite(rect.xMax)
+                && IsFinite(rect.yMin)
+                && IsFinite(rect.yMax);
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
+        }
+
+        private void HandleGeometryChanged(GeometryChangedEvent evt)
+        {
+            if (_isApplyingContentSize) return;
+
+            ScheduleResizeToContent();
+        }
+
+        private void ResizeToContent()
+        {
+            if (_root.layout.width <= 0f || _root.layout.height <= 0f) return;
+
+            Vector2 contentSize = MeasureContentSize(_mainScrollView);
+            if (!HasFiniteSize(contentSize)) return;
+            if (contentSize.x <= 0f || contentSize.y <= 0f) return;
+
+            Vector2 frameSize = _window.position.size - _root.layout.size;
+            if (!HasFiniteSize(frameSize)) return;
+            Rect targetRect = WithContentSize(_window.position, contentSize, frameSize);
+            if (!HasFiniteSize(targetRect.size)) return;
+            if (Approximately(_window.position.size, targetRect.size))
+            {
+                _window.minSize = targetRect.size;
+                _window.maxSize = targetRect.size;
+                return;
+            }
+
+            _isApplyingContentSize = true;
+            _window.minSize = targetRect.size;
+            _window.maxSize = targetRect.size;
+            _window.position = targetRect;
+            _isApplyingContentSize = false;
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindowResizer.cs.meta
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindowResizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3286b30743dc4c4594b96e6ecf4ae6b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Extracts setup wizard resize measurement and scheduling into a dedicated resizer class.
- Keeps the setup wizard resize calculation the same while aligning lifetime handling with the existing migration wizard resizer pattern.

## User Impact
- The setup wizard should keep the same size and centering calculations.
- Closing the window now also cancels any pending resize schedule through the resizer, matching the migration wizard window behavior.

## Changes
- Adds SetupWizardWindowResizer following the existing ThirdPartyToolMigrationWizardWindowResizer pattern.
- Moves resize state, scheduling, geometry helpers, content measurement, and finite-size helpers out of SetupWizardWindow.
- Retargets setup wizard resize helper tests to the new resizer class.
- Intentional non-verbatim move: OnDisable now pauses the resizer schedule, matching ThirdPartyToolMigrationWizardWindow and preventing pending resize work after close.
- Intentional non-verbatim move: ResizeToContent uses the ScrollView captured by the resizer constructor instead of re-querying each time; missing ScrollView wiring now fails fast during construction instead of silently no-oping.

## Verification
- dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.SetupWizardWindowTests"
