### PR TITLE
chore: Setup and installer maintenance now use explicit helper names

### DIFF
--- a/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
+++ b/Assets/Editor/CompileCheckWindow/CompileCheckerExample.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
@@ -27,8 +28,9 @@ namespace io.github.hatayama.UnityCliLoop.Dev
                     return;
                 }
 
-                // How Masamichi requested to use it
-                CompileResult result = await compileController.TryCompileAsync();
+                CompileResult result = await compileController.TryCompileAsync(
+                    forceRecompile: false,
+                    ct: CancellationToken.None);
                 CompilerMessage[] err = result.Errors;
                 CompilerMessage[] warning = result.Warnings;
 
@@ -36,14 +38,12 @@ namespace io.github.hatayama.UnityCliLoop.Dev
                 Debug.Log($"Number of errors: {err.Length}");
                 Debug.Log($"Number of warnings: {warning.Length}");
 
-                // Display error details
-                foreach (var error in err)
+                foreach (CompilerMessage error in err)
                 {
                     Debug.LogError($"Error: {error.message} at {error.file}:{error.line}");
                 }
 
-                // Display warning details
-                foreach (var warn in warning)
+                foreach (CompilerMessage warn in warning)
                 {
                     Debug.LogWarning($"Warning: {warn.message} at {warn.file}:{warn.line}");
                 }
@@ -69,7 +69,9 @@ namespace io.github.hatayama.UnityCliLoop.Dev
                 }
 
                 // Example of forced re-compilation
-                CompileResult result = await compileController.TryCompileAsync(forceRecompile: true);
+                CompileResult result = await compileController.TryCompileAsync(
+                    forceRecompile: true,
+                    ct: CancellationToken.None);
                 CompilerMessage[] err = result.Errors;
                 CompilerMessage[] warning = result.Warnings;
 

--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -23,7 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnMacKeepsDispatcherCurlInstallerAvailable()
         {
             // Verifies that editor installs use the dispatcher installer script, not npm.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommand(
+            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 TestBetaCliVersion,
                 false,
@@ -44,7 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnMacDelegatesPosixSnippetThroughSh()
         {
             // Verifies that fish or other login shells only load environment before POSIX script execution.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommand(
+            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 TestBetaCliVersion,
                 false,
@@ -61,7 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnMacPropagatesInstallerDownloadFailure()
         {
             // Verifies that editor installs do not report success when curl fails before script execution.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommand(
+            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 TestBetaCliVersion,
                 false,
@@ -77,7 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnWindowsKeepsDispatcherPowerShellInstallerAvailable()
         {
             // Verifies that editor installs use the dispatcher PowerShell installer script.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommand(
+            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
                 RuntimePlatform.WindowsEditor,
                 TestBetaCliVersion,
                 false,
@@ -95,7 +95,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnMacDispatcherInstallerDoesNotAdvertiseWindowsLegacyCleanup()
         {
             // Verifies that macOS manual commands do not expose old cleanup flags.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommand(
+            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 TestBetaCliVersion,
                 true,
@@ -109,7 +109,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnWindowsDoesNotNeedLegacyCleanupFlag()
         {
             // Verifies that Windows installs rely on the native CLI install command for legacy cleanup.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommand(
+            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
                 RuntimePlatform.WindowsEditor,
                 TestBetaCliVersion,
                 true,
@@ -123,7 +123,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_WhenVPrefixedVersionUsesDispatcherReleaseTag()
         {
             // Verifies root release tags are normalized to dispatcher releases for installer scripts.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommand(
+            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 "v3.0.0",
                 false,
@@ -156,7 +156,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             try
             {
-                NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommand(
+                NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommandWithPackagePath(
                     RuntimePlatform.OSXEditor,
                     TestBetaCliVersion,
                     false,
@@ -202,7 +202,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             try
             {
-                NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommand(
+                NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommandWithPackagePath(
                     RuntimePlatform.WindowsEditor,
                     TestBetaCliVersion,
                     false,

--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -55,14 +55,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Path.Combine(manualTargetRoot, SkillInstallLayout.SkillsDirName, "find-orphaned-meta"),
                 "---\nname: find-orphaned-meta\n---\n");
             SkillInstallationDetector detector = new();
-            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".claude"),
+            Assert.IsFalse(detector.AreSkillsInstalledInAnyLayout(temporaryRoot, ".claude"),
                 "Manual local skills should not be treated as installed uLoop skills");
 
             string legacyTargetRoot = Path.Combine(temporaryRoot, ".codex");
             WriteSkillFile(
                 Path.Combine(legacyTargetRoot, SkillInstallLayout.SkillsDirName, "acme-third-party"),
                 "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".codex"),
+            Assert.IsTrue(detector.AreSkillsInstalledInAnyLayout(temporaryRoot, ".codex"),
                 "Legacy third-party managed skills should be detected");
 
             string managedTargetRoot = Path.Combine(temporaryRoot, ".agents");
@@ -71,7 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 SkillInstallLayout.SkillsDirName,
                 SkillInstallLayout.ManagedSkillsDirName,
                 "uloop-compile"));
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".agents"),
+            Assert.IsTrue(detector.AreSkillsInstalledInAnyLayout(temporaryRoot, ".agents"),
                 "Namespaced managed skills should be detected");
         }
 
@@ -85,8 +85,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             string flatTargetRoot = Path.Combine(temporaryRoot, ".claude");
             WriteSkillFile(Path.Combine(flatTargetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".claude", false));
-            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".claude", true));
+            Assert.IsTrue(detector.AreSkillsInstalledForLayout(temporaryRoot, ".claude", false));
+            Assert.IsFalse(detector.AreSkillsInstalledForLayout(temporaryRoot, ".claude", true));
 
             string groupedTargetRoot = Path.Combine(temporaryRoot, ".codex");
             WriteSkillFile(Path.Combine(
@@ -94,8 +94,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 SkillInstallLayout.SkillsDirName,
                 SkillInstallLayout.ManagedSkillsDirName,
                 "uloop-compile"));
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".codex", true));
-            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".codex", false));
+            Assert.IsTrue(detector.AreSkillsInstalledForLayout(temporaryRoot, ".codex", true));
+            Assert.IsFalse(detector.AreSkillsInstalledForLayout(temporaryRoot, ".codex", false));
         }
 
         // Tests that an empty legacy managed directory still counts for flat layout migration state.
@@ -107,8 +107,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Directory.CreateDirectory(Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName, "uloop-compile"));
             SkillInstallationDetector detector = new();
 
-            Assert.IsTrue(detector.AreSkillsInstalled(temporaryRoot, ".cursor", false));
-            Assert.IsFalse(detector.AreSkillsInstalled(temporaryRoot, ".cursor", true));
+            Assert.IsTrue(detector.AreSkillsInstalledForLayout(temporaryRoot, ".cursor", false));
+            Assert.IsFalse(detector.AreSkillsInstalledForLayout(temporaryRoot, ".cursor", true));
         }
 
         // Tests that Unity-side discovery includes CLI-only skills from the packaged core CLI.

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -63,6 +63,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs"
         };
 
+        private static readonly Dictionary<string, string[]> OverloadGuardMethodsByPath = new Dictionary<string, string[]>
+        {
+            {
+                "Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs",
+                new[] { "TryCompileAsync" }
+            },
+            {
+                "Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs",
+                new[] { "BuildInstallCommand" }
+            },
+            {
+                "Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs",
+                new[] { "HasInstalledSkills" }
+            },
+            {
+                "Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs",
+                new[] { "AreSkillsInstalled" }
+            },
+            {
+                "Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs",
+                new[] { "GetSelectedTargetInstallState" }
+            }
+        };
+
         private static readonly Regex DirectMutableStaticFieldPattern = new Regex(
             @"\b(private|internal|public|protected)\s+static\s+(?!readonly\b)(?!event\b)(?!extern\b)[^(\r\n;=]*[;=]",
             RegexOptions.Compiled);
@@ -136,6 +160,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Tests that R2-5 refactor targets do not add async methods without the standard ct parameter.
             List<string> violations = FindAsyncMethodsWithoutCancellationTokenCt();
+
+            Assert.That(violations, Is.Empty, string.Join("\n", violations));
+        }
+
+        [Test]
+        public void RefactorTargets_WhenScanned_DoNotDeclareTargetedOverloads()
+        {
+            // Tests that R2-7 refactor targets keep behavior variants in explicitly named methods.
+            List<string> violations = FindTargetedOverloadViolations();
 
             Assert.That(violations, Is.Empty, string.Join("\n", violations));
         }
@@ -411,6 +444,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     string methodName = match.Groups[1].Value;
                     int lineNumber = CountLinesBefore(source, match.Index) + 1;
                     violations.Add($"{relativePath}:{lineNumber}: {methodName}");
+                }
+            }
+
+            return violations;
+        }
+
+        private static List<string> FindTargetedOverloadViolations()
+        {
+            List<string> violations = new();
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+
+            foreach (KeyValuePair<string, string[]> target in OverloadGuardMethodsByPath)
+            {
+                string absolutePath = Path.Combine(projectRoot, target.Key);
+                string source = File.ReadAllText(absolutePath);
+                for (int nameIndex = 0; nameIndex < target.Value.Length; nameIndex++)
+                {
+                    string methodName = target.Value[nameIndex];
+                    Regex declarationPattern = new Regex(
+                        $@"\b(?:public|internal|private|protected)\s+(?:static\s+)?(?:async\s+)?[A-Za-z0-9_<>,\.\[\]\?]+\s+{methodName}\s*\(",
+                        RegexOptions.Compiled);
+                    MatchCollection matches = declarationPattern.Matches(source);
+                    if (matches.Count <= 1)
+                    {
+                        continue;
+                    }
+
+                    for (int matchIndex = 0; matchIndex < matches.Count; matchIndex++)
+                    {
+                        int lineNumber = CountLinesBefore(source, matches[matchIndex].Index) + 1;
+                        violations.Add($"{target.Key}:{lineNumber}: {methodName}");
+                    }
                 }
             }
 

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -79,13 +79,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             },
             {
                 "Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs",
-                new[]
-                {
-                    "AreSkillsInstalledInCurrentProject",
-                    "AreSkillsInstalledInCurrentProjectForLayout",
-                    "AreSkillsInstalledInAnyLayout",
-                    "AreSkillsInstalledForLayout"
-                }
+                new[] { "AreSkillsInstalledInAnyLayout", "AreSkillsInstalledForLayout" }
             },
             {
                 "Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs",

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -71,19 +71,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             },
             {
                 "Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs",
-                new[] { "BuildInstallCommand" }
+                new[] { "BuildRemoteInstallCommand", "BuildInstallCommandWithPackagePath" }
             },
             {
                 "Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs",
-                new[] { "HasInstalledSkills" }
+                new[] { "HasInstalledSkillsInAnyLayout", "HasInstalledSkillsForLayout" }
             },
             {
                 "Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs",
-                new[] { "AreSkillsInstalled" }
+                new[]
+                {
+                    "AreSkillsInstalledInCurrentProject",
+                    "AreSkillsInstalledInCurrentProjectForLayout",
+                    "AreSkillsInstalledInAnyLayout",
+                    "AreSkillsInstalledForLayout"
+                }
             },
             {
                 "Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs",
-                new[] { "GetSelectedTargetInstallState" }
+                new[] { "GetSelectedTargetInstallStateForCurrentProject", "GetSelectedTargetInstallStateAtProjectRoot" }
             }
         };
 
@@ -466,6 +472,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                         $@"\b(?:public|internal|private|protected)\s+(?:static\s+)?(?:async\s+)?[A-Za-z0-9_<>,\.\[\]\?]+\s+{methodName}\s*\(",
                         RegexOptions.Compiled);
                     MatchCollection matches = declarationPattern.Matches(source);
+                    if (matches.Count == 0)
+                    {
+                        violations.Add($"{target.Key}:0: missing guard target {methodName}");
+                        continue;
+                    }
+
                     if (matches.Count <= 1)
                     {
                         continue;

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -84,21 +84,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Executes compilation asynchronously.
         /// </summary>
         /// <param name="forceRecompile">Whether to force a recompile.</param>
-        /// <returns>The compilation result.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the task is not found during compilation.</exception>
-        /// <remarks>
-        /// Callers must validate editor compilation state before invoking compile execution;
-        /// the production pipeline does this in CompileUseCase.
-        /// </remarks>
-        public async Task<CompileResult> TryCompileAsync(bool forceRecompile = false)
-        {
-            return await TryCompileAsync(forceRecompile, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Executes compilation asynchronously.
-        /// </summary>
-        /// <param name="forceRecompile">Whether to force a recompile.</param>
         /// <param name="ct">Cancellation token for the compile execution.</param>
         /// <returns>The compilation result.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the task is not found during compilation.</exception>

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
@@ -28,7 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string cliReleaseTag,
             bool removeLegacyLaunchers)
         {
-            return BuildInstallCommand(
+            return BuildInstallCommandWithPackagePath(
                 platform,
                 cliReleaseTag,
                 removeLegacyLaunchers,
@@ -36,13 +36,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 UnityCliLoopConstants.PackageResolvedPath);
         }
 
-        internal static NativeCliInstallCommand BuildInstallCommand(
+        internal static NativeCliInstallCommand BuildRemoteInstallCommand(
             RuntimePlatform platform,
             string cliReleaseTag,
             bool removeLegacyLaunchers,
             string posixShellPath)
         {
-            return BuildInstallCommand(
+            return BuildInstallCommandWithPackagePath(
                 platform,
                 cliReleaseTag,
                 removeLegacyLaunchers,
@@ -50,7 +50,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 null);
         }
 
-        internal static NativeCliInstallCommand BuildInstallCommand(
+        internal static NativeCliInstallCommand BuildInstallCommandWithPackagePath(
             RuntimePlatform platform,
             string cliReleaseTag,
             bool removeLegacyLaunchers,

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
@@ -128,28 +128,16 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        internal static bool HasInstalledSkills(string targetRoot)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return HasInstalledSkills(projectRoot, targetRoot);
-        }
-
-        internal static bool HasInstalledSkills(string targetRoot, bool groupSkillsUnderUnityCliLoop)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
-        }
-
-        internal static bool HasInstalledSkills(string projectRoot, string targetRoot)
+        internal static bool HasInstalledSkillsInAnyLayout(string projectRoot, string targetRoot)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(targetRoot), "targetRoot must not be null or empty");
 
-            return HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop: false)
-                || HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop: true);
+            return HasInstalledSkillsForLayout(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop: false)
+                || HasInstalledSkillsForLayout(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop: true);
         }
 
-        internal static bool HasInstalledSkills(
+        internal static bool HasInstalledSkillsForLayout(
             string projectRoot,
             string targetRoot,
             bool groupSkillsUnderUnityCliLoop)
@@ -178,7 +166,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             bool groupSkillsUnderUnityCliLoop)
         {
             Dictionary<string, SkillSourceDefinition> expectedSkills = GetSkillSources(projectRoot);
-            bool hasLayoutSkills = HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
+            bool hasLayoutSkills = HasInstalledSkillsForLayout(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
             if (expectedSkills.Count == 0)
             {
                 return hasLayoutSkills ? SkillInstallState.Installed : SkillInstallState.Missing;

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs
@@ -11,32 +11,32 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class SkillInstallationDetector
     {
-        public bool AreSkillsInstalled(string targetDir)
+        public bool AreSkillsInstalledInCurrentProject(string targetDir)
         {
             Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
 
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return AreSkillsInstalled(projectRoot, targetDir);
+            return AreSkillsInstalledInAnyLayout(projectRoot, targetDir);
         }
 
-        public bool AreSkillsInstalled(string targetDir, bool groupSkillsUnderUnityCliLoop)
+        public bool AreSkillsInstalledInCurrentProjectForLayout(string targetDir, bool groupSkillsUnderUnityCliLoop)
         {
             Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
 
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return AreSkillsInstalled(projectRoot, targetDir, groupSkillsUnderUnityCliLoop);
+            return AreSkillsInstalledForLayout(projectRoot, targetDir, groupSkillsUnderUnityCliLoop);
         }
 
-        internal bool AreSkillsInstalled(string projectRoot, string targetDir)
+        internal bool AreSkillsInstalledInAnyLayout(string projectRoot, string targetDir)
         {
             Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
             Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
 
             string targetRoot = Path.Combine(projectRoot, targetDir);
-            return SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot);
+            return SkillInstallLayout.HasInstalledSkillsInAnyLayout(projectRoot, targetRoot);
         }
 
-        internal bool AreSkillsInstalled(
+        internal bool AreSkillsInstalledForLayout(
             string projectRoot,
             string targetDir,
             bool groupSkillsUnderUnityCliLoop)
@@ -45,7 +45,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
 
             string targetRoot = Path.Combine(projectRoot, targetDir);
-            return SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
+            return SkillInstallLayout.HasInstalledSkillsForLayout(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop);
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallationDetector.cs
@@ -11,7 +11,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class SkillInstallationDetector
     {
-        public bool AreSkillsInstalledInCurrentProject(string targetDir)
+        public bool AreSkillsInstalled(string targetDir)
         {
             Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
 
@@ -19,7 +19,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return AreSkillsInstalledInAnyLayout(projectRoot, targetDir);
         }
 
-        public bool AreSkillsInstalledInCurrentProjectForLayout(string targetDir, bool groupSkillsUnderUnityCliLoop)
+        public bool AreSkillsInstalled(string targetDir, bool groupSkillsUnderUnityCliLoop)
         {
             Debug.Assert(!string.IsNullOrEmpty(targetDir), "targetDir must not be null or empty");
 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
@@ -62,7 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 bool hasULoopSkills = hasSkillsDirectory
-                    && SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot);
+                    && SkillInstallLayout.HasInstalledSkillsInAnyLayout(projectRoot, targetRoot);
                 targets.Add(new ToolSkillSynchronizer.SkillTargetInfo(
                     target.DisplayName,
                     target.DirName,
@@ -111,7 +111,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     || installState == SkillInstallState.Checking
                     || installState == SkillInstallState.Outdated;
                 bool hasDifferentLayoutSkills = hasSkillsDirectory
-                    && SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, !groupSkillsUnderUnityCliLoop);
+                    && SkillInstallLayout.HasInstalledSkillsForLayout(projectRoot, targetRoot, !groupSkillsUnderUnityCliLoop);
                 targets.Add(new ToolSkillSynchronizer.SkillTargetInfo(
                     target.DisplayName,
                     target.DirName,
@@ -167,7 +167,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             if (!includeFreshnessCheck)
             {
-                return SkillInstallLayout.HasInstalledSkills(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop)
+                return SkillInstallLayout.HasInstalledSkillsForLayout(projectRoot, targetRoot, groupSkillsUnderUnityCliLoop)
                     ? SkillInstallState.Checking
                     : SkillInstallState.Missing;
             }

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -618,7 +618,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
-            _selectedTargetInstallState = GetSelectedTargetInstallState(includeFreshnessCheck: false);
+            _selectedTargetInstallState = GetSelectedTargetInstallStateForCurrentProject(includeFreshnessCheck: false);
             RefreshCliSetupSection();
         }
 
@@ -653,7 +653,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             SkillInstallState installState = await Task.Run(
-                () => GetSelectedTargetInstallState(projectRoot, includeFreshnessCheck: true));
+                () => GetSelectedTargetInstallStateAtProjectRoot(projectRoot, includeFreshnessCheck: true));
             if (ct.IsCancellationRequested)
             {
                 return;
@@ -663,13 +663,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             RefreshCliSetupSection();
         }
 
-        private SkillInstallState GetSelectedTargetInstallState(bool includeFreshnessCheck)
+        private SkillInstallState GetSelectedTargetInstallStateForCurrentProject(bool includeFreshnessCheck)
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return GetSelectedTargetInstallState(projectRoot, includeFreshnessCheck);
+            return GetSelectedTargetInstallStateAtProjectRoot(projectRoot, includeFreshnessCheck);
         }
 
-        private SkillInstallState GetSelectedTargetInstallState(
+        private SkillInstallState GetSelectedTargetInstallStateAtProjectRoot(
             string projectRoot,
             bool includeFreshnessCheck)
         {


### PR DESCRIPTION
## Summary
- Clarifies setup and installer maintenance helpers by replacing targeted internal overloads with explicit method names.
- Adds a source guard so the R2-7 overload targets do not regress.

## User Impact
- No direct runtime behavior change is intended.
- Future setup, skills, installer, and compile maintenance changes should be easier to review because helper variants now state their scope in the method name.

## Changes
- Removed the unused no-token compile wrapper and updated the debug compile example to pass `CancellationToken.None` explicitly.
- Renamed internal skill-install detection helpers by any-layout and layout-specific scope while preserving public detector method names.
- Split native installer command builders into remote-installer and package-path variants.
- Added a targeted StaticFacadeStateGuardTests source guard for the R2-7 overload names, including missing-target detection.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`
- `dist/darwin-arm64/uloop run-tests --project-path <PROJECT_ROOT> --test-mode EditMode --filter-type regex --filter-value "StaticFacadeStateGuardTests|SkillInstallLayoutTests|NativeCliInstallerTests"`