### PR TITLE
fix: Preserve get-logs response metadata in pause point evidence

### DIFF
--- a/Assets/Tests/Editor/GetLogsResponseContractTests.cs
+++ b/Assets/Tests/Editor/GetLogsResponseContractTests.cs
@@ -78,7 +78,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 return arrayShape;
             }
 
-            return new JValue(true);
+            return new JValue(NormalizeScalarType(value.Type));
+        }
+
+        private static string NormalizeScalarType(JTokenType type)
+        {
+            return type switch
+            {
+                JTokenType.Boolean => "boolean",
+                JTokenType.Float => "number",
+                JTokenType.Integer => "number",
+                JTokenType.Null => "null",
+                JTokenType.String => "string",
+                _ => "unknown"
+            };
         }
     }
 }

--- a/Assets/Tests/Editor/GetLogsResponseContractTests.cs
+++ b/Assets/Tests/Editor/GetLogsResponseContractTests.cs
@@ -1,0 +1,84 @@
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.CompositionRoot;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies Unity get-logs responses stay aligned with the shared Go CLI contract.
+    /// </summary>
+    public sealed class GetLogsResponseContractTests
+    {
+        private const string SharedContractPath = "tests/contracts/get_logs_response_contract.json";
+
+        [Test]
+        public void GetLogsResponse_WhenSerialized_MatchesSharedContractFieldShape()
+        {
+            // Verifies C# does not add, remove, or rename fields without updating the shared CLI contract.
+            JObject expected = ReadSharedContractFieldShape();
+            GetLogsResponse response = new(
+                totalCount: 2,
+                displayedCount: 1,
+                logType: "Error",
+                maxCount: 1,
+                searchText: "pause-point-id",
+                includeStackTrace: true,
+                logs: new[]
+                {
+                    new LogEntry(
+                        type: "Error",
+                        message: "pause-point-id failed",
+                        stackTrace: "Example.StackTrace:42")
+                });
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+            JObject actual = NormalizeFieldShape(JObject.Parse(json));
+
+            Assert.That(JToken.DeepEquals(actual, expected), Is.True, $"Expected {expected} but got {actual}");
+        }
+
+        private static JObject ReadSharedContractFieldShape()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedContractPath));
+            return NormalizeFieldShape(JObject.Parse(json));
+        }
+
+        private static JObject NormalizeFieldShape(JObject value)
+        {
+            JObject shape = new();
+            foreach (JProperty property in value.Properties())
+            {
+                shape[property.Name] = NormalizeTokenFieldShape(property.Value);
+            }
+            return shape;
+        }
+
+        private static JToken NormalizeTokenFieldShape(JToken value)
+        {
+            if (value is JObject objectValue)
+            {
+                return NormalizeFieldShape(objectValue);
+            }
+
+            if (value is JArray arrayValue)
+            {
+                JArray arrayShape = new();
+                if (arrayValue.Count > 0)
+                {
+                    arrayShape.Add(NormalizeTokenFieldShape(arrayValue[0]));
+                }
+                return arrayShape;
+            }
+
+            return new JValue(true);
+        }
+    }
+}

--- a/Assets/Tests/Editor/GetLogsResponseContractTests.cs.meta
+++ b/Assets/Tests/Editor/GetLogsResponseContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 621759be4f3ae44c2a9fdce40167eba3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/project-runner/internal/projectrunner/get_logs_response_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/get_logs_response_contract_test.go
@@ -87,7 +87,15 @@ func normalizeJSONFieldShape(value any) any {
 			return []any{}
 		}
 		return []any{normalizeJSONFieldShape(typedValue[0])}
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case float64:
+		return "number"
+	case string:
+		return "string"
 	default:
-		return true
+		return "unknown"
 	}
 }

--- a/cli/project-runner/internal/projectrunner/get_logs_response_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/get_logs_response_contract_test.go
@@ -1,0 +1,93 @@
+package projectrunner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const getLogsResponseContractPath = "tests/contracts/get_logs_response_contract.json"
+
+// Verifies the Go pause-point get-logs DTO preserves every field in the shared Unity response contract.
+func TestPausePointGetLogsResponseMatchesSharedContract(t *testing.T) {
+	fixture := readGetLogsResponseContract(t)
+
+	var response pausePointGetLogsResponse
+	if err := json.Unmarshal(fixture, &response); err != nil {
+		t.Fatalf("failed to unmarshal shared get-logs response contract: %v", err)
+	}
+
+	roundTripped, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("failed to marshal Go get-logs response: %v", err)
+	}
+
+	expected := readJSONFieldShape(t, fixture)
+	actual := readJSONFieldShape(t, roundTripped)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("get-logs response field shape drifted\nexpected: %#v\nactual:   %#v", expected, actual)
+	}
+}
+
+func readGetLogsResponseContract(t *testing.T) []byte {
+	t.Helper()
+
+	path := findRepoRelativeFile(t, getLogsResponseContractPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read shared get-logs response contract: %v", err)
+	}
+	return data
+}
+
+func findRepoRelativeFile(t *testing.T, relativePath string) string {
+	t.Helper()
+
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to resolve current directory: %v", err)
+	}
+
+	for {
+		candidate := filepath.Join(directory, relativePath)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			t.Fatalf("failed to find %s from %s", relativePath, directory)
+		}
+		directory = parent
+	}
+}
+
+func readJSONFieldShape(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatalf("failed to parse JSON field shape: %v", err)
+	}
+	return normalizeJSONFieldShape(value).(map[string]any)
+}
+
+func normalizeJSONFieldShape(value any) any {
+	switch typedValue := value.(type) {
+	case map[string]any:
+		shape := make(map[string]any, len(typedValue))
+		for key, child := range typedValue {
+			shape[key] = normalizeJSONFieldShape(child)
+		}
+		return shape
+	case []any:
+		if len(typedValue) == 0 {
+			return []any{}
+		}
+		return []any{normalizeJSONFieldShape(typedValue[0])}
+	default:
+		return true
+	}
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_logs.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_logs.go
@@ -18,8 +18,9 @@ const (
 var fetchMatchingLogs = fetchMatchingLogsFromUnity
 
 type pausePointMatchingLog struct {
-	Type    string `json:"Type"`
-	Message string `json:"Message"`
+	Type       string `json:"Type"`
+	Message    string `json:"Message"`
+	StackTrace string `json:"StackTrace"`
 }
 
 type pausePointMatchingLogsResult struct {
@@ -67,11 +68,13 @@ type pausePointWaitResult struct {
 }
 
 type pausePointGetLogsResponse struct {
-	TotalCount     int                     `json:"TotalCount"`
-	DisplayedCount int                     `json:"DisplayedCount"`
-	MaxCount       int                     `json:"MaxCount"`
-	SearchText     string                  `json:"SearchText"`
-	Logs           []pausePointMatchingLog `json:"Logs"`
+	TotalCount        int                     `json:"TotalCount"`
+	DisplayedCount    int                     `json:"DisplayedCount"`
+	LogType           string                  `json:"LogType"`
+	MaxCount          int                     `json:"MaxCount"`
+	SearchText        string                  `json:"SearchText"`
+	IncludeStackTrace bool                    `json:"IncludeStackTrace"`
+	Logs              []pausePointMatchingLog `json:"Logs"`
 }
 
 func fetchMatchingLogsFromUnity(

--- a/cli/project-runner/internal/projectrunner/pause_point_logs.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_logs.go
@@ -24,11 +24,13 @@ type pausePointMatchingLog struct {
 }
 
 type pausePointMatchingLogsResult struct {
-	SearchText     string                  `json:"SearchText"`
-	TotalCount     int                     `json:"TotalCount"`
-	DisplayedCount int                     `json:"DisplayedCount"`
-	MaxCount       int                     `json:"MaxCount"`
-	Logs           []pausePointMatchingLog `json:"Logs"`
+	SearchText        string                  `json:"SearchText"`
+	TotalCount        int                     `json:"TotalCount"`
+	DisplayedCount    int                     `json:"DisplayedCount"`
+	LogType           string                  `json:"LogType"`
+	MaxCount          int                     `json:"MaxCount"`
+	IncludeStackTrace bool                    `json:"IncludeStackTrace"`
+	Logs              []pausePointMatchingLog `json:"Logs"`
 }
 
 type pausePointEvidenceSummary struct {
@@ -54,7 +56,9 @@ type pausePointEvidenceLogs struct {
 	SearchText                   string `json:"SearchText"`
 	MatchingLogCount             int    `json:"MatchingLogCount"`
 	ReturnedLogCount             int    `json:"ReturnedLogCount"`
+	LogType                      string `json:"LogType"`
 	MaxCount                     int    `json:"MaxCount"`
+	IncludeStackTrace            bool   `json:"IncludeStackTrace"`
 	MayBeTruncated               bool   `json:"MayBeTruncated"`
 	MultipleMatchingLogsObserved bool   `json:"MultipleMatchingLogsObserved"`
 }
@@ -119,11 +123,13 @@ func fetchMatchingLogsFromUnity(
 	}
 
 	return pausePointMatchingLogsResult{
-		SearchText:     response.SearchText,
-		TotalCount:     response.TotalCount,
-		DisplayedCount: response.DisplayedCount,
-		MaxCount:       response.MaxCount,
-		Logs:           response.Logs,
+		SearchText:        response.SearchText,
+		TotalCount:        response.TotalCount,
+		DisplayedCount:    response.DisplayedCount,
+		LogType:           response.LogType,
+		MaxCount:          response.MaxCount,
+		IncludeStackTrace: response.IncludeStackTrace,
+		Logs:              response.Logs,
 	}, nil
 }
 
@@ -159,7 +165,9 @@ func buildPausePointEvidenceLogs(logs pausePointMatchingLogsResult) pausePointEv
 		SearchText:                   logs.SearchText,
 		MatchingLogCount:             matchingLogCount,
 		ReturnedLogCount:             returnedLogCount,
+		LogType:                      logs.LogType,
 		MaxCount:                     logs.MaxCount,
+		IncludeStackTrace:            logs.IncludeStackTrace,
 		MayBeTruncated:               matchingLogCount > returnedLogCount,
 		MultipleMatchingLogsObserved: matchingLogCount > 1,
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -428,13 +428,15 @@ func TestRunWaitForPausePointEmbedsMatchingLogsOnHit(t *testing.T) {
 		fetchedSearchText = searchText
 		fetchedMaxCount = maxCount
 		return pausePointMatchingLogsResult{
-			SearchText:     searchText,
-			TotalCount:     2,
-			DisplayedCount: 2,
-			MaxCount:       maxCount,
+			SearchText:        searchText,
+			TotalCount:        2,
+			DisplayedCount:    2,
+			LogType:           "Error",
+			MaxCount:          maxCount,
+			IncludeStackTrace: true,
 			Logs: []pausePointMatchingLog{
-				{Type: "Log", Message: "[jump] velocity=4.2"},
-				{Type: "Log", Message: "[jump] grounded=false"},
+				{Type: "Error", Message: "[jump] velocity=4.2", StackTrace: "trace one"},
+				{Type: "Error", Message: "[jump] grounded=false", StackTrace: "trace two"},
 			},
 		}, nil
 	}
@@ -462,6 +464,9 @@ func TestRunWaitForPausePointEmbedsMatchingLogsOnHit(t *testing.T) {
 	if len(result.MatchingLogs) != 2 || result.MatchingLogs[0].Message != "[jump] velocity=4.2" {
 		t.Fatalf("matching logs mismatch: %#v", result.MatchingLogs)
 	}
+	if result.MatchingLogs[0].StackTrace != "trace one" {
+		t.Fatalf("matching log stack trace mismatch: %#v", result.MatchingLogs)
+	}
 	if result.EvidenceSummary.EditorState.CapturedAt != "PausePointHit" {
 		t.Fatalf("editor state summary mismatch: %#v", result.EvidenceSummary)
 	}
@@ -472,6 +477,10 @@ func TestRunWaitForPausePointEmbedsMatchingLogsOnHit(t *testing.T) {
 		result.EvidenceSummary.MatchingLogs.MatchingLogCount != 2 ||
 		result.EvidenceSummary.MatchingLogs.ReturnedLogCount != 2 {
 		t.Fatalf("matching log summary mismatch: %#v", result.EvidenceSummary)
+	}
+	if result.EvidenceSummary.MatchingLogs.LogType != "Error" ||
+		!result.EvidenceSummary.MatchingLogs.IncludeStackTrace {
+		t.Fatalf("matching log metadata mismatch: %#v", result.EvidenceSummary)
 	}
 	if !strings.Contains(result.EvidenceSummary.Warning, "Multiple matching logs") {
 		t.Fatalf("warning mismatch: %#v", result.EvidenceSummary)

--- a/tests/contracts/get_logs_response_contract.json
+++ b/tests/contracts/get_logs_response_contract.json
@@ -1,0 +1,15 @@
+{
+  "TotalCount": 2,
+  "DisplayedCount": 1,
+  "LogType": "Error",
+  "MaxCount": 1,
+  "SearchText": "pause-point-id",
+  "IncludeStackTrace": true,
+  "Logs": [
+    {
+      "Type": "Error",
+      "Message": "pause-point-id failed",
+      "StackTrace": "Example.StackTrace:42"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Preserve Unity get-logs response metadata in the project runner pause-point log DTO.
- Add a shared contract fixture verified by both Go and Unity tests so future DTO drift fails in CI.

## User Impact
- Pause-point evidence log handling no longer silently drops fields that Unity includes in get-logs responses.
- Future get-logs response shape changes are caught during review instead of being ignored by JSON deserialization.

## Changes
- Added a shared get-logs response contract fixture under tests/contracts.
- Added Go and Unity contract tests that compare field shapes against that fixture.
- Added LogType, IncludeStackTrace, and StackTrace fields to the project runner pause-point get-logs DTO.

## Verification
- go test ./internal/projectrunner -run TestPausePointGetLogsResponseMatchesSharedContract
- dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>
- dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type exact --filter-value io.github.hatayama.UnityCliLoop.Tests.Editor.GetLogsResponseContractTests.GetLogsResponse_WhenSerialized_MatchesSharedContractFieldShape
- scripts/check-go-cli.sh
- go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

