### PR TITLE
chore: Move asmdef reference migration policy into Domain

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -56,6 +56,86 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void ThirdPartyToolMigrationAsmdefReferenceMigrationResult_WhenReferencesIsNull_Throws()
+        {
+            // Verifies that asmdef migration results fail fast when migrated references are missing.
+            Assert.Throws<ArgumentNullException>(() => new ThirdPartyToolMigrationAsmdefReferenceMigrationResult(
+                null,
+                0));
+        }
+
+        [Test]
+        public void MigrateAsmdefReferences_WhenLegacyEditorReferenceNeedsDomain_AddsRequiredReferences()
+        {
+            // Verifies that pure asmdef reference policy expands legacy editor references with required V3 assemblies.
+            ThirdPartyToolMigrationAsmdefReferenceMigrationResult result =
+                ThirdPartyToolMigrationAsmdefReferenceRules.MigrateAsmdefReferences(
+                    new[] { ThirdPartyToolMigrationRuleCatalog.LegacyEditorAssemblyName },
+                    hasLegacyCSharpSource: false,
+                    requiresToolContractsReference: false,
+                    requiresApplicationReference: false,
+                    requiresDomainReference: true,
+                    requiresFirstPartyScreenshotReference: false);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.ReplacementCount, Is.EqualTo(1));
+            Assert.That(result.References, Is.EqualTo(new[]
+            {
+                ThirdPartyToolMigrationRuleCatalog.CurrentToolContractsGuidReference,
+                ThirdPartyToolMigrationRuleCatalog.CurrentDomainGuidReference
+            }));
+        }
+
+        [Test]
+        public void MigrateAsmdefReferences_WhenRequiredReferenceIsMissing_AddsReferenceWithoutJson()
+        {
+            // Verifies that pure asmdef reference policy can add required references without JSON mutation.
+            ThirdPartyToolMigrationAsmdefReferenceMigrationResult result =
+                ThirdPartyToolMigrationAsmdefReferenceRules.MigrateAsmdefReferences(
+                    Array.Empty<string>(),
+                    hasLegacyCSharpSource: false,
+                    requiresToolContractsReference: true,
+                    requiresApplicationReference: false,
+                    requiresDomainReference: false,
+                    requiresFirstPartyScreenshotReference: false);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.ReplacementCount, Is.EqualTo(1));
+            Assert.That(result.References, Is.EqualTo(new[]
+            {
+                ThirdPartyToolMigrationRuleCatalog.CurrentToolContractsGuidReference
+            }));
+        }
+
+        [Test]
+        public void MigrateAsmdefReferences_WhenCurrentNamesAlreadyExist_DoesNotAddDuplicateGuids()
+        {
+            // Verifies that pure asmdef reference policy deduplicates name and GUID forms of current references.
+            ThirdPartyToolMigrationAsmdefReferenceMigrationResult result =
+                ThirdPartyToolMigrationAsmdefReferenceRules.MigrateAsmdefReferences(
+                    new[]
+                    {
+                        ThirdPartyToolMigrationRuleCatalog.CurrentToolContractsAssemblyName,
+                        ThirdPartyToolMigrationRuleCatalog.CurrentApplicationAssemblyName,
+                        ThirdPartyToolMigrationRuleCatalog.CurrentDomainAssemblyName
+                    },
+                    hasLegacyCSharpSource: false,
+                    requiresToolContractsReference: true,
+                    requiresApplicationReference: true,
+                    requiresDomainReference: true,
+                    requiresFirstPartyScreenshotReference: false);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.ReplacementCount, Is.EqualTo(0));
+            Assert.That(result.References, Is.EqualTo(new[]
+            {
+                ThirdPartyToolMigrationRuleCatalog.CurrentToolContractsAssemblyName,
+                ThirdPartyToolMigrationRuleCatalog.CurrentApplicationAssemblyName,
+                ThirdPartyToolMigrationRuleCatalog.CurrentDomainAssemblyName
+            }));
+        }
+
+        [Test]
         public void MigrateCSharpSource_WhenLegacyToolApiIsUsed_RewritesToV3Contracts()
         {
             // Verifies that V2 custom tool source is rewritten to the V3 public contract names.

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationAsmdefReferenceRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationAsmdefReferenceRules.cs
@@ -43,6 +43,67 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return new[] { reference };
         }
 
+        /// <summary>
+        /// Resolves the final asmdef reference list without JSON mutation concerns.
+        /// </summary>
+        public static ThirdPartyToolMigrationAsmdefReferenceMigrationResult MigrateAsmdefReferences(
+            string[] references,
+            bool hasLegacyCSharpSource,
+            bool requiresToolContractsReference,
+            bool requiresApplicationReference,
+            bool requiresDomainReference,
+            bool requiresFirstPartyScreenshotReference)
+        {
+            Debug.Assert(references != null, "references must not be null");
+
+            string[] sourceReferences = references ?? throw new ArgumentNullException(nameof(references));
+            int replacementCount = 0;
+            HashSet<string> addedReferences = new(StringComparer.Ordinal);
+            List<string> migratedReferences = new();
+            foreach (string sourceReference in sourceReferences)
+            {
+                string reference = sourceReference ?? string.Empty;
+                string[] migratedReferenceItems = GetMigratedAsmdefReferences(
+                    reference,
+                    hasLegacyCSharpSource,
+                    requiresApplicationReference,
+                    requiresDomainReference,
+                    requiresFirstPartyScreenshotReference);
+                bool referenceChanged = migratedReferenceItems.Length != 1 ||
+                    !string.Equals(migratedReferenceItems[0], reference, StringComparison.Ordinal);
+                if (referenceChanged)
+                {
+                    replacementCount++;
+                }
+
+                foreach (string migratedReference in migratedReferenceItems)
+                {
+                    string migratedReferenceKey = GetCurrentAsmdefReferenceKey(migratedReference);
+                    if (!addedReferences.Add(migratedReferenceKey))
+                    {
+                        continue;
+                    }
+
+                    migratedReferences.Add(migratedReference);
+                }
+            }
+
+            replacementCount += AppendRequiredCurrentAsmdefReferences(
+                migratedReferences,
+                addedReferences,
+                hasLegacyCSharpSource || requiresToolContractsReference,
+                requiresApplicationReference,
+                requiresDomainReference,
+                requiresFirstPartyScreenshotReference);
+
+            string[] resultReferences = replacementCount == 0
+                ? sourceReferences
+                : migratedReferences.ToArray();
+            return new ThirdPartyToolMigrationAsmdefReferenceMigrationResult(
+                resultReferences,
+                replacementCount);
+        }
+
         private static string[] GetMigratedLegacyEditorReferences(
             bool requiresApplicationReference,
             bool requiresDomainReference,
@@ -82,6 +143,72 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             }
 
             references.Add(reference);
+        }
+
+        private static int AppendRequiredCurrentAsmdefReferences(
+            List<string> references,
+            HashSet<string> addedReferences,
+            bool requiresToolContractsReference,
+            bool requiresApplicationReference,
+            bool requiresDomainReference,
+            bool requiresFirstPartyScreenshotReference)
+        {
+            Debug.Assert(references != null, "references must not be null");
+            Debug.Assert(addedReferences != null, "addedReferences must not be null");
+
+            int replacementCount = 0;
+            if (requiresToolContractsReference)
+            {
+                replacementCount += AppendRequiredCurrentAsmdefReference(
+                    references,
+                    addedReferences,
+                    CurrentToolContractsGuidReference);
+            }
+
+            if (requiresApplicationReference)
+            {
+                replacementCount += AppendRequiredCurrentAsmdefReference(
+                    references,
+                    addedReferences,
+                    CurrentApplicationGuidReference);
+            }
+
+            if (requiresDomainReference)
+            {
+                replacementCount += AppendRequiredCurrentAsmdefReference(
+                    references,
+                    addedReferences,
+                    CurrentDomainGuidReference);
+            }
+
+            if (requiresFirstPartyScreenshotReference)
+            {
+                replacementCount += AppendRequiredCurrentAsmdefReference(
+                    references,
+                    addedReferences,
+                    CurrentFirstPartyToolsScreenshotGuidReference);
+            }
+
+            return replacementCount;
+        }
+
+        private static int AppendRequiredCurrentAsmdefReference(
+            List<string> references,
+            HashSet<string> addedReferences,
+            string reference)
+        {
+            Debug.Assert(references != null, "references must not be null");
+            Debug.Assert(addedReferences != null, "addedReferences must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(reference), "reference must not be null or empty");
+
+            string referenceKey = GetCurrentAsmdefReferenceKey(reference);
+            if (!addedReferences.Add(referenceKey))
+            {
+                return 0;
+            }
+
+            references.Add(reference);
+            return 1;
         }
 
         public static string GetCurrentAsmdefReferenceKey(string reference)

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleData.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleData.cs
@@ -106,4 +106,25 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public RemovedLegacyPlayerLoopTimingSignature[] RemovedPlayerLoopTimingSignatures { get; }
         public bool Changed => ReplacementCount > 0;
     }
+
+    /// <summary>
+    /// Describes migrated asmdef references resolved by pure migration policy.
+    /// </summary>
+    public readonly struct ThirdPartyToolMigrationAsmdefReferenceMigrationResult
+    {
+        public ThirdPartyToolMigrationAsmdefReferenceMigrationResult(
+            string[] references,
+            int replacementCount)
+        {
+            Debug.Assert(references != null, "references must not be null");
+            Debug.Assert(replacementCount >= 0, "replacementCount must not be negative");
+
+            References = references ?? throw new ArgumentNullException(nameof(references));
+            ReplacementCount = replacementCount;
+        }
+
+        public string[] References { get; }
+        public int ReplacementCount { get; }
+        public bool Changed => ReplacementCount > 0;
+    }
 }

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefRules.cs
@@ -1,88 +1,18 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 using RemovedLegacyPlayerLoopTimingSignature = io.github.hatayama.UnityCliLoop.Domain.RemovedLegacyPlayerLoopTimingSignature;
+using ThirdPartyToolMigrationAsmdefReferenceMigrationResult = io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationAsmdefReferenceMigrationResult;
 using ThirdPartyToolMigrationContentResult = io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationContentResult;
 using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationAsmdefReferenceRules;
-using static io.github.hatayama.UnityCliLoop.Domain.ThirdPartyToolMigrationRuleCatalog;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
     internal static class ThirdPartyToolMigrationAsmdefRules
     {
-        internal static void AddRequiredCurrentAsmdefReferences(
-            JArray references,
-            HashSet<string> addedReferences,
-            bool requiresToolContractsReference,
-            bool requiresApplicationReference,
-            bool requiresDomainReference,
-            bool requiresFirstPartyScreenshotReference,
-            ref int replacementCount)
-        {
-            Debug.Assert(references != null, "references must not be null");
-            Debug.Assert(addedReferences != null, "addedReferences must not be null");
-
-            if (requiresToolContractsReference)
-            {
-                AddRequiredCurrentAsmdefReference(
-                    references,
-                    addedReferences,
-                    CurrentToolContractsGuidReference,
-                    ref replacementCount);
-            }
-
-            if (requiresApplicationReference)
-            {
-                AddRequiredCurrentAsmdefReference(
-                    references,
-                    addedReferences,
-                    CurrentApplicationGuidReference,
-                    ref replacementCount);
-            }
-
-            if (requiresDomainReference)
-            {
-                AddRequiredCurrentAsmdefReference(
-                    references,
-                    addedReferences,
-                    CurrentDomainGuidReference,
-                    ref replacementCount);
-            }
-
-            if (requiresFirstPartyScreenshotReference)
-            {
-                AddRequiredCurrentAsmdefReference(
-                    references,
-                    addedReferences,
-                    CurrentFirstPartyToolsScreenshotGuidReference,
-                    ref replacementCount);
-            }
-        }
-
-        internal static void AddRequiredCurrentAsmdefReference(
-            JArray references,
-            HashSet<string> addedReferences,
-            string reference,
-            ref int replacementCount)
-        {
-            Debug.Assert(references != null, "references must not be null");
-            Debug.Assert(addedReferences != null, "addedReferences must not be null");
-            Debug.Assert(!string.IsNullOrEmpty(reference), "reference must not be null or empty");
-
-            string referenceKey = GetCurrentAsmdefReferenceKey(reference);
-            if (!addedReferences.Add(referenceKey))
-            {
-                return;
-            }
-
-            references.Add(reference);
-            replacementCount++;
-        }
-
         internal static ThirdPartyToolMigrationContentResult MigrateAsmdefSource(
             string source,
             bool hasLegacyCSharpSource,
@@ -104,47 +34,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     Array.Empty<RemovedLegacyPlayerLoopTimingSignature>());
             }
 
-            int replacementCount = 0;
-            HashSet<string> addedReferences = new(StringComparer.Ordinal);
-            JArray migratedReferences = new();
-            foreach (JToken referenceToken in references)
-            {
-                string reference = referenceToken.Value<string>() ?? string.Empty;
-                string[] migratedReferenceItems = GetMigratedAsmdefReferences(
-                    reference,
-                    hasLegacyCSharpSource,
-                    requiresApplicationReference,
-                    requiresDomainReference,
-                    requiresFirstPartyScreenshotReference);
-                bool referenceChanged = migratedReferenceItems.Length != 1 ||
-                    !string.Equals(migratedReferenceItems[0], reference, StringComparison.Ordinal);
-                if (referenceChanged)
-                {
-                    replacementCount++;
-                }
-
-                foreach (string migratedReference in migratedReferenceItems)
-                {
-                    string migratedReferenceKey = GetCurrentAsmdefReferenceKey(migratedReference);
-                    if (!addedReferences.Add(migratedReferenceKey))
-                    {
-                        continue;
-                    }
-
-                    migratedReferences.Add(migratedReference);
-                }
-            }
-
-            AddRequiredCurrentAsmdefReferences(
-                migratedReferences,
-                addedReferences,
-                hasLegacyCSharpSource || requiresToolContractsReference,
+            string[] referenceValues = ReadReferenceValues(references);
+            ThirdPartyToolMigrationAsmdefReferenceMigrationResult migrationResult = MigrateAsmdefReferences(
+                referenceValues,
+                hasLegacyCSharpSource,
+                requiresToolContractsReference,
                 requiresApplicationReference,
                 requiresDomainReference,
-                requiresFirstPartyScreenshotReference,
-                ref replacementCount);
+                requiresFirstPartyScreenshotReference);
 
-            if (replacementCount == 0)
+            if (!migrationResult.Changed)
             {
                 return new ThirdPartyToolMigrationContentResult(
                     source,
@@ -152,12 +51,38 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     Array.Empty<RemovedLegacyPlayerLoopTimingSignature>());
             }
 
+            JArray migratedReferences = CreateReferencesArray(migrationResult.References);
             asmdef["references"] = migratedReferences;
             return new ThirdPartyToolMigrationContentResult(
                 asmdef.ToString(Formatting.Indented),
-                replacementCount,
+                migrationResult.ReplacementCount,
                 Array.Empty<RemovedLegacyPlayerLoopTimingSignature>());
         }
 
+        private static string[] ReadReferenceValues(JArray references)
+        {
+            Debug.Assert(references != null, "references must not be null");
+
+            string[] referenceValues = new string[references.Count];
+            for (int index = 0; index < references.Count; index++)
+            {
+                referenceValues[index] = references[index]?.Value<string>() ?? string.Empty;
+            }
+
+            return referenceValues;
+        }
+
+        private static JArray CreateReferencesArray(string[] references)
+        {
+            Debug.Assert(references != null, "references must not be null");
+
+            JArray referencesArray = new();
+            foreach (string reference in references)
+            {
+                referencesArray.Add(reference);
+            }
+
+            return referencesArray;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Move pure asmdef reference migration decisions into Domain.
- Keep Infrastructure responsible only for JSON parsing and applying the final reference list.

## User Impact
- No user-visible behavior change; third-party tool migration keeps producing the same asmdef rewrites.
- The remaining C4-11 asmdef policy is now separated from JObject/JArray mutation, making the architecture boundary clearer.

## Changes
- Add a Domain result DTO for migrated asmdef references.
- Add a pure Domain policy method that returns the final reference list and replacement count.
- Trim Infrastructure asmdef migration rules to convert JArray values to strings, call the Domain policy, and write the resulting JArray only when changed.
- Add direct Domain tests while preserving the existing facade behavior pins.

## Verification
- dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)" -> 0 errors / 0 warnings
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ThirdPartyToolMigrationRulesTests" -> 168/168 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

