### PR TITLE
refactor: extract mouse UI overlay support

### DIFF
--- a/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs
+++ b/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs
@@ -7,7 +7,7 @@ using io.github.hatayama.UnityCliLoop.Runtime;
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
     /// <summary>
-    /// Characterizes synchronous mouse UI cleanup before main-thread scheduling is extracted.
+    /// Characterizes synchronous mouse UI cleanup scheduling.
     /// </summary>
     [TestFixture]
     public sealed class MouseUiMainThreadCleanupSchedulerTests
@@ -24,11 +24,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void ExecuteCleanupOnMainThread_AfterContextCapture_RunsImmediately()
         {
-            SimulateMouseUiUseCase useCase = new();
-            useCase.CaptureMainThreadContext();
+            MouseUiMainThreadCleanupScheduler scheduler = new();
+            scheduler.CaptureMainThreadContext();
             bool cleanupRan = false;
 
-            useCase.ExecuteCleanupOnMainThread(() => cleanupRan = true);
+            scheduler.ExecuteCleanupOnMainThread(() => cleanupRan = true);
 
             Assert.That(cleanupRan, Is.True);
         }
@@ -45,10 +45,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 null,
                 "Target",
                 new Vector2(100f, 200f));
-            SimulateMouseUiUseCase useCase = new();
-            useCase.CaptureMainThreadContext();
+            MouseUiMainThreadCleanupScheduler scheduler = new();
+            scheduler.CaptureMainThreadContext();
 
-            useCase.QueueOverlayClear();
+            scheduler.QueueOverlayClear();
 
             Assert.That(SimulateMouseUiOverlayState.IsActive, Is.False);
         }

--- a/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs
+++ b/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Characterizes synchronous mouse UI cleanup before main-thread scheduling is extracted.
+    /// </summary>
+    [TestFixture]
+    public sealed class MouseUiMainThreadCleanupSchedulerTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            SimulateMouseUiOverlayState.Clear();
+        }
+
+        /// <summary>
+        /// Verifies cleanup executes immediately when invoked from the Unity main thread.
+        /// </summary>
+        [Test]
+        public void ExecuteCleanupOnMainThread_AfterContextCapture_RunsImmediately()
+        {
+            SimulateMouseUiUseCase useCase = new();
+            useCase.CaptureMainThreadContext();
+            bool cleanupRan = false;
+
+            useCase.ExecuteCleanupOnMainThread(() => cleanupRan = true);
+
+            Assert.That(cleanupRan, Is.True);
+        }
+
+        /// <summary>
+        /// Verifies queued overlay cleanup clears active visualization state on the main thread.
+        /// </summary>
+        [Test]
+        public void QueueOverlayClear_WithActiveOverlayState_ClearsState()
+        {
+            SimulateMouseUiOverlayState.Update(
+                MouseAction.Click,
+                new Vector2(10f, 20f),
+                null,
+                "Target",
+                new Vector2(100f, 200f));
+            SimulateMouseUiUseCase useCase = new();
+            useCase.CaptureMainThreadContext();
+
+            useCase.QueueOverlayClear();
+
+            Assert.That(SimulateMouseUiOverlayState.IsActive, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs.meta
+++ b/Assets/Tests/Editor/MouseUiMainThreadCleanupSchedulerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72fcc29882ac411f93a018981970fdc1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiEditorFrameWaiter.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiEditorFrameWaiter.cs
@@ -1,0 +1,30 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Waits for an Editor frame and restores execution to the Unity main thread.
+    /// </summary>
+    internal static class MouseUiEditorFrameWaiter
+    {
+        internal static async Task<bool> WaitForEditorFrameAndSwitchToMainThreadAsync(CancellationToken ct)
+        {
+            bool frameReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                1,
+                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                ct).ConfigureAwait(false);
+            if (!frameReady)
+            {
+                return false;
+            }
+
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+            return true;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiEditorFrameWaiter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiEditorFrameWaiter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a939b9693ec4f35ac24c6caae931084
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiMainThreadCleanupScheduler.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiMainThreadCleanupScheduler.cs
@@ -1,0 +1,54 @@
+#nullable enable
+using System;
+using System.Threading;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Schedules mouse UI cleanup on the captured Unity main thread.
+    /// </summary>
+    internal sealed class MouseUiMainThreadCleanupScheduler
+    {
+        private SynchronizationContext? _mainThreadContext;
+
+        internal void CaptureMainThreadContext()
+        {
+            _mainThreadContext = SynchronizationContext.Current;
+            Debug.Assert(_mainThreadContext != null, "Main thread synchronization context must be captured.");
+        }
+
+        internal void QueueOverlayClear()
+        {
+            ExecuteCleanupOnMainThread(SimulateMouseUiOverlayState.Clear);
+        }
+
+        internal void ExecuteCleanupOnMainThread(Action cleanup)
+        {
+            Debug.Assert(cleanup != null, "cleanup must not be null");
+            if (cleanup == null)
+            {
+                throw new ArgumentNullException(nameof(cleanup));
+            }
+
+            if (MainThreadSwitcher.IsMainThread)
+            {
+                cleanup();
+                return;
+            }
+
+            SynchronizationContext? context = _mainThreadContext;
+            Debug.Assert(context != null, "Main thread synchronization context must be captured before cleanup.");
+            if (context == null)
+            {
+                throw new InvalidOperationException("Main thread synchronization context was not captured.");
+            }
+
+            // Why: timeout continuations can run on timer threads while Unity objects must still be cleaned up on the Editor thread.
+            context.Post(_ => cleanup(), null);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiMainThreadCleanupScheduler.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiMainThreadCleanupScheduler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 862b3081b32e42bc817ece92f218fa64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOverlayAnimator.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOverlayAnimator.cs
@@ -1,0 +1,66 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Animates the mouse UI overlay around simulated pointer actions.
+    /// </summary>
+    internal static class MouseUiOverlayAnimator
+    {
+        internal static async Task<bool> PlayExpandAnimation(CancellationToken ct)
+        {
+            SimulateMouseUiOverlay overlay = OverlayCanvasFactory.VisualizationCanvas.MouseUiOverlay;
+
+            // Previous dissipate sets alpha to 0; restore before expand starts
+            overlay.SetAlpha(1f);
+
+            float startTime = Time.realtimeSinceStartup;
+            float elapsed = 0f;
+            while (elapsed < SimulateMouseUiAnimationConstants.EXPAND_DURATION)
+            {
+                float t = elapsed / SimulateMouseUiAnimationConstants.EXPAND_DURATION;
+                overlay.SetCursorScale(Mathf.Lerp(SimulateMouseUiAnimationConstants.EXPAND_START_SCALE, 1f, t));
+                bool frameReady = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
+                if (!frameReady)
+                {
+                    return false;
+                }
+                await MainThreadSwitcher.SwitchToMainThread(ct);
+                elapsed = Time.realtimeSinceStartup - startTime;
+            }
+            overlay.SetCursorScale(1f);
+            return true;
+        }
+
+        internal static async Task<bool> PlayDissipateAnimation(CancellationToken ct)
+        {
+            SimulateMouseUiOverlay overlay = OverlayCanvasFactory.VisualizationCanvas.MouseUiOverlay;
+
+            float startTime = Time.realtimeSinceStartup;
+            float elapsed = 0f;
+            while (elapsed < SimulateMouseUiAnimationConstants.DISSIPATE_DURATION)
+            {
+                float t = elapsed / SimulateMouseUiAnimationConstants.DISSIPATE_DURATION;
+                overlay.SetCursorScale(Mathf.Lerp(1f, 0f, t));
+                overlay.SetAlpha(Mathf.Lerp(1f, 0f, t));
+                bool frameReady = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
+                if (!frameReady)
+                {
+                    return false;
+                }
+                await MainThreadSwitcher.SwitchToMainThread(ct);
+                elapsed = Time.realtimeSinceStartup - startTime;
+            }
+            overlay!.SetCursorScale(0f);
+            overlay!.SetAlpha(0f);
+            SimulateMouseUiOverlayState.Clear();
+            return true;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOverlayAnimator.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOverlayAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab3c61773ce348259472cf424a950909
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationActivityLogger.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationActivityLogger.cs
@@ -1,0 +1,42 @@
+#nullable enable
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Writes structured activity logs for mouse UI simulations.
+    /// </summary>
+    internal static class MouseUiSimulationActivityLogger
+    {
+        internal static void LogSimulationStart(MouseUiSimulationCommand parameters, string correlationId)
+        {
+            VibeLogger.LogInfo(
+                "simulate_mouse_start",
+                "Mouse simulation started",
+                new
+                {
+                    Action = parameters.Action.ToString(),
+                    X = parameters.X,
+                    Y = parameters.Y,
+                    BypassRaycast = parameters.BypassRaycast,
+                    TargetPath = parameters.TargetPath,
+                    DropTargetPath = parameters.DropTargetPath
+                },
+                correlationId: correlationId
+            );
+        }
+
+        internal static void LogSimulationComplete(
+            MouseUiSimulationCommand parameters,
+            SimulateMouseUiResponse response,
+            string correlationId)
+        {
+            VibeLogger.LogInfo(
+                "simulate_mouse_complete",
+                $"Mouse simulation completed: {response.Message}",
+                new { Action = parameters.Action.ToString(), Success = response.Success },
+                correlationId: correlationId
+            );
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationActivityLogger.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationActivityLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f39df77106c41f18c31870c6a94fdcc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -81,7 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return response;
         }
 
-        private static void LogSimulationStart(MouseUiSimulationCommand parameters, string correlationId)
+        internal static void LogSimulationStart(MouseUiSimulationCommand parameters, string correlationId)
         {
             VibeLogger.LogInfo(
                 "simulate_mouse_start",
@@ -99,7 +99,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             );
         }
 
-        private static void LogSimulationComplete(
+        internal static void LogSimulationComplete(
             MouseUiSimulationCommand parameters,
             SimulateMouseUiResponse response,
             string correlationId)
@@ -927,7 +927,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        private static async Task<bool> PlayExpandAnimation(CancellationToken ct)
+        internal static async Task<bool> PlayExpandAnimation(CancellationToken ct)
         {
             SimulateMouseUiOverlay overlay = OverlayCanvasFactory.VisualizationCanvas.MouseUiOverlay;
 
@@ -952,7 +952,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
-        private static async Task<bool> PlayDissipateAnimation(CancellationToken ct)
+        internal static async Task<bool> PlayDissipateAnimation(CancellationToken ct)
         {
             SimulateMouseUiOverlay overlay = OverlayCanvasFactory.VisualizationCanvas.MouseUiOverlay;
 
@@ -977,7 +977,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
-        private static async Task<bool> WaitForEditorFrameAndSwitchToMainThreadAsync(CancellationToken ct)
+        internal static async Task<bool> WaitForEditorFrameAndSwitchToMainThreadAsync(CancellationToken ct)
         {
             bool frameReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
                 1,
@@ -992,18 +992,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
-        private void CaptureMainThreadContext()
+        internal void CaptureMainThreadContext()
         {
             _mainThreadContext = SynchronizationContext.Current;
             Debug.Assert(_mainThreadContext != null, "Main thread synchronization context must be captured.");
         }
 
-        private void QueueOverlayClear()
+        internal void QueueOverlayClear()
         {
             ExecuteCleanupOnMainThread(SimulateMouseUiOverlayState.Clear);
         }
 
-        private void ExecuteCleanupOnMainThread(Action cleanup)
+        internal void ExecuteCleanupOnMainThread(Action cleanup)
         {
             Debug.Assert(cleanup != null, "cleanup must not be null");
             if (cleanup == null)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -64,7 +64,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(eventSystem != null, "ValidateSimulationStart must reject a missing EventSystem.");
             EventSystem activeEventSystem = eventSystem!;
 
-            LogSimulationStart(parameters, correlationId);
+            MouseUiSimulationActivityLogger.LogSimulationStart(parameters, correlationId);
             EnsureOverlayExists();
 
             SimulateMouseUiResponse? dragStateFailure =
@@ -76,40 +76,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             SimulateMouseUiResponse response =
                 await ExecuteMouseAction(parameters, activeEventSystem, ct).ConfigureAwait(false);
-            LogSimulationComplete(parameters, response, correlationId);
+            MouseUiSimulationActivityLogger.LogSimulationComplete(parameters, response, correlationId);
 
             return response;
-        }
-
-        internal static void LogSimulationStart(MouseUiSimulationCommand parameters, string correlationId)
-        {
-            VibeLogger.LogInfo(
-                "simulate_mouse_start",
-                "Mouse simulation started",
-                new
-                {
-                    Action = parameters.Action.ToString(),
-                    X = parameters.X,
-                    Y = parameters.Y,
-                    BypassRaycast = parameters.BypassRaycast,
-                    TargetPath = parameters.TargetPath,
-                    DropTargetPath = parameters.DropTargetPath
-                },
-                correlationId: correlationId
-            );
-        }
-
-        internal static void LogSimulationComplete(
-            MouseUiSimulationCommand parameters,
-            SimulateMouseUiResponse response,
-            string correlationId)
-        {
-            VibeLogger.LogInfo(
-                "simulate_mouse_complete",
-                $"Mouse simulation completed: {response.Message}",
-                new { Action = parameters.Action.ToString(), Success = response.Success },
-                correlationId: correlationId
-            );
         }
 
         private async Task<SimulateMouseUiResponse> ExecuteMouseAction(

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -21,10 +20,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Wire-visible fragment of the paused preflight message; tests pin the composed string.
         public const string PausedActionDescription = "simulating UI input";
 
-        private const float EXPAND_DURATION = SimulateMouseUiAnimationConstants.EXPAND_DURATION;
-        private const float EXPAND_START_SCALE = SimulateMouseUiAnimationConstants.EXPAND_START_SCALE;
-        private const float DISSIPATE_DURATION = SimulateMouseUiAnimationConstants.DISSIPATE_DURATION;
-        private SynchronizationContext? _mainThreadContext;
+        private readonly MouseUiMainThreadCleanupScheduler _mainThreadCleanupScheduler = new();
 
         public async Task<SimulateMouseUiResponse> ExecuteAsync(
             SimulateMouseUiSchema request,
@@ -36,7 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             ct.ThrowIfCancellationRequested();
-            CaptureMainThreadContext();
+            _mainThreadCleanupScheduler.CaptureMainThreadContext();
 
             (MouseUiSimulationCommand? parameters, string? actionError) = MouseUiSimulationCommand.TryFromSchema(request);
             if (parameters == null)
@@ -65,7 +61,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             EventSystem activeEventSystem = eventSystem!;
 
             MouseUiSimulationActivityLogger.LogSimulationStart(parameters, correlationId);
-            EnsureOverlayExists();
+            OverlayCanvasFactory.EnsureExists();
 
             SimulateMouseUiResponse? dragStateFailure =
                 MouseUiSimulationValidator.ValidateActiveDragState(parameters);
@@ -115,11 +111,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static void EnsureOverlayExists()
-        {
-            OverlayCanvasFactory.EnsureExists();
-        }
-
         // Input coordinates use top-left origin; Unity Screen space uses bottom-left origin.
         // Handles.GetMainGameViewSize() returns the Game view's target resolution (e.g. 1920x1080),
         // which matches the Canvas layout space — unlike Screen.height which returns the window pixel size.
@@ -166,10 +157,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 MouseAction.Click, inputPos, null,
                 targetName, Handles.GetMainGameViewSize());
 
-            bool expandCompleted = await PlayExpandAnimation(ct).ConfigureAwait(false);
+            bool expandCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
             if (!expandCompleted)
             {
-                QueueOverlayClear();
+                _mainThreadCleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Click, inputPos, null, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -177,10 +168,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Fire click events after expand animation so the user sees where the click lands
             ExecutePointerClickEvents(resolvedTargets, pointerData);
 
-            bool dissipateCompleted = await PlayDissipateAnimation(ct).ConfigureAwait(false);
+            bool dissipateCompleted = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
             if (!dissipateCompleted)
             {
-                QueueOverlayClear();
+                _mainThreadCleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateClickResult(parameters, inputPos, targetName, hitTarget);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -230,10 +221,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 MouseAction.LongPress, inputPos, null,
                 targetName, Handles.GetMainGameViewSize());
 
-            bool expandCompleted = await PlayExpandAnimation(ct).ConfigureAwait(false);
+            bool expandCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
             if (!expandCompleted)
             {
-                QueueOverlayClear();
+                _mainThreadCleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -248,10 +239,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 while (elapsed < parameters.Duration)
                 {
                     SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
-                    bool frameReady = await WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
+                    bool frameReady = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
                     if (!frameReady)
                     {
-                        QueueOverlayClear();
+                        _mainThreadCleanupScheduler.QueueOverlayClear();
                         return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
                     }
                     await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -264,15 +255,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Ensure pointerUp fires even if the hold loop is cancelled
                 if (shouldReleasePointer)
                 {
-                    ExecuteCleanupOnMainThread(
+                    _mainThreadCleanupScheduler.ExecuteCleanupOnMainThread(
                         () => ExecuteEvents.Execute(resolvedTargets.Target!, pointerData, ExecuteEvents.pointerUpHandler));
                 }
             }
 
-            bool dissipateCompleted = await PlayDissipateAnimation(ct).ConfigureAwait(false);
+            bool dissipateCompleted = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
             if (!dissipateCompleted)
             {
-                QueueOverlayClear();
+                _mainThreadCleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -410,18 +401,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 SimulateMouseUiOverlayState.Update(
                     MouseAction.Drag, inputStart, null, null, Handles.GetMainGameViewSize());
-                bool expandCompleted = await PlayExpandAnimation(ct).ConfigureAwait(false);
+                bool expandCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
                 if (!expandCompleted)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, null);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
-                bool dissipateCompleted = await PlayDissipateAnimation(ct).ConfigureAwait(false);
+                bool dissipateCompleted = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
                 if (!dissipateCompleted)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, null);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -451,10 +442,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                bool expandCompleted = await PlayExpandAnimation(ct).ConfigureAwait(false);
+                bool expandCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
                 if (!expandCompleted)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -463,31 +454,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     .ConfigureAwait(false);
                 if (!dragCompleted)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
-                bool frameReady = await WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
+                bool frameReady = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
                 if (!frameReady)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Drag, inputStart, inputEnd, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
             }
             finally
             {
-                ExecuteCleanupOnMainThread(() => FinalizeDrag(pointerData, target, explicitDropTarget));
+                _mainThreadCleanupScheduler.ExecuteCleanupOnMainThread(() => FinalizeDrag(pointerData, target, explicitDropTarget));
             }
 
             SimulateMouseUiOverlayState.Update(
                 MouseAction.Drag, inputEnd, inputStart, targetName, Handles.GetMainGameViewSize());
 
-            bool completedDissipate = await PlayDissipateAnimation(ct).ConfigureAwait(false);
+            bool completedDissipate = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
             if (!completedDissipate)
             {
-                QueueOverlayClear();
+                _mainThreadCleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateDragResult(parameters, inputStart, inputEnd, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -544,7 +535,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (duration <= 0f)
             {
-                bool frameReady = await WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
+                bool frameReady = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
                 if (!frameReady)
                 {
                     return false;
@@ -565,7 +556,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             do
             {
-                bool frameReady = await WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
+                bool frameReady = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
                 if (!frameReady)
                 {
                     return false;
@@ -639,18 +630,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 SimulateMouseUiOverlayState.Update(
                     MouseAction.DragStart, inputPos, null, null, Handles.GetMainGameViewSize());
-                bool expandCompleted = await PlayExpandAnimation(ct).ConfigureAwait(false);
+                bool expandCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
                 if (!expandCompleted)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragStart, inputPos, null, null);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
-                bool dissipateCompleted = await PlayDissipateAnimation(ct).ConfigureAwait(false);
+                bool dissipateCompleted = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
                 if (!dissipateCompleted)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragStart, inputPos, null, null);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -681,10 +672,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool animationCompleted = false;
             try
             {
-                animationCompleted = await PlayExpandAnimation(ct).ConfigureAwait(false);
+                animationCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
                 if (!animationCompleted)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragStart, inputPos, null, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -695,7 +686,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Cancellation during animation leaves beginDrag dispatched; clean up
                 if (!animationCompleted)
                 {
-                    ExecuteCleanupOnMainThread(() =>
+                    _mainThreadCleanupScheduler.ExecuteCleanupOnMainThread(() =>
                     {
                         FinalizeDrag(pointerData, target, null);
                         MouseDragState.Clear();
@@ -756,7 +747,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.DragSpeed, ct).ConfigureAwait(false);
             if (!dragCompleted)
             {
-                QueueOverlayClear();
+                _mainThreadCleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragMove, inputEnd, null, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -828,22 +819,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     parameters.DragSpeed, ct).ConfigureAwait(false);
                 if (!dragCompleted)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragEnd, inputEnd, null, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
 
-                bool frameReady = await WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
+                bool frameReady = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
                 if (!frameReady)
                 {
-                    QueueOverlayClear();
+                    _mainThreadCleanupScheduler.QueueOverlayClear();
                     return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.DragEnd, inputEnd, null, targetName);
                 }
                 await MainThreadSwitcher.SwitchToMainThread(ct);
             }
             finally
             {
-                ExecuteCleanupOnMainThread(() =>
+                _mainThreadCleanupScheduler.ExecuteCleanupOnMainThread(() =>
                 {
                     FinalizeDrag(pointerData, target, explicitDropTarget);
                     MouseDragState.Clear();
@@ -853,10 +844,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SimulateMouseUiOverlayState.Update(
                 MouseAction.DragEnd, inputEnd, null, targetName, Handles.GetMainGameViewSize());
 
-            bool dissipateCompleted = await PlayDissipateAnimation(ct).ConfigureAwait(false);
+            bool dissipateCompleted = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
             if (!dissipateCompleted)
             {
-                QueueOverlayClear();
+                _mainThreadCleanupScheduler.QueueOverlayClear();
                 return MouseUiSimulationResponseFactory.CreateDragEndResult(parameters, inputEnd, targetName);
             }
             await MainThreadSwitcher.SwitchToMainThread(ct);
@@ -894,107 +885,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return null;
-        }
-
-        internal static async Task<bool> PlayExpandAnimation(CancellationToken ct)
-        {
-            SimulateMouseUiOverlay overlay = OverlayCanvasFactory.VisualizationCanvas.MouseUiOverlay;
-
-            // Previous dissipate sets alpha to 0; restore before expand starts
-            overlay.SetAlpha(1f);
-
-            float startTime = Time.realtimeSinceStartup;
-            float elapsed = 0f;
-            while (elapsed < EXPAND_DURATION)
-            {
-                float t = elapsed / EXPAND_DURATION;
-                overlay.SetCursorScale(Mathf.Lerp(EXPAND_START_SCALE, 1f, t));
-                bool frameReady = await WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
-                if (!frameReady)
-                {
-                    return false;
-                }
-                await MainThreadSwitcher.SwitchToMainThread(ct);
-                elapsed = Time.realtimeSinceStartup - startTime;
-            }
-            overlay.SetCursorScale(1f);
-            return true;
-        }
-
-        internal static async Task<bool> PlayDissipateAnimation(CancellationToken ct)
-        {
-            SimulateMouseUiOverlay overlay = OverlayCanvasFactory.VisualizationCanvas.MouseUiOverlay;
-
-            float startTime = Time.realtimeSinceStartup;
-            float elapsed = 0f;
-            while (elapsed < DISSIPATE_DURATION)
-            {
-                float t = elapsed / DISSIPATE_DURATION;
-                overlay.SetCursorScale(Mathf.Lerp(1f, 0f, t));
-                overlay.SetAlpha(Mathf.Lerp(1f, 0f, t));
-                bool frameReady = await WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
-                if (!frameReady)
-                {
-                    return false;
-                }
-                await MainThreadSwitcher.SwitchToMainThread(ct);
-                elapsed = Time.realtimeSinceStartup - startTime;
-            }
-            overlay!.SetCursorScale(0f);
-            overlay!.SetAlpha(0f);
-            SimulateMouseUiOverlayState.Clear();
-            return true;
-        }
-
-        internal static async Task<bool> WaitForEditorFrameAndSwitchToMainThreadAsync(CancellationToken ct)
-        {
-            bool frameReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
-                1,
-                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                ct).ConfigureAwait(false);
-            if (!frameReady)
-            {
-                return false;
-            }
-
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-            return true;
-        }
-
-        internal void CaptureMainThreadContext()
-        {
-            _mainThreadContext = SynchronizationContext.Current;
-            Debug.Assert(_mainThreadContext != null, "Main thread synchronization context must be captured.");
-        }
-
-        internal void QueueOverlayClear()
-        {
-            ExecuteCleanupOnMainThread(SimulateMouseUiOverlayState.Clear);
-        }
-
-        internal void ExecuteCleanupOnMainThread(Action cleanup)
-        {
-            Debug.Assert(cleanup != null, "cleanup must not be null");
-            if (cleanup == null)
-            {
-                throw new ArgumentNullException(nameof(cleanup));
-            }
-
-            if (MainThreadSwitcher.IsMainThread)
-            {
-                cleanup();
-                return;
-            }
-
-            SynchronizationContext? context = _mainThreadContext;
-            Debug.Assert(context != null, "Main thread synchronization context must be captured before cleanup.");
-            if (context == null)
-            {
-                throw new InvalidOperationException("Main thread synchronization context was not captured.");
-            }
-
-            // Why: timeout continuations can run on timer threads while Unity objects must still be cleaned up on the Editor thread.
-            context.Post(_ => cleanup(), null);
         }
 
     }


### PR DESCRIPTION
## Summary

- extract structured simulation activity logging into `MouseUiSimulationActivityLogger`
- extract Editor-frame waiting and overlay animation into `MouseUiEditorFrameWaiter` and `MouseUiOverlayAnimator`
- extract captured-main-thread cleanup into `MouseUiMainThreadCleanupScheduler`
- keep event and drag execution in `SimulateMouseUiUseCase` for the next planned split

## Behavioral Preservation

- added synchronous EditMode characterization for immediate cleanup and queued overlay clearing before moving the implementation
- preserved frame timeout, cancellation, `ConfigureAwait(false)`, main-thread switching, animation timing, cleanup posting, and state mutation order
- verified the full `SimulateMouseUiTests` PlayMode suite passed both before and after the move
- normalized the old use case against the new use case and three support classes in both directions; the only residual lines were the planned ownership field and the two adaptations below
- removed the one-line `EnsureOverlayExists` wrapper and now call `OverlayCanvasFactory.EnsureExists()` directly
- removed the three private animation constant aliases and reference `SimulateMouseUiAnimationConstants` directly from the animator

## Validation

- Unity compile: 0 errors, 0 warnings
- `SimulateMouseUiTests` PlayMode: 32 passed
- `MouseUiMainThreadCleanupSchedulerTests`: 2 passed
- `MouseUiPointerTargetResolverTests`: 10 passed
- `MouseUiSimulationResponseFactoryTests`: 12 passed
- `SimulateMouseUiActionValidationTests`: 1 passed
- `PlayModeToolPreflightServiceTests`: 8 passed
- `StaticFacadeStateGuardTests`: 20 passed
- `OnionAssemblyDependencyTests`: 83 passed

## Compatibility

- no IPC request or response shape changed
- no protocol version bump is required


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

