### PR TITLE
fix: CLI-only skills remain discoverable when project path casing differs

### DIFF
--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -121,6 +121,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(skillSources.Select(skill => skill.Name), Does.Contain("uloop-launch"));
         }
 
+        // Tests that differently cased paths follow each editor platform's path identity policy.
+        [TestCase(UnityEngine.RuntimePlatform.WindowsEditor, true)]
+        [TestCase(UnityEngine.RuntimePlatform.OSXEditor, true)]
+        [TestCase(UnityEngine.RuntimePlatform.LinuxEditor, false)]
+        public void HaveSamePathIdentityAtPlatform_WhenCasingDiffers_UsesPlatformPolicy(
+            UnityEngine.RuntimePlatform platform,
+            bool expected)
+        {
+            string lowerCasePath = Path.Combine(_projectRoot, "case-sensitive-root");
+            string upperCasePath = Path.Combine(_projectRoot, "CASE-SENSITIVE-ROOT");
+
+            bool actual = SkillSourceRootEnumerator.HaveSamePathIdentityAtPlatform(
+                lowerCasePath,
+                upperCasePath,
+                platform);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
         // Tests that Tool Settings can read source skill frontmatter descriptions by tool name.
         [Test]
         public void GetToolDescriptionsByToolName_WhenSkillHasDescription_MapsDescriptionToToolName()

--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -140,6 +140,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        // Tests that an optional trailing directory separator does not change path identity.
+        [TestCase(UnityEngine.RuntimePlatform.WindowsEditor)]
+        [TestCase(UnityEngine.RuntimePlatform.OSXEditor)]
+        [TestCase(UnityEngine.RuntimePlatform.LinuxEditor)]
+        public void HaveSamePathIdentityAtPlatform_WhenTrailingSeparatorDiffers_ReturnsTrue(
+            UnityEngine.RuntimePlatform platform)
+        {
+            string path = Path.Combine(_projectRoot, "skill-source-root");
+            string pathWithTrailingSeparator = path + Path.DirectorySeparatorChar;
+
+            bool actual = SkillSourceRootEnumerator.HaveSamePathIdentityAtPlatform(
+                path,
+                pathWithTrailingSeparator,
+                platform);
+
+            Assert.That(actual, Is.True);
+        }
+
         // Tests that Tool Settings can read source skill frontmatter descriptions by tool name.
         [Test]
         public void GetToolDescriptionsByToolName_WhenSkillHasDescription_MapsDescriptionToToolName()

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
@@ -242,10 +242,17 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string rightPath,
             RuntimePlatform platform)
         {
+            // Windows and macOS editor paths follow their default case-insensitive filesystem behavior.
+            // Probing case sensitivity per volume would add I/O and complexity to this CLI-only source gate.
+            bool usesCaseInsensitivePathIdentity = platform == RuntimePlatform.WindowsEditor
+                || platform == RuntimePlatform.OSXEditor;
+            StringComparison comparison = usesCaseInsensitivePathIdentity
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
             return string.Equals(
                 Path.GetFullPath(leftPath),
                 Path.GetFullPath(rightPath),
-                StringComparison.Ordinal);
+                comparison);
         }
 
         private static IEnumerable<string> EnumerateDirectProjectPackageRoots(string projectRoot)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
@@ -250,9 +250,26 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 ? StringComparison.OrdinalIgnoreCase
                 : StringComparison.Ordinal;
             return string.Equals(
-                Path.GetFullPath(leftPath),
-                Path.GetFullPath(rightPath),
+                NormalizePathForIdentity(leftPath),
+                NormalizePathForIdentity(rightPath),
                 comparison);
+        }
+
+        private static string NormalizePathForIdentity(string path)
+        {
+            string fullPath = Path.GetFullPath(path);
+            string root = Path.GetPathRoot(fullPath);
+            if (!string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.OrdinalIgnoreCase))
+            {
+                // Trimming the only separator from a filesystem root would change its identity.
+                return root;
+            }
+
+            string normalizedPath = fullPath.TrimEnd(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar);
+            Debug.Assert(!string.IsNullOrEmpty(normalizedPath), "normalizedPath must not be empty");
+            return normalizedPath;
         }
 
         private static IEnumerable<string> EnumerateDirectProjectPackageRoots(string projectRoot)

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillSourceRootEnumerator.cs
@@ -215,10 +215,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private static string GetCliOnlySkillSourceRoot(string projectRoot)
         {
             string currentProjectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            if (!string.Equals(
-                Path.GetFullPath(projectRoot),
-                Path.GetFullPath(currentProjectRoot),
-                StringComparison.Ordinal))
+            if (!HaveSamePathIdentityAtPlatform(
+                projectRoot,
+                currentProjectRoot,
+                UnityEngine.Application.platform))
             {
                 return null;
             }
@@ -231,9 +231,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
         private static bool IsCliOnlySkillSourceRoot(string searchRoot)
         {
+            return HaveSamePathIdentityAtPlatform(
+                searchRoot,
+                GetCliOnlySkillSourceRoot(UnityCliLoopPathResolver.GetProjectRoot()),
+                UnityEngine.Application.platform);
+        }
+
+        internal static bool HaveSamePathIdentityAtPlatform(
+            string leftPath,
+            string rightPath,
+            RuntimePlatform platform)
+        {
             return string.Equals(
-                Path.GetFullPath(searchRoot),
-                Path.GetFullPath(GetCliOnlySkillSourceRoot(UnityCliLoopPathResolver.GetProjectRoot())),
+                Path.GetFullPath(leftPath),
+                Path.GetFullPath(rightPath),
                 StringComparison.Ordinal);
         }
 


### PR DESCRIPTION
## Summary
- CLI-only skills remain discoverable when the current project path uses different letter casing on Windows or macOS.
- Linux keeps case-sensitive path identity.

## User Impact
- Previously, the CLI-only source gate compared normalized project paths with an ordinal string comparison. Equivalent project paths with different casing could therefore be rejected on the default case-insensitive Windows and macOS filesystems.
- Discovery now follows the editor platform's path identity policy: case-insensitive on Windows/macOS and ordinal on Linux.

## Changes
- Extracted both CLI-only path comparisons into one helper that receives the runtime platform explicitly.
- Kept the extraction behavior-preserving in its own commit, then applied the platform policy in a second commit.
- Added a deterministic Windows/macOS/Linux contract test.
- Normalize optional trailing directory separators while preserving filesystem roots.
- Kept Go unchanged because its CLI-only source path has no current-project identity gate.
- Avoided per-volume filesystem probing because it would add I/O and complexity to a narrow source-discovery gate.

## Test Scope Note
- A final skill-set integration test cannot observe this gate failure in the repository checkout: when the dedicated CLI-only root is rejected, `Packages/src` is still enumerated later as a direct package root and rediscovers the same `Editor/CliOnlyTools~` files. The attempted integration test passed before the fix and was removed because it did not constrain the faulty comparison.
- The contract test targets the actual path identity seam used by both `GetCliOnlySkillSourceRoot` and `IsCliOnlySkillSourceRoot`.

## Verification
- TDD Red: with the extracted ordinal-only helper, the Windows and macOS cases failed while Linux passed (2 failed, 1 passed).
- TDD Green: all three platform cases passed after applying the policy.
- Review TDD Red/Green: trailing-separator equivalence failed on all three platform cases before normalization and passed afterward.
- Repo-local Unity compile: 0 errors, 0 warnings.
- `SkillInstallLayoutTests`: 19 passed.
- `ToolSkillSynchronizerTests`: 52 passed.
- `git diff --check`.

## Review Response
- Accepted cubic's trailing-separator finding after confirming in the active Unity runtime that `Path.GetFullPath` preserves the separator. The fix uses root-safe normalization rather than a plain `TrimEnd` that could collapse `/` or a drive root.

## Compatibility
- Source discovery ordering and wire formats are unchanged, so no protocol version bump is required.
