### PR TITLE
chore: Simplify shared Roslyn worker internals

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -48,6 +48,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         [Test]
+        public void TryParseResponseHeader_WhenHeaderContainsExitCode_ShouldReturnParsedCode()
+        {
+            // Verifies the worker protocol accepts its result prefix followed by a numeric exit code.
+            bool parsed = SharedRoslynCompilerWorkerHost.TryParseResponseHeader("__ULOOP_RESULT__ 7", out int exitCode);
+
+            Assert.That(parsed, Is.True);
+            Assert.That(exitCode, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void GetResponseHeaderFailureReason_WhenPrefixIsInvalid_ShouldReportInvalidHeader()
+        {
+            // Verifies a response without the worker result prefix is classified as an invalid header.
+            string failureReason = SharedRoslynCompilerWorkerHost.GetResponseHeaderFailureReason("unexpected response");
+
+            Assert.That(failureReason, Is.EqualTo("worker_invalid_header"));
+        }
+
+        [Test]
+        public void GetResponseHeaderFailureReason_WhenExitCodeIsInvalid_ShouldReportInvalidExitCode()
+        {
+            // Verifies a prefixed response with a non-numeric status is classified as an invalid exit code.
+            string failureReason = SharedRoslynCompilerWorkerHost.GetResponseHeaderFailureReason(
+                "__ULOOP_RESULT__ not-a-number");
+
+            Assert.That(failureReason, Is.EqualTo("worker_invalid_exit_code"));
+        }
+
+        [Test]
         public void CreateProgramSource_WhenRequestPathHasNoPrefix_ShouldRecoverRawPath()
         {
             string programSource = SharedRoslynCompilerWorkerHost.CreateProgramSourceForTests();

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -33,16 +33,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             string requestFilePath =
                 @"C:\Users\ExampleUser\Documents\unity\SampleWorkspace\SampleUnityProject\Temp\UnityCliLoopCompilation\DynamicCommand_1.worker";
 
-            string command = SharedRoslynCompilerWorkerHost.CreateCompileRequestCommandForTests(requestFilePath);
+            string command = SharedRoslynCompilerWorkerProtocol.CreateCompileRequestCommand(requestFilePath);
 
-            Assert.That(command, Does.StartWith(SharedRoslynCompilerWorkerHost.CompileRequestPathPrefix));
+            Assert.That(command, Does.StartWith(SharedRoslynCompilerWorkerProtocol.CompileRequestPathPrefix));
             Assert.That(command, Does.Not.Contain(requestFilePath));
             foreach (char character in command)
             {
                 Assert.That(character, Is.LessThanOrEqualTo((char)127));
             }
 
-            string encodedPath = command.Substring(SharedRoslynCompilerWorkerHost.CompileRequestPathPrefix.Length);
+            string encodedPath = command.Substring(SharedRoslynCompilerWorkerProtocol.CompileRequestPathPrefix.Length);
             string decodedPath = Encoding.UTF8.GetString(Convert.FromBase64String(encodedPath));
             Assert.That(decodedPath, Is.EqualTo(Path.GetFullPath(requestFilePath)));
         }
@@ -51,7 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         public void TryParseResponseHeader_WhenHeaderContainsExitCode_ShouldReturnParsedCode()
         {
             // Verifies the worker protocol accepts its result prefix followed by a numeric exit code.
-            bool parsed = SharedRoslynCompilerWorkerHost.TryParseResponseHeader("__ULOOP_RESULT__ 7", out int exitCode);
+            bool parsed = SharedRoslynCompilerWorkerProtocol.TryParseResponseHeader("__ULOOP_RESULT__ 7", out int exitCode);
 
             Assert.That(parsed, Is.True);
             Assert.That(exitCode, Is.EqualTo(7));
@@ -61,7 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         public void GetResponseHeaderFailureReason_WhenPrefixIsInvalid_ShouldReportInvalidHeader()
         {
             // Verifies a response without the worker result prefix is classified as an invalid header.
-            string failureReason = SharedRoslynCompilerWorkerHost.GetResponseHeaderFailureReason("unexpected response");
+            string failureReason = SharedRoslynCompilerWorkerProtocol.GetResponseHeaderFailureReason("unexpected response");
 
             Assert.That(failureReason, Is.EqualTo("worker_invalid_header"));
         }
@@ -70,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         public void GetResponseHeaderFailureReason_WhenExitCodeIsInvalid_ShouldReportInvalidExitCode()
         {
             // Verifies a prefixed response with a non-numeric status is classified as an invalid exit code.
-            string failureReason = SharedRoslynCompilerWorkerHost.GetResponseHeaderFailureReason(
+            string failureReason = SharedRoslynCompilerWorkerProtocol.GetResponseHeaderFailureReason(
                 "__ULOOP_RESULT__ not-a-number");
 
             Assert.That(failureReason, Is.EqualTo("worker_invalid_exit_code"));
@@ -79,7 +79,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void CreateProgramSource_WhenRequestPathHasNoPrefix_ShouldRecoverRawPath()
         {
-            string programSource = SharedRoslynCompilerWorkerHost.CreateProgramSourceForTests();
+            string programSource = SharedRoslynCompilerWorkerProtocol.CreateProgramSource();
 
             Assert.That(programSource, Does.Contain("return RecoverRawRequestPath(requestPath);"));
             Assert.That(programSource, Does.Contain("FindWindowsDrivePathIndex"));
@@ -89,24 +89,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void CreateProgramSource_WhenTemplateIsLoaded_ShouldReplaceTokens()
         {
-            string templatePath = SharedRoslynCompilerWorkerHost.GetWorkerProgramTemplatePathForTests();
-            string programSource = SharedRoslynCompilerWorkerHost.CreateProgramSourceForTests();
+            string templatePath = SharedRoslynCompilerWorkerProtocol.GetWorkerProgramTemplatePath();
+            string programSource = SharedRoslynCompilerWorkerProtocol.CreateProgramSource();
 
             Assert.That(File.Exists(templatePath), Is.True);
-            Assert.That(programSource, Does.Contain(SharedRoslynCompilerWorkerHost.CompileRequestPathPrefix));
+            Assert.That(programSource, Does.Contain(SharedRoslynCompilerWorkerProtocol.CompileRequestPathPrefix));
             Assert.That(programSource, Does.Contain(
-                SharedRoslynCompilerWorkerHost.GetSharedCompilerWorkerResultPrefixForTests()));
+                SharedRoslynCompilerWorkerProtocol.SharedCompilerWorkerResultPrefix));
             Assert.That(programSource, Does.Contain(
-                SharedRoslynCompilerWorkerHost.GetSharedCompilerWorkerEndMarkerForTests()));
+                SharedRoslynCompilerWorkerProtocol.SharedCompilerWorkerEndMarker));
             Assert.That(programSource, Does.Contain(
-                SharedRoslynCompilerWorkerHost.GetSharedCompilerWorkerQuitCommandForTests()));
+                SharedRoslynCompilerWorkerProtocol.SharedCompilerWorkerQuitCommand));
             Assert.That(programSource, Does.Not.Contain("{{"));
         }
 
         [Test]
         public void CreateProgramSource_WhenRequestPathPrefixHasLeadingGarbage_ShouldDecodeEncodedPath()
         {
-            string programSource = SharedRoslynCompilerWorkerHost.CreateProgramSourceForTests();
+            string programSource = SharedRoslynCompilerWorkerProtocol.CreateProgramSource();
 
             Assert.That(programSource, Does.Contain("FindRequestPathPrefixIndex"));
             Assert.That(programSource, Does.Contain("IndexOf(RequestPathPrefix"));
@@ -116,7 +116,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void CreateProgramSource_WhenRawPathContainsPrefixAfterDirectorySeparator_ShouldRecoverRawPath()
         {
-            string programSource = SharedRoslynCompilerWorkerHost.CreateProgramSourceForTests();
+            string programSource = SharedRoslynCompilerWorkerProtocol.CreateProgramSource();
 
             Assert.That(programSource, Does.Contain("HasDirectorySeparatorBeforePrefix"));
             Assert.That(programSource, Does.Contain("return HasDirectorySeparatorBeforePrefix(requestPath, encodedPathIndex) ? -1 : encodedPathIndex;"));
@@ -125,7 +125,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void CreateProgramSource_WhenEncodedPayloadIsMalformed_ShouldRecoverRawPath()
         {
-            string programSource = SharedRoslynCompilerWorkerHost.CreateProgramSourceForTests();
+            string programSource = SharedRoslynCompilerWorkerProtocol.CreateProgramSource();
 
             Assert.That(programSource, Does.Contain("IsBase64Payload"));
             Assert.That(programSource, Does.Contain("HasValidBase64Padding"));

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -450,7 +450,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return WorkerAttemptResult.Successful(compilerMessages);
         }
 
-        private static bool TryParseResponseHeader(string responseHeader, out int exitCode)
+        internal static bool TryParseResponseHeader(string responseHeader, out int exitCode)
         {
             exitCode = 0;
 
@@ -463,7 +463,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return int.TryParse(statusText, out exitCode);
         }
 
-        private static string GetResponseHeaderFailureReason(string responseHeader)
+        internal static string GetResponseHeaderFailureReason(string responseHeader)
         {
             if (!responseHeader.StartsWith(SharedCompilerWorkerResultPrefix, StringComparison.Ordinal))
             {

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -19,20 +18,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class SharedRoslynCompilerWorkerHost
     {
         private const int SharedCompilerWorkerMaxAttempts = 2;
-        private const string SharedCompilerWorkerResultPrefix = "__ULOOP_RESULT__";
-        private const string SharedCompilerWorkerEndMarker = "__ULOOP_END__";
-        private const string SharedCompilerWorkerQuitCommand = "__QUIT__";
-        internal const string CompileRequestPathPrefix = "path-base64:";
         private const string RoslynWorkerSourceFileName = "RoslynCompilerWorker.cs";
         private const string RoslynWorkerAssemblyFileName = "RoslynCompilerWorker.dll";
         private const string RoslynWorkerCompileResponseFileName = "RoslynCompilerWorker.rsp";
-        private const string RoslynWorkerProgramTemplateRelativePath =
-            "Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/Templates/SharedRoslynCompilerWorkerProgram.cs.template";
-        private const string SharedCompilerWorkerResultPrefixToken = "{{SHARED_COMPILER_WORKER_RESULT_PREFIX}}";
-        private const string SharedCompilerWorkerEndMarkerToken = "{{SHARED_COMPILER_WORKER_END_MARKER}}";
-        private const string SharedCompilerWorkerQuitCommandToken = "{{SHARED_COMPILER_WORKER_QUIT_COMMAND}}";
-        private const string CompileRequestPathPrefixToken = "{{COMPILE_REQUEST_PATH_PREFIX}}";
-        private const int SharedCompilerWorkerResponseTimeoutMilliseconds = 30000;
         private const int WorkerAssemblyBuildTimeoutMilliseconds = 30000;
         internal const string DotnetMultilevelLookupEnvironmentVariableName = "DOTNET_MULTILEVEL_LOOKUP";
         internal const string DotnetMultilevelLookupDisabledValue = "0";
@@ -392,36 +380,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void SendCompileRequestCore(Process workerProcess, string requestFilePath)
         {
-            string requestCommand = CreateCompileRequestCommand(requestFilePath);
+            string requestCommand = SharedRoslynCompilerWorkerProtocol.CreateCompileRequestCommand(requestFilePath);
             workerProcess.StandardInput.WriteLine(requestCommand);
             workerProcess.StandardInput.Flush();
-        }
-
-        internal static string CreateCompileRequestCommandForTests(string requestFilePath)
-        {
-            return CreateCompileRequestCommand(requestFilePath);
-        }
-
-        internal static string CreateProgramSourceForTests()
-        {
-            return CreateProgramSource();
-        }
-
-        private static string CreateCompileRequestCommand(string requestFilePath)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(requestFilePath), "requestFilePath must not be empty");
-
-            string fullRequestFilePath = Path.GetFullPath(requestFilePath);
-            byte[] requestPathBytes = Encoding.UTF8.GetBytes(fullRequestFilePath);
-            return CompileRequestPathPrefix + Convert.ToBase64String(requestPathBytes);
         }
 
         private static WorkerAttemptResult ReadWorkerResponse(
             string requestFilePath,
             CancellationToken ct)
         {
-            string responseHeader = ReadProtocolLine(
-                _sharedCompilerWorkerProcess.StandardOutput,
+            StreamReader reader = _sharedCompilerWorkerProcess.StandardOutput;
+            string responseHeader = SharedRoslynCompilerWorkerProtocol.ReadProtocolLine(
+                reader,
                 ct);
             if (string.IsNullOrEmpty(responseHeader))
             {
@@ -430,14 +400,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     new { request_file_path = requestFilePath });
             }
 
-            if (!TryParseResponseHeader(responseHeader, out int exitCode))
+            if (!SharedRoslynCompilerWorkerProtocol.TryParseResponseHeader(responseHeader, out int exitCode))
             {
                 return WorkerAttemptResult.RetryableFailure(
-                    GetResponseHeaderFailureReason(responseHeader),
+                    SharedRoslynCompilerWorkerProtocol.GetResponseHeaderFailureReason(responseHeader),
                     new { header = responseHeader });
             }
 
-            List<string> outputLines = ReadDiagnosticLines(ct);
+            List<string> outputLines = SharedRoslynCompilerWorkerProtocol.ReadDiagnosticLines(reader, ct);
             if (outputLines == null)
             {
                 return WorkerAttemptResult.RetryableFailure(
@@ -448,49 +418,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string combinedOutput = string.Join("\n", outputLines);
             CompilerMessage[] compilerMessages = ExternalCompilerMessageParser.Parse(combinedOutput, string.Empty, exitCode);
             return WorkerAttemptResult.Successful(compilerMessages);
-        }
-
-        internal static bool TryParseResponseHeader(string responseHeader, out int exitCode)
-        {
-            exitCode = 0;
-
-            if (!responseHeader.StartsWith(SharedCompilerWorkerResultPrefix, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            string statusText = responseHeader.Substring(SharedCompilerWorkerResultPrefix.Length).Trim();
-            return int.TryParse(statusText, out exitCode);
-        }
-
-        internal static string GetResponseHeaderFailureReason(string responseHeader)
-        {
-            if (!responseHeader.StartsWith(SharedCompilerWorkerResultPrefix, StringComparison.Ordinal))
-            {
-                return "worker_invalid_header";
-            }
-
-            return "worker_invalid_exit_code";
-        }
-
-        private static List<string> ReadDiagnosticLines(CancellationToken ct)
-        {
-            List<string> outputLines = new();
-            while (true)
-            {
-                string outputLine = ReadProtocolLine(_sharedCompilerWorkerProcess.StandardOutput, ct);
-                if (outputLine == null)
-                {
-                    return null;
-                }
-
-                if (outputLine == SharedCompilerWorkerEndMarker)
-                {
-                    return outputLines;
-                }
-
-                outputLines.Add(outputLine);
-            }
         }
 
         private static WorkerPaths CreateWorkerPaths()
@@ -515,7 +442,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void SynchronizeWorkerSource(WorkerPaths workerPaths)
         {
-            string workerSource = CreateProgramSource();
+            string workerSource = SharedRoslynCompilerWorkerProtocol.CreateProgramSource();
             if (File.Exists(workerPaths.SourcePath) && File.ReadAllText(workerPaths.SourcePath) == workerSource)
             {
                 return;
@@ -686,22 +613,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             File.WriteAllLines(responseFilePath, lines);
         }
 
-        private static string ReadProtocolLine(StreamReader reader, CancellationToken ct)
-        {
-            Debug.Assert(reader != null, "reader must not be null");
-
-            Task<string> readTask = Task.Run(() => reader.ReadLine());
-            Task timeoutTask = Task.Delay(SharedCompilerWorkerResponseTimeoutMilliseconds, ct);
-            Task completedTask = Task.WhenAny(readTask, timeoutTask).GetAwaiter().GetResult();
-            if (!ReferenceEquals(completedTask, readTask))
-            {
-                ct.ThrowIfCancellationRequested();
-                return null;
-            }
-
-            return readTask.GetAwaiter().GetResult();
-        }
-
         private static bool HasLiveWorkerProcess()
         {
             return _sharedCompilerWorkerProcess != null && !_sharedCompilerWorkerProcess.HasExited;
@@ -811,7 +722,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (!workerProcess.HasExited)
                 {
-                    workerProcess.StandardInput.WriteLine(SharedCompilerWorkerQuitCommand);
+                    workerProcess.StandardInput.WriteLine(
+                        SharedRoslynCompilerWorkerProtocol.SharedCompilerWorkerQuitCommand);
                     workerProcess.StandardInput.Flush();
                     workerProcess.WaitForExit(500);
                 }
@@ -949,40 +861,5 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             destination.Add(referencePath);
         }
 
-        private static string CreateProgramSource()
-        {
-            string templatePath = GetWorkerProgramTemplatePath();
-            string templateSource = File.ReadAllText(templatePath, Encoding.UTF8);
-            return templateSource
-                .Replace(SharedCompilerWorkerResultPrefixToken, SharedCompilerWorkerResultPrefix)
-                .Replace(SharedCompilerWorkerEndMarkerToken, SharedCompilerWorkerEndMarker)
-                .Replace(SharedCompilerWorkerQuitCommandToken, SharedCompilerWorkerQuitCommand)
-                .Replace(CompileRequestPathPrefixToken, CompileRequestPathPrefix);
-        }
-
-        internal static string GetWorkerProgramTemplatePathForTests()
-        {
-            return GetWorkerProgramTemplatePath();
-        }
-
-        internal static string GetSharedCompilerWorkerResultPrefixForTests()
-        {
-            return SharedCompilerWorkerResultPrefix;
-        }
-
-        internal static string GetSharedCompilerWorkerEndMarkerForTests()
-        {
-            return SharedCompilerWorkerEndMarker;
-        }
-
-        internal static string GetSharedCompilerWorkerQuitCommandForTests()
-        {
-            return SharedCompilerWorkerQuitCommand;
-        }
-
-        private static string GetWorkerProgramTemplatePath()
-        {
-            return Path.Combine(UnityCliLoopConstants.PackageResolvedPath, RoslynWorkerProgramTemplateRelativePath);
-        }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerProtocol.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerProtocol.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Debug = UnityEngine.Debug;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Encodes and decodes the shared Roslyn compiler worker protocol.
+    /// </summary>
+    internal static class SharedRoslynCompilerWorkerProtocol
+    {
+        internal const string SharedCompilerWorkerResultPrefix = "__ULOOP_RESULT__";
+        internal const string SharedCompilerWorkerEndMarker = "__ULOOP_END__";
+        internal const string SharedCompilerWorkerQuitCommand = "__QUIT__";
+        internal const string CompileRequestPathPrefix = "path-base64:";
+        private const string RoslynWorkerProgramTemplateRelativePath =
+            "Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/Templates/SharedRoslynCompilerWorkerProgram.cs.template";
+        private const string SharedCompilerWorkerResultPrefixToken = "{{SHARED_COMPILER_WORKER_RESULT_PREFIX}}";
+        private const string SharedCompilerWorkerEndMarkerToken = "{{SHARED_COMPILER_WORKER_END_MARKER}}";
+        private const string SharedCompilerWorkerQuitCommandToken = "{{SHARED_COMPILER_WORKER_QUIT_COMMAND}}";
+        private const string CompileRequestPathPrefixToken = "{{COMPILE_REQUEST_PATH_PREFIX}}";
+        private const int SharedCompilerWorkerResponseTimeoutMilliseconds = 30000;
+
+        internal static string CreateCompileRequestCommand(string requestFilePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(requestFilePath), "requestFilePath must not be empty");
+
+            string fullRequestFilePath = Path.GetFullPath(requestFilePath);
+            byte[] requestPathBytes = Encoding.UTF8.GetBytes(fullRequestFilePath);
+            return CompileRequestPathPrefix + Convert.ToBase64String(requestPathBytes);
+        }
+
+        internal static bool TryParseResponseHeader(string responseHeader, out int exitCode)
+        {
+            exitCode = 0;
+
+            if (!responseHeader.StartsWith(SharedCompilerWorkerResultPrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            string statusText = responseHeader.Substring(SharedCompilerWorkerResultPrefix.Length).Trim();
+            return int.TryParse(statusText, out exitCode);
+        }
+
+        internal static string GetResponseHeaderFailureReason(string responseHeader)
+        {
+            if (!responseHeader.StartsWith(SharedCompilerWorkerResultPrefix, StringComparison.Ordinal))
+            {
+                return "worker_invalid_header";
+            }
+
+            return "worker_invalid_exit_code";
+        }
+
+        internal static List<string> ReadDiagnosticLines(StreamReader reader, CancellationToken ct)
+        {
+            List<string> outputLines = new();
+            while (true)
+            {
+                string outputLine = ReadProtocolLine(reader, ct);
+                if (outputLine == null)
+                {
+                    return null;
+                }
+
+                if (outputLine == SharedCompilerWorkerEndMarker)
+                {
+                    return outputLines;
+                }
+
+                outputLines.Add(outputLine);
+            }
+        }
+
+        internal static string ReadProtocolLine(StreamReader reader, CancellationToken ct)
+        {
+            Debug.Assert(reader != null, "reader must not be null");
+
+            Task<string> readTask = Task.Run(() => reader.ReadLine());
+            Task timeoutTask = Task.Delay(SharedCompilerWorkerResponseTimeoutMilliseconds, ct);
+            Task completedTask = Task.WhenAny(readTask, timeoutTask).GetAwaiter().GetResult();
+            if (!ReferenceEquals(completedTask, readTask))
+            {
+                ct.ThrowIfCancellationRequested();
+                return null;
+            }
+
+            return readTask.GetAwaiter().GetResult();
+        }
+
+        internal static string CreateProgramSource()
+        {
+            string templatePath = GetWorkerProgramTemplatePath();
+            string templateSource = File.ReadAllText(templatePath, Encoding.UTF8);
+            return templateSource
+                .Replace(SharedCompilerWorkerResultPrefixToken, SharedCompilerWorkerResultPrefix)
+                .Replace(SharedCompilerWorkerEndMarkerToken, SharedCompilerWorkerEndMarker)
+                .Replace(SharedCompilerWorkerQuitCommandToken, SharedCompilerWorkerQuitCommand)
+                .Replace(CompileRequestPathPrefixToken, CompileRequestPathPrefix);
+        }
+
+        internal static string GetWorkerProgramTemplatePath()
+        {
+            return Path.Combine(UnityCliLoopConstants.PackageResolvedPath, RoslynWorkerProgramTemplateRelativePath);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerProtocol.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerProtocol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1207fcd146325443ea468ea8f98e7f63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Separate shared Roslyn worker wire framing and template rendering from process lifecycle orchestration.
- Keep dynamic-code compilation behavior and worker protocol bytes unchanged.

## User Impact
- Execute-dynamic-code compilation, retry, timeout, cancellation, and fallback behavior remain unchanged.
- The smaller worker host makes later lifecycle and assembly-build refactors easier to review independently.

## Changes
- Add `SharedRoslynCompilerWorkerProtocol` to own request encoding, response header parsing, diagnostic framing, protocol read timeout, quit marker, and worker program template token replacement.
- Retarget existing command/template tests directly to the new owner and remove six host test wrappers.
- Add characterization coverage for valid response headers, invalid prefixes, and non-numeric exit codes before extraction.
- Reduce `SharedRoslynCompilerWorkerHost` from 988 to 865 lines while leaving retry, process lifecycle, assembly build, and shutdown state in the host.
- The only non-move production change is passing the current worker `StandardOutput` reader into `ReadDiagnosticLines`; all compile calls run under `SharedCompilerWorkerLock`, and `Process.StandardOutput` returns the same reader instance used for the response header.
- Preserve the existing double `Path.GetFullPath` application, blocking read behavior, strings, markers, timeout values, and `out int exitCode` contract.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` (0 errors, 0 warnings)
- `SharedRoslynCompilerWorkerHostTests` (10 passed)
- `ExternalCompilerPathResolverTests` (15 passed, including worker-build fallback)
- `StaticFacadeStateGuardTests` (20 passed)
- Confirmed that removed host wrappers have zero references and the protocol has no reverse dependency on the host.
- No IPC wire shape, CLI/package protocol version, or release input changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

