### PR TITLE
fix: Recovery completion no longer surfaces as UI errors

### DIFF
--- a/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
@@ -62,9 +62,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void ScheduleStartupRecovery_WhenRecoveryThrowsSynchronously_FaultsTaskAndClearsRecoveryTask()
+        public async Task ScheduleStartupRecovery_WhenRecoveryThrowsSynchronously_CompletesTaskAndClearsRecoveryTask()
         {
-            // Tests that synchronous startup recovery failures fault and clear the tracked task.
+            // Tests that synchronous startup recovery failures log, complete, and clear the tracked task.
             UnityEngine.TestTools.LogAssert.Expect(
                 UnityEngine.LogType.Error,
                 "[UnityCliLoop] Failed to restore server: restore failed");
@@ -77,9 +77,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             scheduledAction();
 
-            Assert.That(recoveryTask.IsFaulted, Is.True);
+            Assert.That(recoveryTask.Status, Is.EqualTo(TaskStatus.RanToCompletion));
+            Assert.That(recoveryTask.IsFaulted, Is.False);
+            Assert.That(recoveryTask.IsCanceled, Is.False);
             Assert.That(service.RecoveryTask, Is.Null);
-            Assert.ThrowsAsync<System.InvalidOperationException>(async () => await recoveryTask);
+            await recoveryTask;
         }
 
         [Test]
@@ -104,6 +106,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(recoveryTask.IsCompleted, Is.True);
             Assert.That(service.RecoveryTask, Is.Null);
+        }
+
+        [Test]
+        public async Task ScheduleStartupRecovery_WhenRecoveryIsCanceled_CompletesTaskAndClearsRecoveryTask()
+        {
+            // Tests that startup recovery cancellation completes as an activity-finished signal.
+            System.Action scheduledAction = null;
+            UnityCliLoopServerRecoveryTrackingService service = CreateRecoveryTrackingService();
+
+            Task recoveryTask = service.ScheduleStartupRecovery(
+                action => scheduledAction = action,
+                () => Task.FromCanceled(new CancellationToken(true)));
+
+            scheduledAction();
+
+            Assert.That(recoveryTask.Status, Is.EqualTo(TaskStatus.RanToCompletion));
+            Assert.That(recoveryTask.IsFaulted, Is.False);
+            Assert.That(recoveryTask.IsCanceled, Is.False);
+            Assert.That(service.RecoveryTask, Is.Null);
+            await recoveryTask;
         }
 
         [Test]
@@ -232,12 +254,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public async Task ScheduleTrackedRecovery_WhenPreviousRecoveryFaulted_StartsNewRecovery()
+        public async Task ScheduleTrackedRecovery_WhenPreviousRecoveryGaveUp_CompletesTaskAndStartsNewRecovery()
         {
-            // Tests that a faulted recovery does not block a later recovery trigger.
+            // Tests that public recovery tracking completes after give-up and does not block later recovery.
             UnityEngine.TestTools.LogAssert.Expect(
                 UnityEngine.LogType.Error,
                 "[UnityCliLoop] Unity CLI Loop server recovery failed before the bridge became ready. first failure");
+            _sessionFlagsRepository.MarkServerStarted();
             int firstRecoveryAttempts = 0;
             bool secondRecoveryStarted = false;
             UnityCliLoopServerRecoveryTrackingService service = CreateRecoveryTrackingService(
@@ -248,7 +271,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 firstRecoveryAttempts++;
                 throw new System.TimeoutException("first failure");
             });
-            Assert.ThrowsAsync<System.InvalidOperationException>(async () => await firstTask);
+            await firstTask;
             Task secondTask = service.ScheduleTrackedRecovery(() =>
             {
                 secondRecoveryStarted = true;
@@ -258,6 +281,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             });
             await secondTask;
 
+            Assert.That(firstTask.Status, Is.EqualTo(TaskStatus.RanToCompletion));
+            Assert.That(firstTask.IsFaulted, Is.False);
+            Assert.That(firstTask.IsCanceled, Is.False);
+            Assert.That(_sessionFlagsRepository.GetIsServerRunning(), Is.False);
             Assert.That(secondTask, Is.Not.SameAs(firstTask));
             Assert.That(
                 firstRecoveryAttempts,

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryTrackingService.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryTrackingService.cs
@@ -29,7 +29,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         }
 
         /// <summary>
-        /// Current recovery task. Can be awaited by other components to ensure recovery completes first.
+        /// Current recovery task. Completion signals that recovery activity ended; failures are carried by
+        /// logs and session state so UI awaiters do not need try-catch around this task.
         /// </summary>
         internal Task RecoveryTask => _currentRecoveryTask;
 
@@ -91,7 +92,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (restoreTask.IsCanceled)
             {
-                scheduledRecoveryCompletionSource.SetCanceled();
+                scheduledRecoveryCompletionSource.SetResult(true);
                 return;
             }
 
@@ -103,7 +104,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 Debug.LogError($"[{UnityCliLoopConstants.PROJECT_NAME}] {message}");
                 VibeLogger.LogError("server_startup_restore_failed",
                     message);
-                scheduledRecoveryCompletionSource.SetException(restoreTask.Exception.GetBaseException());
+                scheduledRecoveryCompletionSource.SetResult(true);
                 return;
             }
 
@@ -118,14 +119,31 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Task recoveryTask = ScheduleRecoveryTask(() =>
             {
                 trackedRecoveryTask = ExecuteTrackedRecoveryAsync(recoveryAction);
-                return trackedRecoveryTask;
+                return CreateNonFaultingRecoveryTask(trackedRecoveryTask);
             }, isTrackedRecovery: true);
             if (trackedRecoveryTask != null)
             {
-                _ = ClearTrackedRecoveryWhenCompleteAsync(trackedRecoveryTask);
+                _ = ClearTrackedRecoveryWhenCompleteAsync(recoveryTask);
             }
 
             return recoveryTask;
+        }
+
+        private Task CreateNonFaultingRecoveryTask(Task recoveryTask)
+        {
+            Debug.Assert(recoveryTask != null, "recoveryTask must not be null");
+
+            return recoveryTask.ContinueWith(task =>
+            {
+                if (!task.IsFaulted)
+                {
+                    return;
+                }
+
+                // Why: the public RecoveryTask is an activity-finished signal; the underlying
+                // recovery failure is already logged and must be observed to avoid finalizer noise.
+                _ = task.Exception;
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
 
         private Task ScheduleRecoveryTask(Func<Task> createRecoveryTask, bool isTrackedRecovery)


### PR DESCRIPTION
## Summary
- Make recovery completion safe to await from UI paths even when recovery ultimately fails.
- Preserve visible recovery failure reporting through logs and session state.

## User Impact
- Settings after-compile handling is no longer at risk of being interrupted by a recovery task exception.
- Recovery failures still appear in the Unity Console and still clear the server session when tracked recovery gives up.

## Changes
- Treat public recovery tasks as activity-finished signals that do not fault or cancel.
- Keep the direct tracked recovery method throwing so internal retry/give-up behavior remains explicitly pinned.
- Observe underlying tracked recovery exceptions in the non-faulting wrapper to avoid unobserved task noise.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopServerControllerRecoveryTests"` (22/22 passed)
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopServerStartupProtectionTests"` (4/4 passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

