### PR TITLE
fix: Worker compiler timeouts no longer block indefinitely

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -59,6 +59,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(completed, Is.True);
         }
 
+        /// <summary>
+        /// Verifies a faulted compiler stream is treated as drained without escaping timeout recovery.
+        /// </summary>
+        [Test]
+        public void WaitForCompilerStreamDrain_WhenStreamFaults_ShouldReturnTrue()
+        {
+            Task<string> faultedStream = Task.FromException<string>(new IOException("stream read failed"));
+
+            bool completed = SharedRoslynCompilerWorkerAssemblyBuilder.WaitForCompilerStreamDrain(
+                Task.FromResult("stdout"),
+                faultedStream,
+                0);
+
+            Assert.That(completed, Is.True);
+        }
+
         [Test]
         public void CreateCompileRequestCommand_WhenPathIsWindowsAbsolutePath_ShouldEncodeAsciiPayload()
         {

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -25,6 +26,37 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(
                 startInfo.EnvironmentVariables[SharedRoslynCompilerWorkerAssemblyBuilder.DotnetMultilevelLookupEnvironmentVariableName],
                 Is.EqualTo(SharedRoslynCompilerWorkerAssemblyBuilder.DotnetMultilevelLookupDisabledValue));
+        }
+
+        /// <summary>
+        /// Verifies a pending compiler stream does not keep the bounded drain waiting.
+        /// </summary>
+        [Test]
+        public void WaitForCompilerStreamDrain_WhenStreamIsPending_ShouldReturnFalse()
+        {
+            TaskCompletionSource<string> pendingStream = new();
+
+            bool completed = SharedRoslynCompilerWorkerAssemblyBuilder.WaitForCompilerStreamDrain(
+                Task.FromResult("stdout"),
+                pendingStream.Task,
+                0);
+            pendingStream.SetResult("stderr");
+
+            Assert.That(completed, Is.False);
+        }
+
+        /// <summary>
+        /// Verifies completed compiler streams satisfy the bounded drain immediately.
+        /// </summary>
+        [Test]
+        public void WaitForCompilerStreamDrain_WhenStreamsAreCompleted_ShouldReturnTrue()
+        {
+            bool completed = SharedRoslynCompilerWorkerAssemblyBuilder.WaitForCompilerStreamDrain(
+                Task.FromResult("stdout"),
+                Task.FromResult("stderr"),
+                0);
+
+            Assert.That(completed, Is.True);
         }
 
         [Test]

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -75,6 +75,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(completed, Is.True);
         }
 
+        /// <summary>
+        /// Verifies one faulted stream does not make a still-pending drain appear complete.
+        /// </summary>
+        [Test]
+        public void WaitForCompilerStreamDrain_WhenFaultedStreamHasPendingPeer_ShouldReturnFalse()
+        {
+            TaskCompletionSource<string> pendingStream = new();
+            Task<string> faultedStream = Task.FromException<string>(new IOException("stream read failed"));
+
+            bool completed = SharedRoslynCompilerWorkerAssemblyBuilder.WaitForCompilerStreamDrain(
+                faultedStream,
+                pendingStream.Task,
+                0);
+            pendingStream.SetResult("stderr");
+
+            Assert.That(completed, Is.False);
+        }
+
         [Test]
         public void CreateCompileRequestCommand_WhenPathIsWindowsAbsolutePath_ShouldEncodeAsciiPayload()
         {

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
@@ -142,23 +142,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(stderrTask != null, "stderrTask must not be null");
             Debug.Assert(timeoutMilliseconds >= 0, "timeoutMilliseconds must not be negative");
 
-            bool completed = Task.WaitAll(
-                new Task[] { stdoutTask, stderrTask },
-                timeoutMilliseconds);
-            if (completed)
-            {
-                return true;
-            }
-
-            ObserveCompilerStreamFailure(stdoutTask);
-            ObserveCompilerStreamFailure(stderrTask);
-            return false;
+            Task streamDrainTask = Task.WhenAll(stdoutTask, stderrTask);
+            bool completed = Task.WaitAny(
+                new[] { streamDrainTask },
+                timeoutMilliseconds) == 0;
+            ObserveCompilerStreamFailure(streamDrainTask);
+            return completed;
         }
 
-        private static void ObserveCompilerStreamFailure(Task<string> streamTask)
+        private static void ObserveCompilerStreamFailure(Task streamDrainTask)
         {
             // Why: disposing the process after a bounded drain can fault a pending read task later.
-            _ = streamTask.ContinueWith(
+            _ = streamDrainTask.ContinueWith(
                 task => { _ = task.Exception; },
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
@@ -16,6 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class SharedRoslynCompilerWorkerAssemblyBuilder
     {
         private const int WorkerAssemblyBuildTimeoutMilliseconds = 30000;
+        private const int WorkerCompilerTerminationTimeoutMilliseconds = 500;
         internal const string DotnetMultilevelLookupEnvironmentVariableName = "DOTNET_MULTILEVEL_LOOKUP";
         internal const string DotnetMultilevelLookupDisabledValue = "0";
 
@@ -107,10 +108,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!process.HasExited)
                 {
                     process.Kill();
-                    process.WaitForExit(500);
+                    process.WaitForExit(WorkerCompilerTerminationTimeoutMilliseconds);
                 }
 
-                Task.WaitAll(stdoutTask, stderrTask);
+                WaitForCompilerStreamDrain(
+                    stdoutTask,
+                    stderrTask,
+                    WorkerCompilerTerminationTimeoutMilliseconds);
                 return WorkerAssemblyBuildResult.StartFailure(
                     "worker_compiler_timeout",
                     new
@@ -127,6 +131,36 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 stderrTask.GetAwaiter().GetResult(),
                 process.ExitCode);
             return WorkerAssemblyBuildResult.Started(compilerMessages);
+        }
+
+        internal static bool WaitForCompilerStreamDrain(
+            Task<string> stdoutTask,
+            Task<string> stderrTask,
+            int timeoutMilliseconds)
+        {
+            Debug.Assert(stdoutTask != null, "stdoutTask must not be null");
+            Debug.Assert(stderrTask != null, "stderrTask must not be null");
+            Debug.Assert(timeoutMilliseconds >= 0, "timeoutMilliseconds must not be negative");
+
+            bool completed = Task.WaitAll(
+                new Task[] { stdoutTask, stderrTask },
+                timeoutMilliseconds);
+            if (completed)
+            {
+                return true;
+            }
+
+            ObserveCompilerStreamFailure(stdoutTask);
+            ObserveCompilerStreamFailure(stderrTask);
+            return false;
+        }
+
+        private static void ObserveCompilerStreamFailure(Task<string> streamTask)
+        {
+            // Why: disposing the process after a bounded drain can fault a pending read task later.
+            _ = streamTask.ContinueWith(
+                task => { _ = task.Exception; },
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
         private static List<string> BuildWorkerReferenceSet(ExternalCompilerPaths externalCompilerPaths)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
@@ -146,6 +146,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool completed = Task.WaitAny(
                 new[] { streamDrainTask },
                 timeoutMilliseconds) == 0;
+            ObserveCompilerStreamFailure(stdoutTask);
+            ObserveCompilerStreamFailure(stderrTask);
             ObserveCompilerStreamFailure(streamDrainTask);
             return completed;
         }


### PR DESCRIPTION
## Summary
- Worker compiler timeouts now remain bounded even when redirected output streams do not close promptly after process termination.
- Late stream-read failures are observed so timeout recovery does not leave unobserved task exceptions.

## User Impact
- Dynamic code worker setup can return its existing timeout failure instead of holding the shared worker lock indefinitely in a failed compiler-process cleanup.
- Successful compiler execution and compiler diagnostic parsing are unchanged.

## Changes
- Reuse one 500 ms termination cleanup limit for both the post-kill process wait and redirected stream draining.
- Replace the timeout path's unbounded stream wait with a bounded, non-throwing drain while preserving the existing `worker_compiler_timeout` result.
- Observe each stream-read failure independently, plus the aggregate drain failure, whether it happens before or after the bound expires.
- Cover completed and pending stream-drain contracts without launching a real child process. A real orphaned-pipe EditMode test is intentionally avoided because it could leave background work or freeze the Unity Test Runner.

## Verification
- Confirmed the initial two tests were Red before implementation because the bounded drain contract did not exist.
- Confirmed the faulted-stream regression test was Red with `AggregateException` before the review fix.
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`: 0 errors, 0 warnings
- `SharedRoslynCompilerWorkerHostTests`: 14 passed
- `ExternalCompilerPathResolverTests`: 15 passed
- `ExternalCompilerMessageParserTests`: 1 passed
- `StaticFacadeStateGuardTests`: 20 passed
- No wire-format or protocol-version change

Refs: R2-31 in the Unity CLI Loop refactoring ToDo.
