### PR TITLE
chore: Move tool execution session state into Domain

### DIFF
--- a/Assets/Tests/Editor/JsonRpcRequestProcessorCliVersionGateTests.cs
+++ b/Assets/Tests/Editor/JsonRpcRequestProcessorCliVersionGateTests.cs
@@ -806,6 +806,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
         }
 
+        // The enum currently has only None, so an undefined value is the only way to exercise security-blocked handling.
         [UnityCliLoopTool(RequiredSecuritySetting = (UnityCliLoopSecuritySetting)999)]
         private sealed class SecurityBlockedTestTool : IUnityCliLoopTool
         {

--- a/Assets/Tests/Editor/JsonRpcRequestProcessorCliVersionGateTests.cs
+++ b/Assets/Tests/Editor/JsonRpcRequestProcessorCliVersionGateTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -275,6 +276,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 UnityCliLoopEditorStateSnapshot.ClearForTesting();
                 RestoreEditorMainThreadDispatcher();
             }
+        }
+
+        [Test]
+        public async Task ProcessRequest_WhenToolIsDisabled_ReturnsInternalErrorShape()
+        {
+            // Verifies disabled tools keep the JSON-RPC internal_error data shape before PR3 folds gates together.
+            InMemoryToolSettingsPort toolSettingsPort = new InMemoryToolSettingsPort();
+            toolSettingsPort.SetToolEnabled(SingleFlightTestTool.Name, false);
+            UnityCliLoopToolRegistrarService service = CreateRegistrarServiceWithToolSettings(toolSettingsPort);
+            service.RegisterCustomTool(new SingleFlightTestTool());
+            JsonRpcRequestProcessor processor = CreateProcessor(service);
+
+            LogAssert.Expect(LogType.Error, new Regex(@"\[JsonRpcRequestProcessor\] Error: Tool 'single-flight-test' is disabled"));
+            string response = await processor.ProcessRequest(
+                BuildToolRequest(SingleFlightTestTool.Name, 1),
+                CancellationToken.None);
+            JObject error = ParseError(response);
+            JObject data = ParseErrorData(response);
+
+            Assert.That(error["message"]?.ToString(), Does.Contain(SingleFlightTestTool.Name));
+            Assert.That(data["type"]?.ToString(), Is.EqualTo("internal_error"));
+        }
+
+        [Test]
+        public async Task ProcessRequest_WhenToolRequiresBlockedSecuritySetting_ReturnsSecurityBlockedShape()
+        {
+            // Verifies security-blocked tools keep their machine-readable JSON-RPC error data.
+            UnityCliLoopToolRegistrarService service = CreateRegistrarService();
+            service.RegisterCustomTool(new SecurityBlockedTestTool());
+            JsonRpcRequestProcessor processor = CreateProcessor(service);
+
+            LogAssert.Expect(LogType.Error, new Regex(@"\[JsonRpcRequestProcessor\] Error: Tool 'security-blocked-test' is blocked by security settings"));
+            string response = await processor.ProcessRequest(
+                BuildToolRequest(SecurityBlockedTestTool.Name, 1),
+                CancellationToken.None);
+            JObject data = ParseErrorData(response);
+
+            Assert.That(data["type"]?.ToString(), Is.EqualTo("security_blocked"));
+            Assert.That(data["command"]?.ToString(), Is.EqualTo(SecurityBlockedTestTool.Name));
+            Assert.That(data["reason"]?.ToString(), Does.Contain("security settings"));
         }
 
         [Test]
@@ -553,6 +594,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             return UnityCliLoopToolRegistrarTestFactory.Create(UnityCliLoopToolDiscovery.DiscoverTools);
         }
 
+        private static UnityCliLoopToolRegistrarService CreateRegistrarServiceWithToolSettings(IToolSettingsPort toolSettingsPort)
+        {
+            return new UnityCliLoopToolRegistrarService(
+                new EmptyInternalToolNameProvider(),
+                toolSettingsPort,
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
+                UnityCliLoopToolDiscovery.DiscoverTools);
+        }
+
         private static JsonRpcRequestProcessor CreateProcessor(UnityCliLoopToolRegistrarService service)
         {
             UnityCliLoopExecutionRouter executionRouter = new(service);
@@ -753,6 +803,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
             {
                 return Task.FromResult<UnityCliLoopToolResponse>(new SingleFlightTestResponse());
+            }
+        }
+
+        [UnityCliLoopTool(RequiredSecuritySetting = (UnityCliLoopSecuritySetting)999)]
+        private sealed class SecurityBlockedTestTool : IUnityCliLoopTool
+        {
+            public const string Name = "security-blocked-test";
+
+            public string ToolName => Name;
+
+            public ToolParameterSchema ParameterSchema => new();
+
+            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
+            {
+                return Task.FromResult<UnityCliLoopToolResponse>(new SingleFlightTestResponse());
+            }
+        }
+
+        private sealed class InMemoryToolSettingsPort : IToolSettingsPort
+        {
+            private readonly HashSet<string> _disabledTools = new();
+
+            public bool IsToolEnabled(string toolName)
+            {
+                return !_disabledTools.Contains(toolName);
+            }
+
+            public void SetToolEnabled(string toolName, bool enabled)
+            {
+                if (enabled)
+                {
+                    _disabledTools.Remove(toolName);
+                    return;
+                }
+
+                _disabledTools.Add(toolName);
+            }
+
+            public string[] GetDisabledTools()
+            {
+                string[] disabledTools = new string[_disabledTools.Count];
+                _disabledTools.CopyTo(disabledTools);
+                return disabledTools;
+            }
+
+            public void InvalidateCache()
+            {
             }
         }
 

--- a/Assets/Tests/Editor/ToolExecutionSessionTests.cs
+++ b/Assets/Tests/Editor/ToolExecutionSessionTests.cs
@@ -1,0 +1,85 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    public sealed class ToolExecutionSessionTests
+    {
+        [Test]
+        public void TryEnter_WhenNoToolIsRunning_ShouldEnterAndAllowExitThenNextTool()
+        {
+            // Tests that an empty session admits a tool and releases the slot after exit.
+            ToolExecutionSession session = new ToolExecutionSession();
+
+            ToolExecutionSessionEnterResult firstResult = session.TryEnter("first-tool");
+            session.Exit();
+            ToolExecutionSessionEnterResult secondResult = session.TryEnter("second-tool");
+
+            Assert.That(firstResult.IsEntered, Is.True);
+            Assert.That(firstResult.RunningToolName, Is.Empty);
+            Assert.That(secondResult.IsEntered, Is.True);
+
+            session.Exit();
+        }
+
+        [Test]
+        public void TryEnter_WhenDifferentToolIsRunning_ShouldReturnBusyWithRunningToolName()
+        {
+            // Tests that the single-flight gate reports the already running tool for rejected requests.
+            ToolExecutionSession session = new ToolExecutionSession();
+
+            ToolExecutionSessionEnterResult firstResult = session.TryEnter("running-tool");
+            ToolExecutionSessionEnterResult busyResult = session.TryEnter("requested-tool");
+
+            Assert.That(firstResult.IsEntered, Is.True);
+            Assert.That(busyResult.IsEntered, Is.False);
+            Assert.That(busyResult.RunningToolName, Is.EqualTo("running-tool"));
+
+            session.Exit();
+        }
+
+        [Test]
+        public void TryEnter_WhenExecuteDynamicCodeIsAlreadyRunning_ShouldAllowSecondExecuteDynamicCode()
+        {
+            // Tests that execute-dynamic-code keeps its existing shared execution slot behavior.
+            ToolExecutionSession session = new ToolExecutionSession();
+
+            ToolExecutionSessionEnterResult firstResult =
+                session.TryEnter(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE);
+            ToolExecutionSessionEnterResult secondResult =
+                session.TryEnter(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE);
+
+            Assert.That(firstResult.IsEntered, Is.True);
+            Assert.That(secondResult.IsEntered, Is.True);
+
+            session.Exit();
+            session.Exit();
+        }
+
+        [Test]
+        public void Exit_WhenTwoSharedDynamicCodeExecutionsEntered_ShouldKeepSlotBusyUntilBothExit()
+        {
+            // Tests that shared execute-dynamic-code entries keep the session busy until every entry exits.
+            ToolExecutionSession session = new ToolExecutionSession();
+
+            session.TryEnter(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE);
+            session.TryEnter(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE);
+
+            ToolExecutionSessionEnterResult busyBeforeExit = session.TryEnter("other-tool");
+            session.Exit();
+            ToolExecutionSessionEnterResult busyAfterOneExit = session.TryEnter("other-tool");
+            session.Exit();
+            ToolExecutionSessionEnterResult enteredAfterBothExit = session.TryEnter("other-tool");
+
+            Assert.That(busyBeforeExit.IsEntered, Is.False);
+            Assert.That(busyBeforeExit.RunningToolName, Is.EqualTo(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE));
+            Assert.That(busyAfterOneExit.IsEntered, Is.False);
+            Assert.That(busyAfterOneExit.RunningToolName, Is.EqualTo(UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE));
+            Assert.That(enteredAfterBothExit.IsEntered, Is.True);
+
+            session.Exit();
+        }
+    }
+}

--- a/Assets/Tests/Editor/ToolExecutionSessionTests.cs.meta
+++ b/Assets/Tests/Editor/ToolExecutionSessionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36c7d5bad1e247e5ba1e036f5cced913
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
@@ -14,12 +14,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
     /// </summary>
     internal sealed class UnityCliLoopToolExecutionService
     {
-        private const string UnknownToolName = "unknown";
-
         private readonly IEditorRuntimeStatePort _editorRuntimeStatePort;
-        private readonly object _executionStateLock = new();
-        private string _runningToolName;
-        private int _runningExecutionCount;
+        private readonly ToolExecutionSession _executionSession = new();
 
         internal UnityCliLoopToolExecutionService(IEditorRuntimeStatePort editorRuntimeStatePort)
         {
@@ -55,9 +51,10 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 throw new UnityCliLoopSecurityException(toolName, "Tool is blocked by security settings");
             }
 
-            if (!TryEnterExecution(toolName, out string runningToolName))
+            ToolExecutionSessionEnterResult enterResult = _executionSession.TryEnter(toolName);
+            if (!enterResult.IsEntered)
             {
-                throw CreateBusyException(runningToolName, toolName, _editorRuntimeStatePort);
+                throw CreateBusyException(enterResult.RunningToolName, toolName, _editorRuntimeStatePort);
             }
 
             try
@@ -76,53 +73,8 @@ namespace io.github.hatayama.UnityCliLoop.Application
             }
             finally
             {
-                ExitExecution();
+                _executionSession.Exit();
             }
-        }
-
-        private bool TryEnterExecution(string toolName, out string runningToolName)
-        {
-            lock (_executionStateLock)
-            {
-                if (_runningExecutionCount == 0)
-                {
-                    _runningToolName = toolName;
-                    _runningExecutionCount = 1;
-                    runningToolName = toolName;
-                    return true;
-                }
-
-                if (CanShareExecutionSlot(_runningToolName, toolName))
-                {
-                    _runningExecutionCount++;
-                    runningToolName = _runningToolName;
-                    return true;
-                }
-
-                runningToolName = GetRunningToolNameInsideLock();
-                return false;
-            }
-        }
-
-        private void ExitExecution()
-        {
-            lock (_executionStateLock)
-            {
-                Debug.Assert(_runningExecutionCount > 0, "running execution count must be positive before exit");
-                _runningExecutionCount--;
-                if (_runningExecutionCount > 0)
-                {
-                    return;
-                }
-
-                _runningToolName = null;
-            }
-        }
-
-        private static bool CanShareExecutionSlot(string runningToolName, string requestedToolName)
-        {
-            return runningToolName == UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE
-                   && requestedToolName == UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE;
         }
 
         internal static UnityCliLoopToolBusyException CreateBusyException(
@@ -157,11 +109,5 @@ namespace io.github.hatayama.UnityCliLoop.Application
             return new UnityCliLoopToolBusyException(runningToolName, requestedToolName);
         }
 
-        private string GetRunningToolNameInsideLock()
-        {
-            return string.IsNullOrWhiteSpace(_runningToolName)
-                ? UnknownToolName
-                : _runningToolName;
-        }
     }
 }

--- a/Packages/src/Editor/Domain/ToolExecutionSession.cs
+++ b/Packages/src/Editor/Domain/ToolExecutionSession.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Owns the thread-safe single-flight state for tool execution sessions.
+    /// </summary>
+    internal sealed class ToolExecutionSession
+    {
+        private const string UnknownToolName = "unknown";
+
+        private readonly object _executionStateLock = new();
+        private string _runningToolName;
+        private int _runningExecutionCount;
+
+        internal ToolExecutionSessionEnterResult TryEnter(string requestedToolName)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(requestedToolName), "requestedToolName must not be null or whitespace");
+
+            lock (_executionStateLock)
+            {
+                if (_runningExecutionCount == 0)
+                {
+                    _runningToolName = requestedToolName;
+                    _runningExecutionCount = 1;
+                    return ToolExecutionSessionEnterResult.Entered();
+                }
+
+                if (CanShareExecutionSlot(_runningToolName, requestedToolName))
+                {
+                    _runningExecutionCount++;
+                    return ToolExecutionSessionEnterResult.Entered();
+                }
+
+                return ToolExecutionSessionEnterResult.Busy(GetRunningToolNameInsideLock());
+            }
+        }
+
+        internal void Exit()
+        {
+            lock (_executionStateLock)
+            {
+                Debug.Assert(_runningExecutionCount > 0, "running execution count must be positive before exit");
+                _runningExecutionCount--;
+                if (_runningExecutionCount > 0)
+                {
+                    return;
+                }
+
+                _runningToolName = null;
+            }
+        }
+
+        private static bool CanShareExecutionSlot(string runningToolName, string requestedToolName)
+        {
+            return runningToolName == UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE
+                   && requestedToolName == UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE;
+        }
+
+        private string GetRunningToolNameInsideLock()
+        {
+            return string.IsNullOrWhiteSpace(_runningToolName)
+                ? UnknownToolName
+                : _runningToolName;
+        }
+    }
+
+    /// <summary>
+    /// Reports whether a tool execution request entered the session or was rejected by the single-flight gate.
+    /// </summary>
+    internal readonly struct ToolExecutionSessionEnterResult
+    {
+        public readonly bool IsEntered;
+        public readonly string RunningToolName;
+
+        private ToolExecutionSessionEnterResult(bool isEntered, string runningToolName)
+        {
+            Debug.Assert(isEntered || !string.IsNullOrWhiteSpace(runningToolName), "runningToolName must not be null or whitespace for busy decisions");
+
+            IsEntered = isEntered;
+            RunningToolName = runningToolName;
+        }
+
+        public static ToolExecutionSessionEnterResult Entered()
+        {
+            return new ToolExecutionSessionEnterResult(true, string.Empty);
+        }
+
+        public static ToolExecutionSessionEnterResult Busy(string runningToolName)
+        {
+            return new ToolExecutionSessionEnterResult(false, runningToolName);
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/ToolExecutionSession.cs.meta
+++ b/Packages/src/Editor/Domain/ToolExecutionSession.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72cc50aac65c4b4b8a4d4185cf9960be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Move the single-flight tool execution slot state into Domain.
- Keep Application responsible for busy exception shaping and editor play-state snapshots.

## User Impact
- No user-facing behavior changes.
- Existing server_busy, disabled, and security-blocked JSON-RPC shapes are pinned by tests.

## Changes
- Add `ToolExecutionSession` and `ToolExecutionSessionEnterResult` in Domain.
- Replace Application-owned execution slot fields with a Domain session instance.
- Add Domain session tests for enter, busy rejection, execute-dynamic-code sharing, and shared-entry release count.
- Add JSON-RPC disabled/security shape tests before PR3 folds enabled/allowed gates into the session admission flow.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ToolExecutionSessionTests.*"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopToolExecutionServiceTests.*"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.JsonRpcRequestProcessorCliVersionGateTests.*"`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

