### PR TITLE
chore: remove unused Roslyn worker cleanup test hook

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -467,11 +467,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Shutdown();
         }
 
-        internal static Action<string> SwapWorkerDirectoryDeleterForTests(Action<string> deleter)
-        {
-            return ServiceValue.SwapWorkerDirectoryDeleterForTests(deleter);
-        }
-
         internal static Action<Process, string> SwapCompileRequestSenderForTests(Action<Process, string> sender)
         {
             return ServiceValue.SwapCompileRequestSenderForTests(sender);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
@@ -16,7 +16,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class SharedRoslynCompilerWorkerSession
     {
         private readonly object _syncRoot = new();
-        private Action<string> _deleteWorkerDirectory = path => Directory.Delete(path, true);
         private Func<ProcessStartInfo, Process> _startProcess = ProcessStartHelper.TryStart;
         private Action<Process, string> _sendCompileRequest = SendCompileRequestCore;
         private Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
@@ -228,15 +227,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        internal Action<string> SwapWorkerDirectoryDeleterForTests(Action<string> deleter)
-        {
-            Debug.Assert(deleter != null, "deleter must not be null");
-
-            Action<string> previous = _deleteWorkerDirectory;
-            _deleteWorkerDirectory = deleter;
-            return previous;
-        }
-
         internal Func<ProcessStartInfo, Process> SwapProcessStarterForTests(
             Func<ProcessStartInfo, Process> starter)
         {
@@ -291,7 +281,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             try
             {
-                _deleteWorkerDirectory(workerDirectoryPath);
+                Directory.Delete(workerDirectoryPath, true);
             }
             catch (IOException ex)
             {


### PR DESCRIPTION
## Summary
- Remove an unused Roslyn worker directory cleanup test hook after its only consumer was deleted for EditMode freeze prevention.
- Keep production temporary-directory cleanup and failure logging unchanged.

## User Impact
- No user-visible behavior changes are intended.
- Shared compiler worker shutdown still deletes its temporary directory directly and still logs `IOException` or `UnauthorizedAccessException` cleanup failures.

## Changes
- Remove the unused host facade and session swap method for the worker directory deleter.
- Remove the delegate field whose only purpose was supporting that test seam.
- Invoke the delegate's original production operation, `Directory.Delete(path, true)`, directly inside the existing cleanup try/catch.

## Verification
- Confirmed the removed identifiers had no rooted C#, test, tooling, JSON, Markdown, serialization, or reflection references.
- Confirmed history: the seam's only test was removed with the real-worker EditMode fixture in the freeze-prevention change.
- Unity compile: 0 errors, 0 warnings.
- `SharedRoslynCompilerWorkerHostTests`: 23/23 passed.
- `ExternalCompilerPathResolverTests`: 15/15 passed.
- `StaticFacadeStateGuardTests`: 20/20 passed.
- Public/type and member/local dead-code scanner passes completed; removed identifiers are absent.
- `git diff --check`: passed.

## Compatibility
- Directory existence checks, session state clearing, lock boundaries, exception filters, warning payloads/messages, and lifecycle callers are unchanged.
- No public API or IPC protocol declaration changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

