### PR TITLE
chore: simplify CLI installation detection internals

### DIFF
--- a/Assets/Tests/Editor/CliDetectionCommandRunnerTests.cs
+++ b/Assets/Tests/Editor/CliDetectionCommandRunnerTests.cs
@@ -1,0 +1,118 @@
+using System.Diagnostics;
+using System.Threading;
+
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies CLI detection command execution behavior.
+    /// </summary>
+    public class CliDetectionCommandRunnerTests
+    {
+        /// <summary>
+        /// Verifies that command execution preserves stdout line order and the exit code.
+        /// </summary>
+        [Test]
+        public void Execute_WhenCommandWritesMultipleLines_ReturnsOrderedLinesAndExitCode()
+        {
+            ProcessStartInfo startInfo = BuildOutputProcessStartInfo(0);
+
+            CliDetectionCommandResult result = CliDetectionCommandRunner.Execute(
+                startInfo,
+                CancellationToken.None);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.StandardOutputLines, Is.EqualTo(new[] { "first", "second" }));
+            Assert.That(result.ExitCode, Is.Zero);
+        }
+
+        /// <summary>
+        /// Verifies that command execution returns captured output for the detection policy to reject.
+        /// </summary>
+        [Test]
+        public void Execute_WhenCommandExitsWithFailure_ReturnsOutputAndExitCode()
+        {
+            ProcessStartInfo startInfo = BuildOutputProcessStartInfo(7);
+
+            CliDetectionCommandResult result = CliDetectionCommandRunner.Execute(
+                startInfo,
+                CancellationToken.None);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.StandardOutputLines, Is.EqualTo(new[] { "first", "second" }));
+            Assert.That(result.ExitCode, Is.EqualTo(7));
+        }
+
+        /// <summary>
+        /// Verifies that a missing executable is represented by an absent execution result.
+        /// </summary>
+        [Test]
+        public void Execute_WhenExecutableDoesNotExist_ReturnsNull()
+        {
+            ProcessStartInfo startInfo = CreateStartInfo(
+                "__uloop_missing_cli_detection_test_executable__",
+                string.Empty);
+
+            CliDetectionCommandResult result = CliDetectionCommandRunner.Execute(
+                startInfo,
+                CancellationToken.None);
+
+            Assert.That(result, Is.Null);
+        }
+
+        /// <summary>
+        /// Verifies that process cleanup tolerates the child exiting before Kill.
+        /// </summary>
+        [Test]
+        public void KillProcessIfRunning_WhenProcessAlreadyExited_DoesNotThrow()
+        {
+            ProcessStartInfo startInfo = BuildImmediateExitProcessStartInfo();
+
+            using Process process = Process.Start(startInfo);
+            process.WaitForExit();
+
+            Assert.DoesNotThrow(() => CliDetectionCommandRunner.KillProcessIfRunning(process));
+        }
+
+        private static ProcessStartInfo BuildOutputProcessStartInfo(int exitCode)
+        {
+            if (UnityEngine.Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                return CreateStartInfo(
+                    "cmd.exe",
+                    $"/d /s /c \"echo first&&echo second&&exit /b {exitCode}\"");
+            }
+
+            return CreateStartInfo(
+                "/bin/sh",
+                $"-c \"printf 'first\\nsecond\\n'; exit {exitCode}\"");
+        }
+
+        private static ProcessStartInfo BuildImmediateExitProcessStartInfo()
+        {
+            if (UnityEngine.Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                return CreateStartInfo("cmd.exe", "/c exit 0");
+            }
+
+            return CreateStartInfo("/bin/sh", "-c \"exit 0\"");
+        }
+
+        private static ProcessStartInfo CreateStartInfo(string fileName, string arguments)
+        {
+            return new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/CliDetectionCommandRunnerTests.cs.meta
+++ b/Assets/Tests/Editor/CliDetectionCommandRunnerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab8af7e561eb4ad7a910dc74357c9974
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/CliInstallationDetectorTests.cs
+++ b/Assets/Tests/Editor/CliInstallationDetectorTests.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Infrastructure;
@@ -304,42 +302,5 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(detection.ExecutablePath, Is.EqualTo("/Users/ExampleUser/.npm-global/bin/uloop"));
         }
 
-        [Test]
-        public void KillProcessIfRunning_WhenProcessAlreadyExited_DoesNotThrow()
-        {
-            // Verifies that process cleanup tolerates the race where the child exits before Kill.
-            ProcessStartInfo startInfo = BuildImmediateExitProcessStartInfo();
-
-            using Process process = Process.Start(startInfo);
-            process.WaitForExit();
-
-            Assert.DoesNotThrow(() => CliInstallationDetector.KillProcessIfRunning(process));
-        }
-
-        private static ProcessStartInfo BuildImmediateExitProcessStartInfo()
-        {
-            if (UnityEngine.Application.platform == UnityEngine.RuntimePlatform.WindowsEditor)
-            {
-                return new ProcessStartInfo
-                {
-                    FileName = "cmd.exe",
-                    Arguments = "/c exit 0",
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true
-                };
-            }
-
-            return new ProcessStartInfo
-            {
-                FileName = "/bin/sh",
-                Arguments = "-c \"exit 0\"",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true
-            };
-        }
     }
 }

--- a/Packages/src/Editor/Infrastructure/CLI/CliDetectionCommandRunner.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliDetectionCommandRunner.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Describes the observable result of a completed CLI detection command.
+    /// </summary>
+    internal sealed class CliDetectionCommandResult
+    {
+        internal CliDetectionCommandResult(IReadOnlyList<string> standardOutputLines, int exitCode)
+        {
+            UnityEngine.Debug.Assert(standardOutputLines != null, "standardOutputLines must not be null");
+
+            StandardOutputLines = standardOutputLines;
+            ExitCode = exitCode;
+        }
+
+        internal IReadOnlyList<string> StandardOutputLines { get; }
+        internal int ExitCode { get; }
+    }
+
+    /// <summary>
+    /// Runs CLI detection commands and captures their process-level results.
+    /// </summary>
+    internal static class CliDetectionCommandRunner
+    {
+        private const int PROCESS_TIMEOUT_MS = 5000;
+
+        internal static CliDetectionCommandResult Execute(ProcessStartInfo startInfo, CancellationToken ct)
+        {
+            UnityEngine.Debug.Assert(startInfo != null, "startInfo must not be null");
+            UnityEngine.Debug.Assert(startInfo.RedirectStandardOutput, "RedirectStandardOutput must be true");
+            UnityEngine.Debug.Assert(startInfo.RedirectStandardError, "RedirectStandardError must be true");
+
+            Process process = ProcessStartHelper.TryStart(startInfo);
+            if (process == null)
+            {
+                return null;
+            }
+
+            using (process)
+            {
+                List<string> standardOutputLines = new();
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if (e.Data != null)
+                    {
+                        standardOutputLines.Add(e.Data);
+                    }
+                };
+                process.ErrorDataReceived += (sender, e) => { };
+
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+
+                using CancellationTokenRegistration registration = ct.Register(() => KillProcessIfRunning(process));
+                bool exited = process.WaitForExit(PROCESS_TIMEOUT_MS);
+                if (!exited)
+                {
+                    KillProcessIfRunning(process);
+                    return null;
+                }
+
+                // Parameterless WaitForExit flushes async output buffers.
+                process.WaitForExit();
+                return new CliDetectionCommandResult(standardOutputLines.ToArray(), process.ExitCode);
+            }
+        }
+
+        internal static void KillProcessIfRunning(Process process)
+        {
+            UnityEngine.Debug.Assert(process != null, "process must not be null");
+
+            try
+            {
+                process.Kill();
+            }
+            catch (System.InvalidOperationException)
+            {
+                // Process exit can race with cancellation or timeout cleanup.
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/CLI/CliDetectionCommandRunner.cs.meta
+++ b/Packages/src/Editor/Infrastructure/CLI/CliDetectionCommandRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7650e6f84efa4e2493e0dacef228f908
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
+++ b/Packages/src/Editor/Infrastructure/CLI/CliInstallationDetector.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -33,7 +32,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// </summary>
     public sealed class CliInstallationDetector : ICliInstallationDetector
     {
-        private const int PROCESS_TIMEOUT_MS = 5000;
         private const string SHELL_PATH_START_MARKER = "__ULOOP_PATH_START__";
         private const string SHELL_PATH_END_MARKER = "__ULOOP_PATH_END__";
         private const string SHELL_VERSION_START_MARKER = "__ULOOP_VERSION_START__";
@@ -217,7 +215,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 pathSetupPlan,
                 Environment.GetEnvironmentVariable(CliConstants.POSIX_PATH_ENVIRONMENT_VARIABLE));
 
-            string output = ExecuteAndGetOutput(startInfo, ct);
+            CliDetectionCommandResult commandResult = CliDetectionCommandRunner.Execute(startInfo, ct);
+            string output = commandResult == null
+                ? null
+                : string.Join(Environment.NewLine, commandResult.StandardOutputLines).Trim();
             return ParseShellCliInstallationOutput(output);
         }
 
@@ -421,60 +422,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 true);
         }
 
-        private static string ExecuteAndGetOutput(ProcessStartInfo startInfo, CancellationToken ct)
-        {
-            UnityEngine.Debug.Assert(startInfo != null, "startInfo must not be null");
-            UnityEngine.Debug.Assert(startInfo.RedirectStandardOutput, "RedirectStandardOutput must be true");
-            UnityEngine.Debug.Assert(startInfo.RedirectStandardError, "RedirectStandardError must be true");
-
-            Process process = ProcessStartHelper.TryStart(startInfo);
-            if (process == null)
-            {
-                return null;
-            }
-
-            using (process)
-            {
-                StringBuilder outputBuilder = new();
-
-                process.OutputDataReceived += (sender, e) =>
-                {
-                    if (e.Data != null)
-                    {
-                        outputBuilder.AppendLine(e.Data);
-                    }
-                };
-                process.ErrorDataReceived += (sender, e) => { };
-
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
-
-                using CancellationTokenRegistration registration = ct.Register(() => KillProcessIfRunning(process));
-                bool exited = process.WaitForExit(PROCESS_TIMEOUT_MS);
-                if (!exited)
-                {
-                    KillProcessIfRunning(process);
-                    return null;
-                }
-
-                process.WaitForExit();
-                return outputBuilder.ToString().Trim();
-            }
-        }
-
-        internal static void KillProcessIfRunning(Process process)
-        {
-            UnityEngine.Debug.Assert(process != null, "process must not be null");
-
-            try
-            {
-                process.Kill();
-            }
-            catch (System.InvalidOperationException)
-            {
-            }
-        }
-
         private static bool IsSuccessfulShellStatus(string statusBlock)
         {
             string status = ExtractFirstNonEmptyLine(statusBlock);
@@ -540,54 +487,21 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 CreateNoWindow = true
             };
 
-            Process process = ProcessStartHelper.TryStart(startInfo);
-            if (process == null)
-            {
-                return null;
-            }
-
-            StringBuilder outputBuilder = new();
-
-            process.OutputDataReceived += (sender, e) =>
-            {
-                if (e.Data != null)
-                {
-                    outputBuilder.Append(e.Data);
-                }
-            };
-            process.ErrorDataReceived += (sender, e) => { };
-
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
-
-            using CancellationTokenRegistration registration = ct.Register(() =>
-            {
-                KillProcessIfRunning(process);
-            });
-
             try
             {
-                bool exited = process.WaitForExit(PROCESS_TIMEOUT_MS);
-
-                if (!exited)
+                CliDetectionCommandResult commandResult = CliDetectionCommandRunner.Execute(startInfo, ct);
+                if (commandResult == null)
                 {
-                    KillProcessIfRunning(process);
-                    process.Dispose();
                     return null;
                 }
 
-                // Parameterless WaitForExit flushes async output buffers
-                process.WaitForExit();
-
-                string output = outputBuilder.ToString().Trim();
-                bool failed = process.ExitCode != 0 || string.IsNullOrEmpty(output);
-                process.Dispose();
+                string output = string.Concat(commandResult.StandardOutputLines).Trim();
+                bool failed = commandResult.ExitCode != 0 || string.IsNullOrEmpty(output);
 
                 return failed ? null : output;
             }
             catch (Exception ex)
             {
-                process.Dispose();
                 if (!ct.IsCancellationRequested)
                 {
                     UnityEngine.Debug.LogWarning($"[UnityCliLoop] Failed to detect CLI version: {ex.Message}");


### PR DESCRIPTION
## Summary
- Keep CLI installation and PATH setup detection behavior unchanged while consolidating child-process execution in one owner.
- Separate detection policy from process startup, output capture, timeout cleanup, and exit reporting.

## User Impact
- No user-visible behavior changes are intended.
- Shell-visible CLI detection, package-owned fallback selection, version parsing, timeout behavior, and cancellation cleanup remain unchanged.

## Changes
- Add `CliDetectionCommandRunner` as the sole owner of detection process startup, ordered stdout capture, stderr draining, cancellation registration, timeout kill, output flush, disposal, and exit-code reporting.
- Return ordered stdout lines and the exit code so `CliInstallationDetector` retains its two existing policies: login-shell marker output preserves line boundaries and ignores the outer shell exit code, while direct version probes concatenate lines and reject non-zero or empty output.
- Move the already-exited process cleanup race test to the runner fixture and add characterization for multiline output, non-zero exit output, and missing executables.
- The direct version probe's existing exception recovery now surrounds runner setup as well as waiting. This is behaviorally equivalent because missing executables already return `null`, redirected output is constructed as a runner precondition, and the caller-owned cancellation token source remains live during execution; avoiding a mutable start/wait session keeps a single execution path.

## Verification
- Red: new runner contract produced 7 expected missing-type/member compile errors before implementation.
- Unity compile: 0 errors, 0 warnings.
- `CliDetectionCommandRunnerTests`: 4/4 passed.
- `CliInstallationDetectorTests`: 14/14 passed.
- `CliSetupApplicationServiceTests`: 4/4 passed.
- `CliPathSetupFlowTests`: 4/4 passed.
- `StaticFacadeStateGuardTests`: 20/20 passed.
- `git diff --check origin/v3-beta...HEAD`: passed.
- Process start, async stdout/stderr capture, wait/flush, timeout cleanup, and kill now occur in one production implementation.

## Compatibility
- Shell command text, output markers, parsing, cache behavior, platform/PATH policy, warning text, and public APIs are unchanged.
- No IPC request/response shape or protocol declaration changed; no protocol version bump is required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

