### PR TITLE
fix: Duplicate skills now follow stable source priority

### DIFF
--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -131,6 +131,44 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(descriptions[UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT], Does.StartWith("Pauses Unity's playback"));
         }
 
+        // Tests that duplicate skill names use the earlier source root across each precedence boundary.
+        [Test]
+        public void GetSkillSourceInfos_WhenNamesOverlap_PrefersEarlierSourceRoot()
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            string manifestPackageRoot = CreateTemporaryProjectRoot();
+            string assetsRoot = Path.Combine(temporaryRoot, "Assets");
+            string directPackageRoot = Path.Combine(temporaryRoot, "Packages", "com.example.direct");
+            string cachePackageRoot = Path.Combine(
+                temporaryRoot,
+                "Library",
+                "PackageCache",
+                "com.example.cached@1.0.0");
+
+            WriteSourceSkill(assetsRoot, "uloop-assets-priority", "assets-winner", "AssetsWinner");
+            WriteSourceSkill(directPackageRoot, "uloop-assets-priority", "direct-loser", "DirectLoser");
+            WriteSourceSkill(directPackageRoot, "uloop-package-priority", "direct-winner", "DirectWinner");
+            WriteSourceSkill(manifestPackageRoot, "uloop-package-priority", "manifest-loser", "ManifestLoser");
+            WriteSourceSkill(manifestPackageRoot, "uloop-manifest-priority", "manifest-winner", "ManifestWinner");
+            WriteSourceSkill(cachePackageRoot, "uloop-manifest-priority", "cache-loser", "CacheLoser");
+
+            string manifestPath = Path.Combine(temporaryRoot, "Packages", "manifest.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(manifestPath));
+            string portableManifestPackageRoot = manifestPackageRoot.Replace(Path.DirectorySeparatorChar, '/');
+            File.WriteAllText(
+                manifestPath,
+                $"{{\"dependencies\":{{\"com.example.manifest\":\"file:{portableManifestPackageRoot}\"," +
+                "\"com.example.cached\":\"1.0.0\"}}}");
+
+            Dictionary<string, SkillInstallLayout.SkillSourceInfo> skillSources = SkillInstallLayout
+                .GetSkillSourceInfos(temporaryRoot)
+                .ToDictionary(skill => skill.Name, StringComparer.Ordinal);
+
+            Assert.That(skillSources["uloop-assets-priority"].ToolName, Is.EqualTo("assets-winner"));
+            Assert.That(skillSources["uloop-package-priority"].ToolName, Is.EqualTo("direct-winner"));
+            Assert.That(skillSources["uloop-manifest-priority"].ToolName, Is.EqualTo("manifest-winner"));
+        }
+
         // Tests that skill discovery follows bundled tools after they move into the first-party plugin assembly.
         [Test]
         public void GetSkillSourceInfos_WhenFirstPartyToolIsUnderFirstPartyTools_IncludesToolSkill()
@@ -345,6 +383,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Path.Combine(skillDir, SkillInstallLayout.SkillFileName),
                 $"---\nname: {skillName}\n{internalLine}---\n");
             File.WriteAllText(Path.Combine(skillDir, additionalFileRelativePath), additionalFileContent);
+        }
+
+        private static void WriteSourceSkill(
+            string sourceRoot,
+            string skillName,
+            string toolName,
+            string toolDirectoryName)
+        {
+            string skillDirectory = Path.Combine(sourceRoot, "Editor", toolDirectoryName, "Skill");
+            Directory.CreateDirectory(skillDirectory);
+            File.WriteAllText(
+                Path.Combine(skillDirectory, SkillInstallLayout.SkillFileName),
+                $"---\nname: {skillName}\ntoolName: {toolName}\n---\n");
         }
 
         /// <summary>

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
@@ -167,39 +167,49 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static IEnumerable<string> EnumerateSkillSourceRoots(string projectRoot)
         {
+            List<string> orderedRoots = new();
             HashSet<string> seenRoots = new(StringComparer.Ordinal);
 
-            AddSkillSourceRoot(seenRoots, GetCliOnlySkillSourceRoot(projectRoot));
-            AddSkillSourceRoot(seenRoots, Path.Combine(projectRoot, "Assets"));
+            AddSkillSourceRoot(orderedRoots, seenRoots, GetCliOnlySkillSourceRoot(projectRoot));
+            AddSkillSourceRoot(orderedRoots, seenRoots, Path.Combine(projectRoot, "Assets"));
             foreach (string packageRoot in EnumerateDirectProjectPackageRoots(projectRoot))
             {
-                AddSkillSourceRoot(seenRoots, packageRoot);
+                AddSkillSourceRoot(orderedRoots, seenRoots, packageRoot);
             }
 
             foreach (string packageRoot in EnumerateManifestLocalPackageRoots(projectRoot))
             {
-                AddSkillSourceRoot(seenRoots, packageRoot);
+                AddSkillSourceRoot(orderedRoots, seenRoots, packageRoot);
             }
 
             foreach (string packageRoot in EnumerateDependencyPackageCacheRoots(projectRoot))
             {
-                AddSkillSourceRoot(seenRoots, packageRoot);
+                AddSkillSourceRoot(orderedRoots, seenRoots, packageRoot);
             }
 
-            foreach (string root in seenRoots)
+            foreach (string root in orderedRoots)
             {
                 yield return root;
             }
         }
 
-        private static void AddSkillSourceRoot(HashSet<string> roots, string root)
+        private static void AddSkillSourceRoot(
+            List<string> orderedRoots,
+            HashSet<string> seenRoots,
+            string root)
         {
             if (string.IsNullOrEmpty(root))
             {
                 return;
             }
 
-            roots.Add(Path.GetFullPath(root));
+            string normalizedRoot = Path.GetFullPath(root);
+            if (!seenRoots.Add(normalizedRoot))
+            {
+                return;
+            }
+
+            orderedRoots.Add(normalizedRoot);
         }
 
         private static string GetCliOnlySkillSourceRoot(string projectRoot)


### PR DESCRIPTION
## Summary
- Duplicate skill names now resolve using a stable source priority.
- Unity skill discovery now guarantees the same ordered-root structure as the native CLI.

## User Impact
- When the same skill name exists in multiple roots, the earlier configured source consistently wins.
- Assets remain ahead of direct packages, direct packages ahead of manifest-local packages, and manifest-local packages ahead of PackageCache entries.

## Changes
- Store normalized source roots in an ordered list while using a separate ordinal set only for deduplication.
- Added a behavior test covering each adjacent priority boundary available in a temporary project.
- Kept CLI-only root behavior unchanged; its current-project-only gate is not exposed through a test-only seam.

## Verification
- Characterization approach: the priority test passed before the implementation on the current Mono runtime, because its present HashSet behavior happens to preserve insertion order. The change removes reliance on that unspecified API behavior rather than reproducing a deterministic failure.
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` (0 errors, 0 warnings)
- `SkillInstallLayoutTests` (11 passed)
- `ToolSkillSynchronizerTests` (52 passed)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

