### PR TITLE
fix: Shared compiler restarts no longer leak process handles

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -45,6 +45,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Verifies replacing the cached worker releases the previously owned process handle.
+        /// </summary>
+        [Test]
+        public void StartProcessLocked_WhenReplacingCachedProcess_ShouldDisposePreviousHandle()
+        {
+            SharedRoslynCompilerWorkerSession session = new();
+            Process previousProcess = new();
+            bool previousProcessDisposed = false;
+            int startAttempt = 0;
+            previousProcess.Disposed += (sender, args) => previousProcessDisposed = true;
+            session.SwapProcessStarterForTests(startInfo =>
+            {
+                startAttempt++;
+                return startAttempt == 1 ? previousProcess : null;
+            });
+            ProcessStartInfo ignoredStartInfo = new();
+
+            try
+            {
+                bool firstStartSucceeded = session.ExecuteLocked(
+                    () => session.StartProcessLocked(ignoredStartInfo));
+                bool secondStartSucceeded = session.ExecuteLocked(
+                    () => session.StartProcessLocked(ignoredStartInfo));
+
+                Assert.That(firstStartSucceeded, Is.True);
+                Assert.That(secondStartSucceeded, Is.False);
+                Assert.That(previousProcessDisposed, Is.True);
+            }
+            finally
+            {
+                previousProcess.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Verifies a pending compiler stream does not keep the bounded drain waiting.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
@@ -16,6 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private readonly object _syncRoot = new();
         private Action<string> _deleteWorkerDirectory = path => Directory.Delete(path, true);
+        private Func<ProcessStartInfo, Process> _startProcess = ProcessStartHelper.TryStart;
         private Action<Process, string> _sendCompileRequest = SendCompileRequestCore;
         private Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
             _compileWorkerAssemblyForTests;
@@ -41,7 +42,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal bool StartProcessLocked(ProcessStartInfo startInfo)
         {
             AssertLockHeld();
-            _workerProcess = ProcessStartHelper.TryStart(startInfo);
+            // EnsureWorkerReady reaches this method only after the same lock observed no live process,
+            // so replacement releases the stale handle without retrying graceful shutdown.
+            Process previousProcess = _workerProcess;
+            _workerProcess = null;
+            previousProcess?.Dispose();
+
+            _workerProcess = _startProcess(startInfo);
             return _workerProcess != null;
         }
 
@@ -146,6 +153,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             Action<string> previous = _deleteWorkerDirectory;
             _deleteWorkerDirectory = deleter;
+            return previous;
+        }
+
+        internal Func<ProcessStartInfo, Process> SwapProcessStarterForTests(
+            Func<ProcessStartInfo, Process> starter)
+        {
+            Debug.Assert(starter != null, "starter must not be null");
+
+            Func<ProcessStartInfo, Process> previous = _startProcess;
+            _startProcess = starter;
             return previous;
         }
 


### PR DESCRIPTION
## Summary
- Shared compiler worker restarts now release the previous process handle before starting a replacement.
- A failed replacement start no longer leaves the stale process object cached.

## User Impact
- Previously, an idle shared compiler worker that exited before the next compile could leave its operating-system process handle undisposed when the worker restarted.
- Repeated recovery now releases each stale handle before acquiring the next worker process.

## Changes
- Dispose the cached worker process and clear session ownership before invoking the replacement process starter.
- Add an injectable process starter that follows the session's existing test-seam pattern.
- Add a process-free regression test that observes the previous `Process` object's synchronous `Disposed` event without waits or background work.
- Keep the shared compiler wire format and protocol version unchanged.

## Verification
- Confirmed the regression test fails before the ownership fix with `Expected: True` / `But was: False` for the disposal observation.
- `dist/darwin-arm64/uloop compile` (0 errors, 0 warnings)
- `SharedRoslynCompilerWorkerHostTests.StartProcessLocked_WhenReplacingCachedProcess_ShouldDisposePreviousHandle` (1 passed)
- `SharedRoslynCompilerWorkerHostTests` and `StaticFacadeStateGuardTests` (36 passed)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

