### PR TITLE
chore: Remove unreachable schema null guards

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/ClearConsole/ClearConsoleTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/ClearConsole/ClearConsoleTool.cs
@@ -15,11 +15,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         protected override Task<ClearConsoleResponse> ExecuteAsync(ClearConsoleSchema parameters, CancellationToken ct)
         {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
             ct.ThrowIfCancellationRequested();
             ConsoleClearService consoleClear = new();
             UnityCliLoopConsoleClearResult result = consoleClear.Clear(parameters.AddConfirmationMessage);

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsTool.cs
@@ -22,11 +22,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static UnityCliLoopGameObjectSearchRequest ToRequest(FindGameObjectsSchema parameters)
         {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
             return new UnityCliLoopGameObjectSearchRequest
             {
                 NamePattern = parameters.NamePattern,

--- a/Packages/src/Editor/FirstPartyTools/GetHierarchy/GetHierarchyTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/GetHierarchy/GetHierarchyTool.cs
@@ -22,11 +22,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static UnityCliLoopHierarchyRequest ToRequest(GetHierarchySchema parameters)
         {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
             return new UnityCliLoopHierarchyRequest
             {
                 IncludeInactive = parameters.IncludeInactive,

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -172,11 +172,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public PausePointResponse Enable(EnablePausePointSchema parameters)
         {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters));
-            }
-
             string idError = ValidateId(parameters.Id);
             if (idError != null)
             {
@@ -196,11 +191,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public PausePointResponse Clear(ClearPausePointSchema parameters)
         {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters));
-            }
-
             if (parameters.All)
             {
                 UloopPausePointClearAllResult clearAllResult = UloopPausePointRegistry.ClearAll();

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputTool.cs
@@ -23,11 +23,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static UnityCliLoopRecordInputRequest ToRequest(RecordInputSchema parameters)
         {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
             return new UnityCliLoopRecordInputRequest
             {
                 Action = parameters.Action,

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputTool.cs
@@ -22,11 +22,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static UnityCliLoopReplayInputRequest ToRequest(ReplayInputSchema parameters)
         {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
             return new UnityCliLoopReplayInputRequest
             {
                 Action = parameters.Action,

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotTool.cs
@@ -24,11 +24,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static UnityCliLoopScreenshotRequest ToRequest(ScreenshotSchema parameters)
         {
-            if (parameters == null)
-            {
-                throw new System.ArgumentNullException(nameof(parameters));
-            }
-
             return new UnityCliLoopScreenshotRequest
             {
                 WindowName = parameters.WindowName,


### PR DESCRIPTION
## Summary
- Remove dead null checks from bundled tool adapter paths that always receive a schema from the tool contract conversion layer.
- Keep directly callable use case null contracts unchanged.

## User Impact
- No runtime behavior changes are expected for CLI users.
- The internal tool execution path is easier to read because it no longer guards against schema null values that ConvertToSchema already prevents.

## Changes
- Removed unreachable schema parameter guards from thin tool adapters and the internal pause-point use case path.
- Confirmed ConvertToSchema returns a non-null schema for null tokens and null deserialize results before adapters execute.
- Intentionally kept remaining use case entry guards, such as GetLogsUseCase and RunTestsUseCase, because they are directly callable public contracts and some are covered by explicit null-contract tests.

## Verification
- dist/darwin-arm64/uloop clear-console --project-path "$(git rev-parse --show-toplevel)"
- dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"
- dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "(ClearConsole|FindGameObjects|GetHierarchy|RecordInput|ReplayInput|Screenshot|PausePoint|UnityCliLoopToolExecutionServiceTests)"

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

