### PR TITLE
chore: Keep skill target detection layout-aware

### DIFF
--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -85,7 +85,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             // Act
             List<ToolSkillSynchronizer.SkillTargetInfo> targets =
-                SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(_projectRoot, requireSkillsDirectory: true);
+                SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
+                    _projectRoot,
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: false,
+                    includeFreshnessCheck: false);
             await ToolSkillSynchronizer.InstallSkillFiles(
                 targets,
                 groupSkillsUnderUnityCliLoop: false,
@@ -670,7 +674,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
 
             // Act
-            string[] detectedTargetDirs = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(temporaryRoot, requireSkillsDirectory: true)
+            string[] detectedTargetDirs = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
+                    temporaryRoot,
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: false,
+                    includeFreshnessCheck: true)
                 .Select(target => target.DirName)
                 .ToArray();
 
@@ -691,9 +699,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Directory.CreateDirectory(Path.Combine(temporaryRoot, dir));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
-                    requireSkillsDirectory: false)
+                    requireSkillsDirectory: false,
+                    groupSkillsUnderUnityCliLoop: false,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
@@ -719,7 +729,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
 
             // Act
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(temporaryRoot, requireSkillsDirectory: true)
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
+                    temporaryRoot,
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: false,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             // Assert
@@ -784,9 +798,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "uloop-compile"));
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
-                    requireSkillsDirectory: true)
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: true,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
@@ -887,9 +903,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "---\nname: acme-third-party\ntoolName: acme-third-party\n---\n");
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
-                    requireSkillsDirectory: true)
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: false,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);
@@ -943,9 +961,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                     "---\nname: find-orphaned-meta\n---\n");
             }
 
-            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsAcrossLayoutsAtProjectRoot(
+            ToolSkillSynchronizer.SkillTargetInfo[] detectedTargets = SkillTargetDetector.DetectTargetsForLayoutStateAtProjectRoot(
                     temporaryRoot,
-                    requireSkillsDirectory: true)
+                    requireSkillsDirectory: true,
+                    groupSkillsUnderUnityCliLoop: false,
+                    includeFreshnessCheck: true)
                 .ToArray();
 
             Assert.AreEqual(SkillTargetDetector.SkillTargetDirs.Length, detectedTargets.Length);

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetDetector.cs
@@ -39,44 +39,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         internal static readonly string[] SkillTargetDirs = SkillTargets.Select(t => t.DirName).ToArray();
 
-        internal static List<ToolSkillSynchronizer.SkillTargetInfo> DetectTargetsAcrossLayoutsAtProjectRoot(
-            string projectRoot,
-            bool requireSkillsDirectory)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
-
-            List<ToolSkillSynchronizer.SkillTargetInfo> targets = new();
-
-            foreach (SkillTargetDefinition target in SkillTargets)
-            {
-                string targetRoot = Path.Combine(projectRoot, target.DirName);
-                if (!Directory.Exists(targetRoot))
-                {
-                    continue;
-                }
-
-                bool hasSkillsDirectory = SkillInstallLayout.HasOptedInSkillsDirectory(targetRoot);
-                if (requireSkillsDirectory && !hasSkillsDirectory)
-                {
-                    continue;
-                }
-
-                bool hasULoopSkills = hasSkillsDirectory
-                    && SkillInstallLayout.HasInstalledSkillsInAnyLayout(projectRoot, targetRoot);
-                targets.Add(new ToolSkillSynchronizer.SkillTargetInfo(
-                    target.DisplayName,
-                    target.DirName,
-                    target.Flag,
-                    hasSkillsDirectory,
-                    hasULoopSkills,
-                    installState: hasULoopSkills
-                        ? SkillInstallState.Installed
-                        : SkillInstallState.Missing));
-            }
-
-            return targets;
-        }
-
         internal static List<ToolSkillSynchronizer.SkillTargetInfo> DetectTargetsForLayoutStateAtProjectRoot(
             string projectRoot,
             bool requireSkillsDirectory,


### PR DESCRIPTION
## Summary
- Keep skill target detection maintenance paths layout-aware by removing the layout-agnostic detector entry that only tests used.
- Preserve the existing setup coverage by making tests choose flat or grouped layout detection explicitly.

## User Impact
- No runtime behavior changes are intended.
- Future setup maintenance is less likely to call a test-only detector that ignores the selected skill layout.

## Changes
- Removed the unused production-only-for-tests across-layout skill target detector entry.
- Updated affected Editor tests to call the layout-state detector with explicit flat or grouped layout settings.

## Verification
- dist/darwin-arm64/uloop clear-console --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2"
- dist/darwin-arm64/uloop compile --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" (0 errors, 0 warnings)
- dist/darwin-arm64/uloop run-tests --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" --test-mode EditMode --filter-type regex --filter-value "^io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.ToolSkillSynchronizerTests\." (51 passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

