### PR TITLE
chore: Simplify native CLI uninstall completion handling

### DIFF
--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -298,7 +298,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             int remainingExistingChecks = 2;
             int delayCount = 0;
 
-            CliInstallResult result = await NativeCliInstaller.WaitForUninstallTargetRemovalAsync(
+            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallTargetRemovalAsync(
                 "C:\\Users\\ExampleUser\\AppData\\Local\\Programs\\uloop\\bin\\uloop.exe",
                 CancellationToken.None,
                 1000,
@@ -320,7 +320,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies that delayed launcher removal failures do not recache a stale installed CLI.
             int delayCount = 0;
 
-            CliInstallResult result = await NativeCliInstaller.WaitForUninstallTargetRemovalAsync(
+            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallTargetRemovalAsync(
                 "C:\\Users\\ExampleUser\\AppData\\Local\\Programs\\uloop\\bin\\uloop.exe",
                 CancellationToken.None,
                 250,
@@ -345,7 +345,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string userPath = installDirectory + ";C:\\npm";
             int delayCount = 0;
 
-            CliInstallResult result = await NativeCliInstaller.WaitForUninstallCompletionAsync(
+            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
                 installDirectory + "\\uloop.exe",
                 installDirectory,
                 RuntimePlatform.WindowsEditor,
@@ -373,7 +373,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string installDirectory = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin";
             int delayCount = 0;
 
-            CliInstallResult result = await NativeCliInstaller.WaitForUninstallCompletionAsync(
+            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
                 installDirectory + "\\uloop.exe",
                 installDirectory,
                 RuntimePlatform.WindowsEditor,
@@ -401,7 +401,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies fallback uninstall failures do not claim ownership of Windows User PATH cleanup.
             string installDirectory = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin";
 
-            CliInstallResult result = await NativeCliInstaller.WaitForUninstallCompletionAsync(
+            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
                 installDirectory + "\\uloop.exe",
                 installDirectory,
                 RuntimePlatform.WindowsEditor,
@@ -424,7 +424,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies fallback launchers can complete uninstall without owning Windows User PATH cleanup.
             string installDirectory = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin";
 
-            CliInstallResult result = await NativeCliInstaller.WaitForUninstallCompletionAsync(
+            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
                 installDirectory + "\\uloop.exe",
                 installDirectory,
                 RuntimePlatform.WindowsEditor,
@@ -443,7 +443,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         public void UninstallCompletionTimeout_IsLongEnoughForDeferredWindowsPowerShellCleanup()
         {
             // Verifies Settings uninstall does not report failure before Windows deferred cleanup can finish.
-            Assert.That(NativeCliInstaller.UNINSTALL_COMPLETION_TIMEOUT_MS, Is.GreaterThanOrEqualTo(30000));
+            Assert.That(
+                NativeCliUninstallCompletionWaiter.UNINSTALL_COMPLETION_TIMEOUT_MS,
+                Is.GreaterThanOrEqualTo(30000));
         }
 
         [Test]

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
@@ -19,7 +19,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         private const int INSTALL_PROCESS_TIMEOUT_MS = 300000;
         private const int INSTALL_PROCESS_WAIT_SLICE_MS = 250;
-        internal const int UNINSTALL_COMPLETION_TIMEOUT_MS = 30000;
 
         public static NativeCliInstallCommand GetInstallCommand(
             RuntimePlatform platform,
@@ -91,12 +90,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             string installPath = NativeCliInstallPathResolver.GetGlobalCliInstallPath(installDirectory, platform);
-            CliInstallResult removalResult = await WaitForUninstallCompletionAsync(
+            CliInstallResult removalResult = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
                 installPath,
                 installDirectory,
                 platform,
                 ct,
-                UNINSTALL_COMPLETION_TIMEOUT_MS,
+                NativeCliUninstallCompletionWaiter.UNINSTALL_COMPLETION_TIMEOUT_MS,
                 INSTALL_PROCESS_WAIT_SLICE_MS,
                 File.Exists,
                 false,
@@ -237,92 +236,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 : new CliInstallResult(false, BuildCliSetupCommandFailure(commandDescription, errorOutput, standardOutput));
         }
 
-        internal static async Task<CliInstallResult> WaitForUninstallTargetRemovalAsync(
-            string targetPath,
-            CancellationToken ct,
-            int timeoutMs,
-            int pollMs,
-            Func<string, bool> fileExists,
-            Func<int, CancellationToken, Task> delayAsync)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(targetPath), "targetPath must not be null or empty");
-            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
-            UnityEngine.Debug.Assert(pollMs > 0, "pollMs must be greater than zero");
-            UnityEngine.Debug.Assert(fileExists != null, "fileExists must not be null");
-            UnityEngine.Debug.Assert(delayAsync != null, "delayAsync must not be null");
-
-            int elapsedMs = 0;
-            while (fileExists(targetPath))
-            {
-                ct.ThrowIfCancellationRequested();
-                if (elapsedMs >= timeoutMs)
-                {
-                    return new CliInstallResult(
-                        false,
-                        $"Timed out waiting for uLoop CLI uninstall to remove {targetPath}.");
-                }
-
-                int delayMs = Math.Min(pollMs, timeoutMs - elapsedMs);
-                await delayAsync(delayMs, ct);
-                elapsedMs += delayMs;
-            }
-
-            return new CliInstallResult(true, "");
-        }
-
-        internal static async Task<CliInstallResult> WaitForUninstallCompletionAsync(
-            string targetPath,
-            string installDirectory,
-            RuntimePlatform platform,
-            CancellationToken ct,
-            int timeoutMs,
-            int pollMs,
-            Func<string, bool> fileExists,
-            bool requireUserPathRemoval,
-            Func<string, EnvironmentVariableTarget, string> getEnvironmentVariable,
-            Func<int, CancellationToken, Task> delayAsync)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(targetPath), "targetPath must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
-            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
-            UnityEngine.Debug.Assert(pollMs > 0, "pollMs must be greater than zero");
-            UnityEngine.Debug.Assert(fileExists != null, "fileExists must not be null");
-            UnityEngine.Debug.Assert(getEnvironmentVariable != null, "getEnvironmentVariable must not be null");
-            UnityEngine.Debug.Assert(delayAsync != null, "delayAsync must not be null");
-
-            int elapsedMs = 0;
-            while (true)
-            {
-                bool targetStillExists = fileExists(targetPath);
-                bool userPathStillContainsInstallDirectory = ShouldWaitForUserPathRemoval(
-                    requireUserPathRemoval,
-                    installDirectory,
-                    platform,
-                    getEnvironmentVariable);
-                if (!targetStillExists && !userPathStillContainsInstallDirectory)
-                {
-                    return new CliInstallResult(true, "");
-                }
-
-                ct.ThrowIfCancellationRequested();
-                if (elapsedMs >= timeoutMs)
-                {
-                    return new CliInstallResult(
-                        false,
-                        BuildUninstallCompletionTimeoutFailure(
-                            targetPath,
-                            installDirectory,
-                            platform,
-                            targetStillExists,
-                            userPathStillContainsInstallDirectory));
-                }
-
-                int delayMs = Math.Min(pollMs, timeoutMs - elapsedMs);
-                await delayAsync(delayMs, ct);
-                elapsedMs += delayMs;
-            }
-        }
-
         internal static CliInstallResult FinishSuccessfulInstall(
             CliInstallResult installResult,
             string installDirectory,
@@ -369,46 +282,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 installDirectory,
                 platform);
             Environment.SetEnvironmentVariable(pathVariableName, updatedPath);
-        }
-
-        private static bool ShouldWaitForUserPathRemoval(
-            bool requireUserPathRemoval,
-            string installDirectory,
-            RuntimePlatform platform,
-            Func<string, EnvironmentVariableTarget, string> getEnvironmentVariable)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
-            UnityEngine.Debug.Assert(getEnvironmentVariable != null, "getEnvironmentVariable must not be null");
-
-            return requireUserPathRemoval
-                && NativeCliInstallPathResolver.DoesUserPathContainInstallDirectory(
-                    installDirectory,
-                    platform,
-                    getEnvironmentVariable);
-        }
-
-        private static string BuildUninstallCompletionTimeoutFailure(
-            string targetPath,
-            string installDirectory,
-            RuntimePlatform platform,
-            bool targetStillExists,
-            bool userPathStillContainsInstallDirectory)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(targetPath), "targetPath must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
-            UnityEngine.Debug.Assert(targetStillExists || userPathStillContainsInstallDirectory, "at least one uninstall cleanup condition must still be pending");
-
-            if (platform != RuntimePlatform.WindowsEditor || !userPathStillContainsInstallDirectory)
-            {
-                return $"Timed out waiting for uLoop CLI uninstall to remove {targetPath}.";
-            }
-
-            if (!targetStillExists)
-            {
-                return $"Timed out waiting for uLoop CLI uninstall to remove {installDirectory} from Windows User PATH.";
-            }
-
-            return $"Timed out waiting for uLoop CLI uninstall to remove {targetPath} and remove {installDirectory} from Windows User PATH.";
         }
 
         private static string BuildCliSetupCommandFailure(

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliUninstallCompletionWaiter.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliUninstallCompletionWaiter.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Waits for native CLI uninstall cleanup to finish.
+    /// </summary>
+    internal static class NativeCliUninstallCompletionWaiter
+    {
+        internal const int UNINSTALL_COMPLETION_TIMEOUT_MS = 30000;
+
+        internal static async Task<CliInstallResult> WaitForUninstallTargetRemovalAsync(
+            string targetPath,
+            CancellationToken ct,
+            int timeoutMs,
+            int pollMs,
+            Func<string, bool> fileExists,
+            Func<int, CancellationToken, Task> delayAsync)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(targetPath), "targetPath must not be null or empty");
+            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
+            UnityEngine.Debug.Assert(pollMs > 0, "pollMs must be greater than zero");
+            UnityEngine.Debug.Assert(fileExists != null, "fileExists must not be null");
+            UnityEngine.Debug.Assert(delayAsync != null, "delayAsync must not be null");
+
+            int elapsedMs = 0;
+            while (fileExists(targetPath))
+            {
+                ct.ThrowIfCancellationRequested();
+                if (elapsedMs >= timeoutMs)
+                {
+                    return new CliInstallResult(
+                        false,
+                        $"Timed out waiting for uLoop CLI uninstall to remove {targetPath}.");
+                }
+
+                int delayMs = Math.Min(pollMs, timeoutMs - elapsedMs);
+                await delayAsync(delayMs, ct);
+                elapsedMs += delayMs;
+            }
+
+            return new CliInstallResult(true, "");
+        }
+
+        internal static async Task<CliInstallResult> WaitForUninstallCompletionAsync(
+            string targetPath,
+            string installDirectory,
+            RuntimePlatform platform,
+            CancellationToken ct,
+            int timeoutMs,
+            int pollMs,
+            Func<string, bool> fileExists,
+            bool requireUserPathRemoval,
+            Func<string, EnvironmentVariableTarget, string> getEnvironmentVariable,
+            Func<int, CancellationToken, Task> delayAsync)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(targetPath), "targetPath must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
+            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
+            UnityEngine.Debug.Assert(pollMs > 0, "pollMs must be greater than zero");
+            UnityEngine.Debug.Assert(fileExists != null, "fileExists must not be null");
+            UnityEngine.Debug.Assert(getEnvironmentVariable != null, "getEnvironmentVariable must not be null");
+            UnityEngine.Debug.Assert(delayAsync != null, "delayAsync must not be null");
+
+            int elapsedMs = 0;
+            while (true)
+            {
+                bool targetStillExists = fileExists(targetPath);
+                bool userPathStillContainsInstallDirectory = ShouldWaitForUserPathRemoval(
+                    requireUserPathRemoval,
+                    installDirectory,
+                    platform,
+                    getEnvironmentVariable);
+                if (!targetStillExists && !userPathStillContainsInstallDirectory)
+                {
+                    return new CliInstallResult(true, "");
+                }
+
+                ct.ThrowIfCancellationRequested();
+                if (elapsedMs >= timeoutMs)
+                {
+                    return new CliInstallResult(
+                        false,
+                        BuildUninstallCompletionTimeoutFailure(
+                            targetPath,
+                            installDirectory,
+                            platform,
+                            targetStillExists,
+                            userPathStillContainsInstallDirectory));
+                }
+
+                int delayMs = Math.Min(pollMs, timeoutMs - elapsedMs);
+                await delayAsync(delayMs, ct);
+                elapsedMs += delayMs;
+            }
+        }
+
+        private static bool ShouldWaitForUserPathRemoval(
+            bool requireUserPathRemoval,
+            string installDirectory,
+            RuntimePlatform platform,
+            Func<string, EnvironmentVariableTarget, string> getEnvironmentVariable)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
+            UnityEngine.Debug.Assert(getEnvironmentVariable != null, "getEnvironmentVariable must not be null");
+
+            return requireUserPathRemoval
+                && NativeCliInstallPathResolver.DoesUserPathContainInstallDirectory(
+                    installDirectory,
+                    platform,
+                    getEnvironmentVariable);
+        }
+
+        private static string BuildUninstallCompletionTimeoutFailure(
+            string targetPath,
+            string installDirectory,
+            RuntimePlatform platform,
+            bool targetStillExists,
+            bool userPathStillContainsInstallDirectory)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(targetPath), "targetPath must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
+            UnityEngine.Debug.Assert(targetStillExists || userPathStillContainsInstallDirectory, "at least one uninstall cleanup condition must still be pending");
+
+            if (platform != RuntimePlatform.WindowsEditor || !userPathStillContainsInstallDirectory)
+            {
+                return $"Timed out waiting for uLoop CLI uninstall to remove {targetPath}.";
+            }
+
+            if (!targetStillExists)
+            {
+                return $"Timed out waiting for uLoop CLI uninstall to remove {installDirectory} from Windows User PATH.";
+            }
+
+            return $"Timed out waiting for uLoop CLI uninstall to remove {targetPath} and remove {installDirectory} from Windows User PATH.";
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliUninstallCompletionWaiter.cs.meta
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliUninstallCompletionWaiter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9dc372d657654ed8b3579d930469685
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Preserve native CLI uninstall behavior while separating cleanup polling from installer orchestration and process execution.
- Keep existing public installer and setup APIs unchanged.

## User Impact
- No user-visible behavior change.
- Uninstall completion, cancellation, timeout timing, and failure messages remain unchanged.

## Changes
- Move uninstall target and Windows User PATH polling into `NativeCliUninstallCompletionWaiter`.
- Move the uninstall completion timeout constant with the waiter.
- Keep polling cadence supplied by `NativeCliInstaller`, allowing process wait timing to be separated in the next refactor.
- Update the installer and seven existing test references to use the waiter directly without compatibility wrappers.
- Keep the test-only target-removal helper unchanged for this move-only PR; its deletion eligibility is recorded as R2-30.

## Verification
- Unity compile: 0 errors, 0 warnings
- `NativeCliInstallerTests`: 33 passed
- `StaticFacadeStateGuardTests`: 20 passed
- No waiter-to-installer or waiter-to-command-builder reverse references
- No IPC or protocol changes

## Review Follow-up
- cubic observed that production passes `requireUserPathRemoval: false`. This is intentional behavior from PR #1250, where the package-local development CLI was removed and the installed launcher became responsible for uninstall and persisted User PATH cleanup.
- The remaining test-only User PATH polling chain is recorded under R2-30 for dead-code scanning and removal after this move-only PR.
