### PR TITLE
chore: Simplify skill install status styling

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -854,21 +854,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(shouldShowDialog, Is.False);
         }
 
-        [TestCase(SkillInstallState.Installed, false, true, "setup-target-item__status--installed")]
-        [TestCase(SkillInstallState.Checking, false, true, "setup-target-item__status--checking")]
-        [TestCase(SkillInstallState.Outdated, false, true, "setup-target-item__status--outdated")]
-        [TestCase(SkillInstallState.Missing, false, true, "setup-target-item__status--missing")]
-        [TestCase(SkillInstallState.Missing, true, true, "setup-target-item__status--different-layout")]
+        [TestCase(SkillInstallState.Installed, false, "setup-target-item__status--installed")]
+        [TestCase(SkillInstallState.Checking, false, "setup-target-item__status--checking")]
+        [TestCase(SkillInstallState.Outdated, false, "setup-target-item__status--outdated")]
+        [TestCase(SkillInstallState.Missing, false, "setup-target-item__status--missing")]
+        [TestCase(SkillInstallState.Missing, true, "setup-target-item__status--different-layout")]
         public void GetSkillInstallStatusClass_ReturnsExpectedClass(
             SkillInstallState installState,
             bool hasDifferentLayoutSkills,
-            bool groupSkillsUnderUnityCliLoop,
             string expectedClass)
         {
+            // Verifies that each skill install state maps to the expected status style class.
             string className = SetupWizardSkillsStepPresenter.GetSkillInstallStatusClass(
                 installState,
-                hasDifferentLayoutSkills,
-                groupSkillsUnderUnityCliLoop);
+                hasDifferentLayoutSkills);
 
             Assert.That(className, Is.EqualTo(expectedClass));
         }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs
@@ -120,8 +120,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 statusLabel.AddToClassList("setup-target-item__status");
                 statusLabel.AddToClassList(GetSkillInstallStatusClass(
                     target.InstallState,
-                    target.HasDifferentLayoutSkills,
-                    groupSkillsUnderUnityCliLoop));
+                    target.HasDifferentLayoutSkills));
                 item.Add(statusLabel);
 
                 _skillsTargetList.Add(item);
@@ -289,8 +288,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal static string GetSkillInstallStatusClass(
             SkillInstallState installState,
-            bool hasDifferentLayoutSkills,
-            bool groupSkillsUnderUnityCliLoop)
+            bool hasDifferentLayoutSkills)
         {
             if (installState == SkillInstallState.Checking)
             {
@@ -312,9 +310,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return "setup-target-item__status--missing";
             }
 
-            return groupSkillsUnderUnityCliLoop
-                ? "setup-target-item__status--different-layout"
-                : "setup-target-item__status--different-layout";
+            return "setup-target-item__status--different-layout";
         }
 
         private void UpdateSkillsStatusLabel(string text)


### PR DESCRIPTION
## Summary
- Keep setup skill status styling behavior unchanged while simplifying the internal class mapping.
- Remove a dead layout grouping parameter from the status class helper.

## User Impact
- No visible behavior changes. Grouped and ungrouped layout mismatches continue to use the same warning style, while the label text still distinguishes the direction.

## Changes
- Replace the redundant identical-branch status class conditional with a single layout-mismatch return.
- Update the setup wizard test to match the simplified helper signature and document the class mapping behavior.

## Verification
- dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)" -> 0 errors / 0 warnings
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.SetupWizardWindowTests" -> 110 passed