### PR TITLE
chore: simplify mouse input simulation support

### DIFF
--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -62,6 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/Infrastructure/SkillSetup/ToolSkillSynchronizer.cs",
             "Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs",
+            "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMainThreadCleanup.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs"
         };
 

--- a/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
@@ -1,0 +1,110 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System;
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
+{
+    /// <summary>
+    /// Characterizes wire-visible mouse input response construction before factory extraction.
+    /// </summary>
+    [TestFixture]
+    public sealed class MouseInputSimulationResponseFactoryTests
+    {
+        private readonly DateTime _nowUtc = new(2026, 7, 9, 0, 0, 0, DateTimeKind.Utc);
+
+        [SetUp]
+        public void SetUp()
+        {
+            UloopPausePointRegistry.ConfigureForTests(new FakePauseController(), () => _nowUtc);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UloopPausePointRegistry.ResetForTests();
+        }
+
+        /// <summary>
+        /// Verifies interrupted button responses project every Pause Point hit and preserve button coordinates.
+        /// </summary>
+        [Test]
+        public void InterruptedButtonResult_WithMultiplePausePointHits_MapsPauseEvidenceAndButtonPosition()
+        {
+            UloopPausePointRegistry.Enable("first-hit", 30);
+            UloopPausePointRegistry.Enable("latest-hit", 30);
+            UloopPausePoint.Pause("first-hit");
+            UloopPausePoint.Pause("latest-hit");
+            Vector2 inputPosition = new(10.25f, 20.75f);
+
+            SimulateMouseInputResponse response = MouseInputSimulationResponseFactory.InterruptedButtonResult(
+                UnityCliLoopMouseInputAction.Click,
+                "Left",
+                inputPosition);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "Mouse input stopped because Unity paused during Pause Point inspection. Unity CLI Loop released its held input bookkeeping."));
+            Assert.That(response.Action, Is.EqualTo(UnityCliLoopMouseInputAction.Click.ToString()));
+            Assert.That(response.Button, Is.EqualTo("Left"));
+            Assert.That(response.PositionX, Is.EqualTo(inputPosition.x));
+            Assert.That(response.PositionY, Is.EqualTo(inputPosition.y));
+            Assert.That(response.InterruptedByPausePoint, Is.True);
+            Assert.That(response.PausePointId, Is.EqualTo("latest-hit"));
+            Assert.That(response.PausePointHitCount, Is.EqualTo(1));
+            Assert.That(response.PausePointHits, Has.Count.EqualTo(2));
+            Assert.That(response.PausePointHits![0].Id, Is.EqualTo("first-hit"));
+            Assert.That(response.PausePointHits[1].Id, Is.EqualTo("latest-hit"));
+        }
+
+        /// <summary>
+        /// Verifies timed-out button responses preserve the action, button, coordinates, and timeout message.
+        /// </summary>
+        [Test]
+        public void TimedOutButtonResult_WithButtonAndPosition_MapsFailureResponse()
+        {
+            Vector2 inputPosition = new(30.5f, 40.25f);
+
+            SimulateMouseInputResponse response = MouseInputSimulationResponseFactory.TimedOutButtonResult(
+                UnityCliLoopMouseInputAction.LongPress,
+                "Right",
+                inputPosition);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "Mouse input timed out while waiting for Unity Editor update. Cleanup is queued for the next Editor tick."));
+            Assert.That(response.Action, Is.EqualTo(UnityCliLoopMouseInputAction.LongPress.ToString()));
+            Assert.That(response.Button, Is.EqualTo("Right"));
+            Assert.That(response.PositionX, Is.EqualTo(inputPosition.x));
+            Assert.That(response.PositionY, Is.EqualTo(inputPosition.y));
+            Assert.That(response.InterruptedByPausePoint, Is.False);
+            Assert.That(response.PausePointId, Is.Null);
+            Assert.That(response.PausePointHitCount, Is.Null);
+            Assert.That(response.PausePointHits, Is.Null);
+        }
+
+        /// <summary>
+        /// Test double that records Pause Point state without pausing the Unity Editor.
+        /// </summary>
+        private sealed class FakePauseController : IUloopPausePointPauseController
+        {
+            public bool IsPlaying => true;
+            public bool IsPaused { get; private set; }
+
+            public void Pause()
+            {
+                IsPaused = true;
+            }
+        }
+    }
+}
+#endif

--- a/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs.meta
+++ b/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ab44557d0cc64ea1877f70eb1e036c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMainThreadCleanup.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMainThreadCleanup.cs
@@ -1,0 +1,141 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+using RuntimeMouseButton = io.github.hatayama.UnityCliLoop.Runtime.MouseButton;
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Restores mouse device and overlay state on the Unity main thread after simulation ends.
+    /// </summary>
+    internal static class MouseInputMainThreadCleanup
+    {
+        internal static async Task<InputSimulationWaitOutcome> ReleaseButtonIfPossible(
+            Mouse mouse,
+            RuntimeMouseButton button,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            if (!CanInjectMouseState(mouse))
+            {
+                return InputSimulationWaitOutcome.Completed;
+            }
+
+            if (EditorApplication.isPaused)
+            {
+                ReleaseButtonImmediately(mouse, button);
+                return InputSimulationWaitOutcome.Completed;
+            }
+
+            InputSimulationWaitOutcome releaseOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                () => MouseInputState.SetButtonState(mouse, button, false),
+                ct).ConfigureAwait(false);
+            if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                ScheduleReleaseButtonImmediately(mouse, button);
+            }
+
+            return releaseOutcome;
+        }
+
+        private static void ScheduleReleaseButtonImmediately(Mouse mouse, RuntimeMouseButton button)
+        {
+            ReleaseButtonImmediatelyOnMainThreadAsync(mouse, button, CancellationToken.None).Forget();
+        }
+
+        private static async Task ReleaseButtonImmediatelyOnMainThreadAsync(
+            Mouse mouse,
+            RuntimeMouseButton button,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            ReleaseButtonImmediately(mouse, button);
+        }
+
+        private static void ReleaseButtonImmediately(Mouse mouse, RuntimeMouseButton button)
+        {
+            Debug.Assert(CanInjectMouseState(mouse), "mouse button can only be released while PlayMode has a mouse");
+            if (!CanInjectMouseState(mouse))
+            {
+                return;
+            }
+
+            MouseInputState.SetButtonState(mouse, button, false);
+            InputSystemUpdateHelper.RunExplicitUpdate(InputUpdateTypeResolver.Resolve());
+        }
+
+        internal static void ResetDeltaIfPossible(Mouse mouse)
+        {
+            if (!CanInjectMouseState(mouse))
+            {
+                return;
+            }
+
+            MouseInputState.InjectDelta(mouse, Vector2.zero);
+            if (EditorApplication.isPaused)
+            {
+                InputSystemUpdateHelper.RunExplicitUpdate(InputUpdateTypeResolver.Resolve());
+            }
+        }
+
+        internal static void ScheduleTimedOutButtonCleanup(
+            Mouse mouse,
+            RuntimeMouseButton button,
+            bool pressWasApplied)
+        {
+            CleanupTimedOutButtonAsync(mouse, button, pressWasApplied, CancellationToken.None).Forget();
+        }
+
+        private static async Task CleanupTimedOutButtonAsync(
+            Mouse mouse,
+            RuntimeMouseButton button,
+            bool pressWasApplied,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            if (pressWasApplied)
+            {
+                await ReleaseButtonIfPossible(mouse, button, ct).ConfigureAwait(false);
+            }
+
+            MouseInputState.SetButtonUp(button);
+            SimulateMouseInputOverlayState.SetButtonHeld(button, false);
+        }
+
+        internal static void ScheduleTimedOutMouseOverlayCleanup()
+        {
+            CleanupTimedOutMouseOverlayAsync(CancellationToken.None).Forget();
+        }
+
+        private static async Task CleanupTimedOutMouseOverlayAsync(CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            SimulateMouseInputOverlayState.Clear();
+        }
+
+        internal static void ScheduleTimedOutDeltaCleanup(Mouse mouse)
+        {
+            CleanupTimedOutDeltaAsync(mouse, CancellationToken.None).Forget();
+        }
+
+        private static async Task CleanupTimedOutDeltaAsync(Mouse mouse, CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            ResetDeltaIfPossible(mouse);
+            SimulateMouseInputOverlayState.Clear();
+        }
+
+        private static bool CanInjectMouseState(Mouse mouse)
+        {
+            return EditorApplication.isPlaying && mouse != null;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMainThreadCleanup.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMainThreadCleanup.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7ab44557d0cc64ea1877f70eb1e036c1
+guid: eea8ef017defc4c7dbc892f72ddc6d8d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
@@ -1,0 +1,116 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Collections.Generic;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Creates wire-visible responses for mouse input simulation outcomes.
+    /// </summary>
+    internal static class MouseInputSimulationResponseFactory
+    {
+        internal static SimulateMouseInputResponse InterruptedButtonResult(
+            UnityCliLoopMouseInputAction action,
+            string buttonName,
+            Vector2 inputPos)
+        {
+            SimulateMouseInputResponse result = InterruptedActionResult(action);
+            result.Button = buttonName;
+            result.PositionX = inputPos.x;
+            result.PositionY = inputPos.y;
+            return result;
+        }
+
+        internal static SimulateMouseInputResponse InterruptedActionResult(
+            UnityCliLoopMouseInputAction action)
+        {
+            SimulateMouseInputResponse result = new()
+            {
+                Success = true,
+                Message = "Mouse input stopped because Unity paused during Pause Point inspection. Unity CLI Loop released its held input bookkeeping.",
+                Action = action.ToString(),
+                InterruptedByPausePoint = true
+            };
+            AttachPausePointHit(result);
+            return result;
+        }
+
+        internal static SimulateMouseInputResponse TimedOutButtonResult(
+            UnityCliLoopMouseInputAction action,
+            string buttonName,
+            Vector2 inputPos)
+        {
+            SimulateMouseInputResponse result = TimedOutActionResult(action);
+            result.Button = buttonName;
+            result.PositionX = inputPos.x;
+            result.PositionY = inputPos.y;
+            return result;
+        }
+
+        internal static SimulateMouseInputResponse TimedOutActionResult(
+            UnityCliLoopMouseInputAction action)
+        {
+            return new SimulateMouseInputResponse
+            {
+                Success = false,
+                Message = "Mouse input timed out while waiting for Unity Editor update. Cleanup is queued for the next Editor tick.",
+                Action = action.ToString()
+            };
+        }
+
+        private static void AttachPausePointHit(SimulateMouseInputResponse result)
+        {
+            if (result == null)
+            {
+                Debug.Assert(false, "result must not be null");
+                return;
+            }
+
+            UloopPausePointSnapshot? snapshot = UloopPausePointRegistry.GetLatestHitSnapshot();
+            if (snapshot == null)
+            {
+                return;
+            }
+
+            if (!snapshot.IsHit)
+            {
+                return;
+            }
+
+            string? snapshotId = snapshot.Id;
+            if (string.IsNullOrEmpty(snapshotId))
+            {
+                return;
+            }
+
+            result.PausePointId = snapshotId;
+            result.PausePointHitCount = snapshot.HitCount;
+            result.PausePointHits = CollectPausePointHits();
+        }
+
+        // One input can hit several markers in the same frame; the representative
+        // PausePointId alone forced agents into extra status calls to find the others.
+        private static List<UnityCliLoopPausePointHit> CollectPausePointHits()
+        {
+            List<UnityCliLoopPausePointHit> hits = new();
+            foreach (UloopPausePointSnapshot snapshot in UloopPausePointRegistry.GetHitSnapshots())
+            {
+                if (!snapshot.IsHit || string.IsNullOrEmpty(snapshot.Id))
+                {
+                    continue;
+                }
+                hits.Add(new UnityCliLoopPausePointHit
+                {
+                    Id = snapshot.Id,
+                    HitCount = snapshot.HitCount
+                });
+            }
+            return hits;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 455a57fc2aef44c599c2e546689be3d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -181,7 +180,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 () => MouseInputState.SetPositionState(mouse, screenPos), ct).ConfigureAwait(false);
             if (positionOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                return TimedOutButtonResult(UnityCliLoopMouseInputAction.Click, buttonName, inputPos);
+                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
+                    UnityCliLoopMouseInputAction.Click,
+                    buttonName,
+                    inputPos);
             }
 
             // Press button
@@ -245,7 +247,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (waitOutcome == InputSimulationWaitOutcome.Paused)
             {
-                return InterruptedButtonResult(
+                return MouseInputSimulationResponseFactory.InterruptedButtonResult(
                     UnityCliLoopMouseInputAction.Click,
                     buttonName,
                     inputPos);
@@ -253,7 +255,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                return TimedOutButtonResult(UnityCliLoopMouseInputAction.Click, buttonName, inputPos);
+                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
+                    UnityCliLoopMouseInputAction.Click,
+                    buttonName,
+                    inputPos);
             }
 
             string durationText = request.Duration > 0f ? $" for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s" : "";
@@ -291,7 +296,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 () => MouseInputState.SetPositionState(mouse, screenPos), ct).ConfigureAwait(false);
             if (positionOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                return TimedOutButtonResult(UnityCliLoopMouseInputAction.LongPress, buttonName, inputPos);
+                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
+                    UnityCliLoopMouseInputAction.LongPress,
+                    buttonName,
+                    inputPos);
             }
 
             // Press button
@@ -358,7 +366,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (waitOutcome == InputSimulationWaitOutcome.Paused)
             {
-                return InterruptedButtonResult(
+                return MouseInputSimulationResponseFactory.InterruptedButtonResult(
                     UnityCliLoopMouseInputAction.LongPress,
                     buttonName,
                     inputPos);
@@ -366,7 +374,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                return TimedOutButtonResult(UnityCliLoopMouseInputAction.LongPress, buttonName, inputPos);
+                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
+                    UnityCliLoopMouseInputAction.LongPress,
+                    buttonName,
+                    inputPos);
             }
 
             return new SimulateMouseInputResponse
@@ -391,7 +402,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 ScheduleTimedOutMouseOverlayCleanup();
-                return TimedOutActionResult(UnityCliLoopMouseInputAction.MoveDelta);
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.MoveDelta);
             }
 
             InputSimulationWaitOutcome waitOutcome = await InputSystemUpdateHelper.WaitForObservationFrames(ct)
@@ -400,13 +412,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
                 SimulateMouseInputOverlayState.Clear();
-                return InterruptedActionResult(UnityCliLoopMouseInputAction.MoveDelta);
+                return MouseInputSimulationResponseFactory.InterruptedActionResult(
+                    UnityCliLoopMouseInputAction.MoveDelta);
             }
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 ScheduleTimedOutMouseOverlayCleanup();
-                return TimedOutActionResult(UnityCliLoopMouseInputAction.MoveDelta);
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.MoveDelta);
             }
 
             return new SimulateMouseInputResponse
@@ -430,7 +444,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 ScheduleTimedOutMouseOverlayCleanup();
-                return TimedOutActionResult(UnityCliLoopMouseInputAction.Scroll);
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.Scroll);
             }
 
             InputSimulationWaitOutcome waitOutcome = await InputSystemUpdateHelper.WaitForObservationFrames(ct)
@@ -439,13 +454,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
                 SimulateMouseInputOverlayState.Clear();
-                return InterruptedActionResult(UnityCliLoopMouseInputAction.Scroll);
+                return MouseInputSimulationResponseFactory.InterruptedActionResult(
+                    UnityCliLoopMouseInputAction.Scroll);
             }
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 ScheduleTimedOutMouseOverlayCleanup();
-                return TimedOutActionResult(UnityCliLoopMouseInputAction.Scroll);
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.Scroll);
             }
 
             return new SimulateMouseInputResponse
@@ -493,7 +510,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
                     ScheduleTimedOutDeltaCleanup(mouse);
-                    return TimedOutActionResult(UnityCliLoopMouseInputAction.SmoothDelta);
+                    return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                        UnityCliLoopMouseInputAction.SmoothDelta);
                 }
 
                 previousT = t;
@@ -504,13 +522,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
                     ResetDeltaIfPossible(mouse);
                     SimulateMouseInputOverlayState.Clear();
-                    return InterruptedActionResult(UnityCliLoopMouseInputAction.SmoothDelta);
+                    return MouseInputSimulationResponseFactory.InterruptedActionResult(
+                        UnityCliLoopMouseInputAction.SmoothDelta);
                 }
 
                 if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
                     ScheduleTimedOutDeltaCleanup(mouse);
-                    return TimedOutActionResult(UnityCliLoopMouseInputAction.SmoothDelta);
+                    return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                        UnityCliLoopMouseInputAction.SmoothDelta);
                 }
 
                 if (t >= 1f)
@@ -525,7 +545,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (resetOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 ScheduleTimedOutDeltaCleanup(mouse);
-                return TimedOutActionResult(UnityCliLoopMouseInputAction.SmoothDelta);
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.SmoothDelta);
             }
 
             return new SimulateMouseInputResponse
@@ -534,105 +555,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Message = $"Smooth delta ({request.DeltaX:F1}, {request.DeltaY:F1}) over {duration:F2}s",
                 Action = UnityCliLoopMouseInputAction.SmoothDelta.ToString()
             };
-        }
-
-        private static SimulateMouseInputResponse InterruptedButtonResult(
-            UnityCliLoopMouseInputAction action,
-            string buttonName,
-            Vector2 inputPos)
-        {
-            SimulateMouseInputResponse result = InterruptedActionResult(action);
-            result.Button = buttonName;
-            result.PositionX = inputPos.x;
-            result.PositionY = inputPos.y;
-            return result;
-        }
-
-        private static SimulateMouseInputResponse InterruptedActionResult(
-            UnityCliLoopMouseInputAction action)
-        {
-            SimulateMouseInputResponse result = new()
-            {
-                Success = true,
-                Message = "Mouse input stopped because Unity paused during Pause Point inspection. Unity CLI Loop released its held input bookkeeping.",
-                Action = action.ToString(),
-                InterruptedByPausePoint = true
-            };
-            AttachPausePointHit(result);
-            return result;
-        }
-
-        private static SimulateMouseInputResponse TimedOutButtonResult(
-            UnityCliLoopMouseInputAction action,
-            string buttonName,
-            Vector2 inputPos)
-        {
-            SimulateMouseInputResponse result = TimedOutActionResult(action);
-            result.Button = buttonName;
-            result.PositionX = inputPos.x;
-            result.PositionY = inputPos.y;
-            return result;
-        }
-
-        private static SimulateMouseInputResponse TimedOutActionResult(
-            UnityCliLoopMouseInputAction action)
-        {
-            return new SimulateMouseInputResponse
-            {
-                Success = false,
-                Message = "Mouse input timed out while waiting for Unity Editor update. Cleanup is queued for the next Editor tick.",
-                Action = action.ToString()
-            };
-        }
-
-        private static void AttachPausePointHit(SimulateMouseInputResponse result)
-        {
-            if (result == null)
-            {
-                Debug.Assert(false, "result must not be null");
-                return;
-            }
-
-            UloopPausePointSnapshot? snapshot = UloopPausePointRegistry.GetLatestHitSnapshot();
-            if (snapshot == null)
-            {
-                return;
-            }
-
-            if (!snapshot.IsHit)
-            {
-                return;
-            }
-
-            string? snapshotId = snapshot.Id;
-            if (string.IsNullOrEmpty(snapshotId))
-            {
-                return;
-            }
-
-            result.PausePointId = snapshotId;
-            result.PausePointHitCount = snapshot.HitCount;
-            result.PausePointHits = CollectPausePointHits();
-        }
-
-        // One input can hit several markers in the same frame; the representative
-        // PausePointId alone forced agents into extra status calls to find the others.
-        private static List<UnityCliLoopPausePointHit> CollectPausePointHits()
-        {
-            List<UnityCliLoopPausePointHit> hits = new();
-            foreach (UloopPausePointSnapshot snapshot in UloopPausePointRegistry.GetHitSnapshots())
-            {
-                if (!snapshot.IsHit || string.IsNullOrEmpty(snapshot.Id))
-                {
-                    continue;
-                }
-                hits.Add(new UnityCliLoopPausePointHit
-                {
-                    Id = snapshot.Id,
-                    HitCount = snapshot.HitCount
-                });
-            }
-            return hits;
         }
 
         private static async Task<InputSimulationWaitOutcome> ReleaseButtonIfPossible(

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using UnityEditor;
 using UnityEngine;
 #if ULOOP_HAS_INPUT_SYSTEM
 using UnityEngine.InputSystem;
@@ -209,16 +208,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
-                    ScheduleTimedOutButtonCleanup(mouse, button, pressWasApplied);
+                    MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, pressWasApplied);
                 }
                 else if (pressWasApplied)
                 {
                     InputSimulationWaitOutcome releaseOutcome =
-                        await ReleaseButtonIfPossible(mouse, button, CancellationToken.None).ConfigureAwait(false);
+                        await MouseInputMainThreadCleanup.ReleaseButtonIfPossible(
+                            mouse,
+                            button,
+                            CancellationToken.None).ConfigureAwait(false);
                     if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
                     {
                         waitOutcome = InputSimulationWaitOutcome.TimedOut;
-                        ScheduleTimedOutButtonCleanup(mouse, button, false);
+                        MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, false);
                     }
                     else
                     {
@@ -328,16 +330,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
-                    ScheduleTimedOutButtonCleanup(mouse, button, pressWasApplied);
+                    MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, pressWasApplied);
                 }
                 else if (pressWasApplied)
                 {
                     InputSimulationWaitOutcome releaseOutcome =
-                        await ReleaseButtonIfPossible(mouse, button, CancellationToken.None).ConfigureAwait(false);
+                        await MouseInputMainThreadCleanup.ReleaseButtonIfPossible(
+                            mouse,
+                            button,
+                            CancellationToken.None).ConfigureAwait(false);
                     if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
                     {
                         waitOutcome = InputSimulationWaitOutcome.TimedOut;
-                        ScheduleTimedOutButtonCleanup(mouse, button, false);
+                        MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, false);
                     }
                     else
                     {
@@ -401,7 +406,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 () => MouseInputState.SetDeltaState(mouse, delta), ct).ConfigureAwait(false);
             if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                ScheduleTimedOutMouseOverlayCleanup();
+                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
                 return MouseInputSimulationResponseFactory.TimedOutActionResult(
                     UnityCliLoopMouseInputAction.MoveDelta);
             }
@@ -418,7 +423,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                ScheduleTimedOutMouseOverlayCleanup();
+                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
                 return MouseInputSimulationResponseFactory.TimedOutActionResult(
                     UnityCliLoopMouseInputAction.MoveDelta);
             }
@@ -443,7 +448,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 () => MouseInputState.SetScrollState(mouse, scroll), ct).ConfigureAwait(false);
             if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                ScheduleTimedOutMouseOverlayCleanup();
+                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
                 return MouseInputSimulationResponseFactory.TimedOutActionResult(
                     UnityCliLoopMouseInputAction.Scroll);
             }
@@ -460,7 +465,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                ScheduleTimedOutMouseOverlayCleanup();
+                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
                 return MouseInputSimulationResponseFactory.TimedOutActionResult(
                     UnityCliLoopMouseInputAction.Scroll);
             }
@@ -509,7 +514,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     () => MouseInputState.InjectDelta(mouse, frameDelta), ct).ConfigureAwait(false);
                 if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
-                    ScheduleTimedOutDeltaCleanup(mouse);
+                    MouseInputMainThreadCleanup.ScheduleTimedOutDeltaCleanup(mouse);
                     return MouseInputSimulationResponseFactory.TimedOutActionResult(
                         UnityCliLoopMouseInputAction.SmoothDelta);
                 }
@@ -520,7 +525,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (waitOutcome == InputSimulationWaitOutcome.Paused)
                 {
                     await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-                    ResetDeltaIfPossible(mouse);
+                    MouseInputMainThreadCleanup.ResetDeltaIfPossible(mouse);
                     SimulateMouseInputOverlayState.Clear();
                     return MouseInputSimulationResponseFactory.InterruptedActionResult(
                         UnityCliLoopMouseInputAction.SmoothDelta);
@@ -528,7 +533,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
-                    ScheduleTimedOutDeltaCleanup(mouse);
+                    MouseInputMainThreadCleanup.ScheduleTimedOutDeltaCleanup(mouse);
                     return MouseInputSimulationResponseFactory.TimedOutActionResult(
                         UnityCliLoopMouseInputAction.SmoothDelta);
                 }
@@ -544,7 +549,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 () => MouseInputState.InjectDelta(mouse, Vector2.zero), ct).ConfigureAwait(false);
             if (resetOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                ScheduleTimedOutDeltaCleanup(mouse);
+                MouseInputMainThreadCleanup.ScheduleTimedOutDeltaCleanup(mouse);
                 return MouseInputSimulationResponseFactory.TimedOutActionResult(
                     UnityCliLoopMouseInputAction.SmoothDelta);
             }
@@ -555,123 +560,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Message = $"Smooth delta ({request.DeltaX:F1}, {request.DeltaY:F1}) over {duration:F2}s",
                 Action = UnityCliLoopMouseInputAction.SmoothDelta.ToString()
             };
-        }
-
-        private static async Task<InputSimulationWaitOutcome> ReleaseButtonIfPossible(
-            Mouse mouse,
-            RuntimeMouseButton button,
-            CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            if (!CanInjectMouseState(mouse))
-            {
-                return InputSimulationWaitOutcome.Completed;
-            }
-
-            if (EditorApplication.isPaused)
-            {
-                ReleaseButtonImmediately(mouse, button);
-                return InputSimulationWaitOutcome.Completed;
-            }
-
-            InputSimulationWaitOutcome releaseOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                () => MouseInputState.SetButtonState(mouse, button, false),
-                ct).ConfigureAwait(false);
-            if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                ScheduleReleaseButtonImmediately(mouse, button);
-            }
-
-            return releaseOutcome;
-        }
-
-        private static void ScheduleReleaseButtonImmediately(Mouse mouse, RuntimeMouseButton button)
-        {
-            ReleaseButtonImmediatelyOnMainThreadAsync(mouse, button, CancellationToken.None).Forget();
-        }
-
-        private static async Task ReleaseButtonImmediatelyOnMainThreadAsync(
-            Mouse mouse,
-            RuntimeMouseButton button,
-            CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            ReleaseButtonImmediately(mouse, button);
-        }
-
-        private static void ReleaseButtonImmediately(Mouse mouse, RuntimeMouseButton button)
-        {
-            Debug.Assert(CanInjectMouseState(mouse), "mouse button can only be released while PlayMode has a mouse");
-            if (!CanInjectMouseState(mouse))
-            {
-                return;
-            }
-
-            MouseInputState.SetButtonState(mouse, button, false);
-            InputSystemUpdateHelper.RunExplicitUpdate(InputUpdateTypeResolver.Resolve());
-        }
-
-        private static void ResetDeltaIfPossible(Mouse mouse)
-        {
-            if (!CanInjectMouseState(mouse))
-            {
-                return;
-            }
-
-            MouseInputState.InjectDelta(mouse, Vector2.zero);
-            if (EditorApplication.isPaused)
-            {
-                InputSystemUpdateHelper.RunExplicitUpdate(InputUpdateTypeResolver.Resolve());
-            }
-        }
-
-        private static void ScheduleTimedOutButtonCleanup(Mouse mouse, RuntimeMouseButton button, bool pressWasApplied)
-        {
-            CleanupTimedOutButtonAsync(mouse, button, pressWasApplied, CancellationToken.None).Forget();
-        }
-
-        private static async Task CleanupTimedOutButtonAsync(
-            Mouse mouse,
-            RuntimeMouseButton button,
-            bool pressWasApplied,
-            CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            if (pressWasApplied)
-            {
-                await ReleaseButtonIfPossible(mouse, button, ct).ConfigureAwait(false);
-            }
-
-            MouseInputState.SetButtonUp(button);
-            SimulateMouseInputOverlayState.SetButtonHeld(button, false);
-        }
-
-        private static void ScheduleTimedOutMouseOverlayCleanup()
-        {
-            CleanupTimedOutMouseOverlayAsync(CancellationToken.None).Forget();
-        }
-
-        private static async Task CleanupTimedOutMouseOverlayAsync(CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            SimulateMouseInputOverlayState.Clear();
-        }
-
-        private static void ScheduleTimedOutDeltaCleanup(Mouse mouse)
-        {
-            CleanupTimedOutDeltaAsync(mouse, CancellationToken.None).Forget();
-        }
-
-        private static async Task CleanupTimedOutDeltaAsync(Mouse mouse, CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            ResetDeltaIfPossible(mouse);
-            SimulateMouseInputOverlayState.Clear();
-        }
-
-        private static bool CanInjectMouseState(Mouse mouse)
-        {
-            return EditorApplication.isPlaying && mouse != null;
         }
 
         private static RuntimeMouseButton ToRuntimeMouseButton(UnityCliLoopMouseButton button)


### PR DESCRIPTION
## Summary
- Isolate mouse input response construction and main-thread cleanup from action execution.
- Keep mouse input simulation behavior, messages, timing, and wire responses unchanged.

## User Impact
- No user-visible behavior change is intended.
- Click, long-press, movement, scroll, timeout cleanup, and Pause Point reporting retain their existing behavior.

## Changes
- Move interrupted and timed-out response projection to `MouseInputSimulationResponseFactory`.
- Add focused characterization coverage for timeout fields and multiple Pause Point hit projection.
- Move button release, delta reset, overlay cleanup, and deferred timeout recovery to stateless `MouseInputMainThreadCleanup`.
- Extend the async CancellationToken source guard to the new cleanup owner.
- Reduce `SimulateMouseInputUseCase` from 770 to 580 lines; action execution remains in the use case for the next R2-42 stages.

## Refactor Safety
- The PR contains two commits so response and cleanup moves can be reviewed independently.
- Statement order, `ConfigureAwait(false)`, `CancellationToken.None` cleanup semantics, fire-and-forget scheduling, response strings and fields, overlay mutations, and Pause Point projection are preserved.
- Moved helpers have no instance or mutable static fields and do not depend back on `SimulateMouseInputUseCase`.
- No schema, public API, wire shape, or protocol declaration changed.

## Verification
- Baseline `SimulateMouseInputTests`: 12/12 passed.
- Red: the two factory characterization tests produced two expected missing-type compile errors before extraction.
- Response factory tests plus existing mouse input PlayMode tests: 14/14 passed.
- Assembly dependency, PlayMode preflight, and static source guard fixtures: 111/111 passed.
- Unity compile: 0 errors, 0 warnings.
- `git diff --check`: passed.

## Follow-up
- R2-42 Stage 2 will move click and long-press execution to a press action executor.
- R2-42 Stage 3 will move delta, scroll, and smooth-delta execution and leave the use case as the tool-level orchestrator.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

