### PR TITLE
chore: remove unreachable mouse UI validation

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationValidator.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiSimulationValidator.cs
@@ -60,11 +60,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     $"Drag actions only support Left button (uGUI ignores non-left drags), got: {parameters.Button}");
             }
 
-            if (parameters.BypassRaycast && !SupportsBypassRaycast(parameters.Action))
-            {
-                return MouseUiSimulationResponseFactory.CreateFailure(parameters, "BypassRaycast is not supported for this action.");
-            }
-
             if (parameters.BypassRaycast &&
                 RequiresBypassTargetPath(parameters.Action) &&
                 string.IsNullOrWhiteSpace(parameters.TargetPath))
@@ -87,13 +82,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static bool RequiresIdlePointer(MouseAction action)
         {
             return action == MouseAction.Click || action == MouseAction.Drag || action == MouseAction.LongPress;
-        }
-
-        private static bool SupportsBypassRaycast(MouseAction action)
-        {
-            return action == MouseAction.Click
-                || action == MouseAction.LongPress
-                || IsDragAction(action);
         }
 
         private static bool RequiresBypassTargetPath(MouseAction action)


### PR DESCRIPTION
## Summary
- Remove a mouse UI validation branch that cannot be reached by any supported action.
- Keep validation responses for every representable request unchanged.

## User Impact
- No user-visible behavior changes are intended.
- Click, long press, one-shot drag, and split drag bypass behavior remains unchanged; unknown actions are still rejected before request-option validation.

## Changes
- Remove the unsupported-bypass failure branch from `MouseUiSimulationValidator`.
- Remove its now-unreferenced `SupportsBypassRaycast` predicate.
- Preserve target-path requirements, drag-button validation, drag-speed validation, drop-target validation, and their evaluation order.

## Verification
- Confirmed `MouseAction` contains exactly Click, LongPress, Drag, DragStart, DragMove, and DragEnd, all of which made the removed predicate true.
- Confirmed schema conversion maps those six values and rejects unknown enum values before validator entry.
- Confirmed the removed predicate and message have zero remaining references.
- Unity compile: 0 errors, 0 warnings.
- Focused Mouse UI EditMode fixtures: 30/30 passed.
- Related preflight, assembly, source guard, and registry fixtures: 152/152 passed.
- `SimulateMouseUiTests` PlayMode suite: 32/32 passed before and after deletion.
- `git diff --check`: passed.

## Compatibility
- Remaining validation statements and wire-visible messages are unchanged.
- No schema, public API, request/response shape, or protocol declaration changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

