### PR TITLE
chore: Separate editor settings storage from domain values

### DIFF
--- a/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
+++ b/Assets/Tests/Editor/OnionAssemblyDependencyTests.cs
@@ -206,18 +206,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void ToolSettings_WhenLoaded_PinPortsToDomainAndStorageDtoToInfrastructure()
+        public void Settings_WhenLoaded_PinPortsToDomainAndStorageDtosToInfrastructure()
         {
-            // Tests that tool-specific settings ports stay in the domain layer while JSON storage DTOs stay in infrastructure.
+            // Tests that settings ports and value objects stay in the domain layer while JSON storage DTOs stay in infrastructure.
             string editorSettingsDataAssemblyName = typeof(UnityCliLoopEditorSettingsData).Assembly.GetName().Name;
             string toolSettingsPortAssemblyName = typeof(IToolSettingsPort).Assembly.GetName().Name;
             string editorSettingsPortAssemblyName = typeof(IUnityCliLoopEditorSettingsPort).Assembly.GetName().Name;
             string toolSettingsDataAssemblyName = typeof(ToolSettingsData).Assembly.GetName().Name;
+            string editorSettingsJsonDataAssemblyName =
+                typeof(UnityCliLoopEditorSettingsJsonData).Assembly.GetName().Name;
 
             Assert.That(editorSettingsDataAssemblyName, Is.EqualTo(DomainAssemblyName));
             Assert.That(toolSettingsPortAssemblyName, Is.EqualTo(DomainAssemblyName));
             Assert.That(editorSettingsPortAssemblyName, Is.EqualTo(DomainAssemblyName));
             Assert.That(toolSettingsDataAssemblyName, Is.EqualTo(InfrastructureAssemblyName));
+            Assert.That(editorSettingsJsonDataAssemblyName, Is.EqualTo(InfrastructureAssemblyName));
         }
 
         [Test]

--- a/Assets/Tests/Editor/UnityCliLoopEditorSettingsRecoveryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSettingsRecoveryTests.cs
@@ -84,15 +84,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void RecoverSettingsFileIfNeeded_WhenPrimaryMissingAndBackupExists_ShouldRestoreBackup()
         {
             UnityCliLoopEditorSettingsData backupData = new() { showDeveloperTools = true };
-            File.WriteAllText(BackupFilePath, JsonUtility.ToJson(backupData, true));
+            File.WriteAllText(BackupFilePath, SerializeSettingsData(backupData));
 
             _editorSettingsPort.RecoverSettingsFileIfNeeded();
 
             Assert.IsTrue(File.Exists(SettingsFilePath), "Primary settings file should be restored from backup");
             Assert.IsFalse(File.Exists(BackupFilePath), "Backup should be consumed after recovery");
 
-            UnityCliLoopEditorSettingsData restored = JsonUtility.FromJson<UnityCliLoopEditorSettingsData>(
-                File.ReadAllText(SettingsFilePath));
+            UnityCliLoopEditorSettingsJsonData restored = DeserializeSettingsJson(File.ReadAllText(SettingsFilePath));
             Assert.AreEqual(backupData.showDeveloperTools, restored.showDeveloperTools);
         }
 
@@ -101,8 +100,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             UnityCliLoopEditorSettingsData oldData = new() { showDeveloperTools = false };
             UnityCliLoopEditorSettingsData newData = new() { showDeveloperTools = true };
-            File.WriteAllText(BackupFilePath, JsonUtility.ToJson(oldData, true));
-            File.WriteAllText(TempFilePath, JsonUtility.ToJson(newData, true));
+            File.WriteAllText(BackupFilePath, SerializeSettingsData(oldData));
+            File.WriteAllText(TempFilePath, SerializeSettingsData(newData));
 
             _editorSettingsPort.RecoverSettingsFileIfNeeded();
 
@@ -110,8 +109,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.IsFalse(File.Exists(BackupFilePath), "Backup should be removed after temp recovery");
             Assert.IsFalse(File.Exists(TempFilePath), "Temp file should be consumed after recovery");
 
-            UnityCliLoopEditorSettingsData restored = JsonUtility.FromJson<UnityCliLoopEditorSettingsData>(
-                File.ReadAllText(SettingsFilePath));
+            UnityCliLoopEditorSettingsJsonData restored = DeserializeSettingsJson(File.ReadAllText(SettingsFilePath));
             Assert.AreEqual(newData.showDeveloperTools, restored.showDeveloperTools);
         }
 
@@ -119,17 +117,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void RecoverSettingsFileIfNeeded_WhenPrimaryExists_ShouldCleanStaleSidecars()
         {
             UnityCliLoopEditorSettingsData primaryData = new() { showDeveloperTools = true };
-            File.WriteAllText(SettingsFilePath, JsonUtility.ToJson(primaryData, true));
-            File.WriteAllText(BackupFilePath, JsonUtility.ToJson(new UnityCliLoopEditorSettingsData { showDeveloperTools = false }, true));
-            File.WriteAllText(TempFilePath, JsonUtility.ToJson(new UnityCliLoopEditorSettingsData { showDeveloperTools = false }, true));
+            File.WriteAllText(SettingsFilePath, SerializeSettingsData(primaryData));
+            File.WriteAllText(BackupFilePath, SerializeSettingsData(new UnityCliLoopEditorSettingsData { showDeveloperTools = false }));
+            File.WriteAllText(TempFilePath, SerializeSettingsData(new UnityCliLoopEditorSettingsData { showDeveloperTools = false }));
 
             _editorSettingsPort.RecoverSettingsFileIfNeeded();
 
             Assert.IsFalse(File.Exists(BackupFilePath), "Backup should not linger once primary exists");
             Assert.IsFalse(File.Exists(TempFilePath), "Temp should not linger once primary exists");
 
-            UnityCliLoopEditorSettingsData restored = JsonUtility.FromJson<UnityCliLoopEditorSettingsData>(
-                File.ReadAllText(SettingsFilePath));
+            UnityCliLoopEditorSettingsJsonData restored = DeserializeSettingsJson(File.ReadAllText(SettingsFilePath));
             Assert.AreEqual(primaryData.showDeveloperTools, restored.showDeveloperTools);
         }
 
@@ -142,7 +139,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 lastSeenSetupWizardVersion = "2.1.1",
                 suppressSetupWizardAutoShow = false
             };
-            File.WriteAllText(LegacySettingsFilePath, JsonUtility.ToJson(legacyData, true));
+            File.WriteAllText(LegacySettingsFilePath, SerializeSettingsData(legacyData));
 
             string lastSeenVersion = _editorSettingsPort.GetLastSeenSetupWizardVersion();
             bool suppressAutoShow = _editorSettingsPort.GetSuppressSetupWizardAutoShow();
@@ -162,7 +159,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 lastSeenSetupWizardVersion = "2.1.1",
                 suppressSetupWizardAutoShow = true
             };
-            File.WriteAllText(LegacySettingsFilePath, JsonUtility.ToJson(legacyData, true));
+            File.WriteAllText(LegacySettingsFilePath, SerializeSettingsData(legacyData));
 
             bool suppressAutoShow = _editorSettingsPort.GetSuppressSetupWizardAutoShow();
 
@@ -184,8 +181,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 lastSeenSetupWizardVersion = "2.1.1",
                 suppressSetupWizardAutoShow = false
             };
-            File.WriteAllText(SettingsFilePath, JsonUtility.ToJson(currentData, true));
-            File.WriteAllText(LegacySettingsFilePath, JsonUtility.ToJson(legacyData, true));
+            File.WriteAllText(SettingsFilePath, SerializeSettingsData(currentData));
+            File.WriteAllText(LegacySettingsFilePath, SerializeSettingsData(legacyData));
 
             string lastSeenVersion = _editorSettingsPort.GetLastSeenSetupWizardVersion();
             bool suppressAutoShow = _editorSettingsPort.GetSuppressSetupWizardAutoShow();
@@ -210,8 +207,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 lastSeenSetupWizardVersion = "2.1.1",
                 suppressSetupWizardAutoShow = true
             };
-            File.WriteAllText(SettingsFilePath, JsonUtility.ToJson(currentData, true));
-            File.WriteAllText(LegacySettingsFilePath, JsonUtility.ToJson(legacyData, true));
+            File.WriteAllText(SettingsFilePath, SerializeSettingsData(currentData));
+            File.WriteAllText(LegacySettingsFilePath, SerializeSettingsData(legacyData));
 
             string lastSeenVersion = _editorSettingsPort.GetLastSeenSetupWizardVersion();
             bool suppressAutoShow = _editorSettingsPort.GetSuppressSetupWizardAutoShow();
@@ -230,6 +227,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool installSkillsFlat = _editorSettingsPort.GetSettings().installSkillsFlat;
 
             Assert.IsTrue(installSkillsFlat);
+        }
+
+        [Test]
+        public void GetSettings_WhenStringFieldIsExplicitNull_ShouldPreserveJsonUtilityEmptyStringMaterializationAndApplyMissingDefaults()
+        {
+            // Verifies that DTO-to-VO conversion preserves JsonUtility's empty-string materialization.
+            File.WriteAllText(SettingsFilePath, "{\"lastSeenSetupWizardVersion\":null}");
+            _editorSettingsRepository.InvalidateCache();
+
+            UnityCliLoopEditorSettingsData settings = _editorSettingsPort.GetSettings();
+
+            Assert.That(settings.lastSeenSetupWizardVersion, Is.Empty);
+            Assert.That(settings.lastSeenSetupWizardMinimumDispatcherVersion, Is.Empty);
+            Assert.That(settings.showUnityCliLoopSecuritySetting, Is.True);
+            Assert.That(settings.showToolSettings, Is.True);
+            Assert.That(settings.installSkillsFlat, Is.True);
         }
 
         [Test]
@@ -325,6 +338,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 File.Delete(path);
             }
+        }
+
+        private static string SerializeSettingsData(UnityCliLoopEditorSettingsData settings)
+        {
+            return JsonUtility.ToJson(UnityCliLoopEditorSettingsJsonData.FromDomain(settings), true);
+        }
+
+        private static UnityCliLoopEditorSettingsJsonData DeserializeSettingsJson(string json)
+        {
+            return JsonUtility.FromJson<UnityCliLoopEditorSettingsJsonData>(json);
         }
 
         /// <summary>

--- a/Packages/src/Editor/Domain/IsExternalInit.cs
+++ b/Packages/src/Editor/Domain/IsExternalInit.cs
@@ -1,0 +1,7 @@
+namespace System.Runtime.CompilerServices
+{
+    // Unity's .NET profile does not provide this marker type, but init accessors require it.
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/Packages/src/Editor/Domain/IsExternalInit.cs.meta
+++ b/Packages/src/Editor/Domain/IsExternalInit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 741f87577bc7e49629afddda7918d8e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/UnityCliLoopEditorSettingsData.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopEditorSettingsData.cs
@@ -1,17 +1,14 @@
-using System;
-
 namespace io.github.hatayama.UnityCliLoop.Domain
 {
-    [Serializable]
     public record UnityCliLoopEditorSettingsData
     {
-        public bool showDeveloperTools = false;
-        public string lastSeenSetupWizardVersion = "";
-        public string lastSeenSetupWizardMinimumDispatcherVersion = "";
-        public bool suppressSetupWizardAutoShow = false;
-        public bool legacySetupWizardStateMigrated = false;
-        public bool showUnityCliLoopSecuritySetting = true;
-        public bool showToolSettings = true;
-        public bool installSkillsFlat = true;
+        public bool showDeveloperTools { get; init; } = false;
+        public string lastSeenSetupWizardVersion { get; init; } = "";
+        public string lastSeenSetupWizardMinimumDispatcherVersion { get; init; } = "";
+        public bool suppressSetupWizardAutoShow { get; init; } = false;
+        public bool legacySetupWizardStateMigrated { get; init; } = false;
+        public bool showUnityCliLoopSecuritySetting { get; init; } = true;
+        public bool showToolSettings { get; init; } = true;
+        public bool installSkillsFlat { get; init; } = true;
     }
 }

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsJsonData.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsJsonData.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Diagnostics;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// JsonUtility storage DTO for Unity CLI Loop editor settings.
+    /// </summary>
+    [Serializable]
+    internal sealed class UnityCliLoopEditorSettingsJsonData
+    {
+        public bool showDeveloperTools = false;
+        public string lastSeenSetupWizardVersion = "";
+        public string lastSeenSetupWizardMinimumDispatcherVersion = "";
+        public bool suppressSetupWizardAutoShow = false;
+        public bool legacySetupWizardStateMigrated = false;
+        public bool showUnityCliLoopSecuritySetting = true;
+        public bool showToolSettings = true;
+        public bool installSkillsFlat = true;
+
+        internal UnityCliLoopEditorSettingsData ToDomain()
+        {
+            return new UnityCliLoopEditorSettingsData
+            {
+                showDeveloperTools = showDeveloperTools,
+                lastSeenSetupWizardVersion = lastSeenSetupWizardVersion,
+                lastSeenSetupWizardMinimumDispatcherVersion = lastSeenSetupWizardMinimumDispatcherVersion,
+                suppressSetupWizardAutoShow = suppressSetupWizardAutoShow,
+                legacySetupWizardStateMigrated = legacySetupWizardStateMigrated,
+                showUnityCliLoopSecuritySetting = showUnityCliLoopSecuritySetting,
+                showToolSettings = showToolSettings,
+                installSkillsFlat = installSkillsFlat
+            };
+        }
+
+        internal static UnityCliLoopEditorSettingsJsonData FromDomain(UnityCliLoopEditorSettingsData settings)
+        {
+            Debug.Assert(settings != null, "settings must not be null");
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            return new UnityCliLoopEditorSettingsJsonData
+            {
+                showDeveloperTools = settings.showDeveloperTools,
+                lastSeenSetupWizardVersion = settings.lastSeenSetupWizardVersion,
+                lastSeenSetupWizardMinimumDispatcherVersion = settings.lastSeenSetupWizardMinimumDispatcherVersion,
+                suppressSetupWizardAutoShow = settings.suppressSetupWizardAutoShow,
+                legacySetupWizardStateMigrated = settings.legacySetupWizardStateMigrated,
+                showUnityCliLoopSecuritySetting = settings.showUnityCliLoopSecuritySetting,
+                showToolSettings = settings.showToolSettings,
+                installSkillsFlat = settings.installSkillsFlat
+            };
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsJsonData.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsJsonData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe2c1cc6743e74e32a4cb12b4e7c9b15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsRepository.cs
+++ b/Packages/src/Editor/Infrastructure/Settings/UnityCliLoopEditorSettingsRepository.cs
@@ -86,7 +86,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 Directory.CreateDirectory(directory);
             }
             
-            string json = JsonUtility.ToJson(settings, true);
+            UnityCliLoopEditorSettingsJsonData jsonData =
+                UnityCliLoopEditorSettingsJsonData.FromDomain(settings);
+            string json = JsonUtility.ToJson(jsonData, true);
             
             // Security: Validate JSON content size
             if (json.Length > UnityCliLoopConstants.MAX_SETTINGS_SIZE_BYTES)
@@ -192,7 +194,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         throw new InvalidDataException("Settings file contains invalid JSON content");
                     }
 
-                    _cachedSettings = JsonUtility.FromJson<UnityCliLoopEditorSettingsData>(json);
+                    UnityCliLoopEditorSettingsJsonData loadedSettings =
+                        JsonUtility.FromJson<UnityCliLoopEditorSettingsJsonData>(json);
+                    _cachedSettings = loadedSettings.ToDomain();
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Keep editor settings behavior and JSON storage shape unchanged while making the domain settings record immutable after construction.
- Move Unity JsonUtility storage concerns into an infrastructure DTO.

## User Impact
- Existing UserSettings JSON remains compatible, including field names, order, and defaults.
- No CLI or Unity Editor behavior changes are intended.

## Changes
- Convert UnityCliLoopEditorSettingsData from mutable serialized fields to lowercase init-only domain properties and remove [Serializable] from the domain value.
- Add UnityCliLoopEditorSettingsJsonData in Infrastructure with the existing JSON fields, declaration order, and defaults, plus DTO/domain conversion methods.
- Add an internal Domain IsExternalInit marker because Unity .NET profile does not provide the type required by init accessors.
- Update recovery tests to serialize through the infrastructure DTO and pin JsonUtility explicit-null string materialization as string.Empty.

## Review Notes
- IUnityCliLoopEditorSettingsPort signatures are unchanged because the public type name and member names are preserved.
- DTO-to-domain conversion does not normalize string values; observed string.Empty for explicit JSON null comes from Unity JsonUtility materialization.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopEditorSettingsRecoveryTests"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopPackageRemovalSettingsResetterTests"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.SetupWizardWindowTests"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.OnionAssemblyDependencyTests"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopSettingsWindowCliActionTests"`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

