### PR TITLE
chore: Keep skill setup file exclusions consistent

### DIFF
--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -297,6 +297,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(actualBytes, Is.EqualTo(expectedBytes));
         }
 
+        // Tests that skill setup file scans share the same generated-file exclusion behavior.
+        [Test]
+        public void IsExcludedSkillFile_WhenGeneratedSkillFileNameIsPassed_ReturnsTrue()
+        {
+            Assert.That(SkillSetupFileExclusion.IsExcludedSkillFile("reference.md.meta"), Is.True);
+            Assert.That(SkillSetupFileExclusion.IsExcludedSkillFile(".DS_Store"), Is.True);
+            Assert.That(SkillSetupFileExclusion.IsExcludedSkillFile(".gitkeep"), Is.True);
+            Assert.That(SkillSetupFileExclusion.IsExcludedSkillFile("SKILL.md"), Is.False);
+        }
+
         private string CreateTemporaryProjectRoot()
         {
             string temporaryRoot = Path.Combine(

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillDirectoryContentSynchronizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillDirectoryContentSynchronizer.cs
@@ -13,13 +13,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     internal static class SkillDirectoryContentSynchronizer
     {
-        private static readonly string[] ExcludedSkillFileNames =
-        {
-            ".meta",
-            ".DS_Store",
-            ".gitkeep"
-        };
-
         internal static void SyncInstalledSkillDirectory(
             string skillDirectory,
             IReadOnlyDictionary<string, byte[]> skillFiles,
@@ -63,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories))
             {
                 string fileName = Path.GetFileName(filePath);
-                if (IsExcludedSkillFile(fileName))
+                if (SkillSetupFileExclusion.IsExcludedSkillFile(fileName))
                 {
                     continue;
                 }
@@ -88,24 +81,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
                 Directory.Delete(directoryPath);
             }
-        }
-
-        internal static bool IsExcludedSkillFile(string fileName)
-        {
-            if (ExcludedSkillFileNames.Contains(fileName))
-            {
-                return true;
-            }
-
-            foreach (string excludedPattern in ExcludedSkillFileNames)
-            {
-                if (fileName.EndsWith(excludedPattern, StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static void WriteSkillFiles(
@@ -168,7 +143,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 ct.ThrowIfCancellationRequested();
                 string fileName = Path.GetFileName(filePath);
-                if (IsExcludedSkillFile(fileName))
+                if (SkillSetupFileExclusion.IsExcludedSkillFile(fileName))
                 {
                     continue;
                 }

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
@@ -28,12 +28,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private const ushort LineFeedCodeUnit = 0x000A;
         private const string EditorDirName = "Editor";
         private const string CliOnlyToolsDirName = "CliOnlyTools~";
-        private static readonly HashSet<string> ExcludedFileNames = new()
-        {
-            ".meta",
-            ".DS_Store",
-            ".gitkeep"
-        };
         private static readonly HashSet<string> TextSkillFileExtensions = new(StringComparer.OrdinalIgnoreCase)
         {
             ".json",
@@ -442,7 +436,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             foreach (string filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories))
             {
                 string fileName = Path.GetFileName(filePath);
-                if (IsExcludedFile(fileName))
+                if (SkillSetupFileExclusion.IsExcludedSkillFile(fileName))
                 {
                     continue;
                 }
@@ -1053,24 +1047,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 internalMatch.Groups[1].Value.Trim(),
                 "true",
                 StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static bool IsExcludedFile(string fileName)
-        {
-            if (ExcludedFileNames.Contains(fileName))
-            {
-                return true;
-            }
-
-            foreach (string excludedPattern in ExcludedFileNames)
-            {
-                if (fileName.EndsWith(excludedPattern, StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static bool IsSafeSkillPathComponent(string skillName)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillSetupFileExclusion.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillSetupFileExclusion.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Identifies generated files that skill setup scans should ignore.
+    /// </summary>
+    internal static class SkillSetupFileExclusion
+    {
+        private static readonly HashSet<string> ExcludedFileNames = new(StringComparer.Ordinal)
+        {
+            ".meta",
+            ".DS_Store",
+            ".gitkeep"
+        };
+
+        internal static bool IsExcludedSkillFile(string fileName)
+        {
+            if (ExcludedFileNames.Contains(fileName))
+            {
+                return true;
+            }
+
+            foreach (string excludedPattern in ExcludedFileNames)
+            {
+                if (fileName.EndsWith(excludedPattern, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillSetupFileExclusion.cs.meta
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillSetupFileExclusion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd80275d3f2e446a8d15695ff85aab7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
@@ -273,7 +273,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 ct.ThrowIfCancellationRequested();
                 string fileName = Path.GetFileName(filePath);
-                if (!SkillDirectoryContentSynchronizer.IsExcludedSkillFile(fileName))
+                if (!SkillSetupFileExclusion.IsExcludedSkillFile(fileName))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Keeps skill setup generated-file exclusions consistent across discovery, sync, and cleanup paths.
- Removes the duplicate .meta / .DS_Store / .gitkeep exclusion implementations.

## User Impact
- Skill setup behavior is unchanged, but future exclusion updates are less likely to drift between scan paths.

## Changes
- Added a shared `SkillSetupFileExclusion` helper for generated skill file names.
- Updated layout discovery, directory synchronization, and cleanup to use the shared helper directly.
- Added an Editor test that pins the shared exclusion behavior.

## Verification
- Red: `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` failed before the helper existed with `SkillSetupFileExclusion` undefined.
- Green: `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.(SkillInstallLayoutTests|ToolSkillSynchronizerTests)"`
- `git diff --cached --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

