### PR TITLE
chore: simplify mouse input press actions

### DIFF
--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -63,6 +63,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMainThreadCleanup.cs",
+            "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs"
         };
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs
@@ -1,0 +1,282 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+using RuntimeMouseButton = io.github.hatayama.UnityCliLoop.Runtime.MouseButton;
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Executes click and long-press mouse input actions.
+    /// </summary>
+    internal static class MouseInputPressActionExecutor
+    {
+        // Input coordinates use top-left origin; Unity Screen space uses bottom-left origin.
+        // Uses Screen.height (runtime resolution) because Mouse.current.position is in
+        // runtime screen space, not the editor Game view target resolution.
+        private static Vector2 InputToScreen(Vector2 inputPos)
+        {
+            return new Vector2(inputPos.x, Screen.height - inputPos.y);
+        }
+
+        internal static async Task<SimulateMouseInputResponse> ExecuteClick(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
+        {
+            if (request.Duration < 0f || float.IsNaN(request.Duration) || float.IsInfinity(request.Duration))
+            {
+                return new SimulateMouseInputResponse
+                {
+                    Success = false,
+                    Message = $"Duration must be non-negative, got: {request.Duration}",
+                    Action = UnityCliLoopMouseInputAction.Click.ToString()
+                };
+            }
+
+            Vector2 inputPos = new(request.X, request.Y);
+            Vector2 screenPos = InputToScreen(inputPos);
+            RuntimeMouseButton button = ToRuntimeMouseButton(request.Button);
+            string buttonName = button.ToString();
+
+            // Set mouse position before clicking
+            InputSimulationWaitOutcome positionOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                () => MouseInputState.SetPositionState(mouse, screenPos), ct).ConfigureAwait(false);
+            if (positionOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
+                    UnityCliLoopMouseInputAction.Click,
+                    buttonName,
+                    inputPos);
+            }
+
+            // Press button
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            MouseInputState.SetButtonDown(button);
+            SimulateMouseInputOverlayState.SetButtonHeld(button, true);
+            bool pressWasApplied = false;
+            InputSimulationWaitOutcome waitOutcome = InputSimulationWaitOutcome.Completed;
+
+            try
+            {
+                waitOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                    () => MouseInputState.SetButtonState(mouse, button, true), ct)
+                    .ConfigureAwait(false);
+                if (waitOutcome == InputSimulationWaitOutcome.Completed)
+                {
+                    pressWasApplied = true;
+                    waitOutcome = await InputSystemUpdateHelper.WaitForPressLifetime(request.Duration, ct)
+                        .ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
+                {
+                    MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, pressWasApplied);
+                }
+                else if (pressWasApplied)
+                {
+                    InputSimulationWaitOutcome releaseOutcome =
+                        await MouseInputMainThreadCleanup.ReleaseButtonIfPossible(
+                            mouse,
+                            button,
+                            CancellationToken.None).ConfigureAwait(false);
+                    if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
+                    {
+                        waitOutcome = InputSimulationWaitOutcome.TimedOut;
+                        MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, false);
+                    }
+                    else
+                    {
+                        await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+                        MouseInputState.SetButtonUp(button);
+                    }
+                }
+                else
+                {
+                    await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+                    MouseInputState.SetButtonUp(button);
+                }
+
+                if (waitOutcome != InputSimulationWaitOutcome.TimedOut)
+                {
+                    if (waitOutcome == InputSimulationWaitOutcome.Paused)
+                    {
+                        SimulateMouseInputOverlayState.Clear();
+                    }
+                    else
+                    {
+                        SimulateMouseInputOverlayState.SetButtonHeld(button, false);
+                    }
+                }
+            }
+
+            if (waitOutcome == InputSimulationWaitOutcome.Paused)
+            {
+                return MouseInputSimulationResponseFactory.InterruptedButtonResult(
+                    UnityCliLoopMouseInputAction.Click,
+                    buttonName,
+                    inputPos);
+            }
+
+            if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
+                    UnityCliLoopMouseInputAction.Click,
+                    buttonName,
+                    inputPos);
+            }
+
+            string durationText = request.Duration > 0f ? $" for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s" : "";
+            return new SimulateMouseInputResponse
+            {
+                Success = true,
+                Message = $"Clicked {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}){durationText}",
+                Action = UnityCliLoopMouseInputAction.Click.ToString(),
+                Button = buttonName,
+                PositionX = inputPos.x,
+                PositionY = inputPos.y
+            };
+        }
+
+        internal static async Task<SimulateMouseInputResponse> ExecuteLongPress(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
+        {
+            if (request.Duration <= 0f || float.IsNaN(request.Duration) || float.IsInfinity(request.Duration))
+            {
+                return new SimulateMouseInputResponse
+                {
+                    Success = false,
+                    Message = $"Duration must be positive for LongPress, got: {request.Duration}",
+                    Action = UnityCliLoopMouseInputAction.LongPress.ToString()
+                };
+            }
+
+            Vector2 inputPos = new(request.X, request.Y);
+            Vector2 screenPos = InputToScreen(inputPos);
+            RuntimeMouseButton button = ToRuntimeMouseButton(request.Button);
+            string buttonName = button.ToString();
+
+            // Set mouse position before pressing
+            InputSimulationWaitOutcome positionOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                () => MouseInputState.SetPositionState(mouse, screenPos), ct).ConfigureAwait(false);
+            if (positionOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
+                    UnityCliLoopMouseInputAction.LongPress,
+                    buttonName,
+                    inputPos);
+            }
+
+            // Press button
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            MouseInputState.SetButtonDown(button);
+            SimulateMouseInputOverlayState.SetButtonHeld(button, true);
+            bool pressWasApplied = false;
+            InputSimulationWaitOutcome waitOutcome = InputSimulationWaitOutcome.Completed;
+
+            try
+            {
+                waitOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                    () => MouseInputState.SetButtonState(mouse, button, true), ct)
+                    .ConfigureAwait(false);
+
+                // Hold for at least the minimum observation frames so the press
+                // is visible to game code, then continue until duration elapses.
+                if (waitOutcome == InputSimulationWaitOutcome.Completed)
+                {
+                    pressWasApplied = true;
+                    waitOutcome = await InputSystemUpdateHelper.WaitForPressLifetime(request.Duration, ct)
+                        .ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
+                {
+                    MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, pressWasApplied);
+                }
+                else if (pressWasApplied)
+                {
+                    InputSimulationWaitOutcome releaseOutcome =
+                        await MouseInputMainThreadCleanup.ReleaseButtonIfPossible(
+                            mouse,
+                            button,
+                            CancellationToken.None).ConfigureAwait(false);
+                    if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
+                    {
+                        waitOutcome = InputSimulationWaitOutcome.TimedOut;
+                        MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, false);
+                    }
+                    else
+                    {
+                        await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+                        MouseInputState.SetButtonUp(button);
+                    }
+                }
+                else
+                {
+                    await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+                    MouseInputState.SetButtonUp(button);
+                }
+
+                if (waitOutcome != InputSimulationWaitOutcome.TimedOut)
+                {
+                    if (waitOutcome == InputSimulationWaitOutcome.Paused)
+                    {
+                        SimulateMouseInputOverlayState.Clear();
+                    }
+                    else
+                    {
+                        SimulateMouseInputOverlayState.SetButtonHeld(button, false);
+                    }
+                }
+            }
+
+            if (waitOutcome == InputSimulationWaitOutcome.Paused)
+            {
+                return MouseInputSimulationResponseFactory.InterruptedButtonResult(
+                    UnityCliLoopMouseInputAction.LongPress,
+                    buttonName,
+                    inputPos);
+            }
+
+            if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
+                    UnityCliLoopMouseInputAction.LongPress,
+                    buttonName,
+                    inputPos);
+            }
+
+            return new SimulateMouseInputResponse
+            {
+                Success = true,
+                Message = $"Long-pressed {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}) for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s",
+                Action = UnityCliLoopMouseInputAction.LongPress.ToString(),
+                Button = buttonName,
+                PositionX = inputPos.x,
+                PositionY = inputPos.y
+            };
+        }
+
+        private static RuntimeMouseButton ToRuntimeMouseButton(UnityCliLoopMouseButton button)
+        {
+            switch (button)
+            {
+                case UnityCliLoopMouseButton.Right:
+                    return RuntimeMouseButton.Right;
+                case UnityCliLoopMouseButton.Middle:
+                    return RuntimeMouseButton.Middle;
+                default:
+                    Debug.Assert(button == UnityCliLoopMouseButton.Left, $"Unexpected mouse button value: {button}");
+                    return RuntimeMouseButton.Left;
+            }
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63d49d1d13ed14d7da1f9a6d6085f329
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -7,7 +7,6 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 #endif
 
-using RuntimeMouseButton = io.github.hatayama.UnityCliLoop.Runtime.MouseButton;
 using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -108,11 +107,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             switch (parameters.Action)
             {
                 case UnityCliLoopMouseInputAction.Click:
-                    response = await ExecuteClick(mouse, parameters, ct);
+                    response = await MouseInputPressActionExecutor.ExecuteClick(mouse, parameters, ct);
                     break;
 
                 case UnityCliLoopMouseInputAction.LongPress:
-                    response = await ExecuteLongPress(mouse, parameters, ct);
+                    response = await MouseInputPressActionExecutor.ExecuteLongPress(mouse, parameters, ct);
                     break;
 
                 case UnityCliLoopMouseInputAction.MoveDelta:
@@ -146,254 +145,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void EnsureOverlayExists()
         {
             OverlayCanvasFactory.EnsureExists();
-        }
-
-        // Input coordinates use top-left origin; Unity Screen space uses bottom-left origin.
-        // Uses Screen.height (runtime resolution) because Mouse.current.position is in
-        // runtime screen space, not the editor Game view target resolution.
-        private static Vector2 InputToScreen(Vector2 inputPos)
-        {
-            return new Vector2(inputPos.x, Screen.height - inputPos.y);
-        }
-
-        private async Task<SimulateMouseInputResponse> ExecuteClick(
-            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
-        {
-            if (request.Duration < 0f || float.IsNaN(request.Duration) || float.IsInfinity(request.Duration))
-            {
-                return new SimulateMouseInputResponse
-                {
-                    Success = false,
-                    Message = $"Duration must be non-negative, got: {request.Duration}",
-                    Action = UnityCliLoopMouseInputAction.Click.ToString()
-                };
-            }
-
-            Vector2 inputPos = new(request.X, request.Y);
-            Vector2 screenPos = InputToScreen(inputPos);
-            RuntimeMouseButton button = ToRuntimeMouseButton(request.Button);
-            string buttonName = button.ToString();
-
-            // Set mouse position before clicking
-            InputSimulationWaitOutcome positionOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                () => MouseInputState.SetPositionState(mouse, screenPos), ct).ConfigureAwait(false);
-            if (positionOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
-                    UnityCliLoopMouseInputAction.Click,
-                    buttonName,
-                    inputPos);
-            }
-
-            // Press button
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            MouseInputState.SetButtonDown(button);
-            SimulateMouseInputOverlayState.SetButtonHeld(button, true);
-            bool pressWasApplied = false;
-            InputSimulationWaitOutcome waitOutcome = InputSimulationWaitOutcome.Completed;
-
-            try
-            {
-                waitOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                    () => MouseInputState.SetButtonState(mouse, button, true), ct)
-                    .ConfigureAwait(false);
-                if (waitOutcome == InputSimulationWaitOutcome.Completed)
-                {
-                    pressWasApplied = true;
-                    waitOutcome = await InputSystemUpdateHelper.WaitForPressLifetime(request.Duration, ct)
-                        .ConfigureAwait(false);
-                }
-            }
-            finally
-            {
-                if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
-                {
-                    MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, pressWasApplied);
-                }
-                else if (pressWasApplied)
-                {
-                    InputSimulationWaitOutcome releaseOutcome =
-                        await MouseInputMainThreadCleanup.ReleaseButtonIfPossible(
-                            mouse,
-                            button,
-                            CancellationToken.None).ConfigureAwait(false);
-                    if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
-                    {
-                        waitOutcome = InputSimulationWaitOutcome.TimedOut;
-                        MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, false);
-                    }
-                    else
-                    {
-                        await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
-                        MouseInputState.SetButtonUp(button);
-                    }
-                }
-                else
-                {
-                    await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
-                    MouseInputState.SetButtonUp(button);
-                }
-
-                if (waitOutcome != InputSimulationWaitOutcome.TimedOut)
-                {
-                    if (waitOutcome == InputSimulationWaitOutcome.Paused)
-                    {
-                        SimulateMouseInputOverlayState.Clear();
-                    }
-                    else
-                    {
-                        SimulateMouseInputOverlayState.SetButtonHeld(button, false);
-                    }
-                }
-            }
-
-            if (waitOutcome == InputSimulationWaitOutcome.Paused)
-            {
-                return MouseInputSimulationResponseFactory.InterruptedButtonResult(
-                    UnityCliLoopMouseInputAction.Click,
-                    buttonName,
-                    inputPos);
-            }
-
-            if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
-                    UnityCliLoopMouseInputAction.Click,
-                    buttonName,
-                    inputPos);
-            }
-
-            string durationText = request.Duration > 0f ? $" for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s" : "";
-            return new SimulateMouseInputResponse
-            {
-                Success = true,
-                Message = $"Clicked {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}){durationText}",
-                Action = UnityCliLoopMouseInputAction.Click.ToString(),
-                Button = buttonName,
-                PositionX = inputPos.x,
-                PositionY = inputPos.y
-            };
-        }
-
-        private async Task<SimulateMouseInputResponse> ExecuteLongPress(
-            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
-        {
-            if (request.Duration <= 0f || float.IsNaN(request.Duration) || float.IsInfinity(request.Duration))
-            {
-                return new SimulateMouseInputResponse
-                {
-                    Success = false,
-                    Message = $"Duration must be positive for LongPress, got: {request.Duration}",
-                    Action = UnityCliLoopMouseInputAction.LongPress.ToString()
-                };
-            }
-
-            Vector2 inputPos = new(request.X, request.Y);
-            Vector2 screenPos = InputToScreen(inputPos);
-            RuntimeMouseButton button = ToRuntimeMouseButton(request.Button);
-            string buttonName = button.ToString();
-
-            // Set mouse position before pressing
-            InputSimulationWaitOutcome positionOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                () => MouseInputState.SetPositionState(mouse, screenPos), ct).ConfigureAwait(false);
-            if (positionOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
-                    UnityCliLoopMouseInputAction.LongPress,
-                    buttonName,
-                    inputPos);
-            }
-
-            // Press button
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            MouseInputState.SetButtonDown(button);
-            SimulateMouseInputOverlayState.SetButtonHeld(button, true);
-            bool pressWasApplied = false;
-            InputSimulationWaitOutcome waitOutcome = InputSimulationWaitOutcome.Completed;
-
-            try
-            {
-                waitOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                    () => MouseInputState.SetButtonState(mouse, button, true), ct)
-                    .ConfigureAwait(false);
-
-                // Hold for at least the minimum observation frames so the press
-                // is visible to game code, then continue until duration elapses.
-                if (waitOutcome == InputSimulationWaitOutcome.Completed)
-                {
-                    pressWasApplied = true;
-                    waitOutcome = await InputSystemUpdateHelper.WaitForPressLifetime(request.Duration, ct)
-                        .ConfigureAwait(false);
-                }
-            }
-            finally
-            {
-                if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
-                {
-                    MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, pressWasApplied);
-                }
-                else if (pressWasApplied)
-                {
-                    InputSimulationWaitOutcome releaseOutcome =
-                        await MouseInputMainThreadCleanup.ReleaseButtonIfPossible(
-                            mouse,
-                            button,
-                            CancellationToken.None).ConfigureAwait(false);
-                    if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
-                    {
-                        waitOutcome = InputSimulationWaitOutcome.TimedOut;
-                        MouseInputMainThreadCleanup.ScheduleTimedOutButtonCleanup(mouse, button, false);
-                    }
-                    else
-                    {
-                        await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
-                        MouseInputState.SetButtonUp(button);
-                    }
-                }
-                else
-                {
-                    await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
-                    MouseInputState.SetButtonUp(button);
-                }
-
-                if (waitOutcome != InputSimulationWaitOutcome.TimedOut)
-                {
-                    if (waitOutcome == InputSimulationWaitOutcome.Paused)
-                    {
-                        SimulateMouseInputOverlayState.Clear();
-                    }
-                    else
-                    {
-                        SimulateMouseInputOverlayState.SetButtonHeld(button, false);
-                    }
-                }
-            }
-
-            if (waitOutcome == InputSimulationWaitOutcome.Paused)
-            {
-                return MouseInputSimulationResponseFactory.InterruptedButtonResult(
-                    UnityCliLoopMouseInputAction.LongPress,
-                    buttonName,
-                    inputPos);
-            }
-
-            if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                return MouseInputSimulationResponseFactory.TimedOutButtonResult(
-                    UnityCliLoopMouseInputAction.LongPress,
-                    buttonName,
-                    inputPos);
-            }
-
-            return new SimulateMouseInputResponse
-            {
-                Success = true,
-                Message = $"Long-pressed {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}) for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s",
-                Action = UnityCliLoopMouseInputAction.LongPress.ToString(),
-                Button = buttonName,
-                PositionX = inputPos.x,
-                PositionY = inputPos.y
-            };
         }
 
         private async Task<SimulateMouseInputResponse> ExecuteMoveDelta(
@@ -562,19 +313,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        private static RuntimeMouseButton ToRuntimeMouseButton(UnityCliLoopMouseButton button)
-        {
-            switch (button)
-            {
-                case UnityCliLoopMouseButton.Right:
-                    return RuntimeMouseButton.Right;
-                case UnityCliLoopMouseButton.Middle:
-                    return RuntimeMouseButton.Middle;
-                default:
-                    Debug.Assert(button == UnityCliLoopMouseButton.Left, $"Unexpected mouse button value: {button}");
-                    return RuntimeMouseButton.Left;
-            }
-        }
 #endif
     }
 }


### PR DESCRIPTION
## Summary
- Isolate click and long-press execution from mouse input tool orchestration.
- Preserve runtime coordinate conversion, button timing, cleanup, and response behavior.

## User Impact
- No user-visible behavior change is intended.
- Click and long-press input remain visible to gameplay updates and retain the same release, timeout, Pause Point, and overlay behavior.

## Changes
- Move `ExecuteClick`, `ExecuteLongPress`, runtime `InputToScreen`, and button mapping to stateless `MouseInputPressActionExecutor`.
- Keep the runtime `Screen.height` coordinate contract and its rationale with the moved conversion helper.
- Dispatch the two press actions directly from `SimulateMouseInputUseCase` without wrappers.
- Extend the async CancellationToken source guard to the new executor.
- Reduce `SimulateMouseInputUseCase` from 580 to 318 lines.

## Refactor Safety
- This is a pure move plus direct type qualification and the minimum private-instance to internal-static visibility changes required by the dispatch boundary.
- Input application order, press lifetime, `try`/`finally`, `CancellationToken.None` cleanup, `ConfigureAwait(false)`, overlay mutations, response fields/messages, and button mapping are unchanged.
- The executor has no instance or mutable static state and has no dependency back to the use case.
- Similar click and long-press flows remain explicit instead of introducing flag/delegate machinery solely to reduce repeated statements.
- No schema, public API, wire shape, or protocol declaration changed.

## Verification
- Baseline response factory plus mouse input PlayMode tests: 14/14 passed.
- After extraction, the same PlayMode tests: 14/14 passed.
- Assembly dependency, PlayMode preflight, and static source guard fixtures: 111/111 passed.
- Unity compile: 0 errors, 0 warnings.
- `git diff --check`: passed.

## Follow-up
- R2-42 Stage 3 will move delta, scroll, and smooth-delta execution and leave the use case as the tool-level orchestrator.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

