### PR TITLE
chore: isolate project IPC response framing

### DIFF
--- a/Assets/Tests/Editor/UnityCliLoopBridgeResponseWriterTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopBridgeResponseWriterTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Tests the byte-level Content-Length framing emitted by the project IPC server.
+    /// </summary>
+    public sealed class UnityCliLoopBridgeResponseWriterTests
+    {
+        /// <summary>
+        /// Verifies an empty JSON response does not emit a frame.
+        /// </summary>
+        [Test]
+        public void CreateContentLengthFrame_WhenJsonIsEmpty_ReturnsEmptyFrame()
+        {
+            string frame = UnityCliLoopBridgeResponseWriter.CreateContentLengthFrame(string.Empty);
+
+            Assert.That(frame, Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies ASCII JSON is framed with its exact UTF-8 byte length and header separators.
+        /// </summary>
+        [Test]
+        public void CreateContentLengthFrame_WhenJsonIsAscii_ReturnsExactFrame()
+        {
+            const string Json = "{\"id\":1}";
+
+            string frame = UnityCliLoopBridgeResponseWriter.CreateContentLengthFrame(Json);
+
+            Assert.That(frame, Is.EqualTo("Content-Length: 8\r\n\r\n{\"id\":1}"));
+        }
+
+        /// <summary>
+        /// Verifies multibyte JSON uses UTF-8 byte length rather than UTF-16 character count.
+        /// </summary>
+        [Test]
+        public void CreateContentLengthFrame_WhenJsonContainsMultibyteText_UsesUtf8ByteLength()
+        {
+            const string Json = "{\"message\":\"あ\"}";
+
+            string frame = UnityCliLoopBridgeResponseWriter.CreateContentLengthFrame(Json);
+
+            Assert.That(frame, Is.EqualTo("Content-Length: 17\r\n\r\n{\"message\":\"あ\"}"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/UnityCliLoopBridgeResponseWriterTests.cs.meta
+++ b/Assets/Tests/Editor/UnityCliLoopBridgeResponseWriterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b07d99dd8364e8f849f35d650a5a27c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeResponseWriter.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeResponseWriter.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Frames and serializes JSON responses written to project IPC client streams.
+    /// </summary>
+    internal static class UnityCliLoopBridgeResponseWriter
+    {
+        /// <summary>
+        /// Creates a Content-Length framed message for JSON-RPC 2.0 communication.
+        /// </summary>
+        /// <param name="jsonContent">The JSON content to frame</param>
+        /// <returns>The framed message with Content-Length header</returns>
+        internal static string CreateContentLengthFrame(string jsonContent)
+        {
+            if (string.IsNullOrEmpty(jsonContent))
+            {
+                return string.Empty;
+            }
+
+            // Calculate content length in bytes (UTF-8 encoding)
+            int contentLength = Encoding.UTF8.GetByteCount(jsonContent);
+
+            // Create the framed message: Content-Length: <n>\r\n\r\n<json_content>
+            return $"Content-Length: {contentLength}\r\n\r\n{jsonContent}";
+        }
+
+        private static async Task WriteJsonResponseAsync(
+            Stream stream,
+            string responseJson,
+            CancellationToken ct)
+        {
+            if (string.IsNullOrEmpty(responseJson))
+            {
+                return;
+            }
+
+            if (!stream.CanWrite || ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            string framedResponse = CreateContentLengthFrame(responseJson);
+            byte[] responseData = Encoding.UTF8.GetBytes(framedResponse);
+            await stream.WriteAsync(responseData, 0, responseData.Length, ct);
+        }
+
+        internal static async Task WriteJsonResponseLockedAsync(
+            Stream stream,
+            SemaphoreSlim streamWriteLock,
+            string responseJson,
+            CancellationToken ct)
+        {
+            // Why: heartbeat frames are written from a background timer while the final
+            // response is written by the request task; interleaved writes would corrupt
+            // Content-Length framing, so all frame writes share one lock per connection.
+            await streamWriteLock.WaitAsync(ct);
+            try
+            {
+                await WriteJsonResponseAsync(stream, responseJson, ct);
+            }
+            finally
+            {
+                streamWriteLock.Release();
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeResponseWriter.cs.meta
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeResponseWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90ec8a0d5ab84fdba1fbc98167d47183
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeServer.cs
@@ -4,7 +4,6 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -575,45 +574,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        /// <summary>
-        /// Creates a Content-Length framed message for JSON-RPC 2.0 communication.
-        /// </summary>
-        /// <param name="jsonContent">The JSON content to frame</param>
-        /// <returns>The framed message with Content-Length header</returns>
-        private string CreateContentLengthFrame(string jsonContent)
-        {
-            if (string.IsNullOrEmpty(jsonContent))
-            {
-                return string.Empty;
-            }
-            
-            // Calculate content length in bytes (UTF-8 encoding)
-            int contentLength = Encoding.UTF8.GetByteCount(jsonContent);
-            
-            // Create the framed message: Content-Length: <n>\r\n\r\n<json_content>
-            return $"Content-Length: {contentLength}\r\n\r\n{jsonContent}";
-        }
-
-        private async Task WriteJsonResponseAsync(
-            Stream stream,
-            string responseJson,
-            CancellationToken ct)
-        {
-            if (string.IsNullOrEmpty(responseJson))
-            {
-                return;
-            }
-
-            if (!stream.CanWrite || ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            string framedResponse = CreateContentLengthFrame(responseJson);
-            byte[] responseData = Encoding.UTF8.GetBytes(framedResponse);
-            await stream.WriteAsync(responseData, 0, responseData.Length, ct);
-        }
-
         private async Task ProcessRequestFrameAsync(
             BridgeClientConnection client,
             Stream stream,
@@ -634,7 +594,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         requestCancellationTokenSource.Token,
                         async (responseJsonValue, cancelOnClientDisconnect, createHeartbeatJson) =>
                         {
-                            await WriteJsonResponseLockedAsync(
+                            await UnityCliLoopBridgeResponseWriter.WriteJsonResponseLockedAsync(
                                 stream, streamWriteLock, responseJsonValue, serverCancellationToken);
 
                             if (createHeartbeatJson != null)
@@ -647,7 +607,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                                 CancellationToken heartbeatToken = heartbeatCancellationSource.Token;
                                 heartbeatTask = _heartbeatService.SendHeartbeatsAsync(
                                     createHeartbeatJson,
-                                    heartbeatJson => WriteJsonResponseLockedAsync(
+                                    heartbeatJson => UnityCliLoopBridgeResponseWriter.WriteJsonResponseLockedAsync(
                                         stream, streamWriteLock, heartbeatJson, heartbeatToken),
                                     TimeSpan.FromSeconds(UnityCliLoopServerConfig.HEARTBEAT_INTERVAL_SECONDS),
                                     heartbeatToken);
@@ -669,7 +629,8 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     await _heartbeatService.StopHeartbeatsAsync(heartbeatTask, heartbeatCancellationSource);
                     heartbeatTask = null;
 
-                    await WriteJsonResponseLockedAsync(stream, streamWriteLock, responseJson, serverCancellationToken);
+                    await UnityCliLoopBridgeResponseWriter.WriteJsonResponseLockedAsync(
+                        stream, streamWriteLock, responseJson, serverCancellationToken);
                 }
                 finally
                 {
@@ -679,26 +640,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                         clientDisconnectMonitorTask,
                         requestCancellationTokenSource);
                 }
-            }
-        }
-
-        private async Task WriteJsonResponseLockedAsync(
-            Stream stream,
-            SemaphoreSlim streamWriteLock,
-            string responseJson,
-            CancellationToken ct)
-        {
-            // Why: heartbeat frames are written from a background timer while the final
-            // response is written by the request task; interleaved writes would corrupt
-            // Content-Length framing, so all frame writes share one lock per connection.
-            await streamWriteLock.WaitAsync(ct);
-            try
-            {
-                await WriteJsonResponseAsync(stream, responseJson, ct);
-            }
-            finally
-            {
-                streamWriteLock.Release();
             }
         }
 


### PR DESCRIPTION
## Summary
- Isolate project IPC Content-Length framing and response writes behind one stateless writer.
- Keep the bridge server focused on request and connection orchestration without changing emitted bytes.

## User Impact
- There is no intended user-visible behavior change.
- CLI request acceptance, heartbeat delivery, final responses, cancellation, and connection handling remain unchanged.

## Changes
- Move Content-Length frame construction, raw stream writes, and per-connection locked writes into `UnityCliLoopBridgeResponseWriter`.
- Keep `ProcessRequestFrameAsync` in the server and preserve its control flow.
- Update exactly three writer callers: the dispatch-accepted response, heartbeat callback, and final response.
- Keep the per-connection `SemaphoreSlim`, heartbeat lifecycle, disconnect monitor, request token source, and JSON generation in their existing owners.

## Verification
- Passed the related EditMode baseline before editing (`139/139`).
- Confirmed the three new frame tests fail before implementation with three `CS0103` errors, then pass after implementation (`3/3`).
- Covered empty output, exact ASCII framing, and UTF-8 multibyte byte length.
- Compared the three moved method bodies after normalizing required visibility/static changes; framing, guards, write parameters, lock handling, and `try/finally` behavior are unchanged.
- Passed the response writer, bridge shutdown, reassembler, heartbeat, cancellation policy, response serializer, client connection, architecture, and static facade guard fixtures (`142/142`).
- Compiled the Unity package with `0` errors and `0` warnings.

## Compatibility
- The emitted frame remains `Content-Length: <UTF-8 byte count>\r\n\r\n<JSON>`.
- Dispatch-accepted, heartbeat, and final JSON shapes are still owned by `JsonRpcRequestProcessor`; their order is unchanged.
- No IPC contract changed, so the protocol version remains unchanged.

## Follow-up
- R2-35 remains open. The next stage will move client stream/task ownership and per-client session processing into a dedicated session manager after separate plan review.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

