### PR TITLE
fix: Ignore malformed RPC capability metadata

### DIFF
--- a/Assets/Tests/Editor/JsonRpcRequestProcessorCliVersionGateTests.cs
+++ b/Assets/Tests/Editor/JsonRpcRequestProcessorCliVersionGateTests.cs
@@ -116,6 +116,59 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task ProcessRequest_WhenDispatchAckFlagIsNotBoolean_DoesNotWriteAcceptedHandshake()
+        {
+            // Verifies metadata feature flags are strict booleans and malformed values fail closed.
+            string acceptedResponse = null;
+            JsonRpcRequestProcessor processor = CreateProcessor(CreateRegistrarService());
+
+            string response = await processor.ProcessRequestWithEarlyResponseAsync(
+                BuildToolRequestWithMetadata(
+                    UnityCliLoopConstants.COMMAND_NAME_GET_VERSION,
+                    1,
+                    "\"acceptsDispatchAck\":\"true\""),
+                CancellationToken.None,
+                (earlyResponse, _, _) =>
+                {
+                    acceptedResponse = earlyResponse;
+                    return Task.CompletedTask;
+                });
+            JObject parsed = JObject.Parse(response);
+
+            Assert.That(parsed["error"], Is.Null);
+            Assert.That(acceptedResponse, Is.Null);
+        }
+
+        [Test]
+        public async Task ProcessRequest_WhenHeartbeatFlagIsNotBoolean_DoesNotNegotiateHeartbeat()
+        {
+            // Verifies malformed heartbeat metadata is treated as unsupported without failing the request.
+            string acceptedResponse = null;
+            Func<string> createHeartbeatJson = () => "";
+            JsonRpcRequestProcessor processor = CreateProcessor(CreateRegistrarService());
+
+            string response = await processor.ProcessRequestWithEarlyResponseAsync(
+                BuildToolRequestWithMetadata(
+                    UnityCliLoopConstants.COMMAND_NAME_GET_VERSION,
+                    1,
+                    "\"acceptsDispatchAck\":true,\"acceptsHeartbeat\":\"true\""),
+                CancellationToken.None,
+                (earlyResponse, _, heartbeatFactory) =>
+                {
+                    acceptedResponse = earlyResponse;
+                    createHeartbeatJson = heartbeatFactory;
+                    return Task.CompletedTask;
+                });
+            JObject parsed = JObject.Parse(response);
+            JObject accepted = JObject.Parse(acceptedResponse);
+
+            Assert.That(parsed["error"], Is.Null);
+            Assert.That(accepted["uloop"]?["phase"]?.ToString(), Is.EqualTo(JsonRpcResponsePhases.Accepted));
+            Assert.That(accepted["uloop"]?["heartbeatIntervalSeconds"], Is.Null);
+            Assert.That(createHeartbeatJson, Is.Null);
+        }
+
+        [Test]
         public async Task ProcessRequest_WhenCliMetadataIsMissing_ReturnsCliUpdateRequiredError()
         {
             // Verifies legacy clients without metadata are stopped with upgrade instructions.
@@ -658,6 +711,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ",\"uloop\":{\"protocolVersion\":" +
                 CliConstants.REQUIRED_CLI_PROTOCOL_VERSION +
                 ",\"acceptsDispatchAck\":true,\"acceptsHeartbeat\":true}}";
+        }
+
+        private static string BuildToolRequestWithMetadata(string toolName, int id, string metadataJson)
+        {
+            return
+                "{\"jsonrpc\":\"2.0\",\"method\":\"" +
+                toolName +
+                "\",\"params\":{},\"id\":" +
+                id +
+                ",\"uloop\":{\"protocolVersion\":" +
+                CliConstants.REQUIRED_CLI_PROTOCOL_VERSION +
+                "," +
+                metadataJson +
+                "}}";
         }
 
         private static JObject ParseErrorData(string response)

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcCompileRequestMetadataReader.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcCompileRequestMetadataReader.cs
@@ -1,0 +1,35 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Reads compile-specific JSON-RPC request metadata used before tool dispatch.
+    /// </summary>
+    internal static class JsonRpcCompileRequestMetadataReader
+    {
+        private const string WaitForDomainReloadParamName = "WaitForDomainReload";
+
+        internal static bool? ReadWaitsForDomainReload(JToken paramsToken)
+        {
+            if (paramsToken is not JObject paramsObject)
+            {
+                return null;
+            }
+
+            JToken waitForDomainReloadToken =
+                paramsObject.GetValue(WaitForDomainReloadParamName, StringComparison.OrdinalIgnoreCase);
+            if (waitForDomainReloadToken == null)
+            {
+                return null;
+            }
+
+            if (waitForDomainReloadToken.Type != JTokenType.Boolean)
+            {
+                return null;
+            }
+
+            return waitForDomainReloadToken.Value<bool>();
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcCompileRequestMetadataReader.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcCompileRequestMetadataReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b50b400d9aaa46f8b3bf41244cc1e685
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcRequestProcessor.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcRequestProcessor.cs
@@ -31,7 +31,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     internal sealed class JsonRpcRequestProcessor
     {
-        private const string WaitForDomainReloadParamName = "WaitForDomainReload";
         private readonly UnityCliLoopExecutionRouter _executionRouter;
 
         // Shared by every response path; JsonConvert only reads the settings, so a single
@@ -93,85 +92,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         /// </summary>
         private static JsonRpcRequest ParseRequest(string jsonRequest)
         {
-            JObject request = JObject.Parse(jsonRequest);
-            return new JsonRpcRequest
-            {
-                Method = request["method"]?.ToString(),
-                Params = request["params"],
-                ClientProjectRunnerVersion = ReadClientProjectRunnerVersion(request),
-                ClientProtocolVersion = ReadClientProtocolVersion(request),
-                AcceptsDispatchAck = ReadAcceptsDispatchAck(request),
-                AcceptsHeartbeat = ReadAcceptsHeartbeat(request),
-                Id = request["id"]?.ToObject<object>()
-            };
-        }
-
-        private static string ReadClientProjectRunnerVersion(JObject request)
-        {
-            JObject metadata = request["uloop"] as JObject;
-            if (metadata == null)
-            {
-                return null;
-            }
-
-            string projectRunnerVersion = metadata["projectRunnerVersion"]?.ToString();
-            return string.IsNullOrWhiteSpace(projectRunnerVersion) ? null : projectRunnerVersion;
-        }
-
-        private static int? ReadClientProtocolVersion(JObject request)
-        {
-            JObject metadata = request["uloop"] as JObject;
-            if (metadata == null)
-            {
-                return null;
-            }
-
-            JToken protocolVersionToken = metadata["protocolVersion"];
-            if (protocolVersionToken == null || protocolVersionToken.Type != JTokenType.Integer)
-            {
-                return null;
-            }
-
-            JValue protocolVersionValue = protocolVersionToken as JValue;
-            object rawProtocolVersion = protocolVersionValue?.Value;
-            if (rawProtocolVersion is int protocolVersion)
-            {
-                return protocolVersion;
-            }
-
-            if (!(rawProtocolVersion is long longProtocolVersion))
-            {
-                return null;
-            }
-
-            if (longProtocolVersion < int.MinValue || longProtocolVersion > int.MaxValue)
-            {
-                return null;
-            }
-
-            return (int)longProtocolVersion;
-        }
-
-        private static bool ReadAcceptsDispatchAck(JObject request)
-        {
-            JObject metadata = request["uloop"] as JObject;
-            if (metadata == null)
-            {
-                return false;
-            }
-
-            return metadata["acceptsDispatchAck"]?.Value<bool>() ?? false;
-        }
-
-        private static bool ReadAcceptsHeartbeat(JObject request)
-        {
-            JObject metadata = request["uloop"] as JObject;
-            if (metadata == null)
-            {
-                return false;
-            }
-
-            return metadata["acceptsHeartbeat"]?.Value<bool>() ?? false;
+            return UloopEnvelope.ParseJsonRpcRequest(jsonRequest);
         }
 
         /// <summary>
@@ -292,32 +213,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             System.Diagnostics.Debug.Assert(request != null, "request must not be null");
 
-            bool? compileWaitsForDomainReload = ReadCompileRequestWaitsForDomainReload(request.Params);
+            bool? compileWaitsForDomainReload =
+                JsonRpcCompileRequestMetadataReader.ReadWaitsForDomainReload(request.Params);
             return JsonRpcAcceptedRequestCancellationPolicy.ShouldCancelOnClientDisconnect(
                 request.Method,
                 compileWaitsForDomainReload);
-        }
-
-        private static bool? ReadCompileRequestWaitsForDomainReload(JToken paramsToken)
-        {
-            if (paramsToken is not JObject paramsObject)
-            {
-                return null;
-            }
-
-            JToken waitForDomainReloadToken =
-                paramsObject.GetValue(WaitForDomainReloadParamName, StringComparison.OrdinalIgnoreCase);
-            if (waitForDomainReloadToken == null)
-            {
-                return null;
-            }
-
-            if (waitForDomainReloadToken.Type != JTokenType.Boolean)
-            {
-                return null;
-            }
-
-            return waitForDomainReloadToken.Value<bool>();
         }
 
         private static bool IsCliProtocolMismatch(int? currentProtocolVersion)

--- a/Packages/src/Editor/Infrastructure/Api/UloopEnvelope.cs
+++ b/Packages/src/Editor/Infrastructure/Api/UloopEnvelope.cs
@@ -1,0 +1,102 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Reads the Unity CLI Loop JSON-RPC envelope without changing the wire keys.
+    /// </summary>
+    internal static class UloopEnvelope
+    {
+        private const string MethodPropertyName = "method";
+        private const string ParamsPropertyName = "params";
+        private const string IdPropertyName = "id";
+        private const string MetadataPropertyName = "uloop";
+        private const string ProjectRunnerVersionPropertyName = "projectRunnerVersion";
+        private const string ProtocolVersionPropertyName = "protocolVersion";
+        private const string AcceptsDispatchAckPropertyName = "acceptsDispatchAck";
+        private const string AcceptsHeartbeatPropertyName = "acceptsHeartbeat";
+
+        internal static JsonRpcRequest ParseJsonRpcRequest(string jsonRequest)
+        {
+            JObject request = JObject.Parse(jsonRequest);
+            JObject metadata = ReadMetadata(request);
+
+            return new JsonRpcRequest
+            {
+                Method = request[MethodPropertyName]?.ToString(),
+                Params = request[ParamsPropertyName],
+                ClientProjectRunnerVersion = ReadClientProjectRunnerVersion(metadata),
+                ClientProtocolVersion = ReadClientProtocolVersion(metadata),
+                AcceptsDispatchAck = ReadStrictBooleanMetadata(metadata, AcceptsDispatchAckPropertyName),
+                AcceptsHeartbeat = ReadStrictBooleanMetadata(metadata, AcceptsHeartbeatPropertyName),
+                Id = request[IdPropertyName]?.ToObject<object>()
+            };
+        }
+
+        private static JObject ReadMetadata(JObject request)
+        {
+            return request[MetadataPropertyName] as JObject;
+        }
+
+        private static string ReadClientProjectRunnerVersion(JObject metadata)
+        {
+            if (metadata == null)
+            {
+                return null;
+            }
+
+            string projectRunnerVersion = metadata[ProjectRunnerVersionPropertyName]?.ToString();
+            return string.IsNullOrWhiteSpace(projectRunnerVersion) ? null : projectRunnerVersion;
+        }
+
+        private static int? ReadClientProtocolVersion(JObject metadata)
+        {
+            if (metadata == null)
+            {
+                return null;
+            }
+
+            JToken protocolVersionToken = metadata[ProtocolVersionPropertyName];
+            if (protocolVersionToken == null || protocolVersionToken.Type != JTokenType.Integer)
+            {
+                return null;
+            }
+
+            JValue protocolVersionValue = protocolVersionToken as JValue;
+            object rawProtocolVersion = protocolVersionValue?.Value;
+            if (rawProtocolVersion is int protocolVersion)
+            {
+                return protocolVersion;
+            }
+
+            if (!(rawProtocolVersion is long longProtocolVersion))
+            {
+                return null;
+            }
+
+            if (longProtocolVersion < int.MinValue || longProtocolVersion > int.MaxValue)
+            {
+                return null;
+            }
+
+            return (int)longProtocolVersion;
+        }
+
+        private static bool ReadStrictBooleanMetadata(JObject metadata, string propertyName)
+        {
+            if (metadata == null)
+            {
+                return false;
+            }
+
+            JToken metadataToken = metadata[propertyName];
+            if (metadataToken == null || metadataToken.Type != JTokenType.Boolean)
+            {
+                return false;
+            }
+
+            return metadataToken.Value<bool>();
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Api/UloopEnvelope.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Api/UloopEnvelope.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd2cfe0c14ef4739a2327e474568eb70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Malformed JSON-RPC capability metadata now fails closed instead of enabling accepted-response or heartbeat behavior.
- JSON-RPC envelope parsing is centralized away from the request processor while keeping the wire shape unchanged.

## User Impact
- Valid Go CLI clients keep the same protocol behavior because they already send boolean capability flags.
- Invalid capability values such as string `"true"` are now treated as unsupported instead of relying on Newtonsoft conversion or parse failures.

## Changes
- Added `UloopEnvelope` to read JSON-RPC request metadata in one place.
- Added `JsonRpcCompileRequestMetadataReader` to preserve compile `WaitForDomainReload` parsing semantics before dispatch.
- Kept protocol version parsing strict integer-only with int-range checks, preserved project runner version whitespace handling, and kept compile wait parsing case-insensitive.

## Review Notes
- Wire keys and JSON shapes are unchanged; no protocolVersion bump is needed.
- `acceptsDispatchAck` and `acceptsHeartbeat` intentionally changed to strict booleans per Fable review direction. Missing, non-object, or type-mismatched values now read as `false` and do not throw.
- C4-8 `completionContext` cleanup is intentionally excluded from this PR and will be handled separately.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.JsonRpcRequestProcessorCliVersionGateTests"` -> 21/21 passed
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.JsonRpcAcceptedRequestCancellationPolicyTests"` -> 4/4 passed
