### PR TITLE
chore: Keep setup CLI step rendering separate from the window

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -556,7 +556,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string requiredCliVersion,
             string expectedLabel)
         {
-            string label = SetupWizardWindow.GetCliButtonTextForSetupWizard(
+            string label = SetupWizardCliStepPresenter.GetCliButtonTextForSetupWizard(
                 cliInstalled,
                 isInstallingCli,
                 isChecking,
@@ -580,7 +580,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string expectedLabel)
         {
             // Verifies that same-version replacement prompts do not expose dispatcher internals.
-            string label = SetupWizardWindow.GetCliStatusTextForSetupWizard(
+            string label = SetupWizardCliStepPresenter.GetCliStatusTextForSetupWizard(
                 cliInstalled,
                 cliCompatible,
                 cliVersion,
@@ -603,7 +603,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool isChecking,
             bool expectedEnabled)
         {
-            bool enabled = SetupWizardWindow.IsCliButtonEnabledForSetupWizard(
+            bool enabled = SetupWizardCliStepPresenter.IsCliButtonEnabledForSetupWizard(
                 cliInstalled,
                 cliVersionMatched,
                 needsCliPathSetup,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs
@@ -1,0 +1,167 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Presents the setup wizard CLI installation step.
+    /// </summary>
+    internal sealed class SetupWizardCliStepPresenter
+    {
+        private readonly VisualElement _statusIcon;
+        private readonly Label _statusLabel;
+        private readonly Button _installButton;
+
+        internal SetupWizardCliStepPresenter(
+            VisualElement statusIcon,
+            Label statusLabel,
+            Button installButton,
+            System.Action onInstallClicked)
+        {
+            Debug.Assert(statusIcon != null, "statusIcon must not be null");
+            Debug.Assert(statusLabel != null, "statusLabel must not be null");
+            Debug.Assert(installButton != null, "installButton must not be null");
+            Debug.Assert(onInstallClicked != null, "onInstallClicked must not be null");
+
+            _statusIcon = statusIcon ?? throw new System.ArgumentNullException(nameof(statusIcon));
+            _statusLabel = statusLabel ?? throw new System.ArgumentNullException(nameof(statusLabel));
+            _installButton = installButton ?? throw new System.ArgumentNullException(nameof(installButton));
+            _installButton.clicked += onInstallClicked
+                ?? throw new System.ArgumentNullException(nameof(onInstallClicked));
+        }
+
+        internal void ShowChecking()
+        {
+            ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--success", false);
+            ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--pending", true);
+            _statusLabel.text = "Checking...";
+            _installButton.SetEnabled(false);
+            _installButton.text = "Checking...";
+        }
+
+        internal void ShowRefreshingPrimaryAction()
+        {
+            _installButton.SetEnabled(false);
+            _installButton.text = "Checking...";
+        }
+
+        internal void Update(
+            bool cliInstalled,
+            string cliVersion,
+            bool cliIsDispatcher,
+            string requiredCliVersion,
+            bool isInstallingCli,
+            bool needsCliPathSetup)
+        {
+            CliSetupCompatibilityState state = CliSetupCompatibility.Evaluate(
+                cliVersion,
+                cliIsDispatcher,
+                requiredCliVersion);
+            string buttonText = GetCliButtonTextForSetupWizard(
+                cliInstalled,
+                isInstallingCli,
+                false,
+                state.NeedsUpdate,
+                needsCliPathSetup,
+                cliVersion,
+                requiredCliVersion);
+            bool cliVersionMatched = state.IsCompatible && cliInstalled;
+            bool buttonEnabled = IsCliButtonEnabledForSetupWizard(
+                cliInstalled,
+                cliVersionMatched,
+                needsCliPathSetup,
+                isInstallingCli,
+                isChecking: false);
+
+            bool cliCompatible = cliInstalled && cliVersionMatched;
+            _statusLabel.text = GetCliStatusTextForSetupWizard(
+                cliInstalled,
+                cliCompatible,
+                cliVersion,
+                requiredCliVersion);
+            ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--success", cliCompatible);
+            ViewDataBinder.ToggleClass(_statusIcon, "setup-status-icon--pending", !cliCompatible);
+            _installButton.SetEnabled(buttonEnabled);
+            _installButton.text = buttonText;
+        }
+
+        internal static string GetCliStatusTextForSetupWizard(
+            bool cliInstalled,
+            bool cliCompatible,
+            string cliVersion,
+            string requiredCliVersion)
+        {
+            if (!cliInstalled)
+            {
+                return "Not installed";
+            }
+
+            if (cliCompatible)
+            {
+                return $"v{cliVersion}";
+            }
+
+            if (CliSetupLabelFormatter.ShouldShowRequiredVersionText(cliVersion, requiredCliVersion))
+            {
+                return $"v{cliVersion} (update required)";
+            }
+
+            return $"v{cliVersion} (requires v{requiredCliVersion})";
+        }
+
+        internal static string GetCliButtonTextForSetupWizard(
+            bool cliInstalled,
+            bool isInstallingCli,
+            bool isChecking,
+            bool needsUpdate,
+            bool needsCliPathSetup,
+            string cliVersion,
+            string requiredCliVersion)
+        {
+            if (isChecking)
+            {
+                return "Checking...";
+            }
+
+            if (isInstallingCli)
+            {
+                if (CliSetupPrimaryActionPolicy.ShouldRepairCliPath(needsCliPathSetup, needsUpdate))
+                {
+                    return "Fixing PATH...";
+                }
+
+                return "Installing...";
+            }
+
+            if (needsUpdate)
+            {
+                return CliSetupLabelFormatter.GetCliReplacementButtonText("Update", cliVersion, requiredCliVersion);
+            }
+
+            if (needsCliPathSetup)
+            {
+                return "Fix PATH";
+            }
+
+            if (!cliInstalled)
+            {
+                return "Install CLI";
+            }
+
+            return "Installed";
+        }
+
+        internal static bool IsCliButtonEnabledForSetupWizard(
+            bool cliInstalled,
+            bool cliVersionMatched,
+            bool needsCliPathSetup,
+            bool isInstallingCli,
+            bool isChecking)
+        {
+            return !isInstallingCli && !isChecking && (!cliInstalled || !cliVersionMatched || needsCliPathSetup);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs.meta
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliStepPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ff47456a5fc4297993d3e9a33bbe254
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -197,11 +197,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private VisualElement _nodejsOk;
         private Button _refreshButton;
 
-        // Step 1
-        private VisualElement _cliStatusIcon;
-        private Label _cliStatusLabel;
-        private Button _installCliButton;
-
         // Step 2
         private VisualElement _groupSkillsRow;
         private VisualElement _skillsTargetRow;
@@ -221,6 +216,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private Label _githubLinkLabel;
         private Image _githubLinkIcon;
         private ScrollView _mainScrollView;
+        private SetupWizardCliStepPresenter _cliStepPresenter;
 
         // State
         private bool _isInstallingCli;
@@ -305,9 +301,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _nodejsOk = rootVisualElement.Q<VisualElement>("nodejs-ok");
             _refreshButton = rootVisualElement.Q<Button>("refresh-button");
 
-            _cliStatusIcon = rootVisualElement.Q<VisualElement>("cli-status-icon");
-            _cliStatusLabel = rootVisualElement.Q<Label>("cli-status-label");
-            _installCliButton = rootVisualElement.Q<Button>("install-cli-button");
+            VisualElement cliStatusIcon = rootVisualElement.Q<VisualElement>("cli-status-icon");
+            Label cliStatusLabel = rootVisualElement.Q<Label>("cli-status-label");
+            Button installCliButton = rootVisualElement.Q<Button>("install-cli-button");
+            _cliStepPresenter = new SetupWizardCliStepPresenter(
+                cliStatusIcon,
+                cliStatusLabel,
+                installCliButton,
+                HandleInstallCli);
 
             _groupSkillsRow = rootVisualElement.Q<VisualElement>("group-skills-row");
             _skillsTargetRow = rootVisualElement.Q<VisualElement>("skills-target-row");
@@ -331,7 +332,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void BindEvents()
         {
             _refreshButton.clicked += () => RefreshUI();
-            _installCliButton.clicked += HandleInstallCli;
             _installSkillsButton.clicked += HandleInstallSkills;
             InitializeSkillsTargetField();
             InitializeGroupSkillsToggle();
@@ -405,11 +405,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             RefreshAutoShowToggle();
             ViewDataBinder.SetVisible(_nodejsWarning, false);
             ViewDataBinder.SetVisible(_nodejsOk, false);
-            ViewDataBinder.ToggleClass(_cliStatusIcon, "setup-status-icon--success", false);
-            ViewDataBinder.ToggleClass(_cliStatusIcon, "setup-status-icon--pending", true);
-            _cliStatusLabel.text = "Checking...";
-            _installCliButton.SetEnabled(false);
-            _installCliButton.text = "Checking...";
+            _cliStepPresenter.ShowChecking();
             ViewDataBinder.SetVisible(_groupSkillsRow, false);
             _groupSkillsToggle.SetEnabled(false);
             UpdateSkillsStatusLabel("Checking installed skills...");
@@ -452,11 +448,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             RefreshAutoShowToggle();
             ViewDataBinder.SetVisible(_nodejsWarning, false);
             ViewDataBinder.SetVisible(_nodejsOk, false);
-            ViewDataBinder.ToggleClass(_cliStatusIcon, "setup-status-icon--success", false);
-            ViewDataBinder.ToggleClass(_cliStatusIcon, "setup-status-icon--pending", true);
-            _cliStatusLabel.text = "Checking...";
-            _installCliButton.SetEnabled(false);
-            _installCliButton.text = "Checking...";
+            _cliStepPresenter.ShowChecking();
             if (refreshSkillsSection)
             {
                 ViewDataBinder.SetVisible(_groupSkillsRow, false);
@@ -482,7 +474,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool cliInstalled = IsCliInstalled(cliVersion);
             _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(CancellationToken.None);
 
-            UpdateCliStep(cliInstalled, cliVersion, cliIsDispatcher, requiredCliVersion);
+            _cliStepPresenter.Update(
+                cliInstalled,
+                cliVersion,
+                cliIsDispatcher,
+                requiredCliVersion,
+                _isInstallingCli,
+                _needsCliPathSetup);
 
             if (!refreshSkillsSection)
             {
@@ -634,120 +632,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                    || selectedTargetInfo.InstallState == SkillInstallState.Checking
                 ? new List<SkillSetupTargetInfo>()
                 : new List<SkillSetupTargetInfo> { selectedTargetInfo };
-        }
-
-        private void UpdateCliStep(
-            bool cliInstalled,
-            string cliVersion,
-            bool cliIsDispatcher,
-            string requiredCliVersion)
-        {
-            CliSetupCompatibilityState state = CliSetupCompatibility.Evaluate(
-                cliVersion,
-                cliIsDispatcher,
-                requiredCliVersion);
-            string buttonText = GetCliButtonTextForSetupWizard(
-                cliInstalled,
-                _isInstallingCli,
-                false,
-                state.NeedsUpdate,
-                _needsCliPathSetup,
-                cliVersion,
-                requiredCliVersion);
-            bool cliVersionMatched = state.IsCompatible && cliInstalled;
-            bool buttonEnabled = IsCliButtonEnabledForSetupWizard(
-                cliInstalled,
-                cliVersionMatched,
-                _needsCliPathSetup,
-                _isInstallingCli,
-                isChecking: false);
-
-            bool cliCompatible = cliInstalled && cliVersionMatched;
-            _cliStatusLabel.text = GetCliStatusTextForSetupWizard(
-                cliInstalled,
-                cliCompatible,
-                cliVersion,
-                requiredCliVersion);
-            ViewDataBinder.ToggleClass(_cliStatusIcon, "setup-status-icon--success", cliCompatible);
-            ViewDataBinder.ToggleClass(_cliStatusIcon, "setup-status-icon--pending", !cliCompatible);
-            _installCliButton.SetEnabled(buttonEnabled);
-            _installCliButton.text = buttonText;
-        }
-
-        internal static string GetCliStatusTextForSetupWizard(
-            bool cliInstalled,
-            bool cliCompatible,
-            string cliVersion,
-            string requiredCliVersion)
-        {
-            if (!cliInstalled)
-            {
-                return "Not installed";
-            }
-
-            if (cliCompatible)
-            {
-                return $"v{cliVersion}";
-            }
-
-            if (CliSetupLabelFormatter.ShouldShowRequiredVersionText(cliVersion, requiredCliVersion))
-            {
-                return $"v{cliVersion} (update required)";
-            }
-
-            return $"v{cliVersion} (requires v{requiredCliVersion})";
-        }
-
-        internal static string GetCliButtonTextForSetupWizard(
-            bool cliInstalled,
-            bool isInstallingCli,
-            bool isChecking,
-            bool needsUpdate,
-            bool needsCliPathSetup,
-            string cliVersion,
-            string requiredCliVersion)
-        {
-            if (isChecking)
-            {
-                return "Checking...";
-            }
-
-            if (isInstallingCli)
-            {
-                if (CliSetupPrimaryActionPolicy.ShouldRepairCliPath(needsCliPathSetup, needsUpdate))
-                {
-                    return "Fixing PATH...";
-                }
-
-                return "Installing...";
-            }
-
-            if (needsUpdate)
-            {
-                return CliSetupLabelFormatter.GetCliReplacementButtonText("Update", cliVersion, requiredCliVersion);
-            }
-
-            if (needsCliPathSetup)
-            {
-                return "Fix PATH";
-            }
-
-            if (!cliInstalled)
-            {
-                return "Install CLI";
-            }
-
-            return "Installed";
-        }
-
-        internal static bool IsCliButtonEnabledForSetupWizard(
-            bool cliInstalled,
-            bool cliVersionMatched,
-            bool needsCliPathSetup,
-            bool isInstallingCli,
-            bool isChecking)
-        {
-            return !isInstallingCli && !isChecking && (!cliInstalled || !cliVersionMatched || needsCliPathSetup);
         }
 
         private static async Task<bool> ShouldRepairCliPathSetupAsync(CancellationToken ct)
@@ -1004,7 +888,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool wasCliInstalledBeforeInstall = _cliSetupApplicationService.IsCliInstalled();
             _needsCliPathSetup = false;
             _isInstallingCli = true;
-            UpdateCliStep(false, null, false, GetMinimumRequiredCliVersion());
+            _cliStepPresenter.Update(
+                cliInstalled: false,
+                cliVersion: null,
+                cliIsDispatcher: false,
+                requiredCliVersion: GetMinimumRequiredCliVersion(),
+                isInstallingCli: _isInstallingCli,
+                needsCliPathSetup: _needsCliPathSetup);
 
             try
             {
@@ -1041,8 +931,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private async Task RefreshCliPrimaryActionStateAsync(CancellationToken ct)
         {
-            _installCliButton.SetEnabled(false);
-            _installCliButton.text = "Checking...";
+            _cliStepPresenter.ShowRefreshingPrimaryAction();
 
             try
             {
@@ -1061,7 +950,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
             string requiredCliVersion = GetMinimumRequiredCliVersion();
             bool cliInstalled = IsCliInstalled(cliVersion);
-            UpdateCliStep(cliInstalled, cliVersion, cliIsDispatcher, requiredCliVersion);
+            _cliStepPresenter.Update(
+                cliInstalled,
+                cliVersion,
+                cliIsDispatcher,
+                requiredCliVersion,
+                _isInstallingCli,
+                _needsCliPathSetup);
         }
 
         internal static bool ShouldRepairCliPathFromPrimaryButton(
@@ -1074,11 +969,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private async Task HandleRepairCliPathSetup()
         {
             _isInstallingCli = true;
-            UpdateCliStep(
+            _cliStepPresenter.Update(
                 cliInstalled: true,
                 cliVersion: _cliSetupApplicationService.GetCachedCliVersion(),
                 cliIsDispatcher: _cliSetupApplicationService.GetCachedCliIsDispatcher(),
-                requiredCliVersion: GetMinimumRequiredCliVersion());
+                requiredCliVersion: GetMinimumRequiredCliVersion(),
+                isInstallingCli: _isInstallingCli,
+                needsCliPathSetup: _needsCliPathSetup);
 
             try
             {


### PR DESCRIPTION
## Summary
- Keep setup CLI step rendering behavior unchanged while moving it out of the setup wizard window.
- Leave CLI install, PATH repair, dialogs, and refresh orchestration in the window.

## User Impact
- Setup still shows the same CLI status text, button labels, enabled states, and status icon classes.
- Install and PATH repair actions continue to run through the same workflow.

## Changes
- Add `SetupWizardCliStepPresenter` for Step 1 status icon, status label, install button rendering, and install click registration.
- Replace direct Step 1 element fields in `SetupWizardWindow` with a single presenter field.
- Retarget CLI step label/enabled tests to the new presenter while keeping primary action and PATH policy tests on `SetupWizardWindow`.

## Boundaries
- Kept `ShouldRepairCliPathFromPrimaryButton` on `SetupWizardWindow` because it chooses the primary action used by `HandleInstallCli`.
- Kept async install/repair flow, compatibility wrapper, PATH setup checks, and minimum-version lookup in `SetupWizardWindow`.
- The presenter receives explicit UI elements plus `Action onInstallClicked`; it does not query `rootVisualElement` or expose its Button back to the window.

## Checking-State Mapping
- `ApplyInitialCheckingState` and full `RefreshUI` use `SetupWizardCliStepPresenter.ShowChecking()` because their five CLI writes were identical.
- `RefreshCliPrimaryActionStateAsync` uses `SetupWizardCliStepPresenter.ShowRefreshingPrimaryAction()` because it only disables the primary button and sets its text to `Checking...`.

## Deviations
- Added constructor `Debug.Assert` and `ArgumentNullException` guards for the three UI elements and the install click action, matching the resizer-style Fail Fast pattern.
- Replaced direct `clicked += HandleInstallCli` with constructor-injected click registration inside the presenter.
- Changed the visual update helper to accept `isInstallingCli` and `needsCliPathSetup` as parameters so async action state remains owned by the window.
- Consolidated only the two fully matching checking blocks into `ShowChecking`; the shorter primary-action refresh block has its own method.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.SetupWizardWindowTests"`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

