### PR TITLE
refactor: extract mouse UI press action execution

### DIFF
--- a/Assets/Tests/Editor/MouseUiCoordinateConverterTests.cs
+++ b/Assets/Tests/Editor/MouseUiCoordinateConverterTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Characterizes coordinate conversion shared by mouse UI action executors.
+    /// </summary>
+    [TestFixture]
+    public sealed class MouseUiCoordinateConverterTests
+    {
+        /// <summary>
+        /// Verifies top-left input coordinates are flipped against the current Game view height.
+        /// </summary>
+        [Test]
+        public void InputToScreen_WithTopLeftCoordinates_FlipsYAgainstCurrentGameViewHeight()
+        {
+            Vector2 inputPosition = new(12.5f, 37.25f);
+            float gameViewHeight = Handles.GetMainGameViewSize().y;
+
+            Vector2 screenPosition = SimulateMouseUiUseCase.InputToScreen(inputPosition);
+
+            Assert.That(
+                screenPosition,
+                Is.EqualTo(new Vector2(inputPosition.x, gameViewHeight - inputPosition.y)));
+        }
+
+        /// <summary>
+        /// Verifies converting input coordinates to screen space and back preserves the position.
+        /// </summary>
+        [Test]
+        public void ScreenToInput_AfterInputToScreen_RestoresPosition()
+        {
+            Vector2 inputPosition = new(42.5f, 64.25f);
+
+            Vector2 screenPosition = SimulateMouseUiUseCase.InputToScreen(inputPosition);
+            Vector2 restoredPosition = SimulateMouseUiUseCase.ScreenToInput(screenPosition);
+
+            Assert.That(restoredPosition, Is.EqualTo(inputPosition));
+        }
+    }
+}

--- a/Assets/Tests/Editor/MouseUiCoordinateConverterTests.cs
+++ b/Assets/Tests/Editor/MouseUiCoordinateConverterTests.cs
@@ -21,7 +21,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Vector2 inputPosition = new(12.5f, 37.25f);
             float gameViewHeight = Handles.GetMainGameViewSize().y;
 
-            Vector2 screenPosition = SimulateMouseUiUseCase.InputToScreen(inputPosition);
+            Vector2 screenPosition = MouseUiCoordinateConverter.InputToScreen(inputPosition);
 
             Assert.That(
                 screenPosition,
@@ -36,8 +36,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             Vector2 inputPosition = new(42.5f, 64.25f);
 
-            Vector2 screenPosition = SimulateMouseUiUseCase.InputToScreen(inputPosition);
-            Vector2 restoredPosition = SimulateMouseUiUseCase.ScreenToInput(screenPosition);
+            Vector2 screenPosition = MouseUiCoordinateConverter.InputToScreen(inputPosition);
+            Vector2 restoredPosition = MouseUiCoordinateConverter.ScreenToInput(screenPosition);
 
             Assert.That(restoredPosition, Is.EqualTo(inputPosition));
         }

--- a/Assets/Tests/Editor/MouseUiCoordinateConverterTests.cs.meta
+++ b/Assets/Tests/Editor/MouseUiCoordinateConverterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87ef2e81957a4e62a25589f09ed27b6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -328,10 +328,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void SimulateMouseUiUseCase_WhenReturningAfterTimeout_UsesCapturedUnityObjectState()
+        public void MouseUiPressActionExecutor_WhenReturningAfterTimeout_UsesCapturedUnityObjectState()
         {
             // Tests that timeout result branches use plain captured bools instead of UnityEngine.Object null checks.
-            string source = ReadSourceFile("Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs");
+            string source = ReadSourceFile(
+                "Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs");
 
             Assert.That(source, Does.Contain("bool hitTarget = resolvedTargets.Target != null;"));
             Assert.That(source, Does.Contain("bool shouldReleasePointer = resolvedTargets.RawTarget != null && resolvedTargets.Target != null;"));

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiCoordinateConverter.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiCoordinateConverter.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using UnityEditor;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Converts between top-left mouse input coordinates and Unity screen coordinates.
+    /// </summary>
+    internal static class MouseUiCoordinateConverter
+    {
+        // Input coordinates use top-left origin; Unity Screen space uses bottom-left origin.
+        // Handles.GetMainGameViewSize() returns the Game view's target resolution (e.g. 1920x1080),
+        // which matches the Canvas layout space — unlike Screen.height which returns the window pixel size.
+        internal static Vector2 InputToScreen(Vector2 inputPos)
+        {
+            float targetHeight = Handles.GetMainGameViewSize().y;
+            return new Vector2(inputPos.x, targetHeight - inputPos.y);
+        }
+
+        internal static Vector2 ScreenToInput(Vector2 screenPos)
+        {
+            float targetHeight = Handles.GetMainGameViewSize().y;
+            return new Vector2(screenPos.x, targetHeight - screenPos.y);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiCoordinateConverter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiCoordinateConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acada63040774a569f5945fc464b30f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
@@ -1,0 +1,218 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Executes click and long-press mouse UI actions.
+    /// </summary>
+    internal static class MouseUiPressActionExecutor
+    {
+        internal static async Task<SimulateMouseUiResponse> ExecuteClick(
+            MouseUiSimulationCommand parameters,
+            EventSystem eventSystem,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
+        {
+            Vector2 inputPos = new(parameters.X, parameters.Y);
+            Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
+            PointerEventData pointerData = MouseUiPointerTargetResolver.CreatePointerPressData(eventSystem, screenPos, parameters.Button);
+            ResolvedPointerTargets resolvedTargets =
+                MouseUiPointerTargetResolver.ResolvePressablePointerTargets(parameters, eventSystem, inputPos, screenPos, pointerData, MouseAction.Click);
+            if (resolvedTargets.FailureResponse != null)
+            {
+                return resolvedTargets.FailureResponse;
+            }
+
+            if (parameters.BypassRaycast && resolvedTargets.Target == null)
+            {
+                return new SimulateMouseUiResponse
+                {
+                    Success = false,
+                    Message = $"TargetPath '{parameters.TargetPath}' has no pointer click or pointer down handler.",
+                    Action = MouseAction.Click.ToString(),
+                    PositionX = inputPos.x,
+                    PositionY = inputPos.y
+                };
+            }
+
+            string? targetName = resolvedTargets.Target?.name;
+            bool hitTarget = resolvedTargets.Target != null;
+            SimulateMouseUiOverlayState.Update(
+                MouseAction.Click, inputPos, null,
+                targetName, Handles.GetMainGameViewSize());
+
+            bool expandCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
+            if (!expandCompleted)
+            {
+                cleanupScheduler.QueueOverlayClear();
+                return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Click, inputPos, null, targetName);
+            }
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+
+            // Fire click events after expand animation so the user sees where the click lands
+            ExecutePointerClickEvents(resolvedTargets, pointerData);
+
+            bool dissipateCompleted = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
+            if (!dissipateCompleted)
+            {
+                cleanupScheduler.QueueOverlayClear();
+                return MouseUiSimulationResponseFactory.CreateClickResult(parameters, inputPos, targetName, hitTarget);
+            }
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+
+            return MouseUiSimulationResponseFactory.CreateClickResult(parameters, inputPos, targetName, hitTarget);
+        }
+
+        internal static async Task<SimulateMouseUiResponse> ExecuteLongPress(
+            MouseUiSimulationCommand parameters,
+            EventSystem eventSystem,
+            MouseUiMainThreadCleanupScheduler cleanupScheduler,
+            CancellationToken ct)
+        {
+            if (parameters.Duration <= 0f || float.IsNaN(parameters.Duration) || float.IsInfinity(parameters.Duration))
+            {
+                return new SimulateMouseUiResponse
+                {
+                    Success = false,
+                    Message = $"Duration must be positive, got: {parameters.Duration}",
+                    Action = MouseAction.LongPress.ToString()
+                };
+            }
+
+            Vector2 inputPos = new(parameters.X, parameters.Y);
+            Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
+            PointerEventData pointerData = MouseUiPointerTargetResolver.CreatePointerPressData(eventSystem, screenPos, parameters.Button);
+            ResolvedPointerTargets resolvedTargets =
+                MouseUiPointerTargetResolver.ResolvePressablePointerTargets(parameters, eventSystem, inputPos, screenPos, pointerData, MouseAction.LongPress);
+            if (resolvedTargets.FailureResponse != null)
+            {
+                return resolvedTargets.FailureResponse;
+            }
+
+            if (parameters.BypassRaycast && resolvedTargets.Target == null)
+            {
+                return new SimulateMouseUiResponse
+                {
+                    Success = false,
+                    Message = $"TargetPath '{parameters.TargetPath}' has no pointer down or pointer click handler.",
+                    Action = MouseAction.LongPress.ToString(),
+                    PositionX = inputPos.x,
+                    PositionY = inputPos.y
+                };
+            }
+
+            string? targetName = resolvedTargets.Target?.name;
+            bool hitTarget = resolvedTargets.Target != null;
+            bool shouldReleasePointer = resolvedTargets.RawTarget != null && resolvedTargets.Target != null;
+            SimulateMouseUiOverlayState.Update(
+                MouseAction.LongPress, inputPos, null,
+                targetName, Handles.GetMainGameViewSize());
+
+            bool expandCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
+            if (!expandCompleted)
+            {
+                cleanupScheduler.QueueOverlayClear();
+                return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
+            }
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+
+            ExecuteLongPressPointerDown(resolvedTargets, pointerData);
+
+            try
+            {
+                // Hold for Duration seconds, updating elapsed time each frame for overlay display
+                float startTime = Time.realtimeSinceStartup;
+                float elapsed = 0f;
+                while (elapsed < parameters.Duration)
+                {
+                    SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
+                    bool frameReady = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
+                    if (!frameReady)
+                    {
+                        cleanupScheduler.QueueOverlayClear();
+                        return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
+                    }
+                    await MainThreadSwitcher.SwitchToMainThread(ct);
+                    elapsed = Time.realtimeSinceStartup - startTime;
+                }
+                SimulateMouseUiOverlayState.UpdateLongPressElapsed(parameters.Duration);
+            }
+            finally
+            {
+                // Ensure pointerUp fires even if the hold loop is cancelled
+                if (shouldReleasePointer)
+                {
+                    cleanupScheduler.ExecuteCleanupOnMainThread(
+                        () => ExecuteEvents.Execute(resolvedTargets.Target!, pointerData, ExecuteEvents.pointerUpHandler));
+                }
+            }
+
+            bool dissipateCompleted = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
+            if (!dissipateCompleted)
+            {
+                cleanupScheduler.QueueOverlayClear();
+                return MouseUiSimulationResponseFactory.CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
+            }
+            await MainThreadSwitcher.SwitchToMainThread(ct);
+
+            return MouseUiSimulationResponseFactory.CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
+        }
+
+        private static void ExecutePointerClickEvents(
+            ResolvedPointerTargets resolvedTargets,
+            PointerEventData pointerData)
+        {
+            if (resolvedTargets.RawTarget == null)
+            {
+                return;
+            }
+
+            if (resolvedTargets.PressTarget != null)
+            {
+                ExecuteEvents.ExecuteHierarchy(
+                    resolvedTargets.RawTarget,
+                    pointerData,
+                    ExecuteEvents.pointerDownHandler);
+            }
+
+            if (resolvedTargets.Target != null)
+            {
+                ExecuteEvents.Execute(
+                    resolvedTargets.Target,
+                    pointerData,
+                    ExecuteEvents.pointerUpHandler);
+            }
+
+            if (resolvedTargets.ClickTarget != null)
+            {
+                ExecuteEvents.Execute(
+                    resolvedTargets.ClickTarget,
+                    pointerData,
+                    ExecuteEvents.pointerClickHandler);
+            }
+        }
+
+        private static void ExecuteLongPressPointerDown(
+            ResolvedPointerTargets resolvedTargets,
+            PointerEventData pointerData)
+        {
+            if (resolvedTargets.RawTarget == null || resolvedTargets.Target == null)
+            {
+                return;
+            }
+
+            ExecuteEvents.ExecuteHierarchy(
+                resolvedTargets.RawTarget,
+                pointerData,
+                ExecuteEvents.pointerDownHandler);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b0a30f1d03b457c870578e67fd99f1b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -114,13 +114,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Input coordinates use top-left origin; Unity Screen space uses bottom-left origin.
         // Handles.GetMainGameViewSize() returns the Game view's target resolution (e.g. 1920x1080),
         // which matches the Canvas layout space — unlike Screen.height which returns the window pixel size.
-        private static Vector2 InputToScreen(Vector2 inputPos)
+        internal static Vector2 InputToScreen(Vector2 inputPos)
         {
             float targetHeight = Handles.GetMainGameViewSize().y;
             return new Vector2(inputPos.x, targetHeight - inputPos.y);
         }
 
-        private static Vector2 ScreenToInput(Vector2 screenPos)
+        internal static Vector2 ScreenToInput(Vector2 screenPos)
         {
             float targetHeight = Handles.GetMainGameViewSize().y;
             return new Vector2(screenPos.x, targetHeight - screenPos.y);

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -111,26 +111,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        // Input coordinates use top-left origin; Unity Screen space uses bottom-left origin.
-        // Handles.GetMainGameViewSize() returns the Game view's target resolution (e.g. 1920x1080),
-        // which matches the Canvas layout space — unlike Screen.height which returns the window pixel size.
-        internal static Vector2 InputToScreen(Vector2 inputPos)
-        {
-            float targetHeight = Handles.GetMainGameViewSize().y;
-            return new Vector2(inputPos.x, targetHeight - inputPos.y);
-        }
-
-        internal static Vector2 ScreenToInput(Vector2 screenPos)
-        {
-            float targetHeight = Handles.GetMainGameViewSize().y;
-            return new Vector2(screenPos.x, targetHeight - screenPos.y);
-        }
-
         private async Task<SimulateMouseUiResponse> ExecuteClick(
             MouseUiSimulationCommand parameters, EventSystem eventSystem, CancellationToken ct)
         {
             Vector2 inputPos = new(parameters.X, parameters.Y);
-            Vector2 screenPos = InputToScreen(inputPos);
+            Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
             PointerEventData pointerData = MouseUiPointerTargetResolver.CreatePointerPressData(eventSystem, screenPos, parameters.Button);
             ResolvedPointerTargets resolvedTargets =
                 MouseUiPointerTargetResolver.ResolvePressablePointerTargets(parameters, eventSystem, inputPos, screenPos, pointerData, MouseAction.Click);
@@ -193,7 +178,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Vector2 inputPos = new(parameters.X, parameters.Y);
-            Vector2 screenPos = InputToScreen(inputPos);
+            Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
             PointerEventData pointerData = MouseUiPointerTargetResolver.CreatePointerPressData(eventSystem, screenPos, parameters.Button);
             ResolvedPointerTargets resolvedTargets =
                 MouseUiPointerTargetResolver.ResolvePressablePointerTargets(parameters, eventSystem, inputPos, screenPos, pointerData, MouseAction.LongPress);
@@ -354,8 +339,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Vector2 inputStart = new(parameters.FromX, parameters.FromY);
             Vector2 inputEnd = new(parameters.X, parameters.Y);
-            Vector2 screenStart = InputToScreen(inputStart);
-            Vector2 screenEnd = InputToScreen(inputEnd);
+            Vector2 screenStart = MouseUiCoordinateConverter.InputToScreen(inputStart);
+            Vector2 screenEnd = MouseUiCoordinateConverter.InputToScreen(inputEnd);
             RaycastResult? hit = parameters.BypassRaycast ? null : UiRaycastHelper.RaycastUI(screenStart, eventSystem);
             RaycastResult startRaycast = new();
             GameObject? rawTarget = null;
@@ -547,7 +532,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 pointerData.delta = endPos - previousPosition;
                 ExecuteEvents.Execute(target, pointerData, ExecuteEvents.dragHandler);
 
-                SimulateMouseUiOverlayState.UpdatePosition(ScreenToInput(endPos));
+                SimulateMouseUiOverlayState.UpdatePosition(MouseUiCoordinateConverter.ScreenToInput(endPos));
                 return true;
             }
 
@@ -573,7 +558,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 ExecuteEvents.Execute(target, pointerData, ExecuteEvents.dragHandler);
 
-                SimulateMouseUiOverlayState.UpdatePosition(ScreenToInput(currentPosition));
+                SimulateMouseUiOverlayState.UpdatePosition(MouseUiCoordinateConverter.ScreenToInput(currentPosition));
             }
             while (t < 1.0f);
 
@@ -596,7 +581,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Vector2 inputPos = new(parameters.X, parameters.Y);
-            Vector2 screenPos = InputToScreen(inputPos);
+            Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
             RaycastResult? hit = parameters.BypassRaycast ? null : UiRaycastHelper.RaycastUI(screenPos, eventSystem);
             RaycastResult startRaycast = new();
             GameObject? rawTarget = null;
@@ -730,14 +715,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Vector2 inputEnd = new(parameters.X, parameters.Y);
-            Vector2 screenEnd = InputToScreen(inputEnd);
+            Vector2 screenEnd = MouseUiCoordinateConverter.InputToScreen(inputEnd);
             PointerEventData pointerData = MouseDragState.PointerData!;
             GameObject target = MouseDragState.Target!;
             string targetName = target.name;
 
             SimulateMouseUiOverlayState.Update(
                 MouseAction.DragMove,
-                ScreenToInput(pointerData.position),
+                MouseUiCoordinateConverter.ScreenToInput(pointerData.position),
                 SimulateMouseUiOverlayState.DragStartPosition,
                 targetName, Handles.GetMainGameViewSize());
 
@@ -790,7 +775,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Vector2 inputEnd = new(parameters.X, parameters.Y);
-            Vector2 screenEnd = InputToScreen(inputEnd);
+            Vector2 screenEnd = MouseUiCoordinateConverter.InputToScreen(inputEnd);
             PointerEventData pointerData = MouseDragState.PointerData!;
             GameObject target = MouseDragState.Target!;
             string targetName = target.name;
@@ -808,7 +793,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             SimulateMouseUiOverlayState.Update(
                 MouseAction.DragEnd,
-                ScreenToInput(pointerData.position),
+                MouseUiCoordinateConverter.ScreenToInput(pointerData.position),
                 SimulateMouseUiOverlayState.DragStartPosition,
                 targetName, Handles.GetMainGameViewSize());
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiUseCase.cs
@@ -85,7 +85,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             switch (parameters.Action)
             {
                 case MouseAction.Click:
-                    return await ExecuteClick(parameters, eventSystem, ct).ConfigureAwait(false);
+                    return await MouseUiPressActionExecutor.ExecuteClick(
+                        parameters,
+                        eventSystem,
+                        _mainThreadCleanupScheduler,
+                        ct).ConfigureAwait(false);
 
                 case MouseAction.Drag:
                     return await ExecuteDragOneShot(parameters, eventSystem, ct).ConfigureAwait(false);
@@ -100,7 +104,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return await ExecuteDragEnd(parameters, ct).ConfigureAwait(false);
 
                 case MouseAction.LongPress:
-                    return await ExecuteLongPress(parameters, eventSystem, ct).ConfigureAwait(false);
+                    return await MouseUiPressActionExecutor.ExecuteLongPress(
+                        parameters,
+                        eventSystem,
+                        _mainThreadCleanupScheduler,
+                        ct).ConfigureAwait(false);
 
                 default:
                     // Unreachable when TryFromSchema succeeds; kept as a defensive Success=false response
@@ -109,200 +117,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         parameters,
                         $"Unknown mouse action: {parameters.Action}");
             }
-        }
-
-        private async Task<SimulateMouseUiResponse> ExecuteClick(
-            MouseUiSimulationCommand parameters, EventSystem eventSystem, CancellationToken ct)
-        {
-            Vector2 inputPos = new(parameters.X, parameters.Y);
-            Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
-            PointerEventData pointerData = MouseUiPointerTargetResolver.CreatePointerPressData(eventSystem, screenPos, parameters.Button);
-            ResolvedPointerTargets resolvedTargets =
-                MouseUiPointerTargetResolver.ResolvePressablePointerTargets(parameters, eventSystem, inputPos, screenPos, pointerData, MouseAction.Click);
-            if (resolvedTargets.FailureResponse != null)
-            {
-                return resolvedTargets.FailureResponse;
-            }
-
-            if (parameters.BypassRaycast && resolvedTargets.Target == null)
-            {
-                return new SimulateMouseUiResponse
-                {
-                    Success = false,
-                    Message = $"TargetPath '{parameters.TargetPath}' has no pointer click or pointer down handler.",
-                    Action = MouseAction.Click.ToString(),
-                    PositionX = inputPos.x,
-                    PositionY = inputPos.y
-                };
-            }
-
-            string? targetName = resolvedTargets.Target?.name;
-            bool hitTarget = resolvedTargets.Target != null;
-            SimulateMouseUiOverlayState.Update(
-                MouseAction.Click, inputPos, null,
-                targetName, Handles.GetMainGameViewSize());
-
-            bool expandCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
-            if (!expandCompleted)
-            {
-                _mainThreadCleanupScheduler.QueueOverlayClear();
-                return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.Click, inputPos, null, targetName);
-            }
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-
-            // Fire click events after expand animation so the user sees where the click lands
-            ExecutePointerClickEvents(resolvedTargets, pointerData);
-
-            bool dissipateCompleted = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
-            if (!dissipateCompleted)
-            {
-                _mainThreadCleanupScheduler.QueueOverlayClear();
-                return MouseUiSimulationResponseFactory.CreateClickResult(parameters, inputPos, targetName, hitTarget);
-            }
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-
-            return MouseUiSimulationResponseFactory.CreateClickResult(parameters, inputPos, targetName, hitTarget);
-        }
-
-        private async Task<SimulateMouseUiResponse> ExecuteLongPress(
-            MouseUiSimulationCommand parameters, EventSystem eventSystem, CancellationToken ct)
-        {
-            if (parameters.Duration <= 0f || float.IsNaN(parameters.Duration) || float.IsInfinity(parameters.Duration))
-            {
-                return new SimulateMouseUiResponse
-                {
-                    Success = false,
-                    Message = $"Duration must be positive, got: {parameters.Duration}",
-                    Action = MouseAction.LongPress.ToString()
-                };
-            }
-
-            Vector2 inputPos = new(parameters.X, parameters.Y);
-            Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
-            PointerEventData pointerData = MouseUiPointerTargetResolver.CreatePointerPressData(eventSystem, screenPos, parameters.Button);
-            ResolvedPointerTargets resolvedTargets =
-                MouseUiPointerTargetResolver.ResolvePressablePointerTargets(parameters, eventSystem, inputPos, screenPos, pointerData, MouseAction.LongPress);
-            if (resolvedTargets.FailureResponse != null)
-            {
-                return resolvedTargets.FailureResponse;
-            }
-
-            if (parameters.BypassRaycast && resolvedTargets.Target == null)
-            {
-                return new SimulateMouseUiResponse
-                {
-                    Success = false,
-                    Message = $"TargetPath '{parameters.TargetPath}' has no pointer down or pointer click handler.",
-                    Action = MouseAction.LongPress.ToString(),
-                    PositionX = inputPos.x,
-                    PositionY = inputPos.y
-                };
-            }
-
-            string? targetName = resolvedTargets.Target?.name;
-            bool hitTarget = resolvedTargets.Target != null;
-            bool shouldReleasePointer = resolvedTargets.RawTarget != null && resolvedTargets.Target != null;
-            SimulateMouseUiOverlayState.Update(
-                MouseAction.LongPress, inputPos, null,
-                targetName, Handles.GetMainGameViewSize());
-
-            bool expandCompleted = await MouseUiOverlayAnimator.PlayExpandAnimation(ct).ConfigureAwait(false);
-            if (!expandCompleted)
-            {
-                _mainThreadCleanupScheduler.QueueOverlayClear();
-                return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
-            }
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-
-            ExecuteLongPressPointerDown(resolvedTargets, pointerData);
-
-            try
-            {
-                // Hold for Duration seconds, updating elapsed time each frame for overlay display
-                float startTime = Time.realtimeSinceStartup;
-                float elapsed = 0f;
-                while (elapsed < parameters.Duration)
-                {
-                    SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
-                    bool frameReady = await MouseUiEditorFrameWaiter.WaitForEditorFrameAndSwitchToMainThreadAsync(ct).ConfigureAwait(false);
-                    if (!frameReady)
-                    {
-                        _mainThreadCleanupScheduler.QueueOverlayClear();
-                        return MouseUiSimulationResponseFactory.CreateFrameTimeoutResult(MouseAction.LongPress, inputPos, null, targetName);
-                    }
-                    await MainThreadSwitcher.SwitchToMainThread(ct);
-                    elapsed = Time.realtimeSinceStartup - startTime;
-                }
-                SimulateMouseUiOverlayState.UpdateLongPressElapsed(parameters.Duration);
-            }
-            finally
-            {
-                // Ensure pointerUp fires even if the hold loop is cancelled
-                if (shouldReleasePointer)
-                {
-                    _mainThreadCleanupScheduler.ExecuteCleanupOnMainThread(
-                        () => ExecuteEvents.Execute(resolvedTargets.Target!, pointerData, ExecuteEvents.pointerUpHandler));
-                }
-            }
-
-            bool dissipateCompleted = await MouseUiOverlayAnimator.PlayDissipateAnimation(ct).ConfigureAwait(false);
-            if (!dissipateCompleted)
-            {
-                _mainThreadCleanupScheduler.QueueOverlayClear();
-                return MouseUiSimulationResponseFactory.CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
-            }
-            await MainThreadSwitcher.SwitchToMainThread(ct);
-
-            return MouseUiSimulationResponseFactory.CreateLongPressResult(parameters, inputPos, targetName, hitTarget);
-        }
-
-        private static void ExecutePointerClickEvents(
-            ResolvedPointerTargets resolvedTargets,
-            PointerEventData pointerData)
-        {
-            if (resolvedTargets.RawTarget == null)
-            {
-                return;
-            }
-
-            if (resolvedTargets.PressTarget != null)
-            {
-                ExecuteEvents.ExecuteHierarchy(
-                    resolvedTargets.RawTarget,
-                    pointerData,
-                    ExecuteEvents.pointerDownHandler);
-            }
-
-            if (resolvedTargets.Target != null)
-            {
-                ExecuteEvents.Execute(
-                    resolvedTargets.Target,
-                    pointerData,
-                    ExecuteEvents.pointerUpHandler);
-            }
-
-            if (resolvedTargets.ClickTarget != null)
-            {
-                ExecuteEvents.Execute(
-                    resolvedTargets.ClickTarget,
-                    pointerData,
-                    ExecuteEvents.pointerClickHandler);
-            }
-        }
-
-        private static void ExecuteLongPressPointerDown(
-            ResolvedPointerTargets resolvedTargets,
-            PointerEventData pointerData)
-        {
-            if (resolvedTargets.RawTarget == null || resolvedTargets.Target == null)
-            {
-                return;
-            }
-
-            ExecuteEvents.ExecuteHierarchy(
-                resolvedTargets.RawTarget,
-                pointerData,
-                ExecuteEvents.pointerDownHandler);
         }
 
         private PointerEventData InitiateDrag(


### PR DESCRIPTION
## Summary

- extract top-left and Unity screen-space conversion into `MouseUiCoordinateConverter`
- extract click and long-press orchestration into `MouseUiPressActionExecutor`
- reduce `SimulateMouseUiUseCase` from 891 lines to 690 lines while leaving all drag execution for the next stages

## Behavioral Preservation

- added synchronous EditMode characterization for the Game view Y flip and coordinate round trip before moving the converter
- moved the coordinate why-comment with the implementation and switched all 11 press and drag call sites directly to the new owner
- preserved click and long-press event ordering, messages, response fields, animation timing, frame timeout handling, cancellation, cleanup posting, and every `ConfigureAwait(false)` call
- normalized the old press block against the new executor; the only difference was a trailing blank line after normalizing the planned scheduler reference change
- retargeted the existing timeout-state source guard to `MouseUiPressActionExecutor` so it continues to reject Unity object re-evaluation after asynchronous timeouts

## Planned Adaptation

- `ExecuteClick` and `ExecuteLongPress` are now static executor entries and receive `MouseUiMainThreadCleanupScheduler` explicitly
- this replaces six use-case field references without adding a constructor, instance executor, delegate, wrapper, or reverse dependency

## Validation

- Unity compile: 0 errors, 0 warnings
- `SimulateMouseUiTests` PlayMode: 32 passed before and after extraction
- related EditMode suites: 138 passed across 8 fixtures
- `StaticFacadeStateGuardTests`: 20 passed after moving the guarded source owner
- helper-to-use-case reverse references: 0
- old press and coordinate definitions remaining in the use case: 0

## Compatibility

- no IPC request or response shape changed
- no protocol version bump is required
- R2-40 and R2-41 remain intentionally out of scope


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

