### PR TITLE
chore: Keep settings CLI setup data separate from the window

### DIFF
--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -1,0 +1,107 @@
+using System;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Presents the CLI setup section in the Unity CLI Loop settings window.
+    /// </summary>
+    internal sealed class UnityCliLoopSettingsCliSetupPresenter
+    {
+        private readonly UnityCliLoopSettingsWindowUI _view;
+        private readonly CliSetupApplicationService _cliSetupApplicationService;
+
+        internal UnityCliLoopSettingsCliSetupPresenter(
+            UnityCliLoopSettingsWindowUI view,
+            CliSetupApplicationService cliSetupApplicationService)
+        {
+            Debug.Assert(view != null, "view must not be null");
+            Debug.Assert(cliSetupApplicationService != null, "cliSetupApplicationService must not be null");
+
+            _view = view ?? throw new ArgumentNullException(nameof(view));
+            _cliSetupApplicationService = cliSetupApplicationService
+                ?? throw new ArgumentNullException(nameof(cliSetupApplicationService));
+        }
+
+        internal void Update(
+            bool needsCliPathSetup,
+            bool isInstallingCli,
+            bool isRefreshingVersion,
+            bool isRefreshingCliPathSetup,
+            bool includeSkillDirectoryChecks,
+            bool installSkillsFlat,
+            SkillInstallState selectedTargetInstallState,
+            SkillsTarget skillsTarget,
+            bool isInstallingSkills)
+        {
+            CliSetupData cliData = CreateCliSetupData(
+                needsCliPathSetup,
+                isInstallingCli,
+                isRefreshingVersion,
+                isRefreshingCliPathSetup,
+                includeSkillDirectoryChecks,
+                installSkillsFlat,
+                selectedTargetInstallState,
+                skillsTarget,
+                isInstallingSkills);
+            _view.UpdateCliSetup(cliData);
+        }
+
+        private CliSetupData CreateCliSetupData(
+            bool needsCliPathSetup,
+            bool isInstallingCli,
+            bool isRefreshingVersion,
+            bool isRefreshingCliPathSetup,
+            bool includeSkillDirectoryChecks,
+            bool installSkillsFlat,
+            SkillInstallState selectedTargetInstallState,
+            SkillsTarget skillsTarget,
+            bool isInstallingSkills)
+        {
+            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
+            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
+            string cliExecutablePath = _cliSetupApplicationService.GetCachedCliExecutablePath();
+            string requiredCliVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
+
+            bool isCliInstalled = cliVersion != null || needsCliPathSetup;
+            bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
+                cliExecutablePath,
+                UnityEngine.Application.platform);
+            bool isChecking = !_cliSetupApplicationService.IsCliCheckCompleted()
+                || isRefreshingVersion
+                || isRefreshingCliPathSetup
+                || !includeSkillDirectoryChecks;
+            CliSetupCompatibilityState state = CliSetupCompatibility.Evaluate(
+                cliVersion,
+                cliIsDispatcher,
+                requiredCliVersion);
+            bool groupSkillsUnderUnityCliLoop = !installSkillsFlat;
+            SkillInstallState displayedTargetInstallState = includeSkillDirectoryChecks
+                ? selectedTargetInstallState
+                : SkillInstallState.Checking;
+
+            return new CliSetupData(
+                isCliInstalled,
+                cliVersion,
+                requiredCliVersion,
+                state.NeedsUpdate,
+                canUninstallCli,
+                needsCliPathSetup,
+                isInstallingCli,
+                isChecking,
+                isClaudeSkillsInstalled: false,
+                isAgentsSkillsInstalled: false,
+                isCursorSkillsInstalled: false,
+                isGeminiSkillsInstalled: false,
+                isCodexSkillsInstalled: false,
+                isAntigravitySkillsInstalled: false,
+                displayedTargetInstallState,
+                skillsTarget,
+                groupSkillsUnderUnityCliLoop,
+                isInstallingSkills);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs.meta
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4b2d4b856eb4d8a90588038353dfd8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -33,6 +33,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private UnityCliLoopSettingsWindowUI _view;
         private UnityCliLoopSettingsModel _model;
         private UnityCliLoopSettingsWindowEventHandler _eventHandler;
+        private UnityCliLoopSettingsCliSetupPresenter _cliSetupPresenter;
         private SkillSetupUseCase _skillSetupUseCase;
         private ToolSettingsUseCase _toolSettingsUseCase;
         private IUnityCliLoopEditorSettingsPort _editorSettingsPort;
@@ -110,6 +111,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             CancelSkillInstallStateRefresh();
             _view?.Dispose();
             _view = null;
+            _cliSetupPresenter = null;
         }
 
         private void CreateGUI()
@@ -149,6 +151,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void InitializeView()
         {
             _view = new UnityCliLoopSettingsWindowUI(rootVisualElement);
+            _cliSetupPresenter = new UnityCliLoopSettingsCliSetupPresenter(
+                _view,
+                _cliSetupApplicationService);
             SetupViewCallbacks();
         }
 
@@ -223,6 +228,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             SaveSessionState();
             _view?.Dispose();
             _view = null;
+            _cliSetupPresenter = null;
         }
 
         private void CleanupEventHandler()
@@ -622,63 +628,21 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void RefreshCliSetupSection(bool includeSkillDirectoryChecks = true)
         {
-            if (_view == null)
+            if (_cliSetupPresenter == null)
             {
                 return;
             }
 
-            CliSetupData cliData = CreateCliSetupData(includeSkillDirectoryChecks);
-            _view.UpdateCliSetup(cliData);
-        }
-
-        private CliSetupData CreateCliSetupData(bool includeSkillDirectoryChecks = true)
-        {
-            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
-            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
-            string cliExecutablePath = _cliSetupApplicationService.GetCachedCliExecutablePath();
-            string requiredCliVersion = GetMinimumRequiredCliVersion();
-
-            bool isCliInstalled = cliVersion != null || _needsCliPathSetup;
-            bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
-                cliExecutablePath,
-                UnityEngine.Application.platform);
-            bool isChecking = !_cliSetupApplicationService.IsCliCheckCompleted()
-                || _isRefreshingVersion
-                || _isRefreshingCliPathSetup
-                || !includeSkillDirectoryChecks;
-            CliSetupCompatibilityState state = CliSetupCompatibility.Evaluate(
-                cliVersion,
-                cliIsDispatcher,
-                requiredCliVersion);
-            bool groupSkillsUnderUnityCliLoop = !_installSkillsFlat;
-            SkillInstallState selectedTargetInstallState = includeSkillDirectoryChecks
-                ? _selectedTargetInstallState
-                : SkillInstallState.Checking;
-
-            return new CliSetupData(
-                isCliInstalled,
-                cliVersion,
-                requiredCliVersion,
-                state.NeedsUpdate,
-                canUninstallCli,
+            _cliSetupPresenter.Update(
                 _needsCliPathSetup,
                 _isInstallingCli,
-                isChecking,
-                isClaudeSkillsInstalled: false,
-                isAgentsSkillsInstalled: false,
-                isCursorSkillsInstalled: false,
-                isGeminiSkillsInstalled: false,
-                isCodexSkillsInstalled: false,
-                isAntigravitySkillsInstalled: false,
-                selectedTargetInstallState,
+                _isRefreshingVersion,
+                _isRefreshingCliPathSetup,
+                includeSkillDirectoryChecks,
+                _installSkillsFlat,
+                _selectedTargetInstallState,
                 _skillsTarget,
-                groupSkillsUnderUnityCliLoop,
                 _isInstallingSkills);
-        }
-
-        private static string GetMinimumRequiredCliVersion()
-        {
-            return GetCliSetupApplicationService().GetMinimumRequiredCliVersion();
         }
 
         private bool ShouldCheckCliPathSetup()


### PR DESCRIPTION
## Summary

Extract `UnityCliLoopSettingsCliSetupPresenter` from `UnityCliLoopSettingsWindow` so Settings CLI setup data assembly is separate from window orchestration.

## User Impact

No behavior change intended. The Settings window should render the same CLI setup state through the existing `CliSetupSection` UI component.

## Changes

- Added `UnityCliLoopSettingsCliSetupPresenter` to build `CliSetupData` and call `UnityCliLoopSettingsWindowUI.UpdateCliSetup(...)`.
- Kept async orchestration, install/uninstall/repair side effects, skill state refresh, and settings mutation in `UnityCliLoopSettingsWindow`.
- Kept CLI primary-action helpers on `UnityCliLoopSettingsWindow` so the existing `TestCliPinReader` seam remains unchanged.
- Left `CliSetupSection` and `CliSetupSectionTests` unchanged because actual UI rendering helpers already live there.

## Checking-State Mapping

Settings has no duplicated UI checking block like the Setup Wizard slices. The moved state is the single `isChecking` expression from `CreateCliSetupData`:

- old: `!_cliSetupApplicationService.IsCliCheckCompleted() || _isRefreshingVersion || _isRefreshingCliPathSetup || !includeSkillDirectoryChecks`
- new: `!_cliSetupApplicationService.IsCliCheckCompleted() || isRefreshingVersion || isRefreshingCliPathSetup || !includeSkillDirectoryChecks`

Actual status/button rendering remains in `CliSetupSection`.

## Deviations

- The old `_view == null` guard remains in the window wrapper as `_cliSetupPresenter == null`, preserving the silent no-op path when async continuations complete before UI construction or after teardown.
- `GetMinimumRequiredCliVersion()` inside data creation became `_cliSetupApplicationService.GetMinimumRequiredCliVersion()` on the injected service instance. Production uses the same service instance; `UnityCliLoopSettingsWindowCliActionTests` keep the static window helper seam and are not retargeted.
- The presenter receives explicit window-owned state parameters rather than storing window state.

## Verification

- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopSettingsWindowCliActionTests"` -> 40 passed
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.CliSetupSectionTests"` -> 33 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

