### PR TITLE
chore: Remove unused compile completion context

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -139,12 +139,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     });
                 CompileResult result =
                     CompileResultFactory.CreateExternalSceneChangeFailureResult(sceneChangeResult);
-                RecordCompileResultIfNeeded(
-                    result,
-                    BuildCompileControllerStateContext(new Dictionary<string, object>
-                    {
-                        ["external_scene_change_failed_before_request"] = true
-                    }));
+                RecordCompileResultIfNeeded(result);
                 return result;
             }
 
@@ -475,19 +470,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             UnityEngine.Debug.Assert(result != null, "result must not be null");
 
             TaskCompletionSource<CompileResult> task = _currentCompileTask;
-            Dictionary<string, object> completionContext = BuildCompileControllerStateContext(
-                new Dictionary<string, object>
-                {
-                    ["unregister_events"] = unregisterEvents,
-                    ["success"] = result.Success,
-                    ["error_count"] = result.ErrorCount,
-                    ["warning_count"] = result.WarningCount,
-                    ["is_indeterminate"] = result.IsIndeterminate
-                });
             // Completion subscribers are outside this controller, so state cleanup cannot depend on them returning.
             try
             {
-                RecordCompileResultIfNeeded(result, completionContext);
+                RecordCompileResultIfNeeded(result);
 
                 if (unregisterEvents)
                 {
@@ -513,12 +499,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private void RecordCompileResultIfNeeded(
-            CompileResult result,
-            Dictionary<string, object> completionContext)
+        private void RecordCompileResultIfNeeded(CompileResult result)
         {
             UnityEngine.Debug.Assert(result != null, "result must not be null");
-            UnityEngine.Debug.Assert(completionContext != null, "completionContext must not be null");
 
             if (!_resultRecordingContext.Enabled)
             {
@@ -532,8 +515,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _resultRecordingContext.ForceRecompile,
                 result,
                 _resultRecordingContext.RequestId);
-            completionContext["result_recorded_in_session_state"] = true;
-            completionContext["request_id"] = _resultRecordingContext.RequestId;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Remove an unobserved compile completion context dictionary left over from C4-8 cleanup.
- Keep compile result recording behavior and emitted VibeLogger contexts unchanged.

## User Impact
- No user-visible behavior change. This only removes dead internal state that was written and never read.

## Changes
- Shrank `RecordCompileResultIfNeeded` to take only the compile result it actually records.
- Removed dead completion context allocation from `CompleteCompileRequest`.
- Removed the same Record-only dead context from the external scene change failure path.

## Review Notes
- The removed dictionary writes were dead stores: `result_recorded_in_session_state` and `request_id` were added after recording but never read by the caller, VibeLogger, response building, SessionState, or Go code.
- This is the C4-8 residual cleanup that was deliberately kept out of earlier C5-4 PRs.
- `BuildCompileControllerStateContext` remains because its other call sites are emitted VibeLogger contexts.
- No wire shape, protocol version, pin, or CLI behavior changes.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` => 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.(CompileUseCaseTests|CompileStatusBridgeCommandTests|CompileSessionResultStoreTests|CompileResultSessionRecorderTests)$"` => 11/11 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

