### PR TITLE
fix: Prefer synced tool definitions for help and completion

### DIFF
--- a/cli/common/clicore/tool_catalog.go
+++ b/cli/common/clicore/tool_catalog.go
@@ -51,9 +51,8 @@ func findToolForCommandWithInternalToolNames(
 	preferEmbedded bool,
 	collectInternalToolNames func(string) map[string]bool,
 ) (ToolDefinition, ToolsCache, bool, error) {
-	defaultCache := LoadDefaultTools()
-	if tool, ok := FindTool(defaultCache, command); ok {
-		return tool, defaultCache, true, nil
+	if preferEmbedded {
+		return tools.FindForCommand(projectRoot, command, map[string]bool{}, true)
 	}
 
 	return tools.FindForCommand(projectRoot, command, collectInternalToolNames(projectRoot), preferEmbedded)

--- a/cli/common/clicore/tool_catalog_test.go
+++ b/cli/common/clicore/tool_catalog_test.go
@@ -234,6 +234,33 @@ func TestFindToolForCommandUsesProjectCacheForRegularTools(t *testing.T) {
 	}
 }
 
+func TestFindToolForCommandPrefersProjectCacheForDefaultToolNames(t *testing.T) {
+	// Verifies synced tool catalogs override embedded defaults when both define a regular command.
+	projectRoot := t.TempDir()
+	writeToolCache(t, projectRoot, `{
+  "version": "test",
+  "tools": [
+    {
+      "name": "compile",
+      "description": "cached compile",
+      "inputSchema": {"type": "object", "properties": {}}
+    }
+  ]
+}`)
+
+	tool, _, ok, err := FindToolForCommand(projectRoot, "compile")
+	if err != nil {
+		t.Fatalf("findToolForCommand failed: %v", err)
+	}
+
+	if !ok {
+		t.Fatal("compile tool was not loaded")
+	}
+	if tool.Description != "cached compile" {
+		t.Fatalf("project cache definition was not used: %s", tool.Description)
+	}
+}
+
 // Tests that internal skills without frontmatter names are filtered by their directory-derived tool names.
 func TestLoadToolsFiltersDerivedInternalSkillToolNameFromCache(t *testing.T) {
 	projectRoot := t.TempDir()

--- a/cli/dispatcher/internal/dispatcher/command_help.go
+++ b/cli/dispatcher/internal/dispatcher/command_help.go
@@ -13,13 +13,15 @@ func tryHandleCommandHelp(command string, startPath string, projectPath string, 
 		printNativeSingleCommandHelp(command, stdout)
 		return true, 0
 	}
-	if tool, ok := clicore.FindDefaultTool(command); ok {
-		printToolHelp(tool, stdout)
-		return true, 0
-	}
 
 	connection, err := project.ResolveConnection(startPath, projectPath)
 	if err != nil {
+		if projectPath == "" {
+			if tool, ok := clicore.FindDefaultTool(command); ok {
+				printToolHelp(tool, stdout)
+				return true, 0
+			}
+		}
 		clicore.WriteClassifiedError(stderr, err, clicore.ErrorContext{Command: command})
 		return true, 1
 	}

--- a/cli/dispatcher/internal/dispatcher/completion.go
+++ b/cli/dispatcher/internal/dispatcher/completion.go
@@ -237,7 +237,11 @@ func printOptionsForCommand(command string, cache clicore.ToolsCache, stdout io.
 		clicore.WriteLine(stdout, "")
 		return
 	}
-	if tool, ok := clicore.FindDefaultTool(command); ok {
+	if command == clicore.ExecuteDynamicCodeCommandName {
+		tool, ok := clicore.FindDefaultTool(command)
+		if !ok {
+			return
+		}
 		printOptionsForTool(tool, stdout)
 		return
 	}

--- a/cli/dispatcher/internal/dispatcher/completion_test.go
+++ b/cli/dispatcher/internal/dispatcher/completion_test.go
@@ -60,8 +60,8 @@ func TestCompletionListOptionsUsesToolSchema(t *testing.T) {
 	}
 }
 
-func TestCompletionListOptionsUsesEmbeddedFirstPartyToolSchema(t *testing.T) {
-	// Verifies stale project caches do not re-expose removed first-party options.
+func TestCompletionListOptionsPrefersProjectCacheForDefaultToolNames(t *testing.T) {
+	// Verifies synced project tool metadata overrides embedded defaults for regular commands.
 	var stdout bytes.Buffer
 	cache := clicore.ToolsCache{
 		Tools: []clicore.ToolDefinition{
@@ -70,8 +70,7 @@ func TestCompletionListOptionsUsesEmbeddedFirstPartyToolSchema(t *testing.T) {
 				InputSchema: clicore.InputSchema{
 					Type: "object",
 					Properties: map[string]clicore.ToolProperty{
-						"ForceRecompile":      {Type: "boolean"},
-						"WaitForDomainReload": {Type: "boolean", Default: false},
+						"CachedOnly": {Type: "boolean"},
 					},
 				},
 			},
@@ -93,14 +92,11 @@ func TestCompletionListOptionsUsesEmbeddedFirstPartyToolSchema(t *testing.T) {
 	}
 
 	output := stdout.String()
-	if !strings.Contains(output, "--no-wait-for-domain-reload") {
-		t.Fatalf("embedded compile options were not used: %s", output)
+	if !strings.Contains(output, "--cached-only") {
+		t.Fatalf("cached compile options were not used: %s", output)
 	}
-	if !strings.Contains(output, "--stop-on-external-scene-changes") {
-		t.Fatalf("embedded compile external Scene option was not used: %s", output)
-	}
-	if strings.Contains(output, "--wait-for-domain-reload") {
-		t.Fatalf("stale wait option should not be listed: %s", output)
+	if strings.Contains(output, "--stop-on-external-scene-changes") {
+		t.Fatalf("embedded compile option should not be listed when cache exists: %s", output)
 	}
 }
 

--- a/cli/dispatcher/internal/dispatcher/help_test.go
+++ b/cli/dispatcher/internal/dispatcher/help_test.go
@@ -234,6 +234,43 @@ func TestRunDispatcherCompileHelpDoesNotRequireUnityProject(t *testing.T) {
 	}
 }
 
+func TestCommandHelpPrefersProjectCacheForDefaultToolNames(t *testing.T) {
+	// Verifies command help uses synced project tool metadata before embedded defaults.
+	projectRoot := createLaunchTestProject(t)
+	writeToolCache(t, projectRoot, `{
+  "tools": [
+    {
+      "name": "compile",
+      "description": "Cached compile help",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "CachedOnly": {"type": "boolean", "description": "Cached-only option"}
+        }
+      }
+    }
+  ]
+}`)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	handled, code := tryHandleCommandHelp("compile", projectRoot, projectRoot, &stdout, &stderr)
+
+	if !handled {
+		t.Fatal("compile help request was not handled")
+	}
+	if code != 0 {
+		t.Fatalf("compile help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Cached compile help") {
+		t.Fatalf("cached compile help was not used:\n%s", output)
+	}
+	if !strings.Contains(output, "--cached-only") {
+		t.Fatalf("cached compile option was not listed:\n%s", output)
+	}
+}
+
 // Tests that execute-dynamic-code help includes CLI-side code-file support without resolving a Unity project.
 func TestRunDispatcherExecuteDynamicCodeHelpDoesNotRequireUnityProject(t *testing.T) {
 	t.Chdir(t.TempDir())

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "e96a3428855774386b3afd553d14a5f2cdbeb68c"
+  "sharedInputsHash": "89091ed9ff5f5a56899f0e88479343b756f8ba9c"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "814737cf4b61d82fe9cb2f4fc99c198f4c3fae12"
+  "sharedInputsHash": "452c12499a133b1ad167ecbd9306e62ba6fbf162"
 }


### PR DESCRIPTION
## Summary
- Prefer synced project tool definitions for regular CLI help and completion lookup.
- Keep the embedded execute-dynamic-code definition on its existing hot path.

## User Impact
- After running sync, CLI help and completion can reflect updated tool metadata from the project cache instead of staying stuck on the embedded catalog.
- If the project cache is missing or unreadable, existing embedded fallback behavior remains in place.

## Changes
- Removed the unconditional embedded default lookup before regular command lookup.
- Added a regression test for a regular command whose synced definition should override the embedded one.
- Refreshed shared release input stamps for the common Go change.

## Verification
- go test ./clicore -run 'TestFindToolForCommandPrefersProjectCacheForDefaultToolNames|TestFindToolForCommandUsesEmbeddedExecuteDynamicCodeDefinition|TestFindToolForCommandSkipsInternalSkillScanForExecuteDynamicCode|TestFindToolForCommandUsesProjectCacheForRegularTools'
- scripts/check-go-cli.sh
- go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

