### PR TITLE
fix: Quoted skill metadata is recognized consistently

### DIFF
--- a/Assets/Tests/Editor/SkillSourceFrontmatterReaderTests.cs
+++ b/Assets/Tests/Editor/SkillSourceFrontmatterReaderTests.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies scalar normalization for SKILL.md frontmatter fields.
+    /// </summary>
+    [TestFixture]
+    public class SkillSourceFrontmatterReaderTests
+    {
+        // Tests that string scalar fields strip surrounding whitespace and single or double quotes.
+        [Test]
+        public void ParseScalarFields_WhenQuoted_StripsWhitespaceAndQuotes()
+        {
+            string content =
+                "---\n" +
+                "name:   'uloop-compile'   \n" +
+                "toolName:   \"compile\"   \n" +
+                "description:   'Compile the project.'   \n" +
+                "---\n";
+
+            Assert.That(
+                SkillSourceFrontmatterReader.ParseNameFromFrontmatter(content),
+                Is.EqualTo("uloop-compile"));
+            Assert.That(
+                SkillSourceFrontmatterReader.ParseToolNameFromFrontmatter(content),
+                Is.EqualTo("compile"));
+            Assert.That(
+                SkillSourceFrontmatterReader.ParseDescriptionFromFrontmatter(content),
+                Is.EqualTo("Compile the project."));
+        }
+
+        // Tests that tool names preserve their original casing after scalar normalization.
+        [Test]
+        public void ParseToolNameFromFrontmatter_WhenQuoted_PreservesCasing()
+        {
+            string content = "---\ntoolName: 'Compile'\n---\n";
+
+            string toolName = SkillSourceFrontmatterReader.ParseToolNameFromFrontmatter(content);
+
+            Assert.That(toolName, Is.EqualTo("Compile"));
+        }
+
+        // Tests that internal flags accept quoted true values without changing case-insensitive semantics.
+        [TestCase("\"TrUe\"")]
+        [TestCase("'TrUe'")]
+        [TestCase("   \"TrUe\"   ")]
+        public void IsInternalSkill_WhenTrueIsQuoted_ReturnsTrue(string scalar)
+        {
+            string content = $"---\ninternal: {scalar}\n---\n";
+
+            bool isInternal = SkillSourceFrontmatterReader.IsInternalSkill(content);
+
+            Assert.That(isInternal, Is.True);
+        }
+
+        // Tests that quoted false values remain non-internal after scalar normalization.
+        [TestCase("\"FALSE\"")]
+        [TestCase("'false'")]
+        public void IsInternalSkill_WhenFalseIsQuoted_ReturnsFalse(string scalar)
+        {
+            string content = $"---\ninternal: {scalar}\n---\n";
+
+            bool isInternal = SkillSourceFrontmatterReader.IsInternalSkill(content);
+
+            Assert.That(isInternal, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/SkillSourceFrontmatterReaderTests.cs.meta
+++ b/Assets/Tests/Editor/SkillSourceFrontmatterReaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b3c91665d9964d978ebecdb2b1290d67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceFrontmatterReader.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceFrontmatterReader.cs
@@ -11,6 +11,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     internal static class SkillSourceFrontmatterReader
     {
+        private static string NormalizeFrontmatterScalar(string value)
+        {
+            return value.Trim().Trim('"', '\'');
+        }
+
         internal static string ParseToolNameFromFrontmatter(string content)
         {
             Match frontmatterMatch = Regex.Match(content, @"^---\r?\n([\s\S]*?)\r?\n---");
@@ -26,7 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return null;
             }
 
-            return toolNameMatch.Groups[1].Value.Trim();
+            return NormalizeFrontmatterScalar(toolNameMatch.Groups[1].Value);
         }
 
         internal static string ParseNameFromFrontmatter(string content)
@@ -44,7 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return null;
             }
 
-            return nameMatch.Groups[1].Value.Trim().Trim('"');
+            return NormalizeFrontmatterScalar(nameMatch.Groups[1].Value);
         }
 
         internal static string ParseDescriptionFromFrontmatter(string content)
@@ -62,7 +67,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return null;
             }
 
-            return descriptionMatch.Groups[1].Value.Trim().Trim('"');
+            return NormalizeFrontmatterScalar(descriptionMatch.Groups[1].Value);
         }
 
         internal static string ResolveToolNameForSkillSource(string skillName, string toolName)
@@ -133,7 +138,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return string.Equals(
-                internalMatch.Groups[1].Value.Trim(),
+                NormalizeFrontmatterScalar(internalMatch.Groups[1].Value),
                 "true",
                 StringComparison.OrdinalIgnoreCase);
         }


### PR DESCRIPTION
## Summary
- Quoted skill frontmatter values are now interpreted consistently by Unity skill setup.
- Single- and double-quoted metadata now matches the native CLI parser.

## User Impact
- `toolName: "compile"` now matches the `compile` tool instead of retaining quote characters.
- `internal: "true"` and `internal: 'true'` now correctly exclude internal skills from installation.
- Tool name casing remains unchanged, while the existing case-insensitive `internal` flag behavior is preserved.

## Changes
- Added one scalar normalization path for `name`, `toolName`, `description`, and `internal` frontmatter fields.
- Added focused EditMode coverage for whitespace, single quotes, double quotes, casing preservation, and quoted boolean values.
- Kept the normalization semantics aligned with `skillscan.ParseSkillFrontmatter` on the Go side.

## Verification
- Red: `SkillSourceFrontmatterReaderTests` failed 5 of 7 cases before the implementation.
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` (0 errors, 0 warnings)
- `SkillSourceFrontmatterReaderTests` (7 passed)
- `SkillInstallLayoutTests` (10 passed)
- `ToolSkillSynchronizerTests` (52 passed)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

