### PR TITLE
chore: Remove obsolete native CLI uninstall polling

### DIFF
--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -302,6 +302,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies uninstall completion reports the launcher path when deferred self-removal times out.
             string targetPath = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin\\uloop.exe";
+            int delayCount = 0;
 
             CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
                 targetPath,
@@ -309,10 +310,15 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 250,
                 100,
                 executablePath => true,
-                (delayMs, ct) => Task.CompletedTask);
+                (delayMs, ct) =>
+                {
+                    delayCount++;
+                    return Task.CompletedTask;
+                });
 
             Assert.That(result.Success, Is.False);
             Assert.That(result.ErrorOutput, Does.Contain(targetPath));
+            Assert.That(delayCount, Is.EqualTo(3));
         }
 
         [Test]

--- a/Assets/Tests/Editor/NativeCliInstallerTests.cs
+++ b/Assets/Tests/Editor/NativeCliInstallerTests.cs
@@ -298,148 +298,34 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public async Task WaitForUninstallTargetRemovalAsync_WhenDeferredRemovalCompletesReturnsSuccess()
+        public async Task WaitForUninstallCompletionAsync_WhenTargetRemainsReportsTimeout()
         {
-            // Verifies that Settings uninstall waits for deferred launcher self-removal before refreshing CLI status.
-            int remainingExistingChecks = 2;
-            int delayCount = 0;
+            // Verifies uninstall completion reports the launcher path when deferred self-removal times out.
+            string targetPath = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin\\uloop.exe";
 
-            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallTargetRemovalAsync(
-                "C:\\Users\\ExampleUser\\AppData\\Local\\Programs\\uloop\\bin\\uloop.exe",
-                CancellationToken.None,
-                1000,
-                100,
-                executablePath => remainingExistingChecks-- > 0,
-                (delayMs, ct) =>
-                {
-                    delayCount++;
-                    return Task.CompletedTask;
-                });
-
-            Assert.That(result.Success, Is.True, result.ErrorOutput);
-            Assert.That(delayCount, Is.EqualTo(2));
-        }
-
-        [Test]
-        public async Task WaitForUninstallTargetRemovalAsync_WhenTargetRemainsReturnsFailure()
-        {
-            // Verifies that delayed launcher removal failures do not recache a stale installed CLI.
-            int delayCount = 0;
-
-            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallTargetRemovalAsync(
-                "C:\\Users\\ExampleUser\\AppData\\Local\\Programs\\uloop\\bin\\uloop.exe",
+            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
+                targetPath,
                 CancellationToken.None,
                 250,
                 100,
                 executablePath => true,
-                (delayMs, ct) =>
-                {
-                    delayCount++;
-                    return Task.CompletedTask;
-                });
-
-            Assert.That(result.Success, Is.False);
-            Assert.That(result.ErrorOutput, Does.Contain("Timed out waiting for uLoop CLI uninstall"));
-            Assert.That(delayCount, Is.EqualTo(3));
-        }
-
-        [Test]
-        public async Task WaitForUninstallCompletionAsync_OnWindowsWaitsForUserPathRemoval()
-        {
-            // Verifies that Settings uninstall waits until Windows User PATH no longer resolves the native CLI directory.
-            string installDirectory = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin";
-            string userPath = installDirectory + ";C:\\npm";
-            int delayCount = 0;
-
-            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
-                installDirectory + "\\uloop.exe",
-                installDirectory,
-                RuntimePlatform.WindowsEditor,
-                CancellationToken.None,
-                1000,
-                100,
-                executablePath => false,
-                true,
-                (name, target) => userPath,
-                (delayMs, ct) =>
-                {
-                    delayCount++;
-                    userPath = "C:\\npm";
-                    return Task.CompletedTask;
-                });
-
-            Assert.That(result.Success, Is.True, result.ErrorOutput);
-            Assert.That(delayCount, Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task WaitForUninstallCompletionAsync_OnWindowsFailsWhenUserPathRemains()
-        {
-            // Verifies that uninstall cannot report success while Windows User PATH still contains the native CLI directory.
-            string installDirectory = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin";
-            int delayCount = 0;
-
-            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
-                installDirectory + "\\uloop.exe",
-                installDirectory,
-                RuntimePlatform.WindowsEditor,
-                CancellationToken.None,
-                250,
-                100,
-                executablePath => false,
-                true,
-                (name, target) => installDirectory + ";C:\\npm",
-                (delayMs, ct) =>
-                {
-                    delayCount++;
-                    return Task.CompletedTask;
-                });
-
-            Assert.That(result.Success, Is.False);
-            Assert.That(result.ErrorOutput, Does.Contain("Windows User PATH"));
-            Assert.That(result.ErrorOutput, Does.Not.Contain("\\uloop.exe"));
-            Assert.That(delayCount, Is.EqualTo(3));
-        }
-
-        [Test]
-        public async Task WaitForUninstallCompletionAsync_WhenUserPathRemovalIsNotRequiredReportsTargetTimeoutOnly()
-        {
-            // Verifies fallback uninstall failures do not claim ownership of Windows User PATH cleanup.
-            string installDirectory = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin";
-
-            CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
-                installDirectory + "\\uloop.exe",
-                installDirectory,
-                RuntimePlatform.WindowsEditor,
-                CancellationToken.None,
-                250,
-                100,
-                executablePath => true,
-                false,
-                (name, target) => installDirectory + ";C:\\npm",
                 (delayMs, ct) => Task.CompletedTask);
 
             Assert.That(result.Success, Is.False);
-            Assert.That(result.ErrorOutput, Does.Contain("\\uloop.exe"));
-            Assert.That(result.ErrorOutput, Does.Not.Contain("Windows User PATH"));
+            Assert.That(result.ErrorOutput, Does.Contain(targetPath));
         }
 
         [Test]
-        public async Task WaitForUninstallCompletionAsync_WhenUserPathRemovalIsNotRequiredIgnoresUserPath()
+        public async Task WaitForUninstallCompletionAsync_WhenTargetIsRemovedReturnsSuccess()
         {
-            // Verifies fallback launchers can complete uninstall without owning Windows User PATH cleanup.
-            string installDirectory = "C:\\Users\\ExampleUser\\Programs\\uloop\\bin";
+            // Verifies uninstall completion succeeds as soon as deferred launcher self-removal finishes.
 
             CliInstallResult result = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
-                installDirectory + "\\uloop.exe",
-                installDirectory,
-                RuntimePlatform.WindowsEditor,
+                "C:\\Users\\ExampleUser\\Programs\\uloop\\bin\\uloop.exe",
                 CancellationToken.None,
                 250,
                 100,
                 executablePath => false,
-                false,
-                (name, target) => installDirectory + ";C:\\npm",
                 (delayMs, ct) => Task.CompletedTask);
 
             Assert.That(result.Success, Is.True, result.ErrorOutput);

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstallPathResolver.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstallPathResolver.cs
@@ -220,24 +220,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 : CliConstants.POSIX_PATH_ENVIRONMENT_VARIABLE;
         }
 
-        internal static bool DoesUserPathContainInstallDirectory(
-            string installDirectory,
-            RuntimePlatform platform,
-            Func<string, EnvironmentVariableTarget, string> getEnvironmentVariable)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
-            UnityEngine.Debug.Assert(getEnvironmentVariable != null, "getEnvironmentVariable must not be null");
-
-            if (platform != RuntimePlatform.WindowsEditor)
-            {
-                return false;
-            }
-
-            string pathVariableName = GetPathEnvironmentVariableName(platform);
-            string currentUserPath = getEnvironmentVariable(pathVariableName, EnvironmentVariableTarget.User);
-            return DoesPathContainInstallDirectory(currentUserPath, installDirectory, platform);
-        }
-
         private static string GetPathSeparator(RuntimePlatform platform)
         {
             return platform == RuntimePlatform.WindowsEditor
@@ -270,42 +252,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return normalizedPath.TrimEnd('\\', '/').Replace('/', '\\');
-        }
-
-        private static bool DoesPathContainInstallDirectory(
-            string currentPath,
-            string installDirectory,
-            RuntimePlatform platform)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
-
-            string normalizedPath = currentPath ?? "";
-            if (string.IsNullOrEmpty(normalizedPath))
-            {
-                return false;
-            }
-
-            string separator = GetPathSeparator(platform);
-            string[] entries = normalizedPath.Split(
-                new[] { separator },
-                StringSplitOptions.RemoveEmptyEntries);
-            string normalizedInstallDirectory = NormalizePathForComparison(installDirectory, platform);
-            StringComparison comparison = GetPathComparison(platform);
-            foreach (string entry in entries)
-            {
-                if (string.IsNullOrWhiteSpace(entry))
-                {
-                    continue;
-                }
-
-                string normalizedEntry = NormalizePathForComparison(entry, platform);
-                if (string.Equals(normalizedEntry, normalizedInstallDirectory, comparison))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static string GetGlobalCliInstallFileName(RuntimePlatform platform)

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliInstaller.cs
@@ -93,14 +93,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string installPath = NativeCliInstallPathResolver.GetGlobalCliInstallPath(installDirectory, platform);
             CliInstallResult removalResult = await NativeCliUninstallCompletionWaiter.WaitForUninstallCompletionAsync(
                 installPath,
-                installDirectory,
-                platform,
                 ct,
                 NativeCliUninstallCompletionWaiter.UNINSTALL_COMPLETION_TIMEOUT_MS,
                 NativeCliSetupCommandRunner.INSTALL_PROCESS_WAIT_SLICE_MS,
                 File.Exists,
-                false,
-                Environment.GetEnvironmentVariable,
                 Task.Delay);
             if (!removalResult.Success)
             {

--- a/Packages/src/Editor/Infrastructure/CLI/NativeCliUninstallCompletionWaiter.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/NativeCliUninstallCompletionWaiter.cs
@@ -15,7 +15,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         internal const int UNINSTALL_COMPLETION_TIMEOUT_MS = 30000;
 
-        internal static async Task<CliInstallResult> WaitForUninstallTargetRemovalAsync(
+        internal static async Task<CliInstallResult> WaitForUninstallCompletionAsync(
             string targetPath,
             CancellationToken ct,
             int timeoutMs,
@@ -30,8 +30,14 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             UnityEngine.Debug.Assert(delayAsync != null, "delayAsync must not be null");
 
             int elapsedMs = 0;
-            while (fileExists(targetPath))
+            while (true)
             {
+                bool targetStillExists = fileExists(targetPath);
+                if (!targetStillExists)
+                {
+                    return new CliInstallResult(true, "");
+                }
+
                 ct.ThrowIfCancellationRequested();
                 if (elapsedMs >= timeoutMs)
                 {
@@ -44,101 +50,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 await delayAsync(delayMs, ct);
                 elapsedMs += delayMs;
             }
-
-            return new CliInstallResult(true, "");
-        }
-
-        internal static async Task<CliInstallResult> WaitForUninstallCompletionAsync(
-            string targetPath,
-            string installDirectory,
-            RuntimePlatform platform,
-            CancellationToken ct,
-            int timeoutMs,
-            int pollMs,
-            Func<string, bool> fileExists,
-            bool requireUserPathRemoval,
-            Func<string, EnvironmentVariableTarget, string> getEnvironmentVariable,
-            Func<int, CancellationToken, Task> delayAsync)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(targetPath), "targetPath must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
-            UnityEngine.Debug.Assert(timeoutMs > 0, "timeoutMs must be greater than zero");
-            UnityEngine.Debug.Assert(pollMs > 0, "pollMs must be greater than zero");
-            UnityEngine.Debug.Assert(fileExists != null, "fileExists must not be null");
-            UnityEngine.Debug.Assert(getEnvironmentVariable != null, "getEnvironmentVariable must not be null");
-            UnityEngine.Debug.Assert(delayAsync != null, "delayAsync must not be null");
-
-            int elapsedMs = 0;
-            while (true)
-            {
-                bool targetStillExists = fileExists(targetPath);
-                bool userPathStillContainsInstallDirectory = ShouldWaitForUserPathRemoval(
-                    requireUserPathRemoval,
-                    installDirectory,
-                    platform,
-                    getEnvironmentVariable);
-                if (!targetStillExists && !userPathStillContainsInstallDirectory)
-                {
-                    return new CliInstallResult(true, "");
-                }
-
-                ct.ThrowIfCancellationRequested();
-                if (elapsedMs >= timeoutMs)
-                {
-                    return new CliInstallResult(
-                        false,
-                        BuildUninstallCompletionTimeoutFailure(
-                            targetPath,
-                            installDirectory,
-                            platform,
-                            targetStillExists,
-                            userPathStillContainsInstallDirectory));
-                }
-
-                int delayMs = Math.Min(pollMs, timeoutMs - elapsedMs);
-                await delayAsync(delayMs, ct);
-                elapsedMs += delayMs;
-            }
-        }
-
-        private static bool ShouldWaitForUserPathRemoval(
-            bool requireUserPathRemoval,
-            string installDirectory,
-            RuntimePlatform platform,
-            Func<string, EnvironmentVariableTarget, string> getEnvironmentVariable)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
-            UnityEngine.Debug.Assert(getEnvironmentVariable != null, "getEnvironmentVariable must not be null");
-
-            return requireUserPathRemoval
-                && NativeCliInstallPathResolver.DoesUserPathContainInstallDirectory(
-                    installDirectory,
-                    platform,
-                    getEnvironmentVariable);
-        }
-
-        private static string BuildUninstallCompletionTimeoutFailure(
-            string targetPath,
-            string installDirectory,
-            RuntimePlatform platform,
-            bool targetStillExists,
-            bool userPathStillContainsInstallDirectory)
-        {
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(targetPath), "targetPath must not be null or empty");
-            UnityEngine.Debug.Assert(!string.IsNullOrWhiteSpace(installDirectory), "installDirectory must not be null or empty");
-            UnityEngine.Debug.Assert(targetStillExists || userPathStillContainsInstallDirectory, "at least one uninstall cleanup condition must still be pending");
-
-            if (platform != RuntimePlatform.WindowsEditor || !userPathStillContainsInstallDirectory)
-            {
-                return $"Timed out waiting for uLoop CLI uninstall to remove {targetPath}.";
-            }
-
-            if (!targetStillExists)
-            {
-                return $"Timed out waiting for uLoop CLI uninstall to remove {installDirectory} from Windows User PATH.";
-            }
-
-            return $"Timed out waiting for uLoop CLI uninstall to remove {targetPath} and remove {installDirectory} from Windows User PATH.";
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove legacy native CLI uninstall branches that became test-only after package-local launchers were retired.
- Keep uninstall completion focused on waiting for the installed launcher to remove itself.

## User Impact
- Native CLI uninstall behavior remains unchanged: Settings still waits for deferred launcher self-removal before refreshing status.
- The obsolete Windows User PATH polling path is removed because the installed launcher has owned User PATH cleanup since PR #1250.

## Changes
- Simplify `WaitForUninstallCompletionAsync` to wait only for the target executable to disappear.
- Preserve the existing evaluation order: file check, success, cancellation, timeout, then delay.
- Preserve the production timeout message byte-for-byte.
- Delete the test-only standalone waiter, false-gated User PATH branch, timeout message variants, and their four obsolete tests.
- Delete the now-unreferenced User PATH resolver chain.
- Retain timeout and success coverage as two focused uninstall completion tests, along with the 30-second deferred Windows cleanup contract.

## Verification
- Ran the C# dead-code scanner before deletion; it reported no keep reason or external public candidate for the removed chain.
- Confirmed by repository-wide search that the removed methods and User PATH branch had no remaining production or non-C# callers.
- Verified commit `93b0176a` / PR #1250 intentionally changed production to `requireUserPathRemoval: false` when package-local development launchers were removed.
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` (0 errors, 0 warnings)
- `NativeCliInstallerTests` (29 passed)
- The target-timeout test preserves the existing 250 ms / 100 ms polling contract by asserting exactly three delay slices.
- `StaticFacadeStateGuardTests` (20 passed)
- No wire format, protocol version, or release input changes.
