### PR TITLE
chore: Simplify native CLI installer command construction

### DIFF
--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -23,7 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnMacKeepsDispatcherCurlInstallerAvailable()
         {
             // Verifies that editor installs use the dispatcher installer script, not npm.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
+            NativeCliInstallCommand command = NativeCliCommandBuilder.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 TestBetaCliVersion,
                 false,
@@ -44,7 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnMacDelegatesPosixSnippetThroughSh()
         {
             // Verifies that fish or other login shells only load environment before POSIX script execution.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
+            NativeCliInstallCommand command = NativeCliCommandBuilder.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 TestBetaCliVersion,
                 false,
@@ -61,7 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnMacPropagatesInstallerDownloadFailure()
         {
             // Verifies that editor installs do not report success when curl fails before script execution.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
+            NativeCliInstallCommand command = NativeCliCommandBuilder.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 TestBetaCliVersion,
                 false,
@@ -77,7 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnWindowsKeepsDispatcherPowerShellInstallerAvailable()
         {
             // Verifies that editor installs use the dispatcher PowerShell installer script.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
+            NativeCliInstallCommand command = NativeCliCommandBuilder.BuildRemoteInstallCommand(
                 RuntimePlatform.WindowsEditor,
                 TestBetaCliVersion,
                 false,
@@ -95,7 +95,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnMacDispatcherInstallerDoesNotAdvertiseWindowsLegacyCleanup()
         {
             // Verifies that macOS manual commands do not expose old cleanup flags.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
+            NativeCliInstallCommand command = NativeCliCommandBuilder.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 TestBetaCliVersion,
                 true,
@@ -109,7 +109,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_OnWindowsDoesNotNeedLegacyCleanupFlag()
         {
             // Verifies that Windows installs rely on the native CLI install command for legacy cleanup.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
+            NativeCliInstallCommand command = NativeCliCommandBuilder.BuildRemoteInstallCommand(
                 RuntimePlatform.WindowsEditor,
                 TestBetaCliVersion,
                 true,
@@ -123,7 +123,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void GetInstallCommand_WhenVPrefixedVersionUsesDispatcherReleaseTag()
         {
             // Verifies root release tags are normalized to dispatcher releases for installer scripts.
-            NativeCliInstallCommand command = NativeCliInstaller.BuildRemoteInstallCommand(
+            NativeCliInstallCommand command = NativeCliCommandBuilder.BuildRemoteInstallCommand(
                 RuntimePlatform.OSXEditor,
                 "v3.0.0",
                 false,
@@ -156,7 +156,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             try
             {
-                NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommandWithPackagePath(
+                NativeCliInstallCommand command = NativeCliCommandBuilder.BuildInstallCommandWithPackagePath(
                     RuntimePlatform.OSXEditor,
                     TestBetaCliVersion,
                     false,
@@ -202,7 +202,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             try
             {
-                NativeCliInstallCommand command = NativeCliInstaller.BuildInstallCommandWithPackagePath(
+                NativeCliInstallCommand command = NativeCliCommandBuilder.BuildInstallCommandWithPackagePath(
                     RuntimePlatform.WindowsEditor,
                     TestBetaCliVersion,
                     false,
@@ -228,7 +228,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void BuildInstallerScriptUrl_WhenBetaVersionUsesReleaseInstallerScript()
         {
             // Verifies that beta editor installs use the script shipped with the selected dispatcher release.
-            string url = NativeCliInstaller.BuildInstallerScriptUrl(
+            string url = NativeCliCommandBuilder.BuildInstallerScriptUrl(
                 TestBetaReleaseTag,
                 CliConstants.POSIX_INSTALL_SCRIPT_NAME);
 
@@ -239,7 +239,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void BuildInstallerScriptUrl_WhenStableVersionUsesReleaseInstallerScript()
         {
             // Verifies that stable editor installs use the script shipped with the selected dispatcher release.
-            string url = NativeCliInstaller.BuildInstallerScriptUrl(
+            string url = NativeCliCommandBuilder.BuildInstallerScriptUrl(
                 TestStableReleaseTag,
                 CliConstants.WINDOWS_INSTALL_SCRIPT_NAME);
 

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -70,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new[] { "TryCompileAsync" }
             },
             {
-                "Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs",
+                "Packages/src/Editor/Infrastructure/CLI/NativeCliCommandBuilder.cs",
                 new[] { "BuildRemoteInstallCommand", "BuildInstallCommandWithPackagePath" }
             },
             {

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliCommandBuilder.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliCommandBuilder.cs
@@ -1,0 +1,189 @@
+using System;
+using System.IO;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Builds native CLI installer commands from platform and package inputs.
+    /// </summary>
+    internal static class NativeCliCommandBuilder
+    {
+        internal static NativeCliInstallCommand BuildRemoteInstallCommand(
+            RuntimePlatform platform,
+            string cliReleaseTag,
+            bool removeLegacyLaunchers,
+            string posixShellPath)
+        {
+            return BuildInstallCommandWithPackagePath(
+                platform,
+                cliReleaseTag,
+                removeLegacyLaunchers,
+                posixShellPath,
+                null);
+        }
+
+        internal static NativeCliInstallCommand BuildInstallCommandWithPackagePath(
+            RuntimePlatform platform,
+            string cliReleaseTag,
+            bool removeLegacyLaunchers,
+            string posixShellPath,
+            string packageResolvedPath)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(cliReleaseTag), "cliReleaseTag must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(posixShellPath), "posixShellPath must not be null or empty");
+            _ = removeLegacyLaunchers;
+
+            string releaseTag = BuildReleaseTag(cliReleaseTag);
+            if (platform == RuntimePlatform.WindowsEditor)
+            {
+                string localScriptPath = ResolvePackageLocalInstallerScriptPath(
+                    packageResolvedPath,
+                    CliConstants.WINDOWS_INSTALL_SCRIPT_NAME);
+                string command = string.IsNullOrEmpty(localScriptPath)
+                    ? BuildWindowsRemoteInstallScriptCommand(
+                        BuildInstallerScriptUrl(releaseTag, CliConstants.WINDOWS_INSTALL_SCRIPT_NAME),
+                        releaseTag)
+                    : BuildWindowsLocalInstallScriptCommand(localScriptPath, releaseTag);
+                return new NativeCliInstallCommand(
+                    "powershell",
+                    $"-NoProfile -ExecutionPolicy Bypass -Command \"{command}\"",
+                    command);
+            }
+
+            string posixLocalScriptPath = ResolvePackageLocalInstallerScriptPath(
+                packageResolvedPath,
+                CliConstants.POSIX_INSTALL_SCRIPT_NAME);
+            string posixCommand = string.IsNullOrEmpty(posixLocalScriptPath)
+                ? BuildPosixRemoteInstallScriptCommand(
+                    BuildInstallerScriptUrl(releaseTag, CliConstants.POSIX_INSTALL_SCRIPT_NAME),
+                    releaseTag)
+                : BuildPosixLocalInstallScriptCommand(posixLocalScriptPath, releaseTag);
+            string loginShellCommand = BuildLoginShellPosixInstallScriptCommand(posixCommand);
+            return new NativeCliInstallCommand(
+                posixShellPath,
+                $"-l -i -c {QuoteProcessArgument(loginShellCommand)}",
+                loginShellCommand);
+        }
+
+        private static string BuildPosixRemoteInstallScriptCommand(string scriptUrl, string releaseTag)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(scriptUrl), "scriptUrl must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
+
+            return "tmp_script=$(mktemp) && "
+                + "trap 'rm -f \"$tmp_script\"' EXIT && "
+                + $"curl -fsSL {QuotePosixShellValue(scriptUrl)} -o \"$tmp_script\" && "
+                + $"{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePosixShellValue(releaseTag)} sh \"$tmp_script\"";
+        }
+
+        private static string BuildPosixLocalInstallScriptCommand(string scriptPath, string releaseTag)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(scriptPath), "scriptPath must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
+
+            return $"{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePosixShellValue(releaseTag)} sh {QuotePosixShellValue(scriptPath)}";
+        }
+
+        internal static string BuildLoginShellPosixInstallScriptCommand(string posixCommand)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(posixCommand), "posixCommand must not be null or empty");
+            return $"{CliConstants.POSIX_SHELL_EXECUTABLE_PATH} -c {QuotePosixShellValue(posixCommand)}";
+        }
+
+        private static string BuildWindowsRemoteInstallScriptCommand(string scriptUrl, string releaseTag)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(scriptUrl), "scriptUrl must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
+
+            return $"$env:{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePowerShellSingleQuotedValue(releaseTag)}; "
+                + $"irm {QuotePowerShellSingleQuotedValue(scriptUrl)} | iex";
+        }
+
+        private static string BuildWindowsLocalInstallScriptCommand(string scriptPath, string releaseTag)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(scriptPath), "scriptPath must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
+
+            return $"$env:{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePowerShellSingleQuotedValue(releaseTag)}; "
+                + $"& {QuotePowerShellSingleQuotedValue(scriptPath)}";
+        }
+
+        internal static string ResolvePackageLocalInstallerScriptPath(string packageResolvedPath, string assetName)
+        {
+            if (string.IsNullOrWhiteSpace(packageResolvedPath) || string.IsNullOrWhiteSpace(assetName))
+            {
+                return null;
+            }
+
+            DirectoryInfo packageDirectory = new(packageResolvedPath);
+            DirectoryInfo packagesDirectory = packageDirectory.Parent;
+            DirectoryInfo repositoryDirectory = packagesDirectory?.Parent;
+            if (repositoryDirectory == null)
+            {
+                return null;
+            }
+
+            if (!string.Equals(packageDirectory.Name, CliConstants.PACKAGE_SOURCE_DIR_NAME, StringComparison.Ordinal)
+                || !string.Equals(packagesDirectory.Name, CliConstants.UNITY_PACKAGES_DIR_NAME, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            string scriptPath = Path.Combine(repositoryDirectory.FullName, CliConstants.SCRIPTS_DIR_NAME, assetName);
+            if (!File.Exists(scriptPath))
+            {
+                return null;
+            }
+
+            return scriptPath;
+        }
+
+        private static string QuotePosixShellValue(string value)
+        {
+            UnityEngine.Debug.Assert(value != null, "value must not be null");
+            return $"'{value.Replace("'", "'\"'\"'")}'";
+        }
+
+        private static string QuotePowerShellSingleQuotedValue(string value)
+        {
+            UnityEngine.Debug.Assert(value != null, "value must not be null");
+            return $"'{value.Replace("'", "''")}'";
+        }
+
+        internal static string QuoteProcessArgument(string value)
+        {
+            UnityEngine.Debug.Assert(value != null, "value must not be null");
+            return $"\"{value.Replace("\"", "\\\"")}\"";
+        }
+
+        private static string BuildReleaseTag(string cliReleaseTag)
+        {
+            if (cliReleaseTag.StartsWith(CliConstants.DISPATCHER_RELEASE_TAG_PREFIX, StringComparison.Ordinal))
+            {
+                return cliReleaseTag;
+            }
+            if (cliReleaseTag.StartsWith(CliConstants.PROJECT_RUNNER_RELEASE_TAG_PREFIX, StringComparison.Ordinal))
+            {
+                return $"{CliConstants.DISPATCHER_RELEASE_TAG_PREFIX}{cliReleaseTag.Substring(CliConstants.PROJECT_RUNNER_RELEASE_TAG_PREFIX.Length)}";
+            }
+            if (cliReleaseTag.StartsWith(CliConstants.RELEASE_TAG_PREFIX, StringComparison.Ordinal))
+            {
+                return $"{CliConstants.DISPATCHER_RELEASE_TAG_PREFIX}{cliReleaseTag.Substring(CliConstants.RELEASE_TAG_PREFIX.Length)}";
+            }
+            return $"{CliConstants.DISPATCHER_RELEASE_TAG_PREFIX}{cliReleaseTag}";
+        }
+
+        internal static string BuildInstallerScriptUrl(string releaseTag, string assetName)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(assetName), "assetName must not be null or empty");
+
+            return $"{CliConstants.RAW_CONTENT_BASE_URL}/{releaseTag}/{CliConstants.SCRIPTS_DIR_NAME}/{assetName}";
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliCommandBuilder.cs.meta
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliCommandBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ffc89cdbedfb948c88b23df88cd41e8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
@@ -28,69 +28,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string cliReleaseTag,
             bool removeLegacyLaunchers)
         {
-            return BuildInstallCommandWithPackagePath(
+            return NativeCliCommandBuilder.BuildInstallCommandWithPackagePath(
                 platform,
                 cliReleaseTag,
                 removeLegacyLaunchers,
                 NodeEnvironmentResolver.GetUserShell(),
                 UnityCliLoopConstants.PackageResolvedPath);
-        }
-
-        internal static NativeCliInstallCommand BuildRemoteInstallCommand(
-            RuntimePlatform platform,
-            string cliReleaseTag,
-            bool removeLegacyLaunchers,
-            string posixShellPath)
-        {
-            return BuildInstallCommandWithPackagePath(
-                platform,
-                cliReleaseTag,
-                removeLegacyLaunchers,
-                posixShellPath,
-                null);
-        }
-
-        internal static NativeCliInstallCommand BuildInstallCommandWithPackagePath(
-            RuntimePlatform platform,
-            string cliReleaseTag,
-            bool removeLegacyLaunchers,
-            string posixShellPath,
-            string packageResolvedPath)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(cliReleaseTag), "cliReleaseTag must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(posixShellPath), "posixShellPath must not be null or empty");
-            _ = removeLegacyLaunchers;
-
-            string releaseTag = BuildReleaseTag(cliReleaseTag);
-            if (platform == RuntimePlatform.WindowsEditor)
-            {
-                string localScriptPath = ResolvePackageLocalInstallerScriptPath(
-                    packageResolvedPath,
-                    CliConstants.WINDOWS_INSTALL_SCRIPT_NAME);
-                string command = string.IsNullOrEmpty(localScriptPath)
-                    ? BuildWindowsRemoteInstallScriptCommand(
-                        BuildInstallerScriptUrl(releaseTag, CliConstants.WINDOWS_INSTALL_SCRIPT_NAME),
-                        releaseTag)
-                    : BuildWindowsLocalInstallScriptCommand(localScriptPath, releaseTag);
-                return new NativeCliInstallCommand(
-                    "powershell",
-                    $"-NoProfile -ExecutionPolicy Bypass -Command \"{command}\"",
-                    command);
-            }
-
-            string posixLocalScriptPath = ResolvePackageLocalInstallerScriptPath(
-                packageResolvedPath,
-                CliConstants.POSIX_INSTALL_SCRIPT_NAME);
-            string posixCommand = string.IsNullOrEmpty(posixLocalScriptPath)
-                ? BuildPosixRemoteInstallScriptCommand(
-                    BuildInstallerScriptUrl(releaseTag, CliConstants.POSIX_INSTALL_SCRIPT_NAME),
-                    releaseTag)
-                : BuildPosixLocalInstallScriptCommand(posixLocalScriptPath, releaseTag);
-            string loginShellCommand = BuildLoginShellPosixInstallScriptCommand(posixCommand);
-            return new NativeCliInstallCommand(
-                posixShellPath,
-                $"-l -i -c {QuoteProcessArgument(loginShellCommand)}",
-                loginShellCommand);
         }
 
         public static async Task<CliInstallResult> InstallAsync(
@@ -178,7 +121,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return new NativeCliInstallCommand(
                 installPath,
                 "uninstall",
-                $"{QuoteProcessArgument(installPath)} uninstall");
+                $"{NativeCliCommandBuilder.QuoteProcessArgument(installPath)} uninstall");
         }
 
         internal static CliInstallResult RunInstallCommand(
@@ -861,121 +804,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 : CliConstants.GLOBAL_UNIX_COMMAND_NAME;
         }
 
-        private static string BuildPosixRemoteInstallScriptCommand(string scriptUrl, string releaseTag)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(scriptUrl), "scriptUrl must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
-
-            return "tmp_script=$(mktemp) && "
-                + "trap 'rm -f \"$tmp_script\"' EXIT && "
-                + $"curl -fsSL {QuotePosixShellValue(scriptUrl)} -o \"$tmp_script\" && "
-                + $"{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePosixShellValue(releaseTag)} sh \"$tmp_script\"";
-        }
-
-        private static string BuildPosixLocalInstallScriptCommand(string scriptPath, string releaseTag)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(scriptPath), "scriptPath must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
-
-            return $"{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePosixShellValue(releaseTag)} sh {QuotePosixShellValue(scriptPath)}";
-        }
-
-        internal static string BuildLoginShellPosixInstallScriptCommand(string posixCommand)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(posixCommand), "posixCommand must not be null or empty");
-            return $"{CliConstants.POSIX_SHELL_EXECUTABLE_PATH} -c {QuotePosixShellValue(posixCommand)}";
-        }
-
-        private static string BuildWindowsRemoteInstallScriptCommand(string scriptUrl, string releaseTag)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(scriptUrl), "scriptUrl must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
-
-            return $"$env:{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePowerShellSingleQuotedValue(releaseTag)}; "
-                + $"irm {QuotePowerShellSingleQuotedValue(scriptUrl)} | iex";
-        }
-
-        private static string BuildWindowsLocalInstallScriptCommand(string scriptPath, string releaseTag)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(scriptPath), "scriptPath must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
-
-            return $"$env:{CliConstants.INSTALL_VERSION_ENVIRONMENT_VARIABLE}={QuotePowerShellSingleQuotedValue(releaseTag)}; "
-                + $"& {QuotePowerShellSingleQuotedValue(scriptPath)}";
-        }
-
-        internal static string ResolvePackageLocalInstallerScriptPath(string packageResolvedPath, string assetName)
-        {
-            if (string.IsNullOrWhiteSpace(packageResolvedPath) || string.IsNullOrWhiteSpace(assetName))
-            {
-                return null;
-            }
-
-            DirectoryInfo packageDirectory = new(packageResolvedPath);
-            DirectoryInfo packagesDirectory = packageDirectory.Parent;
-            DirectoryInfo repositoryDirectory = packagesDirectory?.Parent;
-            if (repositoryDirectory == null)
-            {
-                return null;
-            }
-
-            if (!string.Equals(packageDirectory.Name, CliConstants.PACKAGE_SOURCE_DIR_NAME, StringComparison.Ordinal)
-                || !string.Equals(packagesDirectory.Name, CliConstants.UNITY_PACKAGES_DIR_NAME, StringComparison.Ordinal))
-            {
-                return null;
-            }
-
-            string scriptPath = Path.Combine(repositoryDirectory.FullName, CliConstants.SCRIPTS_DIR_NAME, assetName);
-            if (!File.Exists(scriptPath))
-            {
-                return null;
-            }
-
-            return scriptPath;
-        }
-
-        private static string QuotePosixShellValue(string value)
-        {
-            UnityEngine.Debug.Assert(value != null, "value must not be null");
-            return $"'{value.Replace("'", "'\"'\"'")}'";
-        }
-
-        private static string QuotePowerShellSingleQuotedValue(string value)
-        {
-            UnityEngine.Debug.Assert(value != null, "value must not be null");
-            return $"'{value.Replace("'", "''")}'";
-        }
-
-        private static string QuoteProcessArgument(string value)
-        {
-            UnityEngine.Debug.Assert(value != null, "value must not be null");
-            return $"\"{value.Replace("\"", "\\\"")}\"";
-        }
-
-        private static string BuildReleaseTag(string cliReleaseTag)
-        {
-            if (cliReleaseTag.StartsWith(CliConstants.DISPATCHER_RELEASE_TAG_PREFIX, StringComparison.Ordinal))
-            {
-                return cliReleaseTag;
-            }
-            if (cliReleaseTag.StartsWith(CliConstants.PROJECT_RUNNER_RELEASE_TAG_PREFIX, StringComparison.Ordinal))
-            {
-                return $"{CliConstants.DISPATCHER_RELEASE_TAG_PREFIX}{cliReleaseTag.Substring(CliConstants.PROJECT_RUNNER_RELEASE_TAG_PREFIX.Length)}";
-            }
-            if (cliReleaseTag.StartsWith(CliConstants.RELEASE_TAG_PREFIX, StringComparison.Ordinal))
-            {
-                return $"{CliConstants.DISPATCHER_RELEASE_TAG_PREFIX}{cliReleaseTag.Substring(CliConstants.RELEASE_TAG_PREFIX.Length)}";
-            }
-            return $"{CliConstants.DISPATCHER_RELEASE_TAG_PREFIX}{cliReleaseTag}";
-        }
-
-        internal static string BuildInstallerScriptUrl(string releaseTag, string assetName)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(releaseTag), "releaseTag must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(assetName), "assetName must not be null or empty");
-
-            return $"{CliConstants.RAW_CONTENT_BASE_URL}/{releaseTag}/{CliConstants.SCRIPTS_DIR_NAME}/{assetName}";
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Preserve native CLI installer behavior while separating command construction from process and path responsibilities.
- Keep the existing public installer command API unchanged.

## User Impact
- No user-visible behavior change.
- Setup and uninstall continue to produce the same executable names, arguments, manual commands, release tags, and installer script URLs.

## Changes
- Move install command construction and quoting helpers into `NativeCliCommandBuilder`.
- Keep `NativeCliInstaller.GetInstallCommand` as the public facade.
- Keep uninstall path resolution in `NativeCliInstaller` until the path responsibility is split separately.
- Retarget command-focused tests and the overload guard to the extracted builder; the guard still reports missing targets.

## Verification
- Unity compile: 0 errors, 0 warnings
- `NativeCliInstallerTests`: 32 passed
- `StaticFacadeStateGuardTests`: 20 passed
- `CliSetupApplicationServiceTests`: 4 passed
- `git diff --check`
- No IPC or protocol changes
