### PR TITLE
chore: Extract settings Tool Settings presenter

### DIFF
--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsToolSettingsPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsToolSettingsPresenter.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Presents the Tool Settings section in the Unity CLI Loop settings window.
+    /// </summary>
+    internal sealed class UnityCliLoopSettingsToolSettingsPresenter
+    {
+        private readonly UnityCliLoopSettingsWindowUI _view;
+        private readonly ToolSettingsUseCase _toolSettingsUseCase;
+
+        internal UnityCliLoopSettingsToolSettingsPresenter(
+            UnityCliLoopSettingsWindowUI view,
+            ToolSettingsUseCase toolSettingsUseCase)
+        {
+            Debug.Assert(view != null, "view must not be null");
+            Debug.Assert(toolSettingsUseCase != null, "toolSettingsUseCase must not be null");
+
+            _view = view ?? throw new ArgumentNullException(nameof(view));
+            _toolSettingsUseCase = toolSettingsUseCase
+                ?? throw new ArgumentNullException(nameof(toolSettingsUseCase));
+        }
+
+        internal void UpdateHeader(bool showToolSettings)
+        {
+            ToolSettingsSectionData toolSettingsData = CreateToolSettingsHeaderData(showToolSettings);
+            _view.UpdateToolSettings(toolSettingsData);
+        }
+
+        internal ToolSettingsSectionData UpdateCatalog(bool showToolSettings)
+        {
+            ToolSettingsSectionData toolSettingsData = CreateToolSettingsData(showToolSettings);
+            _view.UpdateToolSettings(toolSettingsData);
+            return toolSettingsData;
+        }
+
+        private static ToolSettingsSectionData CreateToolSettingsHeaderData(bool showToolSettings)
+        {
+            return new ToolSettingsSectionData(
+                showToolSettings,
+                System.Array.Empty<ToolToggleItem>(),
+                System.Array.Empty<ToolToggleItem>(),
+                true,
+                false);
+        }
+
+        private ToolSettingsSectionData CreateToolSettingsData(bool showToolSettings)
+        {
+            bool isRegistryAvailable =
+                _toolSettingsUseCase.TryGetToolCatalog(
+                    out ToolSettingsUseCase.ToolCatalogItem[] allTools);
+            if (!isRegistryAvailable)
+            {
+                return new ToolSettingsSectionData(
+                    showToolSettings,
+                    System.Array.Empty<ToolToggleItem>(),
+                    System.Array.Empty<ToolToggleItem>(),
+                    false,
+                    true);
+            }
+
+            List<ToolToggleItem> builtIn = new();
+            List<ToolToggleItem> thirdParty = new();
+
+            foreach (ToolSettingsUseCase.ToolCatalogItem tool in allTools)
+            {
+                if (tool.DisplayDevelopmentOnly)
+                {
+                    continue;
+                }
+
+                bool isEnabled = _toolSettingsUseCase.IsToolEnabled(tool.Name);
+                bool isThirdPartyTool = tool.IsThirdParty;
+
+                ToolToggleItem item = new(
+                    tool.Name,
+                    isEnabled,
+                    isThirdPartyTool,
+                    tool.SkillDescription);
+                if (isThirdPartyTool)
+                {
+                    thirdParty.Add(item);
+                }
+                else
+                {
+                    builtIn.Add(item);
+                }
+            }
+
+            Comparison<ToolToggleItem> compareByName = (a, b) => string.Compare(a.ToolName, b.ToolName, StringComparison.Ordinal);
+            builtIn.Sort(compareByName);
+            thirdParty.Sort(compareByName);
+
+            return new ToolSettingsSectionData(
+                showToolSettings,
+                builtIn.ToArray(),
+                thirdParty.ToArray(),
+                true,
+                true);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsToolSettingsPresenter.cs.meta
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsToolSettingsPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bb61fea5e374bf6b04864bf7e93cd25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -34,6 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private UnityCliLoopSettingsModel _model;
         private UnityCliLoopSettingsWindowEventHandler _eventHandler;
         private UnityCliLoopSettingsCliSetupPresenter _cliSetupPresenter;
+        private UnityCliLoopSettingsToolSettingsPresenter _toolSettingsPresenter;
         private SkillSetupUseCase _skillSetupUseCase;
         private ToolSettingsUseCase _toolSettingsUseCase;
         private IUnityCliLoopEditorSettingsPort _editorSettingsPort;
@@ -112,6 +113,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _view?.Dispose();
             _view = null;
             _cliSetupPresenter = null;
+            _toolSettingsPresenter = null;
         }
 
         private void CreateGUI()
@@ -154,6 +156,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _cliSetupPresenter = new UnityCliLoopSettingsCliSetupPresenter(
                 _view,
                 _cliSetupApplicationService);
+            _toolSettingsPresenter = new UnityCliLoopSettingsToolSettingsPresenter(
+                _view,
+                _toolSettingsUseCase);
             SetupViewCallbacks();
         }
 
@@ -229,6 +234,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _view?.Dispose();
             _view = null;
             _cliSetupPresenter = null;
+            _toolSettingsPresenter = null;
         }
 
         private void CleanupEventHandler()
@@ -408,14 +414,23 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void RefreshToolSettingsHeader()
         {
-            ToolSettingsSectionData toolSettingsData = CreateToolSettingsHeaderData();
-            _view.UpdateToolSettings(toolSettingsData);
+            if (_toolSettingsPresenter == null)
+            {
+                return;
+            }
+
+            _toolSettingsPresenter.UpdateHeader(_model.UI.ShowToolSettings);
         }
 
         private void RefreshToolSettingsCatalog()
         {
-            ToolSettingsSectionData toolSettingsData = CreateToolSettingsData();
-            _view.UpdateToolSettings(toolSettingsData);
+            if (_toolSettingsPresenter == null)
+            {
+                return;
+            }
+
+            ToolSettingsSectionData toolSettingsData =
+                _toolSettingsPresenter.UpdateCatalog(_model.UI.ShowToolSettings);
 
             if (UnityCliLoopSettingsWindowRefreshPolicy.ShouldKeepToolSettingsCatalogDirty(toolSettingsData))
             {
@@ -447,71 +462,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             RefreshToolSettingsCatalog();
-        }
-
-        private ToolSettingsSectionData CreateToolSettingsHeaderData()
-        {
-            return new ToolSettingsSectionData(
-                _model.UI.ShowToolSettings,
-                System.Array.Empty<ToolToggleItem>(),
-                System.Array.Empty<ToolToggleItem>(),
-                true,
-                false);
-        }
-
-        private ToolSettingsSectionData CreateToolSettingsData()
-        {
-            bool isRegistryAvailable =
-                _toolSettingsUseCase.TryGetToolCatalog(
-                    out ToolSettingsUseCase.ToolCatalogItem[] allTools);
-            if (!isRegistryAvailable)
-            {
-                return new ToolSettingsSectionData(
-                    _model.UI.ShowToolSettings,
-                    System.Array.Empty<ToolToggleItem>(),
-                    System.Array.Empty<ToolToggleItem>(),
-                    false,
-                    true);
-            }
-
-            List<ToolToggleItem> builtIn = new();
-            List<ToolToggleItem> thirdParty = new();
-
-            foreach (ToolSettingsUseCase.ToolCatalogItem tool in allTools)
-            {
-                if (tool.DisplayDevelopmentOnly)
-                {
-                    continue;
-                }
-
-                bool isEnabled = _toolSettingsUseCase.IsToolEnabled(tool.Name);
-                bool isThirdPartyTool = tool.IsThirdParty;
-
-                ToolToggleItem item = new(
-                    tool.Name,
-                    isEnabled,
-                    isThirdPartyTool,
-                    tool.SkillDescription);
-                if (isThirdPartyTool)
-                {
-                    thirdParty.Add(item);
-                }
-                else
-                {
-                    builtIn.Add(item);
-                }
-            }
-
-            Comparison<ToolToggleItem> compareByName = (a, b) => string.Compare(a.ToolName, b.ToolName, StringComparison.Ordinal);
-            builtIn.Sort(compareByName);
-            thirdParty.Sort(compareByName);
-
-            return new ToolSettingsSectionData(
-                _model.UI.ShowToolSettings,
-                builtIn.ToArray(),
-                thirdParty.ToArray(),
-                true,
-                true);
         }
 
         private void UpdateShowToolSettings(bool show)


### PR DESCRIPTION
## Summary
- Extract `UnityCliLoopSettingsToolSettingsPresenter` for Settings Tool Settings section data assembly.
- Keep dirty catalog state, registry warmup scheduling, model updates, and tool toggle side effects in `UnityCliLoopSettingsWindow`.
- Treat the Settings Skills slice as no-op because PR #1566 already moved Skills display data through `UnityCliLoopSettingsCliSetupPresenter`; the remaining Skills code is async orchestration and side effects.

## User Impact
- No intended behavior change. Tool Settings header, loading, unavailable, and loaded list data are built from the same inputs and passed to the same UI section.

## Deviations
- `UpdateCatalog` updates the view and returns `ToolSettingsSectionData` so the window can keep `ShouldKeepToolSettingsCatalogDirty` and warmup policy unchanged. This is the approved minimal deviation from a pure void presenter update.
- `showToolSettings` is parameterized instead of reading `_model.UI.ShowToolSettings` directly inside the moved code.
- No new presenter-specific tests were added because constructing `UnityCliLoopSettingsWindowUI` just for the presenter would make the seam heavier than the moved logic; existing `ToolSettingsSectionTests` and `UnityCliLoopSettingsWindowRefreshPolicyTests` continue to pin the UI and dirty/warmup seams.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ToolSettingsSectionTests"` -> 11/11 passed
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ToolSettingsUseCaseTests"` -> 3/3 passed
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopSettingsWindowRefreshPolicyTests"` -> 30/30 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

