### PR TITLE
fix: Reject malformed dispatcher versions consistently

### DIFF
--- a/Assets/Tests/Editor/CliVersionComparerTests.cs
+++ b/Assets/Tests/Editor/CliVersionComparerTests.cs
@@ -1,6 +1,10 @@
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -9,6 +13,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public class CliVersionComparerTests
     {
+        private const string SharedCompareCasesPath = "cli/common/version/compare_cases.json";
+
+        [Test]
+        public void TryCompareCliVersions_WhenSharedContractCasesLoaded_MatchesContract()
+        {
+            // Verifies that C# comparison behavior matches the shared cross-language contract table.
+            CompareCaseCatalog catalog = ReadCompareCaseCatalog();
+
+            foreach (CompareCase testCase in catalog.Cases)
+            {
+                bool ok = CliVersionComparer.TryCompareCliVersions(
+                    testCase.Left,
+                    testCase.Right,
+                    out int comparison);
+
+                Assert.That(ok, Is.EqualTo(testCase.Ok), testCase.Name);
+                Assert.That(comparison, Is.EqualTo(testCase.Comparison), testCase.Name);
+            }
+        }
+
         [TestCase("3.0.0-beta.0", "3.0.0-beta.0", true)]
         [TestCase("3.0.0-beta.1", "3.0.0-beta.0", true)]
         [TestCase("3.0.0", "3.0.0-beta.0", true)]
@@ -20,6 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string requiredVersion,
             bool expected)
         {
+            // Verifies greater-than-or-equal comparison for CLI setup compatibility checks.
             bool result = CliVersionComparer.IsVersionGreaterThanOrEqual(
                 installedVersion,
                 requiredVersion);
@@ -35,6 +60,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string rightVersion,
             bool expected)
         {
+            // Verifies less-than comparison for CLI downgrade and prerequisite checks.
             bool result = CliVersionComparer.IsVersionLessThan(leftVersion, rightVersion);
 
             Assert.That(result, Is.EqualTo(expected));
@@ -71,11 +97,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void IsVersionGreaterThanOrEqual_WhenVersionIsInvalid_ReturnsFalse()
         {
+            // Verifies malformed CLI versions fail closed during setup compatibility checks.
             bool result = CliVersionComparer.IsVersionGreaterThanOrEqual(
                 "3.0.0-beta.0",
                 "not-a-version");
 
             Assert.That(result, Is.False);
+        }
+
+        private static CompareCaseCatalog ReadCompareCaseCatalog()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedCompareCasesPath));
+            CompareCaseCatalog catalog = JsonConvert.DeserializeObject<CompareCaseCatalog>(json);
+            Assert.That(catalog, Is.Not.Null, "Shared compare cases must parse.");
+            Assert.That(catalog.Cases, Is.Not.Empty, "Shared compare cases must not be empty.");
+            return catalog;
+        }
+
+        private sealed class CompareCaseCatalog
+        {
+            public List<CompareCase> Cases { get; set; } = new List<CompareCase>();
+        }
+
+        private sealed class CompareCase
+        {
+            public string Name { get; set; }
+            public string Left { get; set; }
+            public string Right { get; set; }
+            public bool Ok { get; set; }
+            public int Comparison { get; set; }
         }
     }
 }

--- a/Packages/src/Editor/Domain/CliVersionComparer.cs
+++ b/Packages/src/Editor/Domain/CliVersionComparer.cs
@@ -54,37 +54,160 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 return false;
             }
 
-            string normalized = version.Trim().TrimStart('v', 'V');
+            string normalized = TrimVersionPrefix(version.Trim());
             string[] buildParts = normalized.Split(new[] { '+' }, 2);
             string versionWithoutBuildMetadata = buildParts[0];
-            string[] prereleaseParts = versionWithoutBuildMetadata.Split(new[] { '-' }, 2);
-            string coreVersion = prereleaseParts[0];
+            int prereleaseSeparatorIndex = versionWithoutBuildMetadata.IndexOf('-');
+            string coreVersion = prereleaseSeparatorIndex >= 0
+                ? versionWithoutBuildMetadata.Substring(0, prereleaseSeparatorIndex)
+                : versionWithoutBuildMetadata;
             string[] coreParts = coreVersion.Split('.');
             if (coreParts.Length != 3)
             {
                 return false;
             }
 
-            bool hasMajor = int.TryParse(coreParts[0], out int major);
-            bool hasMinor = int.TryParse(coreParts[1], out int minor);
-            bool hasPatch = int.TryParse(coreParts[2], out int patch);
+            (bool hasMajor, int major) = ParseVersionPart(coreParts[0]);
+            (bool hasMinor, int minor) = ParseVersionPart(coreParts[1]);
+            (bool hasPatch, int patch) = ParseVersionPart(coreParts[2]);
             if (!hasMajor || !hasMinor || !hasPatch)
             {
                 return false;
             }
 
             string[] prereleaseIdentifiers = Array.Empty<string>();
-            if (prereleaseParts.Length == 2)
+            if (prereleaseSeparatorIndex >= 0)
             {
-                if (string.IsNullOrEmpty(prereleaseParts[1]))
+                string prerelease = versionWithoutBuildMetadata.Substring(prereleaseSeparatorIndex + 1);
+                if (!IsValidPrerelease(prerelease))
                 {
                     return false;
                 }
 
-                prereleaseIdentifiers = prereleaseParts[1].Split('.');
+                prereleaseIdentifiers = prerelease.Split('.');
             }
 
             parsedVersion = new ParsedCliVersion(major, minor, patch, prereleaseIdentifiers);
+            return true;
+        }
+
+        private static string TrimVersionPrefix(string version)
+        {
+            if (version.StartsWith("v", StringComparison.Ordinal) ||
+                version.StartsWith("V", StringComparison.Ordinal))
+            {
+                return version.Substring(1);
+            }
+
+            return version;
+        }
+
+        private static (bool IsParsed, int Parsed) ParseVersionPart(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return (false, 0);
+            }
+
+            if (HasLeadingZero(value))
+            {
+                return (false, 0);
+            }
+
+            if (!ContainsOnlyDigits(value))
+            {
+                return (false, 0);
+            }
+
+            int parsed = 0;
+            foreach (char character in value)
+            {
+                int digit = character - '0';
+                if (parsed > (int.MaxValue - digit) / 10)
+                {
+                    return (false, 0);
+                }
+
+                parsed = (parsed * 10) + digit;
+            }
+
+            return (true, parsed);
+        }
+
+        private static bool IsValidPrerelease(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            string[] identifiers = value.Split('.');
+            foreach (string identifier in identifiers)
+            {
+                if (string.IsNullOrEmpty(identifier))
+                {
+                    return false;
+                }
+
+                if (!ContainsOnlyPrereleaseCharacters(identifier))
+                {
+                    return false;
+                }
+
+                if (ContainsOnlyDigits(identifier) && HasLeadingZero(identifier))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool HasLeadingZero(string value)
+        {
+            return value.Length > 1 && value.StartsWith("0", StringComparison.Ordinal);
+        }
+
+        private static bool ContainsOnlyDigits(string value)
+        {
+            foreach (char character in value)
+            {
+                if (character < '0' || character > '9')
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool ContainsOnlyPrereleaseCharacters(string value)
+        {
+            foreach (char character in value)
+            {
+                if (character >= '0' && character <= '9')
+                {
+                    continue;
+                }
+
+                if (character >= 'A' && character <= 'Z')
+                {
+                    continue;
+                }
+
+                if (character >= 'a' && character <= 'z')
+                {
+                    continue;
+                }
+
+                if (character == '-')
+                {
+                    continue;
+                }
+
+                return false;
+            }
+
             return true;
         }
 
@@ -147,8 +270,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
 
         private static int ComparePrereleaseIdentifiers(string leftIdentifier, string rightIdentifier)
         {
-            bool leftIsNumeric = int.TryParse(leftIdentifier, out int leftNumber);
-            bool rightIsNumeric = int.TryParse(rightIdentifier, out int rightNumber);
+            (bool leftIsNumeric, int leftNumber) = ParseVersionPart(leftIdentifier);
+            (bool rightIsNumeric, int rightNumber) = ParseVersionPart(rightIdentifier);
             if (leftIsNumeric && rightIsNumeric)
             {
                 return leftNumber.CompareTo(rightNumber);
@@ -164,7 +287,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 return 1;
             }
 
-            return string.CompareOrdinal(leftIdentifier, rightIdentifier);
+            return Math.Sign(string.CompareOrdinal(leftIdentifier, rightIdentifier));
         }
 
         private readonly struct ParsedCliVersion

--- a/cli/common/version/compare_cases.json
+++ b/cli/common/version/compare_cases.json
@@ -1,0 +1,214 @@
+{
+  "cases": [
+    {
+      "name": "release equal",
+      "left": "1.2.3",
+      "right": "1.2.3",
+      "ok": true,
+      "comparison": 0
+    },
+    {
+      "name": "major greater",
+      "left": "2.0.0",
+      "right": "1.9.9",
+      "ok": true,
+      "comparison": 1
+    },
+    {
+      "name": "minor less",
+      "left": "1.2.0",
+      "right": "1.3.0",
+      "ok": true,
+      "comparison": -1
+    },
+    {
+      "name": "patch greater",
+      "left": "1.2.4",
+      "right": "1.2.3",
+      "ok": true,
+      "comparison": 1
+    },
+    {
+      "name": "prerelease less than release",
+      "left": "1.2.3-alpha",
+      "right": "1.2.3",
+      "ok": true,
+      "comparison": -1
+    },
+    {
+      "name": "release greater than prerelease",
+      "left": "1.2.3",
+      "right": "1.2.3-alpha",
+      "ok": true,
+      "comparison": 1
+    },
+    {
+      "name": "numeric prerelease ordering",
+      "left": "1.2.3-beta.2",
+      "right": "1.2.3-beta.10",
+      "ok": true,
+      "comparison": -1
+    },
+    {
+      "name": "numeric prerelease lower than text",
+      "left": "1.2.3-1",
+      "right": "1.2.3-alpha",
+      "ok": true,
+      "comparison": -1
+    },
+    {
+      "name": "lexical prerelease ordering",
+      "left": "1.2.3-alpha",
+      "right": "1.2.3-beta",
+      "ok": true,
+      "comparison": -1
+    },
+    {
+      "name": "shorter prerelease prefix lower",
+      "left": "1.2.3-alpha",
+      "right": "1.2.3-alpha.1",
+      "ok": true,
+      "comparison": -1
+    },
+    {
+      "name": "build metadata ignored for release",
+      "left": "1.2.3+build.1",
+      "right": "1.2.3+build.2",
+      "ok": true,
+      "comparison": 0
+    },
+    {
+      "name": "build metadata ignored for prerelease",
+      "left": "1.2.3-alpha+build.1",
+      "right": "1.2.3-alpha+build.2",
+      "ok": true,
+      "comparison": 0
+    },
+    {
+      "name": "lowercase v prefix accepted",
+      "left": "v1.2.3",
+      "right": "1.2.3",
+      "ok": true,
+      "comparison": 0
+    },
+    {
+      "name": "uppercase V prefix accepted",
+      "left": "V1.2.3-alpha",
+      "right": "1.2.3-alpha",
+      "ok": true,
+      "comparison": 0
+    },
+    {
+      "name": "surrounding whitespace accepted",
+      "left": " 1.2.3 ",
+      "right": "1.2.3",
+      "ok": true,
+      "comparison": 0
+    },
+    {
+      "name": "core major leading zero rejected",
+      "left": "01.2.3",
+      "right": "1.2.3",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "core minor leading zero rejected",
+      "left": "1.02.3",
+      "right": "1.2.3",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "core patch leading zero rejected",
+      "left": "1.2.03",
+      "right": "1.2.3",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "prerelease numeric leading zero rejected",
+      "left": "1.2.3-alpha.01",
+      "right": "1.2.3-alpha.1",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "empty prerelease rejected",
+      "left": "1.2.3-",
+      "right": "1.2.3",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "empty prerelease identifier rejected",
+      "left": "1.2.3-alpha..1",
+      "right": "1.2.3-alpha.1",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "invalid prerelease underscore rejected",
+      "left": "1.2.3-alpha_1",
+      "right": "1.2.3-alpha.1",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "invalid prerelease slash rejected",
+      "left": "1.2.3-alpha/1",
+      "right": "1.2.3-alpha.1",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "non digit core rejected",
+      "left": "1.x.3",
+      "right": "1.2.3",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "short core rejected",
+      "left": "1.2",
+      "right": "1.2.0",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "duplicate v prefix rejected",
+      "left": "vv1.2.3",
+      "right": "1.2.3",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "signed core numeric rejected",
+      "left": "+1.2.3",
+      "right": "1.2.3",
+      "ok": false,
+      "comparison": 0
+    },
+    {
+      "name": "hyphen prerelease accepted",
+      "left": "1.2.3-alpha-1",
+      "right": "1.2.3-alpha.1",
+      "ok": true,
+      "comparison": 1
+    },
+    {
+      "name": "single zero numeric prerelease accepted",
+      "left": "1.2.3-0",
+      "right": "1.2.3-1",
+      "ok": true,
+      "comparison": -1
+    },
+    {
+      "name": "empty string rejected",
+      "left": "",
+      "right": "1.2.3",
+      "ok": false,
+      "comparison": 0
+    }
+  ]
+}

--- a/cli/common/version/compare_test.go
+++ b/cli/common/version/compare_test.go
@@ -1,6 +1,39 @@
 package version
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+type compareCaseCatalog struct {
+	Cases []compareCase `json:"cases"`
+}
+
+type compareCase struct {
+	Name       string `json:"name"`
+	Left       string `json:"left"`
+	Right      string `json:"right"`
+	OK         bool   `json:"ok"`
+	Comparison int    `json:"comparison"`
+}
+
+func TestCompareMatchesSharedCases(t *testing.T) {
+	// Verifies that Go comparison behavior matches the shared cross-language contract table.
+	catalog := readCompareCaseCatalog(t)
+
+	for _, tt := range catalog.Cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			result, ok := Compare(tt.Left, tt.Right)
+			if ok != tt.OK {
+				t.Fatalf("Compare(%q, %q) ok = %v, want %v", tt.Left, tt.Right, ok, tt.OK)
+			}
+			if result != tt.Comparison {
+				t.Fatalf("Compare(%q, %q) = %d, want %d", tt.Left, tt.Right, result, tt.Comparison)
+			}
+		})
+	}
+}
 
 func TestIsLessThanHandlesPrereleaseVersions(t *testing.T) {
 	// Verifies that CLI version checks follow npm-style prerelease ordering.
@@ -42,4 +75,22 @@ func TestCompareRejectsInvalidVersion(t *testing.T) {
 			t.Fatalf("invalid version %q should not compare successfully", value)
 		}
 	}
+}
+
+func readCompareCaseCatalog(t *testing.T) compareCaseCatalog {
+	t.Helper()
+
+	data, err := os.ReadFile("compare_cases.json")
+	if err != nil {
+		t.Fatalf("failed to read shared compare cases: %v", err)
+	}
+
+	var catalog compareCaseCatalog
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("failed to parse shared compare cases: %v", err)
+	}
+	if len(catalog.Cases) == 0 {
+		t.Fatal("shared compare cases must not be empty")
+	}
+	return catalog
 }


### PR DESCRIPTION
## Summary
- Keep Unity setup compatibility checks aligned with the CLI SemVer rules.
- Add one shared comparison table that both Go and C# tests consume.

## User Impact
- Setup and Settings now reject malformed dispatcher versions consistently instead of accepting versions that the Go CLI comparator would reject.
- Valid existing forms remain supported, including one leading v/V prefix, surrounding whitespace, prerelease ordering, and ignored build metadata.

## Changes
- Added `cli/common/version/compare_cases.json` with 30 shared SemVer comparison cases.
- Updated Go version tests to read the shared table without changing `cli/common/version/compare.go`; no release stamp is needed.
- Tightened `CliVersionComparer` to match existing Go behavior for one v/V prefix, digits-only core fields, leading-zero rejection, prerelease identifier validation, and -1/0/1 comparison results.

## Review Notes
- Behavior change: malformed SemVer strings now fail closed in Unity setup compatibility checks.
- Measured call paths that can observe the reject-side behavior: `CliSetupApplicationService` setup/settings wrappers, `CliSetupLabelFormatter.ShouldShowRequiredVersionText`, `CliSetupCompatibility.Evaluate`, and `CliInstallationDetector.IsShellDetectionUsableForPathSetup`.
- Valid `v`/`V` prefixes, whitespace trimming, and build metadata ignoring are preserved.
- No wire shape or protocol version changes.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` => 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.CliVersionComparerTests"` => 17/17 passed
- `cd cli/common && go test ./version`
- `scripts/check-go-cli.sh`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

