### PR TITLE
chore: Fail fast for migration DTO null contracts

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileServiceTests.cs
@@ -38,6 +38,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void ThirdPartyToolMigrationPreview_WhenFilePathsIsNull_Throws()
+        {
+            // Verifies that preview snapshots fail fast when file paths are missing.
+            Assert.Throws<ArgumentNullException>(() => new ThirdPartyToolMigrationPreview(0, 0, null));
+        }
+
+        [Test]
         public void ThirdPartyToolMigrationResult_WhenInputFilePathsMutate_KeepsSnapshot()
         {
             // Verifies that result file paths cannot be changed by mutating the constructor input array.
@@ -51,6 +58,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             result.FilePaths[0] = "Assets/ChangedAgain.cs";
 
             Assert.That(result.FilePaths, Is.EqualTo(new[] { "Assets/VendorTools/HelloTool.cs" }));
+        }
+
+        [Test]
+        public void ThirdPartyToolMigrationResult_WhenFilePathsIsNull_Throws()
+        {
+            // Verifies that result snapshots fail fast when file paths are missing.
+            Assert.Throws<ArgumentNullException>(() => new ThirdPartyToolMigrationResult(0, 0, null));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 
 using NUnit.Framework;
@@ -12,6 +13,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public sealed class ThirdPartyToolMigrationRulesTests
     {
+        [Test]
+        public void RemovedLegacyPlayerLoopTimingSignature_WhenOriginalParametersIsNull_Throws()
+        {
+            // Verifies that timing signatures fail fast when original parameter snapshots are missing.
+            Assert.Throws<ArgumentNullException>(() => new RemovedLegacyPlayerLoopTimingSignature(
+                "Run",
+                "SampleTool",
+                null,
+                Array.Empty<RemovedLegacyPlayerLoopTimingParameter>()));
+        }
+
+        [Test]
+        public void RemovedLegacyPlayerLoopTimingSignature_WhenRemovedParametersIsNull_Throws()
+        {
+            // Verifies that timing signatures fail fast when removed parameter snapshots are missing.
+            Assert.Throws<ArgumentNullException>(() => new RemovedLegacyPlayerLoopTimingSignature(
+                "Run",
+                "SampleTool",
+                Array.Empty<LegacyPlayerLoopTimingParameterDeclaration>(),
+                null));
+        }
+
+        [Test]
+        public void ThirdPartyToolMigrationContentResult_WhenContentIsNull_Throws()
+        {
+            // Verifies that migration content results fail fast when rewritten content is missing.
+            Assert.Throws<ArgumentNullException>(() => new ThirdPartyToolMigrationContentResult(
+                null,
+                0,
+                Array.Empty<RemovedLegacyPlayerLoopTimingSignature>()));
+        }
+
+        [Test]
+        public void ThirdPartyToolMigrationContentResult_WhenRemovedSignaturesIsNull_Throws()
+        {
+            // Verifies that migration content results fail fast when removed timing signatures are missing.
+            Assert.Throws<ArgumentNullException>(() => new ThirdPartyToolMigrationContentResult(
+                string.Empty,
+                0,
+                null));
+        }
+
         [Test]
         public void MigrateCSharpSource_WhenLegacyToolApiIsUsed_RewritesToV3Contracts()
         {

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationData.cs
@@ -96,7 +96,12 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     {
         internal static string[] Copy(string[] filePaths)
         {
-            if (filePaths == null || filePaths.Length == 0)
+            if (filePaths == null)
+            {
+                throw new ArgumentNullException(nameof(filePaths));
+            }
+
+            if (filePaths.Length == 0)
             {
                 return Array.Empty<string>();
             }

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleData.cs
@@ -22,8 +22,9 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             MethodName = methodName;
             DeclaringTypeName = declaringTypeName;
             OriginalParameters =
-                originalParameters ?? Array.Empty<LegacyPlayerLoopTimingParameterDeclaration>();
-            RemovedParameters = removedParameters ?? Array.Empty<RemovedLegacyPlayerLoopTimingParameter>();
+                originalParameters ?? throw new ArgumentNullException(nameof(originalParameters));
+            RemovedParameters =
+                removedParameters ?? throw new ArgumentNullException(nameof(removedParameters));
         }
 
         public string MethodName { get; }
@@ -93,11 +94,11 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 removedPlayerLoopTimingSignatures != null,
                 "removedPlayerLoopTimingSignatures must not be null");
 
-            Content = content ?? string.Empty;
+            Content = content ?? throw new ArgumentNullException(nameof(content));
             ReplacementCount = replacementCount;
             RemovedPlayerLoopTimingSignatures =
                 removedPlayerLoopTimingSignatures ??
-                Array.Empty<RemovedLegacyPlayerLoopTimingSignature>();
+                throw new ArgumentNullException(nameof(removedPlayerLoopTimingSignatures));
         }
 
         public string Content { get; }


### PR DESCRIPTION
## Summary
- Align third-party tool migration DTOs with their existing non-null contracts.
- Add pinning tests so invalid internal calls fail fast instead of being silently normalized.

## User Impact
- No supported migration workflow changes for valid projects.
- Invalid internal migration data now surfaces immediately during development instead of being converted to empty values.

## Changes
- Replace migration rule data null fallbacks with ArgumentNullException after the existing Debug.Assert contracts.
- Make migration file path snapshots reject null while keeping the empty-array fast path.
- Add focused EditMode tests for the rule data and preview/result null contracts.

## Verification
- dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)" (0 errors, 0 warnings)
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ThirdPartyToolMigrationRulesTests" (164 passed)
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ThirdPartyToolMigrationFileServiceTests" (133 passed, 4 skipped)
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "(RemovedLegacyPlayerLoopTimingSignature_WhenOriginalParametersIsNull_Throws|RemovedLegacyPlayerLoopTimingSignature_WhenRemovedParametersIsNull_Throws|ThirdPartyToolMigrationContentResult_WhenContentIsNull_Throws|ThirdPartyToolMigrationContentResult_WhenRemovedSignaturesIsNull_Throws|ThirdPartyToolMigrationPreview_WhenFilePathsIsNull_Throws|ThirdPartyToolMigrationResult_WhenFilePathsIsNull_Throws)" (6 passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

