### PR TITLE
refactor: extract mouse UI response construction

### DIFF
--- a/Assets/Tests/Editor/MouseUiSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/MouseUiSimulationResponseFactoryTests.cs
@@ -1,0 +1,222 @@
+#nullable enable
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Characterizes wire-visible mouse UI response construction before factory extraction.
+    /// </summary>
+    [TestFixture]
+    public sealed class MouseUiSimulationResponseFactoryTests
+    {
+        /// <summary>
+        /// Verifies generic validation failures preserve the command action and supplied message.
+        /// </summary>
+        [Test]
+        public void CreateFailure_WithCommandAndMessage_MapsFailureResponse()
+        {
+            MouseUiSimulationCommand command = CreateCommand(new SimulateMouseUiSchema
+            {
+                Action = UnityCliLoopMouseUiAction.LongPress
+            });
+
+            SimulateMouseUiResponse response =
+                MouseUiSimulationValidator.CreateFailure(command, "Validation failed.");
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("Validation failed."));
+            Assert.That(response.Action, Is.EqualTo(MouseAction.LongPress.ToString()));
+        }
+
+        /// <summary>
+        /// Verifies frame timeout responses preserve the hit and complete drag coordinates.
+        /// </summary>
+        [Test]
+        public void CreateFrameTimeoutResult_WithEndPosition_MapsAllCoordinates()
+        {
+            Vector2 position = new(10.25f, 20.75f);
+            Vector2 endPosition = new(30.5f, 40.25f);
+
+            SimulateMouseUiResponse response = SimulateMouseUiUseCase.CreateFrameTimeoutResult(
+                MouseAction.Drag,
+                position,
+                endPosition,
+                "DragTarget");
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    $"Timed out after {UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS}ms while waiting for an editor frame."));
+            Assert.That(response.Action, Is.EqualTo(MouseAction.Drag.ToString()));
+            Assert.That(response.HitGameObjectName, Is.EqualTo("DragTarget"));
+            Assert.That(response.PositionX, Is.EqualTo(position.x));
+            Assert.That(response.PositionY, Is.EqualTo(position.y));
+            Assert.That(response.EndPositionX, Is.EqualTo(endPosition.x));
+            Assert.That(response.EndPositionY, Is.EqualTo(endPosition.y));
+        }
+
+        /// <summary>
+        /// Verifies frame timeout responses keep optional hit and end coordinates absent.
+        /// </summary>
+        [Test]
+        public void CreateFrameTimeoutResult_WithoutEndPosition_LeavesOptionalFieldsNull()
+        {
+            Vector2 position = new(10.25f, 20.75f);
+
+            SimulateMouseUiResponse response = SimulateMouseUiUseCase.CreateFrameTimeoutResult(
+                MouseAction.Click,
+                position,
+                null,
+                null);
+
+            Assert.That(response.Action, Is.EqualTo(MouseAction.Click.ToString()));
+            Assert.That(response.HitGameObjectName, Is.Null);
+            Assert.That(response.EndPositionX, Is.Null);
+            Assert.That(response.EndPositionY, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies click results retain normal, bypass, and no-hit message contracts.
+        /// </summary>
+        [TestCase(false, true, "ClickTarget", "", "Clicked 'ClickTarget' at (10.3, 20.8)")]
+        [TestCase(true, true, "ClickTarget", "Canvas/ClickTarget", "Bypass-clicked 'ClickTarget' at (10.3, 20.8) via 'Canvas/ClickTarget'")]
+        [TestCase(false, false, null, "", "Clicked at (10.3, 20.8) - no UI element hit")]
+        public void CreateClickResult_WithHitMode_MapsMessageAndFields(
+            bool bypassRaycast,
+            bool hitTarget,
+            string? targetName,
+            string targetPath,
+            string expectedMessage)
+        {
+            MouseUiSimulationCommand command = CreateCommand(new SimulateMouseUiSchema
+            {
+                Action = UnityCliLoopMouseUiAction.Click,
+                BypassRaycast = bypassRaycast,
+                TargetPath = targetPath
+            });
+            Vector2 position = new(10.25f, 20.75f);
+
+            SimulateMouseUiResponse response =
+                SimulateMouseUiUseCase.CreateClickResult(command, position, targetName, hitTarget);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Message, Is.EqualTo(expectedMessage));
+            Assert.That(response.Action, Is.EqualTo(MouseAction.Click.ToString()));
+            Assert.That(response.HitGameObjectName, Is.EqualTo(targetName));
+            Assert.That(response.PositionX, Is.EqualTo(position.x));
+            Assert.That(response.PositionY, Is.EqualTo(position.y));
+        }
+
+        /// <summary>
+        /// Verifies long-press results retain normal, bypass, and no-hit message contracts.
+        /// </summary>
+        [TestCase(false, true, "PressTarget", "", "Long-pressed 'PressTarget' at (10.3, 20.8) for 1.3s")]
+        [TestCase(true, true, "PressTarget", "Canvas/PressTarget", "Bypass-long-pressed 'PressTarget' at (10.3, 20.8) via 'Canvas/PressTarget' for 1.3s")]
+        [TestCase(false, false, null, "", "Long-pressed at (10.3, 20.8) for 1.3s - no UI element hit")]
+        public void CreateLongPressResult_WithHitMode_MapsMessageAndFields(
+            bool bypassRaycast,
+            bool hitTarget,
+            string? targetName,
+            string targetPath,
+            string expectedMessage)
+        {
+            MouseUiSimulationCommand command = CreateCommand(new SimulateMouseUiSchema
+            {
+                Action = UnityCliLoopMouseUiAction.LongPress,
+                BypassRaycast = bypassRaycast,
+                TargetPath = targetPath,
+                Duration = 1.25f
+            });
+            Vector2 position = new(10.25f, 20.75f);
+
+            SimulateMouseUiResponse response =
+                SimulateMouseUiUseCase.CreateLongPressResult(command, position, targetName, hitTarget);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Message, Is.EqualTo(expectedMessage));
+            Assert.That(response.Action, Is.EqualTo(MouseAction.LongPress.ToString()));
+            Assert.That(response.HitGameObjectName, Is.EqualTo(targetName));
+            Assert.That(response.PositionX, Is.EqualTo(position.x));
+            Assert.That(response.PositionY, Is.EqualTo(position.y));
+        }
+
+        /// <summary>
+        /// Verifies one-shot drag results retain normal and bypass message contracts.
+        /// </summary>
+        [TestCase(false, "", "Dragged 'DragTarget' from (10.3, 20.8) to (30.5, 40.3) at 125 px/s")]
+        [TestCase(true, "Canvas/DragTarget", "Bypass-dragged 'DragTarget' from (10.3, 20.8) to (30.5, 40.3) via 'Canvas/DragTarget' at 125 px/s")]
+        public void CreateDragResult_WithBypassMode_MapsMessageAndFields(
+            bool bypassRaycast,
+            string targetPath,
+            string expectedMessage)
+        {
+            MouseUiSimulationCommand command = CreateCommand(new SimulateMouseUiSchema
+            {
+                Action = UnityCliLoopMouseUiAction.Drag,
+                BypassRaycast = bypassRaycast,
+                TargetPath = targetPath,
+                DragSpeed = 125f
+            });
+            Vector2 startPosition = new(10.25f, 20.75f);
+            Vector2 endPosition = new(30.5f, 40.25f);
+
+            SimulateMouseUiResponse response = SimulateMouseUiUseCase.CreateDragResult(
+                command,
+                startPosition,
+                endPosition,
+                "DragTarget");
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Message, Is.EqualTo(expectedMessage));
+            Assert.That(response.Action, Is.EqualTo(MouseAction.Drag.ToString()));
+            Assert.That(response.HitGameObjectName, Is.EqualTo("DragTarget"));
+            Assert.That(response.PositionX, Is.EqualTo(startPosition.x));
+            Assert.That(response.PositionY, Is.EqualTo(startPosition.y));
+            Assert.That(response.EndPositionX, Is.EqualTo(endPosition.x));
+            Assert.That(response.EndPositionY, Is.EqualTo(endPosition.y));
+        }
+
+        /// <summary>
+        /// Verifies drag-end results preserve the final position and speed message.
+        /// </summary>
+        [Test]
+        public void CreateDragEndResult_WithFinalPosition_MapsMessageAndFields()
+        {
+            MouseUiSimulationCommand command = CreateCommand(new SimulateMouseUiSchema
+            {
+                Action = UnityCliLoopMouseUiAction.DragEnd,
+                DragSpeed = 125f
+            });
+            Vector2 endPosition = new(30.5f, 40.25f);
+
+            SimulateMouseUiResponse response = SimulateMouseUiUseCase.CreateDragEndResult(
+                command,
+                endPosition,
+                "DragTarget");
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(
+                response.Message,
+                Is.EqualTo("Drag ended on 'DragTarget' at (30.5, 40.3) at 125 px/s"));
+            Assert.That(response.Action, Is.EqualTo(MouseAction.DragEnd.ToString()));
+            Assert.That(response.HitGameObjectName, Is.EqualTo("DragTarget"));
+            Assert.That(response.PositionX, Is.EqualTo(endPosition.x));
+            Assert.That(response.PositionY, Is.EqualTo(endPosition.y));
+        }
+
+        private static MouseUiSimulationCommand CreateCommand(SimulateMouseUiSchema schema)
+        {
+            (MouseUiSimulationCommand? command, string? errorMessage) =
+                MouseUiSimulationCommand.TryFromSchema(schema);
+            Assert.That(errorMessage, Is.Null);
+            Assert.That(command, Is.Not.Null);
+            return command!;
+        }
+    }
+}

--- a/Assets/Tests/Editor/MouseUiSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/MouseUiSimulationResponseFactoryTests.cs
@@ -26,7 +26,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             });
 
             SimulateMouseUiResponse response =
-                MouseUiSimulationValidator.CreateFailure(command, "Validation failed.");
+                MouseUiSimulationResponseFactory.CreateFailure(command, "Validation failed.");
 
             Assert.That(response.Success, Is.False);
             Assert.That(response.Message, Is.EqualTo("Validation failed."));
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 position = new(10.25f, 20.75f);
             Vector2 endPosition = new(30.5f, 40.25f);
 
-            SimulateMouseUiResponse response = SimulateMouseUiUseCase.CreateFrameTimeoutResult(
+            SimulateMouseUiResponse response = MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(
                 MouseAction.Drag,
                 position,
                 endPosition,
@@ -69,7 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             Vector2 position = new(10.25f, 20.75f);
 
-            SimulateMouseUiResponse response = SimulateMouseUiUseCase.CreateFrameTimeoutResult(
+            SimulateMouseUiResponse response = MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(
                 MouseAction.Click,
                 position,
                 null,
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 position = new(10.25f, 20.75f);
 
             SimulateMouseUiResponse response =
-                SimulateMouseUiUseCase.CreateClickResult(command, position, targetName, hitTarget);
+                MouseUiSimulationResponseFactory.CreateClickResult(command, position, targetName, hitTarget);
 
             Assert.That(response.Success, Is.True);
             Assert.That(response.Message, Is.EqualTo(expectedMessage));
@@ -136,7 +136,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 position = new(10.25f, 20.75f);
 
             SimulateMouseUiResponse response =
-                SimulateMouseUiUseCase.CreateLongPressResult(command, position, targetName, hitTarget);
+                MouseUiSimulationResponseFactory.CreateLongPressResult(command, position, targetName, hitTarget);
 
             Assert.That(response.Success, Is.True);
             Assert.That(response.Message, Is.EqualTo(expectedMessage));
@@ -166,7 +166,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 startPosition = new(10.25f, 20.75f);
             Vector2 endPosition = new(30.5f, 40.25f);
 
-            SimulateMouseUiResponse response = SimulateMouseUiUseCase.CreateDragResult(
+            SimulateMouseUiResponse response = MouseUiSimulationResponseFactory.CreateDragResult(
                 command,
                 startPosition,
                 endPosition,
@@ -195,7 +195,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             });
             Vector2 endPosition = new(30.5f, 40.25f);
 
-            SimulateMouseUiResponse response = SimulateMouseUiUseCase.CreateDragEndResult(
+            SimulateMouseUiResponse response = MouseUiSimulationResponseFactory.CreateDragEndResult(
                 command,
                 endPosition,
                 "DragTarget");

--- a/Assets/Tests/Editor/MouseUiSimulationResponseFactoryTests.cs.meta
+++ b/Assets/Tests/Editor/MouseUiSimulationResponseFactoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8a4d821c67342d4ab063457c70d4072
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationResponseFactory.cs
@@ -1,0 +1,124 @@
+#nullable enable
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Creates wire-visible responses for mouse UI simulation outcomes.
+    /// </summary>
+    internal static class MouseUiSimulationResponseFactory
+    {
+        internal static SimulateMouseUiResponse CreateFailure(
+            MouseUiSimulationCommand parameters,
+            string message)
+        {
+            return new SimulateMouseUiResponse
+            {
+                Success = false,
+                Message = message,
+                Action = parameters.Action.ToString()
+            };
+        }
+
+        internal static SimulateMouseUiResponse CreateFrameTimeoutResult(
+            MouseAction action,
+            Vector2 position,
+            Vector2? endPosition,
+            string? hitGameObjectName)
+        {
+            return new SimulateMouseUiResponse
+            {
+                Success = false,
+                Message = $"Timed out after {UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS}ms while waiting for an editor frame.",
+                Action = action.ToString(),
+                HitGameObjectName = hitGameObjectName,
+                PositionX = position.x,
+                PositionY = position.y,
+                EndPositionX = endPosition.HasValue ? endPosition.Value.x : null,
+                EndPositionY = endPosition.HasValue ? endPosition.Value.y : null
+            };
+        }
+
+        internal static SimulateMouseUiResponse CreateClickResult(
+            MouseUiSimulationCommand parameters,
+            Vector2 inputPos,
+            string? targetName,
+            bool hitTarget)
+        {
+            return new SimulateMouseUiResponse
+            {
+                Success = true,
+                Message = hitTarget
+                    ? parameters.BypassRaycast
+                        ? $"Bypass-clicked '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1}) via '{parameters.TargetPath}'"
+                        : $"Clicked '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1})"
+                    : $"Clicked at ({inputPos.x:F1}, {inputPos.y:F1}) - no UI element hit",
+                Action = MouseAction.Click.ToString(),
+                HitGameObjectName = targetName,
+                PositionX = inputPos.x,
+                PositionY = inputPos.y
+            };
+        }
+
+        internal static SimulateMouseUiResponse CreateLongPressResult(
+            MouseUiSimulationCommand parameters,
+            Vector2 inputPos,
+            string? targetName,
+            bool hitTarget)
+        {
+            return new SimulateMouseUiResponse
+            {
+                Success = true,
+                Message = hitTarget
+                    ? parameters.BypassRaycast
+                        ? $"Bypass-long-pressed '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1}) via '{parameters.TargetPath}' for {parameters.Duration:F1}s"
+                        : $"Long-pressed '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1}) for {parameters.Duration:F1}s"
+                    : $"Long-pressed at ({inputPos.x:F1}, {inputPos.y:F1}) for {parameters.Duration:F1}s - no UI element hit",
+                Action = MouseAction.LongPress.ToString(),
+                HitGameObjectName = targetName,
+                PositionX = inputPos.x,
+                PositionY = inputPos.y
+            };
+        }
+
+        internal static SimulateMouseUiResponse CreateDragResult(
+            MouseUiSimulationCommand parameters,
+            Vector2 inputStart,
+            Vector2 inputEnd,
+            string targetName)
+        {
+            return new SimulateMouseUiResponse
+            {
+                Success = true,
+                Message = parameters.BypassRaycast
+                    ? $"Bypass-dragged '{targetName}' from ({inputStart.x:F1}, {inputStart.y:F1}) to ({inputEnd.x:F1}, {inputEnd.y:F1}) via '{parameters.TargetPath}' at {parameters.DragSpeed:F0} px/s"
+                    : $"Dragged '{targetName}' from ({inputStart.x:F1}, {inputStart.y:F1}) to ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s",
+                Action = MouseAction.Drag.ToString(),
+                HitGameObjectName = targetName,
+                PositionX = inputStart.x,
+                PositionY = inputStart.y,
+                EndPositionX = inputEnd.x,
+                EndPositionY = inputEnd.y
+            };
+        }
+
+        internal static SimulateMouseUiResponse CreateDragEndResult(
+            MouseUiSimulationCommand parameters,
+            Vector2 inputEnd,
+            string targetName)
+        {
+            return new SimulateMouseUiResponse
+            {
+                Success = true,
+                Message = $"Drag ended on '{targetName}' at ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s",
+                Action = MouseAction.DragEnd.ToString(),
+                HitGameObjectName = targetName,
+                PositionX = inputEnd.x,
+                PositionY = inputEnd.y
+            };
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationResponseFactory.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationResponseFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b56a2e6129684475a65e9cfdfa18ccfd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationValidator.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationValidator.cs
@@ -20,12 +20,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 PlayModeToolPreflightService.RequireActiveAndNotPaused(pausedActionDescription);
             if (!playModeResult.IsValid)
             {
-                return CreateFailure(parameters, playModeResult.ErrorMessage);
+                return MouseUiSimulationResponseFactory.CreateFailure(parameters, playModeResult.ErrorMessage);
             }
 
             if (eventSystem == null)
             {
-                return CreateFailure(
+                return MouseUiSimulationResponseFactory.CreateFailure(
                     parameters,
                     "No EventSystem found in the scene. Ensure an EventSystem GameObject exists.");
             }
@@ -40,21 +40,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return null;
             }
 
-            return CreateFailure(
+            return MouseUiSimulationResponseFactory.CreateFailure(
                 parameters,
                 $"Cannot {parameters.Action.ToString()} while a split drag is active. Call DragEnd first.");
-        }
-
-        internal static SimulateMouseUiResponse CreateFailure(
-            MouseUiSimulationCommand parameters,
-            string message)
-        {
-            return new SimulateMouseUiResponse
-            {
-                Success = false,
-                Message = message,
-                Action = parameters.Action.ToString()
-            };
         }
 
         private static SimulateMouseUiResponse? ValidateSimulationRequestOptions(
@@ -62,26 +50,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (parameters.Action != MouseAction.Click && parameters.Action != MouseAction.LongPress && parameters.DragSpeed < 0f)
             {
-                return CreateFailure(parameters, $"DragSpeed must be non-negative, got: {parameters.DragSpeed}");
+                return MouseUiSimulationResponseFactory.CreateFailure(parameters, $"DragSpeed must be non-negative, got: {parameters.DragSpeed}");
             }
 
             if (IsDragAction(parameters.Action) && parameters.Button != MouseButton.Left)
             {
-                return CreateFailure(
+                return MouseUiSimulationResponseFactory.CreateFailure(
                     parameters,
                     $"Drag actions only support Left button (uGUI ignores non-left drags), got: {parameters.Button}");
             }
 
             if (parameters.BypassRaycast && !SupportsBypassRaycast(parameters.Action))
             {
-                return CreateFailure(parameters, "BypassRaycast is not supported for this action.");
+                return MouseUiSimulationResponseFactory.CreateFailure(parameters, "BypassRaycast is not supported for this action.");
             }
 
             if (parameters.BypassRaycast &&
                 RequiresBypassTargetPath(parameters.Action) &&
                 string.IsNullOrWhiteSpace(parameters.TargetPath))
             {
-                return CreateFailure(
+                return MouseUiSimulationResponseFactory.CreateFailure(
                     parameters,
                     "TargetPath is required when BypassRaycast is true for Click, LongPress, Drag, or DragStart.");
             }
@@ -90,7 +78,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.Action != MouseAction.Drag &&
                 parameters.Action != MouseAction.DragEnd)
             {
-                return CreateFailure(parameters, "DropTargetPath supports Drag and DragEnd only.");
+                return MouseUiSimulationResponseFactory.CreateFailure(parameters, "DropTargetPath supports Drag and DragEnd only.");
             }
 
             return null;

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -1128,7 +1128,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             context.Post(_ => cleanup(), null);
         }
 
-        private static SimulateMouseUiResponse CreateFrameTimeoutResult(
+        internal static SimulateMouseUiResponse CreateFrameTimeoutResult(
             MouseAction action,
             Vector2 position,
             Vector2? endPosition,
@@ -1147,7 +1147,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static SimulateMouseUiResponse CreateClickResult(
+        internal static SimulateMouseUiResponse CreateClickResult(
             MouseUiSimulationCommand parameters,
             Vector2 inputPos,
             string? targetName,
@@ -1168,7 +1168,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static SimulateMouseUiResponse CreateLongPressResult(
+        internal static SimulateMouseUiResponse CreateLongPressResult(
             MouseUiSimulationCommand parameters,
             Vector2 inputPos,
             string? targetName,
@@ -1189,7 +1189,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static SimulateMouseUiResponse CreateDragResult(
+        internal static SimulateMouseUiResponse CreateDragResult(
             MouseUiSimulationCommand parameters,
             Vector2 inputStart,
             Vector2 inputEnd,
@@ -1210,7 +1210,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static SimulateMouseUiResponse CreateDragEndResult(
+        internal static SimulateMouseUiResponse CreateDragEndResult(
             MouseUiSimulationCommand parameters,
             Vector2 inputEnd,
             string targetName)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -140,7 +140,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 default:
                     // Unreachable when TryFromSchema succeeds; kept as a defensive Success=false response
                     // instead of a throw so any future MouseAction addition surfaces as a validation failure.
-                    return MouseUiSimulationValidator.CreateFailure(
+                    return MouseUiSimulationResponseFactory.CreateFailure(
                         parameters,
                         $"Unknown mouse action: {parameters.Action}");
             }
@@ -214,7 +214,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!expandCompleted)
             {
                 QueueOverlayClear();
-                return CreateFrameTimeoutResult(MouseAction.Click, inputPos, null, targetName);
+                return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Click, inputPos, null, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -225,11 +225,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!dissipateCompleted)
             {
                 QueueOverlayClear();
-                return CreateClickResult(parameters, inputPos, targetName, hitTarget);
+                return MouseUiSimulationResponseFactory.CreateClickResult(parameters, inputPos, targetName, hitTarget);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
-            return CreateClickResult(parameters, inputPos, targetName, hitTarget);
+            return MouseUiSimulationResponseFactory.CreateClickResult(parameters, inputPos, targetName, hitTarget);
         }
 
         private async Task<SimulateMouseUiResponse> ExecuteLongPress(
@@ -278,7 +278,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!expandCompleted)
             {
                 QueueOverlayClear();
-                return CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
+                return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -296,7 +296,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     if (!frameReady)
                     {
                         QueueOverlayClear();
-                        return CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
+                        return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
                     }
                     await MainThreadSwitcher.SwitchToMainThread(ct);
                     elapsed = Time.realtimeSinceStartup - startTime;
@@ -317,11 +317,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!dissipateCompleted)
             {
                 QueueOverlayClear();
-                return CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
+                return MouseUiSimulationResponseFactory.CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
-            return CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
+            return MouseUiSimulationResponseFactory.CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
         }
 
         private static PointerEventData CreatePointerPressData(
@@ -545,7 +545,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!expandCompleted)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, null);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, null);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -553,7 +553,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!dissipateCompleted)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, null);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, null);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -586,7 +586,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!expandCompleted)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -595,7 +595,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!dragCompleted)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -603,7 +603,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!frameReady)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
             }
@@ -619,11 +619,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!completedDissipate)
             {
                 QueueOverlayClear();
-                return CreateDragResult(parameters, inputStart, inputEnd, targetName);
+                return MouseUiSimulationResponseFactory.CreateDragResult(parameters, inputStart, inputEnd, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
-            return CreateDragResult(parameters, inputStart, inputEnd, targetName);
+            return MouseUiSimulationResponseFactory.CreateDragResult(parameters, inputStart, inputEnd, targetName);
         }
 
         // Lifecycle must match StandaloneInputModule: raycast → pointerUp → drop → endDrag
@@ -774,7 +774,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!expandCompleted)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.DragStart, inputPos, null, null);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragStart, inputPos, null, null);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -782,7 +782,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!dissipateCompleted)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.DragStart, inputPos, null, null);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragStart, inputPos, null, null);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -816,7 +816,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!animationCompleted)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.DragStart, inputPos, null, targetName);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragStart, inputPos, null, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
                 animationCompleted = true;
@@ -888,7 +888,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!dragCompleted)
             {
                 QueueOverlayClear();
-                return CreateFrameTimeoutResult(MouseAction.DragMove, inputEnd, null, targetName);
+                return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragMove, inputEnd, null, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -960,7 +960,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!dragCompleted)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.DragEnd, inputEnd, null, targetName);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragEnd, inputEnd, null, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
@@ -968,7 +968,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (!frameReady)
                 {
                     QueueOverlayClear();
-                    return CreateFrameTimeoutResult(MouseAction.DragEnd, inputEnd, null, targetName);
+                    return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragEnd, inputEnd, null, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
             }
@@ -988,11 +988,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!dissipateCompleted)
             {
                 QueueOverlayClear();
-                return CreateDragEndResult(parameters, inputEnd, targetName);
+                return MouseUiSimulationResponseFactory.CreateDragEndResult(parameters, inputEnd, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
 
-            return CreateDragEndResult(parameters, inputEnd, targetName);
+            return MouseUiSimulationResponseFactory.CreateDragEndResult(parameters, inputEnd, targetName);
         }
 
         // User input during a CLI drag can cause Unity's StandaloneInputModule to
@@ -1126,104 +1126,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Why: timeout continuations can run on timer threads while Unity objects must still be cleaned up on the Editor thread.
             context.Post(_ => cleanup(), null);
-        }
-
-        internal static SimulateMouseUiResponse CreateFrameTimeoutResult(
-            MouseAction action,
-            Vector2 position,
-            Vector2? endPosition,
-            string? hitGameObjectName)
-        {
-            return new SimulateMouseUiResponse
-            {
-                Success = false,
-                Message = $"Timed out after {UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS}ms while waiting for an editor frame.",
-                Action = action.ToString(),
-                HitGameObjectName = hitGameObjectName,
-                PositionX = position.x,
-                PositionY = position.y,
-                EndPositionX = endPosition.HasValue ? endPosition.Value.x : null,
-                EndPositionY = endPosition.HasValue ? endPosition.Value.y : null
-            };
-        }
-
-        internal static SimulateMouseUiResponse CreateClickResult(
-            MouseUiSimulationCommand parameters,
-            Vector2 inputPos,
-            string? targetName,
-            bool hitTarget)
-        {
-            return new SimulateMouseUiResponse
-            {
-                Success = true,
-                Message = hitTarget
-                    ? parameters.BypassRaycast
-                        ? $"Bypass-clicked '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1}) via '{parameters.TargetPath}'"
-                        : $"Clicked '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1})"
-                    : $"Clicked at ({inputPos.x:F1}, {inputPos.y:F1}) - no UI element hit",
-                Action = MouseAction.Click.ToString(),
-                HitGameObjectName = targetName,
-                PositionX = inputPos.x,
-                PositionY = inputPos.y
-            };
-        }
-
-        internal static SimulateMouseUiResponse CreateLongPressResult(
-            MouseUiSimulationCommand parameters,
-            Vector2 inputPos,
-            string? targetName,
-            bool hitTarget)
-        {
-            return new SimulateMouseUiResponse
-            {
-                Success = true,
-                Message = hitTarget
-                    ? parameters.BypassRaycast
-                        ? $"Bypass-long-pressed '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1}) via '{parameters.TargetPath}' for {parameters.Duration:F1}s"
-                        : $"Long-pressed '{targetName}' at ({inputPos.x:F1}, {inputPos.y:F1}) for {parameters.Duration:F1}s"
-                    : $"Long-pressed at ({inputPos.x:F1}, {inputPos.y:F1}) for {parameters.Duration:F1}s - no UI element hit",
-                Action = MouseAction.LongPress.ToString(),
-                HitGameObjectName = targetName,
-                PositionX = inputPos.x,
-                PositionY = inputPos.y
-            };
-        }
-
-        internal static SimulateMouseUiResponse CreateDragResult(
-            MouseUiSimulationCommand parameters,
-            Vector2 inputStart,
-            Vector2 inputEnd,
-            string targetName)
-        {
-            return new SimulateMouseUiResponse
-            {
-                Success = true,
-                Message = parameters.BypassRaycast
-                    ? $"Bypass-dragged '{targetName}' from ({inputStart.x:F1}, {inputStart.y:F1}) to ({inputEnd.x:F1}, {inputEnd.y:F1}) via '{parameters.TargetPath}' at {parameters.DragSpeed:F0} px/s"
-                    : $"Dragged '{targetName}' from ({inputStart.x:F1}, {inputStart.y:F1}) to ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s",
-                Action = MouseAction.Drag.ToString(),
-                HitGameObjectName = targetName,
-                PositionX = inputStart.x,
-                PositionY = inputStart.y,
-                EndPositionX = inputEnd.x,
-                EndPositionY = inputEnd.y
-            };
-        }
-
-        internal static SimulateMouseUiResponse CreateDragEndResult(
-            MouseUiSimulationCommand parameters,
-            Vector2 inputEnd,
-            string targetName)
-        {
-            return new SimulateMouseUiResponse
-            {
-                Success = true,
-                Message = $"Drag ended on '{targetName}' at ({inputEnd.x:F1}, {inputEnd.y:F1}) at {parameters.DragSpeed:F0} px/s",
-                Action = MouseAction.DragEnd.ToString(),
-                HitGameObjectName = targetName,
-                PositionX = inputEnd.x,
-                PositionY = inputEnd.y
-            };
         }
 
         private static RaycastResult? RaycastUI(Vector2 screenPosition, EventSystem eventSystem)


### PR DESCRIPTION
## Summary

- extract the six existing mouse UI response helpers into `MouseUiSimulationResponseFactory`
- move the temporarily validator-owned failure response into the same stateless factory
- add synchronous EditMode characterization coverage for every current message branch and response field
- reduce `SimulateMouseUiUseCase` from 1,403 to 1,305 lines and `MouseUiSimulationValidator` from 127 to 115 lines

## Scope Notes

- The characterization commit makes five private use-case helpers `internal`; this is their required final visibility because the use case remains a direct caller after extraction. `CreateFailure` was already `internal` on the validator.
- A normalized comparison of the six old method bodies and the new factory body is clean after accounting for the five `private` to `internal` changes and blank lines. Conditions, messages, field assignments, nullability, and timeout constants are unchanged.
- Existing inline response construction remains with command conversion, target resolution, and action execution. Moving those blocks would require inventing new parameter APIs and is reserved for their later R2-33 extraction stages.
- R2-40's unreachable bypass validation branch remains unchanged for its separate TDD cleanup.
- Response DTOs and IPC wire shapes are unchanged, so no protocol version bump is required.

## Verification

- `dist/darwin-arm64/uloop compile` (0 errors, 0 warnings)
- EditMode `MouseUiSimulationResponseFactoryTests` before and after the move (12 passed)
- PlayMode `SimulateMouseUiTests` (32 passed)
- EditMode `SimulateMouseUiActionValidationTests` (1 passed)
- EditMode `PlayModeToolPreflightServiceTests` (8 passed)
- EditMode `StaticFacadeStateGuardTests` (20 passed)
- EditMode `OnionAssemblyDependencyTests` (83 passed)
- normalized old/new factory body comparison (no differences)
- old owner references and factory-to-owner reverse references (0)
- `git diff --check origin/v3-beta...HEAD`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

