### PR TITLE
fix: Reject malformed dispatcher minimum versions consistently

### DIFF
--- a/cli/common/clitest/clitest.go
+++ b/cli/common/clitest/clitest.go
@@ -74,8 +74,7 @@ func RequireValidContractVersion(t *testing.T, label string, value string) {
 	if value == "" {
 		t.Fatalf("%s must not be empty", label)
 	}
-	_, ok := version.Compare(value, value)
-	if !ok {
+	if !version.IsValid(value) {
 		t.Fatalf("%s must be valid semver: %s", label, value)
 	}
 }

--- a/cli/common/version/compare.go
+++ b/cli/common/version/compare.go
@@ -17,6 +17,11 @@ func IsLessThan(left string, right string) bool {
 	return ok && result < 0
 }
 
+func IsValid(value string) bool {
+	_, ok := parseSemanticVersion(value)
+	return ok
+}
+
 func Compare(left string, right string) (int, bool) {
 	leftVersion, leftOK := parseSemanticVersion(left)
 	rightVersion, rightOK := parseSemanticVersion(right)

--- a/cli/common/version/compare.go
+++ b/cli/common/version/compare.go
@@ -103,24 +103,14 @@ func parseVersionPart(value string) (int, bool) {
 }
 
 func isValidPrerelease(value string) bool {
-	if value == "" {
-		return false
-	}
-	for _, identifier := range strings.Split(value, ".") {
-		if identifier == "" {
-			return false
-		}
-		if !containsOnlyPrereleaseCharacters(identifier) {
-			return false
-		}
-		if containsOnlyDigits(identifier) && hasLeadingZero(identifier) {
-			return false
-		}
-	}
-	return true
+	return isValidSemanticIdentifierList(value, true)
 }
 
 func isValidBuildMetadata(value string) bool {
+	return isValidSemanticIdentifierList(value, false)
+}
+
+func isValidSemanticIdentifierList(value string, rejectLeadingZeroNumericIdentifiers bool) bool {
 	if value == "" {
 		return false
 	}
@@ -129,6 +119,9 @@ func isValidBuildMetadata(value string) bool {
 			return false
 		}
 		if !containsOnlyPrereleaseCharacters(identifier) {
+			return false
+		}
+		if rejectLeadingZeroNumericIdentifiers && containsOnlyDigits(identifier) && hasLeadingZero(identifier) {
 			return false
 		}
 	}

--- a/cli/common/version/compare.go
+++ b/cli/common/version/compare.go
@@ -43,7 +43,10 @@ func Compare(left string, right string) (int, bool) {
 
 func parseSemanticVersion(value string) (semanticVersion, bool) {
 	trimmed := trimVersionPrefix(value)
-	withoutBuildMetadata, _, _ := strings.Cut(trimmed, "+")
+	withoutBuildMetadata, buildMetadata, hasBuildMetadata := strings.Cut(trimmed, "+")
+	if hasBuildMetadata && !isValidBuildMetadata(buildMetadata) {
+		return semanticVersion{}, false
+	}
 	versionPart, prerelease, hasPrerelease := strings.Cut(withoutBuildMetadata, "-")
 	parts := strings.Split(versionPart, ".")
 	if len(parts) != 3 {
@@ -111,6 +114,21 @@ func isValidPrerelease(value string) bool {
 			return false
 		}
 		if containsOnlyDigits(identifier) && hasLeadingZero(identifier) {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidBuildMetadata(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, identifier := range strings.Split(value, ".") {
+		if identifier == "" {
+			return false
+		}
+		if !containsOnlyPrereleaseCharacters(identifier) {
 			return false
 		}
 	}

--- a/cli/common/version/compare_test.go
+++ b/cli/common/version/compare_test.go
@@ -57,6 +57,28 @@ func TestIsLessThanHandlesPrereleaseVersions(t *testing.T) {
 	}
 }
 
+func TestIsValidMatchesCompareValidity(t *testing.T) {
+	// Verifies callers can validate semver strings without using self-comparison as a proxy.
+	cases := []struct {
+		value    string
+		expected bool
+	}{
+		{value: "3.0.0", expected: true},
+		{value: "v3.0.0-beta.1", expected: true},
+		{value: "V3.0.0-beta.1+build.7", expected: true},
+		{value: "not-a-version", expected: false},
+		{value: "3.00.1", expected: false},
+		{value: "3.0.0-01", expected: false},
+	}
+
+	for _, tt := range cases {
+		result := IsValid(tt.value)
+		if result != tt.expected {
+			t.Fatalf("IsValid(%q) = %v, want %v", tt.value, result, tt.expected)
+		}
+	}
+}
+
 func TestCompareRejectsInvalidVersion(t *testing.T) {
 	// Verifies that malformed CLI versions do not pass compatibility checks.
 	cases := []string{

--- a/cli/common/version/compare_test.go
+++ b/cli/common/version/compare_test.go
@@ -69,6 +69,9 @@ func TestIsValidMatchesCompareValidity(t *testing.T) {
 		{value: "not-a-version", expected: false},
 		{value: "3.00.1", expected: false},
 		{value: "3.0.0-01", expected: false},
+		{value: "3.0.0+../../payload", expected: false},
+		{value: "3.0.0+", expected: false},
+		{value: "3.0.0+build..7", expected: false},
 	}
 
 	for _, tt := range cases {
@@ -89,6 +92,7 @@ func TestCompareRejectsInvalidVersion(t *testing.T) {
 		"1.02.3",
 		"1.2.03",
 		"1.2.3-alpha.01",
+		"1.2.3+../../payload",
 	}
 
 	for _, value := range cases {

--- a/cli/dispatcher/internal/dispatcher/dispatcher_pin.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_pin.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
-)
 
-var dispatcherProjectRunnerVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
+	sharedversion "github.com/hatayama/unity-cli-loop/common/version"
+)
 
 type dispatcherPin struct {
 	ProjectRunnerVersion     string `json:"projectRunnerVersion"`
@@ -105,7 +104,7 @@ func normalizeDispatcherVersion(value string) string {
 }
 
 func validateDispatcherProjectRunnerVersion(projectRunnerVersion string) error {
-	if !dispatcherProjectRunnerVersionPattern.MatchString(projectRunnerVersion) {
+	if !sharedversion.IsValid(projectRunnerVersion) {
 		return fmt.Errorf("expected semantic version, got %q", projectRunnerVersion)
 	}
 	return nil

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -771,6 +771,19 @@ func TestLoadDispatcherPinRejectsInvalidMinimumDispatcherVersion(t *testing.T) {
 	}
 }
 
+func TestLoadDispatcherPinRejectsMinimumDispatcherVersionWithLeadingZero(t *testing.T) {
+	// Verifies dispatcher pin validation rejects versions the shared comparator cannot order.
+	projectRoot := createDispatcherUnityProject(t)
+	pinPath := filepath.Join(projectRoot, dispatcherProjectPinRelativePath)
+	writeDispatcherPinFileWithMinimum(t, pinPath, "3.0.0-beta.58", "3.00.1")
+
+	_, err := loadDispatcherPin(projectRoot)
+
+	if err == nil {
+		t.Fatal("expected invalid minimumDispatcherVersion error")
+	}
+}
+
 func TestLoadDispatcherPinFailsWhenPinFileMissing(t *testing.T) {
 	// Verifies loadDispatcherPin now requires a pin JSON and does not fall back to CliConstants.cs.
 	projectRoot := createDispatcherUnityProject(t)

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -758,6 +758,19 @@ func TestLoadDispatcherPinRejectsInvalidProjectRunnerVersion(t *testing.T) {
 	}
 }
 
+func TestLoadDispatcherPinRejectsProjectRunnerVersionWithInvalidBuildMetadata(t *testing.T) {
+	// Verifies project pin build metadata cannot smuggle path segments through semver validation.
+	projectRoot := createDispatcherUnityProject(t)
+	pinPath := filepath.Join(projectRoot, dispatcherProjectPinRelativePath)
+	writeDispatcherPinFileWithMinimum(t, pinPath, "3.0.0+../../payload", "3.0.0-beta.39")
+
+	_, err := loadDispatcherPin(projectRoot)
+
+	if err == nil {
+		t.Fatal("expected invalid projectRunnerVersion error")
+	}
+}
+
 func TestLoadDispatcherPinRejectsInvalidMinimumDispatcherVersion(t *testing.T) {
 	// Verifies malformed dispatcher minimums fail closed instead of bypassing freshness checks.
 	projectRoot := createDispatcherUnityProject(t)

--- a/cli/dispatcher/internal/update/command.go
+++ b/cli/dispatcher/internal/update/command.go
@@ -50,8 +50,7 @@ func commandForScript(name string, scriptName string, version string, updateSele
 }
 
 func IsValidTargetVersion(value string) bool {
-	_, ok := sharedversion.Compare(value, value)
-	return ok
+	return sharedversion.IsValid(value)
 }
 
 func NormalizeTargetVersion(value string) string {

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "3d31ae511306e9e5dc7ed2bdb08dcd4297d4f15a"
+  "sharedInputsHash": "e96a3428855774386b3afd553d14a5f2cdbeb68c"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "78e567f2db0cdbe631c742fb669a96601c5f4194"
+  "sharedInputsHash": "3d31ae511306e9e5dc7ed2bdb08dcd4297d4f15a"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "3f3307c144a2772e20885a3dd1b8643746991312"
+  "sharedInputsHash": "78e567f2db0cdbe631c742fb669a96601c5f4194"
 }

--- a/cli/release-automation/internal/automation/protocol_minimum_version_parse.go
+++ b/cli/release-automation/internal/automation/protocol_minimum_version_parse.go
@@ -38,7 +38,7 @@ func ParseProtocolMinimumVersionValues(constantsContent []byte, pinContent []byt
 		values.RequiredProtocolVersion = requiredProtocolVersion
 		values.HasRequiredProtocol = true
 	}
-	if _, ok := sharedversion.Compare(pinVersion, pinVersion); !ok {
+	if !sharedversion.IsValid(pinVersion) {
 		return ProtocolMinimumVersionValues{}, fmt.Errorf("%s projectRunnerVersion must be semver, got %q", unityPackageCliPinFile, pinVersion)
 	}
 	return values, nil


### PR DESCRIPTION
## Summary
- Ensure dispatcher package pins and release automation validate semantic versions through the shared parser.
- Reject malformed dispatcher minimum versions, including leading-zero values, before freshness checks can silently bypass updates.

## User Impact
- Invalid version values in package pins now fail closed consistently across dispatcher and release automation paths.
- Dispatcher update decisions no longer depend on a looser local regex than the comparator used for freshness checks.

## Changes
- Add shared `version.IsValid` for semver validation without self-comparison.
- Replace dispatcher pin regex validation and release automation self-comparison with the shared validator.
- Add regression coverage for leading-zero minimum dispatcher versions and refresh the dispatcher shared input stamp.

## Verification
- `go test ./version` from `cli/common`
- `go test ./internal/dispatcher -run 'TestLoadDispatcherPinRejectsMinimumDispatcherVersionWithLeadingZero|TestLoadDispatcherPinRejectsInvalidMinimumDispatcherVersion|TestLoadDispatcherPinNormalizesVersionPrefixes'` from `cli/dispatcher`
- `go test ./internal/automation -run 'TestParseProtocolMinimumVersionValues_WhenMinimumVersionIsInvalid_Fails'` from `cli/release-automation`
- `scripts/check-go-cli.sh`
- `go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD` from `cli/release-automation`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

