### PR TITLE
chore: Simplify native CLI setup internals

### DIFF
--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -255,7 +255,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 "--version",
                 "missing-uloop-release-installer --version");
 
-            CliInstallResult result = NativeCliInstaller.RunInstallCommand(command, CancellationToken.None, 1000);
+            CliInstallResult result = NativeCliSetupCommandRunner.RunInstallCommand(
+                command,
+                CancellationToken.None,
+                1000);
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.ErrorOutput, Does.Contain("Failed to start release CLI installer"));
@@ -267,7 +270,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies that release installer stalls cannot leave the editor setup task alive forever.
             NativeCliInstallCommand command = BuildLongRunningInstallCommand();
 
-            CliInstallResult result = NativeCliInstaller.RunInstallCommand(command, CancellationToken.None, 50);
+            CliInstallResult result = NativeCliSetupCommandRunner.RunInstallCommand(
+                command,
+                CancellationToken.None,
+                50);
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.ErrorOutput, Does.Contain("timed out"));
@@ -281,7 +287,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             using CancellationTokenSource cts = new();
             cts.CancelAfter(10);
 
-            CliInstallResult result = NativeCliInstaller.RunUninstallCommand(
+            CliInstallResult result = NativeCliSetupCommandRunner.RunUninstallCommand(
                 command,
                 "/Users/ExampleUser/.local/bin",
                 cts.Token,

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Diagnostics;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -18,7 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     public static class NativeCliInstaller
     {
         private const int INSTALL_PROCESS_TIMEOUT_MS = 300000;
-        private const int INSTALL_PROCESS_WAIT_SLICE_MS = 250;
 
         public static NativeCliInstallCommand GetInstallCommand(
             RuntimePlatform platform,
@@ -51,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             NativeCliInstallCommand command = GetInstallCommand(platform, cliReleaseTag, true);
             CliInstallResult result = await Task.Run(
-                () => RunInstallCommand(command, ct, INSTALL_PROCESS_TIMEOUT_MS),
+                () => NativeCliSetupCommandRunner.RunInstallCommand(command, ct, INSTALL_PROCESS_TIMEOUT_MS),
                 ct);
 
             if (result.Success)
@@ -82,7 +79,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 installDirectory,
                 platform);
             CliInstallResult result = await Task.Run(
-                () => RunUninstallCommand(command, installDirectory, ct, INSTALL_PROCESS_TIMEOUT_MS),
+                () => NativeCliSetupCommandRunner.RunUninstallCommand(
+                    command,
+                    installDirectory,
+                    ct,
+                    INSTALL_PROCESS_TIMEOUT_MS),
                 ct);
             if (!result.Success)
             {
@@ -96,7 +97,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 platform,
                 ct,
                 NativeCliUninstallCompletionWaiter.UNINSTALL_COMPLETION_TIMEOUT_MS,
-                INSTALL_PROCESS_WAIT_SLICE_MS,
+                NativeCliSetupCommandRunner.INSTALL_PROCESS_WAIT_SLICE_MS,
                 File.Exists,
                 false,
                 Environment.GetEnvironmentVariable,
@@ -108,132 +109,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
 
             RemoveInstallDirectoryFromCurrentProcessPath(platform);
             return result;
-        }
-
-        internal static CliInstallResult RunInstallCommand(
-            NativeCliInstallCommand command,
-            CancellationToken ct,
-            int timeoutMs)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.FileName), "command.FileName must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.Arguments), "command.Arguments must not be null or empty");
-            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
-            ct.ThrowIfCancellationRequested();
-
-            return RunCliSetupCommand(
-                command,
-                ct,
-                timeoutMs,
-                "release CLI installer",
-                startInfo => { });
-        }
-
-        internal static CliInstallResult RunUninstallCommand(
-            NativeCliInstallCommand command,
-            string installDirectory,
-            CancellationToken ct,
-            int timeoutMs)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(installDirectory), "installDirectory must not be null or empty");
-
-            return RunCliSetupCommand(
-                command,
-                ct,
-                timeoutMs,
-                "global CLI uninstall command",
-                startInfo =>
-                {
-                    startInfo.EnvironmentVariables[CliConstants.INSTALL_DIR_ENVIRONMENT_VARIABLE] = installDirectory;
-                });
-        }
-
-        private static CliInstallResult RunCliSetupCommand(
-            NativeCliInstallCommand command,
-            CancellationToken ct,
-            int timeoutMs,
-            string commandDescription,
-            Action<ProcessStartInfo> configureStartInfo)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.FileName), "command.FileName must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.Arguments), "command.Arguments must not be null or empty");
-            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(commandDescription), "commandDescription must not be null or empty");
-            UnityEngine.Debug.Assert(configureStartInfo != null, "configureStartInfo must not be null");
-            ct.ThrowIfCancellationRequested();
-
-            ProcessStartInfo startInfo = new()
-            {
-                FileName = command.FileName,
-                Arguments = command.Arguments,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
-            configureStartInfo(startInfo);
-
-            Process process = ProcessStartHelper.TryStart(startInfo);
-            if (process == null)
-            {
-                return new CliInstallResult(
-                    false,
-                    $"Failed to start {commandDescription}: {command.FileName}");
-            }
-
-            StringBuilder standardOutputBuilder = new();
-            StringBuilder errorOutputBuilder = new();
-            process.OutputDataReceived += (sender, e) =>
-            {
-                if (e.Data != null)
-                {
-                    standardOutputBuilder.AppendLine(e.Data);
-                }
-            };
-            process.ErrorDataReceived += (sender, e) =>
-            {
-                if (e.Data != null)
-                {
-                    errorOutputBuilder.AppendLine(e.Data);
-                }
-            };
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
-
-            bool canceled;
-            bool exited = WaitForInstallProcessExit(process, ct, timeoutMs, out canceled);
-            if (!exited)
-            {
-                KillProcessIfRunning(process);
-                process.WaitForExit(INSTALL_PROCESS_WAIT_SLICE_MS);
-                string timedOutStandardOutput = standardOutputBuilder.ToString();
-                string timedOutErrorOutput = errorOutputBuilder.ToString();
-                process.Dispose();
-
-                if (canceled)
-                {
-                    return new CliInstallResult(
-                        false,
-                        $"{BuildSentenceSubject(commandDescription)} was canceled.");
-                }
-
-                return new CliInstallResult(
-                    false,
-                    BuildCliSetupCommandTimeoutFailure(
-                        commandDescription,
-                        timeoutMs,
-                        timedOutErrorOutput,
-                        timedOutStandardOutput));
-            }
-
-            process.WaitForExit();
-            string standardOutput = standardOutputBuilder.ToString();
-            string errorOutput = errorOutputBuilder.ToString();
-            bool success = process.ExitCode == 0;
-            process.Dispose();
-
-            return success
-                ? new CliInstallResult(true, standardOutput)
-                : new CliInstallResult(false, BuildCliSetupCommandFailure(commandDescription, errorOutput, standardOutput));
         }
 
         internal static CliInstallResult FinishSuccessfulInstall(
@@ -282,101 +157,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 installDirectory,
                 platform);
             Environment.SetEnvironmentVariable(pathVariableName, updatedPath);
-        }
-
-        private static string BuildCliSetupCommandFailure(
-            string commandDescription,
-            string errorOutput,
-            string standardOutput)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(commandDescription), "commandDescription must not be null or empty");
-
-            if (!string.IsNullOrWhiteSpace(errorOutput))
-            {
-                return errorOutput;
-            }
-
-            if (!string.IsNullOrWhiteSpace(standardOutput))
-            {
-                return standardOutput;
-            }
-
-            return $"{BuildSentenceSubject(commandDescription)} failed without output.";
-        }
-
-        private static string BuildCliSetupCommandTimeoutFailure(
-            string commandDescription,
-            int timeoutMs,
-            string errorOutput,
-            string standardOutput)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(commandDescription), "commandDescription must not be null or empty");
-
-            string capturedOutput = BuildCliSetupCommandFailure(commandDescription, errorOutput, standardOutput);
-            string noOutputMessage = $"{BuildSentenceSubject(commandDescription)} failed without output.";
-            if (string.Equals(capturedOutput, noOutputMessage, StringComparison.Ordinal))
-            {
-                return $"{BuildSentenceSubject(commandDescription)} timed out after {timeoutMs} ms.";
-            }
-
-            return $"{BuildSentenceSubject(commandDescription)} timed out after {timeoutMs} ms.\n{capturedOutput}";
-        }
-
-        private static string BuildSentenceSubject(string value)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(value), "value must not be null or empty");
-
-            return char.ToUpperInvariant(value[0]) + value.Substring(1);
-        }
-
-        private static bool WaitForInstallProcessExit(
-            Process process,
-            CancellationToken ct,
-            int timeoutMs,
-            out bool canceled)
-        {
-            UnityEngine.Debug.Assert(process != null, "process must not be null");
-            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
-
-            canceled = false;
-            int remainingMs = timeoutMs;
-            while (remainingMs > 0)
-            {
-                if (ct.IsCancellationRequested)
-                {
-                    canceled = true;
-                    return false;
-                }
-
-                int waitMs = Math.Min(INSTALL_PROCESS_WAIT_SLICE_MS, remainingMs);
-                if (process.WaitForExit(waitMs))
-                {
-                    return true;
-                }
-
-                remainingMs -= waitMs;
-            }
-
-            return false;
-        }
-
-        private static void KillProcessIfRunning(Process process)
-        {
-            UnityEngine.Debug.Assert(process != null, "process must not be null");
-
-            try
-            {
-                if (process.HasExited)
-                {
-                    return;
-                }
-
-                process.Kill();
-            }
-            catch (InvalidOperationException)
-            {
-                // Process exit can race with Kill, and timeout/cancel still needs to return a CliInstallResult.
-            }
         }
 
     }

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliSetupCommandRunner.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliSetupCommandRunner.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Runs native CLI install and uninstall processes.
+    /// </summary>
+    internal static class NativeCliSetupCommandRunner
+    {
+        internal const int INSTALL_PROCESS_WAIT_SLICE_MS = 250;
+
+        internal static CliInstallResult RunInstallCommand(
+            NativeCliInstallCommand command,
+            CancellationToken ct,
+            int timeoutMs)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.FileName), "command.FileName must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.Arguments), "command.Arguments must not be null or empty");
+            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
+            ct.ThrowIfCancellationRequested();
+
+            return RunCliSetupCommand(
+                command,
+                ct,
+                timeoutMs,
+                "release CLI installer",
+                startInfo => { });
+        }
+
+        internal static CliInstallResult RunUninstallCommand(
+            NativeCliInstallCommand command,
+            string installDirectory,
+            CancellationToken ct,
+            int timeoutMs)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(installDirectory), "installDirectory must not be null or empty");
+
+            return RunCliSetupCommand(
+                command,
+                ct,
+                timeoutMs,
+                "global CLI uninstall command",
+                startInfo =>
+                {
+                    startInfo.EnvironmentVariables[CliConstants.INSTALL_DIR_ENVIRONMENT_VARIABLE] = installDirectory;
+                });
+        }
+
+        private static CliInstallResult RunCliSetupCommand(
+            NativeCliInstallCommand command,
+            CancellationToken ct,
+            int timeoutMs,
+            string commandDescription,
+            Action<ProcessStartInfo> configureStartInfo)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.FileName), "command.FileName must not be null or empty");
+            UnityEngine.Debug.Assert(!string.IsNullOrEmpty(command.Arguments), "command.Arguments must not be null or empty");
+            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(commandDescription), "commandDescription must not be null or empty");
+            UnityEngine.Debug.Assert(configureStartInfo != null, "configureStartInfo must not be null");
+            ct.ThrowIfCancellationRequested();
+
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = command.FileName,
+                Arguments = command.Arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            configureStartInfo(startInfo);
+
+            Process process = ProcessStartHelper.TryStart(startInfo);
+            if (process == null)
+            {
+                return new CliInstallResult(
+                    false,
+                    $"Failed to start {commandDescription}: {command.FileName}");
+            }
+
+            StringBuilder standardOutputBuilder = new();
+            StringBuilder errorOutputBuilder = new();
+            process.OutputDataReceived += (sender, e) =>
+            {
+                if (e.Data != null)
+                {
+                    standardOutputBuilder.AppendLine(e.Data);
+                }
+            };
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                if (e.Data != null)
+                {
+                    errorOutputBuilder.AppendLine(e.Data);
+                }
+            };
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            bool canceled;
+            bool exited = WaitForInstallProcessExit(process, ct, timeoutMs, out canceled);
+            if (!exited)
+            {
+                KillProcessIfRunning(process);
+                process.WaitForExit(INSTALL_PROCESS_WAIT_SLICE_MS);
+                string timedOutStandardOutput = standardOutputBuilder.ToString();
+                string timedOutErrorOutput = errorOutputBuilder.ToString();
+                process.Dispose();
+
+                if (canceled)
+                {
+                    return new CliInstallResult(
+                        false,
+                        $"{BuildSentenceSubject(commandDescription)} was canceled.");
+                }
+
+                return new CliInstallResult(
+                    false,
+                    BuildCliSetupCommandTimeoutFailure(
+                        commandDescription,
+                        timeoutMs,
+                        timedOutErrorOutput,
+                        timedOutStandardOutput));
+            }
+
+            process.WaitForExit();
+            string standardOutput = standardOutputBuilder.ToString();
+            string errorOutput = errorOutputBuilder.ToString();
+            bool success = process.ExitCode == 0;
+            process.Dispose();
+
+            return success
+                ? new CliInstallResult(true, standardOutput)
+                : new CliInstallResult(false, BuildCliSetupCommandFailure(commandDescription, errorOutput, standardOutput));
+        }
+
+        private static string BuildCliSetupCommandFailure(
+            string commandDescription,
+            string errorOutput,
+            string standardOutput)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(commandDescription), "commandDescription must not be null or empty");
+
+            if (!string.IsNullOrWhiteSpace(errorOutput))
+            {
+                return errorOutput;
+            }
+
+            if (!string.IsNullOrWhiteSpace(standardOutput))
+            {
+                return standardOutput;
+            }
+
+            return $"{BuildSentenceSubject(commandDescription)} failed without output.";
+        }
+
+        private static string BuildCliSetupCommandTimeoutFailure(
+            string commandDescription,
+            int timeoutMs,
+            string errorOutput,
+            string standardOutput)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(commandDescription), "commandDescription must not be null or empty");
+
+            string capturedOutput = BuildCliSetupCommandFailure(commandDescription, errorOutput, standardOutput);
+            string noOutputMessage = $"{BuildSentenceSubject(commandDescription)} failed without output.";
+            if (string.Equals(capturedOutput, noOutputMessage, StringComparison.Ordinal))
+            {
+                return $"{BuildSentenceSubject(commandDescription)} timed out after {timeoutMs} ms.";
+            }
+
+            return $"{BuildSentenceSubject(commandDescription)} timed out after {timeoutMs} ms.\n{capturedOutput}";
+        }
+
+        private static string BuildSentenceSubject(string value)
+        {
+            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(value), "value must not be null or empty");
+
+            return char.ToUpperInvariant(value[0]) + value.Substring(1);
+        }
+
+        private static bool WaitForInstallProcessExit(
+            Process process,
+            CancellationToken ct,
+            int timeoutMs,
+            out bool canceled)
+        {
+            UnityEngine.Debug.Assert(process != null, "process must not be null");
+            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
+
+            canceled = false;
+            int remainingMs = timeoutMs;
+            while (remainingMs > 0)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    canceled = true;
+                    return false;
+                }
+
+                int waitMs = Math.Min(INSTALL_PROCESS_WAIT_SLICE_MS, remainingMs);
+                if (process.WaitForExit(waitMs))
+                {
+                    return true;
+                }
+
+                remainingMs -= waitMs;
+            }
+
+            return false;
+        }
+
+        private static void KillProcessIfRunning(Process process)
+        {
+            UnityEngine.Debug.Assert(process != null, "process must not be null");
+
+            try
+            {
+                if (process.HasExited)
+                {
+                    return;
+                }
+
+                process.Kill();
+            }
+            catch (InvalidOperationException)
+            {
+                // Process exit can race with Kill, and timeout/cancel still needs to return a CliInstallResult.
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliSetupCommandRunner.cs.meta
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliSetupCommandRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4da499d28c294e2f8387d50281b7adf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Keep native CLI setup behavior unchanged while separating process execution from setup orchestration.
- Reduce the installer facade to orchestration and current-process environment updates.

## User Impact
- Native CLI install, uninstall, timeout, cancellation, and error-reporting behavior remain unchanged.
- This internal separation makes future setup maintenance easier to review without changing the wire protocol or release inputs.

## Changes
- Move install and uninstall process execution into `NativeCliSetupCommandRunner`.
- Route production callers and the three existing command-execution tests directly through the extracted owner.
- Move `INSTALL_PROCESS_WAIT_SLICE_MS` with the execution logic; its `private` to `internal` visibility change is required by the uninstall completion caller.
- Remove the now-unused `System.Diagnostics` and `System.Text` imports from `NativeCliInstaller`.
- Preserve the existing process-race exception handling and `out bool canceled` contract as-is.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` (0 errors, 0 warnings)
- `NativeCliInstallerTests` (33 passed)
- `StaticFacadeStateGuardTests` (20 passed)
- Mechanically compared the moved method bodies before and after extraction after normalizing the required constant visibility change; no logic, string, or branch changes were found.
- Confirmed that the runner has no reverse dependency on the installer, command builder, or uninstall completion waiter.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

