### PR TITLE
fix: Async setup and input cleanup now carry cancellation tokens

### DIFF
--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -55,6 +55,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/Infrastructure/Server/DomainReloadDetectionFileService.cs"
         };
 
+        private static readonly string[] AsyncCancellationTokenGuardPaths = new string[]
+        {
+            "Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs",
+            "Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs",
+            "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs",
+            "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs"
+        };
+
         private static readonly Regex DirectMutableStaticFieldPattern = new Regex(
             @"\b(private|internal|public|protected)\s+static\s+(?!readonly\b)(?!event\b)(?!extern\b)[^(\r\n;=]*[;=]",
             RegexOptions.Compiled);
@@ -78,6 +86,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private static readonly Regex AllowedStaticIdentifierPattern = new Regex(
             @"\b(ServiceValue|RepositoryValue|RegistryValue|RegisteredUseCase)\b",
             RegexOptions.Compiled);
+
+        private static readonly Regex AsyncMethodSignaturePattern = new Regex(
+            @"\b(?:private|internal|public|protected)\s+(?:static\s+)?async\s+(?:void|Task(?:<[^>]+>)?)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)",
+            RegexOptions.Compiled | RegexOptions.Singleline);
 
         [Test]
         public void MigratedFacadeFiles_WhenScanned_DoNotOwnMutableStaticState()
@@ -111,6 +123,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Tests that migrated services stay instance-owned instead of sliding back into static services.
             List<string> violations = FindStaticClassViolations(InstanceServicePaths);
+
+            Assert.That(violations, Is.Empty, string.Join("\n", violations));
+        }
+
+        [Test]
+        public void RefactorTargets_WhenDeclaringAsyncMethods_RequireCancellationTokenCt()
+        {
+            // Tests that R2-5 refactor targets do not add async methods without the standard ct parameter.
+            List<string> violations = FindAsyncMethodsWithoutCancellationTokenCt();
 
             Assert.That(violations, Is.Empty, string.Join("\n", violations));
         }
@@ -342,6 +363,48 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
 
             return violations;
+        }
+
+        private static List<string> FindAsyncMethodsWithoutCancellationTokenCt()
+        {
+            List<string> violations = new();
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+
+            for (int pathIndex = 0; pathIndex < AsyncCancellationTokenGuardPaths.Length; pathIndex++)
+            {
+                string relativePath = AsyncCancellationTokenGuardPaths[pathIndex];
+                string absolutePath = Path.Combine(projectRoot, relativePath);
+                string source = File.ReadAllText(absolutePath);
+                MatchCollection matches = AsyncMethodSignaturePattern.Matches(source);
+                foreach (Match match in matches)
+                {
+                    string parameterList = match.Groups[2].Value;
+                    if (parameterList.Contains("CancellationToken ct"))
+                    {
+                        continue;
+                    }
+
+                    string methodName = match.Groups[1].Value;
+                    int lineNumber = CountLinesBefore(source, match.Index) + 1;
+                    violations.Add($"{relativePath}:{lineNumber}: {methodName}");
+                }
+            }
+
+            return violations;
+        }
+
+        private static int CountLinesBefore(string source, int index)
+        {
+            int lineCount = 0;
+            for (int charIndex = 0; charIndex < index; charIndex++)
+            {
+                if (source[charIndex] == '\n')
+                {
+                    lineCount++;
+                }
+            }
+
+            return lineCount;
         }
 
         private static List<string> FindStaticClassViolations(string[] relativePaths)

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -91,6 +91,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             @"\b(?:private|internal|public|protected)\s+(?:static\s+)?async\s+(?:void|Task(?:<[^>]+>)?)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)",
             RegexOptions.Compiled | RegexOptions.Singleline);
 
+        private static readonly Regex CancellationTokenCtParameterPattern = new Regex(
+            @"\bCancellationToken\s+ct\b",
+            RegexOptions.Compiled);
+
         [Test]
         public void MigratedFacadeFiles_WhenScanned_DoNotOwnMutableStaticState()
         {
@@ -134,6 +138,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             List<string> violations = FindAsyncMethodsWithoutCancellationTokenCt();
 
             Assert.That(violations, Is.Empty, string.Join("\n", violations));
+        }
+
+        [Test]
+        public void CancellationTokenCtParameterPattern_WhenNameOnlyStartsWithCt_DoesNotMatch()
+        {
+            // Tests that the async guard requires the exact ct parameter name.
+            Assert.That(CancellationTokenCtParameterPattern.IsMatch("CancellationToken ct"), Is.True);
+            Assert.That(CancellationTokenCtParameterPattern.IsMatch("CancellationToken cts"), Is.False);
         }
 
         [Test]
@@ -379,7 +391,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 foreach (Match match in matches)
                 {
                     string parameterList = match.Groups[2].Value;
-                    if (parameterList.Contains("CancellationToken ct"))
+                    if (CancellationTokenCtParameterPattern.IsMatch(parameterList))
                     {
                         continue;
                     }

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -88,7 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RegexOptions.Compiled);
 
         private static readonly Regex AsyncMethodSignaturePattern = new Regex(
-            @"\b(?:(?:private|internal|public|protected)\s+)?(?:static\s+)?async\s+(?:void|Task(?:<[^()\n]+>)?)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)",
+            @"\b(?:(?:private|internal|public|protected)\s+)?(?:static\s+)?async\s+(?:void|Task(?:<[^()\n]+>)?)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:<[^()\n]+>)?\s*\(([^)]*)\)",
             RegexOptions.Compiled | RegexOptions.Singleline);
 
         private static readonly Regex CancellationTokenCtParameterPattern = new Regex(
@@ -152,7 +152,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void AsyncMethodSignaturePattern_WhenVisibilityIsImplicitAndReturnTypeIsNestedGeneric_Matches()
         {
             // Tests that the async guard does not skip implicit-private methods or nested generic Task returns.
-            string source = "async Task<List<string>> LoadAsync(CancellationToken ct) => new List<string>();";
+            string source = "async Task<List<string>> LoadAsync<T>(CancellationToken ct) => new List<string>();";
             Match match = AsyncMethodSignaturePattern.Match(source);
 
             Assert.That(match.Success, Is.True);

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -88,7 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             RegexOptions.Compiled);
 
         private static readonly Regex AsyncMethodSignaturePattern = new Regex(
-            @"\b(?:private|internal|public|protected)\s+(?:static\s+)?async\s+(?:void|Task(?:<[^>]+>)?)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)",
+            @"\b(?:(?:private|internal|public|protected)\s+)?(?:static\s+)?async\s+(?:void|Task(?:<[^()\n]+>)?)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)",
             RegexOptions.Compiled | RegexOptions.Singleline);
 
         private static readonly Regex CancellationTokenCtParameterPattern = new Regex(
@@ -146,6 +146,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that the async guard requires the exact ct parameter name.
             Assert.That(CancellationTokenCtParameterPattern.IsMatch("CancellationToken ct"), Is.True);
             Assert.That(CancellationTokenCtParameterPattern.IsMatch("CancellationToken cts"), Is.False);
+        }
+
+        [Test]
+        public void AsyncMethodSignaturePattern_WhenVisibilityIsImplicitAndReturnTypeIsNestedGeneric_Matches()
+        {
+            // Tests that the async guard does not skip implicit-private methods or nested generic Task returns.
+            string source = "async Task<List<string>> LoadAsync(CancellationToken ct) => new List<string>();";
+            Match match = AsyncMethodSignaturePattern.Match(source);
+
+            Assert.That(match.Success, Is.True);
+            Assert.That(match.Groups[1].Value, Is.EqualTo("LoadAsync"));
+            Assert.That(match.Groups[2].Value, Is.EqualTo("CancellationToken ct"));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -211,7 +211,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 else if (pressWasApplied)
                 {
                     InputSimulationWaitOutcome releaseOutcome =
-                        await ReleaseKeyStateIfPossible(keyboard, key).ConfigureAwait(false);
+                        await ReleaseKeyStateIfPossible(keyboard, key, CancellationToken.None).ConfigureAwait(false);
                     if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
                     {
                         waitOutcome = InputSimulationWaitOutcome.TimedOut;
@@ -310,7 +310,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 else if (keyDownApplied && !committed)
                 {
                     InputSimulationWaitOutcome rollbackOutcome =
-                        await RollbackHeldKey(keyboard, key, keyName).ConfigureAwait(false);
+                        await RollbackHeldKey(keyboard, key, keyName, CancellationToken.None).ConfigureAwait(false);
                     if (rollbackOutcome == InputSimulationWaitOutcome.TimedOut)
                     {
                         waitOutcome = InputSimulationWaitOutcome.TimedOut;
@@ -357,7 +357,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             InputSimulationWaitOutcome releaseOutcome =
-                await ReleaseKeyStateIfPossible(keyboard, key).ConfigureAwait(false);
+                await ReleaseKeyStateIfPossible(keyboard, key, CancellationToken.None).ConfigureAwait(false);
 
             if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
             {
@@ -499,26 +499,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 CancellationToken.None).ConfigureAwait(false);
         }
 
-        private static async Task<InputSimulationWaitOutcome> RollbackHeldKey(Keyboard keyboard, Key key, string keyName)
+        private static async Task<InputSimulationWaitOutcome> RollbackHeldKey(
+            Keyboard keyboard,
+            Key key,
+            string keyName,
+            CancellationToken ct)
         {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
             InputSimulationWaitOutcome releaseOutcome =
-                await ReleaseKeyStateIfPossible(keyboard, key).ConfigureAwait(false);
+                await ReleaseKeyStateIfPossible(keyboard, key, ct).ConfigureAwait(false);
             if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 ScheduleTimedOutHeldKeyCleanup(keyboard, key, keyName, false);
                 return releaseOutcome;
             }
 
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
             KeyboardKeyState.SetKeyUp(key);
             SimulateKeyboardOverlayState.RemoveHeldKey(keyName);
             return releaseOutcome;
         }
 
-        private static async Task<InputSimulationWaitOutcome> ReleaseKeyStateIfPossible(Keyboard keyboard, Key key)
+        private static async Task<InputSimulationWaitOutcome> ReleaseKeyStateIfPossible(
+            Keyboard keyboard,
+            Key key,
+            CancellationToken ct)
         {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
             if (!CanInjectKeyboardState(keyboard))
             {
                 return InputSimulationWaitOutcome.Completed;
@@ -532,7 +539,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             InputSimulationWaitOutcome releaseOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
                 () => KeyboardKeyState.SetKeyState(keyboard, key, false),
-                CancellationToken.None).ConfigureAwait(false);
+                ct).ConfigureAwait(false);
             if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 ScheduleReleaseKeyStateImmediately(keyboard, key);
@@ -581,7 +588,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
             if (pressWasApplied)
             {
-                await ReleaseKeyStateIfPossible(keyboard, key).ConfigureAwait(false);
+                await ReleaseKeyStateIfPossible(keyboard, key, ct).ConfigureAwait(false);
             }
 
             KeyboardKeyState.UnregisterTransientKey(key);
@@ -603,7 +610,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
             if (keyWasApplied)
             {
-                await ReleaseKeyStateIfPossible(keyboard, key).ConfigureAwait(false);
+                await ReleaseKeyStateIfPossible(keyboard, key, ct).ConfigureAwait(false);
             }
 
             KeyboardKeyState.SetKeyUp(key);

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -212,7 +212,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 else if (pressWasApplied)
                 {
                     InputSimulationWaitOutcome releaseOutcome =
-                        await ReleaseButtonIfPossible(mouse, button).ConfigureAwait(false);
+                        await ReleaseButtonIfPossible(mouse, button, CancellationToken.None).ConfigureAwait(false);
                     if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
                     {
                         waitOutcome = InputSimulationWaitOutcome.TimedOut;
@@ -325,7 +325,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 else if (pressWasApplied)
                 {
                     InputSimulationWaitOutcome releaseOutcome =
-                        await ReleaseButtonIfPossible(mouse, button).ConfigureAwait(false);
+                        await ReleaseButtonIfPossible(mouse, button, CancellationToken.None).ConfigureAwait(false);
                     if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
                     {
                         waitOutcome = InputSimulationWaitOutcome.TimedOut;
@@ -635,9 +635,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return hits;
         }
 
-        private static async Task<InputSimulationWaitOutcome> ReleaseButtonIfPossible(Mouse mouse, RuntimeMouseButton button)
+        private static async Task<InputSimulationWaitOutcome> ReleaseButtonIfPossible(
+            Mouse mouse,
+            RuntimeMouseButton button,
+            CancellationToken ct)
         {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
             if (!CanInjectMouseState(mouse))
             {
                 return InputSimulationWaitOutcome.Completed;
@@ -651,7 +654,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             InputSimulationWaitOutcome releaseOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
                 () => MouseInputState.SetButtonState(mouse, button, false),
-                CancellationToken.None).ConfigureAwait(false);
+                ct).ConfigureAwait(false);
             if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 ScheduleReleaseButtonImmediately(mouse, button);
@@ -714,7 +717,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
             if (pressWasApplied)
             {
-                await ReleaseButtonIfPossible(mouse, button).ConfigureAwait(false);
+                await ReleaseButtonIfPossible(mouse, button, ct).ConfigureAwait(false);
             }
 
             MouseInputState.SetButtonUp(button);

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -431,9 +431,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ScheduleResizeToContent();
         }
 
-        private async void RefreshUI(bool refreshSkillsSection = true)
+        private void RefreshUI(bool refreshSkillsSection = true)
+        {
+            RefreshUIAsync(refreshSkillsSection, CancellationToken.None).Forget();
+        }
+
+        private async Task RefreshUIAsync(
+            bool refreshSkillsSection,
+            CancellationToken ct)
         {
             CancelSkillInstallStateRefresh();
+            ct.ThrowIfCancellationRequested();
             RefreshAutoShowToggle();
             ViewDataBinder.SetVisible(_nodejsWarning, false);
             ViewDataBinder.SetVisible(_nodejsOk, false);
@@ -446,17 +454,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             await Task.Yield();
+            ct.ThrowIfCancellationRequested();
 
             ViewDataBinder.SetVisible(_nodejsWarning, false);
             ViewDataBinder.SetVisible(_nodejsOk, false);
 
-            await _cliSetupApplicationService.ForceRefreshCliVersionAsync(CancellationToken.None);
+            await _cliSetupApplicationService.ForceRefreshCliVersionAsync(ct);
             string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
             bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             string requiredCliVersion = GetMinimumRequiredCliVersion();
             bool cliInstalled = IsCliInstalled(cliVersion);
-            _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(CancellationToken.None);
+            _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
 
             _cliStepPresenter.Update(
                 cliInstalled,
@@ -500,10 +509,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             CancellationTokenSource cts = new();
             _skillInstallStateRefreshCts = cts;
-            RefreshDisplayedSkillTargetsAsync(cts.Token);
+            RefreshDisplayedSkillTargetsAsync(cts.Token).Forget();
         }
 
-        private async void RefreshDisplayedSkillTargetsAsync(CancellationToken ct)
+        private async Task RefreshDisplayedSkillTargetsAsync(CancellationToken ct)
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             List<SkillSetupTargetInfo> targets =
@@ -608,9 +617,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 _isInstallingSkills);
         }
 
-        private async void HandleInstallCli()
+        private void HandleInstallCli()
         {
-            await RefreshCliPrimaryActionStateAsync(CancellationToken.None);
+            HandleInstallCliAsync(CancellationToken.None).Forget();
+        }
+
+        private async Task HandleInstallCliAsync(CancellationToken ct)
+        {
+            await RefreshCliPrimaryActionStateAsync(ct);
 
             string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
             bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
@@ -619,7 +633,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliIsDispatcher);
             if (ShouldRepairCliPathFromPrimaryButton(_needsCliPathSetup, state.NeedsUpdate))
             {
-                await HandleRepairCliPathSetup();
+                await HandleRepairCliPathSetup(ct);
                 return;
             }
 
@@ -638,7 +652,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 CliInstallResult result = await _cliSetupApplicationService.InstallGlobalCliAsync(
                     UnityEngine.Application.platform,
-                    CancellationToken.None);
+                    ct);
 
                 if (!result.Success)
                 {
@@ -656,8 +670,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
                     UnityEngine.Application.platform,
                     _cliSetupApplicationService,
-                    CancellationToken.None);
-                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(CancellationToken.None);
+                    ct);
+                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
             }
             finally
             {
@@ -704,7 +718,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return CliSetupPrimaryActionPolicy.ShouldRepairCliPath(needsCliPathSetup, needsUpdate);
         }
 
-        private async Task HandleRepairCliPathSetup()
+        private async Task HandleRepairCliPathSetup(CancellationToken ct)
         {
             _isInstallingCli = true;
             _cliStepPresenter.Update(
@@ -720,8 +734,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
                     UnityEngine.Application.platform,
                     _cliSetupApplicationService,
-                    CancellationToken.None);
-                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(CancellationToken.None);
+                    ct);
+                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
             }
             finally
             {
@@ -730,7 +744,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
         }
 
-        private async void HandleInstallSkills()
+        private void HandleInstallSkills()
+        {
+            HandleInstallSkillsAsync(CancellationToken.None).Forget();
+        }
+
+        private async Task HandleInstallSkillsAsync(CancellationToken ct)
         {
             CancelSkillInstallStateRefresh();
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
@@ -752,7 +771,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 await _skillSetupUseCase.InstallSkillFilesAsync(
                     installableTargets,
                     !_installSkillsFlat,
-                    CancellationToken.None);
+                    ct);
                 if (shouldShowSkillsInstalledDialog)
                 {
                     EditorDialogHelper.ShowSkillsInstalledDialog();


### PR DESCRIPTION
## Summary
- Setup wizard async workflows now use Task-based cores with `CancellationToken ct` instead of async void bodies.
- Mouse and keyboard input cleanup helpers now accept `CancellationToken ct` while preserving uncancelable release paths for held input state.

## User Impact
- Async setup and input cleanup paths are easier to cancel and reason about without changing the visible setup or input simulation behavior.
- Held input cleanup still runs even when the originating operation is canceled, preventing synthetic input from being left active.

## Changes
- Add a source guard for the R2-5 refactor target files so async methods keep the standard `CancellationToken ct` parameter.
- Convert Setup Wizard event handlers into void wrappers that call cancellable Task-based implementations.
- Add `ct` parameters to simulate mouse/keyboard release helpers and pass the existing uncancelable cleanup token where cleanup must complete.

## Verification
- dist/darwin-arm64/uloop clear-console --project-path "<PROJECT_ROOT>"
- dist/darwin-arm64/uloop compile --project-path "<PROJECT_ROOT>"
- dist/darwin-arm64/uloop run-tests --project-path "<PROJECT_ROOT>" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.StaticFacadeStateGuardTests.RefactorTargets_WhenDeclaringAsyncMethods_RequireCancellationTokenCt"
- dist/darwin-arm64/uloop run-tests --project-path "<PROJECT_ROOT>" --test-mode EditMode --filter-type regex --filter-value "StaticFacadeStateGuardTests"
- dist/darwin-arm64/uloop run-tests --project-path "<PROJECT_ROOT>" --test-mode EditMode --filter-type regex --filter-value "InputSystemOptionalCompileGuardTests|PlayModeToolPreflightServiceTests"