### PR TITLE
fix: Local skill packages no longer include stale cached skills

### DIFF
--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -169,6 +169,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(skillSources["uloop-manifest-priority"].ToolName, Is.EqualTo("manifest-winner"));
         }
 
+        // Tests that local manifest dependencies do not also discover stale PackageCache-only skills.
+        [TestCase("file:")]
+        [TestCase("path:")]
+        public void GetSkillSourceInfos_WhenLocalDependencyHasStaleCache_ExcludesCacheOnlySkill(
+            string dependencyPrefix)
+        {
+            string temporaryRoot = CreateTemporaryProjectRoot();
+            string localPackageRoot = CreateTemporaryProjectRoot();
+            string cachePackageRoot = Path.Combine(
+                temporaryRoot,
+                "Library",
+                "PackageCache",
+                "com.example.local@1.0.0");
+            WriteSourceSkill(localPackageRoot, "uloop-local-skill", "local-tool", "LocalTool");
+            WriteSourceSkill(cachePackageRoot, "uloop-stale-cache-skill", "stale-tool", "StaleTool");
+
+            string manifestPath = Path.Combine(temporaryRoot, "Packages", "manifest.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(manifestPath));
+            string portableLocalPackageRoot = localPackageRoot.Replace(Path.DirectorySeparatorChar, '/');
+            File.WriteAllText(
+                manifestPath,
+                $"{{\"dependencies\":{{\"com.example.local\":" +
+                $"\"{dependencyPrefix}{portableLocalPackageRoot}\"}}}}");
+
+            string[] skillNames = SkillInstallLayout.GetSkillSourceInfos(temporaryRoot)
+                .Select(skill => skill.Name)
+                .ToArray();
+
+            Assert.That(skillNames, Does.Contain("uloop-local-skill"));
+            Assert.That(skillNames, Does.Not.Contain("uloop-stale-cache-skill"));
+        }
+
         // Tests that skill discovery follows bundled tools after they move into the first-party plugin assembly.
         [Test]
         public void GetSkillSourceInfos_WhenFirstPartyToolIsUnderFirstPartyTools_IncludesToolSkill()

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
@@ -268,7 +268,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static IEnumerable<string> EnumerateDependencyPackageCacheRoots(string projectRoot)
         {
             HashSet<string> dependencyNames = new(
-                EnumerateManifestDependencies(projectRoot).Select(dependency => dependency.Key),
+                EnumerateManifestDependencies(projectRoot)
+                    .Where(dependency => ResolveLocalDependencyPath(dependency.Value, projectRoot) == null)
+                    .Select(dependency => dependency.Key),
                 StringComparer.OrdinalIgnoreCase);
             if (dependencyNames.Count == 0)
             {

--- a/cli/common/skillscan/packages.go
+++ b/cli/common/skillscan/packages.go
@@ -166,7 +166,10 @@ func enumeratePackageCacheResults(projectRoot string) []PackageSearchResult {
 		return []PackageSearchResult{}
 	}
 	dependencyNames := map[string]bool{}
-	for dependencyName := range dependencies {
+	for dependencyName, dependencyValue := range dependencies {
+		if resolveLocalDependencyPath(dependencyValue, projectRoot) != "" {
+			continue
+		}
 		dependencyNames[strings.ToLower(dependencyName)] = true
 	}
 	packageCacheDir := filepath.Join(projectRoot, "Library", "PackageCache")

--- a/cli/common/skillscan/packages_test.go
+++ b/cli/common/skillscan/packages_test.go
@@ -47,6 +47,40 @@ func TestEnumerateSourceRootsUsesPackageSearchResults(t *testing.T) {
 	}
 }
 
+// Tests that local manifest dependencies exclude stale roots with the same identity from PackageCache.
+func TestEnumeratePackageSearchResultsExcludesStaleCacheForLocalDependencies(t *testing.T) {
+	for _, dependencyPrefix := range []string{"file:", "path:"} {
+		t.Run(dependencyPrefix, func(t *testing.T) {
+			projectRoot := t.TempDir()
+			localPackageRoot := filepath.Join(t.TempDir(), "local-package")
+			if err := os.MkdirAll(localPackageRoot, 0o755); err != nil {
+				t.Fatalf("failed to create local package: %v", err)
+			}
+			staleCacheRoot := filepath.Join(
+				projectRoot,
+				"Library",
+				"PackageCache",
+				"com.example.local@1.0.0")
+			if err := os.MkdirAll(staleCacheRoot, 0o755); err != nil {
+				t.Fatalf("failed to create stale cache package: %v", err)
+			}
+			writeManifest(
+				t,
+				projectRoot,
+				`{"dependencies":{"com.example.local":"`+dependencyPrefix+
+					filepath.ToSlash(localPackageRoot)+`"}}`)
+
+			results := EnumeratePackageSearchResults(projectRoot)
+
+			actual := packageResultSummaries(results)
+			expected := []string{"com.example.local|" + filepath.Clean(localPackageRoot)}
+			if !reflect.DeepEqual(actual, expected) {
+				t.Fatalf("package results mismatch:\nactual:   %#v\nexpected: %#v", actual, expected)
+			}
+		})
+	}
+}
+
 // Tests that package search results expose stable package identities for direct, manifest, and cached roots.
 func TestEnumeratePackageSearchResultsCapturesPackageIdentities(t *testing.T) {
 	projectRoot := t.TempDir()

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d2612511f3e961536ba7a96427b4aff4a6f6a2f3"
+  "sharedInputsHash": "c1b345cfb13b50c52c529f4746a4b481ddbd0615"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d61682d89b48e4595a01f18e08c3b96ed648e12a"
+  "sharedInputsHash": "beb7eb4a81fe05748dd1c11442357fbc06188c5d"
 }


### PR DESCRIPTION
## Summary
- Local `file:` and `path:` skill packages no longer expose stale skills from an old PackageCache copy.
- C# package discovery and the native CLI now apply the same local-dependency filtering contract.

## User Impact
- Previously, a project using a local package dependency could discover skills that existed only in a stale PackageCache directory with the same package identity.
- Discovery now treats the local package root as authoritative and excludes that dependency identity from ordinary PackageCache candidates.

## Changes
- Reused the existing local-dependency resolvers in both C# and Go instead of introducing another `file:`/`path:` parser.
- Added regression coverage for both dependency prefixes in the Unity package and native CLI.
- Refreshed the project-runner and dispatcher shared-input stamps required by the common Go change.
- Kept the Unity CLI Loop-specific cache fallback independent and unchanged. `FindUnityCliLoopPackage` now prefers the true local source when a stale cache exists, while its existing fallback path and tests remain intact.

## Verification
- Confirmed both new C# cases and both new Go subtests failed before the production fix and passed afterward.
- `scripts/check-go-cli.sh`
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` (0 errors, 0 warnings)
- `SkillInstallLayoutTests` (13 passed)
- `ToolSkillSynchronizerTests` (52 passed)
- `git diff --check`

## Compatibility
- The wire format is unchanged, so no protocol version bump is required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

