### PR TITLE
fix: UTF-16BE skill files keep their byte order during setup

### DIFF
--- a/Assets/Tests/Editor/SkillFileContentNormalizerTests.cs
+++ b/Assets/Tests/Editor/SkillFileContentNormalizerTests.cs
@@ -57,6 +57,46 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(actualBytes, Is.EqualTo(expectedBytes));
         }
 
+        // Tests that an explicit big-endian BOM wins over byte patterns that resemble little-endian CR.
+        [Test]
+        public void NormalizeSkillFileContent_WhenUtf16BigEndianBomContainsAmbiguousCodeUnit_PreservesEncoding()
+        {
+            byte[] sourceBytes = Encoding.BigEndianUnicode.GetPreamble()
+                .Concat(Encoding.BigEndianUnicode.GetBytes("\u0D00\r\nline"))
+                .ToArray();
+            byte[] expectedBytes = Encoding.BigEndianUnicode.GetPreamble()
+                .Concat(Encoding.BigEndianUnicode.GetBytes("\u0D00\nline"))
+                .ToArray();
+
+            byte[] actualBytes = SkillFileContentNormalizer.NormalizeSkillFileContent("reference.md", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
+        }
+
+        // Tests that BOM-less UTF-16 little-endian text still uses line-ending heuristics.
+        [Test]
+        public void NormalizeSkillFileContent_WhenUtf16LittleEndianHasNoBom_NormalizesCrlf()
+        {
+            byte[] sourceBytes = Encoding.Unicode.GetBytes("line1\r\nline2\r\n");
+            byte[] expectedBytes = Encoding.Unicode.GetBytes("line1\nline2\n");
+
+            byte[] actualBytes = SkillFileContentNormalizer.NormalizeSkillFileContent("reference.md", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
+        }
+
+        // Tests that BOM-less UTF-16 big-endian text still uses line-ending heuristics.
+        [Test]
+        public void NormalizeSkillFileContent_WhenUtf16BigEndianHasNoBom_NormalizesCrlf()
+        {
+            byte[] sourceBytes = Encoding.BigEndianUnicode.GetBytes("line1\r\nline2\r\n");
+            byte[] expectedBytes = Encoding.BigEndianUnicode.GetBytes("line1\nline2\n");
+
+            byte[] actualBytes = SkillFileContentNormalizer.NormalizeSkillFileContent("reference.md", sourceBytes);
+
+            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
+        }
+
         // Tests that files outside the text extension allowlist keep their original bytes.
         [Test]
         public void NormalizeSkillFileContent_WhenExtensionIsNotText_ReturnsOriginalContent()

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillFileContentNormalizer.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillFileContentNormalizer.cs
@@ -39,12 +39,22 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return content;
             }
 
-            if (HasUtf16LittleEndianBom(content) || HasUtf16LittleEndianLineEnding(content))
+            if (HasUtf16LittleEndianBom(content))
             {
                 return NormalizeUtf16LineEndings(content, isLittleEndian: true);
             }
 
-            if (HasUtf16BigEndianBom(content) || HasUtf16BigEndianLineEnding(content))
+            if (HasUtf16BigEndianBom(content))
+            {
+                return NormalizeUtf16LineEndings(content, isLittleEndian: false);
+            }
+
+            if (HasUtf16LittleEndianLineEnding(content))
+            {
+                return NormalizeUtf16LineEndings(content, isLittleEndian: true);
+            }
+
+            if (HasUtf16BigEndianLineEnding(content))
             {
                 return NormalizeUtf16LineEndings(content, isLittleEndian: false);
             }


### PR DESCRIPTION
## Summary
- UTF-16 big-endian skill files now keep their byte order when valid content resembles a little-endian carriage return.
- BOM-less UTF-16 line-ending detection remains unchanged.

## User Impact
- Previously, a UTF-16BE text skill file with an explicit BOM could be routed through the little-endian heuristic when its payload contained bytes such as `0D 00`. Setup could then rewrite valid content using the wrong byte order.
- Explicit UTF-16 BOMs are now authoritative, so generated skill copies preserve their declared encoding while still normalizing CRLF to LF.

## Root Cause
- The little-endian BOM and line-ending heuristic were combined in the first branch. A BE BOM did not match the LE BOM check, but the LE heuristic still scanned the BE payload before the explicit BE BOM branch ran.

## Changes
- Evaluate explicit little-endian and big-endian BOMs before either BOM-less line-ending heuristic.
- Keep the existing LE-then-BE heuristic order for content without a BOM.
- Add a regression test containing UTF-16BE `U+0D00` followed by CRLF.
- Add BOM-less LE and BE characterization tests to protect the existing heuristic paths.

## Verification
- TDD Red: the new ambiguous UTF-16BE case failed while the other 8 normalizer tests passed.
- TDD Green: `SkillFileContentNormalizerTests` 9 passed.
- Repo-local Unity compile: 0 errors, 0 warnings.
- `SkillInstallLayoutTests`: 18 passed.
- `ToolSkillSynchronizerTests`: 52 passed.
- `git diff --check`.

## Compatibility
- Only local skill file byte normalization changes. Wire formats and protocol declarations are unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

