### PR TITLE
chore: Keep setup startup coordination out of the window

### DIFF
--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -893,10 +893,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(
                 setupWizardStartupFlowSource,
                 Does.Contain("EditorApplication.delayCall += () => _showWindowOnVersionChange();"));
+            Assert.That(setupWizardSource, Does.Not.Contain("\n            startupFlow.TryShowOnVersionChange();"));
+        }
+
+        [Test]
+        public void SetupWizardStartup_WhenMigrationAutoScanIsRequested_SchedulesAutoScanThroughDelayCall()
+        {
+            // Tests that startup migration auto-scan runs through a delayed Editor callback.
+            string setupWizardStartupFlowSource = ReadProductionSource(
+                "Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs");
+
             Assert.That(
                 setupWizardStartupFlowSource,
                 Does.Contain("EditorApplication.delayCall += () => _showThirdPartyMigrationAutoScan();"));
-            Assert.That(setupWizardSource, Does.Not.Contain("\n            startupFlow.TryShowOnVersionChange();"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -884,9 +884,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that Setup Wizard settings reads run after the synchronous Editor startup hook.
             string setupWizardSource = ReadProductionSource(
                 "Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs");
+            string setupWizardStartupFlowSource = ReadProductionSource(
+                "Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs");
 
-            Assert.That(setupWizardSource, Does.Contain("EditorApplication.delayCall += TryShowOnVersionChange;"));
-            Assert.That(setupWizardSource, Does.Not.Contain("\n            TryShowOnVersionChange();"));
+            Assert.That(
+                setupWizardSource,
+                Does.Contain("EditorApplication.delayCall += startupFlow.TryShowOnVersionChange;"));
+            Assert.That(
+                setupWizardStartupFlowSource,
+                Does.Contain("EditorApplication.delayCall += () => _showWindowOnVersionChange();"));
+            Assert.That(
+                setupWizardStartupFlowSource,
+                Does.Contain("EditorApplication.delayCall += () => _showThirdPartyMigrationAutoScan();"));
+            Assert.That(setupWizardSource, Does.Not.Contain("\n            startupFlow.TryShowOnVersionChange();"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -48,7 +48,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UnityCliLoopEditorSessionStateTestFactory.ClearAll();
             SetupWizardWindow.InitializeEditorServices(
                 _editorSettingsPort,
-                _sessionFlagsRepository,
                 CreateCliSetupApplicationService(),
                 CreateSkillSetupUseCase());
             _editorSettingsRepository.InvalidateCache();

--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -85,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies that package and dispatcher requirement changes auto-show only for actionable updates.
             bool shouldAutoShow =
-                SetupWizardWindow.ShouldAutoShowForVersion(
+                SetupWizardStartupFlow.ShouldAutoShowForVersion(
                     currentVersion,
                     lastSeenVersion,
                     currentMinimumDispatcherVersion,
@@ -108,7 +108,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     installState: SkillInstallState.Outdated)
             };
 
-            bool hasSkillUpdate = SetupWizardWindow.HasSkillUpdateForSetupWizard(targets);
+            bool hasSkillUpdate = SetupWizardStartupFlow.HasSkillUpdateForSetupWizard(targets);
 
             Assert.That(hasSkillUpdate, Is.True);
         }
@@ -127,7 +127,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     installState)
             };
 
-            bool hasSkillUpdate = SetupWizardWindow.HasSkillUpdateForSetupWizard(targets);
+            bool hasSkillUpdate = SetupWizardStartupFlow.HasSkillUpdateForSetupWizard(targets);
 
             Assert.That(hasSkillUpdate, Is.False);
         }
@@ -143,7 +143,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     installState: SkillInstallState.Outdated)
             };
 
-            bool hasSkillUpdate = SetupWizardWindow.HasSkillUpdateForSetupWizard(targets);
+            bool hasSkillUpdate = SetupWizardStartupFlow.HasSkillUpdateForSetupWizard(targets);
 
             Assert.That(hasSkillUpdate, Is.False);
         }
@@ -160,7 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     hasDifferentLayoutSkills: true)
             };
 
-            bool hasSkillUpdate = SetupWizardWindow.HasSkillUpdateForSetupWizard(targets);
+            bool hasSkillUpdate = SetupWizardStartupFlow.HasSkillUpdateForSetupWizard(targets);
 
             Assert.That(hasSkillUpdate, Is.True);
         }
@@ -179,7 +179,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies that V3 startup scans run for V2 upgrades or missing prior setup state.
             bool shouldAutoScan =
-                SetupWizardWindow.ShouldAutoScanThirdPartyToolMigration(currentVersion, lastSeenVersion);
+                SetupWizardStartupFlow.ShouldAutoScanThirdPartyToolMigration(currentVersion, lastSeenVersion);
 
             Assert.That(shouldAutoScan, Is.EqualTo(expected));
         }
@@ -188,7 +188,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void MaybeMarkThirdPartyToolMigrationAutoScan_WhenEnabled_SetsSessionFlag()
         {
             // Verifies that the V2-to-V3 upgrade signal is stored only in the current Editor session.
-            SetupWizardWindow.MaybeMarkThirdPartyToolMigrationAutoScan(true);
+            SetupWizardStartupFlow.MaybeMarkThirdPartyToolMigrationAutoScan(_sessionFlagsRepository, true);
 
             Assert.That(_sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.True);
         }
@@ -197,7 +197,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void MaybeMarkThirdPartyToolMigrationAutoScan_WhenDisabled_KeepsSessionFlagFalse()
         {
             // Verifies that non-upgrade version checks do not request migration scans.
-            SetupWizardWindow.MaybeMarkThirdPartyToolMigrationAutoScan(false);
+            SetupWizardStartupFlow.MaybeMarkThirdPartyToolMigrationAutoScan(_sessionFlagsRepository, false);
 
             Assert.That(_sessionFlagsRepository.GetShouldAutoScanThirdPartyToolMigration(), Is.False);
         }
@@ -205,13 +205,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void MaybeRecordLastSeenSetupWizardState_WhenAutoShow_UpdatesStoredState()
         {
+            // Verifies that auto-show records the setup wizard version state.
             _editorSettingsPort.SaveSettings(new UnityCliLoopEditorSettingsData
             {
                 lastSeenSetupWizardVersion = "1.7.2",
                 lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
-            SetupWizardWindow.MaybeRecordLastSeenSetupWizardState(true, "1.7.3", "3.0.2");
+            SetupWizardStartupFlow.MaybeRecordLastSeenSetupWizardState(
+                _editorSettingsPort,
+                true,
+                "1.7.3",
+                "3.0.2");
 
             Assert.That(_editorSettingsPort.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.3"));
             Assert.That(
@@ -222,13 +227,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void MaybeRecordLastSeenSetupWizardState_WhenManualShow_KeepsStoredState()
         {
+            // Verifies that manual opens do not update the setup wizard version state.
             _editorSettingsPort.SaveSettings(new UnityCliLoopEditorSettingsData
             {
                 lastSeenSetupWizardVersion = "1.7.2",
                 lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
-            SetupWizardWindow.MaybeRecordLastSeenSetupWizardState(false, "1.7.3", "3.0.2");
+            SetupWizardStartupFlow.MaybeRecordLastSeenSetupWizardState(
+                _editorSettingsPort,
+                false,
+                "1.7.3",
+                "3.0.2");
 
             Assert.That(_editorSettingsPort.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
             Assert.That(
@@ -239,13 +249,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void MaybeRecordSuppressedSetupWizardState_WhenAutoShowSuppressed_UpdatesStoredState()
         {
+            // Verifies that suppressing auto-show records the current setup wizard state.
             _editorSettingsPort.SaveSettings(new UnityCliLoopEditorSettingsData
             {
                 lastSeenSetupWizardVersion = "1.7.2",
                 lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
-            SetupWizardWindow.MaybeRecordSuppressedSetupWizardState(true, "1.7.3", "3.0.2");
+            SetupWizardStartupFlow.MaybeRecordSuppressedSetupWizardState(
+                _editorSettingsPort,
+                true,
+                "1.7.3",
+                "3.0.2");
 
             Assert.That(_editorSettingsPort.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.3"));
             Assert.That(
@@ -256,13 +271,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void MaybeRecordSuppressedSetupWizardState_WhenAutoShowAllowed_KeepsStoredState()
         {
+            // Verifies that allowing auto-show leaves the stored setup wizard state unchanged.
             _editorSettingsPort.SaveSettings(new UnityCliLoopEditorSettingsData
             {
                 lastSeenSetupWizardVersion = "1.7.2",
                 lastSeenSetupWizardMinimumDispatcherVersion = "3.0.1"
             });
 
-            SetupWizardWindow.MaybeRecordSuppressedSetupWizardState(false, "1.7.3", "3.0.2");
+            SetupWizardStartupFlow.MaybeRecordSuppressedSetupWizardState(
+                _editorSettingsPort,
+                false,
+                "1.7.3",
+                "3.0.2");
 
             Assert.That(_editorSettingsPort.GetLastSeenSetupWizardVersion(), Is.EqualTo("1.7.2"));
             Assert.That(

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs
@@ -1,0 +1,311 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Coordinates setup wizard startup auto-show and migration auto-scan decisions.
+    /// </summary>
+    internal sealed class SetupWizardStartupFlow
+    {
+        private static readonly char[] VersionMajorSeparators = { '.', '-' };
+
+        private readonly IUnityCliLoopEditorSettingsPort _editorSettingsPort;
+        private readonly ISessionFlagsRepository _sessionFlagsRepository;
+        private readonly CliSetupApplicationService _cliSetupApplicationService;
+        private readonly SkillSetupUseCase _skillSetupUseCase;
+        private readonly System.Action _showWindowOnVersionChange;
+        private readonly System.Action _showThirdPartyMigrationAutoScan;
+
+        internal SetupWizardStartupFlow(
+            IUnityCliLoopEditorSettingsPort editorSettingsPort,
+            ISessionFlagsRepository sessionFlagsRepository,
+            CliSetupApplicationService cliSetupApplicationService,
+            SkillSetupUseCase skillSetupUseCase,
+            System.Action showWindowOnVersionChange,
+            System.Action showThirdPartyMigrationAutoScan)
+        {
+            Debug.Assert(editorSettingsPort != null, "editorSettingsPort must not be null");
+            Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
+            Debug.Assert(cliSetupApplicationService != null, "cliSetupApplicationService must not be null");
+            Debug.Assert(skillSetupUseCase != null, "skillSetupUseCase must not be null");
+            Debug.Assert(showWindowOnVersionChange != null, "showWindowOnVersionChange must not be null");
+            Debug.Assert(showThirdPartyMigrationAutoScan != null, "showThirdPartyMigrationAutoScan must not be null");
+
+            _editorSettingsPort = editorSettingsPort
+                ?? throw new System.ArgumentNullException(nameof(editorSettingsPort));
+            _sessionFlagsRepository = sessionFlagsRepository
+                ?? throw new System.ArgumentNullException(nameof(sessionFlagsRepository));
+            _cliSetupApplicationService = cliSetupApplicationService
+                ?? throw new System.ArgumentNullException(nameof(cliSetupApplicationService));
+            _skillSetupUseCase = skillSetupUseCase ?? throw new System.ArgumentNullException(nameof(skillSetupUseCase));
+            _showWindowOnVersionChange = showWindowOnVersionChange
+                ?? throw new System.ArgumentNullException(nameof(showWindowOnVersionChange));
+            _showThirdPartyMigrationAutoScan = showThirdPartyMigrationAutoScan
+                ?? throw new System.ArgumentNullException(nameof(showThirdPartyMigrationAutoScan));
+        }
+
+        internal static bool ShouldAutoShowForVersion(
+            string currentVersion,
+            string lastSeenVersion,
+            string currentMinimumDispatcherVersion,
+            string lastSeenMinimumDispatcherVersion,
+            bool suppressAutoShow,
+            bool needsCliUpdate,
+            bool hasSkillUpdate)
+        {
+            bool versionChanged = !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
+            bool minimumDispatcherVersionChanged = !string.Equals(
+                currentMinimumDispatcherVersion,
+                lastSeenMinimumDispatcherVersion,
+                System.StringComparison.Ordinal);
+            if (!versionChanged && !minimumDispatcherVersionChanged) return false;
+            if (suppressAutoShow) return false;
+
+            return string.IsNullOrEmpty(lastSeenVersion)
+                || needsCliUpdate
+                || (versionChanged && hasSkillUpdate);
+        }
+
+        internal static bool ShouldAutoScanThirdPartyToolMigration(string currentVersion, string lastSeenVersion)
+        {
+            if (!TryGetMajorVersion(currentVersion, out int currentMajorVersion))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(lastSeenVersion))
+            {
+                return currentMajorVersion == 3;
+            }
+
+            if (!TryGetMajorVersion(lastSeenVersion, out int lastSeenMajorVersion))
+            {
+                return false;
+            }
+
+            return lastSeenMajorVersion < 3 && currentMajorVersion == 3;
+        }
+
+        internal static void MaybeMarkThirdPartyToolMigrationAutoScan(
+            ISessionFlagsRepository sessionFlagsRepository,
+            bool shouldAutoScan)
+        {
+            Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
+
+            if (!shouldAutoScan)
+            {
+                return;
+            }
+
+            sessionFlagsRepository.SetShouldAutoScanThirdPartyToolMigration(true);
+        }
+
+        internal static void MaybeRecordLastSeenSetupWizardState(
+            IUnityCliLoopEditorSettingsPort editorSettingsPort,
+            bool shouldRecordState,
+            string version,
+            string minimumDispatcherVersion)
+        {
+            Debug.Assert(editorSettingsPort != null, "editorSettingsPort must not be null");
+
+            if (!shouldRecordState) return;
+
+            Debug.Assert(!string.IsNullOrEmpty(version), "version must not be null or empty");
+            Debug.Assert(
+                !string.IsNullOrEmpty(minimumDispatcherVersion),
+                "minimumDispatcherVersion must not be null or empty");
+
+            editorSettingsPort.UpdateSettings((UnityCliLoopEditorSettingsData settings) => settings with
+            {
+                lastSeenSetupWizardVersion = version,
+                lastSeenSetupWizardMinimumDispatcherVersion = minimumDispatcherVersion
+            });
+        }
+
+        internal static void MaybeRecordSuppressedSetupWizardState(
+            IUnityCliLoopEditorSettingsPort editorSettingsPort,
+            bool suppressAutoShow,
+            string version,
+            string minimumDispatcherVersion)
+        {
+            if (!suppressAutoShow) return;
+
+            MaybeRecordLastSeenSetupWizardState(editorSettingsPort, true, version, minimumDispatcherVersion);
+        }
+
+        internal static bool HasSkillUpdateForSetupWizard(IEnumerable<SkillSetupTargetInfo> targets)
+        {
+            Debug.Assert(targets != null, "targets must not be null");
+            return targets.Any(
+                target => target.HasSkillsDirectory
+                    && (target.InstallState == SkillInstallState.Outdated
+                        || target.HasDifferentLayoutSkills));
+        }
+
+        internal void TryShowOnVersionChange()
+        {
+            EvaluateVersionChange(CancellationToken.None);
+        }
+
+        private static bool TryGetMajorVersion(string version, out int majorVersion)
+        {
+            majorVersion = 0;
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                return false;
+            }
+
+            int separatorIndex = version.IndexOfAny(VersionMajorSeparators);
+            string majorText = separatorIndex < 0 ? version : version.Substring(0, separatorIndex);
+            return int.TryParse(majorText, out majorVersion);
+        }
+
+        private async void EvaluateVersionChange(CancellationToken ct)
+        {
+            string currentVersion = UnityCliLoopConstants.PackageInfo.version;
+            string currentMinimumDispatcherVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
+            UnityCliLoopEditorSettingsData settings = _editorSettingsPort.GetSettings();
+            bool suppressAutoShow = settings.suppressSetupWizardAutoShow;
+            string lastSeenVersion = settings.lastSeenSetupWizardVersion ?? string.Empty;
+            string lastSeenMinimumDispatcherVersion =
+                settings.lastSeenSetupWizardMinimumDispatcherVersion ?? string.Empty;
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            bool shouldAutoScanThirdPartyToolMigration = ShouldAutoScanThirdPartyToolMigration(
+                currentVersion,
+                lastSeenVersion);
+            MaybeScheduleThirdPartyToolMigrationAutoScan(shouldAutoScanThirdPartyToolMigration);
+
+            bool versionChanged = !string.Equals(
+                currentVersion,
+                lastSeenVersion,
+                System.StringComparison.Ordinal);
+            bool minimumDispatcherVersionChanged = !string.Equals(
+                currentMinimumDispatcherVersion,
+                lastSeenMinimumDispatcherVersion,
+                System.StringComparison.Ordinal);
+            if (suppressAutoShow)
+            {
+                MaybeRecordSuppressedSetupWizardState(
+                    _editorSettingsPort,
+                    suppressAutoShow,
+                    currentVersion,
+                    currentMinimumDispatcherVersion);
+                return;
+            }
+
+            if (!versionChanged && !minimumDispatcherVersionChanged)
+            {
+                return;
+            }
+
+            bool needsCliUpdate = false;
+            bool hasSkillUpdate = false;
+            if (!string.IsNullOrEmpty(lastSeenVersion))
+            {
+                needsCliUpdate = await NeedsCliUpdateForSetupWizardAsync(ct);
+                if (ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                if (versionChanged && !needsCliUpdate)
+                {
+                    hasSkillUpdate = await HasSkillUpdateForSetupWizardAsync(ct);
+                    if (ct.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                }
+            }
+
+            bool shouldAutoShow = ShouldAutoShowForVersion(
+                currentVersion,
+                lastSeenVersion,
+                currentMinimumDispatcherVersion,
+                lastSeenMinimumDispatcherVersion,
+                suppressAutoShow,
+                needsCliUpdate,
+                hasSkillUpdate);
+
+            if (!shouldAutoShow)
+            {
+                MaybeRecordLastSeenSetupWizardState(
+                    _editorSettingsPort,
+                    true,
+                    currentVersion,
+                    currentMinimumDispatcherVersion);
+                return;
+            }
+
+            EditorApplication.delayCall += () => _showWindowOnVersionChange();
+        }
+
+        private async Task<bool> NeedsCliUpdateForSetupWizardAsync(CancellationToken ct)
+        {
+            await _cliSetupApplicationService.ForceRefreshCliVersionAsync(ct);
+            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
+            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
+            if (string.IsNullOrEmpty(cliVersion))
+            {
+                return false;
+            }
+
+            CliSetupCompatibilityState state = EvaluateCliSetupCompatibility(
+                cliVersion,
+                cliIsDispatcher);
+            return state.NeedsUpdate;
+        }
+
+        private CliSetupCompatibilityState EvaluateCliSetupCompatibility(
+            string cliVersion,
+            bool cliIsDispatcher)
+        {
+            string minimumRequiredCliVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
+            return CliSetupCompatibility.Evaluate(
+                cliVersion,
+                cliIsDispatcher,
+                minimumRequiredCliVersion);
+        }
+
+        private async Task<bool> HasSkillUpdateForSetupWizardAsync(CancellationToken ct)
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            List<SkillSetupTargetInfo> targets = await Task.Run(
+                () => _skillSetupUseCase.DetectSkillTargetsForLayoutAtProjectRoot(
+                    projectRoot,
+                    !SetupWizardWindow.ForceFlatSkillInstall),
+                ct);
+            if (ct.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            return HasSkillUpdateForSetupWizard(targets);
+        }
+
+        private void MaybeScheduleThirdPartyToolMigrationAutoScan(bool shouldAutoScan)
+        {
+            MaybeMarkThirdPartyToolMigrationAutoScan(_sessionFlagsRepository, shouldAutoScan);
+            if (!shouldAutoScan)
+            {
+                return;
+            }
+
+            EditorApplication.delayCall += () => _showThirdPartyMigrationAutoScan();
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs.meta
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62783612b3514214a7a2f1c318d972ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -24,10 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string UXML_RELATIVE_PATH = "Editor/Presentation/Setup/SetupWizardWindow.uxml";
         private const string USS_RELATIVE_PATH = "Editor/Presentation/Setup/SetupWizardWindow.uss";
         private const string GITHUB_ICON_RELATIVE_PATH = "Editor/Presentation/Setup/GitHub_Invertocat_White.png";
-        private const bool ForceFlatSkillInstall = true;
-        private static readonly char[] VersionMajorSeparators = { '.', '-' };
+        internal const bool ForceFlatSkillInstall = true;
         private static IUnityCliLoopEditorSettingsPort RegisteredEditorSettingsPort;
-        private static ISessionFlagsRepository RegisteredSessionFlagsRepository;
         private static CliSetupApplicationService RegisteredCliSetupApplicationService;
         private static SkillSetupUseCase RegisteredSkillSetupUseCase;
 
@@ -46,7 +44,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             if (AssetDatabase.IsAssetImportWorkerProcess()) return;
             if (UnityEngine.Application.isBatchMode) return;
 
-            EditorApplication.delayCall += TryShowOnVersionChange;
+            SetupWizardStartupFlow startupFlow = new(
+                editorSettingsPort,
+                sessionFlagsRepository,
+                cliSetupApplicationService,
+                skillSetupUseCase,
+                ShowWindowOnVersionChange,
+                ThirdPartyToolMigrationWizardWindow.ShowWindowForAutoScan);
+            EditorApplication.delayCall += startupFlow.TryShowOnVersionChange;
         }
 
         internal static void InitializeEditorServices(
@@ -62,8 +67,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             RegisteredEditorSettingsPort = editorSettingsPort
                 ?? throw new System.ArgumentNullException(nameof(editorSettingsPort));
-            RegisteredSessionFlagsRepository = sessionFlagsRepository
-                ?? throw new System.ArgumentNullException(nameof(sessionFlagsRepository));
             RegisteredCliSetupApplicationService = cliSetupApplicationService
                 ?? throw new System.ArgumentNullException(nameof(cliSetupApplicationService));
             RegisteredSkillSetupUseCase = skillSetupUseCase
@@ -74,209 +77,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         public static void ShowWindow()
         {
             ShowWindowInternal(false);
-        }
-
-        internal static bool ShouldAutoShowForVersion(
-            string currentVersion,
-            string lastSeenVersion,
-            string currentMinimumDispatcherVersion,
-            string lastSeenMinimumDispatcherVersion,
-            bool suppressAutoShow,
-            bool needsCliUpdate,
-            bool hasSkillUpdate)
-        {
-            bool versionChanged = !string.Equals(currentVersion, lastSeenVersion, System.StringComparison.Ordinal);
-            bool minimumDispatcherVersionChanged = !string.Equals(
-                currentMinimumDispatcherVersion,
-                lastSeenMinimumDispatcherVersion,
-                System.StringComparison.Ordinal);
-            if (!versionChanged && !minimumDispatcherVersionChanged) return false;
-            if (suppressAutoShow) return false;
-
-            return string.IsNullOrEmpty(lastSeenVersion)
-                || needsCliUpdate
-                || (versionChanged && hasSkillUpdate);
-        }
-
-        internal static bool ShouldAutoScanThirdPartyToolMigration(string currentVersion, string lastSeenVersion)
-        {
-            if (!TryGetMajorVersion(currentVersion, out int currentMajorVersion))
-            {
-                return false;
-            }
-
-            if (string.IsNullOrEmpty(lastSeenVersion))
-            {
-                return currentMajorVersion == 3;
-            }
-
-            if (!TryGetMajorVersion(lastSeenVersion, out int lastSeenMajorVersion))
-            {
-                return false;
-            }
-
-            return lastSeenMajorVersion < 3 && currentMajorVersion == 3;
-        }
-
-        internal static void MaybeMarkThirdPartyToolMigrationAutoScan(bool shouldAutoScan)
-        {
-            if (!shouldAutoScan)
-            {
-                return;
-            }
-
-            GetSessionFlagsRepository().SetShouldAutoScanThirdPartyToolMigration(true);
-        }
-
-        internal static void MaybeRecordLastSeenSetupWizardState(
-            bool shouldRecordState,
-            string version,
-            string minimumDispatcherVersion)
-        {
-            if (!shouldRecordState) return;
-
-            Debug.Assert(!string.IsNullOrEmpty(version), "version must not be null or empty");
-            Debug.Assert(
-                !string.IsNullOrEmpty(minimumDispatcherVersion),
-                "minimumDispatcherVersion must not be null or empty");
-
-            GetEditorSettingsPort().UpdateSettings((UnityCliLoopEditorSettingsData settings) => settings with
-            {
-                lastSeenSetupWizardVersion = version,
-                lastSeenSetupWizardMinimumDispatcherVersion = minimumDispatcherVersion
-            });
-        }
-
-        internal static void MaybeRecordSuppressedSetupWizardState(
-            bool suppressAutoShow,
-            string version,
-            string minimumDispatcherVersion)
-        {
-            if (!suppressAutoShow) return;
-
-            MaybeRecordLastSeenSetupWizardState(true, version, minimumDispatcherVersion);
-        }
-
-        private static void TryShowOnVersionChange()
-        {
-            EvaluateVersionChange(CancellationToken.None);
-        }
-
-        private static async void EvaluateVersionChange(CancellationToken ct)
-        {
-            string currentVersion = UnityCliLoopConstants.PackageInfo.version;
-            string currentMinimumDispatcherVersion = GetMinimumRequiredCliVersion();
-            IUnityCliLoopEditorSettingsPort editorSettingsPort = GetEditorSettingsPort();
-            UnityCliLoopEditorSettingsData settings = editorSettingsPort.GetSettings();
-            bool suppressAutoShow = settings.suppressSetupWizardAutoShow;
-            string lastSeenVersion = settings.lastSeenSetupWizardVersion ?? string.Empty;
-            string lastSeenMinimumDispatcherVersion =
-                settings.lastSeenSetupWizardMinimumDispatcherVersion ?? string.Empty;
-            if (ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            bool shouldAutoScanThirdPartyToolMigration = ShouldAutoScanThirdPartyToolMigration(
-                currentVersion,
-                lastSeenVersion);
-            MaybeScheduleThirdPartyToolMigrationAutoScan(shouldAutoScanThirdPartyToolMigration);
-
-            bool versionChanged = !string.Equals(
-                currentVersion,
-                lastSeenVersion,
-                System.StringComparison.Ordinal);
-            bool minimumDispatcherVersionChanged = !string.Equals(
-                currentMinimumDispatcherVersion,
-                lastSeenMinimumDispatcherVersion,
-                System.StringComparison.Ordinal);
-            if (suppressAutoShow)
-            {
-                MaybeRecordSuppressedSetupWizardState(
-                    suppressAutoShow,
-                    currentVersion,
-                    currentMinimumDispatcherVersion);
-                return;
-            }
-
-            if (!versionChanged && !minimumDispatcherVersionChanged)
-            {
-                return;
-            }
-
-            bool needsCliUpdate = false;
-            bool hasSkillUpdate = false;
-            if (!string.IsNullOrEmpty(lastSeenVersion))
-            {
-                needsCliUpdate = await NeedsCliUpdateForSetupWizardAsync(ct);
-                if (ct.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                if (versionChanged && !needsCliUpdate)
-                {
-                    hasSkillUpdate = await HasSkillUpdateForSetupWizardAsync(ct);
-                    if (ct.IsCancellationRequested)
-                    {
-                        return;
-                    }
-                }
-            }
-
-            bool shouldAutoShow = ShouldAutoShowForVersion(
-                currentVersion,
-                lastSeenVersion,
-                currentMinimumDispatcherVersion,
-                lastSeenMinimumDispatcherVersion,
-                suppressAutoShow,
-                needsCliUpdate,
-                hasSkillUpdate);
-
-            if (!shouldAutoShow)
-            {
-                MaybeRecordLastSeenSetupWizardState(
-                    true,
-                    currentVersion,
-                    currentMinimumDispatcherVersion);
-                return;
-            }
-
-            EditorApplication.delayCall += ShowWindowOnVersionChange;
-        }
-
-        private static async Task<bool> NeedsCliUpdateForSetupWizardAsync(CancellationToken ct)
-        {
-            CliSetupApplicationService cliSetupApplicationService = GetCliSetupApplicationService();
-            await cliSetupApplicationService.ForceRefreshCliVersionAsync(ct);
-            string cliVersion = cliSetupApplicationService.GetCachedCliVersion();
-            bool cliIsDispatcher = cliSetupApplicationService.GetCachedCliIsDispatcher();
-            if (string.IsNullOrEmpty(cliVersion))
-            {
-                return false;
-            }
-
-            CliSetupCompatibilityState state = EvaluateCliSetupCompatibilityForSetupWizard(
-                cliVersion,
-                cliIsDispatcher);
-            return state.NeedsUpdate;
-        }
-
-        private static async Task<bool> HasSkillUpdateForSetupWizardAsync(CancellationToken ct)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            SkillSetupUseCase skillSetupUseCase = GetSkillSetupUseCase();
-            List<SkillSetupTargetInfo> targets = await Task.Run(
-                () => skillSetupUseCase.DetectSkillTargetsForLayoutAtProjectRoot(
-                    projectRoot,
-                    !ForceFlatSkillInstall),
-                ct);
-            if (ct.IsCancellationRequested)
-            {
-                return false;
-            }
-
-            return HasSkillUpdateForSetupWizard(targets);
         }
 
         private static void ShowWindowOnVersionChange()
@@ -334,7 +134,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 !string.IsNullOrEmpty(currentMinimumDispatcherVersion),
                 "currentMinimumDispatcherVersion must not be null or empty");
             focusExistingWindow();
-            MaybeRecordLastSeenSetupWizardState(
+            SetupWizardStartupFlow.MaybeRecordLastSeenSetupWizardState(
+                GetEditorSettingsPort(),
                 shouldRecordVersion,
                 currentVersion,
                 currentMinimumDispatcherVersion);
@@ -373,16 +174,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return RegisteredEditorSettingsPort;
         }
 
-        private static ISessionFlagsRepository GetSessionFlagsRepository()
-        {
-            if (RegisteredSessionFlagsRepository == null)
-            {
-                throw new System.InvalidOperationException("Setup Wizard session flags repository is not initialized.");
-            }
-
-            return RegisteredSessionFlagsRepository;
-        }
-
         private static CliSetupApplicationService GetCliSetupApplicationService()
         {
             if (RegisteredCliSetupApplicationService == null)
@@ -402,30 +193,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             return RegisteredSkillSetupUseCase;
-        }
-
-        private static void MaybeScheduleThirdPartyToolMigrationAutoScan(bool shouldAutoScan)
-        {
-            MaybeMarkThirdPartyToolMigrationAutoScan(shouldAutoScan);
-            if (!shouldAutoScan)
-            {
-                return;
-            }
-
-            EditorApplication.delayCall += ThirdPartyToolMigrationWizardWindow.ShowWindowForAutoScan;
-        }
-
-        private static bool TryGetMajorVersion(string version, out int majorVersion)
-        {
-            majorVersion = 0;
-            if (string.IsNullOrWhiteSpace(version))
-            {
-                return false;
-            }
-
-            int separatorIndex = version.IndexOfAny(VersionMajorSeparators);
-            string majorText = separatorIndex < 0 ? version : version.Substring(0, separatorIndex);
-            return int.TryParse(majorText, out majorVersion);
         }
 
         // Prerequisite
@@ -507,7 +274,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void RecordLastSeenSetupWizardStateAfterSuccessfulCreateGui()
         {
-            MaybeRecordLastSeenSetupWizardState(
+            SetupWizardStartupFlow.MaybeRecordLastSeenSetupWizardState(
+                _editorSettingsPort,
                 _shouldRecordLastSeenVersionAfterCreateGui,
                 UnityCliLoopConstants.PackageInfo.version,
                 GetMinimumRequiredCliVersion());
@@ -789,16 +557,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return targets
                 .Where(target => target.HasSkillsDirectory)
                 .ToList();
-        }
-
-        internal static bool HasSkillUpdateForSetupWizard(
-            IEnumerable<SkillSetupTargetInfo> targets)
-        {
-            Debug.Assert(targets != null, "targets must not be null");
-            return targets.Any(
-                target => target.HasSkillsDirectory
-                    && (target.InstallState == SkillInstallState.Outdated
-                        || target.HasDifferentLayoutSkills));
         }
 
         internal static bool ShouldShowSkillsInstalledDialog(
@@ -1380,7 +1138,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void HandleSuppressAutoShowChanged(bool suppressAutoShow)
         {
             _editorSettingsPort.SetSuppressSetupWizardAutoShow(suppressAutoShow);
-            MaybeRecordSuppressedSetupWizardState(
+            SetupWizardStartupFlow.MaybeRecordSuppressedSetupWizardState(
+                _editorSettingsPort,
                 suppressAutoShow,
                 UnityCliLoopConstants.PackageInfo.version,
                 GetMinimumRequiredCliVersion());

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -37,7 +37,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             InitializeEditorServices(
                 editorSettingsPort,
-                sessionFlagsRepository,
                 cliSetupApplicationService,
                 skillSetupUseCase);
 
@@ -56,12 +55,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal static void InitializeEditorServices(
             IUnityCliLoopEditorSettingsPort editorSettingsPort,
-            ISessionFlagsRepository sessionFlagsRepository,
             CliSetupApplicationService cliSetupApplicationService,
             SkillSetupUseCase skillSetupUseCase)
         {
             Debug.Assert(editorSettingsPort != null, "editorSettingsPort must not be null");
-            Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
             Debug.Assert(cliSetupApplicationService != null, "cliSetupApplicationService must not be null");
             Debug.Assert(skillSetupUseCase != null, "skillSetupUseCase must not be null");
 


### PR DESCRIPTION
## Summary
- Keep setup startup auto-show and migration auto-scan behavior unchanged while moving the coordination code out of the setup window.
- Preserve the existing setup window UI mechanics and focus/open behavior.

## User Impact
- Setup still auto-opens only for the same package, dispatcher, CLI, and skill-update conditions as before.
- Third-party migration auto-scan still runs only after the same V2-to-V3 startup signal.

## Changes
- Add `SetupWizardStartupFlow` to coordinate startup auto-show, third-party migration auto-scan, version recording, and skill update checks.
- Keep window opening mechanics in `SetupWizardWindow` by injecting `Action` callbacks for version-change open and third-party auto-scan.
- Retarget setup startup source-text guards to scan both `SetupWizardWindow.cs` and `SetupWizardStartupFlow.cs`, so delay scheduling guards do not become vacuous after extraction.

## Timing Invariants
- Editor startup still registers services before creating the startup flow, then registers the initial `delayCall` with `startupFlow.TryShowOnVersionChange` after the asset-import-worker and batch-mode guards.
- The flow still evaluates version state in the delayed callback, then sets the auto-scan session flag before registering the auto-scan `delayCall`.
- The setup window open callback is registered through `delayCall` only after `ShouldAutoShowForVersion` returns true.

## Deviations
- `SetupWizardStartupFlow` has a private compatibility glue helper that calls `CliSetupCompatibility.Evaluate` with the injected `CliSetupApplicationService` minimum version. This avoids reaching back through `SetupWizardWindow` static service state from the extracted flow.
- `ForceFlatSkillInstall` was widened from `private const` to `internal const` because both the setup window UI flow and the extracted startup flow use the shared value; duplicating the value would be worse, and the window-side use remains in `SetupWizardWindow.cs`.
- Two parameterized static helpers gained argument precondition `Debug.Assert` checks as boundary contracts, matching the accepted `CliPathSetupPrompt` pattern.
- Four retargeted tests gained missing behavior comments so the moved assertions continue to satisfy the test comment rule.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "(SetupWizardWindowTests|OnionAssemblyDependencyTests)"`
- After review fixes: `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- After review fixes: `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "(SetupWizardWindowTests|OnionAssemblyDependencyTests)"`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->