### PR TITLE
chore: simplify mouse input motion actions

### DIFF
--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -64,6 +64,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMainThreadCleanup.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs",
+            "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMotionActionExecutor.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs"
         };
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMotionActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMotionActionExecutor.cs
@@ -1,0 +1,185 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Executes delta, scroll, and smooth-delta mouse input actions.
+    /// </summary>
+    internal static class MouseInputMotionActionExecutor
+    {
+        internal static async Task<SimulateMouseInputResponse> ExecuteMoveDelta(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
+        {
+            Vector2 delta = new(request.DeltaX, request.DeltaY);
+            SimulateMouseInputOverlayState.SetMoveDelta(delta);
+
+            InputSimulationWaitOutcome applyOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                () => MouseInputState.SetDeltaState(mouse, delta), ct).ConfigureAwait(false);
+            if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.MoveDelta);
+            }
+
+            InputSimulationWaitOutcome waitOutcome = await InputSystemUpdateHelper.WaitForObservationFrames(ct)
+                .ConfigureAwait(false);
+            if (waitOutcome == InputSimulationWaitOutcome.Paused)
+            {
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+                SimulateMouseInputOverlayState.Clear();
+                return MouseInputSimulationResponseFactory.InterruptedActionResult(
+                    UnityCliLoopMouseInputAction.MoveDelta);
+            }
+
+            if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.MoveDelta);
+            }
+
+            return new SimulateMouseInputResponse
+            {
+                Success = true,
+                Message = $"Mouse delta injected: ({request.DeltaX:F1}, {request.DeltaY:F1})",
+                Action = UnityCliLoopMouseInputAction.MoveDelta.ToString()
+            };
+        }
+
+        internal static async Task<SimulateMouseInputResponse> ExecuteScroll(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
+        {
+            Vector2 scroll = new(request.ScrollX, request.ScrollY);
+
+            int scrollDir = request.ScrollY > 0f ? 1 : request.ScrollY < 0f ? -1 : 0;
+            SimulateMouseInputOverlayState.SetScrollDirection(scrollDir);
+
+            InputSimulationWaitOutcome applyOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                () => MouseInputState.SetScrollState(mouse, scroll), ct).ConfigureAwait(false);
+            if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.Scroll);
+            }
+
+            InputSimulationWaitOutcome waitOutcome = await InputSystemUpdateHelper.WaitForObservationFrames(ct)
+                .ConfigureAwait(false);
+            if (waitOutcome == InputSimulationWaitOutcome.Paused)
+            {
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+                SimulateMouseInputOverlayState.Clear();
+                return MouseInputSimulationResponseFactory.InterruptedActionResult(
+                    UnityCliLoopMouseInputAction.Scroll);
+            }
+
+            if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.Scroll);
+            }
+
+            return new SimulateMouseInputResponse
+            {
+                Success = true,
+                Message = $"Scroll injected: ({request.ScrollX:F1}, {request.ScrollY:F1})",
+                Action = UnityCliLoopMouseInputAction.Scroll.ToString()
+            };
+        }
+
+        // Distributes totalDelta across frames over duration for human-like smooth movement.
+        // Uses ApplyOnNextConfiguredUpdate per frame so the delta is visible to game code
+        // in the same Input System update cycle. Resets delta to zero only after the final frame.
+        internal static async Task<SimulateMouseInputResponse> ExecuteSmoothDelta(
+            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
+        {
+            if (request.Duration <= 0f || float.IsNaN(request.Duration) || float.IsInfinity(request.Duration))
+            {
+                return new SimulateMouseInputResponse
+                {
+                    Success = false,
+                    Message = $"Duration must be positive for SmoothDelta, got: {request.Duration}",
+                    Action = UnityCliLoopMouseInputAction.SmoothDelta.ToString()
+                };
+            }
+
+            Vector2 totalDelta = new(request.DeltaX, request.DeltaY);
+            float duration = request.Duration;
+            float startTime = Time.realtimeSinceStartup;
+            float previousT = 0f;
+
+            while (true)
+            {
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+
+                float elapsed = Time.realtimeSinceStartup - startTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+
+                float frameFraction = t - previousT;
+                Vector2 frameDelta = totalDelta * frameFraction;
+                SimulateMouseInputOverlayState.SetMoveDelta(frameDelta);
+
+                InputSimulationWaitOutcome applyOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                    () => MouseInputState.InjectDelta(mouse, frameDelta), ct).ConfigureAwait(false);
+                if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
+                {
+                    MouseInputMainThreadCleanup.ScheduleTimedOutDeltaCleanup(mouse);
+                    return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                        UnityCliLoopMouseInputAction.SmoothDelta);
+                }
+
+                previousT = t;
+                InputSimulationWaitOutcome waitOutcome = await InputSystemUpdateHelper.WaitForRuntimeFrames(1, ct)
+                    .ConfigureAwait(false);
+                if (waitOutcome == InputSimulationWaitOutcome.Paused)
+                {
+                    await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+                    MouseInputMainThreadCleanup.ResetDeltaIfPossible(mouse);
+                    SimulateMouseInputOverlayState.Clear();
+                    return MouseInputSimulationResponseFactory.InterruptedActionResult(
+                        UnityCliLoopMouseInputAction.SmoothDelta);
+                }
+
+                if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
+                {
+                    MouseInputMainThreadCleanup.ScheduleTimedOutDeltaCleanup(mouse);
+                    return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                        UnityCliLoopMouseInputAction.SmoothDelta);
+                }
+
+                if (t >= 1f)
+                {
+                    break;
+                }
+            }
+
+            // Reset delta to zero after the smooth operation completes
+            InputSimulationWaitOutcome resetOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                () => MouseInputState.InjectDelta(mouse, Vector2.zero), ct).ConfigureAwait(false);
+            if (resetOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                MouseInputMainThreadCleanup.ScheduleTimedOutDeltaCleanup(mouse);
+                return MouseInputSimulationResponseFactory.TimedOutActionResult(
+                    UnityCliLoopMouseInputAction.SmoothDelta);
+            }
+
+            return new SimulateMouseInputResponse
+            {
+                Success = true,
+                Message = $"Smooth delta ({request.DeltaX:F1}, {request.DeltaY:F1}) over {duration:F2}s",
+                Action = UnityCliLoopMouseInputAction.SmoothDelta.ToString()
+            };
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMotionActionExecutor.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMotionActionExecutor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6088d10835a25484198c1afc5732f5e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using UnityEngine;
 #if ULOOP_HAS_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
@@ -115,15 +114,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     break;
 
                 case UnityCliLoopMouseInputAction.MoveDelta:
-                    response = await ExecuteMoveDelta(mouse, parameters, ct);
+                    response = await MouseInputMotionActionExecutor.ExecuteMoveDelta(mouse, parameters, ct);
                     break;
 
                 case UnityCliLoopMouseInputAction.Scroll:
-                    response = await ExecuteScroll(mouse, parameters, ct);
+                    response = await MouseInputMotionActionExecutor.ExecuteScroll(mouse, parameters, ct);
                     break;
 
                 case UnityCliLoopMouseInputAction.SmoothDelta:
-                    response = await ExecuteSmoothDelta(mouse, parameters, ct);
+                    response = await MouseInputMotionActionExecutor.ExecuteSmoothDelta(mouse, parameters, ct);
                     break;
 
                 default:
@@ -145,172 +144,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static void EnsureOverlayExists()
         {
             OverlayCanvasFactory.EnsureExists();
-        }
-
-        private async Task<SimulateMouseInputResponse> ExecuteMoveDelta(
-            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
-        {
-            Vector2 delta = new(request.DeltaX, request.DeltaY);
-            SimulateMouseInputOverlayState.SetMoveDelta(delta);
-
-            InputSimulationWaitOutcome applyOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                () => MouseInputState.SetDeltaState(mouse, delta), ct).ConfigureAwait(false);
-            if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
-                return MouseInputSimulationResponseFactory.TimedOutActionResult(
-                    UnityCliLoopMouseInputAction.MoveDelta);
-            }
-
-            InputSimulationWaitOutcome waitOutcome = await InputSystemUpdateHelper.WaitForObservationFrames(ct)
-                .ConfigureAwait(false);
-            if (waitOutcome == InputSimulationWaitOutcome.Paused)
-            {
-                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-                SimulateMouseInputOverlayState.Clear();
-                return MouseInputSimulationResponseFactory.InterruptedActionResult(
-                    UnityCliLoopMouseInputAction.MoveDelta);
-            }
-
-            if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
-                return MouseInputSimulationResponseFactory.TimedOutActionResult(
-                    UnityCliLoopMouseInputAction.MoveDelta);
-            }
-
-            return new SimulateMouseInputResponse
-            {
-                Success = true,
-                Message = $"Mouse delta injected: ({request.DeltaX:F1}, {request.DeltaY:F1})",
-                Action = UnityCliLoopMouseInputAction.MoveDelta.ToString()
-            };
-        }
-
-        private async Task<SimulateMouseInputResponse> ExecuteScroll(
-            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
-        {
-            Vector2 scroll = new(request.ScrollX, request.ScrollY);
-
-            int scrollDir = request.ScrollY > 0f ? 1 : request.ScrollY < 0f ? -1 : 0;
-            SimulateMouseInputOverlayState.SetScrollDirection(scrollDir);
-
-            InputSimulationWaitOutcome applyOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                () => MouseInputState.SetScrollState(mouse, scroll), ct).ConfigureAwait(false);
-            if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
-                return MouseInputSimulationResponseFactory.TimedOutActionResult(
-                    UnityCliLoopMouseInputAction.Scroll);
-            }
-
-            InputSimulationWaitOutcome waitOutcome = await InputSystemUpdateHelper.WaitForObservationFrames(ct)
-                .ConfigureAwait(false);
-            if (waitOutcome == InputSimulationWaitOutcome.Paused)
-            {
-                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-                SimulateMouseInputOverlayState.Clear();
-                return MouseInputSimulationResponseFactory.InterruptedActionResult(
-                    UnityCliLoopMouseInputAction.Scroll);
-            }
-
-            if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                MouseInputMainThreadCleanup.ScheduleTimedOutMouseOverlayCleanup();
-                return MouseInputSimulationResponseFactory.TimedOutActionResult(
-                    UnityCliLoopMouseInputAction.Scroll);
-            }
-
-            return new SimulateMouseInputResponse
-            {
-                Success = true,
-                Message = $"Scroll injected: ({request.ScrollX:F1}, {request.ScrollY:F1})",
-                Action = UnityCliLoopMouseInputAction.Scroll.ToString()
-            };
-        }
-
-        // Distributes totalDelta across frames over duration for human-like smooth movement.
-        // Uses ApplyOnNextConfiguredUpdate per frame so the delta is visible to game code
-        // in the same Input System update cycle. Resets delta to zero only after the final frame.
-        private async Task<SimulateMouseInputResponse> ExecuteSmoothDelta(
-            Mouse mouse, SimulateMouseInputSchema request, CancellationToken ct)
-        {
-            if (request.Duration <= 0f || float.IsNaN(request.Duration) || float.IsInfinity(request.Duration))
-            {
-                return new SimulateMouseInputResponse
-                {
-                    Success = false,
-                    Message = $"Duration must be positive for SmoothDelta, got: {request.Duration}",
-                    Action = UnityCliLoopMouseInputAction.SmoothDelta.ToString()
-                };
-            }
-
-            Vector2 totalDelta = new(request.DeltaX, request.DeltaY);
-            float duration = request.Duration;
-            float startTime = Time.realtimeSinceStartup;
-            float previousT = 0f;
-
-            while (true)
-            {
-                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-
-                float elapsed = Time.realtimeSinceStartup - startTime;
-                float t = Mathf.Clamp01(elapsed / duration);
-
-                float frameFraction = t - previousT;
-                Vector2 frameDelta = totalDelta * frameFraction;
-                SimulateMouseInputOverlayState.SetMoveDelta(frameDelta);
-
-                InputSimulationWaitOutcome applyOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                    () => MouseInputState.InjectDelta(mouse, frameDelta), ct).ConfigureAwait(false);
-                if (applyOutcome == InputSimulationWaitOutcome.TimedOut)
-                {
-                    MouseInputMainThreadCleanup.ScheduleTimedOutDeltaCleanup(mouse);
-                    return MouseInputSimulationResponseFactory.TimedOutActionResult(
-                        UnityCliLoopMouseInputAction.SmoothDelta);
-                }
-
-                previousT = t;
-                InputSimulationWaitOutcome waitOutcome = await InputSystemUpdateHelper.WaitForRuntimeFrames(1, ct)
-                    .ConfigureAwait(false);
-                if (waitOutcome == InputSimulationWaitOutcome.Paused)
-                {
-                    await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-                    MouseInputMainThreadCleanup.ResetDeltaIfPossible(mouse);
-                    SimulateMouseInputOverlayState.Clear();
-                    return MouseInputSimulationResponseFactory.InterruptedActionResult(
-                        UnityCliLoopMouseInputAction.SmoothDelta);
-                }
-
-                if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
-                {
-                    MouseInputMainThreadCleanup.ScheduleTimedOutDeltaCleanup(mouse);
-                    return MouseInputSimulationResponseFactory.TimedOutActionResult(
-                        UnityCliLoopMouseInputAction.SmoothDelta);
-                }
-
-                if (t >= 1f)
-                {
-                    break;
-                }
-            }
-
-            // Reset delta to zero after the smooth operation completes
-            InputSimulationWaitOutcome resetOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                () => MouseInputState.InjectDelta(mouse, Vector2.zero), ct).ConfigureAwait(false);
-            if (resetOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                MouseInputMainThreadCleanup.ScheduleTimedOutDeltaCleanup(mouse);
-                return MouseInputSimulationResponseFactory.TimedOutActionResult(
-                    UnityCliLoopMouseInputAction.SmoothDelta);
-            }
-
-            return new SimulateMouseInputResponse
-            {
-                Success = true,
-                Message = $"Smooth delta ({request.DeltaX:F1}, {request.DeltaY:F1}) over {duration:F2}s",
-                Action = UnityCliLoopMouseInputAction.SmoothDelta.ToString()
-            };
         }
 
 #endif


### PR DESCRIPTION
## Summary
- Isolate movement and scroll execution from mouse input tool orchestration.
- Complete the R2-42 responsibility split while preserving Input System behavior.

## User Impact
- No user-visible behavior change is intended.
- MoveDelta, Scroll, and SmoothDelta retain their existing per-frame injection, timeout, Pause Point, cleanup, overlay, and response behavior.

## Changes
- Move `ExecuteMoveDelta`, `ExecuteScroll`, and `ExecuteSmoothDelta` to stateless `MouseInputMotionActionExecutor`.
- Keep smooth interpolation and final delta reset together with their action owner.
- Dispatch all three motion actions directly from `SimulateMouseInputUseCase` without wrappers.
- Extend the async CancellationToken source guard to the new executor.
- Reduce `SimulateMouseInputUseCase` from 318 to 151 lines, leaving package fallback, preflight, validation, device acquisition, logging, run-in-background scope, overlay setup, and action dispatch.

## Refactor Safety
- This is a pure move plus direct type qualification and the minimum private-instance to internal-static visibility changes required by the dispatch boundary.
- Apply/wait ordering, scroll direction, smooth frame fractions, time source, `ConfigureAwait(false)`, Pause Point branches, timeout cleanup, delta reset, overlay mutations, and response fields/messages are unchanged.
- The executor has no instance or mutable static state and has no dependency back to the use case.
- Similar MoveDelta and Scroll flows remain explicit instead of introducing delegate machinery solely to reduce repeated statements.
- No schema, public API, wire shape, or protocol declaration changed.

## Verification
- Baseline response factory plus mouse input PlayMode tests: 14/14 passed.
- After extraction, the same PlayMode tests: 14/14 passed.
- Assembly dependency, PlayMode preflight, and static source guard fixtures: 111/111 passed.
- Unity compile: 0 errors, 0 warnings.
- `git diff --check`: passed.

## R2-42 Completion
- The original 770-line use case is now a 151-line tool orchestrator.
- Response projection, main-thread cleanup, press actions, and motion actions have explicit stateless owners; held-button and per-frame reset state remains owned by `MouseInputStateService`.
- No command DTO or cross-tool abstraction was introduced, preserving the direct schema contract established earlier.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

