### PR TITLE
fix: Native CLI setup avoids duplicate PATH entries

### DIFF
--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -515,6 +515,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void BuildPathWithInstallDirectory_OnWindowsRemovesTrailingSeparatorDuplicate()
+        {
+            // Verifies that a trailing separator does not preserve a duplicate native install directory.
+            string result = NativeCliInstallPathResolver.BuildPathWithInstallDirectory(
+                "C:\\npm;C:\\Users\\ExampleUser\\Programs\\uloop\\bin\\;C:\\Tools",
+                "C:\\Users\\ExampleUser\\Programs\\uloop\\bin",
+                RuntimePlatform.WindowsEditor);
+
+            Assert.That(
+                result,
+                Is.EqualTo("C:\\Users\\ExampleUser\\Programs\\uloop\\bin;C:\\npm;C:\\Tools"));
+        }
+
+        [Test]
         public void BuildPathWithInstallDirectory_OnMacPrependsMissingNativeInstallDir()
         {
             // Verifies that POSIX PATH prefers the freshly installed native CLI.

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstallPathResolver.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstallPathResolver.cs
@@ -43,10 +43,15 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 new[] { separator },
                 StringSplitOptions.RemoveEmptyEntries);
             StringComparison comparison = GetPathComparison(platform);
+            string normalizedInstallDirectory = NormalizePathForComparison(installDirectory, platform);
             StringBuilder builder = new(installDirectory);
             foreach (string entry in entries)
             {
-                if (string.Equals(entry, installDirectory, comparison))
+                if (!string.IsNullOrWhiteSpace(entry)
+                    && string.Equals(
+                        NormalizePathForComparison(entry, platform),
+                        normalizedInstallDirectory,
+                        comparison))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Prevent native CLI setup from leaving duplicate current-process PATH entries when an existing entry has a trailing separator.
- Keep unrelated PATH entry text and ordering unchanged.

## User Impact
- Repeated native CLI setup no longer leaves equivalent install directories in the Unity process PATH solely because one form ends with a separator.
- CLI resolution behavior and the persisted User PATH remain unchanged.

## Root Cause
- `BuildPathWithInstallDirectory` compared raw PATH entry text while removal and ownership checks compared normalized path identities.
- Equivalent paths with different trailing separators were therefore treated as different entries during setup.

## Changes
- Normalize the install directory and each non-empty existing PATH entry before equality comparison.
- Continue appending the original text for unrelated entries.
- Add a Windows trailing-separator regression test.

## TDD Verification
- Red: the new regression test retained both the canonical install directory and the trailing-separator duplicate.
- Green: the regression test passes with one canonical install entry.
- Unity compile: 0 errors, 0 warnings
- `NativeCliInstallerTests`: 33 passed
- Related detector, PATH setup, and application service fixtures: 31 passed
- No IPC or protocol changes


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

