### PR TITLE
fix: Keep fallback tool metadata aligned

### DIFF
--- a/Assets/Tests/Editor/DefaultToolsCatalogDriftTests.cs
+++ b/Assets/Tests/Editor/DefaultToolsCatalogDriftTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
+using io.github.hatayama.UnityCliLoop.CompositionRoot;
 using io.github.hatayama.UnityCliLoop.Domain;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 using ToolParameterInfo = io.github.hatayama.UnityCliLoop.ToolContracts.ParameterInfo;
@@ -91,7 +92,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private static Dictionary<string, JObject> ReadLiveSchemas(string[] embeddedToolNames)
         {
-            UnityCliLoopToolRegistry registry = ToolRegistryTestFactory.Create();
+            // Why: this drift guard compares catalog structure, so local tool settings
+            // must not hide disabled tools and turn developer preferences into failures.
+            UnityCliLoopToolRegistry registry = new UnityCliLoopToolRegistry(
+                new AlwaysEnabledToolSettingsPort(),
+                internalToolNameProvider: null,
+                toolDiscovery: UnityCliLoopToolDiscovery.DiscoverTools);
             HashSet<string> embeddedNameSet = new(embeddedToolNames, StringComparer.Ordinal);
 
             return registry.GetRegisteredTools()
@@ -131,7 +137,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             return new JObject
             {
                 ["type"] = "object",
-                ["required"] = new JArray(schema.Required),
+                ["required"] = NormalizeStringValues(schema.Required),
                 ["properties"] = normalizedProperties
             };
         }
@@ -174,7 +180,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 return new JArray();
             }
 
-            return new JArray(values.Values<string>());
+            return NormalizeStringValues(values.Values<string>());
+        }
+
+        private static JArray NormalizeStringValues(IEnumerable<string> values)
+        {
+            if (values == null)
+            {
+                return new JArray();
+            }
+
+            return new JArray(values.OrderBy(value => value, StringComparer.Ordinal));
         }
 
         private static string NormalizeSchemaType(string type)
@@ -214,6 +230,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
 
             return comparableSchema;
+        }
+
+        /// <summary>
+        /// Test-only settings port that exposes every discovered tool.
+        /// </summary>
+        private sealed class AlwaysEnabledToolSettingsPort : IToolSettingsPort
+        {
+            public bool IsToolEnabled(string toolName)
+            {
+                return true;
+            }
+
+            public void SetToolEnabled(string toolName, bool enabled)
+            {
+            }
+
+            public string[] GetDisabledTools()
+            {
+                return Array.Empty<string>();
+            }
+
+            public void InvalidateCache()
+            {
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/DefaultToolsCatalogDriftTests.cs
+++ b/Assets/Tests/Editor/DefaultToolsCatalogDriftTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+using ToolParameterInfo = io.github.hatayama.UnityCliLoop.ToolContracts.ParameterInfo;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies embedded CLI tool schemas stay aligned with Unity's live registry.
+    /// </summary>
+    public sealed class DefaultToolsCatalogDriftTests
+    {
+        private const string DefaultToolsPath = "cli/common/tools/default-tools.json";
+        private static readonly string[] CliOwnedCommandsWithoutLiveUnityTools =
+        {
+            // Why: focus-window is implemented by the Go CLI through OS process focus
+            // (`cli/common/clicore/focus.go`) and Unity only accepts a compatibility
+            // notification in JsonRpcRequestProcessor; it must stay in the fallback
+            // catalog even though the Unity registry intentionally has no live tool.
+            // Keep this list explicit so future CLI-owned fallback commands fail the
+            // guard first and get human review before being excluded.
+            "focus-window"
+        };
+
+        [Test]
+        public void DefaultToolsJson_WhenComparedWithLiveRegistry_DoesNotDrift()
+        {
+            // Verifies embedded CLI fallback schemas match live Unity parameter schemas.
+            // The comparison intentionally normalizes inputSchema/parameterSchema, integer/number,
+            // and enum order. It ignores descriptions, defaults, CLI-only hidden flags, array item
+            // details that Unity schemas cannot express, explicitly listed CLI-owned commands that
+            // have no live Unity registry tool, and embedded-only enum metadata when the live schema
+            // cannot express enums for string-backed parameters. If the live schema later exposes an
+            // enum for that property, the same embedded enum automatically becomes required to match.
+            Dictionary<string, JObject> embeddedSchemas = ReadEmbeddedSchemas();
+            Dictionary<string, JObject> liveSchemas = ReadLiveSchemas(embeddedSchemas.Keys.ToArray());
+            string[] missingLiveTools = embeddedSchemas.Keys
+                .Where(name => !CliOwnedCommandsWithoutLiveUnityTools.Contains(name))
+                .Where(name => !liveSchemas.ContainsKey(name))
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.That(missingLiveTools, Is.Empty, "Embedded tools must exist in the live Unity registry.");
+
+            List<string> driftMessages = new();
+            foreach (string toolName in embeddedSchemas.Keys.OrderBy(name => name, StringComparer.Ordinal))
+            {
+                if (CliOwnedCommandsWithoutLiveUnityTools.Contains(toolName))
+                {
+                    continue;
+                }
+
+                JObject liveSchema = liveSchemas[toolName];
+                JObject embeddedSchema = RemoveEmbeddedOnlyEnums(embeddedSchemas[toolName], liveSchema);
+                if (JToken.DeepEquals(embeddedSchema, liveSchema))
+                {
+                    continue;
+                }
+
+                driftMessages.Add(
+                    toolName +
+                    "\nembedded: " +
+                    embeddedSchema.ToString(Newtonsoft.Json.Formatting.None) +
+                    "\nlive:     " +
+                    liveSchema.ToString(Newtonsoft.Json.Formatting.None));
+            }
+
+            Assert.That(driftMessages, Is.Empty, string.Join("\n\n", driftMessages));
+        }
+
+        private static Dictionary<string, JObject> ReadEmbeddedSchemas()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, DefaultToolsPath));
+            JObject catalog = JObject.Parse(json);
+            JArray tools = catalog["tools"] as JArray ?? new JArray();
+
+            return tools
+                .OfType<JObject>()
+                .ToDictionary(
+                    tool => tool["name"]?.ToString() ?? "",
+                    tool => NormalizeEmbeddedSchema(tool["inputSchema"] as JObject),
+                    StringComparer.Ordinal);
+        }
+
+        private static Dictionary<string, JObject> ReadLiveSchemas(string[] embeddedToolNames)
+        {
+            UnityCliLoopToolRegistry registry = ToolRegistryTestFactory.Create();
+            HashSet<string> embeddedNameSet = new(embeddedToolNames, StringComparer.Ordinal);
+
+            return registry.GetRegisteredTools()
+                .Where(tool => embeddedNameSet.Contains(tool.Name))
+                .ToDictionary(
+                    tool => tool.Name,
+                    tool => NormalizeLiveSchema(tool.ParameterSchema),
+                    StringComparer.Ordinal);
+        }
+
+        private static JObject NormalizeEmbeddedSchema(JObject schema)
+        {
+            JObject properties = schema?["properties"] as JObject ?? new JObject();
+            JObject normalizedProperties = new();
+            foreach (JProperty property in properties.Properties().OrderBy(property => property.Name, StringComparer.Ordinal))
+            {
+                normalizedProperties[property.Name] = NormalizeEmbeddedProperty(property.Value as JObject);
+            }
+
+            return new JObject
+            {
+                ["type"] = schema?["type"]?.ToString() ?? "",
+                ["required"] = NormalizeStringArray(schema?["required"] as JArray),
+                ["properties"] = normalizedProperties
+            };
+        }
+
+        private static JObject NormalizeLiveSchema(ToolParameterSchema schema)
+        {
+            JObject normalizedProperties = new();
+            foreach (KeyValuePair<string, ToolParameterInfo> property in
+                schema.Properties.OrderBy(property => property.Key, StringComparer.Ordinal))
+            {
+                normalizedProperties[property.Key] = NormalizeLiveProperty(property.Value);
+            }
+
+            return new JObject
+            {
+                ["type"] = "object",
+                ["required"] = new JArray(schema.Required),
+                ["properties"] = normalizedProperties
+            };
+        }
+
+        private static JObject NormalizeEmbeddedProperty(JObject property)
+        {
+            JObject normalized = new()
+            {
+                ["type"] = NormalizeSchemaType(property?["type"]?.ToString() ?? "")
+            };
+
+            JArray enumValues = property?["enum"] as JArray;
+            if (enumValues != null)
+            {
+                normalized["enum"] = NormalizeEnumValues(enumValues.Values<string>());
+            }
+
+            return normalized;
+        }
+
+        private static JObject NormalizeLiveProperty(ToolParameterInfo property)
+        {
+            JObject normalized = new()
+            {
+                ["type"] = NormalizeSchemaType(property.Type)
+            };
+
+            if (property.Enum != null && property.Enum.Length > 0)
+            {
+                normalized["enum"] = NormalizeEnumValues(property.Enum);
+            }
+
+            return normalized;
+        }
+
+        private static JArray NormalizeStringArray(JArray values)
+        {
+            if (values == null)
+            {
+                return new JArray();
+            }
+
+            return new JArray(values.Values<string>());
+        }
+
+        private static string NormalizeSchemaType(string type)
+        {
+            // Why: the Unity generator maps every numeric CLR type to "number", while
+            // the embedded CLI catalog has historically used "integer" for integral
+            // values. Both are numeric parameters for current CLI parsing purposes.
+            if (type == "integer")
+            {
+                return "number";
+            }
+
+            return type;
+        }
+
+        private static JArray NormalizeEnumValues(IEnumerable<string> values)
+        {
+            return new JArray(values.OrderBy(value => value, StringComparer.Ordinal));
+        }
+
+        private static JObject RemoveEmbeddedOnlyEnums(JObject embeddedSchema, JObject liveSchema)
+        {
+            JObject comparableSchema = (JObject)embeddedSchema.DeepClone();
+            JObject embeddedProperties = comparableSchema["properties"] as JObject ?? new JObject();
+            JObject liveProperties = liveSchema["properties"] as JObject ?? new JObject();
+
+            foreach (JProperty embeddedProperty in embeddedProperties.Properties())
+            {
+                JObject liveProperty = liveProperties[embeddedProperty.Name] as JObject;
+                if (liveProperty != null && liveProperty["enum"] != null)
+                {
+                    continue;
+                }
+
+                JObject embeddedPropertyValue = embeddedProperty.Value as JObject;
+                embeddedPropertyValue?.Remove("enum");
+            }
+
+            return comparableSchema;
+        }
+    }
+}

--- a/Assets/Tests/Editor/DefaultToolsCatalogDriftTests.cs.meta
+++ b/Assets/Tests/Editor/DefaultToolsCatalogDriftTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ae48bf9f5644a698a8e7c6cdcd2f1eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -311,11 +311,12 @@
         "properties": {
           "Action": {
             "type": "string",
-            "description": "Action to perform: Play - Start play mode, Stop - Stop play mode, Pause - Pause play mode",
+            "description": "Action to perform: Play - Start play mode, Stop - Stop play mode, Pause - Pause play mode, Step - advance one frame while paused",
             "enum": [
               "Play",
               "Stop",
-              "Pause"
+              "Pause",
+              "Step"
             ],
             "default": "Play"
           },


### PR DESCRIPTION
## Summary
- Add a guard that catches structural drift between the embedded CLI fallback catalog and Unity's live tool registry.
- Keep the fallback catalog current for `control-play-mode` by adding the live `Step` action.

## User Impact
- CLI fallback help and completion stay aligned with the tools Unity actually exposes.
- `control-play-mode` fallback metadata now includes `Step` when the CLI cannot read a live project cache.

## Changes
- Added `DefaultToolsCatalogDriftTests` for tool names, property names, normalized numeric types, live-expressed enum members, and required fields.
- Documented intentional asymmetries: `focus-window` is CLI-owned, descriptions/defaults are curated metadata, array item details are CLI-only, and string-backed embedded enums can carry curated completion metadata until the live schema can express them.
- Updated `cli/common/tools/default-tools.json` to include `Step` for `control-play-mode.Action`.

## Review Notes
- `default-tools.json` changed, so the IPC protocol reminder may appear. This is catalog fallback metadata only; no request/response wire shape changes and no protocolVersion bump is needed.
- Descriptions and defaults are intentionally not compared in this PR because the live generator currently emits fallback descriptions/defaults while the embedded catalog carries curated CLI help.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.DefaultToolsCatalogDriftTests"` -> 1/1 passed
- `(cd cli/common && go test ./tools ./clicore)` -> passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

