### PR TITLE
chore: Simplify Settings CLI action checks

### DIFF
--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -1,11 +1,8 @@
 using NUnit.Framework;
 using UnityEngine;
 
-using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.Domain;
-using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.Presentation;
-using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -14,21 +11,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public class UnityCliLoopSettingsWindowCliActionTests
     {
-        private const string TestProjectRunnerVersion = "3.0.0";
         private const string TestMinimumDispatcherVersion = "3.0.0";
-
-        [SetUp]
-        public void SetUp()
-        {
-            RegisterCliSetupService(new TestCliPinReader(TestMinimumDispatcherVersion));
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            CliPinReaderService cliPinReaderService = new();
-            RegisterCliSetupService(cliPinReaderService);
-        }
 
         [TestCase(null, false, true, false)]
         [TestCase("2.9.0", false, true, false)]
@@ -47,7 +30,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool result = UnityCliLoopSettingsWindow.ShouldUninstallCliFromPrimaryButton(
                 cliVersion,
                 cliIsDispatcher,
-                canUninstallCli);
+                canUninstallCli,
+                TestMinimumDispatcherVersion);
 
             Assert.That(result, Is.EqualTo(expected));
         }
@@ -90,7 +74,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     needsCliPathSetup,
                     cliVersion,
                     cliIsDispatcher,
-                    canUninstallCli);
+                    canUninstallCli,
+                    TestMinimumDispatcherVersion);
 
             Assert.That(result.ToString(), Is.EqualTo(expected));
         }
@@ -146,7 +131,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool expected)
         {
             // Verifies that the settings UI updates non-dispatcher or older dispatcher installs.
-            bool result = UnityCliLoopSettingsWindow.IsCliUpdateNeeded(cliVersion, cliIsDispatcher);
+            bool result = UnityCliLoopSettingsWindow.IsCliUpdateNeeded(
+                cliVersion,
+                cliIsDispatcher,
+                TestMinimumDispatcherVersion);
 
             Assert.That(result, Is.EqualTo(expected));
         }
@@ -185,93 +173,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             return (CliSetupPrimaryAction)
                 System.Enum.Parse(typeof(CliSetupPrimaryAction), action);
-        }
-
-        private static void RegisterCliSetupService(ICliPinReader cliPinReader)
-        {
-            IUnityCliLoopEditorSettingsPort editorSettingsPort =
-                UnityCliLoopEditorSettingsTestFactory.CreatePortWithRepository(
-                    out UnityCliLoopEditorSettingsRepository _);
-            ISessionFlagsRepository sessionFlagsRepository =
-                UnityCliLoopEditorSessionStateTestFactory.CreateSessionFlagsRepository();
-            UnityCliLoopSettingsWindow.InitializeEditorServices(
-                editorSettingsPort,
-                sessionFlagsRepository,
-                new UnityCliLoopServerApplicationService(new TestServerController()),
-                new CliSetupApplicationService(
-                    new CliInstallationDetector(cliPinReader),
-                    new NativeCliInstallerService(),
-                    cliPinReader),
-                CreateToolSettingsUseCase(),
-                CreateSkillSetupUseCase());
-        }
-
-        private static ToolSettingsUseCase CreateToolSettingsUseCase()
-        {
-            IToolSettingsPort toolSettingsPort = new ToolSettingsRepository();
-            UnityCliLoopToolRegistrarService toolRegistrarService =
-                UnityCliLoopToolRegistrarTestFactory.Create(() => System.Array.Empty<IUnityCliLoopTool>());
-            return new ToolSettingsUseCase(
-                toolSettingsPort,
-                toolRegistrarService,
-                new SkillInstallLayoutToolSkillDescriptionProvider());
-        }
-
-        private static SkillSetupUseCase CreateSkillSetupUseCase()
-        {
-            return new SkillSetupUseCase(new ToolSkillSetupService(new ToolSettingsRepository()));
-        }
-
-        private sealed class TestCliPinReader : ICliPinReader
-        {
-            private readonly string _minimumDispatcherVersion;
-
-            public TestCliPinReader(string minimumDispatcherVersion)
-            {
-                _minimumDispatcherVersion = minimumDispatcherVersion;
-            }
-
-            public CliPinLoadResult LoadPackagePin()
-            {
-                return CliPinLoadResult.FromSuccess(
-                    new CliPin(TestProjectRunnerVersion, _minimumDispatcherVersion));
-            }
-
-            public string LoadMinimumDispatcherVersionOrThrow()
-            {
-                return _minimumDispatcherVersion;
-            }
-        }
-
-        private sealed class TestServerController : IUnityCliLoopServerController
-        {
-            public bool IsServerRunning => false;
-
-            public System.Threading.Tasks.Task RecoveryTask => System.Threading.Tasks.Task.CompletedTask;
-
-            public void StartServer()
-            {
-            }
-
-            public void StopServer()
-            {
-            }
-
-            public void AddServerStateChangedHandler(System.Action handler)
-            {
-            }
-
-            public void RemoveServerStateChangedHandler(System.Action handler)
-            {
-            }
-
-            public void AddServerStartedHandler(System.Action handler)
-            {
-            }
-
-            public void RemoveServerStartedHandler(System.Action handler)
-            {
-            }
         }
     }
 }

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -779,20 +779,23 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
                 cliExecutablePath,
                 UnityEngine.Application.platform);
+            string requiredCliVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
             return ResolveCliPrimaryButtonAction(
                 _needsCliPathSetup,
                 cliVersion,
                 cliIsDispatcher,
-                canUninstallCli);
+                canUninstallCli,
+                requiredCliVersion);
         }
 
         internal static bool ShouldUninstallCliFromPrimaryButton(
             string cliVersion,
             bool cliIsDispatcher,
-            bool canUninstallCli)
+            bool canUninstallCli,
+            string requiredCliVersion)
         {
             bool isCliInstalled = cliVersion != null;
-            bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher);
+            bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
             return CliSetupPrimaryActionPolicy.ShouldUninstallCli(
                 isCliInstalled,
                 needsUpdate,
@@ -803,9 +806,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsCliPathSetup,
             string cliVersion,
             bool cliIsDispatcher,
-            bool canUninstallCli)
+            bool canUninstallCli,
+            string requiredCliVersion)
         {
-            bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher);
+            bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
             bool isCliInstalled = cliVersion != null;
             return CliSetupPrimaryActionPolicy.ResolveSettingsPrimaryAction(
                 needsCliPathSetup,
@@ -881,9 +885,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
         }
 
-        internal static bool IsCliUpdateNeeded(string cliVersion, bool cliIsDispatcher)
+        internal static bool IsCliUpdateNeeded(
+            string cliVersion,
+            bool cliIsDispatcher,
+            string requiredCliVersion)
         {
-            return EvaluateCliSetupCompatibility(cliVersion, cliIsDispatcher).NeedsUpdate;
+            return EvaluateCliSetupCompatibility(
+                cliVersion,
+                cliIsDispatcher,
+                requiredCliVersion).NeedsUpdate;
         }
 
         internal static bool ShouldShowSkillsInstalledDialog(SkillSetupTargetInfo targetInfo)
@@ -894,14 +904,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private static CliSetupCompatibilityState EvaluateCliSetupCompatibility(
             string cliVersion,
-            bool cliIsDispatcher)
+            bool cliIsDispatcher,
+            string requiredCliVersion)
         {
-            // Why: route through the setup service so the pin JSON stays the single source for the minimum
-            // dispatcher version instead of duplicating the constant in the presentation layer.
             return CliSetupCompatibility.Evaluate(
                 cliVersion,
                 cliIsDispatcher,
-                GetCliSetupApplicationService().GetMinimumRequiredCliVersion());
+                requiredCliVersion);
         }
 
         private async Task HandleUninstallCli()


### PR DESCRIPTION
## Summary
- Keep Settings CLI action behavior unchanged while making the required CLI version an explicit helper input.
- Remove the test-only CLI setup service seam from the Settings CLI action tests.

## User Impact
- No visible behavior changes. Settings still uses the package pin minimum dispatcher version when choosing update, repair, and uninstall actions.

## Changes
- Pass requiredCliVersion through the Settings primary-action helper chain instead of reading it inside the static helper.
- Keep ResolveExecutableCliPrimaryButtonAction and ShouldRepairCliPathFromPrimaryButton unchanged because they do not depend on the required version.
- Delete the now-unused TestCliPinReader setup helpers from UnityCliLoopSettingsWindowCliActionTests.

## Review Notes
- GetCliSetupApplicationService remains used by InitializeApplicationServices, so the static getter is intentionally retained.
- The similarly named CreateSkillSetupUseCase found in SetupWizardWindowTests is a separate test helper and was not touched.

## Verification
- dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)" -> 0 errors / 0 warnings
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopSettingsWindowCliActionTests" -> 40 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

