### PR TITLE
chore: Align internal method terminology with glossary

### DIFF
--- a/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
+++ b/Packages/src/Editor/Infrastructure/Api/InternalBridgeCommandRouter.cs
@@ -12,49 +12,49 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     internal static class InternalBridgeCommandRouter
     {
-        public static bool IsInternalCommand(string commandName)
+        public static bool IsInternalCommand(string methodName)
         {
-            return commandName == UnityCliLoopConstants.COMMAND_NAME_GET_VERSION ||
-                   commandName == UnityCliLoopConstants.COMMAND_NAME_GET_COMPILE_STATUS ||
-                   commandName == UnityCliLoopConstants.COMMAND_NAME_GET_PAUSE_POINT_STATUS ||
-                   commandName == UnityCliLoopConstants.COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS ||
-                   commandName == UnityCliLoopConstants.COMMAND_NAME_GET_TOOL_DETAILS;
+            return methodName == UnityCliLoopConstants.COMMAND_NAME_GET_VERSION ||
+                   methodName == UnityCliLoopConstants.COMMAND_NAME_GET_COMPILE_STATUS ||
+                   methodName == UnityCliLoopConstants.COMMAND_NAME_GET_PAUSE_POINT_STATUS ||
+                   methodName == UnityCliLoopConstants.COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS ||
+                   methodName == UnityCliLoopConstants.COMMAND_NAME_GET_TOOL_DETAILS;
         }
 
         public static UnityCliLoopToolResponse Execute(
-            string commandName,
+            string methodName,
             JToken paramsToken,
             UnityCliLoopToolRegistrarService toolRegistrarService)
         {
-            Debug.Assert(IsInternalCommand(commandName), $"Unknown internal bridge command: {commandName}");
+            Debug.Assert(IsInternalCommand(methodName), $"Unknown internal bridge command: {methodName}");
             Debug.Assert(toolRegistrarService != null, "toolRegistrarService must not be null");
 
-            if (commandName == UnityCliLoopConstants.COMMAND_NAME_GET_VERSION)
+            if (methodName == UnityCliLoopConstants.COMMAND_NAME_GET_VERSION)
             {
                 return GetVersionBridgeCommand.Execute();
             }
 
-            if (commandName == UnityCliLoopConstants.COMMAND_NAME_GET_TOOL_DETAILS)
+            if (methodName == UnityCliLoopConstants.COMMAND_NAME_GET_TOOL_DETAILS)
             {
                 return GetToolDetailsBridgeCommand.Execute(paramsToken, toolRegistrarService);
             }
 
-            if (commandName == UnityCliLoopConstants.COMMAND_NAME_GET_COMPILE_STATUS)
+            if (methodName == UnityCliLoopConstants.COMMAND_NAME_GET_COMPILE_STATUS)
             {
                 return CompileStatusBridgeCommand.Execute(paramsToken);
             }
 
-            if (commandName == UnityCliLoopConstants.COMMAND_NAME_GET_PAUSE_POINT_STATUS)
+            if (methodName == UnityCliLoopConstants.COMMAND_NAME_GET_PAUSE_POINT_STATUS)
             {
                 return PausePointStatusBridgeCommand.Execute(paramsToken);
             }
 
-            if (commandName == UnityCliLoopConstants.COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS)
+            if (methodName == UnityCliLoopConstants.COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS)
             {
                 return PausePointStatusBridgeCommand.Clear(paramsToken);
             }
 
-            throw new ArgumentException($"Unknown internal bridge command: {commandName}", nameof(commandName));
+            throw new ArgumentException($"Unknown internal bridge command: {methodName}", nameof(methodName));
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/Api/UnityCliLoopExecutionRouter.cs
+++ b/Packages/src/Editor/Infrastructure/Api/UnityCliLoopExecutionRouter.cs
@@ -28,28 +28,27 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         }
 
         /// <summary>
-        /// Generic command execution method
-        /// Uses new command-based structure
+        /// Routes one JSON-RPC method to either an internal bridge command or a registered tool.
         /// </summary>
-        /// <param name="commandName">Command name</param>
+        /// <param name="methodName">JSON-RPC method name</param>
         /// <param name="paramsToken">Parameters</param>
         /// <returns>Execution result</returns>
         public async Task<UnityCliLoopToolResponse> ExecuteAsync(
-            string commandName,
+            string methodName,
             JToken paramsToken,
             CancellationToken ct)
         {
             UnityCliLoopToolResponse response;
-            if (InternalBridgeCommandRouter.IsInternalCommand(commandName))
+            if (InternalBridgeCommandRouter.IsInternalCommand(methodName))
             {
                 await MainThreadSwitcher.SwitchToMainThread(ct);
                 ct.ThrowIfCancellationRequested();
-                response = InternalBridgeCommandRouter.Execute(commandName, paramsToken, _toolRegistrarService);
+                response = InternalBridgeCommandRouter.Execute(methodName, paramsToken, _toolRegistrarService);
                 return response;
             }
 
             response = await _toolRegistrarService.ExecuteToolAsync(
-                commandName,
+                methodName,
                 paramsToken,
                 ct);
             return response;

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -10,6 +10,21 @@ terminology cleanup (see the repository guidelines). When an internal identifier
 with this glossary, prefer renaming the internal identifier; when a public identifier
 conflicts, keep the identifier and document the mismatch here instead.
 
+## Known Naming Debt (Public API, Kept by Policy)
+
+The following public identifiers are kept by policy even though their names do not fully
+match the current glossary:
+
+- `UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT` and
+  `UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS` are used as tool catalog names,
+  not internal bridge commands.
+- The skill target types `SkillsTarget`, `SkillSetupTargetInfo`,
+  `ToolSkillSynchronizer.SkillTargetDefinition`, and `ToolSkillSynchronizer.SkillTargetInfo`
+  describe related concepts at different layers, but they remain public package identifiers.
+- Several first-party tool UseCases implement `IUnityCliLoop*Service` interfaces. The names
+  are preserved because renaming public identifiers is outside terminology cleanup; removing
+  the pass-through interfaces would be a separate structural refactor.
+
 ## Terms
 
 ### Tool


### PR DESCRIPTION
## Summary
- Rename internal JSON-RPC dispatch parameters from `commandName` to `methodName` in the Infrastructure API router and internal bridge command router.
- Refresh stale router XML comments to use glossary terms for JSON-RPC methods, tools, and internal bridge commands.
- Document public naming debt that is intentionally kept by policy instead of renaming public package identifiers.

## Review Notes
- `UnityCliLoopExecutionRouter` and `InternalBridgeCommandRouter` are internal Infrastructure API routing types, not extension-facing API surface, so the parameter rename does not affect public named-argument compatibility.
- Public `UnityCliLoopConstants` constants, skill target types, and first-party service interface names are intentionally left unchanged per the glossary and Fable 5裁定.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopToolRegistryTests"` -> 32/32 passed
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.JsonRpcRequestProcessorCliVersionGateTests"` -> 17/17 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

