### PR TITLE
chore: Isolate skill file normalization from layout handling

### DIFF
--- a/Assets/Tests/Editor/SkillFileContentNormalizerTests.cs
+++ b/Assets/Tests/Editor/SkillFileContentNormalizerTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using System.Text;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies deterministic line-ending normalization for generated skill files.
+    /// </summary>
+    [TestFixture]
+    public class SkillFileContentNormalizerTests
+    {
+        // Tests that CRLF and lone CR line endings become LF in single-byte text files.
+        [Test]
+        public void NormalizeSkillFileContent_WhenSingleByteTextUsesCarriageReturns_ReturnsLfContent()
+        {
+            byte[] sourceBytes = Encoding.UTF8.GetBytes("line1\r\nline2\rline3\n");
+            byte[] expectedBytes = Encoding.UTF8.GetBytes("line1\nline2\nline3\n");
+
+            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("reference.md", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
+        }
+
+        // Tests that UTF-16 little-endian text keeps its BOM and encoding while line endings become LF.
+        [Test]
+        public void NormalizeSkillFileContent_WhenUtf16LittleEndianTextUsesCrlf_PreservesEncoding()
+        {
+            byte[] sourceBytes = Encoding.Unicode.GetPreamble()
+                .Concat(Encoding.Unicode.GetBytes("line1\r\nline2\r\n"))
+                .ToArray();
+            byte[] expectedBytes = Encoding.Unicode.GetPreamble()
+                .Concat(Encoding.Unicode.GetBytes("line1\nline2\n"))
+                .ToArray();
+
+            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("install.ps1", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
+        }
+
+        // Tests that UTF-16 big-endian text keeps its BOM and encoding while line endings become LF.
+        [Test]
+        public void NormalizeSkillFileContent_WhenUtf16BigEndianTextUsesCrlf_PreservesEncoding()
+        {
+            byte[] sourceBytes = Encoding.BigEndianUnicode.GetPreamble()
+                .Concat(Encoding.BigEndianUnicode.GetBytes("line1\r\nline2\r\n"))
+                .ToArray();
+            byte[] expectedBytes = Encoding.BigEndianUnicode.GetPreamble()
+                .Concat(Encoding.BigEndianUnicode.GetBytes("line1\nline2\n"))
+                .ToArray();
+
+            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("install.ps1", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
+        }
+
+        // Tests that files outside the text extension allowlist keep their original bytes.
+        [Test]
+        public void NormalizeSkillFileContent_WhenExtensionIsNotText_ReturnsOriginalContent()
+        {
+            byte[] sourceBytes = Encoding.UTF8.GetBytes("line1\r\nline2\r\n");
+
+            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("image.png", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(sourceBytes));
+        }
+
+        // Tests that NUL-containing binary data is not rewritten even when its extension is textual.
+        [Test]
+        public void NormalizeSkillFileContent_WhenTextExtensionContainsBinaryData_ReturnsOriginalContent()
+        {
+            byte[] sourceBytes = { 0x41, 0x42, 0x00, 0x43, 0x0D, 0x44 };
+
+            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("reference.md", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(sourceBytes));
+        }
+
+        // Tests that LF-only text content remains byte-identical.
+        [Test]
+        public void NormalizeSkillFileContent_WhenTextAlreadyUsesLf_ReturnsOriginalContent()
+        {
+            byte[] sourceBytes = Encoding.UTF8.GetBytes("line1\nline2\n");
+
+            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("reference.md", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(sourceBytes));
+        }
+    }
+}

--- a/Assets/Tests/Editor/SkillFileContentNormalizerTests.cs
+++ b/Assets/Tests/Editor/SkillFileContentNormalizerTests.cs
@@ -20,7 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             byte[] sourceBytes = Encoding.UTF8.GetBytes("line1\r\nline2\rline3\n");
             byte[] expectedBytes = Encoding.UTF8.GetBytes("line1\nline2\nline3\n");
 
-            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("reference.md", sourceBytes);
+            byte[] actualBytes = SkillFileContentNormalizer.NormalizeSkillFileContent("reference.md", sourceBytes);
 
             Assert.That(actualBytes, Is.EqualTo(expectedBytes));
         }
@@ -36,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 .Concat(Encoding.Unicode.GetBytes("line1\nline2\n"))
                 .ToArray();
 
-            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("install.ps1", sourceBytes);
+            byte[] actualBytes = SkillFileContentNormalizer.NormalizeSkillFileContent("install.ps1", sourceBytes);
 
             Assert.That(actualBytes, Is.EqualTo(expectedBytes));
         }
@@ -52,7 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 .Concat(Encoding.BigEndianUnicode.GetBytes("line1\nline2\n"))
                 .ToArray();
 
-            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("install.ps1", sourceBytes);
+            byte[] actualBytes = SkillFileContentNormalizer.NormalizeSkillFileContent("install.ps1", sourceBytes);
 
             Assert.That(actualBytes, Is.EqualTo(expectedBytes));
         }
@@ -63,7 +63,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             byte[] sourceBytes = Encoding.UTF8.GetBytes("line1\r\nline2\r\n");
 
-            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("image.png", sourceBytes);
+            byte[] actualBytes = SkillFileContentNormalizer.NormalizeSkillFileContent("image.png", sourceBytes);
 
             Assert.That(actualBytes, Is.EqualTo(sourceBytes));
         }
@@ -74,7 +74,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             byte[] sourceBytes = { 0x41, 0x42, 0x00, 0x43, 0x0D, 0x44 };
 
-            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("reference.md", sourceBytes);
+            byte[] actualBytes = SkillFileContentNormalizer.NormalizeSkillFileContent("reference.md", sourceBytes);
 
             Assert.That(actualBytes, Is.EqualTo(sourceBytes));
         }
@@ -85,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             byte[] sourceBytes = Encoding.UTF8.GetBytes("line1\nline2\n");
 
-            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("reference.md", sourceBytes);
+            byte[] actualBytes = SkillFileContentNormalizer.NormalizeSkillFileContent("reference.md", sourceBytes);
 
             Assert.That(actualBytes, Is.EqualTo(sourceBytes));
         }

--- a/Assets/Tests/Editor/SkillFileContentNormalizerTests.cs.meta
+++ b/Assets/Tests/Editor/SkillFileContentNormalizerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b97a05adf16244c2a0afe54f8d558bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -386,22 +385,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(catalogNames, Does.Contain("public-tool"));
             Assert.That(registeredToolNames, Does.Not.Contain("internal-tool"));
             Assert.That(registeredToolNames, Does.Contain("public-tool"));
-        }
-
-        // Tests that PowerShell scripts keep their source encoding while line endings are normalized.
-        [Test]
-        public void NormalizeSkillFileContent_WhenPowerShellScriptUsesUtf16LittleEndian_PreservesEncoding()
-        {
-            byte[] sourceBytes = Encoding.Unicode.GetPreamble()
-                .Concat(Encoding.Unicode.GetBytes("line1\r\nline2\r\n"))
-                .ToArray();
-            byte[] expectedBytes = Encoding.Unicode.GetPreamble()
-                .Concat(Encoding.Unicode.GetBytes("line1\nline2\n"))
-                .ToArray();
-
-            byte[] actualBytes = SkillInstallLayout.NormalizeSkillFileContent("install.ps1", sourceBytes);
-
-            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
         }
 
         // Tests that skill setup file scans share the same generated-file exclusion behavior.

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillFileContentNormalizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillFileContentNormalizer.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Normalizes line endings in generated text skill files without changing their encoding.
+    /// </summary>
+    internal static class SkillFileContentNormalizer
+    {
+        private const byte Utf16LittleEndianBomFirstByte = 0xFF;
+        private const byte Utf16LittleEndianBomSecondByte = 0xFE;
+        private const byte Utf16BigEndianBomFirstByte = 0xFE;
+        private const byte Utf16BigEndianBomSecondByte = 0xFF;
+        private const int Utf16CodeUnitByteCount = 2;
+        private const ushort CarriageReturnCodeUnit = 0x000D;
+        private const ushort LineFeedCodeUnit = 0x000A;
+        private static readonly HashSet<string> TextSkillFileExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".json",
+            ".md",
+            ".ps1",
+            ".sh",
+            ".txt",
+            ".yaml",
+            ".yml"
+        };
+
+        internal static byte[] NormalizeSkillFileContent(string relativePath, byte[] content)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(relativePath), "relativePath must not be null or empty");
+            Debug.Assert(content != null, "content must not be null");
+
+            if (!ShouldNormalizeLineEndings(relativePath) || Array.IndexOf(content, (byte)'\r') < 0)
+            {
+                return content;
+            }
+
+            if (HasUtf16LittleEndianBom(content) || HasUtf16LittleEndianLineEnding(content))
+            {
+                return NormalizeUtf16LineEndings(content, isLittleEndian: true);
+            }
+
+            if (HasUtf16BigEndianBom(content) || HasUtf16BigEndianLineEnding(content))
+            {
+                return NormalizeUtf16LineEndings(content, isLittleEndian: false);
+            }
+
+            if (Array.IndexOf(content, (byte)0) >= 0)
+            {
+                return content;
+            }
+
+            return NormalizeSingleByteLineEndings(content);
+        }
+
+        private static bool ShouldNormalizeLineEndings(string relativePath)
+        {
+            string extension = Path.GetExtension(relativePath);
+            return TextSkillFileExtensions.Contains(extension);
+        }
+
+        private static byte[] NormalizeSingleByteLineEndings(byte[] content)
+        {
+            List<byte> normalized = new(content.Length);
+            for (int index = 0; index < content.Length; index++)
+            {
+                byte current = content[index];
+                if (current != (byte)'\r')
+                {
+                    normalized.Add(current);
+                    continue;
+                }
+
+                normalized.Add((byte)'\n');
+                if (index + 1 < content.Length && content[index + 1] == (byte)'\n')
+                {
+                    index++;
+                }
+            }
+
+            return normalized.ToArray();
+        }
+
+        private static byte[] NormalizeUtf16LineEndings(byte[] content, bool isLittleEndian)
+        {
+            List<byte> normalized = new(content.Length);
+            int index = 0;
+            if (HasMatchingUtf16Bom(content, isLittleEndian))
+            {
+                normalized.Add(content[0]);
+                normalized.Add(content[1]);
+                index = Utf16CodeUnitByteCount;
+            }
+
+            while (index + 1 < content.Length)
+            {
+                ushort codeUnit = ReadUtf16CodeUnit(content, index, isLittleEndian);
+                if (codeUnit == CarriageReturnCodeUnit)
+                {
+                    WriteUtf16CodeUnit(normalized, LineFeedCodeUnit, isLittleEndian);
+                    int nextIndex = index + Utf16CodeUnitByteCount;
+                    if (nextIndex + 1 < content.Length &&
+                        ReadUtf16CodeUnit(content, nextIndex, isLittleEndian) == LineFeedCodeUnit)
+                    {
+                        index += Utf16CodeUnitByteCount * 2;
+                        continue;
+                    }
+
+                    index += Utf16CodeUnitByteCount;
+                    continue;
+                }
+
+                WriteUtf16CodeUnit(normalized, codeUnit, isLittleEndian);
+                index += Utf16CodeUnitByteCount;
+            }
+
+            if (index < content.Length)
+            {
+                normalized.Add(content[index]);
+            }
+
+            return normalized.ToArray();
+        }
+
+        private static bool HasUtf16LittleEndianBom(byte[] content)
+        {
+            return content.Length >= Utf16CodeUnitByteCount &&
+                   content[0] == Utf16LittleEndianBomFirstByte &&
+                   content[1] == Utf16LittleEndianBomSecondByte;
+        }
+
+        private static bool HasUtf16BigEndianBom(byte[] content)
+        {
+            return content.Length >= Utf16CodeUnitByteCount &&
+                   content[0] == Utf16BigEndianBomFirstByte &&
+                   content[1] == Utf16BigEndianBomSecondByte;
+        }
+
+        private static bool HasMatchingUtf16Bom(byte[] content, bool isLittleEndian)
+        {
+            return isLittleEndian ? HasUtf16LittleEndianBom(content) : HasUtf16BigEndianBom(content);
+        }
+
+        private static bool HasUtf16LittleEndianLineEnding(byte[] content)
+        {
+            return HasUtf16LineEnding(content, isLittleEndian: true);
+        }
+
+        private static bool HasUtf16BigEndianLineEnding(byte[] content)
+        {
+            return HasUtf16LineEnding(content, isLittleEndian: false);
+        }
+
+        private static bool HasUtf16LineEnding(byte[] content, bool isLittleEndian)
+        {
+            int startIndex = HasMatchingUtf16Bom(content, isLittleEndian) ? Utf16CodeUnitByteCount : 0;
+            for (int index = startIndex; index + 1 < content.Length; index += Utf16CodeUnitByteCount)
+            {
+                ushort codeUnit = ReadUtf16CodeUnit(content, index, isLittleEndian);
+                if (codeUnit == CarriageReturnCodeUnit || codeUnit == LineFeedCodeUnit)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static ushort ReadUtf16CodeUnit(byte[] content, int index, bool isLittleEndian)
+        {
+            return isLittleEndian
+                ? (ushort)(content[index] | (content[index + 1] << 8))
+                : (ushort)((content[index] << 8) | content[index + 1]);
+        }
+
+        private static void WriteUtf16CodeUnit(List<byte> output, ushort codeUnit, bool isLittleEndian)
+        {
+            if (isLittleEndian)
+            {
+                output.Add((byte)(codeUnit & 0xFF));
+                output.Add((byte)(codeUnit >> 8));
+                return;
+            }
+
+            output.Add((byte)(codeUnit >> 8));
+            output.Add((byte)(codeUnit & 0xFF));
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillFileContentNormalizer.cs.meta
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillFileContentNormalizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c53e19fa3b9b4148821c8c9b91197df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillInstallLayout.cs
@@ -18,23 +18,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         internal const string SkillsDirName = "skills";
         internal const string ManagedSkillsDirName = "unity-cli-loop";
         internal const string SkillFileName = "SKILL.md";
-        private const byte Utf16LittleEndianBomFirstByte = 0xFF;
-        private const byte Utf16LittleEndianBomSecondByte = 0xFE;
-        private const byte Utf16BigEndianBomFirstByte = 0xFE;
-        private const byte Utf16BigEndianBomSecondByte = 0xFF;
-        private const int Utf16CodeUnitByteCount = 2;
-        private const ushort CarriageReturnCodeUnit = 0x000D;
-        private const ushort LineFeedCodeUnit = 0x000A;
-        private static readonly HashSet<string> TextSkillFileExtensions = new(StringComparer.OrdinalIgnoreCase)
-        {
-            ".json",
-            ".md",
-            ".ps1",
-            ".sh",
-            ".txt",
-            ".yaml",
-            ".yml"
-        };
 
         internal readonly struct SkillSourceInfo
         {
@@ -353,7 +336,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 }
 
                 string relativePath = Path.GetRelativePath(skillDirectory, filePath);
-                files[relativePath] = NormalizeSkillFileContent(relativePath, File.ReadAllBytes(filePath));
+                files[relativePath] = SkillFileContentNormalizer.NormalizeSkillFileContent(
+                    relativePath,
+                    File.ReadAllBytes(filePath));
             }
 
             return files;
@@ -373,169 +358,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             return new Dictionary<string, byte[]>(StringComparer.Ordinal)
             {
-                [SkillFileName] = NormalizeSkillFileContent(SkillFileName, File.ReadAllBytes(skillFilePath))
+                [SkillFileName] = SkillFileContentNormalizer.NormalizeSkillFileContent(
+                    SkillFileName,
+                    File.ReadAllBytes(skillFilePath))
             };
-        }
-
-        internal static byte[] NormalizeSkillFileContent(string relativePath, byte[] content)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(relativePath), "relativePath must not be null or empty");
-            Debug.Assert(content != null, "content must not be null");
-
-            if (!ShouldNormalizeLineEndings(relativePath) || Array.IndexOf(content, (byte)'\r') < 0)
-            {
-                return content;
-            }
-
-            if (HasUtf16LittleEndianBom(content) || HasUtf16LittleEndianLineEnding(content))
-            {
-                return NormalizeUtf16LineEndings(content, isLittleEndian: true);
-            }
-
-            if (HasUtf16BigEndianBom(content) || HasUtf16BigEndianLineEnding(content))
-            {
-                return NormalizeUtf16LineEndings(content, isLittleEndian: false);
-            }
-
-            if (Array.IndexOf(content, (byte)0) >= 0)
-            {
-                return content;
-            }
-
-            return NormalizeSingleByteLineEndings(content);
-        }
-
-        private static bool ShouldNormalizeLineEndings(string relativePath)
-        {
-            string extension = Path.GetExtension(relativePath);
-            return TextSkillFileExtensions.Contains(extension);
-        }
-
-        private static byte[] NormalizeSingleByteLineEndings(byte[] content)
-        {
-            List<byte> normalized = new(content.Length);
-            for (int index = 0; index < content.Length; index++)
-            {
-                byte current = content[index];
-                if (current != (byte)'\r')
-                {
-                    normalized.Add(current);
-                    continue;
-                }
-
-                normalized.Add((byte)'\n');
-                if (index + 1 < content.Length && content[index + 1] == (byte)'\n')
-                {
-                    index++;
-                }
-            }
-
-            return normalized.ToArray();
-        }
-
-        private static byte[] NormalizeUtf16LineEndings(byte[] content, bool isLittleEndian)
-        {
-            List<byte> normalized = new(content.Length);
-            int index = 0;
-            if (HasMatchingUtf16Bom(content, isLittleEndian))
-            {
-                normalized.Add(content[0]);
-                normalized.Add(content[1]);
-                index = Utf16CodeUnitByteCount;
-            }
-
-            while (index + 1 < content.Length)
-            {
-                ushort codeUnit = ReadUtf16CodeUnit(content, index, isLittleEndian);
-                if (codeUnit == CarriageReturnCodeUnit)
-                {
-                    WriteUtf16CodeUnit(normalized, LineFeedCodeUnit, isLittleEndian);
-                    int nextIndex = index + Utf16CodeUnitByteCount;
-                    if (nextIndex + 1 < content.Length &&
-                        ReadUtf16CodeUnit(content, nextIndex, isLittleEndian) == LineFeedCodeUnit)
-                    {
-                        index += Utf16CodeUnitByteCount * 2;
-                        continue;
-                    }
-
-                    index += Utf16CodeUnitByteCount;
-                    continue;
-                }
-
-                WriteUtf16CodeUnit(normalized, codeUnit, isLittleEndian);
-                index += Utf16CodeUnitByteCount;
-            }
-
-            if (index < content.Length)
-            {
-                normalized.Add(content[index]);
-            }
-
-            return normalized.ToArray();
-        }
-
-        private static bool HasUtf16LittleEndianBom(byte[] content)
-        {
-            return content.Length >= Utf16CodeUnitByteCount &&
-                   content[0] == Utf16LittleEndianBomFirstByte &&
-                   content[1] == Utf16LittleEndianBomSecondByte;
-        }
-
-        private static bool HasUtf16BigEndianBom(byte[] content)
-        {
-            return content.Length >= Utf16CodeUnitByteCount &&
-                   content[0] == Utf16BigEndianBomFirstByte &&
-                   content[1] == Utf16BigEndianBomSecondByte;
-        }
-
-        private static bool HasMatchingUtf16Bom(byte[] content, bool isLittleEndian)
-        {
-            return isLittleEndian ? HasUtf16LittleEndianBom(content) : HasUtf16BigEndianBom(content);
-        }
-
-        private static bool HasUtf16LittleEndianLineEnding(byte[] content)
-        {
-            return HasUtf16LineEnding(content, isLittleEndian: true);
-        }
-
-        private static bool HasUtf16BigEndianLineEnding(byte[] content)
-        {
-            return HasUtf16LineEnding(content, isLittleEndian: false);
-        }
-
-        private static bool HasUtf16LineEnding(byte[] content, bool isLittleEndian)
-        {
-            int startIndex = HasMatchingUtf16Bom(content, isLittleEndian) ? Utf16CodeUnitByteCount : 0;
-            for (int index = startIndex; index + 1 < content.Length; index += Utf16CodeUnitByteCount)
-            {
-                ushort codeUnit = ReadUtf16CodeUnit(content, index, isLittleEndian);
-                if (codeUnit == CarriageReturnCodeUnit || codeUnit == LineFeedCodeUnit)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static ushort ReadUtf16CodeUnit(byte[] content, int index, bool isLittleEndian)
-        {
-            return isLittleEndian
-                ? (ushort)(content[index] | (content[index + 1] << 8))
-                : (ushort)((content[index] << 8) | content[index + 1]);
-        }
-
-        private static void WriteUtf16CodeUnit(List<byte> output, ushort codeUnit, bool isLittleEndian)
-        {
-            if (isLittleEndian)
-            {
-                output.Add((byte)(codeUnit & 0xFF));
-                output.Add((byte)(codeUnit >> 8));
-                return;
-            }
-
-            output.Add((byte)(codeUnit >> 8));
-            output.Add((byte)(codeUnit & 0xFF));
         }
 
         internal static bool IsSafeSkillPathComponent(string skillName)


### PR DESCRIPTION
## Summary
- Skill file line-ending and encoding normalization now has a focused owner instead of living inside layout detection.
- Existing generated skill content remains byte-compatible.

## User Impact
- There is no intended behavior change. Generated skill copies continue to normalize supported text files to LF while preserving UTF-16 endianness, BOMs, non-text files, and binary content.
- The smaller layout class makes future skill setup maintenance easier to review without mixing byte-encoding logic into directory layout rules.

## Changes
- Added focused characterization coverage before moving production code.
- Extracted the text extension allowlist, UTF-16 detection, and byte-level normalization helpers into `SkillFileContentNormalizer` without changing their logic or names.
- Updated both production callers and the focused test fixture to reference the extracted class directly.
- Removed the old entry point from `SkillInstallLayout` instead of leaving a compatibility wrapper.
- Reduced `SkillInstallLayout` from 571 lines to 397 lines.

## Verification
- Characterization tests were Green before and after extraction.
- Repo-local Unity compile: 0 errors, 0 warnings.
- `SkillFileContentNormalizerTests`: 6 passed.
- `SkillInstallLayoutTests`: 18 passed.
- `ToolSkillSynchronizerTests`: 52 passed.
- `git diff --check`.

## Compatibility
- Source discovery behavior, generated byte content, and wire formats are unchanged, so no protocol version bump is required.

## Deferred Review Finding
- cubic identified a pre-existing UTF-16BE ambiguity where the little-endian line-ending heuristic runs before the explicit BE BOM check. The same ordering existed before this move-only extraction, so it is recorded as R2-28 for a separate Red-first bug-fix PR rather than mixing behavior changes into this refactor.
