### PR TITLE
chore: Keep setup skills step rendering separate from the window

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -455,7 +455,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             };
 
             List<SkillSetupTargetInfo> installableTargets =
-                SetupWizardWindow.FilterInstallableSkillTargets(targets);
+                SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
 
             Assert.That(installableTargets.Count, Is.EqualTo(2));
             Assert.That(installableTargets[0].DirName, Is.EqualTo(".claude"));
@@ -498,7 +498,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ShouldShowSkillsTargetRow_WhenFirstInstallAndCliMissing_ReturnsTrue()
         {
             // Verifies that first-time setup can choose a skill target before CLI installation.
-            bool shouldShow = SetupWizardWindow.ShouldShowSkillsTargetRowForSetupWizard(
+            bool shouldShow = SetupWizardSkillsStepPresenter.ShouldShowSkillsTargetRowForSetupWizard(
                 shouldUseFirstInstallSkillsUi: true);
 
             Assert.That(shouldShow, Is.True);
@@ -508,7 +508,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ShouldShowSkillsTargetRow_WhenNotFirstInstall_ReturnsFalse()
         {
             // Verifies that returning setup keeps the compact target row hidden.
-            bool shouldShow = SetupWizardWindow.ShouldShowSkillsTargetRowForSetupWizard(
+            bool shouldShow = SetupWizardSkillsStepPresenter.ShouldShowSkillsTargetRowForSetupWizard(
                 shouldUseFirstInstallSkillsUi: false);
 
             Assert.That(shouldShow, Is.False);
@@ -518,7 +518,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ShouldShowSkillsTargetList_WhenCliMissing_ReturnsFalse()
         {
             // Verifies that multi-target status rows stay hidden until the CLI can inspect skill state.
-            bool shouldShow = SetupWizardWindow.ShouldShowSkillsTargetListForSetupWizard(
+            bool shouldShow = SetupWizardSkillsStepPresenter.ShouldShowSkillsTargetListForSetupWizard(
                 canManageSkills: false,
                 shouldUseFirstInstallSkillsUi: false);
 
@@ -529,7 +529,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void ShouldShowSkillsTargetList_WhenCliInstalledAndNotFirstInstall_ReturnsTrue()
         {
             // Verifies that returning users keep the multi-target skill status view.
-            bool shouldShow = SetupWizardWindow.ShouldShowSkillsTargetListForSetupWizard(
+            bool shouldShow = SetupWizardSkillsStepPresenter.ShouldShowSkillsTargetListForSetupWizard(
                 canManageSkills: true,
                 shouldUseFirstInstallSkillsUi: false);
 
@@ -649,7 +649,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void CreateFirstInstallSkillTarget_WhenClaudeSelected_ReturnsClaudeProjectTarget()
         {
             SkillSetupTargetInfo target =
-                SetupWizardWindow.CreateFirstInstallSkillTarget(SkillsTarget.Claude, true);
+                SetupWizardSkillsStepPresenter.CreateFirstInstallSkillTarget(SkillsTarget.Claude, true);
 
             Assert.That(target.DisplayName, Is.EqualTo("Claude Code"));
             Assert.That(target.DirName, Is.EqualTo(".claude"));
@@ -669,7 +669,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string expectedInstallFlag)
         {
             SkillSetupTargetInfo target =
-                SetupWizardWindow.CreateFirstInstallSkillTarget(targetType, true);
+                SetupWizardSkillsStepPresenter.CreateFirstInstallSkillTarget(targetType, true);
 
             Assert.That(target.DisplayName, Is.EqualTo(expectedDisplayName));
             Assert.That(target.DirName, Is.EqualTo(expectedDirName));
@@ -682,7 +682,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void CreateFirstInstallSkillTarget_WhenGroupingDisabled_KeepsTargetMetadata()
         {
             SkillSetupTargetInfo target =
-                SetupWizardWindow.CreateFirstInstallSkillTarget(SkillsTarget.Claude, false);
+                SetupWizardSkillsStepPresenter.CreateFirstInstallSkillTarget(SkillsTarget.Claude, false);
 
             Assert.That(target.DisplayName, Is.EqualTo("Claude Code"));
             Assert.That(target.DirName, Is.EqualTo(".claude"));
@@ -703,7 +703,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     installState: SkillInstallState.Installed)
             };
 
-            SkillSetupTargetInfo target = SetupWizardWindow.GetSelectedSkillTargetInfo(
+            SkillSetupTargetInfo target = SetupWizardSkillsStepPresenter.GetSelectedSkillTargetInfo(
                 targets,
                 SkillsTarget.Claude,
                 groupSkillsUnderUnityCliLoop: true);
@@ -727,7 +727,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             };
 
             List<SkillSetupTargetInfo> installableTargets =
-                SetupWizardWindow.GetFirstInstallableSkillTargets(
+                SetupWizardSkillsStepPresenter.GetFirstInstallableSkillTargets(
                     targets,
                     SkillsTarget.Claude,
                     groupSkillsUnderUnityCliLoop: true);
@@ -739,7 +739,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetFirstInstallableSkillTargets_WhenSelectedTargetIsMissing_ReturnsMappedTarget()
         {
             List<SkillSetupTargetInfo> installableTargets =
-                SetupWizardWindow.GetFirstInstallableSkillTargets(
+                SetupWizardSkillsStepPresenter.GetFirstInstallableSkillTargets(
                     new List<SkillSetupTargetInfo>(),
                     SkillsTarget.Claude,
                     groupSkillsUnderUnityCliLoop: true);
@@ -761,7 +761,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool groupSkillsUnderUnityCliLoop,
             string expectedLabel)
         {
-            string label = SetupWizardWindow.GetSkillInstallStatusText(
+            string label = SetupWizardSkillsStepPresenter.GetSkillInstallStatusText(
                 installState,
                 hasDifferentLayoutSkills,
                 groupSkillsUnderUnityCliLoop);
@@ -777,7 +777,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool hasOutdatedSkills,
             string expectedLabel)
         {
-            string label = SetupWizardWindow.GetInstallSkillsButtonText(
+            string label = SetupWizardSkillsStepPresenter.GetInstallSkillsButtonText(
                 isInstallingSkills,
                 hasOutdatedSkills);
 
@@ -794,7 +794,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool hasOutdatedSkills,
             string expectedLabel)
         {
-            string label = SetupWizardWindow.GetSkillsButtonTextForSetupWizard(
+            string label = SetupWizardSkillsStepPresenter.GetSkillsButtonTextForSetupWizard(
                 cliInstalled,
                 isInstallingSkills,
                 hasOutdatedSkills);
@@ -865,7 +865,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool groupSkillsUnderUnityCliLoop,
             string expectedClass)
         {
-            string className = SetupWizardWindow.GetSkillInstallStatusClass(
+            string className = SetupWizardSkillsStepPresenter.GetSkillInstallStatusClass(
                 installState,
                 hasDifferentLayoutSkills,
                 groupSkillsUnderUnityCliLoop);

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs
@@ -1,0 +1,328 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Presents the setup wizard skill installation step.
+    /// </summary>
+    internal sealed class SetupWizardSkillsStepPresenter
+    {
+        private readonly VisualElement _skillsTargetRow;
+        private readonly VisualElement _skillsTargetList;
+        private readonly VisualElement _skillsStatusDivider;
+        private readonly Label _skillsStatusLabel;
+        private readonly Button _installSkillsButton;
+
+        internal SetupWizardSkillsStepPresenter(
+            VisualElement skillsTargetRow,
+            VisualElement skillsTargetList,
+            VisualElement skillsStatusDivider,
+            Label skillsStatusLabel,
+            Button installSkillsButton,
+            System.Action onInstallSkillsClicked)
+        {
+            Debug.Assert(skillsTargetRow != null, "skillsTargetRow must not be null");
+            Debug.Assert(skillsTargetList != null, "skillsTargetList must not be null");
+            Debug.Assert(skillsStatusDivider != null, "skillsStatusDivider must not be null");
+            Debug.Assert(skillsStatusLabel != null, "skillsStatusLabel must not be null");
+            Debug.Assert(installSkillsButton != null, "installSkillsButton must not be null");
+            Debug.Assert(onInstallSkillsClicked != null, "onInstallSkillsClicked must not be null");
+
+            _skillsTargetRow = skillsTargetRow
+                ?? throw new System.ArgumentNullException(nameof(skillsTargetRow));
+            _skillsTargetList = skillsTargetList
+                ?? throw new System.ArgumentNullException(nameof(skillsTargetList));
+            _skillsStatusDivider = skillsStatusDivider
+                ?? throw new System.ArgumentNullException(nameof(skillsStatusDivider));
+            _skillsStatusLabel = skillsStatusLabel
+                ?? throw new System.ArgumentNullException(nameof(skillsStatusLabel));
+            _installSkillsButton = installSkillsButton
+                ?? throw new System.ArgumentNullException(nameof(installSkillsButton));
+            _installSkillsButton.clicked += onInstallSkillsClicked
+                ?? throw new System.ArgumentNullException(nameof(onInstallSkillsClicked));
+        }
+
+        internal void ShowChecking(bool shouldUseFirstInstallSkillsUi)
+        {
+            UpdateSkillsStatusLabel("Checking installed skills...");
+            _installSkillsButton.SetEnabled(false);
+            _installSkillsButton.text = "Checking...";
+            ViewDataBinder.SetVisible(_skillsTargetRow, shouldUseFirstInstallSkillsUi);
+            ViewDataBinder.SetVisible(_skillsTargetList, !shouldUseFirstInstallSkillsUi);
+            _skillsTargetList.Clear();
+        }
+
+        internal void Update(
+            bool canManageSkills,
+            List<SkillSetupTargetInfo> targets,
+            bool shouldUseFirstInstallSkillsUi,
+            SkillsTarget selectedTarget,
+            bool groupSkillsUnderUnityCliLoop,
+            bool isInstallingSkills)
+        {
+            _skillsTargetList.Clear();
+            ViewDataBinder.SetVisible(
+                _skillsTargetRow,
+                ShouldShowSkillsTargetRowForSetupWizard(shouldUseFirstInstallSkillsUi));
+            ViewDataBinder.SetVisible(
+                _skillsTargetList,
+                ShouldShowSkillsTargetListForSetupWizard(canManageSkills, shouldUseFirstInstallSkillsUi));
+
+            if (!canManageSkills)
+            {
+                UpdateSkillsStatusLabel(string.Empty);
+                _installSkillsButton.SetEnabled(false);
+                _installSkillsButton.text = GetSkillsButtonTextForSetupWizard(
+                    cliInstalled: false,
+                    isInstallingSkills,
+                    hasOutdatedSkills: false);
+                return;
+            }
+
+            if (shouldUseFirstInstallSkillsUi)
+            {
+                SkillSetupTargetInfo selectedTargetInfo = GetSelectedSkillTargetInfo(
+                    targets,
+                    selectedTarget,
+                    groupSkillsUnderUnityCliLoop);
+                UpdateSkillsStatusLabel(string.Empty);
+                _installSkillsButton.text = CliSetupSection.GetInstallSkillsButtonText(
+                    isCliInstalled: true,
+                    isInstallingSkills,
+                    selectedTargetInfo.InstallState);
+                _installSkillsButton.SetEnabled(CliSetupSection.IsInstallSkillsButtonEnabled(
+                    isCliInstalled: true,
+                    isInstallingSkills,
+                    selectedTargetInfo.InstallState));
+                return;
+            }
+
+            List<SkillSetupTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
+
+            foreach (SkillSetupTargetInfo target in installableTargets)
+            {
+                VisualElement item = new();
+                item.AddToClassList("setup-target-item");
+
+                Label nameLabel = new($"{target.DisplayName} ({target.DirName}/)");
+                nameLabel.AddToClassList("setup-target-item__label");
+                item.Add(nameLabel);
+
+                Label statusLabel = new(GetSkillInstallStatusText(
+                    target.InstallState,
+                    target.HasDifferentLayoutSkills,
+                    groupSkillsUnderUnityCliLoop));
+                statusLabel.AddToClassList("setup-target-item__status");
+                statusLabel.AddToClassList(GetSkillInstallStatusClass(
+                    target.InstallState,
+                    target.HasDifferentLayoutSkills,
+                    groupSkillsUnderUnityCliLoop));
+                item.Add(statusLabel);
+
+                _skillsTargetList.Add(item);
+            }
+
+            if (installableTargets.Count == 0)
+            {
+                UpdateSkillsStatusLabel(
+                    "Create a tool folder to enable skill installation (.claude/, .agents/, etc.)");
+                _installSkillsButton.SetEnabled(false);
+                _installSkillsButton.text = "Install Skills";
+                return;
+            }
+
+            bool isCheckingSkills = installableTargets.Any(
+                t => t.InstallState == SkillInstallState.Checking);
+            if (isCheckingSkills)
+            {
+                UpdateSkillsStatusLabel("Checking installed skills...");
+                _installSkillsButton.SetEnabled(false);
+                _installSkillsButton.text = "Checking...";
+                return;
+            }
+
+            bool allSkillsInstalled = installableTargets.All(
+                t => t.InstallState == SkillInstallState.Installed);
+            if (allSkillsInstalled)
+            {
+                UpdateSkillsStatusLabel($"Installed for {installableTargets.Count} targets");
+                _installSkillsButton.SetEnabled(false);
+                _installSkillsButton.text = "Installed";
+            }
+            else
+            {
+                bool hasOutdatedSkills = installableTargets.Any(
+                    t => t.InstallState == SkillInstallState.Outdated);
+                UpdateSkillsStatusLabel(string.Empty);
+                _installSkillsButton.SetEnabled(!isInstallingSkills);
+                _installSkillsButton.text = GetSkillsButtonTextForSetupWizard(
+                    cliInstalled: true,
+                    isInstallingSkills,
+                    hasOutdatedSkills);
+            }
+        }
+
+        internal static List<SkillSetupTargetInfo> FilterInstallableSkillTargets(
+            IEnumerable<SkillSetupTargetInfo> targets)
+        {
+            Debug.Assert(targets != null, "targets must not be null");
+            return targets
+                .Where(target => target.HasSkillsDirectory)
+                .ToList();
+        }
+
+        internal static bool ShouldShowSkillsTargetRowForSetupWizard(bool shouldUseFirstInstallSkillsUi)
+        {
+            return shouldUseFirstInstallSkillsUi;
+        }
+
+        internal static bool ShouldShowSkillsTargetListForSetupWizard(
+            bool canManageSkills,
+            bool shouldUseFirstInstallSkillsUi)
+        {
+            return canManageSkills && !shouldUseFirstInstallSkillsUi;
+        }
+
+        internal static SkillSetupTargetInfo CreateFirstInstallSkillTarget(
+            SkillsTarget target,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
+                target,
+                groupSkillsUnderUnityCliLoop);
+            return new(
+                selection.DisplayName,
+                selection.DirectoryName,
+                selection.InstallFlag,
+                hasSkillsDirectory: false,
+                hasExistingSkills: false,
+                hasDifferentLayoutSkills: false,
+                SkillInstallState.Missing);
+        }
+
+        internal static SkillSetupTargetInfo GetSelectedSkillTargetInfo(
+            IEnumerable<SkillSetupTargetInfo> targets,
+            SkillsTarget target,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            Debug.Assert(targets != null, "targets must not be null");
+
+            SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
+                target,
+                groupSkillsUnderUnityCliLoop);
+            SkillSetupTargetInfo selectedTargetInfo = targets
+                .FirstOrDefault(info => info.DirName == selection.DirectoryName);
+            return string.IsNullOrEmpty(selectedTargetInfo.DirName)
+                ? CreateFirstInstallSkillTarget(target, groupSkillsUnderUnityCliLoop)
+                : selectedTargetInfo;
+        }
+
+        internal static List<SkillSetupTargetInfo> GetFirstInstallableSkillTargets(
+            IEnumerable<SkillSetupTargetInfo> targets,
+            SkillsTarget target,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            SkillSetupTargetInfo selectedTargetInfo = GetSelectedSkillTargetInfo(
+                targets,
+                target,
+                groupSkillsUnderUnityCliLoop);
+            return selectedTargetInfo.InstallState == SkillInstallState.Installed
+                   || selectedTargetInfo.InstallState == SkillInstallState.Checking
+                ? new List<SkillSetupTargetInfo>()
+                : new List<SkillSetupTargetInfo> { selectedTargetInfo };
+        }
+
+        internal static string GetSkillsButtonTextForSetupWizard(
+            bool cliInstalled,
+            bool isInstallingSkills,
+            bool hasOutdatedSkills)
+        {
+            return !cliInstalled
+                ? "Install Skills"
+                : GetInstallSkillsButtonText(isInstallingSkills, hasOutdatedSkills);
+        }
+
+        internal static string GetInstallSkillsButtonText(
+            bool isInstallingSkills,
+            bool hasOutdatedSkills)
+        {
+            if (isInstallingSkills)
+            {
+                return "Installing...";
+            }
+
+            return hasOutdatedSkills ? "Update Skills" : "Install Skills";
+        }
+
+        internal static string GetSkillInstallStatusText(
+            SkillInstallState installState,
+            bool hasDifferentLayoutSkills,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            if (installState == SkillInstallState.Checking)
+            {
+                return "Checking...";
+            }
+
+            if (installState == SkillInstallState.Installed)
+            {
+                return "Installed";
+            }
+
+            if (installState == SkillInstallState.Outdated)
+            {
+                return "Outdated";
+            }
+
+            if (!hasDifferentLayoutSkills)
+            {
+                return "Missing";
+            }
+
+            return groupSkillsUnderUnityCliLoop ? "Not grouped" : "Grouped";
+        }
+
+        internal static string GetSkillInstallStatusClass(
+            SkillInstallState installState,
+            bool hasDifferentLayoutSkills,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            if (installState == SkillInstallState.Checking)
+            {
+                return "setup-target-item__status--checking";
+            }
+
+            if (installState == SkillInstallState.Installed)
+            {
+                return "setup-target-item__status--installed";
+            }
+
+            if (installState == SkillInstallState.Outdated)
+            {
+                return "setup-target-item__status--outdated";
+            }
+
+            if (!hasDifferentLayoutSkills)
+            {
+                return "setup-target-item__status--missing";
+            }
+
+            return groupSkillsUnderUnityCliLoop
+                ? "setup-target-item__status--different-layout"
+                : "setup-target-item__status--different-layout";
+        }
+
+        private void UpdateSkillsStatusLabel(string text)
+        {
+            _skillsStatusLabel.text = text;
+            bool isVisible = !string.IsNullOrEmpty(text);
+            ViewDataBinder.SetVisible(_skillsStatusDivider, isVisible);
+            ViewDataBinder.SetVisible(_skillsStatusLabel, isVisible);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs.meta
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f22074d3a0cc4d2895895bc150236085
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -199,14 +199,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         // Step 2
         private VisualElement _groupSkillsRow;
-        private VisualElement _skillsTargetRow;
         private EnumField _skillsTargetField;
         private Toggle _groupSkillsToggle;
         private Label _groupSkillsLabel;
-        private VisualElement _skillsTargetList;
-        private VisualElement _skillsStatusDivider;
-        private Label _skillsStatusLabel;
-        private Button _installSkillsButton;
 
         // Footer
         private Toggle _suppressAutoShowToggle;
@@ -217,6 +212,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private Image _githubLinkIcon;
         private ScrollView _mainScrollView;
         private SetupWizardCliStepPresenter _cliStepPresenter;
+        private SetupWizardSkillsStepPresenter _skillsStepPresenter;
 
         // State
         private bool _isInstallingCli;
@@ -311,14 +307,21 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 HandleInstallCli);
 
             _groupSkillsRow = rootVisualElement.Q<VisualElement>("group-skills-row");
-            _skillsTargetRow = rootVisualElement.Q<VisualElement>("skills-target-row");
             _skillsTargetField = rootVisualElement.Q<EnumField>("skills-target-field");
             _groupSkillsToggle = rootVisualElement.Q<Toggle>("group-skills-toggle");
             _groupSkillsLabel = rootVisualElement.Q<Label>("group-skills-label");
-            _skillsTargetList = rootVisualElement.Q<VisualElement>("skills-target-list");
-            _skillsStatusDivider = rootVisualElement.Q<VisualElement>("skills-status-divider");
-            _skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
-            _installSkillsButton = rootVisualElement.Q<Button>("install-skills-button");
+            VisualElement skillsTargetRow = rootVisualElement.Q<VisualElement>("skills-target-row");
+            VisualElement skillsTargetList = rootVisualElement.Q<VisualElement>("skills-target-list");
+            VisualElement skillsStatusDivider = rootVisualElement.Q<VisualElement>("skills-status-divider");
+            Label skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
+            Button installSkillsButton = rootVisualElement.Q<Button>("install-skills-button");
+            _skillsStepPresenter = new SetupWizardSkillsStepPresenter(
+                skillsTargetRow,
+                skillsTargetList,
+                skillsStatusDivider,
+                skillsStatusLabel,
+                installSkillsButton,
+                HandleInstallSkills);
 
             _suppressAutoShowToggle = rootVisualElement.Q<Toggle>("suppress-auto-show-toggle");
             _openSettingsButton = rootVisualElement.Q<Button>("open-settings-button");
@@ -332,7 +335,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void BindEvents()
         {
             _refreshButton.clicked += () => RefreshUI();
-            _installSkillsButton.clicked += HandleInstallSkills;
             InitializeSkillsTargetField();
             InitializeGroupSkillsToggle();
             _suppressAutoShowToggle.RegisterValueChangedCallback(evt => HandleSuppressAutoShowChanged(evt.newValue));
@@ -408,20 +410,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _cliStepPresenter.ShowChecking();
             ViewDataBinder.SetVisible(_groupSkillsRow, false);
             _groupSkillsToggle.SetEnabled(false);
-            UpdateSkillsStatusLabel("Checking installed skills...");
-            _installSkillsButton.SetEnabled(false);
-            _installSkillsButton.text = "Checking...";
-            ViewDataBinder.SetVisible(_skillsTargetRow, _shouldUseFirstInstallSkillsUi);
-            ViewDataBinder.SetVisible(_skillsTargetList, !_shouldUseFirstInstallSkillsUi);
-            _skillsTargetList.Clear();
-        }
-
-        private void UpdateSkillsStatusLabel(string text)
-        {
-            _skillsStatusLabel.text = text;
-            bool isVisible = !string.IsNullOrEmpty(text);
-            ViewDataBinder.SetVisible(_skillsStatusDivider, isVisible);
-            ViewDataBinder.SetVisible(_skillsStatusLabel, isVisible);
+            _skillsStepPresenter.ShowChecking(_shouldUseFirstInstallSkillsUi);
         }
 
         private void ScheduleInitialRefresh()
@@ -453,12 +442,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 ViewDataBinder.SetVisible(_groupSkillsRow, false);
                 _groupSkillsToggle.SetEnabled(false);
-                UpdateSkillsStatusLabel("Checking installed skills...");
-                _installSkillsButton.SetEnabled(false);
-                _installSkillsButton.text = "Checking...";
-                ViewDataBinder.SetVisible(_skillsTargetRow, _shouldUseFirstInstallSkillsUi);
-                ViewDataBinder.SetVisible(_skillsTargetList, !_shouldUseFirstInstallSkillsUi);
-                _skillsTargetList.Clear();
+                _skillsStepPresenter.ShowChecking(_shouldUseFirstInstallSkillsUi);
             }
 
             await Task.Yield();
@@ -545,15 +529,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _skillInstallStateRefreshCts = null;
         }
 
-        internal static List<SkillSetupTargetInfo> FilterInstallableSkillTargets(
-            IEnumerable<SkillSetupTargetInfo> targets)
-        {
-            Debug.Assert(targets != null, "targets must not be null");
-            return targets
-                .Where(target => target.HasSkillsDirectory)
-                .ToList();
-        }
-
         internal static bool ShouldShowSkillsInstalledDialog(
             IEnumerable<SkillSetupTargetInfo> targets)
         {
@@ -571,67 +546,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool CanManageSkills(bool cliInstalled)
         {
             return cliInstalled;
-        }
-
-        internal static bool ShouldShowSkillsTargetRowForSetupWizard(bool shouldUseFirstInstallSkillsUi)
-        {
-            return shouldUseFirstInstallSkillsUi;
-        }
-
-        internal static bool ShouldShowSkillsTargetListForSetupWizard(
-            bool canManageSkills,
-            bool shouldUseFirstInstallSkillsUi)
-        {
-            return canManageSkills && !shouldUseFirstInstallSkillsUi;
-        }
-
-        internal static SkillSetupTargetInfo CreateFirstInstallSkillTarget(
-            SkillsTarget target,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
-                target,
-                groupSkillsUnderUnityCliLoop);
-            return new(
-                selection.DisplayName,
-                selection.DirectoryName,
-                selection.InstallFlag,
-                hasSkillsDirectory: false,
-                hasExistingSkills: false,
-                hasDifferentLayoutSkills: false,
-                SkillInstallState.Missing);
-        }
-
-        internal static SkillSetupTargetInfo GetSelectedSkillTargetInfo(
-            IEnumerable<SkillSetupTargetInfo> targets,
-            SkillsTarget target,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            Debug.Assert(targets != null, "targets must not be null");
-
-            SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
-                target,
-                groupSkillsUnderUnityCliLoop);
-            SkillSetupTargetInfo selectedTargetInfo = targets
-                .FirstOrDefault(info => info.DirName == selection.DirectoryName);
-            return string.IsNullOrEmpty(selectedTargetInfo.DirName)
-                ? CreateFirstInstallSkillTarget(target, groupSkillsUnderUnityCliLoop)
-                : selectedTargetInfo;
-        }
-
-        internal static List<SkillSetupTargetInfo> GetFirstInstallableSkillTargets(
-            IEnumerable<SkillSetupTargetInfo> targets,
-            SkillsTarget target,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            SkillSetupTargetInfo selectedTargetInfo = GetSelectedSkillTargetInfo(
-                targets,
-                target,
-                groupSkillsUnderUnityCliLoop);
-            return selectedTargetInfo.InstallState == SkillInstallState.Installed
-                   || selectedTargetInfo.InstallState == SkillInstallState.Checking
-                ? new List<SkillSetupTargetInfo>()
-                : new List<SkillSetupTargetInfo> { selectedTargetInfo };
         }
 
         private static async Task<bool> ShouldRepairCliPathSetupAsync(CancellationToken ct)
@@ -684,190 +598,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canManageSkills,
             List<SkillSetupTargetInfo> targets)
         {
-            _skillsTargetList.Clear();
-            bool useFirstInstallSkillsUi = _shouldUseFirstInstallSkillsUi;
-            ViewDataBinder.SetVisible(
-                _skillsTargetRow,
-                ShouldShowSkillsTargetRowForSetupWizard(useFirstInstallSkillsUi));
-            ViewDataBinder.SetVisible(
-                _skillsTargetList,
-                ShouldShowSkillsTargetListForSetupWizard(canManageSkills, useFirstInstallSkillsUi));
-
-            if (!canManageSkills)
-            {
-                UpdateSkillsStatusLabel(string.Empty);
-                _installSkillsButton.SetEnabled(false);
-                _installSkillsButton.text = GetSkillsButtonTextForSetupWizard(
-                    cliInstalled: false,
-                    _isInstallingSkills,
-                    hasOutdatedSkills: false);
-                _groupSkillsToggle.SetEnabled(false);
-                return;
-            }
-
-            _groupSkillsToggle.SetEnabled(!_isInstallingSkills);
-
-            if (useFirstInstallSkillsUi)
-            {
-                SkillSetupTargetInfo selectedTargetInfo = GetSelectedSkillTargetInfo(
-                    targets,
-                    _skillsTarget,
-                    !_installSkillsFlat);
-                UpdateSkillsStatusLabel(string.Empty);
-                _installSkillsButton.text = CliSetupSection.GetInstallSkillsButtonText(
-                    isCliInstalled: true,
-                    _isInstallingSkills,
-                    selectedTargetInfo.InstallState);
-                _installSkillsButton.SetEnabled(CliSetupSection.IsInstallSkillsButtonEnabled(
-                    isCliInstalled: true,
-                    _isInstallingSkills,
-                    selectedTargetInfo.InstallState));
-                return;
-            }
-
-            List<SkillSetupTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
-
-            foreach (SkillSetupTargetInfo target in installableTargets)
-            {
-                VisualElement item = new();
-                item.AddToClassList("setup-target-item");
-
-                Label nameLabel = new($"{target.DisplayName} ({target.DirName}/)");
-                nameLabel.AddToClassList("setup-target-item__label");
-                item.Add(nameLabel);
-
-                Label statusLabel = new(GetSkillInstallStatusText(
-                    target.InstallState,
-                    target.HasDifferentLayoutSkills,
-                    !_installSkillsFlat));
-                statusLabel.AddToClassList("setup-target-item__status");
-                statusLabel.AddToClassList(GetSkillInstallStatusClass(
-                    target.InstallState,
-                    target.HasDifferentLayoutSkills,
-                    !_installSkillsFlat));
-                item.Add(statusLabel);
-
-                _skillsTargetList.Add(item);
-            }
-
-            if (installableTargets.Count == 0)
-            {
-                UpdateSkillsStatusLabel(
-                    "Create a tool folder to enable skill installation (.claude/, .agents/, etc.)");
-                _installSkillsButton.SetEnabled(false);
-                _installSkillsButton.text = "Install Skills";
-                return;
-            }
-
-            bool isCheckingSkills = installableTargets.Any(
-                t => t.InstallState == SkillInstallState.Checking);
-            if (isCheckingSkills)
-            {
-                UpdateSkillsStatusLabel("Checking installed skills...");
-                _installSkillsButton.SetEnabled(false);
-                _installSkillsButton.text = "Checking...";
-                return;
-            }
-
-            bool allSkillsInstalled = installableTargets.All(
-                t => t.InstallState == SkillInstallState.Installed);
-            if (allSkillsInstalled)
-            {
-                UpdateSkillsStatusLabel($"Installed for {installableTargets.Count} targets");
-                _installSkillsButton.SetEnabled(false);
-                _installSkillsButton.text = "Installed";
-            }
-            else
-            {
-                bool hasOutdatedSkills = installableTargets.Any(
-                    t => t.InstallState == SkillInstallState.Outdated);
-                UpdateSkillsStatusLabel(string.Empty);
-                _installSkillsButton.SetEnabled(!_isInstallingSkills);
-                _installSkillsButton.text = GetSkillsButtonTextForSetupWizard(
-                    cliInstalled: true,
-                    _isInstallingSkills,
-                    hasOutdatedSkills);
-            }
-        }
-
-        internal static string GetSkillsButtonTextForSetupWizard(
-            bool cliInstalled,
-            bool isInstallingSkills,
-            bool hasOutdatedSkills)
-        {
-            return !cliInstalled
-                ? "Install Skills"
-                : GetInstallSkillsButtonText(isInstallingSkills, hasOutdatedSkills);
-        }
-
-        internal static string GetInstallSkillsButtonText(
-            bool isInstallingSkills,
-            bool hasOutdatedSkills)
-        {
-            if (isInstallingSkills)
-            {
-                return "Installing...";
-            }
-
-            return hasOutdatedSkills ? "Update Skills" : "Install Skills";
-        }
-
-        internal static string GetSkillInstallStatusText(
-            SkillInstallState installState,
-            bool hasDifferentLayoutSkills,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            if (installState == SkillInstallState.Checking)
-            {
-                return "Checking...";
-            }
-
-            if (installState == SkillInstallState.Installed)
-            {
-                return "Installed";
-            }
-
-            if (installState == SkillInstallState.Outdated)
-            {
-                return "Outdated";
-            }
-
-            if (!hasDifferentLayoutSkills)
-            {
-                return "Missing";
-            }
-
-            return groupSkillsUnderUnityCliLoop ? "Not grouped" : "Grouped";
-        }
-
-        internal static string GetSkillInstallStatusClass(
-            SkillInstallState installState,
-            bool hasDifferentLayoutSkills,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            if (installState == SkillInstallState.Checking)
-            {
-                return "setup-target-item__status--checking";
-            }
-
-            if (installState == SkillInstallState.Installed)
-            {
-                return "setup-target-item__status--installed";
-            }
-
-            if (installState == SkillInstallState.Outdated)
-            {
-                return "setup-target-item__status--outdated";
-            }
-
-            if (!hasDifferentLayoutSkills)
-            {
-                return "setup-target-item__status--missing";
-            }
-
-            return groupSkillsUnderUnityCliLoop
-                ? "setup-target-item__status--different-layout"
-                : "setup-target-item__status--different-layout";
+            _groupSkillsToggle.SetEnabled(canManageSkills && !_isInstallingSkills);
+            _skillsStepPresenter.Update(
+                canManageSkills,
+                targets,
+                _shouldUseFirstInstallSkillsUi,
+                _skillsTarget,
+                !_installSkillsFlat,
+                _isInstallingSkills);
         }
 
         private async void HandleInstallCli()
@@ -998,8 +736,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             List<SkillSetupTargetInfo> targets = DetectDisplayedSkillTargets(projectRoot);
             List<SkillSetupTargetInfo> installableTargets = _shouldUseFirstInstallSkillsUi
-                ? GetFirstInstallableSkillTargets(targets, _skillsTarget, !_installSkillsFlat)
-                : FilterInstallableSkillTargets(targets);
+                ? SetupWizardSkillsStepPresenter.GetFirstInstallableSkillTargets(
+                    targets,
+                    _skillsTarget,
+                    !_installSkillsFlat)
+                : SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
             if (installableTargets.Count == 0) return;
 
             bool shouldShowSkillsInstalledDialog = ShouldShowSkillsInstalledDialog(installableTargets);


### PR DESCRIPTION
## Summary

Extract `SetupWizardSkillsStepPresenter` from `SetupWizardWindow` so the setup wizard skills step rendering is isolated from window orchestration.

## User Impact

No behavior change intended. The setup wizard should render the skills target/status/install controls exactly as before.

## Changes

- Added `SetupWizardSkillsStepPresenter` for the skills step target row/list, status label/divider, and install button.
- Kept `SkillSetupUseCase`, async target refresh, async install flow, success dialog decision, first-install mode decision, and CLI-to-skills manageability policy on `SetupWizardWindow`.
- Kept `group-skills-row`, `group-skills-toggle`, and `group-skills-label` on `SetupWizardWindow` because they mutate window state/settings rather than only render.
- Retargeted skills-step display helper tests from `SetupWizardWindow` to `SetupWizardSkillsStepPresenter`.

## Checking-State Mapping

The old skills checking block appeared in `ApplyInitialCheckingState` and `RefreshUI` with the same behavior split:

- `ViewDataBinder.SetVisible(_groupSkillsRow, false)` remains in `SetupWizardWindow`.
- `_groupSkillsToggle.SetEnabled(false)` remains in `SetupWizardWindow`.
- `UpdateSkillsStatusLabel("Checking installed skills...")` moved into `SetupWizardSkillsStepPresenter.ShowChecking(...)`.
- `_installSkillsButton.SetEnabled(false)` moved into `SetupWizardSkillsStepPresenter.ShowChecking(...)`.
- `_installSkillsButton.text = "Checking..."` moved into `SetupWizardSkillsStepPresenter.ShowChecking(...)`.
- target row/list visibility moved into `SetupWizardSkillsStepPresenter.ShowChecking(...)`.
- target list clearing moved into `SetupWizardSkillsStepPresenter.ShowChecking(...)`.

## Deviations

- The install-skills button click binding moved from `SetupWizardWindow.BindEvents` to the presenter constructor, matching the CLI presenter pattern.
- `UpdateSkillsStatusLabel` is now a private presenter helper.
- `_groupSkillsToggle.SetEnabled(canManageSkills && !_isInstallingSkills)` remains in `SetupWizardWindow` and is placed immediately before `SetupWizardSkillsStepPresenter.Update(...)` so the group-setting control stays window-owned.
- `ShowChecking` takes `shouldUseFirstInstallSkillsUi` so presenter rendering stays parameterized by window-owned state.

## Verification

- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.SetupWizardWindowTests"` -> 110 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

