### PR TITLE
chore: Move tool admission into the session domain

### DIFF
--- a/Assets/Tests/Editor/ToolExecutionSessionTests.cs
+++ b/Assets/Tests/Editor/ToolExecutionSessionTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Domain;
@@ -7,6 +12,95 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     public sealed class ToolExecutionSessionTests
     {
+        [Test]
+        public void Begin_WhenToolIsUnknown_ShouldThrowArgumentExceptionWithoutEnteringSession()
+        {
+            // Tests that unknown tool rejection preserves the exception message and leaves the session slot clean.
+            ToolExecutionSession session = new ToolExecutionSession();
+            UnityCliLoopToolRegistry registry = CreateRegistry(new InMemoryToolSettingsPort(), new IUnityCliLoopTool[0]);
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => session.Begin(registry, "missing-tool"));
+            ToolExecutionSessionEnterResult enterResult = session.TryEnter("other-tool");
+
+            Assert.That(exception.Message, Is.EqualTo("Unknown tool: missing-tool"));
+            Assert.That(enterResult.IsEntered, Is.True);
+
+            session.Exit();
+        }
+
+        [Test]
+        public void Begin_WhenToolIsDisabled_ShouldThrowToolDisabledExceptionWithoutEnteringSession()
+        {
+            // Tests that disabled tool rejection happens before session entry and keeps the slot available.
+            ToolExecutionSession session = new ToolExecutionSession();
+            InMemoryToolSettingsPort settingsPort = new InMemoryToolSettingsPort();
+            SessionTestTool disabledTool = new SessionTestTool("disabled-tool");
+            settingsPort.SetToolEnabled(disabledTool.ToolName, false);
+            UnityCliLoopToolRegistry registry = CreateRegistry(settingsPort, new IUnityCliLoopTool[] { disabledTool });
+
+            ToolDisabledException exception = Assert.Throws<ToolDisabledException>(() => session.Begin(registry, disabledTool.ToolName));
+            ToolExecutionSessionEnterResult enterResult = session.TryEnter("other-tool");
+
+            Assert.That(exception.Message, Is.EqualTo("Tool 'disabled-tool' is disabled"));
+            Assert.That(exception.ToolName, Is.EqualTo(disabledTool.ToolName));
+            Assert.That(enterResult.IsEntered, Is.True);
+
+            session.Exit();
+        }
+
+        [Test]
+        public void Begin_WhenToolIsBlockedBySecurity_ShouldThrowSecurityExceptionWithoutEnteringSession()
+        {
+            // Tests that security rejection preserves the reason string and leaves the session slot clean.
+            ToolExecutionSession session = new ToolExecutionSession();
+            SecurityBlockedSessionTestTool blockedTool = new SecurityBlockedSessionTestTool();
+            UnityCliLoopToolRegistry registry = CreateRegistry(new InMemoryToolSettingsPort(), new IUnityCliLoopTool[] { blockedTool });
+
+            UnityCliLoopSecurityException exception = Assert.Throws<UnityCliLoopSecurityException>(() => session.Begin(registry, blockedTool.ToolName));
+            ToolExecutionSessionEnterResult enterResult = session.TryEnter("other-tool");
+
+            Assert.That(exception.SecurityReason, Is.EqualTo("Tool is blocked by security settings"));
+            Assert.That(exception.ToolName, Is.EqualTo(blockedTool.ToolName));
+            Assert.That(enterResult.IsEntered, Is.True);
+
+            session.Exit();
+        }
+
+        [Test]
+        public void Begin_WhenToolIsAllowed_ShouldReturnEnteredResultWithTool()
+        {
+            // Tests that a registered, enabled, allowed tool enters the session and carries the selected tool.
+            ToolExecutionSession session = new ToolExecutionSession();
+            SessionTestTool tool = new SessionTestTool("allowed-tool");
+            UnityCliLoopToolRegistry registry = CreateRegistry(new InMemoryToolSettingsPort(), new IUnityCliLoopTool[] { tool });
+
+            ToolExecutionSessionBeginResult result = session.Begin(registry, tool.ToolName);
+
+            Assert.That(result.IsEntered, Is.True);
+            Assert.That(result.Tool, Is.SameAs(tool));
+            Assert.That(result.RunningToolName, Is.Empty);
+
+            session.Exit();
+        }
+
+        [Test]
+        public void Begin_WhenDifferentToolIsRunning_ShouldReturnBusyWithRunningToolName()
+        {
+            // Tests that admission returns busy after policy gates pass when another tool owns the slot.
+            ToolExecutionSession session = new ToolExecutionSession();
+            SessionTestTool requestedTool = new SessionTestTool("requested-tool");
+            UnityCliLoopToolRegistry registry = CreateRegistry(new InMemoryToolSettingsPort(), new IUnityCliLoopTool[] { requestedTool });
+            session.TryEnter("running-tool");
+
+            ToolExecutionSessionBeginResult result = session.Begin(registry, requestedTool.ToolName);
+
+            Assert.That(result.IsEntered, Is.False);
+            Assert.That(result.Tool, Is.Null);
+            Assert.That(result.RunningToolName, Is.EqualTo("running-tool"));
+
+            session.Exit();
+        }
+
         [Test]
         public void TryEnter_WhenNoToolIsRunning_ShouldEnterAndAllowExitThenNextTool()
         {
@@ -80,6 +174,89 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(enteredAfterBothExit.IsEntered, Is.True);
 
             session.Exit();
+        }
+
+        private static UnityCliLoopToolRegistry CreateRegistry(InMemoryToolSettingsPort settingsPort, IUnityCliLoopTool[] tools)
+        {
+            UnityCliLoopToolRegistry registry = new UnityCliLoopToolRegistry(
+                settingsPort,
+                internalToolNameProvider: null,
+                toolDiscovery: null);
+
+            foreach (IUnityCliLoopTool tool in tools)
+            {
+                registry.RegisterTool(tool);
+            }
+
+            return registry;
+        }
+
+        private sealed class SessionTestTool : IUnityCliLoopTool
+        {
+            public SessionTestTool(string toolName)
+            {
+                ToolName = toolName;
+            }
+
+            public string ToolName { get; }
+
+            public ToolParameterSchema ParameterSchema => new();
+
+            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
+            {
+                return Task.FromResult<UnityCliLoopToolResponse>(new SessionTestResponse());
+            }
+        }
+
+        // The enum currently has only None, so an undefined value is the only way to exercise security-blocked handling.
+        [UnityCliLoopTool(RequiredSecuritySetting = (UnityCliLoopSecuritySetting)999)]
+        private sealed class SecurityBlockedSessionTestTool : IUnityCliLoopTool
+        {
+            public string ToolName => "security-blocked-session-test";
+
+            public ToolParameterSchema ParameterSchema => new();
+
+            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
+            {
+                return Task.FromResult<UnityCliLoopToolResponse>(new SessionTestResponse());
+            }
+        }
+
+        private sealed class InMemoryToolSettingsPort : IToolSettingsPort
+        {
+            private readonly HashSet<string> _disabledTools = new();
+
+            public bool IsToolEnabled(string toolName)
+            {
+                return !_disabledTools.Contains(toolName);
+            }
+
+            public void SetToolEnabled(string toolName, bool enabled)
+            {
+                if (enabled)
+                {
+                    _disabledTools.Remove(toolName);
+                    return;
+                }
+
+                _disabledTools.Add(toolName);
+            }
+
+            public string[] GetDisabledTools()
+            {
+                string[] disabledTools = new string[_disabledTools.Count];
+                _disabledTools.CopyTo(disabledTools);
+                return disabledTools;
+            }
+
+            public void InvalidateCache()
+            {
+            }
+        }
+
+        private sealed class SessionTestResponse : UnityCliLoopToolResponse
+        {
+            public bool Success { get; set; } = true;
         }
     }
 }

--- a/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
@@ -35,26 +35,10 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
             ct.ThrowIfCancellationRequested();
 
-            if (!registry.TryGetTool(toolName, out IUnityCliLoopTool tool))
+            ToolExecutionSessionBeginResult beginResult = _executionSession.Begin(registry, toolName);
+            if (!beginResult.IsEntered)
             {
-                throw new ArgumentException($"Unknown tool: {toolName}");
-            }
-
-            if (!registry.IsToolEnabled(toolName)
-                && !ToolExecutionAvailability.ShouldReportDependencyUnavailableBeforeDisabled(toolName))
-            {
-                throw new ToolDisabledException(toolName);
-            }
-
-            if (!UnityCliLoopSecurityChecker.IsToolAllowed(registry, toolName))
-            {
-                throw new UnityCliLoopSecurityException(toolName, "Tool is blocked by security settings");
-            }
-
-            ToolExecutionSessionEnterResult enterResult = _executionSession.TryEnter(toolName);
-            if (!enterResult.IsEntered)
-            {
-                throw CreateBusyException(enterResult.RunningToolName, toolName, _editorRuntimeStatePort);
+                throw CreateBusyException(beginResult.RunningToolName, toolName, _editorRuntimeStatePort);
             }
 
             try
@@ -63,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 ct.ThrowIfCancellationRequested();
                 UnityCliLoopEditorStateGuard.Validate(toolName, _editorRuntimeStatePort);
 
-                UnityCliLoopToolResponse response = await tool.ExecuteAsync(paramsToken, ct).ConfigureAwait(false);
+                UnityCliLoopToolResponse response = await beginResult.Tool.ExecuteAsync(paramsToken, ct).ConfigureAwait(false);
                 if (response == null)
                 {
                     throw new InvalidOperationException($"Tool returned null response: {toolName}");
@@ -108,6 +92,5 @@ namespace io.github.hatayama.UnityCliLoop.Application
 
             return new UnityCliLoopToolBusyException(runningToolName, requestedToolName);
         }
-
     }
 }

--- a/Packages/src/Editor/Domain/ToolExecutionSession.cs
+++ b/Packages/src/Editor/Domain/ToolExecutionSession.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -14,6 +15,36 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         private readonly object _executionStateLock = new();
         private string _runningToolName;
         private int _runningExecutionCount;
+
+        internal ToolExecutionSessionBeginResult Begin(UnityCliLoopToolRegistry registry, string toolName)
+        {
+            Debug.Assert(registry != null, "registry must not be null");
+            Debug.Assert(!string.IsNullOrWhiteSpace(toolName), "toolName must not be null or whitespace");
+
+            if (!registry.TryGetTool(toolName, out IUnityCliLoopTool tool))
+            {
+                throw new ArgumentException($"Unknown tool: {toolName}");
+            }
+
+            if (!registry.IsToolEnabled(toolName)
+                && !ToolExecutionAvailability.ShouldReportDependencyUnavailableBeforeDisabled(toolName))
+            {
+                throw new ToolDisabledException(toolName);
+            }
+
+            if (!UnityCliLoopSecurityChecker.IsToolAllowed(registry, toolName))
+            {
+                throw new UnityCliLoopSecurityException(toolName, "Tool is blocked by security settings");
+            }
+
+            ToolExecutionSessionEnterResult enterResult = TryEnter(toolName);
+            if (!enterResult.IsEntered)
+            {
+                return ToolExecutionSessionBeginResult.Busy(enterResult.RunningToolName);
+            }
+
+            return ToolExecutionSessionBeginResult.Entered(tool);
+        }
 
         internal ToolExecutionSessionEnterResult TryEnter(string requestedToolName)
         {
@@ -64,6 +95,38 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             return string.IsNullOrWhiteSpace(_runningToolName)
                 ? UnknownToolName
                 : _runningToolName;
+        }
+    }
+
+    /// <summary>
+    /// Reports whether a tool execution request passed admission and entered the session.
+    /// </summary>
+    internal readonly struct ToolExecutionSessionBeginResult
+    {
+        public readonly bool IsEntered;
+        public readonly IUnityCliLoopTool Tool;
+        public readonly string RunningToolName;
+
+        private ToolExecutionSessionBeginResult(bool isEntered, IUnityCliLoopTool tool, string runningToolName)
+        {
+            Debug.Assert(isEntered == (tool != null), "entered sessions must carry a tool");
+            Debug.Assert(isEntered || !string.IsNullOrWhiteSpace(runningToolName), "runningToolName must not be null or whitespace for busy decisions");
+
+            IsEntered = isEntered;
+            Tool = tool;
+            RunningToolName = runningToolName;
+        }
+
+        public static ToolExecutionSessionBeginResult Entered(IUnityCliLoopTool tool)
+        {
+            Debug.Assert(tool != null, "tool must not be null");
+
+            return new ToolExecutionSessionBeginResult(true, tool, string.Empty);
+        }
+
+        public static ToolExecutionSessionBeginResult Busy(string runningToolName)
+        {
+            return new ToolExecutionSessionBeginResult(false, null, runningToolName);
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep tool execution admission behavior unchanged while moving the policy decision into the domain session object.
- Leave the application service focused on cancellation, editor readiness, execution, and busy exception translation.

## User Impact
- Tool execution responses and error shapes stay the same for unknown, disabled, security-blocked, and busy requests.
- This reduces implementation coupling before the next domain boundary cleanup without changing CLI behavior.

## Changes
- Add ToolExecutionSession.Begin to run unknown, enabled, security, and busy admission in the existing order.
- Return the selected tool only through the admission result while keeping busy translation in the application layer.
- Add domain tests that verify rejection does not dirty the execution slot.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ToolExecutionSessionTests"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopToolExecutionServiceTests"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.JsonRpcRequestProcessorCliVersionGateTests"`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

