### PR TITLE
chore: Remove dead asmdef migration parameter

### DIFF
--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationAsmdefReferenceRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationAsmdefReferenceRules.cs
@@ -14,7 +14,6 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public static string[] GetMigratedAsmdefReferences(
             string reference,
             bool hasLegacyCSharpSource,
-            bool requiresToolContractsReference,
             bool requiresApplicationReference,
             bool requiresDomainReference,
             bool requiresFirstPartyScreenshotReference)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefRules.cs
@@ -113,7 +113,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 string[] migratedReferenceItems = GetMigratedAsmdefReferences(
                     reference,
                     hasLegacyCSharpSource,
-                    requiresToolContractsReference,
                     requiresApplicationReference,
                     requiresDomainReference,
                     requiresFirstPartyScreenshotReference);


### PR DESCRIPTION
## Summary
- Remove a dead asmdef reference migration parameter without changing migration behavior.

## User Impact
- No visible behavior changes. Third-party tool asmdef migration keeps the same reference rewrite decisions.

## Changes
- Drop the unused requiresToolContractsReference argument from GetMigratedAsmdefReferences.
- Update the single caller in the Infrastructure asmdef migration rule.

## Review Notes
- requiresToolContractsReference remains live in MigrateAsmdefSource and AddRequiredCurrentAsmdefReferences, where it still controls whether the ToolContracts reference is added.
- rg confirmed GetMigratedAsmdefReferences has only the single updated caller.

## Verification
- dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)" -> 0 errors / 0 warnings
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ThirdPartyToolMigrationRulesTests" -> 160 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

