### PR TITLE
fix: Server recovery now surfaces cleanup failures

### DIFF
--- a/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopServerControllerStartupLockTests.cs
@@ -347,6 +347,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void StartRecoveryIfNeededAsync_WhenPartiallyCreatedServerDisposeFails_ShouldSurfaceDisposeFailure()
+        {
+            // Tests that recovery cleanup does not hide a failed partially-created server disposal.
+            using CancellationTokenSource cancellationTokenSource = new();
+            TestServerInstance partiallyCreatedServer = new(
+                throwOnStart: true,
+                throwOnDispose: true,
+                onDispose: cancellationTokenSource.Cancel);
+            TestServerInstanceFactory serverInstanceFactory = new(
+                serverInstance: partiallyCreatedServer);
+            UnityCliLoopServerControllerService service = CreateControllerService(
+                serverInstanceFactory: serverInstanceFactory);
+
+            System.InvalidOperationException exception =
+                Assert.ThrowsAsync<System.InvalidOperationException>(
+                    async () => await service.StartRecoveryIfNeededAsync(
+                        isAfterCompile: false,
+                        cancellationTokenSource.Token));
+
+            Assert.That(exception.Message, Is.EqualTo("dispose failed"));
+        }
+
+        [Test]
         public void StartRecoveryIfNeededAsync_WhenEditorNeverBecomesIdle_ShouldFailWithoutReadinessProbe()
         {
             // Tests that recovery does not hang forever when Unity never leaves compile or update state.
@@ -709,10 +732,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private sealed class TestServerInstanceFactory : IUnityCliLoopServerInstanceFactory
         {
             private readonly bool _throwOnCreate;
+            private readonly TestServerInstance _serverInstance;
 
-            public TestServerInstanceFactory(bool throwOnCreate = false)
+            public TestServerInstanceFactory(
+                bool throwOnCreate = false,
+                TestServerInstance serverInstance = null)
             {
                 _throwOnCreate = throwOnCreate;
+                _serverInstance = serverInstance;
             }
 
             public TestServerInstance LastCreated { get; private set; }
@@ -724,7 +751,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     throw new System.InvalidOperationException("start failed");
                 }
 
-                LastCreated = new TestServerInstance();
+                LastCreated = _serverInstance ?? new TestServerInstance();
                 return LastCreated;
             }
         }
@@ -734,11 +761,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// </summary>
         private sealed class TestServerInstance : IUnityCliLoopServerInstance
         {
+            private readonly bool _throwOnStart;
             private readonly bool _throwOnDispose;
+            private readonly System.Action _onDispose;
 
-            public TestServerInstance(bool throwOnDispose = false)
+            public TestServerInstance(
+                bool throwOnDispose = false,
+                bool throwOnStart = false,
+                System.Action onDispose = null)
             {
+                _throwOnStart = throwOnStart;
                 _throwOnDispose = throwOnDispose;
+                _onDispose = onDispose;
             }
 
             public bool IsRunning { get; private set; }
@@ -747,6 +781,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             public void StartServer()
             {
+                if (_throwOnStart)
+                {
+                    throw new System.InvalidOperationException("start failed");
+                }
+
                 IsRunning = true;
             }
 
@@ -757,6 +796,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             public void Dispose()
             {
+                _onDispose?.Invoke();
+
                 if (_throwOnDispose)
                 {
                     throw new System.InvalidOperationException("dispose failed");

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -488,7 +488,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 catch (Exception ex)
                 {
                     // Ensure partially created server is cleaned up on failure
-                    try { server?.Dispose(); } catch { }
+                    server?.Dispose();
                     // Unwrap SocketException details if present
                     SocketException sockEx = ex as SocketException;
                     if (ex is InvalidOperationException && ex.InnerException is SocketException innerSock)


### PR DESCRIPTION
## Summary
- Server recovery now surfaces cleanup disposal failures instead of hiding them during retry cleanup.

## User Impact
- When a partially-created server cannot be cleaned up after a startup failure, the real cleanup failure is now visible for diagnosis.
- Recovery no longer masks that failure behind a later retry or cancellation result.

## Changes
- Remove the empty disposal catch from the partially-created server cleanup path.
- Add an EditMode regression test for surfacing cleanup disposal failures during recovery.

## Verification
- dist/darwin-arm64/uloop clear-console --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2"
- dist/darwin-arm64/uloop compile --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2"
- dist/darwin-arm64/uloop run-tests --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.UnityCliLoopServerControllerRecoveryTests.StartRecoveryIfNeededAsync_WhenPartiallyCreatedServerDisposeFails_ShouldSurfaceDisposeFailure"
- dist/darwin-arm64/uloop run-tests --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" --test-mode EditMode --filter-type regex --filter-value "UnityCliLoopServerControllerRecoveryTests"

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

