### PR TITLE
chore: Simplify skill setup synchronization internals

### DIFF
--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies skill layout discovery behavior.
+    /// </summary>
+    [TestFixture]
+    public class SkillInstallLayoutTests
+    {
+        private string _projectRoot;
+        private string[] _temporaryRoots;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            _temporaryRoots = new string[0];
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (string temporaryRoot in _temporaryRoots)
+            {
+                if (Directory.Exists(temporaryRoot))
+                {
+                    Directory.Delete(temporaryRoot, true);
+                }
+            }
+        }
+
+        // Tests that skill installation detection accepts managed legacy and namespaced skills only.
+        [Test]
+        public void AreSkillsInstalled_ReturnsTrueForManagedLegacyAndNamespacedSkillsOnly()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
+
+            string manualTargetRoot = Path.Combine(temporaryRoot, ".claude");
+            WriteSkillFile(
+                Path.Combine(manualTargetRoot, SkillInstallLayout.SkillsDirName, "find-orphaned-meta"),
+                "---\nname: find-orphaned-meta\n---\n");
+            SkillInstallationDetector detector = new();
+            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".claude"),
+                "Manual local skills should not be treated as installed uLoop skills");
+
+            string legacyTargetRoot = Path.Combine(temporaryRoot, ".codex");
+            WriteSkillFile(
+                Path.Combine(legacyTargetRoot, SkillInstallLayout.SkillsDirName, "acme-third-party"),
+                "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
+            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".codex"),
+                "Legacy third-party managed skills should be detected");
+
+            string managedTargetRoot = Path.Combine(temporaryRoot, ".agents");
+            WriteSkillFile(Path.Combine(
+                managedTargetRoot,
+                SkillInstallLayout.SkillsDirName,
+                SkillInstallLayout.ManagedSkillsDirName,
+                "uloop-compile"));
+            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".agents"),
+                "Namespaced managed skills should be detected");
+        }
+
+        // Tests that layout-specific detection only matches the selected layout.
+        [Test]
+        public void AreSkillsInstalled_WhenLayoutSpecified_MatchesOnlySelectedLayout()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
+            SkillInstallationDetector detector = new();
+
+            string flatTargetRoot = Path.Combine(temporaryRoot, ".claude");
+            WriteSkillFile(Path.Combine(flatTargetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
+            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".claude", false));
+            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".claude", true));
+
+            string groupedTargetRoot = Path.Combine(temporaryRoot, ".codex");
+            WriteSkillFile(Path.Combine(
+                groupedTargetRoot,
+                SkillInstallLayout.SkillsDirName,
+                SkillInstallLayout.ManagedSkillsDirName,
+                "uloop-compile"));
+            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".codex", true));
+            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".codex", false));
+        }
+
+        // Tests that an empty legacy managed directory still counts for flat layout migration state.
+        [Test]
+        public void AreSkillsInstalled_WhenLegacyManagedDirectoryIsEmpty_StillDetectsFlatLayout()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            string targetRoot = Path.Combine(temporaryRoot, ".cursor");
+            Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
+            SkillInstallationDetector detector = new();
+
+            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".cursor", false));
+            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".cursor", true));
+        }
+
+        // Tests that Unity-side discovery includes CLI-only skills from the packaged core CLI.
+        [Test]
+        public void GetSkillSourceInfos_WhenProjectIsCurrentRoot_IncludesCliOnlyCoreSkills()
+        {
+            SkillInstallLayout.SkillSourceInfo[] skillSources = SkillInstallLayout.GetSkillSourceInfos(_projectRoot)
+                .ToArray();
+
+            Assert.That(skillSources.Select(skill => skill.Name), Does.Contain("uloop-launch"));
+        }
+
+        // Tests that Tool Settings can read source skill frontmatter descriptions by tool name.
+        [Test]
+        public void GetToolDescriptionsByToolName_WhenSkillHasDescription_MapsDescriptionToToolName()
+        {
+            IReadOnlyDictionary<string, string> descriptions = SkillInstallLayout.GetToolDescriptionsByToolName(_projectRoot);
+
+            Assert.That(descriptions["compile"], Is.EqualTo("Compile the Unity project and report errors/warnings. Use after C# edits."));
+            Assert.That(descriptions[UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT], Does.StartWith("Pauses Unity's playback"));
+        }
+
+        // Tests that skill discovery follows bundled tools after they move into the first-party plugin assembly.
+        [Test]
+        public void GetSkillSourceInfos_WhenFirstPartyToolIsUnderFirstPartyTools_IncludesToolSkill()
+        {
+            SkillInstallLayout.SkillSourceInfo[] skillSources = SkillInstallLayout.GetSkillSourceInfos(_projectRoot)
+                .ToArray();
+
+            SkillInstallLayout.SkillSourceInfo controlPlayModeSkill = skillSources
+                .Single(skill => skill.Name == "uloop-control-play-mode");
+
+            Assert.That(controlPlayModeSkill.ToolName, Is.EqualTo("control-play-mode"));
+            Assert.That(controlPlayModeSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo getLogsSkill = skillSources
+                .Single(skill => skill.Name == "uloop-get-logs");
+
+            Assert.That(getLogsSkill.ToolName, Is.EqualTo("get-logs"));
+            Assert.That(getLogsSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo compileSkill = skillSources
+                .Single(skill => skill.Name == "uloop-compile");
+
+            Assert.That(compileSkill.ToolName, Is.EqualTo("compile"));
+            Assert.That(compileSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo executeDynamicCodeSkill = skillSources
+                .Single(skill => skill.Name == "uloop-execute-dynamic-code");
+
+            Assert.That(executeDynamicCodeSkill.ToolName, Is.EqualTo("execute-dynamic-code"));
+            Assert.That(executeDynamicCodeSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo clearConsoleSkill = skillSources
+                .Single(skill => skill.Name == "uloop-clear-console");
+
+            Assert.That(clearConsoleSkill.ToolName, Is.EqualTo("clear-console"));
+            Assert.That(clearConsoleSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo getHierarchySkill = skillSources
+                .Single(skill => skill.Name == "uloop-get-hierarchy");
+
+            Assert.That(getHierarchySkill.ToolName, Is.EqualTo("get-hierarchy"));
+            Assert.That(getHierarchySkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo runTestsSkill = skillSources
+                .Single(skill => skill.Name == "uloop-run-tests");
+
+            Assert.That(runTestsSkill.ToolName, Is.EqualTo("run-tests"));
+            Assert.That(runTestsSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo findGameObjectsSkill = skillSources
+                .Single(skill => skill.Name == "uloop-find-game-objects");
+
+            Assert.That(findGameObjectsSkill.ToolName, Is.EqualTo("find-game-objects"));
+            Assert.That(findGameObjectsSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo screenshotSkill = skillSources
+                .Single(skill => skill.Name == "uloop-screenshot");
+
+            Assert.That(screenshotSkill.ToolName, Is.EqualTo("screenshot"));
+            Assert.That(screenshotSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo recordInputSkill = skillSources
+                .Single(skill => skill.Name == "uloop-record-input");
+
+            Assert.That(recordInputSkill.ToolName, Is.EqualTo("record-input"));
+            Assert.That(recordInputSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo replayInputSkill = skillSources
+                .Single(skill => skill.Name == "uloop-replay-input");
+
+            Assert.That(replayInputSkill.ToolName, Is.EqualTo("replay-input"));
+            Assert.That(replayInputSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo simulateKeyboardSkill = skillSources
+                .Single(skill => skill.Name == "uloop-simulate-keyboard");
+
+            Assert.That(simulateKeyboardSkill.ToolName, Is.EqualTo("simulate-keyboard"));
+            Assert.That(simulateKeyboardSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo simulateMouseInputSkill = skillSources
+                .Single(skill => skill.Name == "uloop-simulate-mouse-input");
+
+            Assert.That(simulateMouseInputSkill.ToolName, Is.EqualTo("simulate-mouse-input"));
+            Assert.That(simulateMouseInputSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+
+            SkillInstallLayout.SkillSourceInfo simulateMouseUiSkill = skillSources
+                .Single(skill => skill.Name == "uloop-simulate-mouse-ui");
+
+            Assert.That(simulateMouseUiSkill.ToolName, Is.EqualTo("simulate-mouse-ui"));
+            Assert.That(simulateMouseUiSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
+        }
+
+        // Tests that internal skill metadata maps back to the hidden tool name only.
+        [Test]
+        public void GetInternalSkillToolNames_WhenInternalSkillUsesSkillName_ReturnsToolName()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-public-skill",
+                "PublicTool",
+                "reference.md",
+                "reference");
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-internal-skill",
+                "InternalTool",
+                "reference.md",
+                "internal-reference",
+                isInternal: true);
+
+            HashSet<string> internalToolNames = SkillInstallLayout.GetInternalSkillToolNames(temporaryRoot);
+
+            Assert.That(internalToolNames, Does.Contain("internal-skill"));
+            Assert.That(internalToolNames, Does.Not.Contain("public-skill"));
+        }
+
+        // Tests that user-facing tool catalogs omit tools backed by internal skills.
+        [Test]
+        public void GetToolSettingsCatalogForProjectRoot_WhenSkillIsInternal_HidesToolFromUserFacingLists()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-internal-tool",
+                "InternalTool",
+                "reference.md",
+                "internal-reference",
+                isInternal: true);
+
+            UnityCliLoopToolRegistry registry = new UnityCliLoopToolRegistry(
+                new ToolSettingsRepository(),
+                new SkillInstallLayoutInternalToolNameProvider(),
+                toolDiscovery: null);
+            registry.RegisterTool(new FakeUnityTool("internal-tool"));
+            registry.RegisterTool(new FakeUnityTool("public-tool"));
+
+            string[] catalogNames = registry.GetToolSettingsCatalogForProjectRoot(temporaryRoot)
+                .Select(tool => tool.Name)
+                .ToArray();
+            string[] registeredToolNames = registry.GetRegisteredToolsForProjectRoot(temporaryRoot)
+                .Select(tool => tool.Name)
+                .ToArray();
+
+            Assert.That(catalogNames, Does.Not.Contain("internal-tool"));
+            Assert.That(catalogNames, Does.Contain("public-tool"));
+            Assert.That(registeredToolNames, Does.Not.Contain("internal-tool"));
+            Assert.That(registeredToolNames, Does.Contain("public-tool"));
+        }
+
+        // Tests that PowerShell scripts keep their source encoding while line endings are normalized.
+        [Test]
+        public void NormalizeSkillFileContent_WhenPowerShellScriptUsesUtf16LittleEndian_PreservesEncoding()
+        {
+            byte[] sourceBytes = Encoding.Unicode.GetPreamble()
+                .Concat(Encoding.Unicode.GetBytes("line1\r\nline2\r\n"))
+                .ToArray();
+            byte[] expectedBytes = Encoding.Unicode.GetPreamble()
+                .Concat(Encoding.Unicode.GetBytes("line1\nline2\n"))
+                .ToArray();
+
+            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("install.ps1", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
+        }
+
+        private string CreateTemporaryProjectRoot()
+        {
+            string temporaryRoot = Path.Combine(
+                Path.GetTempPath(),
+                "SkillInstallLayoutTests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(temporaryRoot);
+            _temporaryRoots = _temporaryRoots.Append(temporaryRoot).ToArray();
+            return temporaryRoot;
+        }
+
+        private static void WriteSkillFile(string skillDir, string content = "---\nname: uloop-compile\n---\n")
+        {
+            Directory.CreateDirectory(skillDir);
+            File.WriteAllText(Path.Combine(skillDir, SkillInstallLayout.SkillFileName), content);
+        }
+
+        private static void CreateFakeSourceSkill(
+            string projectRoot,
+            string skillName,
+            string toolDirectoryName,
+            string additionalFileRelativePath,
+            string additionalFileContent,
+            bool isInternal = false)
+        {
+            string skillDir = Path.Combine(
+                projectRoot,
+                "Packages",
+                "com.example.fake",
+                "Editor",
+                toolDirectoryName,
+                "Skill");
+            Directory.CreateDirectory(skillDir);
+            string internalLine = isInternal ? "internal: true\n" : string.Empty;
+            File.WriteAllText(
+                Path.Combine(skillDir, SkillInstallLayout.SkillFileName),
+                $"---\nname: {skillName}\n{internalLine}---\n");
+            File.WriteAllText(Path.Combine(skillDir, additionalFileRelativePath), additionalFileContent);
+        }
+
+        /// <summary>
+        /// Test support type used by editor fixtures.
+        /// </summary>
+        private sealed class FakeUnityTool : IUnityCliLoopTool
+        {
+            public string ToolName { get; }
+
+            public ToolParameterSchema ParameterSchema { get; } = new();
+
+            public FakeUnityTool(string toolName)
+            {
+                ToolName = toolName;
+            }
+
+            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
+            {
+                return Task.FromResult<UnityCliLoopToolResponse>(new FakeToolResponse());
+            }
+        }
+
+        /// <summary>
+        /// Test support type used by editor fixtures.
+        /// </summary>
+        private sealed class FakeToolResponse : UnityCliLoopToolResponse
+        {
+        }
+    }
+}

--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs.meta
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0dc989fa0ebc44cdb791df127f1584e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -86,7 +86,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             // Act
             List<ToolSkillSynchronizer.SkillTargetInfo> targets =
-                ToolSkillSynchronizer.DetectTargets(_projectRoot, requireSkillsDirectory: true);
+                ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(_projectRoot, requireSkillsDirectory: true);
             await ToolSkillSynchronizer.InstallSkillFiles(
                 targets,
                 groupSkillsUnderUnityCliLoop: false,
@@ -658,7 +658,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
 
             // Act
-            string[] detectedTargetDirs = ToolSkillSynchronizer.DetectTargets(temporaryRoot, requireSkillsDirectory: true)
+            string[] detectedTargetDirs = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(temporaryRoot, requireSkillsDirectory: true)
                 .Select(target => target.DirName)
                 .ToArray();
 
@@ -679,7 +679,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Directory.CreateDirectory(Path.Combine(temporaryRoot, dir));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: false)
                 .ToArray();
@@ -707,7 +707,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
 
             // Act
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(temporaryRoot, requireSkillsDirectory: true)
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(temporaryRoot, requireSkillsDirectory: true)
                 .ToArray();
 
             // Assert
@@ -772,7 +772,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "uloop-compile"));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true)
                 .ToArray();
@@ -795,7 +795,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 WriteSkillFile(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -818,7 +818,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string targetRoot = Path.Combine(temporaryRoot, ".cursor");
             Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -847,7 +847,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "uloop-compile"));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: false,
@@ -875,7 +875,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true)
                 .ToArray();
@@ -904,7 +904,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -931,7 +931,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "---\nname: find-orphaned-meta\n---\n");
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true)
                 .ToArray();
@@ -975,7 +975,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\nname: uloop-cached-skill\n---\n");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1072,7 +1072,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "uloop-fake-skill",
                 "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1099,7 +1099,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\nname: uloop-fake-skill\n---\nchanged");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1133,7 +1133,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\nname: uloop-public-skill\n---\n");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1336,7 +1336,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\nname: uloop-public-skill\n---\n");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1369,7 +1369,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
             File.WriteAllText(Path.Combine(installedSkillDir, "stale.md"), "stale");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1402,7 +1402,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\r\nname: uloop-public-skill\r\n---\r\n");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "line1\r\nline2\r\n");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1521,7 +1521,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "uloop-execute-menu-item");
             WriteSkillFile(executeMenuItemSkillDir, "---\nname: uloop-execute-menu-item\n---\n");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1640,7 +1640,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ".claude",
                 SkillInstallLayout.SkillsDirName));
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1668,7 +1668,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ".claude",
                 SkillInstallLayout.SkillsDirName));
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -152,7 +152,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: true);
+                    groupSkillsUnderUnityCliLoop: true,
+                    disabledTools: Array.Empty<string>());
 
             string installedSkillDir = Path.Combine(
                 targetRoot,
@@ -199,7 +200,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: Array.Empty<string>());
 
             string installedSkillDir = Path.Combine(
                 targetRoot,
@@ -249,7 +251,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: Array.Empty<string>());
 
             string installedSkillDir = Path.Combine(
                 skillsRoot,
@@ -291,7 +294,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: Array.Empty<string>());
 
             string installedSkillDir = Path.Combine(
                 skillsRoot,
@@ -333,7 +337,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: Array.Empty<string>());
 
             string installedSkillDir = Path.Combine(
                 skillsRoot,
@@ -376,7 +381,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesForToolAtProjectRoot(
                     temporaryRoot,
                     "enabled-skill",
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: Array.Empty<string>());
 
             string enabledSkillDir = Path.Combine(skillsRoot, "uloop-enabled-skill");
 
@@ -588,7 +594,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: Array.Empty<string>());
 
             string installedSkillDir = Path.Combine(
                 skillsRoot,
@@ -633,7 +640,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: Array.Empty<string>());
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(Directory.Exists(managedSkillsRoot), Is.False);
@@ -1428,7 +1436,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                 temporaryRoot,
                 new[] { target },
-                groupSkillsUnderUnityCliLoop: true);
+                groupSkillsUnderUnityCliLoop: true,
+                disabledTools: Array.Empty<string>());
 
             string installedReferencePath = Path.Combine(
                 temporaryRoot,
@@ -1562,7 +1571,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: true);
+                    groupSkillsUnderUnityCliLoop: true,
+                    disabledTools: Array.Empty<string>());
 
             string installedSkillDir = Path.Combine(
                 targetRoot,
@@ -1608,7 +1618,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: Array.Empty<string>());
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(Directory.Exists(executeMenuItemSkillDir), Is.False);

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -1702,7 +1702,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 });
 
             ToolSkillSynchronizer.SkillInstallResult result =
-                await ToolSkillSynchronizer.InstallSpecificSkillFilesAtProjectRoot(
+                await V3MigrationSkillInstaller.InstallSpecificSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
                     skill,
@@ -1713,7 +1713,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ".codex",
                 SkillInstallLayout.SkillsDirName,
                 CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME);
-            SkillInstallState installState = ToolSkillSynchronizer.GetSkillInstallStateAtProjectRoot(
+            SkillInstallState installState = V3MigrationSkillInstaller.GetSkillInstallStateAtProjectRoot(
                 temporaryRoot,
                 target,
                 skill,
@@ -1738,12 +1738,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 hasExistingSkills: false);
 
             ToolSkillSynchronizer.SkillInstallResult result =
-                await ToolSkillSynchronizer.InstallV3MigrationSkillFilesAtProjectRoot(
+                await V3MigrationSkillInstaller.InstallV3MigrationSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: true);
 
-            SkillInstallState installState = ToolSkillSynchronizer.GetV3MigrationSkillInstallStateAtProjectRoot(
+            SkillInstallState installState = V3MigrationSkillInstaller.GetV3MigrationSkillInstallStateAtProjectRoot(
                 temporaryRoot,
                 target,
                 groupSkillsUnderUnityCliLoop: false);
@@ -1770,7 +1770,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 groupSkillsUnderUnityCliLoop: false);
             Directory.CreateDirectory(Path.Combine(migrationSkillDir, "references"));
 
-            SkillInstallState installState = ToolSkillSynchronizer.GetV3MigrationSkillInstallStateAtProjectRoot(
+            SkillInstallState installState = V3MigrationSkillInstaller.GetV3MigrationSkillInstallStateAtProjectRoot(
                 temporaryRoot,
                 target,
                 groupSkillsUnderUnityCliLoop: false);
@@ -1802,7 +1802,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(unrelatedSkillDir, "---\nname: uloop-compile\n---\n");
 
             ToolSkillSynchronizer.SkillInstallResult result =
-                await ToolSkillSynchronizer.RemoveSpecificSkillFilesAtProjectRoot(
+                await V3MigrationSkillInstaller.RemoveSpecificSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
                     CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME,
@@ -1842,7 +1842,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(unrelatedSkillDir, "---\nname: uloop-compile\n---\n");
 
             ToolSkillSynchronizer.SkillInstallResult result =
-                await ToolSkillSynchronizer.RemoveV3MigrationSkillFilesAtProjectRoot(
+                await V3MigrationSkillInstaller.RemoveV3MigrationSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: false);

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -37,7 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             _toolSettingsFileExisted = File.Exists(ToolSettingsFilePath);
             _toolSettingsFileContent = _toolSettingsFileExisted ? File.ReadAllText(ToolSettingsFilePath) : null;
 
-            _nonExistentDirsBefore = ToolSkillSynchronizer.SkillTargetDirs
+            _nonExistentDirsBefore = SkillTargetDetector.SkillTargetDirs
                 .Where(dir => !Directory.Exists(Path.Combine(_projectRoot, dir)))
                 .ToArray();
             _temporaryRoots = new string[0];
@@ -86,7 +86,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             // Act
             List<ToolSkillSynchronizer.SkillTargetInfo> targets =
-                ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(_projectRoot, requireSkillsDirectory: true);
+                SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(_projectRoot, requireSkillsDirectory: true);
             await ToolSkillSynchronizer.InstallSkillFiles(
                 targets,
                 groupSkillsUnderUnityCliLoop: false,
@@ -652,18 +652,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Arrange
             string temporaryRoot = CreateTemporaryProjectRoot();
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 Directory.CreateDirectory(Path.Combine(temporaryRoot, dir));
             }
 
             // Act
-            string[] detectedTargetDirs = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(temporaryRoot, requireSkillsDirectory: true)
+            string[] detectedTargetDirs = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(temporaryRoot, requireSkillsDirectory: true)
                 .Select(target => target.DirName)
                 .ToArray();
 
             // Assert
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 Assert.IsFalse(detectedTargetDirs.Contains(dir),
                     $"Target '{dir}' should not be detected when only the parent directory exists");
@@ -674,17 +674,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void DetectTargets_WhenParentDirectoryExists_ReportsTargetAsNotOptedIn()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 Directory.CreateDirectory(Path.Combine(temporaryRoot, dir));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: false)
                 .ToArray();
 
-            Assert.AreEqual(ToolSkillSynchronizer.SkillTargetDirs.Length, detectedTargets.Length);
+            Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
             {
                 Assert.IsNotEmpty(target.InstallFlag,
@@ -701,17 +701,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Arrange
             string temporaryRoot = CreateTemporaryProjectRoot();
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 Directory.CreateDirectory(Path.Combine(temporaryRoot, dir, SkillInstallLayout.SkillsDirName));
             }
 
             // Act
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(temporaryRoot, requireSkillsDirectory: true)
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(temporaryRoot, requireSkillsDirectory: true)
                 .ToArray();
 
             // Assert
-            Assert.AreEqual(ToolSkillSynchronizer.SkillTargetDirs.Length, detectedTargets.Length,
+            Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length,
                 "Targets with a skills directory should be detected");
 
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
@@ -731,7 +731,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             ToolSkillSynchronizer.RemoveSkillFilesAtProjectRoot(temporaryRoot, testToolName);
 
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 string fullPath = Path.Combine(temporaryRoot, dir);
                 Assert.IsFalse(Directory.Exists(fullPath),
@@ -762,7 +762,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
             CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(temporaryRoot, dir);
                 WriteSkillFile(Path.Combine(
@@ -772,12 +772,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "uloop-compile"));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true)
                 .ToArray();
 
-            Assert.AreEqual(ToolSkillSynchronizer.SkillTargetDirs.Length, detectedTargets.Length);
+            Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
             {
                 Assert.IsTrue(target.HasExistingSkills,
@@ -789,13 +789,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void DetectTargets_WhenGroupedLayoutRequested_IgnoresFlatInstalledSkills()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(temporaryRoot, dir);
                 WriteSkillFile(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -818,7 +818,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string targetRoot = Path.Combine(temporaryRoot, ".cursor");
             Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -837,7 +837,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
             CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(temporaryRoot, dir);
                 WriteSkillFile(Path.Combine(
@@ -847,7 +847,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "uloop-compile"));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: false,
@@ -867,7 +867,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void DetectTargets_WhenLegacyThirdPartySkillsExist_ReportsInstalled()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(temporaryRoot, dir);
                 WriteSkillFile(
@@ -875,12 +875,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true)
                 .ToArray();
 
-            Assert.AreEqual(ToolSkillSynchronizer.SkillTargetDirs.Length, detectedTargets.Length);
+            Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
             {
                 Assert.IsTrue(target.HasExistingSkills,
@@ -892,7 +892,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void DetectTargets_WhenOnlyGroupedThirdPartySkillsExist_DoesNotReportInstalled()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(temporaryRoot, dir);
                 WriteSkillFile(
@@ -904,14 +904,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
                     includeFreshnessCheck: true)
                 .ToArray();
 
-            Assert.AreEqual(ToolSkillSynchronizer.SkillTargetDirs.Length, detectedTargets.Length);
+            Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
             {
                 Assert.IsFalse(target.HasExistingSkills,
@@ -923,7 +923,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void DetectTargets_WhenOnlyManualLegacySkillsExist_DoesNotReportInstalled()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
-            foreach (string dir in ToolSkillSynchronizer.SkillTargetDirs)
+            foreach (string dir in SkillTargetDetector.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(temporaryRoot, dir);
                 WriteSkillFile(
@@ -931,12 +931,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "---\nname: find-orphaned-meta\n---\n");
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsAcrossLayoutsAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true)
                 .ToArray();
 
-            Assert.AreEqual(ToolSkillSynchronizer.SkillTargetDirs.Length, detectedTargets.Length);
+            Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
             {
                 Assert.IsFalse(target.HasExistingSkills,
@@ -975,7 +975,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\nname: uloop-cached-skill\n---\n");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1072,7 +1072,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "uloop-fake-skill",
                 "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1099,7 +1099,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\nname: uloop-fake-skill\n---\nchanged");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1133,7 +1133,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\nname: uloop-public-skill\n---\n");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1336,7 +1336,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\nname: uloop-public-skill\n---\n");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1369,7 +1369,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "reference");
             File.WriteAllText(Path.Combine(installedSkillDir, "stale.md"), "stale");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1402,7 +1402,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WriteSkillFile(installedSkillDir, "---\r\nname: uloop-public-skill\r\n---\r\n");
             File.WriteAllText(Path.Combine(installedSkillDir, "reference.md"), "line1\r\nline2\r\n");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1522,7 +1522,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "uloop-execute-menu-item");
             WriteSkillFile(executeMenuItemSkillDir, "---\nname: uloop-execute-menu-item\n---\n");
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1641,7 +1641,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ".claude",
                 SkillInstallLayout.SkillsDirName));
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,
@@ -1669,7 +1669,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 ".claude",
                 SkillInstallLayout.SkillsDirName));
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargetsForLayoutStateAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
                     requireSkillsDirectory: true,
                     groupSkillsUnderUnityCliLoop: true,

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -787,7 +787,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
@@ -809,7 +810,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -837,7 +839,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: false)
+                    groupSkillsUnderUnityCliLoop: false,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             foreach (ToolSkillSynchronizer.SkillTargetInfo target in detectedTargets)
@@ -893,7 +896,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.AreEqual(ToolSkillSynchronizer.SkillTargetDirs.Length, detectedTargets.Length);
@@ -963,7 +967,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1059,7 +1064,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1085,7 +1091,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1118,7 +1125,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1320,7 +1328,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1352,7 +1361,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1384,7 +1394,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1501,7 +1512,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1617,7 +1629,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
@@ -1644,7 +1657,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = ToolSkillSynchronizer.DetectTargets(
                     temporaryRoot,
                     requireSkillsDirectory: true,
-                    groupSkillsUnderUnityCliLoop: true)
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.That(detectedTargets.Length, Is.EqualTo(1));

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -1483,7 +1483,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             File.WriteAllText(installedReferencePath, "line1\r\nline2\r\n");
             byte[] backupBytes = File.ReadAllBytes(installedReferencePath);
 
-            Dictionary<string, byte[]> backupFiles = ToolSkillSynchronizer.ReadSkillFilesForRollback(installedSkillDir);
+            Dictionary<string, byte[]> backupFiles =
+                SkillDirectoryContentSynchronizer.ReadSkillFilesForRollback(installedSkillDir);
 
             Assert.That(backupFiles["reference.md"], Is.EqualTo(backupBytes));
         }

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -85,7 +85,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "At least one target directory should not exist for this test to be meaningful");
 
             // Act
-            await ToolSkillSynchronizer.InstallSkillFiles();
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets =
+                ToolSkillSynchronizer.DetectTargets(_projectRoot, requireSkillsDirectory: true);
+            await ToolSkillSynchronizer.InstallSkillFiles(
+                targets,
+                groupSkillsUnderUnityCliLoop: false,
+                Array.Empty<string>());
 
             // Assert: directories that didn't exist before should still not exist
             foreach (string dir in _nonExistentDirsBefore)
@@ -96,13 +101,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
         }
 
-        // Tests that the public install path preserves disabled tool settings.
+        // Tests that disabled tool inputs prevent skill recreation.
         [Test]
-        public async Task InstallSkillFiles_WhenToolIsDisabledInSettings_DoesNotRecreateSkill()
+        public async Task InstallSkillFiles_WhenToolIsDisabled_DoesNotRecreateSkill()
         {
-            Directory.CreateDirectory(UnityCliLoopConstants.ULOOP_DIR);
-            File.WriteAllText(ToolSettingsFilePath, "{\"disabledTools\":[\"compile\"]}");
-
             string temporaryRoot = CreateTemporaryProjectRoot();
             string targetRoot = Path.Combine(temporaryRoot, ".claude");
             string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
@@ -118,7 +120,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             ToolSkillSynchronizer.SkillInstallResult result =
                 await ToolSkillSynchronizer.InstallSkillFiles(
                     new List<ToolSkillSynchronizer.SkillTargetInfo> { target },
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: new[] { "compile" });
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(Directory.Exists(disabledSkillDir), Is.False);

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -90,7 +90,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             await ToolSkillSynchronizer.InstallSkillFiles(
                 targets,
                 groupSkillsUnderUnityCliLoop: false,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                ct: CancellationToken.None);
 
             // Assert: directories that didn't exist before should still not exist
             foreach (string dir in _nonExistentDirsBefore)
@@ -121,7 +122,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await ToolSkillSynchronizer.InstallSkillFiles(
                     new List<ToolSkillSynchronizer.SkillTargetInfo> { target },
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools: new[] { "compile" });
+                    disabledTools: new[] { "compile" },
+                    ct: CancellationToken.None);
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(Directory.Exists(disabledSkillDir), Is.False);
@@ -153,7 +155,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: true,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             string installedSkillDir = Path.Combine(
                 targetRoot,
@@ -201,7 +204,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             string installedSkillDir = Path.Combine(
                 targetRoot,
@@ -252,7 +256,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             string installedSkillDir = Path.Combine(
                 skillsRoot,
@@ -295,7 +300,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             string installedSkillDir = Path.Combine(
                 skillsRoot,
@@ -338,7 +344,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             string installedSkillDir = Path.Combine(
                 skillsRoot,
@@ -382,7 +389,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     "enabled-skill",
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             string enabledSkillDir = Path.Combine(skillsRoot, "uloop-enabled-skill");
 
@@ -416,7 +424,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     "disabled-skill",
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools);
+                    disabledTools,
+                    ct: CancellationToken.None);
 
             string disabledSkillDir = Path.Combine(skillsRoot, "uloop-disabled-skill");
 
@@ -503,7 +512,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     "enabled-skill",
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools);
+                    disabledTools,
+                    ct: CancellationToken.None);
 
             string enabledSkillDir = Path.Combine(skillsRoot, "uloop-enabled-skill");
 
@@ -552,7 +562,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     "enabled-skill",
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools);
+                    disabledTools,
+                    ct: CancellationToken.None);
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(Directory.Exists(flatDisabledSkillDir), Is.False);
@@ -595,7 +606,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             string installedSkillDir = Path.Combine(
                 skillsRoot,
@@ -641,7 +653,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(Directory.Exists(managedSkillsRoot), Is.False);
@@ -1437,7 +1450,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 temporaryRoot,
                 new[] { target },
                 groupSkillsUnderUnityCliLoop: true,
-                disabledTools: Array.Empty<string>());
+                disabledTools: Array.Empty<string>(),
+                ct: CancellationToken.None);
 
             string installedReferencePath = Path.Combine(
                 temporaryRoot,
@@ -1573,7 +1587,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: true,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             string installedSkillDir = Path.Combine(
                 targetRoot,
@@ -1620,7 +1635,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     groupSkillsUnderUnityCliLoop: false,
-                    disabledTools: Array.Empty<string>());
+                    disabledTools: Array.Empty<string>(),
+                    ct: CancellationToken.None);
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(Directory.Exists(executeMenuItemSkillDir), Is.False);
@@ -1706,7 +1722,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     skill,
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    ct: CancellationToken.None);
 
             string installedSkillDir = Path.Combine(
                 temporaryRoot,
@@ -1741,7 +1758,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await V3MigrationSkillInstaller.InstallV3MigrationSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: true);
+                    groupSkillsUnderUnityCliLoop: true,
+                    ct: CancellationToken.None);
 
             SkillInstallState installState = V3MigrationSkillInstaller.GetV3MigrationSkillInstallStateAtProjectRoot(
                 temporaryRoot,
@@ -1806,7 +1824,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     temporaryRoot,
                     new[] { target },
                     CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME,
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    ct: CancellationToken.None);
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(Directory.Exists(migrationSkillDir), Is.False);
@@ -1845,7 +1864,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await V3MigrationSkillInstaller.RemoveV3MigrationSkillFilesAtProjectRoot(
                     temporaryRoot,
                     new[] { target },
-                    groupSkillsUnderUnityCliLoop: false);
+                    groupSkillsUnderUnityCliLoop: false,
+                    ct: CancellationToken.None);
 
             Assert.That(result.IsSuccessful, Is.True);
             Assert.That(Directory.Exists(flatMigrationSkillDir), Is.False);

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -435,7 +435,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new Dictionary<string, byte[]>());
             string[] disabledTools = { UnityCliLoopConstants.TOOL_NAME_RUN_TESTS };
 
-            bool isDisabled = ToolSkillSynchronizer.IsSkillDisabledByToolSettings(
+            bool isDisabled = SkillDisabledToolFilter.IsSkillDisabledByToolSettings(
                 skill,
                 disabledTools);
 
@@ -452,7 +452,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new Dictionary<string, byte[]>());
             string[] disabledTools = Array.Empty<string>();
 
-            bool isDisabled = ToolSkillSynchronizer.IsSkillDisabledByToolSettings(
+            bool isDisabled = SkillDisabledToolFilter.IsSkillDisabledByToolSettings(
                 skill,
                 disabledTools);
 

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Application;
@@ -1000,71 +999,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void AreSkillsInstalled_ReturnsTrueForManagedLegacyAndNamespacedSkillsOnly()
-        {
-            string temporaryRoot = CreateTemporaryProjectRoot();
-            CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
-
-            string manualTargetRoot = Path.Combine(temporaryRoot, ".claude");
-            WriteSkillFile(
-                Path.Combine(manualTargetRoot, SkillInstallLayout.SkillsDirName, "find-orphaned-meta"),
-                "---\nname: find-orphaned-meta\n---\n");
-            SkillInstallationDetector detector = new();
-            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".claude"),
-                "Manual local skills should not be treated as installed uLoop skills");
-
-            string legacyTargetRoot = Path.Combine(temporaryRoot, ".codex");
-            WriteSkillFile(
-                Path.Combine(legacyTargetRoot, SkillInstallLayout.SkillsDirName, "acme-third-party"),
-                "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".codex"),
-                "Legacy third-party managed skills should be detected");
-
-            string managedTargetRoot = Path.Combine(temporaryRoot, ".agents");
-            WriteSkillFile(Path.Combine(
-                managedTargetRoot,
-                SkillInstallLayout.SkillsDirName,
-                SkillInstallLayout.ManagedSkillsDirName,
-                "uloop-compile"));
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".agents"),
-                "Namespaced managed skills should be detected");
-        }
-
-        [Test]
-        public void AreSkillsInstalled_WhenLayoutSpecified_MatchesOnlySelectedLayout()
-        {
-            string temporaryRoot = CreateTemporaryProjectRoot();
-            CreateFakeSourceSkill(temporaryRoot, "uloop-compile", "CompileTool", "reference.md", "reference");
-            SkillInstallationDetector detector = new();
-
-            string flatTargetRoot = Path.Combine(temporaryRoot, ".claude");
-            WriteSkillFile(Path.Combine(flatTargetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".claude", false));
-            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".claude", true));
-
-            string groupedTargetRoot = Path.Combine(temporaryRoot, ".codex");
-            WriteSkillFile(Path.Combine(
-                groupedTargetRoot,
-                SkillInstallLayout.SkillsDirName,
-                SkillInstallLayout.ManagedSkillsDirName,
-                "uloop-compile"));
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".codex", true));
-            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".codex", false));
-        }
-
-        [Test]
-        public void AreSkillsInstalled_WhenLegacyManagedDirectoryIsEmpty_StillDetectsFlatLayout()
-        {
-            string temporaryRoot = CreateTemporaryProjectRoot();
-            string targetRoot = Path.Combine(temporaryRoot, ".cursor");
-            Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
-            SkillInstallationDetector detector = new();
-
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".cursor", false));
-            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".cursor", true));
-        }
-
-        [Test]
         public void DetectTargets_WhenExpectedLayoutMatchesSourceContent_ReportsInstalled()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();
@@ -1156,176 +1090,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(detectedTargets.Length, Is.EqualTo(1));
             Assert.That(detectedTargets[0].InstallState, Is.EqualTo(SkillInstallState.Installed));
             Assert.That(detectedTargets[0].HasExistingSkills, Is.True);
-        }
-
-        // Tests that Unity-side discovery includes CLI-only skills from the packaged core CLI.
-        [Test]
-        public void GetSkillSourceInfos_WhenProjectIsCurrentRoot_IncludesCliOnlyCoreSkills()
-        {
-            SkillInstallLayout.SkillSourceInfo[] skillSources = SkillInstallLayout.GetSkillSourceInfos(_projectRoot)
-                .ToArray();
-
-            Assert.That(skillSources.Select(skill => skill.Name), Does.Contain("uloop-launch"));
-        }
-
-        // Tests that Tool Settings can read source skill frontmatter descriptions by tool name.
-        [Test]
-        public void GetToolDescriptionsByToolName_WhenSkillHasDescription_MapsDescriptionToToolName()
-        {
-            IReadOnlyDictionary<string, string> descriptions = SkillInstallLayout.GetToolDescriptionsByToolName(_projectRoot);
-
-            Assert.That(descriptions["compile"], Is.EqualTo("Compile the Unity project and report errors/warnings. Use after C# edits."));
-            Assert.That(descriptions[UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT], Does.StartWith("Pauses Unity's playback"));
-        }
-
-        // Tests that skill discovery follows bundled tools after they move into the first-party plugin assembly.
-        [Test]
-        public void GetSkillSourceInfos_WhenFirstPartyToolIsUnderFirstPartyTools_IncludesToolSkill()
-        {
-            SkillInstallLayout.SkillSourceInfo[] skillSources = SkillInstallLayout.GetSkillSourceInfos(_projectRoot)
-                .ToArray();
-
-            SkillInstallLayout.SkillSourceInfo controlPlayModeSkill = skillSources
-                .Single(skill => skill.Name == "uloop-control-play-mode");
-
-            Assert.That(controlPlayModeSkill.ToolName, Is.EqualTo("control-play-mode"));
-            Assert.That(controlPlayModeSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo getLogsSkill = skillSources
-                .Single(skill => skill.Name == "uloop-get-logs");
-
-            Assert.That(getLogsSkill.ToolName, Is.EqualTo("get-logs"));
-            Assert.That(getLogsSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo compileSkill = skillSources
-                .Single(skill => skill.Name == "uloop-compile");
-
-            Assert.That(compileSkill.ToolName, Is.EqualTo("compile"));
-            Assert.That(compileSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo executeDynamicCodeSkill = skillSources
-                .Single(skill => skill.Name == "uloop-execute-dynamic-code");
-
-            Assert.That(executeDynamicCodeSkill.ToolName, Is.EqualTo("execute-dynamic-code"));
-            Assert.That(executeDynamicCodeSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo clearConsoleSkill = skillSources
-                .Single(skill => skill.Name == "uloop-clear-console");
-
-            Assert.That(clearConsoleSkill.ToolName, Is.EqualTo("clear-console"));
-            Assert.That(clearConsoleSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo getHierarchySkill = skillSources
-                .Single(skill => skill.Name == "uloop-get-hierarchy");
-
-            Assert.That(getHierarchySkill.ToolName, Is.EqualTo("get-hierarchy"));
-            Assert.That(getHierarchySkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo runTestsSkill = skillSources
-                .Single(skill => skill.Name == "uloop-run-tests");
-
-            Assert.That(runTestsSkill.ToolName, Is.EqualTo("run-tests"));
-            Assert.That(runTestsSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo findGameObjectsSkill = skillSources
-                .Single(skill => skill.Name == "uloop-find-game-objects");
-
-            Assert.That(findGameObjectsSkill.ToolName, Is.EqualTo("find-game-objects"));
-            Assert.That(findGameObjectsSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo screenshotSkill = skillSources
-                .Single(skill => skill.Name == "uloop-screenshot");
-
-            Assert.That(screenshotSkill.ToolName, Is.EqualTo("screenshot"));
-            Assert.That(screenshotSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo recordInputSkill = skillSources
-                .Single(skill => skill.Name == "uloop-record-input");
-
-            Assert.That(recordInputSkill.ToolName, Is.EqualTo("record-input"));
-            Assert.That(recordInputSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo replayInputSkill = skillSources
-                .Single(skill => skill.Name == "uloop-replay-input");
-
-            Assert.That(replayInputSkill.ToolName, Is.EqualTo("replay-input"));
-            Assert.That(replayInputSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo simulateKeyboardSkill = skillSources
-                .Single(skill => skill.Name == "uloop-simulate-keyboard");
-
-            Assert.That(simulateKeyboardSkill.ToolName, Is.EqualTo("simulate-keyboard"));
-            Assert.That(simulateKeyboardSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo simulateMouseInputSkill = skillSources
-                .Single(skill => skill.Name == "uloop-simulate-mouse-input");
-
-            Assert.That(simulateMouseInputSkill.ToolName, Is.EqualTo("simulate-mouse-input"));
-            Assert.That(simulateMouseInputSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-
-            SkillInstallLayout.SkillSourceInfo simulateMouseUiSkill = skillSources
-                .Single(skill => skill.Name == "uloop-simulate-mouse-ui");
-
-            Assert.That(simulateMouseUiSkill.ToolName, Is.EqualTo("simulate-mouse-ui"));
-            Assert.That(simulateMouseUiSkill.SkillFiles.Keys, Does.Contain(SkillInstallLayout.SkillFileName));
-        }
-
-        // Tests that internal skill metadata maps back to the hidden tool name only.
-        [Test]
-        public void GetInternalSkillToolNames_WhenInternalSkillUsesSkillName_ReturnsToolName()
-        {
-            string temporaryRoot = CreateTemporaryProjectRoot();
-            CreateFakeSourceSkill(
-                temporaryRoot,
-                "uloop-public-skill",
-                "PublicTool",
-                "reference.md",
-                "reference");
-            CreateFakeSourceSkill(
-                temporaryRoot,
-                "uloop-internal-skill",
-                "InternalTool",
-                "reference.md",
-                "internal-reference",
-                isInternal: true);
-
-            HashSet<string> internalToolNames = SkillInstallLayout.GetInternalSkillToolNames(temporaryRoot);
-
-            Assert.That(internalToolNames, Does.Contain("internal-skill"));
-            Assert.That(internalToolNames, Does.Not.Contain("public-skill"));
-        }
-
-        // Tests that user-facing tool catalogs omit tools backed by internal skills.
-        [Test]
-        public void GetToolSettingsCatalogForProjectRoot_WhenSkillIsInternal_HidesToolFromUserFacingLists()
-        {
-            string temporaryRoot = CreateTemporaryProjectRoot();
-            CreateFakeSourceSkill(
-                temporaryRoot,
-                "uloop-internal-tool",
-                "InternalTool",
-                "reference.md",
-                "internal-reference",
-                isInternal: true);
-
-            UnityCliLoopToolRegistry registry = new UnityCliLoopToolRegistry(
-                new ToolSettingsRepository(),
-                new SkillInstallLayoutInternalToolNameProvider(),
-                toolDiscovery: null);
-            registry.RegisterTool(new FakeUnityTool("internal-tool"));
-            registry.RegisterTool(new FakeUnityTool("public-tool"));
-
-            string[] catalogNames = registry.GetToolSettingsCatalogForProjectRoot(temporaryRoot)
-                .Select(tool => tool.Name)
-                .ToArray();
-            string[] registeredToolNames = registry.GetRegisteredToolsForProjectRoot(temporaryRoot)
-                .Select(tool => tool.Name)
-                .ToArray();
-
-            Assert.That(catalogNames, Does.Not.Contain("internal-tool"));
-            Assert.That(catalogNames, Does.Contain("public-tool"));
-            Assert.That(registeredToolNames, Does.Not.Contain("internal-tool"));
-            Assert.That(registeredToolNames, Does.Contain("public-tool"));
         }
 
         [Test]
@@ -1463,22 +1227,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             byte[] installedBytes = File.ReadAllBytes(installedReferencePath);
 
             Assert.That(installedBytes, Has.No.Member((byte)'\r'));
-        }
-
-        // Tests that PowerShell scripts keep their source encoding while line endings are normalized.
-        [Test]
-        public void NormalizeSkillFileContent_WhenPowerShellScriptUsesUtf16LittleEndian_PreservesEncoding()
-        {
-            byte[] sourceBytes = Encoding.Unicode.GetPreamble()
-                .Concat(Encoding.Unicode.GetBytes("line1\r\nline2\r\n"))
-                .ToArray();
-            byte[] expectedBytes = Encoding.Unicode.GetPreamble()
-                .Concat(Encoding.Unicode.GetBytes("line1\nline2\n"))
-                .ToArray();
-
-            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("install.ps1", sourceBytes);
-
-            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
         }
 
         // Tests that rollback backups preserve the previous generated skill bytes.
@@ -1960,31 +1708,5 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "{\n  \"dependencies\": {\n" + dependenciesContent + "\n  }\n}");
         }
 
-        /// <summary>
-        /// Test support type used by editor and play mode fixtures.
-        /// </summary>
-        private sealed class FakeUnityTool : IUnityCliLoopTool
-        {
-            public string ToolName { get; }
-
-            public ToolParameterSchema ParameterSchema { get; } = new();
-
-            public FakeUnityTool(string toolName)
-            {
-                ToolName = toolName;
-            }
-
-            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
-            {
-                return Task.FromResult<UnityCliLoopToolResponse>(new FakeToolResponse());
-            }
-        }
-
-        /// <summary>
-        /// Test support type used by editor and play mode fixtures.
-        /// </summary>
-        private sealed class FakeToolResponse : UnityCliLoopToolResponse
-        {
-        }
     }
 }

--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -1491,6 +1491,64 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void InstallSpecificSkillsForTarget_WhenCancellationRequested_DoesNotWriteSkill()
+        {
+            // Tests that target installation observes cancellation before writing managed skill files.
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            ToolSkillSynchronizer.SkillTargetInfo target = new(
+                "Codex CLI",
+                ".codex",
+                "--codex",
+                hasSkillsDirectory: true,
+                hasExistingSkills: false);
+            SkillInstallLayout.SkillSourceInfo skill = new(
+                "uloop-cancelled-skill",
+                string.Empty,
+                new Dictionary<string, byte[]>
+                {
+                    [SkillInstallLayout.SkillFileName] = Encoding.UTF8.GetBytes(
+                        "---\nname: uloop-cancelled-skill\n---\n")
+                });
+            using CancellationTokenSource cancellation = new();
+            cancellation.Cancel();
+
+            Assert.Throws<OperationCanceledException>(() =>
+                SkillTargetInstaller.InstallSpecificSkillsForTarget(
+                    temporaryRoot,
+                    target,
+                    Array.Empty<SkillInstallLayout.SkillSourceInfo>(),
+                    new[] { skill },
+                    groupSkillsUnderUnityCliLoop: false,
+                    cancellation.Token));
+            Assert.That(
+                Directory.Exists(Path.Combine(
+                    temporaryRoot,
+                    ".codex",
+                    SkillInstallLayout.SkillsDirName,
+                    "uloop-cancelled-skill")),
+                Is.False);
+        }
+
+        [Test]
+        public void ValidateV3MigrationSkillSourceName_WhenNameDiffers_Throws()
+        {
+            // Tests that the packaged migration skill is rejected if its frontmatter name violates the contract.
+            SkillInstallLayout.SkillSourceInfo skill = new(
+                "unexpected-migration-skill",
+                string.Empty,
+                new Dictionary<string, byte[]>
+                {
+                    [SkillInstallLayout.SkillFileName] = Encoding.UTF8.GetBytes(
+                        "---\nname: unexpected-migration-skill\n---\n")
+                });
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                V3MigrationSkillInstaller.ValidateV3MigrationSkillSourceName(skill));
+
+            Assert.That(exception.Message, Does.Contain(CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME));
+        }
+
+        [Test]
         public async Task GetV3MigrationSkillInstallStateAtProjectRoot_WhenSkillExistsInAlternateLayout_ReturnsInstalled()
         {
             // Tests that the temporary migration skill is detected even when it exists in the alternate layout.

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillDirectoryContentSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillDirectoryContentSynchronizer.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Debug = UnityEngine.Debug;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Synchronizes the files inside one installed skill directory.
+    /// </summary>
+    internal static class SkillDirectoryContentSynchronizer
+    {
+        private static readonly string[] ExcludedSkillFileNames =
+        {
+            ".meta",
+            ".DS_Store",
+            ".gitkeep"
+        };
+
+        internal static void SyncInstalledSkillDirectory(
+            string skillDirectory,
+            IReadOnlyDictionary<string, byte[]> skillFiles)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(skillDirectory), "skillDirectory must not be null or empty");
+            Debug.Assert(skillFiles != null, "skillFiles must not be null");
+            Debug.Assert(skillFiles.ContainsKey(SkillInstallLayout.SkillFileName),
+                "skillFiles must contain SKILL.md");
+
+            string parentDirectory = Path.GetDirectoryName(skillDirectory);
+            Debug.Assert(!string.IsNullOrEmpty(parentDirectory), "parentDirectory must not be null or empty");
+            Directory.CreateDirectory(parentDirectory);
+            bool skillDirectoryExisted = Directory.Exists(skillDirectory);
+            Dictionary<string, byte[]> backupFiles = skillDirectoryExisted
+                ? ReadSkillFilesForRollback(skillDirectory)
+                : new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            Directory.CreateDirectory(skillDirectory);
+
+            bool syncCompleted = false;
+            try
+            {
+                WriteSkillFiles(skillDirectory, skillFiles);
+                DeleteUnexpectedSkillFiles(skillDirectory, skillFiles.Keys);
+                DeleteEmptyDirectories(skillDirectory);
+                syncCompleted = true;
+            }
+            finally
+            {
+                if (!syncCompleted)
+                {
+                    RollbackSkillDirectory(skillDirectory, backupFiles, skillDirectoryExisted);
+                }
+            }
+        }
+
+        internal static Dictionary<string, byte[]> ReadSkillFilesForRollback(string skillDirectory)
+        {
+            Dictionary<string, byte[]> files = new(StringComparer.Ordinal);
+            foreach (string filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories))
+            {
+                string fileName = Path.GetFileName(filePath);
+                if (IsExcludedSkillFile(fileName))
+                {
+                    continue;
+                }
+
+                string relativePath = Path.GetRelativePath(skillDirectory, filePath);
+                files[relativePath] = File.ReadAllBytes(filePath);
+            }
+
+            return files;
+        }
+
+        internal static void DeleteEmptyDirectories(string skillDirectory)
+        {
+            foreach (string directoryPath in Directory.EnumerateDirectories(skillDirectory, "*", SearchOption.AllDirectories)
+                         .OrderByDescending(path => path.Length))
+            {
+                if (Directory.EnumerateFileSystemEntries(directoryPath).Any())
+                {
+                    continue;
+                }
+
+                Directory.Delete(directoryPath);
+            }
+        }
+
+        internal static bool IsExcludedSkillFile(string fileName)
+        {
+            if (ExcludedSkillFileNames.Contains(fileName))
+            {
+                return true;
+            }
+
+            foreach (string excludedPattern in ExcludedSkillFileNames)
+            {
+                if (fileName.EndsWith(excludedPattern, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void WriteSkillFiles(
+            string skillDirectory,
+            IReadOnlyDictionary<string, byte[]> skillFiles)
+        {
+            foreach (KeyValuePair<string, byte[]> skillFile in skillFiles)
+            {
+                string fullPath = Path.Combine(skillDirectory, skillFile.Key);
+                string fileDirectory = Path.GetDirectoryName(fullPath);
+                Debug.Assert(!string.IsNullOrEmpty(fileDirectory), "fileDirectory must not be null or empty");
+                Directory.CreateDirectory(fileDirectory);
+                if (File.Exists(fullPath) && File.ReadAllBytes(fullPath).SequenceEqual(skillFile.Value))
+                {
+                    continue;
+                }
+
+                WriteFileAtomically(fullPath, skillFile.Value);
+            }
+        }
+
+        private static void WriteFileAtomically(string fullPath, byte[] content)
+        {
+            string fileDirectory = Path.GetDirectoryName(fullPath);
+            Debug.Assert(!string.IsNullOrEmpty(fileDirectory), "fileDirectory must not be null or empty");
+
+            string tempPath = Path.Combine(
+                fileDirectory,
+                $"{Path.GetFileName(fullPath)}.tmp-{Guid.NewGuid():N}");
+            File.WriteAllBytes(tempPath, content);
+
+            try
+            {
+                if (File.Exists(fullPath))
+                {
+                    File.Replace(tempPath, fullPath, null, true);
+                    return;
+                }
+
+                File.Move(tempPath, fullPath);
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
+        }
+
+        private static void DeleteUnexpectedSkillFiles(
+            string skillDirectory,
+            IEnumerable<string> expectedRelativePaths)
+        {
+            HashSet<string> expectedPaths = new(expectedRelativePaths, StringComparer.Ordinal);
+            foreach (string filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories))
+            {
+                string fileName = Path.GetFileName(filePath);
+                if (IsExcludedSkillFile(fileName))
+                {
+                    continue;
+                }
+
+                string relativePath = Path.GetRelativePath(skillDirectory, filePath);
+                if (expectedPaths.Contains(relativePath))
+                {
+                    continue;
+                }
+
+                File.Delete(filePath);
+            }
+        }
+
+        private static void RollbackSkillDirectory(
+            string skillDirectory,
+            IReadOnlyDictionary<string, byte[]> backupFiles,
+            bool skillDirectoryExisted)
+        {
+            if (!skillDirectoryExisted)
+            {
+                if (Directory.Exists(skillDirectory))
+                {
+                    Directory.Delete(skillDirectory, true);
+                }
+
+                return;
+            }
+
+            Directory.CreateDirectory(skillDirectory);
+            WriteSkillFiles(skillDirectory, backupFiles);
+            DeleteUnexpectedSkillFiles(skillDirectory, backupFiles.Keys);
+            DeleteEmptyDirectories(skillDirectory);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillDirectoryContentSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillDirectoryContentSynchronizer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 using Debug = UnityEngine.Debug;
 
@@ -21,12 +22,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         internal static void SyncInstalledSkillDirectory(
             string skillDirectory,
-            IReadOnlyDictionary<string, byte[]> skillFiles)
+            IReadOnlyDictionary<string, byte[]> skillFiles,
+            CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(skillDirectory), "skillDirectory must not be null or empty");
             Debug.Assert(skillFiles != null, "skillFiles must not be null");
             Debug.Assert(skillFiles.ContainsKey(SkillInstallLayout.SkillFileName),
                 "skillFiles must contain SKILL.md");
+            ct.ThrowIfCancellationRequested();
 
             string parentDirectory = Path.GetDirectoryName(skillDirectory);
             Debug.Assert(!string.IsNullOrEmpty(parentDirectory), "parentDirectory must not be null or empty");
@@ -40,9 +43,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             bool syncCompleted = false;
             try
             {
-                WriteSkillFiles(skillDirectory, skillFiles);
-                DeleteUnexpectedSkillFiles(skillDirectory, skillFiles.Keys);
-                DeleteEmptyDirectories(skillDirectory);
+                WriteSkillFiles(skillDirectory, skillFiles, ct);
+                DeleteUnexpectedSkillFiles(skillDirectory, skillFiles.Keys, ct);
+                DeleteEmptyDirectories(skillDirectory, ct);
                 syncCompleted = true;
             }
             finally
@@ -72,11 +75,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return files;
         }
 
-        internal static void DeleteEmptyDirectories(string skillDirectory)
+        internal static void DeleteEmptyDirectories(string skillDirectory, CancellationToken ct)
         {
             foreach (string directoryPath in Directory.EnumerateDirectories(skillDirectory, "*", SearchOption.AllDirectories)
                          .OrderByDescending(path => path.Length))
             {
+                ct.ThrowIfCancellationRequested();
                 if (Directory.EnumerateFileSystemEntries(directoryPath).Any())
                 {
                     continue;
@@ -106,10 +110,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static void WriteSkillFiles(
             string skillDirectory,
-            IReadOnlyDictionary<string, byte[]> skillFiles)
+            IReadOnlyDictionary<string, byte[]> skillFiles,
+            CancellationToken ct)
         {
             foreach (KeyValuePair<string, byte[]> skillFile in skillFiles)
             {
+                ct.ThrowIfCancellationRequested();
                 string fullPath = Path.Combine(skillDirectory, skillFile.Key);
                 string fileDirectory = Path.GetDirectoryName(fullPath);
                 Debug.Assert(!string.IsNullOrEmpty(fileDirectory), "fileDirectory must not be null or empty");
@@ -154,11 +160,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static void DeleteUnexpectedSkillFiles(
             string skillDirectory,
-            IEnumerable<string> expectedRelativePaths)
+            IEnumerable<string> expectedRelativePaths,
+            CancellationToken ct)
         {
             HashSet<string> expectedPaths = new(expectedRelativePaths, StringComparer.Ordinal);
             foreach (string filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories))
             {
+                ct.ThrowIfCancellationRequested();
                 string fileName = Path.GetFileName(filePath);
                 if (IsExcludedSkillFile(fileName))
                 {
@@ -191,9 +199,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             Directory.CreateDirectory(skillDirectory);
-            WriteSkillFiles(skillDirectory, backupFiles);
-            DeleteUnexpectedSkillFiles(skillDirectory, backupFiles.Keys);
-            DeleteEmptyDirectories(skillDirectory);
+            WriteSkillFiles(skillDirectory, backupFiles, CancellationToken.None);
+            DeleteUnexpectedSkillFiles(skillDirectory, backupFiles.Keys, CancellationToken.None);
+            DeleteEmptyDirectories(skillDirectory, CancellationToken.None);
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillDirectoryContentSynchronizer.cs.meta
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillDirectoryContentSynchronizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f49120c9b8cc841288f87c533c8ccd68
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillDisabledToolFilter.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillDisabledToolFilter.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Resolves tool names from skills and filters skills disabled by tool settings.
+    /// </summary>
+    internal static class SkillDisabledToolFilter
+    {
+        internal static bool IsSkillDisabledByToolSettings(
+            SkillInstallLayout.SkillSourceInfo skill,
+            IReadOnlyCollection<string> disabledTools)
+        {
+            if (disabledTools.Count == 0)
+            {
+                return false;
+            }
+
+            string toolName = GetToolNameForSkill(skill);
+            if (string.IsNullOrEmpty(toolName))
+            {
+                return false;
+            }
+
+            return disabledTools.Contains(toolName);
+        }
+
+        internal static string[] GetCurrentDisabledTools()
+        {
+            ToolSettingsRepository repository = new ToolSettingsRepository();
+            return repository.GetDisabledTools();
+        }
+
+        internal static bool IsSkillForTool(
+            SkillInstallLayout.SkillSourceInfo skill,
+            string toolName)
+        {
+            string skillToolName = GetToolNameForSkill(skill);
+            return string.Equals(skillToolName, toolName, StringComparison.Ordinal);
+        }
+
+        private static string GetToolNameForSkill(SkillInstallLayout.SkillSourceInfo skill)
+        {
+            string toolName = skill.ToolName;
+            if (string.IsNullOrEmpty(toolName) && skill.Name.StartsWith(CliConstants.SKILL_DIR_PREFIX, StringComparison.Ordinal))
+            {
+                toolName = skill.Name.Substring(CliConstants.SKILL_DIR_PREFIX.Length);
+            }
+
+            return toolName;
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillDisabledToolFilter.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillDisabledToolFilter.cs
@@ -29,12 +29,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return disabledTools.Contains(toolName);
         }
 
-        internal static string[] GetCurrentDisabledTools()
-        {
-            ToolSettingsRepository repository = new ToolSettingsRepository();
-            return repository.GetDisabledTools();
-        }
-
         internal static bool IsSkillForTool(
             SkillInstallLayout.SkillSourceInfo skill,
             string toolName)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillDisabledToolFilter.cs.meta
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillDisabledToolFilter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19cd7088f4c26496da42cfdbb611a4e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Debug = UnityEngine.Debug;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Detects skill installation targets and their current install state.
+    /// </summary>
+    internal static class SkillTargetDetector
+    {
+        private readonly struct SkillTargetDefinition
+        {
+            internal readonly string DirName;
+            internal readonly string Flag;
+            internal readonly string DisplayName;
+
+            internal SkillTargetDefinition(string dirName, string flag, string displayName)
+            {
+                DirName = dirName;
+                Flag = flag;
+                DisplayName = displayName;
+            }
+        }
+
+        private static readonly SkillTargetDefinition[] SkillTargets =
+        {
+            new(".claude", "--claude", "Claude Code"),
+            new(".cursor", "--cursor", "Cursor"),
+            new(".gemini", "--gemini", "Gemini CLI"),
+            new(".codex", "--codex", "Codex CLI"),
+            new(".agents", "--agents", "Other (.agents)"),
+            new(".agent", "--antigravity", "Antigravity")
+        };
+
+        internal static readonly string[] SkillTargetDirs = SkillTargets.Select(t => t.DirName).ToArray();
+
+        internal static List<ToolSkillSynchronizer.SkillTargetInfo> DetectTargetsAcrossLayoutsAtProjectRoot(
+            string projectRoot,
+            bool requireSkillsDirectory)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = new();
+
+            foreach (SkillTargetDefinition target in SkillTargets)
+            {
+                string targetRoot = Path.Combine(projectRoot, target.DirName);
+                if (!Directory.Exists(targetRoot))
+                {
+                    continue;
+                }
+
+                bool hasSkillsDirectory = SkillInstallLayout.HasOptedInSkillsDirectory(targetRoot);
+                if (requireSkillsDirectory && !hasSkillsDirectory)
+                {
+                    continue;
+                }
+
+                bool hasULoopSkills = hasSkillsDirectory
+                    && SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot);
+                targets.Add(new ToolSkillSynchronizer.SkillTargetInfo(
+                    target.DisplayName,
+                    target.DirName,
+                    target.Flag,
+                    hasSkillsDirectory,
+                    hasULoopSkills,
+                    installState: hasULoopSkills
+                        ? SkillInstallState.Installed
+                        : SkillInstallState.Missing));
+            }
+
+            return targets;
+        }
+
+        internal static List<ToolSkillSynchronizer.SkillTargetInfo> DetectTargetsForLayoutStateAtProjectRoot(
+            string projectRoot,
+            bool requireSkillsDirectory,
+            bool groupSkillsUnderUnityCliLoop,
+            bool includeFreshnessCheck)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = new();
+
+            foreach (SkillTargetDefinition target in SkillTargets)
+            {
+                string targetRoot = Path.Combine(projectRoot, target.DirName);
+                if (!Directory.Exists(targetRoot))
+                {
+                    continue;
+                }
+
+                bool hasSkillsDirectory = SkillInstallLayout.HasOptedInSkillsDirectory(targetRoot);
+                if (requireSkillsDirectory && !hasSkillsDirectory)
+                {
+                    continue;
+                }
+
+                SkillInstallState installState = ResolveInstallState(
+                    projectRoot,
+                    targetRoot,
+                    hasSkillsDirectory,
+                    groupSkillsUnderUnityCliLoop,
+                    includeFreshnessCheck);
+                bool hasULoopSkills = installState == SkillInstallState.Installed
+                    || installState == SkillInstallState.Checking
+                    || installState == SkillInstallState.Outdated;
+                bool hasDifferentLayoutSkills = hasSkillsDirectory
+                    && SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, !groupSkillsUnderUnityCliLoop);
+                targets.Add(new ToolSkillSynchronizer.SkillTargetInfo(
+                    target.DisplayName,
+                    target.DirName,
+                    target.Flag,
+                    hasSkillsDirectory,
+                    hasULoopSkills,
+                    hasDifferentLayoutSkills,
+                    installState));
+            }
+
+            return targets;
+        }
+
+        internal static List<ToolSkillSynchronizer.SkillTargetInfo> DetectTargetsWithSkillsDirectory(string projectRoot)
+        {
+            List<ToolSkillSynchronizer.SkillTargetInfo> targets = new();
+            foreach (SkillTargetDefinition target in SkillTargets)
+            {
+                string targetRoot = Path.Combine(projectRoot, target.DirName);
+                if (!Directory.Exists(targetRoot))
+                {
+                    continue;
+                }
+
+                bool hasSkillsDirectory = SkillInstallLayout.HasOptedInSkillsDirectory(targetRoot);
+                if (!hasSkillsDirectory)
+                {
+                    continue;
+                }
+
+                targets.Add(new ToolSkillSynchronizer.SkillTargetInfo(
+                    target.DisplayName,
+                    target.DirName,
+                    target.Flag,
+                    hasSkillsDirectory,
+                    hasExistingSkills: false));
+            }
+
+            return targets;
+        }
+
+        private static SkillInstallState ResolveInstallState(
+            string projectRoot,
+            string targetRoot,
+            bool hasSkillsDirectory,
+            bool groupSkillsUnderUnityCliLoop,
+            bool includeFreshnessCheck)
+        {
+            if (!hasSkillsDirectory)
+            {
+                return SkillInstallState.Missing;
+            }
+
+            if (!includeFreshnessCheck)
+            {
+                return SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop)
+                    ? SkillInstallState.Checking
+                    : SkillInstallState.Missing;
+            }
+
+            return SkillInstallLayout.GetInstalledState(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs.meta
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b90bc4dd9f8ee4f1daef5662e24024c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Installs and removes managed skill directories for one target root.
+    /// </summary>
+    internal static class SkillTargetInstaller
+    {
+        private static readonly string[] DeprecatedSkillNames =
+        {
+            "uloop-capture-window",
+            "uloop-get-provider-details",
+            "uloop-unity-search",
+            "uloop-get-menu-items",
+            "uloop-get-unity-search-providers",
+            "uloop-execute-menu-item"
+        };
+
+        internal static void InstallSkillsForTarget(
+            string projectRoot,
+            ToolSkillSynchronizer.SkillTargetInfo target,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> enabledSkills,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            string targetRoot = Path.Combine(projectRoot, target.DirName);
+            string skillsRoot = SkillInstallLayout.GetSkillsRoot(targetRoot);
+            HashSet<string> managedSkillNames = new(
+                enabledSkills.Select(skill => skill.Name),
+                StringComparer.Ordinal);
+            managedSkillNames.UnionWith(disabledSkills.Select(skill => skill.Name));
+            managedSkillNames.UnionWith(DeprecatedSkillNames);
+            Directory.CreateDirectory(skillsRoot);
+
+            if (groupSkillsUnderUnityCliLoop)
+            {
+                Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
+            }
+
+            DeleteDeprecatedSkillDirectoriesFromAllLayouts(targetRoot);
+            DeleteDisabledSkillDirectoriesFromAllLayouts(targetRoot, disabledSkills);
+
+            foreach (SkillInstallLayout.SkillSourceInfo skill in enabledSkills)
+            {
+                string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
+                    targetRoot,
+                    skill.Name,
+                    groupSkillsUnderUnityCliLoop);
+                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop);
+            }
+
+            DeleteUnexpectedInstalledSkillDirectories(
+                targetRoot,
+                enabledSkills.Select(skill => skill.Name),
+                managedSkillNames,
+                groupSkillsUnderUnityCliLoop);
+
+            if (!groupSkillsUnderUnityCliLoop)
+            {
+                DeleteUnexpectedInstalledSkillDirectories(
+                    targetRoot,
+                    enabledSkills.Select(skill => skill.Name),
+                    managedSkillNames,
+                    groupSkillsUnderUnityCliLoop: true);
+                DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
+                    targetRoot,
+                    groupSkillsUnderUnityCliLoop: true);
+            }
+        }
+
+        internal static void InstallSpecificSkillsForTarget(
+            string projectRoot,
+            ToolSkillSynchronizer.SkillTargetInfo target,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> skills,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            string targetRoot = Path.Combine(projectRoot, target.DirName);
+            string skillsRoot = SkillInstallLayout.GetSkillsRoot(targetRoot);
+            Directory.CreateDirectory(skillsRoot);
+
+            if (groupSkillsUnderUnityCliLoop)
+            {
+                Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
+            }
+
+            DeleteDeprecatedSkillDirectoriesForLayout(targetRoot, groupSkillsUnderUnityCliLoop);
+            DeleteDisabledSkillDirectoriesForLayout(targetRoot, disabledSkills, groupSkillsUnderUnityCliLoop);
+
+            foreach (SkillInstallLayout.SkillSourceInfo skill in skills)
+            {
+                string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
+                    targetRoot,
+                    skill.Name,
+                    groupSkillsUnderUnityCliLoop);
+                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop);
+            }
+
+            if (!groupSkillsUnderUnityCliLoop)
+            {
+                DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
+                    targetRoot,
+                    groupSkillsUnderUnityCliLoop: true);
+            }
+        }
+
+        internal static void DeleteSkillDirectoryIfExists(
+            string targetRoot,
+            string skillName,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
+                targetRoot,
+                skillName,
+                groupSkillsUnderUnityCliLoop);
+            if (!Directory.Exists(installedSkillDirectory))
+            {
+                return;
+            }
+
+            Directory.Delete(installedSkillDirectory, true);
+            DeleteEmptyManagedSkillsParentDirectoryIfNeeded(targetRoot, groupSkillsUnderUnityCliLoop);
+        }
+
+        private static void DeleteUnexpectedInstalledSkillDirectories(
+            string targetRoot,
+            IEnumerable<string> expectedSkillNames,
+            IEnumerable<string> removableSkillNames,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            HashSet<string> expectedSkillNameSet = new(expectedSkillNames, StringComparer.Ordinal);
+            HashSet<string> removableSkillNameSet = new(removableSkillNames, StringComparer.Ordinal);
+            foreach (string installedSkillName in SkillInstallLayout.EnumerateInstalledSkillDirectoryNamesForLayout(
+                         targetRoot,
+                         groupSkillsUnderUnityCliLoop))
+            {
+                if (expectedSkillNameSet.Contains(installedSkillName))
+                {
+                    continue;
+                }
+
+                if (!removableSkillNameSet.Contains(installedSkillName))
+                {
+                    continue;
+                }
+
+                DeleteSkillDirectoryIfExists(targetRoot, installedSkillName, groupSkillsUnderUnityCliLoop);
+            }
+        }
+
+        private static void DeleteDeprecatedSkillDirectoriesFromAllLayouts(string targetRoot)
+        {
+            foreach (string deprecatedSkillName in DeprecatedSkillNames)
+            {
+                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: true);
+                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: false);
+            }
+        }
+
+        private static void DeleteDisabledSkillDirectoriesFromAllLayouts(
+            string targetRoot,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills)
+        {
+            foreach (SkillInstallLayout.SkillSourceInfo skill in disabledSkills)
+            {
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: true);
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: false);
+            }
+        }
+
+        private static void DeleteDeprecatedSkillDirectoriesForLayout(
+            string targetRoot,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            foreach (string deprecatedSkillName in DeprecatedSkillNames)
+            {
+                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop);
+            }
+        }
+
+        private static void DeleteDisabledSkillDirectoriesForLayout(
+            string targetRoot,
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            foreach (SkillInstallLayout.SkillSourceInfo skill in disabledSkills)
+            {
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop);
+            }
+        }
+
+        private static void DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
+            string targetRoot,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            if (!groupSkillsUnderUnityCliLoop)
+            {
+                return;
+            }
+
+            string managedSkillsRoot = SkillInstallLayout.GetManagedSkillsRoot(targetRoot);
+            if (!Directory.Exists(managedSkillsRoot))
+            {
+                return;
+            }
+
+            DeleteExcludedFilesAtRoot(managedSkillsRoot);
+            DeleteEmptyDirectoriesAtRoot(managedSkillsRoot);
+            if (Directory.EnumerateFileSystemEntries(managedSkillsRoot).Any())
+            {
+                return;
+            }
+
+            Directory.Delete(managedSkillsRoot);
+        }
+
+        private static void DeleteExcludedFilesAtRoot(string directoryPath)
+        {
+            foreach (string filePath in Directory.EnumerateFiles(directoryPath))
+            {
+                string fileName = Path.GetFileName(filePath);
+                if (!SkillDirectoryContentSynchronizer.IsExcludedSkillFile(fileName))
+                {
+                    continue;
+                }
+
+                File.Delete(filePath);
+            }
+        }
+
+        private static void DeleteEmptyDirectoriesAtRoot(string directoryPath)
+        {
+            foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
+            {
+                SkillDirectoryContentSynchronizer.DeleteEmptyDirectories(childDirectoryPath);
+                if (Directory.EnumerateFileSystemEntries(childDirectoryPath).Any())
+                {
+                    continue;
+                }
+
+                Directory.Delete(childDirectoryPath);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
@@ -25,8 +26,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             ToolSkillSynchronizer.SkillTargetInfo target,
             IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
             IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> enabledSkills,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
+            ct.ThrowIfCancellationRequested();
             string targetRoot = Path.Combine(projectRoot, target.DirName);
             string skillsRoot = SkillInstallLayout.GetSkillsRoot(targetRoot);
             HashSet<string> managedSkillNames = new(
@@ -41,24 +44,26 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
             }
 
-            DeleteDeprecatedSkillDirectoriesFromAllLayouts(targetRoot);
-            DeleteDisabledSkillDirectoriesFromAllLayouts(targetRoot, disabledSkills);
+            DeleteDeprecatedSkillDirectoriesFromAllLayouts(targetRoot, ct);
+            DeleteDisabledSkillDirectoriesFromAllLayouts(targetRoot, disabledSkills, ct);
 
             foreach (SkillInstallLayout.SkillSourceInfo skill in enabledSkills)
             {
+                ct.ThrowIfCancellationRequested();
                 string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
                     targetRoot,
                     skill.Name,
                     groupSkillsUnderUnityCliLoop);
-                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop);
+                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles, ct);
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop, ct);
             }
 
             DeleteUnexpectedInstalledSkillDirectories(
                 targetRoot,
                 enabledSkills.Select(skill => skill.Name),
                 managedSkillNames,
-                groupSkillsUnderUnityCliLoop);
+                groupSkillsUnderUnityCliLoop,
+                ct);
 
             if (!groupSkillsUnderUnityCliLoop)
             {
@@ -66,10 +71,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     targetRoot,
                     enabledSkills.Select(skill => skill.Name),
                     managedSkillNames,
-                    groupSkillsUnderUnityCliLoop: true);
+                    groupSkillsUnderUnityCliLoop: true,
+                    ct);
                 DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
                     targetRoot,
-                    groupSkillsUnderUnityCliLoop: true);
+                    groupSkillsUnderUnityCliLoop: true,
+                    ct);
             }
         }
 
@@ -78,8 +85,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             ToolSkillSynchronizer.SkillTargetInfo target,
             IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
             IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> skills,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
+            ct.ThrowIfCancellationRequested();
             string targetRoot = Path.Combine(projectRoot, target.DirName);
             string skillsRoot = SkillInstallLayout.GetSkillsRoot(targetRoot);
             Directory.CreateDirectory(skillsRoot);
@@ -89,32 +98,36 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
             }
 
-            DeleteDeprecatedSkillDirectoriesForLayout(targetRoot, groupSkillsUnderUnityCliLoop);
-            DeleteDisabledSkillDirectoriesForLayout(targetRoot, disabledSkills, groupSkillsUnderUnityCliLoop);
+            DeleteDeprecatedSkillDirectoriesForLayout(targetRoot, groupSkillsUnderUnityCliLoop, ct);
+            DeleteDisabledSkillDirectoriesForLayout(targetRoot, disabledSkills, groupSkillsUnderUnityCliLoop, ct);
 
             foreach (SkillInstallLayout.SkillSourceInfo skill in skills)
             {
+                ct.ThrowIfCancellationRequested();
                 string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
                     targetRoot,
                     skill.Name,
                     groupSkillsUnderUnityCliLoop);
-                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop);
+                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles, ct);
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop, ct);
             }
 
             if (!groupSkillsUnderUnityCliLoop)
             {
                 DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
                     targetRoot,
-                    groupSkillsUnderUnityCliLoop: true);
+                    groupSkillsUnderUnityCliLoop: true,
+                    ct);
             }
         }
 
         internal static void DeleteSkillDirectoryIfExists(
             string targetRoot,
             string skillName,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
+            ct.ThrowIfCancellationRequested();
             string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
                 targetRoot,
                 skillName,
@@ -125,14 +138,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             Directory.Delete(installedSkillDirectory, true);
-            DeleteEmptyManagedSkillsParentDirectoryIfNeeded(targetRoot, groupSkillsUnderUnityCliLoop);
+            DeleteEmptyManagedSkillsParentDirectoryIfNeeded(targetRoot, groupSkillsUnderUnityCliLoop, ct);
         }
 
         private static void DeleteUnexpectedInstalledSkillDirectories(
             string targetRoot,
             IEnumerable<string> expectedSkillNames,
             IEnumerable<string> removableSkillNames,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
             HashSet<string> expectedSkillNameSet = new(expectedSkillNames, StringComparer.Ordinal);
             HashSet<string> removableSkillNameSet = new(removableSkillNames, StringComparer.Ordinal);
@@ -140,6 +154,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                          targetRoot,
                          groupSkillsUnderUnityCliLoop))
             {
+                ct.ThrowIfCancellationRequested();
                 if (expectedSkillNameSet.Contains(installedSkillName))
                 {
                     continue;
@@ -150,55 +165,64 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     continue;
                 }
 
-                DeleteSkillDirectoryIfExists(targetRoot, installedSkillName, groupSkillsUnderUnityCliLoop);
+                DeleteSkillDirectoryIfExists(targetRoot, installedSkillName, groupSkillsUnderUnityCliLoop, ct);
             }
         }
 
-        private static void DeleteDeprecatedSkillDirectoriesFromAllLayouts(string targetRoot)
+        private static void DeleteDeprecatedSkillDirectoriesFromAllLayouts(string targetRoot, CancellationToken ct)
         {
             foreach (string deprecatedSkillName in DeprecatedSkillNames)
             {
-                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: true);
-                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: false);
+                ct.ThrowIfCancellationRequested();
+                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: true, ct);
+                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: false, ct);
             }
         }
 
         private static void DeleteDisabledSkillDirectoriesFromAllLayouts(
             string targetRoot,
-            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills)
+            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
+            CancellationToken ct)
         {
             foreach (SkillInstallLayout.SkillSourceInfo skill in disabledSkills)
             {
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: true);
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: false);
+                ct.ThrowIfCancellationRequested();
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: true, ct);
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: false, ct);
             }
         }
 
         private static void DeleteDeprecatedSkillDirectoriesForLayout(
             string targetRoot,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
             foreach (string deprecatedSkillName in DeprecatedSkillNames)
             {
-                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop);
+                ct.ThrowIfCancellationRequested();
+                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop, ct);
             }
         }
 
         private static void DeleteDisabledSkillDirectoriesForLayout(
             string targetRoot,
             IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
             foreach (SkillInstallLayout.SkillSourceInfo skill in disabledSkills)
             {
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop);
+                ct.ThrowIfCancellationRequested();
+                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop, ct);
             }
         }
 
         private static void DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
             string targetRoot,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
+            ct.ThrowIfCancellationRequested();
             if (!groupSkillsUnderUnityCliLoop)
             {
                 return;
@@ -210,8 +234,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return;
             }
 
-            DeleteExcludedFilesAtRoot(managedSkillsRoot);
-            DeleteEmptyDirectoriesAtRoot(managedSkillsRoot);
+            DeleteExcludedFilesAtRoot(managedSkillsRoot, ct);
+            DeleteEmptyDirectoriesAtRoot(managedSkillsRoot, ct);
             if (Directory.EnumerateFileSystemEntries(managedSkillsRoot).Any())
             {
                 return;
@@ -220,10 +244,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Directory.Delete(managedSkillsRoot);
         }
 
-        private static void DeleteExcludedFilesAtRoot(string directoryPath)
+        private static void DeleteExcludedFilesAtRoot(string directoryPath, CancellationToken ct)
         {
             foreach (string filePath in Directory.EnumerateFiles(directoryPath))
             {
+                ct.ThrowIfCancellationRequested();
                 string fileName = Path.GetFileName(filePath);
                 if (!SkillDirectoryContentSynchronizer.IsExcludedSkillFile(fileName))
                 {
@@ -234,11 +259,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        private static void DeleteEmptyDirectoriesAtRoot(string directoryPath)
+        private static void DeleteEmptyDirectoriesAtRoot(string directoryPath, CancellationToken ct)
         {
             foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
             {
-                SkillDirectoryContentSynchronizer.DeleteEmptyDirectories(childDirectoryPath);
+                ct.ThrowIfCancellationRequested();
+                SkillDirectoryContentSynchronizer.DeleteEmptyDirectories(childDirectoryPath, ct);
                 if (Directory.EnumerateFileSystemEntries(childDirectoryPath).Any())
                 {
                     continue;

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs.meta
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: baa8d9096e6264b589a54056ec16544d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSetupService.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSetupService.cs
@@ -80,7 +80,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
             ct.ThrowIfCancellationRequested();
 
-            await ToolSkillSynchronizer.InstallSkillFilesForTool(
+            await ToolSkillSynchronizer.InstallSkillFilesForToolWithDisabledTools(
                 toolName,
                 groupSkillsUnderUnityCliLoop,
                 _toolSettingsPort.GetDisabledTools());

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSetupService.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSetupService.cs
@@ -69,7 +69,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             await ToolSkillSynchronizer.InstallSkillFiles(
                 synchronizerTargets,
                 groupSkillsUnderUnityCliLoop,
-                _toolSettingsPort.GetDisabledTools());
+                _toolSettingsPort.GetDisabledTools(),
+                ct);
         }
 
         public async Task InstallSkillFilesForToolAsync(
@@ -83,7 +84,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             await ToolSkillSynchronizer.InstallSkillFilesForToolWithDisabledTools(
                 toolName,
                 groupSkillsUnderUnityCliLoop,
-                _toolSettingsPort.GetDisabledTools());
+                _toolSettingsPort.GetDisabledTools(),
+                ct);
         }
 
         public SkillInstallState GetV3MigrationSkillInstallStateAtProjectRoot(
@@ -115,7 +117,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             await ToolSkillSynchronizer.InstallV3MigrationSkillFilesAtProjectRoot(
                 projectRoot,
                 synchronizerTargets,
-                groupSkillsUnderUnityCliLoop);
+                groupSkillsUnderUnityCliLoop,
+                ct);
         }
 
         public async Task RemoveV3MigrationSkillFilesAsync(
@@ -134,7 +137,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             await ToolSkillSynchronizer.RemoveV3MigrationSkillFilesAtProjectRoot(
                 projectRoot,
                 synchronizerTargets,
-                groupSkillsUnderUnityCliLoop);
+                groupSkillsUnderUnityCliLoop,
+                ct);
         }
 
         private static SkillSetupTargetInfo ToDomainInfo(ToolSkillSynchronizer.SkillTargetInfo target)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.Types.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.Types.cs
@@ -1,0 +1,51 @@
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    public static partial class ToolSkillSynchronizer
+    {
+        public readonly struct SkillInstallResult
+        {
+            public readonly int AttemptedTargets;
+            public readonly int SucceededTargets;
+
+            public SkillInstallResult(int attemptedTargets, int succeededTargets)
+            {
+                AttemptedTargets = attemptedTargets;
+                SucceededTargets = succeededTargets;
+            }
+
+            public int FailedTargets => AttemptedTargets - SucceededTargets;
+            public bool IsSuccessful => FailedTargets == 0;
+        }
+
+        public readonly struct SkillTargetInfo
+        {
+            public readonly string DisplayName;
+            public readonly string DirName;
+            public readonly string InstallFlag;
+            public readonly bool HasSkillsDirectory;
+            public readonly bool HasExistingSkills;
+            public readonly bool HasDifferentLayoutSkills;
+            public readonly SkillInstallState InstallState;
+
+            public SkillTargetInfo(
+                string displayName,
+                string dirName,
+                string installFlag,
+                bool hasSkillsDirectory,
+                bool hasExistingSkills,
+                bool hasDifferentLayoutSkills = false,
+                SkillInstallState installState = SkillInstallState.Missing)
+            {
+                DisplayName = displayName;
+                DirName = dirName;
+                InstallFlag = installFlag;
+                HasSkillsDirectory = hasSkillsDirectory;
+                HasExistingSkills = hasExistingSkills;
+                HasDifferentLayoutSkills = hasDifferentLayoutSkills;
+                InstallState = installState;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.Types.cs.meta
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.Types.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5a67eed7ed46421fa649248a72cc7d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -121,23 +121,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 includeFreshnessCheck: false);
         }
 
-        public static async Task<SkillInstallResult> InstallSkillFilesForTool(
-            string toolName,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            return await InstallSkillFilesForToolWithDisabledTools(
-                toolName,
-                groupSkillsUnderUnityCliLoop,
-                SkillDisabledToolFilter.GetCurrentDisabledTools());
-        }
-
         internal static async Task<SkillInstallResult> InstallSkillFilesForToolWithDisabledTools(
             string toolName,
             bool groupSkillsUnderUnityCliLoop,
-            string[] disabledTools)
+            string[] disabledTools,
+            CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
             Debug.Assert(disabledTools != null, "disabledTools must not be null");
+            ct.ThrowIfCancellationRequested();
 
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
@@ -146,16 +138,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 projectRoot,
                 toolName,
                 groupSkillsUnderUnityCliLoop,
-                disabledTools);
+                disabledTools,
+                ct);
         }
 
         internal static async Task<SkillInstallResult> InstallSkillFiles(
             List<SkillTargetInfo> targets,
             bool groupSkillsUnderUnityCliLoop,
-            string[] disabledTools)
+            string[] disabledTools,
+            CancellationToken ct)
         {
             Debug.Assert(targets != null, "targets must not be null");
             Debug.Assert(disabledTools != null, "disabledTools must not be null");
+            ct.ThrowIfCancellationRequested();
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
@@ -163,18 +158,21 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 projectRoot,
                 targets,
                 groupSkillsUnderUnityCliLoop,
-                disabledTools);
+                disabledTools,
+                ct);
         }
 
         internal static async Task<SkillInstallResult> InstallSkillFilesAtProjectRoot(
             string projectRoot,
             IEnumerable<SkillTargetInfo> targets,
             bool groupSkillsUnderUnityCliLoop,
-            string[] disabledTools)
+            string[] disabledTools,
+            CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(targets != null, "targets must not be null");
             Debug.Assert(disabledTools != null, "disabledTools must not be null");
+            ct.ThrowIfCancellationRequested();
 
             SkillTargetInfo[] targetArray = targets.ToArray();
             return await Task.Run(() =>
@@ -202,18 +200,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 return new SkillInstallResult(targetArray.Length, succeeded);
-            });
+            }, ct);
         }
 
         internal static async Task<SkillInstallResult> InstallSkillFilesForToolAtProjectRoot(
             string projectRoot,
             string toolName,
             bool groupSkillsUnderUnityCliLoop,
-            string[] disabledTools)
+            string[] disabledTools,
+            CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
             Debug.Assert(disabledTools != null, "disabledTools must not be null");
+            ct.ThrowIfCancellationRequested();
 
             if (disabledTools.Contains(toolName))
             {
@@ -250,7 +250,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 return new SkillInstallResult(targetArray.Length, succeeded);
-            });
+            }, ct);
         }
 
         internal static SkillInstallState GetV3MigrationSkillInstallStateAtProjectRoot(
@@ -267,23 +267,27 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal static async Task<SkillInstallResult> InstallV3MigrationSkillFilesAtProjectRoot(
             string projectRoot,
             IEnumerable<SkillTargetInfo> targets,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
             return await V3MigrationSkillInstaller.InstallV3MigrationSkillFilesAtProjectRoot(
                 projectRoot,
                 targets,
-                groupSkillsUnderUnityCliLoop);
+                groupSkillsUnderUnityCliLoop,
+                ct);
         }
 
         internal static async Task<SkillInstallResult> RemoveV3MigrationSkillFilesAtProjectRoot(
             string projectRoot,
             IEnumerable<SkillTargetInfo> targets,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
             return await V3MigrationSkillInstaller.RemoveV3MigrationSkillFilesAtProjectRoot(
                 projectRoot,
                 targets,
-                groupSkillsUnderUnityCliLoop);
+                groupSkillsUnderUnityCliLoop,
+                ct);
         }
 
     }

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -19,52 +19,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// Synchronizes skill files when tools are enabled/disabled.
     /// Removes skill directories on disable, re-installs on enable.
     /// </summary>
-    public static class ToolSkillSynchronizer
+    public static partial class ToolSkillSynchronizer
     {
-        public readonly struct SkillInstallResult
-        {
-            public readonly int AttemptedTargets;
-            public readonly int SucceededTargets;
-
-            public SkillInstallResult(int attemptedTargets, int succeededTargets)
-            {
-                AttemptedTargets = attemptedTargets;
-                SucceededTargets = succeededTargets;
-            }
-
-            public int FailedTargets => AttemptedTargets - SucceededTargets;
-            public bool IsSuccessful => FailedTargets == 0;
-        }
-
-        public readonly struct SkillTargetInfo
-        {
-            public readonly string DisplayName;
-            public readonly string DirName;
-            public readonly string InstallFlag;
-            public readonly bool HasSkillsDirectory;
-            public readonly bool HasExistingSkills;
-            public readonly bool HasDifferentLayoutSkills;
-            public readonly SkillInstallState InstallState;
-
-            public SkillTargetInfo(
-                string displayName,
-                string dirName,
-                string installFlag,
-                bool hasSkillsDirectory,
-                bool hasExistingSkills,
-                bool hasDifferentLayoutSkills = false,
-                SkillInstallState installState = SkillInstallState.Missing)
-            {
-                DisplayName = displayName;
-                DirName = dirName;
-                InstallFlag = installFlag;
-                HasSkillsDirectory = hasSkillsDirectory;
-                HasExistingSkills = hasExistingSkills;
-                HasDifferentLayoutSkills = hasDifferentLayoutSkills;
-                InstallState = installState;
-            }
-        }
-
         public static void RemoveSkillFiles(string toolName)
         {
             Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -366,18 +366,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal static async Task<SkillInstallResult> InstallSkillFilesAtProjectRoot(
             string projectRoot,
             IEnumerable<SkillTargetInfo> targets,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            return await InstallSkillFilesAtProjectRoot(
-                projectRoot,
-                targets,
-                groupSkillsUnderUnityCliLoop,
-                Array.Empty<string>());
-        }
-
-        internal static async Task<SkillInstallResult> InstallSkillFilesAtProjectRoot(
-            string projectRoot,
-            IEnumerable<SkillTargetInfo> targets,
             bool groupSkillsUnderUnityCliLoop,
             string[] disabledTools)
         {
@@ -412,18 +400,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 return new SkillInstallResult(targetArray.Length, succeeded);
             });
-        }
-
-        internal static async Task<SkillInstallResult> InstallSkillFilesForToolAtProjectRoot(
-            string projectRoot,
-            string toolName,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            return await InstallSkillFilesForToolAtProjectRoot(
-                projectRoot,
-                toolName,
-                groupSkillsUnderUnityCliLoop,
-                Array.Empty<string>());
         }
 
         internal static async Task<SkillInstallResult> InstallSkillFilesForToolAtProjectRoot(

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -318,23 +318,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return SkillInstallLayout.GetInstalledState(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
         }
 
-        /// <summary>
-        /// Re-installs skills only for targets that already opted in via an existing skills directory.
-        /// </summary>
-        public static async Task<SkillInstallResult> InstallSkillFiles()
-        {
-            return await InstallSkillFiles(groupSkillsUnderUnityCliLoop: false);
-        }
-
-        public static async Task<SkillInstallResult> InstallSkillFiles(bool groupSkillsUnderUnityCliLoop)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            List<SkillTargetInfo> targets = DetectTargets(projectRoot, requireSkillsDirectory: true);
-            return await InstallSkillFiles(targets, groupSkillsUnderUnityCliLoop);
-        }
-
         public static async Task<SkillInstallResult> InstallSkillFilesForTool(
             string toolName,
             bool groupSkillsUnderUnityCliLoop)
@@ -361,21 +344,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 toolName,
                 groupSkillsUnderUnityCliLoop,
                 disabledTools);
-        }
-
-        public static async Task<SkillInstallResult> InstallSkillFiles(List<SkillTargetInfo> targets)
-        {
-            return await InstallSkillFiles(targets, groupSkillsUnderUnityCliLoop: false);
-        }
-
-        public static async Task<SkillInstallResult> InstallSkillFiles(
-            List<SkillTargetInfo> targets,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            return await InstallSkillFiles(
-                targets,
-                groupSkillsUnderUnityCliLoop,
-                GetCurrentDisabledTools());
         }
 
         internal static async Task<SkillInstallResult> InstallSkillFiles(

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -170,11 +170,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return false;
         }
 
-        public static List<SkillTargetInfo> DetectTargets()
-        {
-            return DetectTargets(requireSkillsDirectory: false);
-        }
-
         public static List<SkillTargetInfo> DetectTargetsForLayout(bool groupSkillsUnderUnityCliLoop)
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
@@ -217,43 +212,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 includeFreshnessCheck: false);
         }
 
-        internal static List<SkillTargetInfo> DetectTargets(bool requireSkillsDirectory)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return DetectTargets(projectRoot, requireSkillsDirectory);
-        }
-
-        internal static List<SkillTargetInfo> DetectTargets(
-            bool requireSkillsDirectory,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return DetectTargets(
-                projectRoot,
-                requireSkillsDirectory,
-                groupSkillsUnderUnityCliLoop,
-                includeFreshnessCheck: true);
-        }
-
-        internal static List<SkillTargetInfo> DetectTargets(
-            bool requireSkillsDirectory,
-            bool groupSkillsUnderUnityCliLoop,
-            bool includeFreshnessCheck)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            return DetectTargets(
-                projectRoot,
-                requireSkillsDirectory,
-                groupSkillsUnderUnityCliLoop,
-                includeFreshnessCheck);
-        }
-
         internal static List<SkillTargetInfo> DetectTargets(string projectRoot, bool requireSkillsDirectory)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
@@ -288,18 +246,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return targets;
-        }
-
-        internal static List<SkillTargetInfo> DetectTargets(
-            string projectRoot,
-            bool requireSkillsDirectory,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            return DetectTargets(
-                projectRoot,
-                requireSkillsDirectory,
-                groupSkillsUnderUnityCliLoop,
-                includeFreshnessCheck: true);
         }
 
         internal static List<SkillTargetInfo> DetectTargets(
@@ -382,7 +328,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         public static async Task<SkillInstallResult> InstallSkillFiles(bool groupSkillsUnderUnityCliLoop)
         {
-            List<SkillTargetInfo> targets = DetectTargets(requireSkillsDirectory: true);
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            List<SkillTargetInfo> targets = DetectTargets(projectRoot, requireSkillsDirectory: true);
             return await InstallSkillFiles(targets, groupSkillsUnderUnityCliLoop);
         }
 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -187,7 +187,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return await InstallSkillFilesForToolWithDisabledTools(
                 toolName,
                 groupSkillsUnderUnityCliLoop,
-                GetCurrentDisabledTools());
+                SkillDisabledToolFilter.GetCurrentDisabledTools());
         }
 
         internal static async Task<SkillInstallResult> InstallSkillFilesForToolWithDisabledTools(
@@ -240,7 +240,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 List<SkillInstallLayout.SkillSourceInfo> allSkills = SkillInstallLayout.GetSkillSourceInfos(projectRoot);
                 List<SkillInstallLayout.SkillSourceInfo> disabledSkills = allSkills
-                    .Where(skill => IsSkillDisabledByToolSettings(
+                    .Where(skill => SkillDisabledToolFilter.IsSkillDisabledByToolSettings(
                         skill,
                         disabledTools))
                     .ToList();
@@ -284,12 +284,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 List<SkillInstallLayout.SkillSourceInfo> allSkills = SkillInstallLayout.GetSkillSourceInfos(projectRoot);
                 List<SkillInstallLayout.SkillSourceInfo> disabledSkills = allSkills
-                    .Where(skill => IsSkillDisabledByToolSettings(
+                    .Where(skill => SkillDisabledToolFilter.IsSkillDisabledByToolSettings(
                         skill,
                         disabledTools))
                     .ToList();
                 List<SkillInstallLayout.SkillSourceInfo> toolSkills = allSkills
-                    .Where(skill => IsSkillForTool(skill, toolName))
+                    .Where(skill => SkillDisabledToolFilter.IsSkillForTool(skill, toolName))
                     .ToList();
                 if (toolSkills.Count == 0)
                 {
@@ -549,49 +549,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     targetRoot,
                     groupSkillsUnderUnityCliLoop: true);
             }
-        }
-
-        internal static bool IsSkillDisabledByToolSettings(
-            SkillInstallLayout.SkillSourceInfo skill,
-            IReadOnlyCollection<string> disabledTools)
-        {
-            if (disabledTools.Count == 0)
-            {
-                return false;
-            }
-
-            string toolName = GetToolNameForSkill(skill);
-            if (string.IsNullOrEmpty(toolName))
-            {
-                return false;
-            }
-
-            return disabledTools.Contains(toolName);
-        }
-
-        private static string[] GetCurrentDisabledTools()
-        {
-            ToolSettingsRepository repository = new ToolSettingsRepository();
-            return repository.GetDisabledTools();
-        }
-
-        private static bool IsSkillForTool(
-            SkillInstallLayout.SkillSourceInfo skill,
-            string toolName)
-        {
-            string skillToolName = GetToolNameForSkill(skill);
-            return string.Equals(skillToolName, toolName, StringComparison.Ordinal);
-        }
-
-        private static string GetToolNameForSkill(SkillInstallLayout.SkillSourceInfo skill)
-        {
-            string toolName = skill.ToolName;
-            if (string.IsNullOrEmpty(toolName) && skill.Name.StartsWith(CliConstants.SKILL_DIR_PREFIX, StringComparison.Ordinal))
-            {
-                toolName = skill.Name.Substring(CliConstants.SKILL_DIR_PREFIX.Length);
-            }
-
-            return toolName;
         }
 
         private static void DeleteUnexpectedInstalledSkillDirectories(

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -21,20 +21,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public static class ToolSkillSynchronizer
     {
-        public readonly struct SkillTargetDefinition
-        {
-            public readonly string DirName;
-            public readonly string Flag;
-            public readonly string DisplayName;
-
-            public SkillTargetDefinition(string dirName, string flag, string displayName)
-            {
-                DirName = dirName;
-                Flag = flag;
-                DisplayName = displayName;
-            }
-        }
-
         public readonly struct SkillInstallResult
         {
             public readonly int AttemptedTargets;
@@ -79,16 +65,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        private static readonly SkillTargetDefinition[] SkillTargets =
-        {
-            new(".claude", "--claude", "Claude Code"),
-            new(".cursor", "--cursor", "Cursor"),
-            new(".gemini", "--gemini", "Gemini CLI"),
-            new(".codex", "--codex", "Codex CLI"),
-            new(".agents", "--agents", "Other (.agents)"),
-            new(".agent", "--antigravity", "Antigravity")
-        };
-
         private static readonly string[] DeprecatedSkillNames =
         {
             "uloop-capture-window",
@@ -104,8 +80,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME,
             "Skill");
 
-        internal static readonly string[] SkillTargetDirs = SkillTargets.Select(t => t.DirName).ToArray();
-
         public static void RemoveSkillFiles(string toolName)
         {
             Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
@@ -119,7 +93,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
 
-            foreach (string targetDir in SkillTargetDirs)
+            foreach (string targetDir in SkillTargetDetector.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(projectRoot, targetDir);
                 if (!Directory.Exists(targetRoot))
@@ -144,7 +118,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
 
-            foreach (string targetDir in SkillTargetDirs)
+            foreach (string targetDir in SkillTargetDetector.SkillTargetDirs)
             {
                 string targetRoot = Path.Combine(projectRoot, targetDir);
                 if (!Directory.Exists(targetRoot))
@@ -186,7 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            return DetectTargetsForLayoutStateAtProjectRoot(
+            return SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                 projectRoot,
                 requireSkillsDirectory: false,
                 groupSkillsUnderUnityCliLoop,
@@ -199,119 +173,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            return DetectTargetsForLayoutStateAtProjectRoot(
+            return SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                 projectRoot,
                 requireSkillsDirectory: false,
                 groupSkillsUnderUnityCliLoop,
                 includeFreshnessCheck: false);
-        }
-
-        internal static List<SkillTargetInfo> DetectTargetsAcrossLayoutsAtProjectRoot(
-            string projectRoot,
-            bool requireSkillsDirectory)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            List<SkillTargetInfo> targets = new();
-
-            foreach (SkillTargetDefinition target in SkillTargets)
-            {
-                string targetRoot = Path.Combine(projectRoot, target.DirName);
-                if (!Directory.Exists(targetRoot))
-                {
-                    continue;
-                }
-
-                bool hasSkillsDirectory = SkillInstallLayout.HasOptedInSkillsDirectory(targetRoot);
-                if (requireSkillsDirectory && !hasSkillsDirectory)
-                {
-                    continue;
-                }
-
-                bool hasULoopSkills = hasSkillsDirectory
-                    && SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot);
-                targets.Add(new SkillTargetInfo(
-                    target.DisplayName,
-                    target.DirName,
-                    target.Flag,
-                    hasSkillsDirectory,
-                    hasULoopSkills,
-                    installState: hasULoopSkills
-                        ? SkillInstallState.Installed
-                        : SkillInstallState.Missing));
-            }
-
-            return targets;
-        }
-
-        internal static List<SkillTargetInfo> DetectTargetsForLayoutStateAtProjectRoot(
-            string projectRoot,
-            bool requireSkillsDirectory,
-            bool groupSkillsUnderUnityCliLoop,
-            bool includeFreshnessCheck)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            List<SkillTargetInfo> targets = new();
-
-            foreach (SkillTargetDefinition target in SkillTargets)
-            {
-                string targetRoot = Path.Combine(projectRoot, target.DirName);
-                if (!Directory.Exists(targetRoot))
-                {
-                    continue;
-                }
-
-                bool hasSkillsDirectory = SkillInstallLayout.HasOptedInSkillsDirectory(targetRoot);
-                if (requireSkillsDirectory && !hasSkillsDirectory)
-                {
-                    continue;
-                }
-
-                SkillInstallState installState = ResolveInstallState(
-                    projectRoot,
-                    targetRoot,
-                    hasSkillsDirectory,
-                    groupSkillsUnderUnityCliLoop,
-                    includeFreshnessCheck);
-                bool hasULoopSkills = installState == SkillInstallState.Installed
-                    || installState == SkillInstallState.Checking
-                    || installState == SkillInstallState.Outdated;
-                bool hasDifferentLayoutSkills = hasSkillsDirectory
-                    && SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, !groupSkillsUnderUnityCliLoop);
-                targets.Add(new SkillTargetInfo(
-                    target.DisplayName,
-                    target.DirName,
-                    target.Flag,
-                    hasSkillsDirectory,
-                    hasULoopSkills,
-                    hasDifferentLayoutSkills,
-                    installState));
-            }
-
-            return targets;
-        }
-
-        private static SkillInstallState ResolveInstallState(
-            string projectRoot,
-            string targetRoot,
-            bool hasSkillsDirectory,
-            bool groupSkillsUnderUnityCliLoop,
-            bool includeFreshnessCheck)
-        {
-            if (!hasSkillsDirectory)
-            {
-                return SkillInstallState.Missing;
-            }
-
-            if (!includeFreshnessCheck)
-            {
-                return SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop)
-                    ? SkillInstallState.Checking
-                    : SkillInstallState.Missing;
-            }
-
-            return SkillInstallLayout.GetInstalledState(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
         }
 
         public static async Task<SkillInstallResult> InstallSkillFilesForTool(
@@ -413,7 +279,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return new SkillInstallResult(0, 0);
             }
 
-            SkillTargetInfo[] targetArray = DetectTargetsWithSkillsDirectory(projectRoot).ToArray();
+            SkillTargetInfo[] targetArray = SkillTargetDetector.DetectTargetsWithSkillsDirectory(projectRoot).ToArray();
             return await Task.Run(() =>
             {
                 List<SkillInstallLayout.SkillSourceInfo> allSkills = SkillInstallLayout.GetSkillSourceInfos(projectRoot);
@@ -726,34 +592,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return toolName;
-        }
-
-        private static List<SkillTargetInfo> DetectTargetsWithSkillsDirectory(string projectRoot)
-        {
-            List<SkillTargetInfo> targets = new();
-            foreach (SkillTargetDefinition target in SkillTargets)
-            {
-                string targetRoot = Path.Combine(projectRoot, target.DirName);
-                if (!Directory.Exists(targetRoot))
-                {
-                    continue;
-                }
-
-                bool hasSkillsDirectory = SkillInstallLayout.HasOptedInSkillsDirectory(targetRoot);
-                if (!hasSkillsDirectory)
-                {
-                    continue;
-                }
-
-                targets.Add(new SkillTargetInfo(
-                    target.DisplayName,
-                    target.DirName,
-                    target.Flag,
-                    hasSkillsDirectory,
-                    hasExistingSkills: false));
-            }
-
-            return targets;
         }
 
         private static void DeleteUnexpectedInstalledSkillDirectories(

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -98,12 +98,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             "uloop-get-unity-search-providers",
             "uloop-execute-menu-item"
         };
-        private static readonly string[] ExcludedSkillFileNames =
-        {
-            ".meta",
-            ".DS_Store",
-            ".gitkeep"
-        };
         private static readonly string V3MigrationSkillSourceDirectory = Path.Combine(
             UnityCliLoopConstants.PackageResolvedPath,
             CliConstants.TEMPORARY_SKILLS_DIR_NAME,
@@ -631,7 +625,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     targetRoot,
                     skill.Name,
                     groupSkillsUnderUnityCliLoop);
-                SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
+                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
                 DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop);
             }
 
@@ -679,7 +673,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     targetRoot,
                     skill.Name,
                     groupSkillsUnderUnityCliLoop);
-                SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
+                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
                 DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop);
             }
 
@@ -788,41 +782,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        private static void SyncInstalledSkillDirectory(
-            string skillDirectory,
-            IReadOnlyDictionary<string, byte[]> skillFiles)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(skillDirectory), "skillDirectory must not be null or empty");
-            Debug.Assert(skillFiles != null, "skillFiles must not be null");
-            Debug.Assert(skillFiles.ContainsKey(SkillInstallLayout.SkillFileName),
-                "skillFiles must contain SKILL.md");
-
-            string parentDirectory = Path.GetDirectoryName(skillDirectory);
-            Debug.Assert(!string.IsNullOrEmpty(parentDirectory), "parentDirectory must not be null or empty");
-            Directory.CreateDirectory(parentDirectory);
-            bool skillDirectoryExisted = Directory.Exists(skillDirectory);
-            Dictionary<string, byte[]> backupFiles = skillDirectoryExisted
-                ? ReadSkillFilesForRollback(skillDirectory)
-                : new Dictionary<string, byte[]>(StringComparer.Ordinal);
-            Directory.CreateDirectory(skillDirectory);
-
-            bool syncCompleted = false;
-            try
-            {
-                WriteSkillFiles(skillDirectory, skillFiles);
-                DeleteUnexpectedSkillFiles(skillDirectory, skillFiles.Keys);
-                DeleteEmptyDirectories(skillDirectory);
-                syncCompleted = true;
-            }
-            finally
-            {
-                if (!syncCompleted)
-                {
-                    RollbackSkillDirectory(skillDirectory, backupFiles, skillDirectoryExisted);
-                }
-            }
-        }
-
         private static void DeleteDeprecatedSkillDirectoriesFromAllLayouts(string targetRoot)
         {
             foreach (string deprecatedSkillName in DeprecatedSkillNames)
@@ -862,148 +821,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop);
             }
-        }
-
-        private static void WriteSkillFiles(
-            string skillDirectory,
-            IReadOnlyDictionary<string, byte[]> skillFiles)
-        {
-            foreach (KeyValuePair<string, byte[]> skillFile in skillFiles)
-            {
-                string fullPath = Path.Combine(skillDirectory, skillFile.Key);
-                string fileDirectory = Path.GetDirectoryName(fullPath);
-                Debug.Assert(!string.IsNullOrEmpty(fileDirectory), "fileDirectory must not be null or empty");
-                Directory.CreateDirectory(fileDirectory);
-                if (File.Exists(fullPath) && File.ReadAllBytes(fullPath).SequenceEqual(skillFile.Value))
-                {
-                    continue;
-                }
-
-                WriteFileAtomically(fullPath, skillFile.Value);
-            }
-        }
-
-        internal static Dictionary<string, byte[]> ReadSkillFilesForRollback(string skillDirectory)
-        {
-            Dictionary<string, byte[]> files = new(StringComparer.Ordinal);
-            foreach (string filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories))
-            {
-                string fileName = Path.GetFileName(filePath);
-                if (IsExcludedSkillFile(fileName))
-                {
-                    continue;
-                }
-
-                string relativePath = Path.GetRelativePath(skillDirectory, filePath);
-                files[relativePath] = File.ReadAllBytes(filePath);
-            }
-
-            return files;
-        }
-
-        private static void WriteFileAtomically(string fullPath, byte[] content)
-        {
-            string fileDirectory = Path.GetDirectoryName(fullPath);
-            Debug.Assert(!string.IsNullOrEmpty(fileDirectory), "fileDirectory must not be null or empty");
-
-            string tempPath = Path.Combine(
-                fileDirectory,
-                $"{Path.GetFileName(fullPath)}.tmp-{Guid.NewGuid():N}");
-            File.WriteAllBytes(tempPath, content);
-
-            try
-            {
-                if (File.Exists(fullPath))
-                {
-                    File.Replace(tempPath, fullPath, null, true);
-                    return;
-                }
-
-                File.Move(tempPath, fullPath);
-            }
-            finally
-            {
-                if (File.Exists(tempPath))
-                {
-                    File.Delete(tempPath);
-                }
-            }
-        }
-
-        private static void DeleteUnexpectedSkillFiles(
-            string skillDirectory,
-            IEnumerable<string> expectedRelativePaths)
-        {
-            HashSet<string> expectedPaths = new(expectedRelativePaths, StringComparer.Ordinal);
-            foreach (string filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories))
-            {
-                string fileName = Path.GetFileName(filePath);
-                if (IsExcludedSkillFile(fileName))
-                {
-                    continue;
-                }
-
-                string relativePath = Path.GetRelativePath(skillDirectory, filePath);
-                if (expectedPaths.Contains(relativePath))
-                {
-                    continue;
-                }
-
-                File.Delete(filePath);
-            }
-        }
-
-        private static void DeleteEmptyDirectories(string skillDirectory)
-        {
-            foreach (string directoryPath in Directory.EnumerateDirectories(skillDirectory, "*", SearchOption.AllDirectories)
-                         .OrderByDescending(path => path.Length))
-            {
-                if (Directory.EnumerateFileSystemEntries(directoryPath).Any())
-                {
-                    continue;
-                }
-
-                Directory.Delete(directoryPath);
-            }
-        }
-
-        private static void RollbackSkillDirectory(
-            string skillDirectory,
-            IReadOnlyDictionary<string, byte[]> backupFiles,
-            bool skillDirectoryExisted)
-        {
-            if (!skillDirectoryExisted)
-            {
-                if (Directory.Exists(skillDirectory))
-                {
-                    Directory.Delete(skillDirectory, true);
-                }
-
-                return;
-            }
-
-            Directory.CreateDirectory(skillDirectory);
-            WriteSkillFiles(skillDirectory, backupFiles);
-            DeleteUnexpectedSkillFiles(skillDirectory, backupFiles.Keys);
-            DeleteEmptyDirectories(skillDirectory);
-        }
-
-        private static bool IsExcludedSkillFile(string fileName)
-        {
-            if (ExcludedSkillFileNames.Contains(fileName))
-            {
-                return true;
-            }
-
-            foreach (string excludedPattern in ExcludedSkillFileNames)
-            {
-                if (fileName.EndsWith(excludedPattern, StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static void DeleteSkillDirectoryIfExists(
@@ -1054,7 +871,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string filePath in Directory.EnumerateFiles(directoryPath))
             {
                 string fileName = Path.GetFileName(filePath);
-                if (!IsExcludedSkillFile(fileName))
+                if (!SkillDirectoryContentSynchronizer.IsExcludedSkillFile(fileName))
                 {
                     continue;
                 }
@@ -1067,7 +884,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
             {
-                DeleteEmptyDirectories(childDirectoryPath);
+                SkillDirectoryContentSynchronizer.DeleteEmptyDirectories(childDirectoryPath);
                 if (Directory.EnumerateFileSystemEntries(childDirectoryPath).Any())
                 {
                     continue;

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -65,12 +65,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        private static readonly string V3MigrationSkillSourceDirectory = Path.Combine(
-            UnityCliLoopConstants.PackageResolvedPath,
-            CliConstants.TEMPORARY_SKILLS_DIR_NAME,
-            CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME,
-            "Skill");
-
         public static void RemoveSkillFiles(string toolName)
         {
             Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
@@ -308,22 +302,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             SkillTargetInfo target,
             bool groupSkillsUnderUnityCliLoop)
         {
-            SkillInstallLayout.SkillSourceInfo skill = GetV3MigrationSkillSourceInfo();
-            SkillInstallState preferredLayoutState = GetSkillInstallStateAtProjectRoot(
+            return V3MigrationSkillInstaller.GetV3MigrationSkillInstallStateAtProjectRoot(
                 projectRoot,
                 target,
-                skill,
                 groupSkillsUnderUnityCliLoop);
-            if (preferredLayoutState != SkillInstallState.Missing)
-            {
-                return preferredLayoutState;
-            }
-
-            return GetSkillInstallStateAtProjectRoot(
-                projectRoot,
-                target,
-                skill,
-                !groupSkillsUnderUnityCliLoop);
         }
 
         internal static async Task<SkillInstallResult> InstallV3MigrationSkillFilesAtProjectRoot(
@@ -331,11 +313,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             IEnumerable<SkillTargetInfo> targets,
             bool groupSkillsUnderUnityCliLoop)
         {
-            SkillInstallLayout.SkillSourceInfo skill = GetV3MigrationSkillSourceInfo();
-            return await InstallSpecificSkillFilesAtProjectRoot(
+            return await V3MigrationSkillInstaller.InstallV3MigrationSkillFilesAtProjectRoot(
                 projectRoot,
                 targets,
-                skill,
                 groupSkillsUnderUnityCliLoop);
         }
 
@@ -344,112 +324,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             IEnumerable<SkillTargetInfo> targets,
             bool groupSkillsUnderUnityCliLoop)
         {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-            Debug.Assert(targets != null, "targets must not be null");
-
-            SkillInstallLayout.SkillSourceInfo skill = GetV3MigrationSkillSourceInfo();
-            SkillTargetInfo[] targetArray = targets.ToArray();
-            return await Task.Run(() =>
-            {
-                int succeeded = 0;
-                foreach (SkillTargetInfo target in targetArray)
-                {
-                    string targetRoot = Path.Combine(projectRoot, target.DirName);
-                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
-                        targetRoot,
-                        skill.Name,
-                        groupSkillsUnderUnityCliLoop);
-                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
-                        targetRoot,
-                        skill.Name,
-                        !groupSkillsUnderUnityCliLoop);
-                    succeeded++;
-                }
-
-                return new SkillInstallResult(targetArray.Length, succeeded);
-            });
-        }
-
-        internal static SkillInstallState GetSkillInstallStateAtProjectRoot(
-            string projectRoot,
-            SkillTargetInfo target,
-            SkillInstallLayout.SkillSourceInfo skill,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-            Debug.Assert(!string.IsNullOrEmpty(target.DirName), "target dir name must not be null or empty");
-
-            string targetRoot = Path.Combine(projectRoot, target.DirName);
-            if (!Directory.Exists(targetRoot))
-            {
-                return SkillInstallState.Missing;
-            }
-
-            return SkillInstallLayout.GetInstalledStateForSkillSource(
-                targetRoot,
-                skill,
+            return await V3MigrationSkillInstaller.RemoveV3MigrationSkillFilesAtProjectRoot(
+                projectRoot,
+                targets,
                 groupSkillsUnderUnityCliLoop);
-        }
-
-        internal static async Task<SkillInstallResult> InstallSpecificSkillFilesAtProjectRoot(
-            string projectRoot,
-            IEnumerable<SkillTargetInfo> targets,
-            SkillInstallLayout.SkillSourceInfo skill,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-            Debug.Assert(targets != null, "targets must not be null");
-
-            SkillTargetInfo[] targetArray = targets.ToArray();
-            return await Task.Run(() =>
-            {
-                int succeeded = 0;
-                foreach (SkillTargetInfo target in targetArray)
-                {
-                    SkillTargetInstaller.InstallSpecificSkillsForTarget(
-                        projectRoot,
-                        target,
-                        Array.Empty<SkillInstallLayout.SkillSourceInfo>(),
-                        new[] { skill },
-                        groupSkillsUnderUnityCliLoop);
-                    succeeded++;
-                }
-
-                return new SkillInstallResult(targetArray.Length, succeeded);
-            });
-        }
-
-        internal static async Task<SkillInstallResult> RemoveSpecificSkillFilesAtProjectRoot(
-            string projectRoot,
-            IEnumerable<SkillTargetInfo> targets,
-            string skillName,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-            Debug.Assert(targets != null, "targets must not be null");
-            Debug.Assert(!string.IsNullOrEmpty(skillName), "skillName must not be null or empty");
-
-            SkillTargetInfo[] targetArray = targets.ToArray();
-            return await Task.Run(() =>
-            {
-                int succeeded = 0;
-                foreach (SkillTargetInfo target in targetArray)
-                {
-                    string targetRoot = Path.Combine(projectRoot, target.DirName);
-                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
-                        targetRoot,
-                        skillName,
-                        groupSkillsUnderUnityCliLoop);
-                    succeeded++;
-                }
-
-                return new SkillInstallResult(targetArray.Length, succeeded);
-            });
-        }
-
-        private static SkillInstallLayout.SkillSourceInfo GetV3MigrationSkillSourceInfo()
-        {
-            return SkillInstallLayout.GetSkillSourceInfoFromDirectory(V3MigrationSkillSourceDirectory);
         }
 
     }

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -190,12 +190,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int succeeded = 0;
                 foreach (SkillTargetInfo target in targetArray)
                 {
+                    ct.ThrowIfCancellationRequested();
                     SkillTargetInstaller.InstallSkillsForTarget(
                         projectRoot,
                         target,
                         disabledSkills,
                         enabledSkills,
-                        groupSkillsUnderUnityCliLoop);
+                        groupSkillsUnderUnityCliLoop,
+                        ct);
                     succeeded++;
                 }
 
@@ -240,12 +242,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int succeeded = 0;
                 foreach (SkillTargetInfo target in targetArray)
                 {
+                    ct.ThrowIfCancellationRequested();
                     SkillTargetInstaller.InstallSpecificSkillsForTarget(
                         projectRoot,
                         target,
                         disabledSkills,
                         toolSkills,
-                        groupSkillsUnderUnityCliLoop);
+                        groupSkillsUnderUnityCliLoop,
+                        ct);
                     succeeded++;
                 }
 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -65,15 +65,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        private static readonly string[] DeprecatedSkillNames =
-        {
-            "uloop-capture-window",
-            "uloop-get-provider-details",
-            "uloop-unity-search",
-            "uloop-get-menu-items",
-            "uloop-get-unity-search-providers",
-            "uloop-execute-menu-item"
-        };
         private static readonly string V3MigrationSkillSourceDirectory = Path.Combine(
             UnityCliLoopConstants.PackageResolvedPath,
             CliConstants.TEMPORARY_SKILLS_DIR_NAME,
@@ -251,7 +242,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int succeeded = 0;
                 foreach (SkillTargetInfo target in targetArray)
                 {
-                    InstallSkillsForTarget(
+                    SkillTargetInstaller.InstallSkillsForTarget(
                         projectRoot,
                         target,
                         disabledSkills,
@@ -299,7 +290,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int succeeded = 0;
                 foreach (SkillTargetInfo target in targetArray)
                 {
-                    InstallSpecificSkillsForTarget(
+                    SkillTargetInstaller.InstallSpecificSkillsForTarget(
                         projectRoot,
                         target,
                         disabledSkills,
@@ -364,11 +355,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 foreach (SkillTargetInfo target in targetArray)
                 {
                     string targetRoot = Path.Combine(projectRoot, target.DirName);
-                    DeleteSkillDirectoryIfExists(
+                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
                         targetRoot,
                         skill.Name,
                         groupSkillsUnderUnityCliLoop);
-                    DeleteSkillDirectoryIfExists(
+                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
                         targetRoot,
                         skill.Name,
                         !groupSkillsUnderUnityCliLoop);
@@ -415,7 +406,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int succeeded = 0;
                 foreach (SkillTargetInfo target in targetArray)
                 {
-                    InstallSpecificSkillsForTarget(
+                    SkillTargetInstaller.InstallSpecificSkillsForTarget(
                         projectRoot,
                         target,
                         Array.Empty<SkillInstallLayout.SkillSourceInfo>(),
@@ -445,7 +436,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 foreach (SkillTargetInfo target in targetArray)
                 {
                     string targetRoot = Path.Combine(projectRoot, target.DirName);
-                    DeleteSkillDirectoryIfExists(
+                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
                         targetRoot,
                         skillName,
                         groupSkillsUnderUnityCliLoop);
@@ -461,232 +452,5 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return SkillInstallLayout.GetSkillSourceInfoFromDirectory(V3MigrationSkillSourceDirectory);
         }
 
-        private static void InstallSkillsForTarget(
-            string projectRoot,
-            SkillTargetInfo target,
-            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
-            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> enabledSkills,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            string targetRoot = Path.Combine(projectRoot, target.DirName);
-            string skillsRoot = SkillInstallLayout.GetSkillsRoot(targetRoot);
-            HashSet<string> managedSkillNames = new(
-                enabledSkills.Select(skill => skill.Name),
-                StringComparer.Ordinal);
-            managedSkillNames.UnionWith(disabledSkills.Select(skill => skill.Name));
-            managedSkillNames.UnionWith(DeprecatedSkillNames);
-            Directory.CreateDirectory(skillsRoot);
-
-            if (groupSkillsUnderUnityCliLoop)
-            {
-                Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
-            }
-
-            DeleteDeprecatedSkillDirectoriesFromAllLayouts(targetRoot);
-            DeleteDisabledSkillDirectoriesFromAllLayouts(targetRoot, disabledSkills);
-
-            foreach (SkillInstallLayout.SkillSourceInfo skill in enabledSkills)
-            {
-                string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
-                    targetRoot,
-                    skill.Name,
-                    groupSkillsUnderUnityCliLoop);
-                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop);
-            }
-
-            DeleteUnexpectedInstalledSkillDirectories(
-                targetRoot,
-                enabledSkills.Select(skill => skill.Name),
-                managedSkillNames,
-                groupSkillsUnderUnityCliLoop);
-
-            if (!groupSkillsUnderUnityCliLoop)
-            {
-                DeleteUnexpectedInstalledSkillDirectories(
-                    targetRoot,
-                    enabledSkills.Select(skill => skill.Name),
-                    managedSkillNames,
-                    groupSkillsUnderUnityCliLoop: true);
-                DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
-                    targetRoot,
-                    groupSkillsUnderUnityCliLoop: true);
-            }
-        }
-
-        private static void InstallSpecificSkillsForTarget(
-            string projectRoot,
-            SkillTargetInfo target,
-            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
-            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> skills,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            string targetRoot = Path.Combine(projectRoot, target.DirName);
-            string skillsRoot = SkillInstallLayout.GetSkillsRoot(targetRoot);
-            Directory.CreateDirectory(skillsRoot);
-
-            if (groupSkillsUnderUnityCliLoop)
-            {
-                Directory.CreateDirectory(SkillInstallLayout.GetManagedSkillsRoot(targetRoot));
-            }
-
-            DeleteDeprecatedSkillDirectoriesForLayout(targetRoot, groupSkillsUnderUnityCliLoop);
-            DeleteDisabledSkillDirectoriesForLayout(targetRoot, disabledSkills, groupSkillsUnderUnityCliLoop);
-
-            foreach (SkillInstallLayout.SkillSourceInfo skill in skills)
-            {
-                string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
-                    targetRoot,
-                    skill.Name,
-                    groupSkillsUnderUnityCliLoop);
-                SkillDirectoryContentSynchronizer.SyncInstalledSkillDirectory(installedSkillDirectory, skill.SkillFiles);
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop);
-            }
-
-            if (!groupSkillsUnderUnityCliLoop)
-            {
-                DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
-                    targetRoot,
-                    groupSkillsUnderUnityCliLoop: true);
-            }
-        }
-
-        private static void DeleteUnexpectedInstalledSkillDirectories(
-            string targetRoot,
-            IEnumerable<string> expectedSkillNames,
-            IEnumerable<string> removableSkillNames,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            HashSet<string> expectedSkillNameSet = new(expectedSkillNames, StringComparer.Ordinal);
-            HashSet<string> removableSkillNameSet = new(removableSkillNames, StringComparer.Ordinal);
-            foreach (string installedSkillName in SkillInstallLayout.EnumerateInstalledSkillDirectoryNamesForLayout(
-                         targetRoot,
-                         groupSkillsUnderUnityCliLoop))
-            {
-                if (expectedSkillNameSet.Contains(installedSkillName))
-                {
-                    continue;
-                }
-
-                if (!removableSkillNameSet.Contains(installedSkillName))
-                {
-                    continue;
-                }
-
-                DeleteSkillDirectoryIfExists(targetRoot, installedSkillName, groupSkillsUnderUnityCliLoop);
-            }
-        }
-
-        private static void DeleteDeprecatedSkillDirectoriesFromAllLayouts(string targetRoot)
-        {
-            foreach (string deprecatedSkillName in DeprecatedSkillNames)
-            {
-                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: true);
-                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop: false);
-            }
-        }
-
-        private static void DeleteDisabledSkillDirectoriesFromAllLayouts(
-            string targetRoot,
-            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills)
-        {
-            foreach (SkillInstallLayout.SkillSourceInfo skill in disabledSkills)
-            {
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: true);
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop: false);
-            }
-        }
-
-        private static void DeleteDeprecatedSkillDirectoriesForLayout(
-            string targetRoot,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            foreach (string deprecatedSkillName in DeprecatedSkillNames)
-            {
-                DeleteSkillDirectoryIfExists(targetRoot, deprecatedSkillName, groupSkillsUnderUnityCliLoop);
-            }
-        }
-
-        private static void DeleteDisabledSkillDirectoriesForLayout(
-            string targetRoot,
-            IReadOnlyCollection<SkillInstallLayout.SkillSourceInfo> disabledSkills,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            foreach (SkillInstallLayout.SkillSourceInfo skill in disabledSkills)
-            {
-                DeleteSkillDirectoryIfExists(targetRoot, skill.Name, groupSkillsUnderUnityCliLoop);
-            }
-        }
-
-        private static void DeleteSkillDirectoryIfExists(
-            string targetRoot,
-            string skillName,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            string installedSkillDirectory = SkillInstallLayout.GetInstalledSkillDirectoryPathForLayout(
-                targetRoot,
-                skillName,
-                groupSkillsUnderUnityCliLoop);
-            if (!Directory.Exists(installedSkillDirectory))
-            {
-                return;
-            }
-
-            Directory.Delete(installedSkillDirectory, true);
-            DeleteEmptyManagedSkillsParentDirectoryIfNeeded(targetRoot, groupSkillsUnderUnityCliLoop);
-        }
-
-        private static void DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
-            string targetRoot,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            if (!groupSkillsUnderUnityCliLoop)
-            {
-                return;
-            }
-
-            string managedSkillsRoot = SkillInstallLayout.GetManagedSkillsRoot(targetRoot);
-            if (!Directory.Exists(managedSkillsRoot))
-            {
-                return;
-            }
-
-            DeleteExcludedFilesAtRoot(managedSkillsRoot);
-            DeleteEmptyDirectoriesAtRoot(managedSkillsRoot);
-            if (Directory.EnumerateFileSystemEntries(managedSkillsRoot).Any())
-            {
-                return;
-            }
-
-            Directory.Delete(managedSkillsRoot);
-        }
-
-        private static void DeleteExcludedFilesAtRoot(string directoryPath)
-        {
-            foreach (string filePath in Directory.EnumerateFiles(directoryPath))
-            {
-                string fileName = Path.GetFileName(filePath);
-                if (!SkillDirectoryContentSynchronizer.IsExcludedSkillFile(fileName))
-                {
-                    continue;
-                }
-
-                File.Delete(filePath);
-            }
-        }
-
-        private static void DeleteEmptyDirectoriesAtRoot(string directoryPath)
-        {
-            foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath))
-            {
-                SkillDirectoryContentSynchronizer.DeleteEmptyDirectories(childDirectoryPath);
-                if (Directory.EnumerateFileSystemEntries(childDirectoryPath).Any())
-                {
-                    continue;
-                }
-
-                Directory.Delete(childDirectoryPath);
-            }
-        }
     }
 }

--- a/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs
@@ -192,7 +192,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            return DetectTargets(
+            return DetectTargetsForLayoutStateAtProjectRoot(
                 projectRoot,
                 requireSkillsDirectory: false,
                 groupSkillsUnderUnityCliLoop,
@@ -205,14 +205,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
-            return DetectTargets(
+            return DetectTargetsForLayoutStateAtProjectRoot(
                 projectRoot,
                 requireSkillsDirectory: false,
                 groupSkillsUnderUnityCliLoop,
                 includeFreshnessCheck: false);
         }
 
-        internal static List<SkillTargetInfo> DetectTargets(string projectRoot, bool requireSkillsDirectory)
+        internal static List<SkillTargetInfo> DetectTargetsAcrossLayoutsAtProjectRoot(
+            string projectRoot,
+            bool requireSkillsDirectory)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
@@ -248,7 +250,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return targets;
         }
 
-        internal static List<SkillTargetInfo> DetectTargets(
+        internal static List<SkillTargetInfo> DetectTargetsForLayoutStateAtProjectRoot(
             string projectRoot,
             bool requireSkillsDirectory,
             bool groupSkillsUnderUnityCliLoop,
@@ -322,13 +324,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string toolName,
             bool groupSkillsUnderUnityCliLoop)
         {
-            return await InstallSkillFilesForTool(
+            return await InstallSkillFilesForToolWithDisabledTools(
                 toolName,
                 groupSkillsUnderUnityCliLoop,
                 GetCurrentDisabledTools());
         }
 
-        internal static async Task<SkillInstallResult> InstallSkillFilesForTool(
+        internal static async Task<SkillInstallResult> InstallSkillFilesForToolWithDisabledTools(
             string toolName,
             bool groupSkillsUnderUnityCliLoop,
             string[] disabledTools)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Debug = UnityEngine.Debug;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Installs, detects, and removes the temporary v3 CLI invocation migration skill.
+    /// </summary>
+    internal static class V3MigrationSkillInstaller
+    {
+        private static readonly string V3MigrationSkillSourceDirectory = Path.Combine(
+            UnityCliLoopConstants.PackageResolvedPath,
+            CliConstants.TEMPORARY_SKILLS_DIR_NAME,
+            CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME,
+            "Skill");
+
+        internal static SkillInstallState GetV3MigrationSkillInstallStateAtProjectRoot(
+            string projectRoot,
+            ToolSkillSynchronizer.SkillTargetInfo target,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            SkillInstallLayout.SkillSourceInfo skill = GetV3MigrationSkillSourceInfo();
+            SkillInstallState preferredLayoutState = GetSkillInstallStateAtProjectRoot(
+                projectRoot,
+                target,
+                skill,
+                groupSkillsUnderUnityCliLoop);
+            if (preferredLayoutState != SkillInstallState.Missing)
+            {
+                return preferredLayoutState;
+            }
+
+            return GetSkillInstallStateAtProjectRoot(
+                projectRoot,
+                target,
+                skill,
+                !groupSkillsUnderUnityCliLoop);
+        }
+
+        internal static async Task<ToolSkillSynchronizer.SkillInstallResult> InstallV3MigrationSkillFilesAtProjectRoot(
+            string projectRoot,
+            IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            SkillInstallLayout.SkillSourceInfo skill = GetV3MigrationSkillSourceInfo();
+            return await InstallSpecificSkillFilesAtProjectRoot(
+                projectRoot,
+                targets,
+                skill,
+                groupSkillsUnderUnityCliLoop);
+        }
+
+        internal static async Task<ToolSkillSynchronizer.SkillInstallResult> RemoveV3MigrationSkillFilesAtProjectRoot(
+            string projectRoot,
+            IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(targets != null, "targets must not be null");
+
+            SkillInstallLayout.SkillSourceInfo skill = GetV3MigrationSkillSourceInfo();
+            ToolSkillSynchronizer.SkillTargetInfo[] targetArray = targets.ToArray();
+            return await Task.Run(() =>
+            {
+                int succeeded = 0;
+                foreach (ToolSkillSynchronizer.SkillTargetInfo target in targetArray)
+                {
+                    string targetRoot = Path.Combine(projectRoot, target.DirName);
+                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
+                        targetRoot,
+                        skill.Name,
+                        groupSkillsUnderUnityCliLoop);
+                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
+                        targetRoot,
+                        skill.Name,
+                        !groupSkillsUnderUnityCliLoop);
+                    succeeded++;
+                }
+
+                return new ToolSkillSynchronizer.SkillInstallResult(targetArray.Length, succeeded);
+            });
+        }
+
+        internal static SkillInstallState GetSkillInstallStateAtProjectRoot(
+            string projectRoot,
+            ToolSkillSynchronizer.SkillTargetInfo target,
+            SkillInstallLayout.SkillSourceInfo skill,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(target.DirName), "target dir name must not be null or empty");
+
+            string targetRoot = Path.Combine(projectRoot, target.DirName);
+            if (!Directory.Exists(targetRoot))
+            {
+                return SkillInstallState.Missing;
+            }
+
+            return SkillInstallLayout.GetInstalledStateForSkillSource(
+                targetRoot,
+                skill,
+                groupSkillsUnderUnityCliLoop);
+        }
+
+        internal static async Task<ToolSkillSynchronizer.SkillInstallResult> InstallSpecificSkillFilesAtProjectRoot(
+            string projectRoot,
+            IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
+            SkillInstallLayout.SkillSourceInfo skill,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(targets != null, "targets must not be null");
+
+            ToolSkillSynchronizer.SkillTargetInfo[] targetArray = targets.ToArray();
+            return await Task.Run(() =>
+            {
+                int succeeded = 0;
+                foreach (ToolSkillSynchronizer.SkillTargetInfo target in targetArray)
+                {
+                    SkillTargetInstaller.InstallSpecificSkillsForTarget(
+                        projectRoot,
+                        target,
+                        Array.Empty<SkillInstallLayout.SkillSourceInfo>(),
+                        new[] { skill },
+                        groupSkillsUnderUnityCliLoop);
+                    succeeded++;
+                }
+
+                return new ToolSkillSynchronizer.SkillInstallResult(targetArray.Length, succeeded);
+            });
+        }
+
+        internal static async Task<ToolSkillSynchronizer.SkillInstallResult> RemoveSpecificSkillFilesAtProjectRoot(
+            string projectRoot,
+            IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
+            string skillName,
+            bool groupSkillsUnderUnityCliLoop)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+            Debug.Assert(targets != null, "targets must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(skillName), "skillName must not be null or empty");
+
+            ToolSkillSynchronizer.SkillTargetInfo[] targetArray = targets.ToArray();
+            return await Task.Run(() =>
+            {
+                int succeeded = 0;
+                foreach (ToolSkillSynchronizer.SkillTargetInfo target in targetArray)
+                {
+                    string targetRoot = Path.Combine(projectRoot, target.DirName);
+                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
+                        targetRoot,
+                        skillName,
+                        groupSkillsUnderUnityCliLoop);
+                    succeeded++;
+                }
+
+                return new ToolSkillSynchronizer.SkillInstallResult(targetArray.Length, succeeded);
+            });
+        }
+
+        private static SkillInstallLayout.SkillSourceInfo GetV3MigrationSkillSourceInfo()
+        {
+            return SkillInstallLayout.GetSkillSourceInfoFromDirectory(V3MigrationSkillSourceDirectory);
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs
@@ -78,15 +78,18 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int succeeded = 0;
                 foreach (ToolSkillSynchronizer.SkillTargetInfo target in targetArray)
                 {
+                    ct.ThrowIfCancellationRequested();
                     string targetRoot = Path.Combine(projectRoot, target.DirName);
                     SkillTargetInstaller.DeleteSkillDirectoryIfExists(
                         targetRoot,
                         skill.Name,
-                        groupSkillsUnderUnityCliLoop);
+                        groupSkillsUnderUnityCliLoop,
+                        ct);
                     SkillTargetInstaller.DeleteSkillDirectoryIfExists(
                         targetRoot,
                         skill.Name,
-                        !groupSkillsUnderUnityCliLoop);
+                        !groupSkillsUnderUnityCliLoop,
+                        ct);
                     succeeded++;
                 }
 
@@ -132,12 +135,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int succeeded = 0;
                 foreach (ToolSkillSynchronizer.SkillTargetInfo target in targetArray)
                 {
+                    ct.ThrowIfCancellationRequested();
                     SkillTargetInstaller.InstallSpecificSkillsForTarget(
                         projectRoot,
                         target,
                         Array.Empty<SkillInstallLayout.SkillSourceInfo>(),
                         new[] { skill },
-                        groupSkillsUnderUnityCliLoop);
+                        groupSkillsUnderUnityCliLoop,
+                        ct);
                     succeeded++;
                 }
 
@@ -163,11 +168,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 int succeeded = 0;
                 foreach (ToolSkillSynchronizer.SkillTargetInfo target in targetArray)
                 {
+                    ct.ThrowIfCancellationRequested();
                     string targetRoot = Path.Combine(projectRoot, target.DirName);
                     SkillTargetInstaller.DeleteSkillDirectoryIfExists(
                         targetRoot,
                         skillName,
-                        groupSkillsUnderUnityCliLoop);
+                        groupSkillsUnderUnityCliLoop,
+                        ct);
                     succeeded++;
                 }
 
@@ -177,7 +184,24 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static SkillInstallLayout.SkillSourceInfo GetV3MigrationSkillSourceInfo()
         {
-            return SkillInstallLayout.GetSkillSourceInfoFromDirectory(V3MigrationSkillSourceDirectory);
+            SkillInstallLayout.SkillSourceInfo skill =
+                SkillInstallLayout.GetSkillSourceInfoFromDirectory(V3MigrationSkillSourceDirectory);
+            ValidateV3MigrationSkillSourceName(skill);
+            return skill;
+        }
+
+        internal static void ValidateV3MigrationSkillSourceName(SkillInstallLayout.SkillSourceInfo skill)
+        {
+            if (string.Equals(
+                    skill.Name,
+                    CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME,
+                    StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            throw new InvalidOperationException(
+                $"V3 migration skill source name must be '{CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME}', but was '{skill.Name}'.");
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Debug = UnityEngine.Debug;
@@ -48,23 +49,27 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal static async Task<ToolSkillSynchronizer.SkillInstallResult> InstallV3MigrationSkillFilesAtProjectRoot(
             string projectRoot,
             IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
             SkillInstallLayout.SkillSourceInfo skill = GetV3MigrationSkillSourceInfo();
             return await InstallSpecificSkillFilesAtProjectRoot(
                 projectRoot,
                 targets,
                 skill,
-                groupSkillsUnderUnityCliLoop);
+                groupSkillsUnderUnityCliLoop,
+                ct);
         }
 
         internal static async Task<ToolSkillSynchronizer.SkillInstallResult> RemoveV3MigrationSkillFilesAtProjectRoot(
             string projectRoot,
             IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(targets != null, "targets must not be null");
+            ct.ThrowIfCancellationRequested();
 
             SkillInstallLayout.SkillSourceInfo skill = GetV3MigrationSkillSourceInfo();
             ToolSkillSynchronizer.SkillTargetInfo[] targetArray = targets.ToArray();
@@ -86,7 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 return new ToolSkillSynchronizer.SkillInstallResult(targetArray.Length, succeeded);
-            });
+            }, ct);
         }
 
         internal static SkillInstallState GetSkillInstallStateAtProjectRoot(
@@ -114,10 +119,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string projectRoot,
             IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
             SkillInstallLayout.SkillSourceInfo skill,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(targets != null, "targets must not be null");
+            ct.ThrowIfCancellationRequested();
 
             ToolSkillSynchronizer.SkillTargetInfo[] targetArray = targets.ToArray();
             return await Task.Run(() =>
@@ -135,18 +142,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 return new ToolSkillSynchronizer.SkillInstallResult(targetArray.Length, succeeded);
-            });
+            }, ct);
         }
 
         internal static async Task<ToolSkillSynchronizer.SkillInstallResult> RemoveSpecificSkillFilesAtProjectRoot(
             string projectRoot,
             IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
             string skillName,
-            bool groupSkillsUnderUnityCliLoop)
+            bool groupSkillsUnderUnityCliLoop,
+            CancellationToken ct)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(targets != null, "targets must not be null");
             Debug.Assert(!string.IsNullOrEmpty(skillName), "skillName must not be null or empty");
+            ct.ThrowIfCancellationRequested();
 
             ToolSkillSynchronizer.SkillTargetInfo[] targetArray = targets.ToArray();
             return await Task.Run(() =>
@@ -163,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 return new ToolSkillSynchronizer.SkillInstallResult(targetArray.Length, succeeded);
-            });
+            }, ct);
         }
 
         private static SkillInstallLayout.SkillSourceInfo GetV3MigrationSkillSourceInfo()

--- a/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs.meta
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1fdf210a2fe94c1ca9d8d122c895e57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Split the large skill synchronization facade into focused internal classes for target detection, content synchronization, disabled-tool filtering, target installation, and V3 migration skill handling.
- Keep the setup service entry points stable while adding a pre-start cancellation gate to the remaining async synchronization paths.
- Move layout-specific tests into a dedicated fixture so synchronizer tests focus on synchronization behavior.

## User Impact
- This is an internal maintenance change; skill setup behavior is intended to remain unchanged.
- Future changes to setup, migration, and skill installation logic should be easier to review and verify because responsibilities are separated.

## Changes
- Removed test-only wrapper overloads and renamed remaining internal entry points to avoid overload ambiguity.
- Extracted `SkillDirectoryContentSynchronizer`, `SkillTargetDetector`, `SkillDisabledToolFilter`, `SkillTargetInstaller`, and `V3MigrationSkillInstaller`.
- Moved synchronizer contract structs into a partial type file and reduced the facade to 294 lines.
- Added `CancellationToken ct` parameters and start-of-operation cancellation checks for surviving async skill setup methods; loop-internal cancellation remains out of scope for this refactor.
- Removed an unreachable disabled-tool settings wrapper left behind by the overload cleanup.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value '.*(ToolSkillSynchronizerTests|SkillInstallLayoutTests).*'`
- Result: compile errors 0 / warnings 0; tests 57/57 passed