### PR TITLE
chore: Simplify shared Roslyn worker lifecycle ownership

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -29,6 +29,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Verifies shutdown remains an idempotent no-op before a worker process or directory exists.
+        /// </summary>
+        [Test]
+        public void Shutdown_WhenWorkerWasNeverStarted_ShouldRemainIdempotent()
+        {
+            SharedRoslynCompilerWorkerSession session = new();
+            string unusedWorkerDirectoryPath = Path.Combine(
+                Path.GetTempPath(),
+                $"SharedRoslynCompilerWorkerSessionTests_{Guid.NewGuid():N}");
+
+            Assert.That(Directory.Exists(unusedWorkerDirectoryPath), Is.False);
+            Assert.DoesNotThrow(() => session.Shutdown(unusedWorkerDirectoryPath));
+            Assert.DoesNotThrow(() => session.Shutdown(unusedWorkerDirectoryPath));
+        }
+
+        /// <summary>
         /// Verifies a pending compiler stream does not keep the bounded drain waiting.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -20,6 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/Application/UnityCliLoopToolRegistrar.cs",
             "Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs",
             "Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeForegroundWarmupState.cs",
+            "Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs",
             "Packages/src/Editor/ToolContracts/EditorFrameWaiter.cs",
             "Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorder.cs",
             "Packages/src/Editor/FirstPartyTools/RecordInput/Application/RecordingsApplicationFacade.cs",
@@ -52,7 +53,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/Application/SessionRecoveryService.cs",
             "Packages/src/Editor/Application/UseCases/SkillSetupUseCase.cs",
             "Packages/src/Editor/Domain/UnityCliLoopCompileSessionLifecycleService.cs",
-            "Packages/src/Editor/Infrastructure/Server/DomainReloadDetectionFileService.cs"
+            "Packages/src/Editor/Infrastructure/Server/DomainReloadDetectionFileService.cs",
+            "Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs"
         };
 
         private static readonly string[] AsyncCancellationTokenGuardPaths = new string[]

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Threading;
 using UnityEditor;
 using UnityEditor.Compilation;
-using Debug = UnityEngine.Debug;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -21,13 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string RoslynWorkerAssemblyFileName = "RoslynCompilerWorker.dll";
         private const string RoslynWorkerCompileResponseFileName = "RoslynCompilerWorker.rsp";
 
-        private static readonly object SharedCompilerWorkerLock = new();
-        private static Action<string> s_deleteWorkerDirectory = path => Directory.Delete(path, true);
-        private static Action<Process, string> s_sendCompileRequest = SendCompileRequestCore;
-        private static Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
-            s_compileWorkerAssemblyForTests;
-        private static Process _sharedCompilerWorkerProcess;
-        private static string _workerDirectoryPath;
+        private static readonly SharedRoslynCompilerWorkerSession ServiceValue = new();
 
         /// <summary>
         /// Carries the result data produced by Worker Attempt behavior.
@@ -138,16 +131,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action markBuildFinished,
             Action incrementBuildCount)
         {
-            lock (SharedCompilerWorkerLock)
-            {
-                return TryCompileWithRetries(
+            return ServiceValue.ExecuteLocked(
+                () => TryCompileWithRetries(
                     requestFilePath,
                     externalCompilerPaths,
                     ct,
                     markBuildStarted,
                     markBuildFinished,
-                    incrementBuildCount);
-            }
+                    incrementBuildCount));
         }
 
         private static CompilerMessage[] TryCompileWithRetries(
@@ -173,7 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return attemptResult.Messages;
                 }
 
-                ShutdownWorkerProcessLocked();
+                ServiceValue.ShutdownProcessLocked();
 
                 if (attemptResult.ShouldRetry && attempt < SharedCompilerWorkerMaxAttempts)
                 {
@@ -215,7 +206,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static WorkerStartupResult EnsureWorkerReady(ExternalCompilerPaths externalCompilerPaths)
         {
-            if (HasLiveWorkerProcess())
+            if (ServiceValue.HasLiveProcessLocked())
             {
                 return WorkerStartupResult.Ready();
             }
@@ -243,11 +234,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return WorkerStartupResult.Ready();
             }
 
-            SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult buildResult = CompileWorkerAssembly(
-                externalCompilerPaths,
-                workerPaths.SourcePath,
-                workerPaths.AssemblyPath,
-                workerPaths.CompileResponseFilePath);
+            SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult buildResult =
+                ServiceValue.CompileWorkerAssemblyLocked(
+                    externalCompilerPaths,
+                    workerPaths.SourcePath,
+                    workerPaths.AssemblyPath,
+                    workerPaths.CompileResponseFilePath);
             if (!buildResult.StartedSuccessfully)
             {
                 return WorkerStartupResult.Failure(
@@ -275,8 +267,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             WorkerPaths workerPaths)
         {
             ProcessStartInfo startInfo = CreateWorkerStartInfo(externalCompilerPaths, workerPaths);
-            _sharedCompilerWorkerProcess = ProcessStartHelper.TryStart(startInfo);
-            if (_sharedCompilerWorkerProcess == null)
+            if (!ServiceValue.StartProcessLocked(startInfo))
             {
                 return WorkerStartupResult.Failure(
                     "worker_start_failed",
@@ -297,7 +288,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action markBuildFinished,
             Action incrementBuildCount)
         {
-            if (!HasLiveWorkerProcess())
+            if (!ServiceValue.HasLiveProcessLocked())
             {
                 return WorkerAttemptResult.RetryableFailure(
                     "worker_process_missing",
@@ -323,7 +314,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             catch (OperationCanceledException)
             {
-                ShutdownWorkerProcessLocked();
+                ServiceValue.ShutdownProcessLocked();
                 throw;
             }
             finally
@@ -335,21 +326,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void SendCompileRequest(string requestFilePath)
         {
             string absoluteRequestFilePath = Path.GetFullPath(requestFilePath);
-            s_sendCompileRequest(_sharedCompilerWorkerProcess, absoluteRequestFilePath);
-        }
-
-        private static void SendCompileRequestCore(Process workerProcess, string requestFilePath)
-        {
-            string requestCommand = SharedRoslynCompilerWorkerProtocol.CreateCompileRequestCommand(requestFilePath);
-            workerProcess.StandardInput.WriteLine(requestCommand);
-            workerProcess.StandardInput.Flush();
+            ServiceValue.SendCompileRequestLocked(absoluteRequestFilePath);
         }
 
         private static WorkerAttemptResult ReadWorkerResponse(
             string requestFilePath,
             CancellationToken ct)
         {
-            StreamReader reader = _sharedCompilerWorkerProcess.StandardOutput;
+            StreamReader reader = ServiceValue.GetOutputReaderLocked();
             string responseHeader = SharedRoslynCompilerWorkerProtocol.ReadProtocolLine(
                 reader,
                 ct);
@@ -384,7 +368,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             string workerDirectoryPath = GetWorkerDirectoryPath();
             Directory.CreateDirectory(workerDirectoryPath);
-            _workerDirectoryPath = workerDirectoryPath;
+            ServiceValue.RecordWorkerDirectoryLocked(workerDirectoryPath);
             return new WorkerPaths(
                 workerDirectoryPath,
                 Path.Combine(workerDirectoryPath, RoslynWorkerSourceFileName),
@@ -437,34 +421,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return startInfo;
         }
 
-        private static SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult CompileWorkerAssembly(
-            ExternalCompilerPaths externalCompilerPaths,
-            string workerSourcePath,
-            string workerAssemblyPath,
-            string workerCompileResponseFilePath)
-        {
-            if (s_compileWorkerAssemblyForTests != null)
-            {
-                return SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult.Started(
-                    s_compileWorkerAssemblyForTests(
-                        externalCompilerPaths,
-                        workerSourcePath,
-                        workerAssemblyPath,
-                        workerCompileResponseFilePath));
-            }
-
-            return SharedRoslynCompilerWorkerAssemblyBuilder.CompileWorkerAssembly(
-                externalCompilerPaths,
-                workerSourcePath,
-                workerAssemblyPath,
-                workerCompileResponseFilePath);
-        }
-
-        private static bool HasLiveWorkerProcess()
-        {
-            return _sharedCompilerWorkerProcess != null && !_sharedCompilerWorkerProcess.HasExited;
-        }
-
         private static bool HasErrors(IReadOnlyCollection<CompilerMessage> messages)
         {
             foreach (CompilerMessage message in messages)
@@ -513,127 +469,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static Action<string> SwapWorkerDirectoryDeleterForTests(Action<string> deleter)
         {
-            Debug.Assert(deleter != null, "deleter must not be null");
-
-            Action<string> previous = s_deleteWorkerDirectory;
-            s_deleteWorkerDirectory = deleter;
-            return previous;
+            return ServiceValue.SwapWorkerDirectoryDeleterForTests(deleter);
         }
 
         internal static Action<Process, string> SwapCompileRequestSenderForTests(Action<Process, string> sender)
         {
-            Debug.Assert(sender != null, "sender must not be null");
-
-            Action<Process, string> previous = s_sendCompileRequest;
-            s_sendCompileRequest = sender;
-            return previous;
+            return ServiceValue.SwapCompileRequestSenderForTests(sender);
         }
 
         internal static Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
             SwapWorkerAssemblyCompilerForTests(
                 Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]> compiler)
         {
-            Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]> previous =
-                s_compileWorkerAssemblyForTests;
-            s_compileWorkerAssemblyForTests = compiler;
-            return previous;
+            return ServiceValue.SwapWorkerAssemblyCompilerForTests(compiler);
         }
 
         private static void Shutdown()
         {
-            lock (SharedCompilerWorkerLock)
-            {
-                ShutdownWorkerProcessLocked();
-                CleanupWorkerDirectoryLocked();
-            }
-        }
-
-        private static void ShutdownWorkerProcessLocked()
-        {
-            Process workerProcess = _sharedCompilerWorkerProcess;
-            _sharedCompilerWorkerProcess = null;
-            if (workerProcess == null)
-            {
-                return;
-            }
-
-            try
-            {
-                if (!workerProcess.HasExited)
-                {
-                    workerProcess.StandardInput.WriteLine(
-                        SharedRoslynCompilerWorkerProtocol.SharedCompilerWorkerQuitCommand);
-                    workerProcess.StandardInput.Flush();
-                    workerProcess.WaitForExit(500);
-                }
-
-                if (!workerProcess.HasExited)
-                {
-                    workerProcess.Kill();
-                    workerProcess.WaitForExit(500);
-                }
-            }
-            catch (IOException ex)
-            {
-                LogWorkerShutdownFailure(ex);
-            }
-            catch (ObjectDisposedException ex)
-            {
-                LogWorkerShutdownFailure(ex);
-            }
-            catch (InvalidOperationException ex)
-            {
-                LogWorkerShutdownFailure(ex);
-            }
-            finally
-            {
-                workerProcess.Dispose();
-            }
-        }
-
-        private static void CleanupWorkerDirectoryLocked()
-        {
-            string workerDirectoryPath = _workerDirectoryPath ?? GetWorkerDirectoryPath();
-            if (!Directory.Exists(workerDirectoryPath))
-            {
-                _workerDirectoryPath = null;
-                return;
-            }
-
-            TryDeleteWorkerDirectory(workerDirectoryPath);
-            _workerDirectoryPath = null;
-        }
-
-        private static void TryDeleteWorkerDirectory(string workerDirectoryPath)
-        {
-            try
-            {
-                s_deleteWorkerDirectory(workerDirectoryPath);
-            }
-            catch (IOException ex)
-            {
-                LogWorkerDirectoryCleanupFailure(workerDirectoryPath, ex);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                LogWorkerDirectoryCleanupFailure(workerDirectoryPath, ex);
-            }
-        }
-
-        private static void LogWorkerDirectoryCleanupFailure(string workerDirectoryPath, Exception ex)
-        {
-            VibeLogger.LogWarning(
-                "dynamic_code_shared_worker_cleanup_failed",
-                "execute-dynamic-code shared Roslyn worker directory cleanup failed during shutdown",
-                new
-                {
-                    worker_directory_path = workerDirectoryPath,
-                    exception_type = ex.GetType().FullName,
-                    exception_message = ex.Message
-                },
-                humanNote: "Shared Roslyn worker cleanup could not remove its temporary directory during shutdown.",
-                aiTodo: "Investigate file locks or permission issues if temporary worker directories continue to accumulate.");
-            Debug.LogWarning($"[{UnityCliLoopConstants.PROJECT_NAME}] Failed to delete shared Roslyn worker directory '{workerDirectoryPath}': {ex.Message}");
+            ServiceValue.Shutdown(GetWorkerDirectoryPath());
         }
 
         private static WorkerAttemptResult CreateRetryableWorkerCommunicationFailure(
@@ -648,20 +501,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     exception_type = ex.GetType().FullName,
                     exception_message = ex.Message
                 });
-        }
-
-        private static void LogWorkerShutdownFailure(Exception ex)
-        {
-            VibeLogger.LogWarning(
-                "dynamic_code_shared_worker_shutdown_failed",
-                "execute-dynamic-code shared Roslyn worker shutdown observed a communication failure",
-                new
-                {
-                    exception_type = ex.GetType().FullName,
-                    exception_message = ex.Message
-                },
-                humanNote: "Shared Roslyn worker shutdown saw a broken communication channel while cleaning up a crashed worker.",
-                aiTodo: "Investigate repeated worker shutdown communication failures if shared compilation stops recovering cleanly.");
         }
 
         private static object AppendAttempt(object failureContext, int attempt)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using UnityEditor.Compilation;
+using Debug = UnityEngine.Debug;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Owns the shared Roslyn compiler worker process, temporary directory, and synchronized lifecycle.
+    /// </summary>
+    internal sealed class SharedRoslynCompilerWorkerSession
+    {
+        private readonly object _syncRoot = new();
+        private Action<string> _deleteWorkerDirectory = path => Directory.Delete(path, true);
+        private Action<Process, string> _sendCompileRequest = SendCompileRequestCore;
+        private Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
+            _compileWorkerAssemblyForTests;
+        private Process _workerProcess;
+        private string _workerDirectoryPath;
+
+        internal T ExecuteLocked<T>(Func<T> operation)
+        {
+            Debug.Assert(operation != null, "operation must not be null");
+
+            lock (_syncRoot)
+            {
+                return operation();
+            }
+        }
+
+        internal bool HasLiveProcessLocked()
+        {
+            AssertLockHeld();
+            return _workerProcess != null && !_workerProcess.HasExited;
+        }
+
+        internal bool StartProcessLocked(ProcessStartInfo startInfo)
+        {
+            AssertLockHeld();
+            _workerProcess = ProcessStartHelper.TryStart(startInfo);
+            return _workerProcess != null;
+        }
+
+        internal void SendCompileRequestLocked(string requestFilePath)
+        {
+            AssertLockHeld();
+            _sendCompileRequest(_workerProcess, requestFilePath);
+        }
+
+        internal StreamReader GetOutputReaderLocked()
+        {
+            AssertLockHeld();
+            return _workerProcess.StandardOutput;
+        }
+
+        internal void RecordWorkerDirectoryLocked(string workerDirectoryPath)
+        {
+            AssertLockHeld();
+            _workerDirectoryPath = workerDirectoryPath;
+        }
+
+        internal SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult CompileWorkerAssemblyLocked(
+            ExternalCompilerPaths externalCompilerPaths,
+            string workerSourcePath,
+            string workerAssemblyPath,
+            string workerCompileResponseFilePath)
+        {
+            AssertLockHeld();
+            if (_compileWorkerAssemblyForTests != null)
+            {
+                return SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult.Started(
+                    _compileWorkerAssemblyForTests(
+                        externalCompilerPaths,
+                        workerSourcePath,
+                        workerAssemblyPath,
+                        workerCompileResponseFilePath));
+            }
+
+            return SharedRoslynCompilerWorkerAssemblyBuilder.CompileWorkerAssembly(
+                externalCompilerPaths,
+                workerSourcePath,
+                workerAssemblyPath,
+                workerCompileResponseFilePath);
+        }
+
+        internal void ShutdownProcessLocked()
+        {
+            AssertLockHeld();
+            Process workerProcess = _workerProcess;
+            _workerProcess = null;
+            if (workerProcess == null)
+            {
+                return;
+            }
+
+            try
+            {
+                if (!workerProcess.HasExited)
+                {
+                    workerProcess.StandardInput.WriteLine(
+                        SharedRoslynCompilerWorkerProtocol.SharedCompilerWorkerQuitCommand);
+                    workerProcess.StandardInput.Flush();
+                    workerProcess.WaitForExit(500);
+                }
+
+                if (!workerProcess.HasExited)
+                {
+                    workerProcess.Kill();
+                    workerProcess.WaitForExit(500);
+                }
+            }
+            catch (IOException ex)
+            {
+                LogWorkerShutdownFailure(ex);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                LogWorkerShutdownFailure(ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                LogWorkerShutdownFailure(ex);
+            }
+            finally
+            {
+                workerProcess.Dispose();
+            }
+        }
+
+        internal void Shutdown(string fallbackWorkerDirectoryPath)
+        {
+            lock (_syncRoot)
+            {
+                ShutdownProcessLocked();
+                CleanupWorkerDirectoryLocked(fallbackWorkerDirectoryPath);
+            }
+        }
+
+        internal Action<string> SwapWorkerDirectoryDeleterForTests(Action<string> deleter)
+        {
+            Debug.Assert(deleter != null, "deleter must not be null");
+
+            Action<string> previous = _deleteWorkerDirectory;
+            _deleteWorkerDirectory = deleter;
+            return previous;
+        }
+
+        internal Action<Process, string> SwapCompileRequestSenderForTests(Action<Process, string> sender)
+        {
+            Debug.Assert(sender != null, "sender must not be null");
+
+            Action<Process, string> previous = _sendCompileRequest;
+            _sendCompileRequest = sender;
+            return previous;
+        }
+
+        internal Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
+            SwapWorkerAssemblyCompilerForTests(
+                Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]> compiler)
+        {
+            Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]> previous =
+                _compileWorkerAssemblyForTests;
+            _compileWorkerAssemblyForTests = compiler;
+            return previous;
+        }
+
+        private static void SendCompileRequestCore(Process workerProcess, string requestFilePath)
+        {
+            string requestCommand = SharedRoslynCompilerWorkerProtocol.CreateCompileRequestCommand(requestFilePath);
+            workerProcess.StandardInput.WriteLine(requestCommand);
+            workerProcess.StandardInput.Flush();
+        }
+
+        private void CleanupWorkerDirectoryLocked(string fallbackWorkerDirectoryPath)
+        {
+            AssertLockHeld();
+            string workerDirectoryPath = _workerDirectoryPath ?? fallbackWorkerDirectoryPath;
+            if (!Directory.Exists(workerDirectoryPath))
+            {
+                _workerDirectoryPath = null;
+                return;
+            }
+
+            TryDeleteWorkerDirectory(workerDirectoryPath);
+            _workerDirectoryPath = null;
+        }
+
+        private void TryDeleteWorkerDirectory(string workerDirectoryPath)
+        {
+            try
+            {
+                _deleteWorkerDirectory(workerDirectoryPath);
+            }
+            catch (IOException ex)
+            {
+                LogWorkerDirectoryCleanupFailure(workerDirectoryPath, ex);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LogWorkerDirectoryCleanupFailure(workerDirectoryPath, ex);
+            }
+        }
+
+        private static void LogWorkerDirectoryCleanupFailure(string workerDirectoryPath, Exception ex)
+        {
+            VibeLogger.LogWarning(
+                "dynamic_code_shared_worker_cleanup_failed",
+                "execute-dynamic-code shared Roslyn worker directory cleanup failed during shutdown",
+                new
+                {
+                    worker_directory_path = workerDirectoryPath,
+                    exception_type = ex.GetType().FullName,
+                    exception_message = ex.Message
+                },
+                humanNote: "Shared Roslyn worker cleanup could not remove its temporary directory during shutdown.",
+                aiTodo: "Investigate file locks or permission issues if temporary worker directories continue to accumulate.");
+            Debug.LogWarning($"[{UnityCliLoopConstants.PROJECT_NAME}] Failed to delete shared Roslyn worker directory '{workerDirectoryPath}': {ex.Message}");
+        }
+
+        private static void LogWorkerShutdownFailure(Exception ex)
+        {
+            VibeLogger.LogWarning(
+                "dynamic_code_shared_worker_shutdown_failed",
+                "execute-dynamic-code shared Roslyn worker shutdown observed a communication failure",
+                new
+                {
+                    exception_type = ex.GetType().FullName,
+                    exception_message = ex.Message
+                },
+                humanNote: "Shared Roslyn worker shutdown saw a broken communication channel while cleaning up a crashed worker.",
+                aiTodo: "Investigate repeated worker shutdown communication failures if shared compilation stops recovering cleanly.");
+        }
+
+        private void AssertLockHeld()
+        {
+            Debug.Assert(Monitor.IsEntered(_syncRoot), "Shared worker session lock must be held");
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35eec184e19040a3a2dad9a75933e215
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- The shared Roslyn worker now has one instance-owned session for its process, temporary directory, synchronization lock, and test seams.
- The static host remains the stable orchestration facade without directly owning mutable worker state.

## User Impact
- Dynamic code compilation behavior, retry policy, shutdown timing, fallback behavior, and diagnostics are unchanged.
- Worker lifecycle ownership is explicit, reducing the risk of future start, retry, and shutdown paths mutating related state under different locks.

## Changes
- Add `SharedRoslynCompilerWorkerSession` as the single owner of worker process and directory state, synchronization, startup, request I/O, compiler test delegation, and shutdown cleanup.
- Keep the existing `SharedRoslynCompilerWorkerHost` entrypoints and test facades, delegating through one private `ServiceValue`.
- Preserve the existing whole-compile lock scope with `ExecuteLocked<T>` and assert every lock-required session operation with `Monitor.IsEntered`.
- Extend static facade guards so mutable state cannot move back into the host and the session cannot become a static service.
- Preserve the currently orphaned directory-deleter test seam for behavior-equivalent extraction; its removal is tracked separately as R2-37.
- Add a process-free test that verifies shutdown is idempotent before a worker starts. Real worker lifecycle EditMode tests remain intentionally excluded because PR #942 removed them to prevent Unity Test Runner freezes.

## Verification
- Confirmed the static facade guard was Red before extraction on the host's direct lock, request sender, process, and directory state.
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`: 0 errors, 0 warnings
- `SharedRoslynCompilerWorkerHostTests`: 15 passed
- `ExternalCompilerPathResolverTests`: 15 passed
- `ExternalCompilerMessageParserTests`: 1 passed
- `StaticFacadeStateGuardTests`: 20 passed
- `OnionAssemblyDependencyTests`: 83 passed
- Confirmed `SharedRoslynCompilerWorkerSession` has no dependency on `SharedRoslynCompilerWorkerHost`.
- No wire-format or protocol-version change

Refs: R2-32 in the Unity CLI Loop refactoring ToDo.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

