### PR TITLE
chore: Share v3 migration skill target handling

### DIFF
--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -1639,6 +1639,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task RemoveSpecificSkillFilesAtProjectRoot_WithMultipleTargets_ReportsAllTargetsSucceeded()
+        {
+            // Tests that migration skill removal reports one successful result per requested target.
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            ToolSkillSynchronizer.SkillTargetInfo codexTarget = new(
+                "Codex CLI",
+                ".codex",
+                "--codex",
+                hasSkillsDirectory: true,
+                hasExistingSkills: false);
+            ToolSkillSynchronizer.SkillTargetInfo claudeTarget = new(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: false);
+            string codexSkillDir = Path.Combine(
+                temporaryRoot,
+                ".codex",
+                SkillInstallLayout.SkillsDirName,
+                CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME);
+            string claudeSkillDir = Path.Combine(
+                temporaryRoot,
+                ".claude",
+                SkillInstallLayout.SkillsDirName,
+                CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME);
+            WriteSkillFile(codexSkillDir, "---\nname: v3-cli-invocation-migration\n---\n");
+            WriteSkillFile(claudeSkillDir, "---\nname: v3-cli-invocation-migration\n---\n");
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await V3MigrationSkillInstaller.RemoveSpecificSkillFilesAtProjectRoot(
+                    temporaryRoot,
+                    new[] { codexTarget, claudeTarget },
+                    CliConstants.V3_CLI_INVOCATION_MIGRATION_SKILL_NAME,
+                    groupSkillsUnderUnityCliLoop: false,
+                    ct: CancellationToken.None);
+
+            Assert.That(result.AttemptedTargets, Is.EqualTo(2));
+            Assert.That(result.SucceededTargets, Is.EqualTo(2));
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(Directory.Exists(codexSkillDir), Is.False);
+            Assert.That(Directory.Exists(claudeSkillDir), Is.False);
+        }
+
+        [Test]
         public async Task RemoveV3MigrationSkillFilesAtProjectRoot_WhenSkillExistsInBothLayouts_RemovesBothLayouts()
         {
             // Tests that temporary migration skill removal cleans up both supported install layouts.

--- a/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/V3MigrationSkillInstaller.cs
@@ -72,29 +72,23 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             ct.ThrowIfCancellationRequested();
 
             SkillInstallLayout.SkillSourceInfo skill = GetV3MigrationSkillSourceInfo();
-            ToolSkillSynchronizer.SkillTargetInfo[] targetArray = targets.ToArray();
-            return await Task.Run(() =>
-            {
-                int succeeded = 0;
-                foreach (ToolSkillSynchronizer.SkillTargetInfo target in targetArray)
+            return await RunForTargetsAsync(
+                targets,
+                (ToolSkillSynchronizer.SkillTargetInfo target, CancellationToken targetCt) =>
                 {
-                    ct.ThrowIfCancellationRequested();
                     string targetRoot = Path.Combine(projectRoot, target.DirName);
                     SkillTargetInstaller.DeleteSkillDirectoryIfExists(
                         targetRoot,
                         skill.Name,
                         groupSkillsUnderUnityCliLoop,
-                        ct);
+                        targetCt);
                     SkillTargetInstaller.DeleteSkillDirectoryIfExists(
                         targetRoot,
                         skill.Name,
                         !groupSkillsUnderUnityCliLoop,
-                        ct);
-                    succeeded++;
-                }
-
-                return new ToolSkillSynchronizer.SkillInstallResult(targetArray.Length, succeeded);
-            }, ct);
+                        targetCt);
+                },
+                ct);
         }
 
         internal static SkillInstallState GetSkillInstallStateAtProjectRoot(
@@ -129,25 +123,19 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(targets != null, "targets must not be null");
             ct.ThrowIfCancellationRequested();
 
-            ToolSkillSynchronizer.SkillTargetInfo[] targetArray = targets.ToArray();
-            return await Task.Run(() =>
-            {
-                int succeeded = 0;
-                foreach (ToolSkillSynchronizer.SkillTargetInfo target in targetArray)
+            return await RunForTargetsAsync(
+                targets,
+                (ToolSkillSynchronizer.SkillTargetInfo target, CancellationToken targetCt) =>
                 {
-                    ct.ThrowIfCancellationRequested();
                     SkillTargetInstaller.InstallSpecificSkillsForTarget(
                         projectRoot,
                         target,
                         Array.Empty<SkillInstallLayout.SkillSourceInfo>(),
                         new[] { skill },
                         groupSkillsUnderUnityCliLoop,
-                        ct);
-                    succeeded++;
-                }
-
-                return new ToolSkillSynchronizer.SkillInstallResult(targetArray.Length, succeeded);
-            }, ct);
+                        targetCt);
+                },
+                ct);
         }
 
         internal static async Task<ToolSkillSynchronizer.SkillInstallResult> RemoveSpecificSkillFilesAtProjectRoot(
@@ -162,6 +150,28 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(!string.IsNullOrEmpty(skillName), "skillName must not be null or empty");
             ct.ThrowIfCancellationRequested();
 
+            return await RunForTargetsAsync(
+                targets,
+                (ToolSkillSynchronizer.SkillTargetInfo target, CancellationToken targetCt) =>
+                {
+                    string targetRoot = Path.Combine(projectRoot, target.DirName);
+                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
+                        targetRoot,
+                        skillName,
+                        groupSkillsUnderUnityCliLoop,
+                        targetCt);
+                },
+                ct);
+        }
+
+        private static async Task<ToolSkillSynchronizer.SkillInstallResult> RunForTargetsAsync(
+            IEnumerable<ToolSkillSynchronizer.SkillTargetInfo> targets,
+            Action<ToolSkillSynchronizer.SkillTargetInfo, CancellationToken> targetOperation,
+            CancellationToken ct)
+        {
+            Debug.Assert(targets != null, "targets must not be null");
+            Debug.Assert(targetOperation != null, "targetOperation must not be null");
+
             ToolSkillSynchronizer.SkillTargetInfo[] targetArray = targets.ToArray();
             return await Task.Run(() =>
             {
@@ -169,12 +179,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 foreach (ToolSkillSynchronizer.SkillTargetInfo target in targetArray)
                 {
                     ct.ThrowIfCancellationRequested();
-                    string targetRoot = Path.Combine(projectRoot, target.DirName);
-                    SkillTargetInstaller.DeleteSkillDirectoryIfExists(
-                        targetRoot,
-                        skillName,
-                        groupSkillsUnderUnityCliLoop,
-                        ct);
+                    targetOperation(target, ct);
                     succeeded++;
                 }
 


### PR DESCRIPTION
## Summary
- Keeps v3 migration skill install and removal result counting consistent across target loops.
- Removes the repeated Task.Run target iteration skeleton from migration install/remove paths.

## User Impact
- Migration skill setup behavior is unchanged, but cancellation and target counting now flow through one implementation.

## Changes
- Added a shared private target runner for v3 migration skill operations.
- Updated v3 migration install, full removal, and specific removal paths to pass only their per-target operation.
- Added a multiple-target removal test that pins attempted/succeeded result counts.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type regex --filter-value "io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.ToolSkillSynchronizerTests\.(InstallSpecificSkillFilesAtProjectRoot_WhenSingleSkillSourceIsProvided_InstallsOnlyThatSkill|GetV3MigrationSkillInstallStateAtProjectRoot_WhenSkillExistsInAlternateLayout_ReturnsInstalled|RemoveSpecificSkillFilesAtProjectRoot_WhenSkillExists_RemovesOnlyThatSkill|RemoveSpecificSkillFilesAtProjectRoot_WithMultipleTargets_ReportsAllTargetsSucceeded|RemoveV3MigrationSkillFilesAtProjectRoot_WhenSkillExistsInBothLayouts_RemovesBothLayouts)"`
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --test-mode EditMode --filter-type exact --filter-value "io.github.hatayama.UnityCliLoop.Tests.Editor.ToolSkillSynchronizerTests"`
- `git diff --cached --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

