### PR TITLE
chore: Simplify full sync skill cleanup

### DIFF
--- a/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
+++ b/Assets/Tests/Editor/ToolSkillSynchronizerTests.cs
@@ -316,6 +316,57 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task InstallSkillFilesAtProjectRoot_WhenDisabledSkillExistsInBothLayouts_RemovesBothLayouts()
+        {
+            // Tests that full sync removes disabled skills through the scope cleanup before installing enabled skills.
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-enabled-skill",
+                "EnabledTool",
+                "reference.md",
+                "enabled-reference");
+            CreateFakeSourceSkill(
+                temporaryRoot,
+                "uloop-disabled-skill",
+                "DisabledTool",
+                "reference.md",
+                "disabled-reference");
+
+            string targetRoot = Path.Combine(temporaryRoot, ".claude");
+            string skillsRoot = Path.Combine(targetRoot, SkillInstallLayout.SkillsDirName);
+            string managedSkillsRoot = Path.Combine(
+                skillsRoot,
+                SkillInstallLayout.ManagedSkillsDirName);
+            string flatDisabledSkillDir = Path.Combine(skillsRoot, "uloop-disabled-skill");
+            string groupedDisabledSkillDir = Path.Combine(managedSkillsRoot, "uloop-disabled-skill");
+            WriteSkillFile(flatDisabledSkillDir, "---\nname: uloop-disabled-skill\n---\n");
+            WriteSkillFile(groupedDisabledSkillDir, "---\nname: uloop-disabled-skill\n---\n");
+
+            ToolSkillSynchronizer.SkillTargetInfo target = new(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true);
+
+            ToolSkillSynchronizer.SkillInstallResult result =
+                await ToolSkillSynchronizer.InstallSkillFilesAtProjectRoot(
+                    temporaryRoot,
+                    new[] { target },
+                    groupSkillsUnderUnityCliLoop: false,
+                    disabledTools: new[] { "disabled-skill" },
+                    ct: CancellationToken.None);
+
+            string enabledSkillDir = Path.Combine(skillsRoot, "uloop-enabled-skill");
+
+            Assert.That(result.IsSuccessful, Is.True);
+            Assert.That(File.Exists(Path.Combine(enabledSkillDir, SkillInstallLayout.SkillFileName)), Is.True);
+            Assert.That(Directory.Exists(flatDisabledSkillDir), Is.False);
+            Assert.That(Directory.Exists(groupedDisabledSkillDir), Is.False);
+        }
+
+        [Test]
         public async Task InstallSkillFilesAtProjectRoot_WhenFlatLayoutRequested_InstallsProjectLocalCustomSkills()
         {
             string temporaryRoot = CreateTemporaryProjectRoot();

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
@@ -332,18 +332,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return GetInstalledSkillDirectoryPath(targetRoot, skillName, groupSkillsUnderUnityCliLoop);
         }
 
-        internal static IEnumerable<string> EnumerateInstalledSkillDirectoryNamesForLayout(
-            string targetRoot,
-            bool groupSkillsUnderUnityCliLoop)
-        {
-            IEnumerable<string> installedSkillDirectories = groupSkillsUnderUnityCliLoop
-                ? EnumerateManagedSkillDirectories(targetRoot)
-                : EnumerateLegacyManagedSkillDirectories(targetRoot);
-            return installedSkillDirectories
-                .Select(Path.GetFileName)
-                .Where(name => !string.IsNullOrEmpty(name));
-        }
-
         private static IEnumerable<string> EnumerateManagedSkillDirectories(string targetRoot)
         {
             string managedSkillsRoot = GetManagedSkillsRoot(targetRoot);

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -96,27 +95,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 DeleteSkillDirectoryIfExists(targetRoot, skill.Name, !groupSkillsUnderUnityCliLoop, ct);
             }
 
-            if (syncScope == SkillSyncScope.FullSync)
-            {
-                HashSet<string> managedSkillNames = GetManagedSkillNames(skills, disabledSkills);
-                DeleteUnexpectedInstalledSkillDirectories(
-                    targetRoot,
-                    skills.Select(skill => skill.Name),
-                    managedSkillNames,
-                    groupSkillsUnderUnityCliLoop,
-                    ct);
-
-                if (!groupSkillsUnderUnityCliLoop)
-                {
-                    DeleteUnexpectedInstalledSkillDirectories(
-                        targetRoot,
-                        skills.Select(skill => skill.Name),
-                        managedSkillNames,
-                        groupSkillsUnderUnityCliLoop: true,
-                        ct);
-                }
-            }
-
             if (!groupSkillsUnderUnityCliLoop)
             {
                 DeleteEmptyManagedSkillsParentDirectoryIfNeeded(
@@ -124,18 +102,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     groupSkillsUnderUnityCliLoop: true,
                     ct);
             }
-        }
-
-        private static HashSet<string> GetManagedSkillNames(
-            IEnumerable<SkillInstallLayout.SkillSourceInfo> skills,
-            IEnumerable<SkillInstallLayout.SkillSourceInfo> disabledSkills)
-        {
-            HashSet<string> managedSkillNames = new(
-                skills.Select(skill => skill.Name),
-                StringComparer.Ordinal);
-            managedSkillNames.UnionWith(disabledSkills.Select(skill => skill.Name));
-            managedSkillNames.UnionWith(DeprecatedSkillNames);
-            return managedSkillNames;
         }
 
         internal static void DeleteSkillDirectoryIfExists(
@@ -156,34 +122,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             Directory.Delete(installedSkillDirectory, true);
             DeleteEmptyManagedSkillsParentDirectoryIfNeeded(targetRoot, groupSkillsUnderUnityCliLoop, ct);
-        }
-
-        private static void DeleteUnexpectedInstalledSkillDirectories(
-            string targetRoot,
-            IEnumerable<string> expectedSkillNames,
-            IEnumerable<string> removableSkillNames,
-            bool groupSkillsUnderUnityCliLoop,
-            CancellationToken ct)
-        {
-            HashSet<string> expectedSkillNameSet = new(expectedSkillNames, StringComparer.Ordinal);
-            HashSet<string> removableSkillNameSet = new(removableSkillNames, StringComparer.Ordinal);
-            foreach (string installedSkillName in SkillInstallLayout.EnumerateInstalledSkillDirectoryNamesForLayout(
-                         targetRoot,
-                         groupSkillsUnderUnityCliLoop))
-            {
-                ct.ThrowIfCancellationRequested();
-                if (expectedSkillNameSet.Contains(installedSkillName))
-                {
-                    continue;
-                }
-
-                if (!removableSkillNameSet.Contains(installedSkillName))
-                {
-                    continue;
-                }
-
-                DeleteSkillDirectoryIfExists(targetRoot, installedSkillName, groupSkillsUnderUnityCliLoop, ct);
-            }
         }
 
         private static void DeleteDeprecatedSkillDirectories(


### PR DESCRIPTION
## Summary
- Simplify full skill synchronization by removing a prune pass that no longer had an effective deletion target.
- Keep cleanup behavior covered with a test that disabled skills are removed from both skill layouts during full sync.

## User Impact
- No user-facing behavior change is intended.
- Setup maintenance becomes easier to reason about because disabled/deprecated cleanup is handled in one explicit path before enabled skills are installed.

## Changes
- Removed the full-sync unexpected-directory prune branch from skill target installation.
- Removed the now-unused installed skill directory name enumerator created only for that prune path.
- Added Editor coverage for disabled skill cleanup across flat and grouped layouts.

## Verification
- dist/darwin-arm64/uloop clear-console --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2"
- dist/darwin-arm64/uloop compile --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" (0 errors, 0 warnings)
- dist/darwin-arm64/uloop run-tests --project-path "/Users/a12115/ghq/hatayama/unity-cli-loop2" --test-mode EditMode --filter-type regex --filter-value "^io\.github\.hatayama\.UnityCliLoop\.Tests\.Editor\.ToolSkillSynchronizerTests\." (52 passed)
- git diff --check
- Repository search confirmed no remaining references to DeleteUnexpectedInstalledSkillDirectories, GetManagedSkillNames, or EnumerateInstalledSkillDirectoryNamesForLayout

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

