### PR TITLE
chore: Remove redundant startup protection cleanup

### DIFF
--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -343,6 +343,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             // OnServerLoopExited fires from thread pool — marshal to main thread for Unity API safety
             EditorApplication.delayCall += () =>
             {
+                // The server just crashed — startup protection blocks recovery if the crash happens
+                // within the 5-second protection window after a successful start
                 _startupProtectionService.ClearStartupProtection();
 
                 VibeLogger.LogWarning(
@@ -353,11 +355,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 // Resources already cleaned up by CleanupAfterUnexpectedLoopExit — just clear the reference
                 _bridgeServer = null;
-
-                // The server just crashed — startup protection blocks recovery if the crash happens
-                // within the 5-second protection window after a successful start
-                _startupProtectionService.ClearStartupProtection();
-
                 _recoveryTrackingService.ScheduleTrackedRecovery(() => StartRecoveryIfNeededAsync(false, CancellationToken.None));
             };
         }


### PR DESCRIPTION
## Summary
- Remove a duplicate startup-protection clear from the unexpected server-loop exit recovery path.

## User Impact
- No user-facing behavior changes are expected.
- Recovery still clears startup protection before scheduling automatic recovery; the second identical clear was redundant.

## Changes
- Drop the second ClearStartupProtection call inside OnServerLoopUnexpectedlyExited.
- Keep the existing tracked recovery scheduling and recovery behavior unchanged.

## Verification
- dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)" (0 errors, 0 warnings)
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopServerControllerRecoveryTests" (15 passed)
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopServerStartupProtectionTests" (4 passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

