### PR TITLE
chore: simplify mouse UI target resolution results

### DIFF
--- a/Assets/Tests/Editor/MouseUiPointerTargetResolverTests.cs
+++ b/Assets/Tests/Editor/MouseUiPointerTargetResolverTests.cs
@@ -53,22 +53,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Verifies an exact unique hierarchy path resolves to its active GameObject.
         /// </summary>
         [Test]
-        public void TryResolveGameObjectPath_WithUniquePath_ReturnsTarget()
+        public void ResolveGameObjectPath_WithUniquePath_ReturnsTarget()
         {
             GameObject root = CreateGameObject("MouseUiTargetResolverTests_UniqueRoot");
             GameObject expectedTarget = CreateGameObject("Target", root.transform);
             string targetPath = GameObjectPathUtility.GetFullPath(expectedTarget);
             Vector2 inputPosition = new(10f, 20f);
 
-            bool resolved = MouseUiPointerTargetResolver.TryResolveGameObjectPath(
-                targetPath,
-                "TargetPath",
-                MouseAction.Click,
-                inputPosition,
-                out GameObject? target,
-                out SimulateMouseUiResponse? failureResponse);
+            (GameObject? target, SimulateMouseUiResponse? failureResponse) =
+                MouseUiPointerTargetResolver.ResolveGameObjectPath(
+                    targetPath,
+                    "TargetPath",
+                    MouseAction.Click,
+                    inputPosition);
 
-            Assert.That(resolved, Is.True);
             Assert.That(target, Is.SameAs(expectedTarget));
             Assert.That(failureResponse, Is.Null);
         }
@@ -77,20 +75,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Verifies a missing hierarchy path returns the exact wire-visible failure response.
         /// </summary>
         [Test]
-        public void TryResolveGameObjectPath_WithMissingPath_ReturnsNotFoundFailure()
+        public void ResolveGameObjectPath_WithMissingPath_ReturnsNotFoundFailure()
         {
             string targetPath = "MouseUiTargetResolverTests_MissingRoot/Target";
             Vector2 inputPosition = new(10f, 20f);
 
-            bool resolved = MouseUiPointerTargetResolver.TryResolveGameObjectPath(
-                targetPath,
-                "TargetPath",
-                MouseAction.Click,
-                inputPosition,
-                out GameObject? target,
-                out SimulateMouseUiResponse? failureResponse);
+            (GameObject? target, SimulateMouseUiResponse? failureResponse) =
+                MouseUiPointerTargetResolver.ResolveGameObjectPath(
+                    targetPath,
+                    "TargetPath",
+                    MouseAction.Click,
+                    inputPosition);
 
-            Assert.That(resolved, Is.False);
             Assert.That(target, Is.Null);
             Assert.That(failureResponse, Is.Not.Null);
             Assert.That(failureResponse!.Success, Is.False);
@@ -104,7 +100,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Verifies duplicate hierarchy paths return the exact ambiguity count and no target.
         /// </summary>
         [Test]
-        public void TryResolveGameObjectPath_WithDuplicatePath_ReturnsAmbiguousFailure()
+        public void ResolveGameObjectPath_WithDuplicatePath_ReturnsAmbiguousFailure()
         {
             GameObject firstRoot = CreateGameObject("MouseUiTargetResolverTests_DuplicateRoot");
             GameObject firstTarget = CreateGameObject("Target", firstRoot.transform);
@@ -113,15 +109,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string targetPath = GameObjectPathUtility.GetFullPath(firstTarget);
             Vector2 inputPosition = new(10f, 20f);
 
-            bool resolved = MouseUiPointerTargetResolver.TryResolveGameObjectPath(
-                targetPath,
-                "TargetPath",
-                MouseAction.Click,
-                inputPosition,
-                out GameObject? target,
-                out SimulateMouseUiResponse? failureResponse);
+            (GameObject? target, SimulateMouseUiResponse? failureResponse) =
+                MouseUiPointerTargetResolver.ResolveGameObjectPath(
+                    targetPath,
+                    "TargetPath",
+                    MouseAction.Click,
+                    inputPosition);
 
-            Assert.That(resolved, Is.False);
             Assert.That(target, Is.Null);
             Assert.That(failureResponse, Is.Not.Null);
             Assert.That(
@@ -134,7 +128,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Verifies an empty drop path succeeds without resolving an explicit target.
         /// </summary>
         [Test]
-        public void TryResolveDropTargetPath_WithoutPath_ReturnsNoTarget()
+        public void ResolveDropTargetPath_WithoutPath_ReturnsNoTarget()
         {
             MouseUiSimulationCommand command = CreateCommand(new SimulateMouseUiSchema
             {
@@ -142,14 +136,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 DropTargetPath = " "
             });
 
-            bool resolved = MouseUiPointerTargetResolver.TryResolveDropTargetPath(
-                command,
-                MouseAction.Drag,
-                new Vector2(10f, 20f),
-                out GameObject? dropTarget,
-                out SimulateMouseUiResponse? failureResponse);
+            (GameObject? dropTarget, SimulateMouseUiResponse? failureResponse) =
+                MouseUiPointerTargetResolver.ResolveDropTargetPath(
+                    command,
+                    MouseAction.Drag,
+                    new Vector2(10f, 20f));
 
-            Assert.That(resolved, Is.True);
             Assert.That(dropTarget, Is.Null);
             Assert.That(failureResponse, Is.Null);
         }
@@ -158,7 +150,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Verifies an explicit drop target without a handler returns the exact failure response.
         /// </summary>
         [Test]
-        public void TryResolveDropTargetPath_WithoutDropHandler_ReturnsFailure()
+        public void ResolveDropTargetPath_WithoutDropHandler_ReturnsFailure()
         {
             GameObject root = CreateGameObject("MouseUiTargetResolverTests_DropRoot");
             GameObject target = CreateGameObject("DropTarget", root.transform);
@@ -170,14 +162,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             });
             Vector2 inputPosition = new(10f, 20f);
 
-            bool resolved = MouseUiPointerTargetResolver.TryResolveDropTargetPath(
-                command,
-                MouseAction.Drag,
-                inputPosition,
-                out GameObject? dropTarget,
-                out SimulateMouseUiResponse? failureResponse);
+            (GameObject? dropTarget, SimulateMouseUiResponse? failureResponse) =
+                MouseUiPointerTargetResolver.ResolveDropTargetPath(
+                    command,
+                    MouseAction.Drag,
+                    inputPosition);
 
-            Assert.That(resolved, Is.False);
             Assert.That(dropTarget, Is.Null);
             Assert.That(failureResponse, Is.Not.Null);
             Assert.That(
@@ -192,7 +182,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         /// Verifies an explicit drop target with a hierarchy handler returns its raw target.
         /// </summary>
         [Test]
-        public void TryResolveDropTargetPath_WithDropHandler_ReturnsRawTarget()
+        public void ResolveDropTargetPath_WithDropHandler_ReturnsRawTarget()
         {
             GameObject root = CreateGameObject("MouseUiTargetResolverTests_DropHandlerRoot");
             root.AddComponent<MouseUiPointerTargetResolverTestHandler>();
@@ -204,14 +194,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 DropTargetPath = targetPath
             });
 
-            bool resolved = MouseUiPointerTargetResolver.TryResolveDropTargetPath(
-                command,
-                MouseAction.Drag,
-                new Vector2(10f, 20f),
-                out GameObject? dropTarget,
-                out SimulateMouseUiResponse? failureResponse);
+            (GameObject? dropTarget, SimulateMouseUiResponse? failureResponse) =
+                MouseUiPointerTargetResolver.ResolveDropTargetPath(
+                    command,
+                    MouseAction.Drag,
+                    new Vector2(10f, 20f));
 
-            Assert.That(resolved, Is.True);
             Assert.That(dropTarget, Is.SameAs(expectedTarget));
             Assert.That(failureResponse, Is.Null);
         }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiDragTargetResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiDragTargetResolver.cs
@@ -29,17 +29,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (parameters.BypassRaycast)
             {
-                if (!MouseUiPointerTargetResolver.TryResolveGameObjectPath(
-                    parameters.TargetPath,
-                    "TargetPath",
-                    action,
-                    inputPosition,
-                    out rawTarget,
-                    out SimulateMouseUiResponse? failureResponse))
+                (GameObject? Target, SimulateMouseUiResponse? FailureResponse) resolution =
+                    MouseUiPointerTargetResolver.ResolveGameObjectPath(
+                        parameters.TargetPath,
+                        "TargetPath",
+                        action,
+                        inputPosition);
+                if (resolution.FailureResponse != null)
                 {
-                    return (startRaycast, null, failureResponse);
+                    return (startRaycast, null, resolution.FailureResponse);
                 }
 
+                rawTarget = resolution.Target;
                 startRaycast = MouseUiPointerTargetResolver.CreateDirectRaycastResult(rawTarget!);
             }
             else if (hit != null)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiIncrementalDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiIncrementalDragExecutor.cs
@@ -219,16 +219,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             PointerEventData pointerData = MouseDragState.PointerData!;
             GameObject target = MouseDragState.Target!;
             string targetName = target.name;
-            GameObject? explicitDropTarget = null;
-
-            if (!MouseUiPointerTargetResolver.TryResolveDropTargetPath(
-                parameters,
-                MouseAction.DragEnd,
-                inputEnd,
-                out explicitDropTarget,
-                out SimulateMouseUiResponse? dropFailureResponse))
+            (GameObject? explicitDropTarget, SimulateMouseUiResponse? dropFailureResponse) =
+                MouseUiPointerTargetResolver.ResolveDropTargetPath(
+                    parameters,
+                    MouseAction.DragEnd,
+                    inputEnd);
+            if (dropFailureResponse != null)
             {
-                return dropFailureResponse!;
+                return dropFailureResponse;
             }
 
             SimulateMouseUiOverlayState.Update(

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiOneShotDragExecutor.cs
@@ -37,15 +37,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return targetFailureResponse;
             }
 
-            GameObject? explicitDropTarget = null;
-            if (!MouseUiPointerTargetResolver.TryResolveDropTargetPath(
-                parameters,
-                MouseAction.Drag,
-                inputEnd,
-                out explicitDropTarget,
-                out SimulateMouseUiResponse? dropFailureResponse))
+            (GameObject? explicitDropTarget, SimulateMouseUiResponse? dropFailureResponse) =
+                MouseUiPointerTargetResolver.ResolveDropTargetPath(
+                    parameters,
+                    MouseAction.Drag,
+                    inputEnd);
+            if (dropFailureResponse != null)
             {
-                return dropFailureResponse!;
+                return dropFailureResponse;
             }
 
             if (target == null)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPointerTargetResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPointerTargetResolver.cs
@@ -66,13 +66,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             PointerEventData pointerData,
             MouseAction action)
         {
-            if (!TryResolveGameObjectPath(
-                parameters.TargetPath,
-                "TargetPath",
-                action,
-                inputPos,
-                out GameObject? rawTarget,
-                out SimulateMouseUiResponse? failureResponse))
+            (GameObject? rawTarget, SimulateMouseUiResponse? failureResponse) =
+                ResolveGameObjectPath(
+                    parameters.TargetPath,
+                    "TargetPath",
+                    action,
+                    inputPos);
+            if (failureResponse != null)
             {
                 return ResolvedPointerTargets.Failure(failureResponse);
             }
@@ -112,27 +112,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ResolvedPointerTargets.Success(rawTarget, pressTarget, clickTarget, target);
         }
 
-        internal static bool TryResolveGameObjectPath(
+        internal static (GameObject? Target, SimulateMouseUiResponse? FailureResponse) ResolveGameObjectPath(
             string targetPath,
             string parameterName,
             MouseAction action,
-            Vector2 inputPosition,
-            out GameObject? target,
-            out SimulateMouseUiResponse? failureResponse)
+            Vector2 inputPosition)
         {
             TargetPathLookupResult lookupResult = FindActiveGameObjectByPath(targetPath);
-            target = lookupResult.Target;
-            if (target != null)
+            if (lookupResult.Target != null)
             {
-                failureResponse = null;
-                return true;
+                return (lookupResult.Target, null);
             }
 
             string message = lookupResult.MatchCount == 0
                 ? $"{parameterName} '{targetPath}' was not found."
                 : $"{parameterName} '{targetPath}' matched {lookupResult.MatchCount} active GameObjects. Use a unique hierarchy path.";
 
-            failureResponse = new SimulateMouseUiResponse
+            SimulateMouseUiResponse failureResponse = new()
             {
                 Success = false,
                 Message = message,
@@ -140,33 +136,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 PositionX = inputPosition.x,
                 PositionY = inputPosition.y
             };
-            return false;
+            return (null, failureResponse);
         }
 
-        internal static bool TryResolveDropTargetPath(
+        internal static (GameObject? Target, SimulateMouseUiResponse? FailureResponse) ResolveDropTargetPath(
             MouseUiSimulationCommand parameters,
             MouseAction action,
-            Vector2 inputPosition,
-            out GameObject? dropTarget,
-            out SimulateMouseUiResponse? failureResponse)
+            Vector2 inputPosition)
         {
-            dropTarget = null;
-            failureResponse = null;
-
             if (string.IsNullOrWhiteSpace(parameters.DropTargetPath))
             {
-                return true;
+                return (null, null);
             }
 
-            if (!TryResolveGameObjectPath(
-                parameters.DropTargetPath,
-                "DropTargetPath",
-                action,
-                inputPosition,
-                out GameObject? rawDropTarget,
-                out failureResponse))
+            (GameObject? rawDropTarget, SimulateMouseUiResponse? failureResponse) =
+                ResolveGameObjectPath(
+                    parameters.DropTargetPath,
+                    "DropTargetPath",
+                    action,
+                    inputPosition);
+            if (failureResponse != null)
             {
-                return false;
+                return (null, failureResponse);
             }
 
             GameObject? dropHandler = ExecuteEvents.GetEventHandler<IDropHandler>(rawDropTarget!);
@@ -180,11 +171,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     PositionX = inputPosition.x,
                     PositionY = inputPosition.y
                 };
-                return false;
+                return (null, failureResponse);
             }
 
-            dropTarget = rawDropTarget;
-            return true;
+            return (rawDropTarget, null);
         }
 
         private static TargetPathLookupResult FindActiveGameObjectByPath(string targetPath)


### PR DESCRIPTION
## Summary
- Simplify mouse UI hierarchy target resolution by returning named results instead of boolean and `out` parameter chains.
- Preserve every target, optional no-target, and failure response outcome.

## User Impact
- No user-visible behavior changes are intended.
- Bypass target lookup, explicit drop targets, duplicate-path diagnostics, missing-path diagnostics, and no-drop-handler failures remain unchanged.

## Changes
- Replace `TryResolveGameObjectPath` with `ResolveGameObjectPath`, returning `(Target, FailureResponse)`.
- Replace `TryResolveDropTargetPath` with `ResolveDropTargetPath` using the same tuple contract; `(null, null)` continues to represent a successful optional no-path result.
- Adapt bypass press, drag target, one-shot drag, and DragEnd callers to check `FailureResponse != null`.
- Update the six existing characterization tests to the new API while keeping all target and exact response assertions.

## Verification
- Red: the six converted tests produced six expected missing-method compile errors before production adaptation.
- Confirmed the old boolean was redundant on every return path: success iff `FailureResponse` is null.
- Confirmed old method names and `out`/`ref` usage are zero across both resolver APIs, all callers, and their tests.
- Unity compile: 0 errors, 0 warnings.
- Focused Mouse UI EditMode fixtures: 30/30 passed.
- Related preflight, assembly, source guard, and registry fixtures: 152/152 passed.
- `SimulateMouseUiTests` PlayMode suite: 32/32 passed before and after the refactor.
- `git diff --check`: passed.

## Compatibility
- Lookup matching, duplicate counts, exact failure messages/fields, drop-handler lookup, failure ordering, raw-target semantics, schema, and wire responses are unchanged.
- No public API or protocol declaration changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

