### PR TITLE
chore: Keep Input System setup guidance consistent

### DIFF
--- a/Assets/Tests/Editor/InputSystemPackageRequirementMessageTests.cs
+++ b/Assets/Tests/Editor/InputSystemPackageRequirementMessageTests.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies missing Input System package warning text shared by first-party input tools.
+    /// </summary>
+    [TestFixture]
+    public sealed class InputSystemPackageRequirementMessageTests
+    {
+        [TestCase(
+            "simulate-keyboard",
+            "simulate-keyboard requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.")]
+        [TestCase(
+            "simulate-mouse-input",
+            "simulate-mouse-input requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.")]
+        [TestCase(
+            "record-input",
+            "record-input requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.")]
+        [TestCase(
+            "replay-input",
+            "replay-input requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.")]
+        public void Format_WithToolName_ReturnsExistingWarningMessage(string toolName, string expected)
+        {
+            // Verifies the shared formatter preserves the existing wire-visible warning text.
+            string result = InputSystemPackageRequirementMessage.Format(toolName);
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Assets/Tests/Editor/InputSystemPackageRequirementMessageTests.cs.meta
+++ b/Assets/Tests/Editor/InputSystemPackageRequirementMessageTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4322471909334d6791e1d4422443b8de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemPackageRequirementMessage.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemPackageRequirementMessage.cs
@@ -1,0 +1,20 @@
+#nullable enable
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Formats the shared missing Input System package warning for first-party input tools.
+    /// </summary>
+    internal static class InputSystemPackageRequirementMessage
+    {
+        private const string MissingPackageRequirement =
+            "requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.";
+
+        public static string Format(string toolName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must identify the CLI tool.");
+            return $"{toolName} {MissingPackageRequirement}";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemPackageRequirementMessage.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemPackageRequirementMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02207cac5f0f4568950af7e9d356dd80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputUseCase.cs
@@ -41,7 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new RecordInputResponse
             {
                 Success = false,
-                Message = "record-input requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.",
+                Message = InputSystemPackageRequirementMessage.Format("record-input"),
                 Action = request.Action.ToString()
             };
 #else

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
@@ -38,7 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new ReplayInputResponse
             {
                 Success = false,
-                Message = "replay-input requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.",
+                Message = InputSystemPackageRequirementMessage.Format("replay-input"),
                 Action = request.Action.ToString()
             };
 #else

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -43,7 +43,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new SimulateKeyboardResponse
             {
                 Success = false,
-                Message = "simulate-keyboard requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.",
+                Message = InputSystemPackageRequirementMessage.Format("simulate-keyboard"),
                 Action = parameters.Action.ToString()
             };
 #else

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -44,7 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new SimulateMouseInputResponse
             {
                 Success = false,
-                Message = "simulate-mouse-input requires the Input System package (com.unity.inputsystem). Install it via Package Manager and set Active Input Handling to 'Input System Package (New)' or 'Both' in Player Settings.",
+                Message = InputSystemPackageRequirementMessage.Format("simulate-mouse-input"),
                 Action = parameters.Action.ToString()
             };
 #else


### PR DESCRIPTION
## Summary
- Keeps the missing Input System package guidance consistent across first-party input tools.
- Preserves the existing warning text while removing the duplicated string body.

## User Impact
- Projects without the Input System package continue to see the same setup guidance.
- Future message updates can be made in one place, reducing the chance that one input tool drifts from the others.

## Changes
- Added a shared formatter for the missing Input System package warning.
- Updated record, replay, keyboard simulation, and mouse simulation fallbacks to use the shared formatter.
- Added an Editor test that pins the existing warning text for all four tools.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.InputSystemPackageRequirementMessageTests"`
- `git diff --cached --check`
