### PR TITLE
chore: Inject release PR check command runner

### DIFF
--- a/cli/release-automation/internal/automation/release_pr_check_runs.go
+++ b/cli/release-automation/internal/automation/release_pr_check_runs.go
@@ -14,8 +14,8 @@ type releaseWorkflowRun struct {
 	CreatedAt  string `json:"createdAt"`
 }
 
-func dispatchReleasePRCheckWorkflow(ctx context.Context, config releasePRCheckConfig, workflow string, releasePR releasePullRequest) error {
-	_, err := runReleasePRCheckOutput(ctx, "gh", "workflow", "run", workflow, "--repo", config.repository, "--ref", releasePR.HeadRefName)
+func dispatchReleasePRCheckWorkflow(ctx context.Context, config releasePRCheckConfig, workflow string, releasePR releasePullRequest, deps releasePRCheckDeps) error {
+	_, err := deps.runOutput(ctx, "gh", "workflow", "run", workflow, "--repo", config.repository, "--ref", releasePR.HeadRefName)
 	return err
 }
 
@@ -25,9 +25,10 @@ func findDispatchedReleasePRCheckRun(
 	workflow string,
 	releasePR releasePullRequest,
 	dispatchedAt time.Time,
+	deps releasePRCheckDeps,
 ) (releaseWorkflowRun, error) {
 	for attempt := 0; attempt < config.lookupAttempts; attempt++ {
-		run, found, err := latestReleasePRCheckRun(ctx, config, workflow, releasePR, dispatchedAt)
+		run, found, err := latestReleasePRCheckRun(ctx, config, workflow, releasePR, dispatchedAt, deps)
 		if err != nil {
 			return releaseWorkflowRun{}, err
 		}
@@ -35,7 +36,7 @@ func findDispatchedReleasePRCheckRun(
 			return run, nil
 		}
 		if attempt+1 < config.lookupAttempts {
-			err = releasePRCheckSleep(ctx, time.Duration(config.lookupIntervalSeconds)*time.Second)
+			err = deps.sleep(ctx, time.Duration(config.lookupIntervalSeconds)*time.Second)
 			if err != nil {
 				return releaseWorkflowRun{}, err
 			}
@@ -50,8 +51,9 @@ func latestReleasePRCheckRun(
 	workflow string,
 	releasePR releasePullRequest,
 	dispatchedAt time.Time,
+	deps releasePRCheckDeps,
 ) (releaseWorkflowRun, bool, error) {
-	output, err := runReleasePRCheckOutput(
+	output, err := deps.runOutput(
 		ctx,
 		"gh",
 		"run",
@@ -102,8 +104,8 @@ func latestReleasePRCheckRun(
 	return latestRun, true, nil
 }
 
-func watchReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, runID int64) error {
-	_, err := runReleasePRCheckOutput(
+func watchReleasePRCheckRun(ctx context.Context, config releasePRCheckConfig, runID int64, deps releasePRCheckDeps) error {
+	_, err := deps.runOutput(
 		ctx,
 		"gh",
 		"run",

--- a/cli/release-automation/internal/automation/release_pr_checks.go
+++ b/cli/release-automation/internal/automation/release_pr_checks.go
@@ -49,6 +49,12 @@ type releasePRCheckConfig struct {
 	watchIntervalSeconds  int
 }
 
+type releasePRCheckDeps struct {
+	now       func() time.Time
+	sleep     func(context.Context, time.Duration) error
+	runOutput func(context.Context, string, ...string) (string, error)
+}
+
 type releasePullRequest struct {
 	Number      int    `json:"number"`
 	HeadRefName string `json:"headRefName"`
@@ -62,13 +68,25 @@ type releasePullRequestBody struct {
 }
 
 func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.Writer) int {
+	return runReleasePleasePRChecksWithDeps(ctx, stdout, stderr, defaultReleasePRCheckDeps())
+}
+
+func defaultReleasePRCheckDeps() releasePRCheckDeps {
+	return releasePRCheckDeps{
+		now:       releasePRCheckNow,
+		sleep:     releasePRCheckSleep,
+		runOutput: runReleasePRCheckCommandOutput,
+	}
+}
+
+func runReleasePleasePRChecksWithDeps(ctx context.Context, stdout io.Writer, stderr io.Writer, deps releasePRCheckDeps) int {
 	config, err := releasePRCheckConfigFromEnvironment()
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
 	}
 
-	releasePR, found, err := findReleasePRCheckPullRequestWithRetry(ctx, config)
+	releasePR, found, err := findReleasePRCheckPullRequestWithRetry(ctx, config, deps)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
@@ -78,7 +96,7 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 		return 0
 	}
 
-	bodyChanged, err := clarifyReleasePRCheckBody(ctx, config, releasePR)
+	bodyChanged, err := clarifyReleasePRCheckBody(ctx, config, releasePR, deps)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
@@ -87,17 +105,17 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 		writeReleasePRCheckLine(stdout, fmt.Sprintf("Updated release PR #%d body to clarify release component labels.", releasePR.Number))
 	}
 
-	err = markReleasePRCheckDraft(ctx, config, releasePR)
+	err = markReleasePRCheckDraft(ctx, config, releasePR, deps)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
 	}
 	writeReleasePRCheckLine(stdout, fmt.Sprintf("Marked release PR #%d as draft while checks run.", releasePR.Number))
 
-	dispatchedAt := releasePRCheckNow().UTC().Truncate(time.Second)
+	dispatchedAt := deps.now().UTC().Truncate(time.Second)
 	for _, workflow := range config.workflows {
 		writeReleasePRCheckLine(stdout, fmt.Sprintf("Dispatching %s for release PR #%d: %s", workflow, releasePR.Number, releasePR.URL))
-		err = dispatchReleasePRCheckWorkflow(ctx, config, workflow, releasePR)
+		err = dispatchReleasePRCheckWorkflow(ctx, config, workflow, releasePR, deps)
 		if err != nil {
 			writeReleasePRCheckLine(stderr, err)
 			return 1
@@ -107,14 +125,14 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 	checkedHeadSHA := ""
 	checkedHeadWorkflow := ""
 	for _, workflow := range config.workflows {
-		run, err := findDispatchedReleasePRCheckRun(ctx, config, workflow, releasePR, dispatchedAt)
+		run, err := findDispatchedReleasePRCheckRun(ctx, config, workflow, releasePR, dispatchedAt, deps)
 		if err != nil {
 			writeReleasePRCheckLine(stderr, err)
 			return 1
 		}
 
 		writeReleasePRCheckLine(stdout, fmt.Sprintf("Watching %s run %d for release PR #%d.", workflow, run.DatabaseID, releasePR.Number))
-		err = watchReleasePRCheckRun(ctx, config, run.DatabaseID)
+		err = watchReleasePRCheckRun(ctx, config, run.DatabaseID, deps)
 		if err != nil {
 			writeReleasePRCheckLine(stderr, err)
 			return 1
@@ -136,13 +154,13 @@ func RunReleasePleasePRChecks(ctx context.Context, stdout io.Writer, stderr io.W
 		}
 	}
 
-	err = verifyReleasePRCheckHeadMatchesRun(ctx, config, releasePR, checkedHeadSHA)
+	err = verifyReleasePRCheckHeadMatchesRun(ctx, config, releasePR, checkedHeadSHA, deps)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
 	}
 
-	err = markReleasePRCheckReady(ctx, config, releasePR)
+	err = markReleasePRCheckReady(ctx, config, releasePR, deps)
 	if err != nil {
 		writeReleasePRCheckLine(stderr, err)
 		return 1
@@ -221,8 +239,8 @@ func releasePRCheckPositiveIntFromEnvironment(name string, defaultValue int) (in
 	return parsedValue, nil
 }
 
-func findReleasePRCheckPullRequest(ctx context.Context, config releasePRCheckConfig) (releasePullRequest, bool, error) {
-	output, err := runReleasePRCheckOutput(
+func findReleasePRCheckPullRequest(ctx context.Context, config releasePRCheckConfig, deps releasePRCheckDeps) (releasePullRequest, bool, error) {
+	output, err := deps.runOutput(
 		ctx,
 		"gh",
 		"pr",
@@ -267,14 +285,14 @@ func findReleasePRCheckPullRequest(ctx context.Context, config releasePRCheckCon
 	return matchingPRs[0], true, nil
 }
 
-func findReleasePRCheckPullRequestWithRetry(ctx context.Context, config releasePRCheckConfig) (releasePullRequest, bool, error) {
+func findReleasePRCheckPullRequestWithRetry(ctx context.Context, config releasePRCheckConfig, deps releasePRCheckDeps) (releasePullRequest, bool, error) {
 	for attempt := 0; attempt < config.lookupAttempts; attempt++ {
-		releasePR, found, err := findReleasePRCheckPullRequest(ctx, config)
+		releasePR, found, err := findReleasePRCheckPullRequest(ctx, config, deps)
 		if err != nil || found {
 			return releasePR, found, err
 		}
 		if attempt+1 < config.lookupAttempts {
-			err = releasePRCheckSleep(ctx, time.Duration(config.lookupIntervalSeconds)*time.Second)
+			err = deps.sleep(ctx, time.Duration(config.lookupIntervalSeconds)*time.Second)
 			if err != nil {
 				return releasePullRequest{}, false, err
 			}
@@ -306,18 +324,18 @@ func releasePRCheckTitleMatches(title string) bool {
 	return rest == "release" || strings.HasPrefix(rest, "release ")
 }
 
-func markReleasePRCheckDraft(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) error {
-	_, err := runReleasePRCheckOutput(ctx, "gh", "pr", "ready", strconv.Itoa(releasePR.Number), "--repo", config.repository, "--undo")
+func markReleasePRCheckDraft(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest, deps releasePRCheckDeps) error {
+	_, err := deps.runOutput(ctx, "gh", "pr", "ready", strconv.Itoa(releasePR.Number), "--repo", config.repository, "--undo")
 	return err
 }
 
-func markReleasePRCheckReady(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) error {
-	_, err := runReleasePRCheckOutput(ctx, "gh", "pr", "ready", strconv.Itoa(releasePR.Number), "--repo", config.repository)
+func markReleasePRCheckReady(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest, deps releasePRCheckDeps) error {
+	_, err := deps.runOutput(ctx, "gh", "pr", "ready", strconv.Itoa(releasePR.Number), "--repo", config.repository)
 	return err
 }
 
-func clarifyReleasePRCheckBody(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest) (bool, error) {
-	output, err := runReleasePRCheckOutput(ctx, "gh", "pr", "view", strconv.Itoa(releasePR.Number), "--repo", config.repository, "--json", "body")
+func clarifyReleasePRCheckBody(ctx context.Context, config releasePRCheckConfig, releasePR releasePullRequest, deps releasePRCheckDeps) (bool, error) {
+	output, err := deps.runOutput(ctx, "gh", "pr", "view", strconv.Itoa(releasePR.Number), "--repo", config.repository, "--json", "body")
 	if err != nil {
 		return false, err
 	}
@@ -339,7 +357,7 @@ func clarifyReleasePRCheckBody(ctx context.Context, config releasePRCheckConfig,
 	}
 	defer cleanup()
 
-	_, err = runReleasePRCheckOutput(ctx, "gh", "pr", "edit", strconv.Itoa(releasePR.Number), "--repo", config.repository, "--body-file", bodyFile)
+	_, err = deps.runOutput(ctx, "gh", "pr", "edit", strconv.Itoa(releasePR.Number), "--repo", config.repository, "--body-file", bodyFile)
 	if err != nil {
 		return false, err
 	}
@@ -371,8 +389,9 @@ func verifyReleasePRCheckHeadMatchesRun(
 	config releasePRCheckConfig,
 	releasePR releasePullRequest,
 	checkedHeadSHA string,
+	deps releasePRCheckDeps,
 ) error {
-	currentReleasePR, found, err := findReleasePRCheckPullRequest(ctx, config)
+	currentReleasePR, found, err := findReleasePRCheckPullRequest(ctx, config, deps)
 	if err != nil {
 		return err
 	}
@@ -388,7 +407,7 @@ func verifyReleasePRCheckHeadMatchesRun(
 	return nil
 }
 
-func runReleasePRCheckOutput(ctx context.Context, name string, args ...string) (string, error) {
+func runReleasePRCheckCommandOutput(ctx context.Context, name string, args ...string) (string, error) {
 	command := exec.CommandContext(ctx, name, args...)
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}

--- a/cli/release-automation/internal/automation/release_pr_checks_test.go
+++ b/cli/release-automation/internal/automation/release_pr_checks_test.go
@@ -3,6 +3,7 @@ package automation
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -120,6 +121,56 @@ func TestReleasePRChecksDispatchAndMarkReady(t *testing.T) {
 	assertReleasePRCheckLogContains(t, result.ghLog, "run watch 4242 --repo owner/repository --exit-status --compact --interval 1")
 	assertReleasePRCheckLogContains(t, result.ghLog, "run watch 5353 --repo owner/repository --exit-status --compact --interval 1")
 	assertReleasePRCheckLogContainsLine(t, result.ghLog, "pr ready 1043 --repo owner/repository")
+}
+
+// Verifies release PR checks can run through the injected command runner instead of direct exec.
+func TestReleasePRChecksUseInjectedCommandRunner(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "owner/repository")
+	t.Setenv("TARGET_BRANCH", "v3-beta")
+	t.Setenv("RELEASE_PR_CHECK_LOOKUP_ATTEMPTS", "1")
+	t.Setenv("RELEASE_PR_CHECK_WATCH_INTERVAL_SECONDS", "1")
+	commandLog := []string{}
+	deps := releasePRCheckDeps{
+		now: func() time.Time {
+			return time.Date(2026, 5, 30, 1, 0, 0, 0, time.UTC)
+		},
+		sleep: func(ctx context.Context, duration time.Duration) error {
+			return ctx.Err()
+		},
+		runOutput: func(ctx context.Context, name string, args ...string) (string, error) {
+			commandLine := strings.Join(append([]string{name}, args...), " ")
+			commandLog = append(commandLog, commandLine)
+			if commandLine == "gh pr list --repo owner/repository --state open --base v3-beta --label autorelease: pending --json number,headRefName,headRefOid,title,url" {
+				return `[{"number":1043,"headRefName":"release-please--branches--v3-beta","headRefOid":"abc123","title":"chore: release v3-beta","url":"https://example.test/pr/1043"}]`, nil
+			}
+			if commandLine == "gh pr view 1043 --repo owner/repository --json body" {
+				return `{"body":""}`, nil
+			}
+			if commandLine == "gh pr ready 1043 --repo owner/repository --undo" ||
+				commandLine == "gh workflow run build-and-test.yml --repo owner/repository --ref release-please--branches--v3-beta" ||
+				commandLine == "gh workflow run unity-compile-check-and-test-runner.yml --repo owner/repository --ref release-please--branches--v3-beta" ||
+				commandLine == "gh run watch 4242 --repo owner/repository --exit-status --compact --interval 1" ||
+				commandLine == "gh pr ready 1043 --repo owner/repository" {
+				return "", nil
+			}
+			if strings.HasPrefix(commandLine, "gh run list --repo owner/repository --workflow ") {
+				return `[{"databaseId":4242,"headSha":"abc123","createdAt":"2026-05-30T01:00:01Z","status":"queued","conclusion":"","url":"https://example.test/run/4242"}]`, nil
+			}
+			return "", fmt.Errorf("unexpected command: %s", commandLine)
+		},
+	}
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	exitCode := runReleasePleasePRChecksWithDeps(context.Background(), &stdout, &stderr, deps)
+
+	if exitCode != 0 {
+		t.Fatalf("release PR checks failed: stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	commandLogText := strings.Join(commandLog, "\n")
+	assertReleasePRCheckLogContains(t, commandLogText, "gh workflow run build-and-test.yml --repo owner/repository --ref release-please--branches--v3-beta")
+	assertReleasePRCheckLogContains(t, commandLogText, "gh run watch 4242 --repo owner/repository --exit-status --compact --interval 1")
+	assertReleasePRCheckLogContainsLine(t, commandLogText, "gh pr ready 1043 --repo owner/repository")
 }
 
 // Verifies that the RELEASE_PR_CHECK_WORKFLOWS environment override replaces the default workflow list.


### PR DESCRIPTION
## Summary
- Keep release PR check behavior unchanged while routing GitHub CLI command execution through dependencies.
- Add a regression test that runs the release PR check flow through an injected command runner instead of direct process execution.

## User Impact
- No user-facing behavior changes. This makes release automation easier to test without shelling out to real commands.

## Changes
- Add releasePRCheckDeps with now, sleep, and runOutput dependencies.
- Thread the command runner through release PR lookup, body clarification, workflow dispatch, run lookup, run watch, and ready/draft transitions.
- Keep the public RunReleasePleasePRChecks entry point on default dependencies.
- Address cubic feedback by making the injected test runner fail on unexpected commands.

## Verification
- go test ./internal/automation -run "TestReleasePRChecks" (from cli/release-automation)
- go test ./internal/automation -run "TestContractFileAtRefWithLegacyFallback_WhenLegacyChainProbeFails_PreservesOriginalShowError" -count=1 (reran after one unrelated timing failure in the first full check)
- scripts/check-go-cli.sh (pass after rerun)
- git diff --check
