### PR TITLE
chore: Keep RPC boolean metadata validation strict

### DIFF
--- a/Assets/Tests/Editor/StrictJsonBooleanMetadataReaderTests.cs
+++ b/Assets/Tests/Editor/StrictJsonBooleanMetadataReaderTests.cs
@@ -1,0 +1,69 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests strict JSON boolean metadata parsing shared by JSON-RPC request readers.
+    /// </summary>
+    public sealed class StrictJsonBooleanMetadataReaderTests
+    {
+        [Test]
+        public void ReadOptionalBoolean_WhenPropertyIsBoolean_ReturnsValue()
+        {
+            // Verifies real JSON booleans are accepted without coercion.
+            JObject metadata = JObject.Parse("{\"enabled\":true}");
+
+            bool? value = StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
+                metadata,
+                "enabled",
+                System.StringComparison.Ordinal);
+
+            Assert.That(value, Is.True);
+        }
+
+        [Test]
+        public void ReadOptionalBoolean_WhenPropertyIsString_ReturnsNull()
+        {
+            // Verifies string values are rejected instead of being coerced to booleans.
+            JObject metadata = JObject.Parse("{\"enabled\":\"true\"}");
+
+            bool? value = StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
+                metadata,
+                "enabled",
+                System.StringComparison.Ordinal);
+
+            Assert.That(value, Is.Null);
+        }
+
+        [Test]
+        public void ReadOptionalBoolean_WhenPropertyUsesDifferentCaseAndOrdinalIgnoreCase_ReturnsValue()
+        {
+            // Verifies compile request params can keep their case-insensitive JSON contract.
+            JObject metadata = JObject.Parse("{\"Enabled\":false}");
+
+            bool? value = StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
+                metadata,
+                "enabled",
+                System.StringComparison.OrdinalIgnoreCase);
+
+            Assert.That(value, Is.False);
+        }
+
+        [Test]
+        public void ReadOptionalBoolean_WhenPropertyIsMissing_ReturnsNull()
+        {
+            // Verifies absent optional flags stay unknown for callers that choose their own default.
+            JObject metadata = JObject.Parse("{}");
+
+            bool? value = StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
+                metadata,
+                "enabled",
+                System.StringComparison.Ordinal);
+
+            Assert.That(value, Is.Null);
+        }
+    }
+}

--- a/Assets/Tests/Editor/StrictJsonBooleanMetadataReaderTests.cs
+++ b/Assets/Tests/Editor/StrictJsonBooleanMetadataReaderTests.cs
@@ -65,5 +65,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(value, Is.Null);
         }
+
+        [Test]
+        public void ReadOptionalBoolean_WhenMetadataIsNull_ReturnsNull()
+        {
+            // Verifies absent metadata stays unknown for callers that choose their own default.
+            bool? value = StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
+                null,
+                "enabled",
+                System.StringComparison.Ordinal);
+
+            Assert.That(value, Is.Null);
+        }
     }
 }

--- a/Assets/Tests/Editor/StrictJsonBooleanMetadataReaderTests.cs.meta
+++ b/Assets/Tests/Editor/StrictJsonBooleanMetadataReaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 706a7d1d9db54a50adac0b7e1f9eff8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
@@ -49,6 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string SimulateKeyboardAssemblyName = "UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor";
         private const string SimulateMouseInputAssemblyName = "UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor";
         private const string SimulateMouseUiAssemblyName = "UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor";
+        private const string DevelopmentOnlyCatalogTestToolName = "development-only-catalog-test";
 
         [Test]
         public void Constructor_WhenFirstPartyToolsUseToolAttribute_RegistersThem()
@@ -355,6 +356,50 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task ExecuteCommandAsync_WhenGetToolDetailsIncludesDevelopmentOnly_ReturnsDevelopmentTools()
+        {
+            // Tests that real JSON booleans can opt into development-only catalog entries.
+            UnityCliLoopExecutionRouter executionRouter = CreateExecutionRouterWithDevelopmentOnlyTool();
+            JObject parameters = new()
+            {
+                ["includeDevelopmentOnly"] = true
+            };
+
+            UnityCliLoopToolResponse response = await executionRouter.ExecuteAsync(
+                UnityCliLoopConstants.COMMAND_NAME_GET_TOOL_DETAILS,
+                parameters,
+                CancellationToken.None);
+            GetToolDetailsResponse getToolDetailsResponse = response as GetToolDetailsResponse;
+            string[] toolNames = getToolDetailsResponse?.Tools
+                .Select(tool => tool.Name)
+                .ToArray() ?? new string[0];
+
+            Assert.That(toolNames, Does.Contain(DevelopmentOnlyCatalogTestToolName));
+        }
+
+        [Test]
+        public async Task ExecuteCommandAsync_WhenGetToolDetailsIncludeDevelopmentOnlyIsString_ExcludesDevelopmentTools()
+        {
+            // Tests that string values are not coerced into development-only catalog access.
+            UnityCliLoopExecutionRouter executionRouter = CreateExecutionRouterWithDevelopmentOnlyTool();
+            JObject parameters = new()
+            {
+                ["IncludeDevelopmentOnly"] = "true"
+            };
+
+            UnityCliLoopToolResponse response = await executionRouter.ExecuteAsync(
+                UnityCliLoopConstants.COMMAND_NAME_GET_TOOL_DETAILS,
+                parameters,
+                CancellationToken.None);
+            GetToolDetailsResponse getToolDetailsResponse = response as GetToolDetailsResponse;
+            string[] toolNames = getToolDetailsResponse?.Tools
+                .Select(tool => tool.Name)
+                .ToArray() ?? new string[0];
+
+            Assert.That(toolNames, Does.Not.Contain(DevelopmentOnlyCatalogTestToolName));
+        }
+
+        [Test]
         public async Task ExecuteCommandAsync_WhenCommandIsGetCompileStatus_ReturnsBridgeStatusPayload()
         {
             // Tests that compile status polling routes as a CLI-only bridge command, not a public tool.
@@ -492,6 +537,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             return new UnityCliLoopExecutionRouter(toolRegistrarService);
         }
 
+        private static UnityCliLoopExecutionRouter CreateExecutionRouterWithDevelopmentOnlyTool()
+        {
+            UnityCliLoopToolRegistrarService toolRegistrarService =
+                UnityCliLoopToolRegistrarTestFactory.Create(UnityCliLoopToolDiscovery.DiscoverTools);
+            toolRegistrarService.RegisterCustomTool(new DevelopmentOnlyCatalogTestTool());
+            return new UnityCliLoopExecutionRouter(toolRegistrarService);
+        }
+
         [Test]
         public void CustomCommandSamplesAsmdef_ReferencesOnlyToolContracts()
         {
@@ -623,6 +676,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private sealed class ManualRegistrationResponse : UnityCliLoopToolResponse
         {
+        }
+
+        [UnityCliLoopTool(DisplayDevelopmentOnly = true)]
+        private sealed class DevelopmentOnlyCatalogTestTool : IUnityCliLoopTool
+        {
+            public string ToolName => DevelopmentOnlyCatalogTestToolName;
+            public ToolParameterSchema ParameterSchema { get; } = new();
+
+            public Task<UnityCliLoopToolResponse> ExecuteAsync(JToken paramsToken, CancellationToken ct)
+            {
+                UnityCliLoopToolResponse response = new ManualRegistrationResponse();
+                return Task.FromResult(response);
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopToolRegistryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -372,7 +373,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             GetToolDetailsResponse getToolDetailsResponse = response as GetToolDetailsResponse;
             string[] toolNames = getToolDetailsResponse?.Tools
                 .Select(tool => tool.Name)
-                .ToArray() ?? new string[0];
+                .ToArray() ?? Array.Empty<string>();
 
             Assert.That(toolNames, Does.Contain(DevelopmentOnlyCatalogTestToolName));
         }
@@ -394,7 +395,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             GetToolDetailsResponse getToolDetailsResponse = response as GetToolDetailsResponse;
             string[] toolNames = getToolDetailsResponse?.Tools
                 .Select(tool => tool.Name)
-                .ToArray() ?? new string[0];
+                .ToArray() ?? Array.Empty<string>();
 
             Assert.That(toolNames, Does.Not.Contain(DevelopmentOnlyCatalogTestToolName));
         }

--- a/Packages/src/Editor/Infrastructure/Api/GetToolDetailsBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/GetToolDetailsBridgeCommand.cs
@@ -13,7 +13,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     internal static class GetToolDetailsBridgeCommand
     {
         private const string IncludeDevelopmentOnlyPropertyName = "IncludeDevelopmentOnly";
-        private const string IncludeDevelopmentOnlyCamelCasePropertyName = "includeDevelopmentOnly";
 
         public static GetToolDetailsResponse Execute(
             JToken paramsToken,
@@ -46,9 +45,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return false;
             }
 
-            JToken valueToken = parameters[IncludeDevelopmentOnlyPropertyName] ??
-                                parameters[IncludeDevelopmentOnlyCamelCasePropertyName];
-            return valueToken?.Value<bool>() ?? false;
+            return StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
+                parameters,
+                IncludeDevelopmentOnlyPropertyName,
+                System.StringComparison.OrdinalIgnoreCase) ?? false;
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/Api/GetToolDetailsBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/GetToolDetailsBridgeCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
@@ -48,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
                 parameters,
                 IncludeDevelopmentOnlyPropertyName,
-                System.StringComparison.OrdinalIgnoreCase) ?? false;
+                StringComparison.OrdinalIgnoreCase) ?? false;
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcCompileRequestMetadataReader.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcCompileRequestMetadataReader.cs
@@ -17,19 +17,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return null;
             }
 
-            JToken waitForDomainReloadToken =
-                paramsObject.GetValue(WaitForDomainReloadParamName, StringComparison.OrdinalIgnoreCase);
-            if (waitForDomainReloadToken == null)
-            {
-                return null;
-            }
-
-            if (waitForDomainReloadToken.Type != JTokenType.Boolean)
-            {
-                return null;
-            }
-
-            return waitForDomainReloadToken.Value<bool>();
+            return StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
+                paramsObject,
+                WaitForDomainReloadParamName,
+                StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Packages/src/Editor/Infrastructure/Api/StrictJsonBooleanMetadataReader.cs
+++ b/Packages/src/Editor/Infrastructure/Api/StrictJsonBooleanMetadataReader.cs
@@ -1,0 +1,32 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Reads optional JSON metadata flags only when they are encoded as real JSON booleans.
+    /// </summary>
+    internal static class StrictJsonBooleanMetadataReader
+    {
+        internal static bool? ReadOptionalBoolean(
+            JObject metadata,
+            string propertyName,
+            StringComparison propertyNameComparison)
+        {
+            System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(propertyName), "propertyName must not be empty");
+
+            if (metadata == null)
+            {
+                return null;
+            }
+
+            JToken metadataToken = metadata.GetValue(propertyName, propertyNameComparison);
+            if (metadataToken == null || metadataToken.Type != JTokenType.Boolean)
+            {
+                return null;
+            }
+
+            return metadataToken.Value<bool>();
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Api/StrictJsonBooleanMetadataReader.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Api/StrictJsonBooleanMetadataReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b05f726775bb47d1a04370c8956ceb9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/Api/UloopEnvelope.cs
+++ b/Packages/src/Editor/Infrastructure/Api/UloopEnvelope.cs
@@ -85,18 +85,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static bool ReadStrictBooleanMetadata(JObject metadata, string propertyName)
         {
-            if (metadata == null)
-            {
-                return false;
-            }
-
-            JToken metadataToken = metadata[propertyName];
-            if (metadataToken == null || metadataToken.Type != JTokenType.Boolean)
-            {
-                return false;
-            }
-
-            return metadataToken.Value<bool>();
+            return StrictJsonBooleanMetadataReader.ReadOptionalBoolean(
+                metadata,
+                propertyName,
+                StringComparison.Ordinal) ?? false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Keep malformed boolean metadata from being treated as enabled flags across JSON-RPC request paths.
- Share the strict boolean reader used by envelope feature flags with compile request metadata parsing.

## User Impact
- Requests that send strings such as "true" or "false" for boolean metadata continue to fail closed instead of changing request behavior.
- Boolean metadata handling is now less likely to drift between request paths.

## Changes
- Added a shared strict JSON boolean metadata reader.
- Reused it for envelope feature flags and compile reload-wait metadata.
- Added focused EditMode tests for strict boolean parsing and case-sensitive/case-insensitive lookup behavior.

## Verification
- dist/darwin-arm64/uloop clear-console --project-path "$(git rev-parse --show-toplevel)"
- dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "(StrictJsonBooleanMetadataReaderTests|JsonRpcRequestProcessorCliVersionGateTests)"

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

