### PR TITLE
chore: simplify keyboard input simulation support

### DIFF
--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -65,7 +65,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMainThreadCleanup.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMotionActionExecutor.cs",
-            "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs"
+            "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs",
+            "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputMainThreadCleanup.cs"
         };
 
         private static readonly Dictionary<string, string[]> OverloadGuardMethodsByPath = new Dictionary<string, string[]>

--- a/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs
@@ -1,0 +1,130 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
+{
+    /// <summary>
+    /// Characterizes wire-visible keyboard input response construction before factory extraction.
+    /// </summary>
+    [TestFixture]
+    public sealed class KeyboardInputSimulationResponseFactoryTests
+    {
+        private readonly DateTime _nowUtc = new(2026, 7, 9, 0, 0, 0, DateTimeKind.Utc);
+
+        [SetUp]
+        public void SetUp()
+        {
+            UloopPausePointRegistry.ConfigureForTests(new FakePauseController(), () => _nowUtc);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UloopPausePointRegistry.ResetForTests();
+        }
+
+        /// <summary>
+        /// Verifies interrupted press responses preserve edge observations and project every Pause Point hit.
+        /// </summary>
+        [TestCase(true)]
+        [TestCase(false)]
+        public void InterruptedKeyResult_WithMultiplePausePointHits_MapsPauseEvidenceAndPressEdge(
+            bool pressEdgeObserved)
+        {
+            UloopPausePointRegistry.Enable("first-hit", 30);
+            UloopPausePointRegistry.Enable("latest-hit", 30);
+            UloopPausePoint.Pause("first-hit");
+            UloopPausePoint.Pause("latest-hit");
+
+            SimulateKeyboardResponse response = KeyboardInputSimulationResponseFactory.InterruptedKeyResult(
+                UnityCliLoopKeyboardAction.Press,
+                "Space",
+                pressEdgeObserved);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "Keyboard input stopped because Unity paused during Pause Point inspection. Key 'Space' was released from Unity CLI Loop bookkeeping."));
+            Assert.That(response.Action, Is.EqualTo(UnityCliLoopKeyboardAction.Press.ToString()));
+            Assert.That(response.KeyName, Is.EqualTo("Space"));
+            Assert.That(response.InterruptedByPausePoint, Is.True);
+            Assert.That(response.PressEdgeObserved, Is.EqualTo(pressEdgeObserved));
+            Assert.That(response.PausePointId, Is.EqualTo("latest-hit"));
+            Assert.That(response.PausePointHitCount, Is.EqualTo(1));
+            Assert.That(response.PausePointHits, Has.Count.EqualTo(2));
+            Assert.That(response.PausePointHits![0].Id, Is.EqualTo("first-hit"));
+            Assert.That(response.PausePointHits[1].Id, Is.EqualTo("latest-hit"));
+        }
+
+        /// <summary>
+        /// Verifies interrupted key-up responses preserve the absent press edge and project a single Pause Point hit.
+        /// </summary>
+        [Test]
+        public void InterruptedKeyResult_ForKeyUp_MapsNullPressEdgeAndSinglePausePointHit()
+        {
+            UloopPausePointRegistry.Enable("key-up-hit", 30);
+            UloopPausePoint.Pause("key-up-hit");
+
+            SimulateKeyboardResponse response = KeyboardInputSimulationResponseFactory.InterruptedKeyResult(
+                UnityCliLoopKeyboardAction.KeyUp,
+                "Enter",
+                null);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Action, Is.EqualTo(UnityCliLoopKeyboardAction.KeyUp.ToString()));
+            Assert.That(response.KeyName, Is.EqualTo("Enter"));
+            Assert.That(response.InterruptedByPausePoint, Is.True);
+            Assert.That(response.PressEdgeObserved, Is.Null);
+            Assert.That(response.PausePointId, Is.EqualTo("key-up-hit"));
+            Assert.That(response.PausePointHitCount, Is.EqualTo(1));
+            Assert.That(response.PausePointHits, Has.Count.EqualTo(1));
+            Assert.That(response.PausePointHits![0].Id, Is.EqualTo("key-up-hit"));
+        }
+
+        /// <summary>
+        /// Verifies timed-out key responses preserve the action, key name, and timeout failure fields.
+        /// </summary>
+        [Test]
+        public void TimedOutKeyResult_WithActionAndKeyName_MapsFailureResponse()
+        {
+            SimulateKeyboardResponse response = KeyboardInputSimulationResponseFactory.TimedOutKeyResult(
+                UnityCliLoopKeyboardAction.KeyDown,
+                "W");
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(
+                response.Message,
+                Is.EqualTo(
+                    "Keyboard input timed out while waiting for Unity Editor update. Key 'W' cleanup is queued for the next Editor tick."));
+            Assert.That(response.Action, Is.EqualTo(UnityCliLoopKeyboardAction.KeyDown.ToString()));
+            Assert.That(response.KeyName, Is.EqualTo("W"));
+            Assert.That(response.InterruptedByPausePoint, Is.False);
+            Assert.That(response.PressEdgeObserved, Is.Null);
+            Assert.That(response.PausePointId, Is.Null);
+            Assert.That(response.PausePointHitCount, Is.Null);
+            Assert.That(response.PausePointHits, Is.Null);
+        }
+
+        /// <summary>
+        /// Test double that records Pause Point state without pausing the Unity Editor.
+        /// </summary>
+        private sealed class FakePauseController : IUloopPausePointPauseController
+        {
+            public bool IsPlaying => true;
+            public bool IsPaused { get; private set; }
+
+            public void Pause()
+            {
+                IsPaused = true;
+            }
+        }
+    }
+}
+#endif

--- a/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs.meta
+++ b/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a66b1bde64734e4f9b31d409f0d230a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputMainThreadCleanup.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputMainThreadCleanup.cs
@@ -1,0 +1,163 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Restores keyboard device and overlay state on the Unity main thread after simulation ends.
+    /// </summary>
+    internal static class KeyboardInputMainThreadCleanup
+    {
+        internal static async Task FinalizePressOverlay(CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+            if (ct.IsCancellationRequested)
+            {
+                SimulateKeyboardOverlayState.ClearPress();
+                return;
+            }
+
+            SimulateKeyboardOverlayState.ReleasePress();
+            await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                1,
+                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+
+        internal static async Task<InputSimulationWaitOutcome> RollbackHeldKey(
+            Keyboard keyboard,
+            Key key,
+            string keyName,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            InputSimulationWaitOutcome releaseOutcome =
+                await ReleaseKeyStateIfPossible(keyboard, key, ct).ConfigureAwait(false);
+            if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                ScheduleTimedOutHeldKeyCleanup(keyboard, key, keyName, false);
+                return releaseOutcome;
+            }
+
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            KeyboardKeyState.SetKeyUp(key);
+            SimulateKeyboardOverlayState.RemoveHeldKey(keyName);
+            return releaseOutcome;
+        }
+
+        internal static async Task<InputSimulationWaitOutcome> ReleaseKeyStateIfPossible(
+            Keyboard keyboard,
+            Key key,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            if (!CanInjectKeyboardState(keyboard))
+            {
+                return InputSimulationWaitOutcome.Completed;
+            }
+
+            if (EditorApplication.isPaused)
+            {
+                ReleaseKeyStateImmediately(keyboard, key);
+                return InputSimulationWaitOutcome.Completed;
+            }
+
+            InputSimulationWaitOutcome releaseOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
+                () => KeyboardKeyState.SetKeyState(keyboard, key, false),
+                ct).ConfigureAwait(false);
+            if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
+            {
+                ScheduleReleaseKeyStateImmediately(keyboard, key);
+            }
+
+            return releaseOutcome;
+        }
+
+        private static void ScheduleReleaseKeyStateImmediately(Keyboard keyboard, Key key)
+        {
+            ReleaseKeyStateImmediatelyOnMainThreadAsync(keyboard, key, CancellationToken.None).Forget();
+        }
+
+        private static async Task ReleaseKeyStateImmediatelyOnMainThreadAsync(
+            Keyboard keyboard,
+            Key key,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            ReleaseKeyStateImmediately(keyboard, key);
+        }
+
+        private static void ReleaseKeyStateImmediately(Keyboard keyboard, Key key)
+        {
+            Debug.Assert(CanInjectKeyboardState(keyboard), "keyboard state can only be released while PlayMode has a keyboard");
+            if (!CanInjectKeyboardState(keyboard))
+            {
+                return;
+            }
+
+            KeyboardKeyState.SetKeyState(keyboard, key, false);
+            InputSystemUpdateHelper.RunExplicitUpdate(InputUpdateTypeResolver.Resolve());
+        }
+
+        internal static void ScheduleTimedOutPressCleanup(Keyboard keyboard, Key key, bool pressWasApplied)
+        {
+            CleanupTimedOutPressAsync(keyboard, key, pressWasApplied, CancellationToken.None).Forget();
+        }
+
+        private static async Task CleanupTimedOutPressAsync(
+            Keyboard keyboard,
+            Key key,
+            bool pressWasApplied,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            if (pressWasApplied)
+            {
+                await ReleaseKeyStateIfPossible(keyboard, key, ct).ConfigureAwait(false);
+            }
+
+            KeyboardKeyState.UnregisterTransientKey(key);
+            SimulateKeyboardOverlayState.ClearPress();
+        }
+
+        internal static void ScheduleTimedOutHeldKeyCleanup(
+            Keyboard keyboard,
+            Key key,
+            string keyName,
+            bool keyWasApplied)
+        {
+            CleanupTimedOutHeldKeyAsync(keyboard, key, keyName, keyWasApplied, CancellationToken.None).Forget();
+        }
+
+        private static async Task CleanupTimedOutHeldKeyAsync(
+            Keyboard keyboard,
+            Key key,
+            string keyName,
+            bool keyWasApplied,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            if (keyWasApplied)
+            {
+                await ReleaseKeyStateIfPossible(keyboard, key, ct).ConfigureAwait(false);
+            }
+
+            KeyboardKeyState.SetKeyUp(key);
+            SimulateKeyboardOverlayState.RemoveHeldKey(keyName);
+        }
+
+        private static bool CanInjectKeyboardState(Keyboard keyboard)
+        {
+            return EditorApplication.isPlaying && keyboard != null;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputMainThreadCleanup.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputMainThreadCleanup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4528fdd6d18c440f8332a3ddec94d376
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputSimulationResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputSimulationResponseFactory.cs
@@ -1,0 +1,101 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Collections.Generic;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Creates wire-visible responses for keyboard input simulation outcomes.
+    /// </summary>
+    internal static class KeyboardInputSimulationResponseFactory
+    {
+        // pressEdgeObserved stays nullable because KeyUp has no press edge to report;
+        // Press/KeyDown must pass their observation so pause-point interruptions (the
+        // most common E2E path) do not silently drop the field.
+        internal static SimulateKeyboardResponse InterruptedKeyResult(
+            UnityCliLoopKeyboardAction action,
+            string keyName,
+            bool? pressEdgeObserved)
+        {
+            SimulateKeyboardResponse result = new()
+            {
+                Success = true,
+                Message = $"Keyboard input stopped because Unity paused during Pause Point inspection. Key '{keyName}' was released from Unity CLI Loop bookkeeping.",
+                Action = action.ToString(),
+                KeyName = keyName,
+                InterruptedByPausePoint = true,
+                PressEdgeObserved = pressEdgeObserved
+            };
+            AttachPausePointHit(result);
+            return result;
+        }
+
+        internal static SimulateKeyboardResponse TimedOutKeyResult(
+            UnityCliLoopKeyboardAction action,
+            string keyName)
+        {
+            return new SimulateKeyboardResponse
+            {
+                Success = false,
+                Message = $"Keyboard input timed out while waiting for Unity Editor update. Key '{keyName}' cleanup is queued for the next Editor tick.",
+                Action = action.ToString(),
+                KeyName = keyName
+            };
+        }
+
+        private static void AttachPausePointHit(SimulateKeyboardResponse result)
+        {
+            if (result == null)
+            {
+                Debug.Assert(false, "result must not be null");
+                return;
+            }
+
+            UloopPausePointSnapshot? snapshot = UloopPausePointRegistry.GetLatestHitSnapshot();
+            if (snapshot == null)
+            {
+                return;
+            }
+
+            if (!snapshot.IsHit)
+            {
+                return;
+            }
+
+            string? snapshotId = snapshot.Id;
+            if (string.IsNullOrEmpty(snapshotId))
+            {
+                return;
+            }
+
+            result.PausePointId = snapshotId;
+            result.PausePointHitCount = snapshot.HitCount;
+            result.PausePointHits = CollectPausePointHits();
+        }
+
+        // One input can hit several markers in the same frame; the representative
+        // PausePointId alone forced agents into extra status calls to find the others.
+        private static List<UnityCliLoopPausePointHit> CollectPausePointHits()
+        {
+            List<UnityCliLoopPausePointHit> hits = new();
+            foreach (UloopPausePointSnapshot snapshot in UloopPausePointRegistry.GetHitSnapshots())
+            {
+                if (!snapshot.IsHit || string.IsNullOrEmpty(snapshot.Id))
+                {
+                    continue;
+                }
+                hits.Add(new UnityCliLoopPausePointHit
+                {
+                    Id = snapshot.Id,
+                    HitCount = snapshot.HitCount
+                });
+            }
+            return hits;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputSimulationResponseFactory.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputSimulationResponseFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78948d1855194e8cb4c9fde19b01776d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using UnityEditor;
-using UnityEngine;
 #if ULOOP_HAS_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
@@ -205,16 +203,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 InputSystem.onAfterUpdate -= pressEdgeMonitor;
                 if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
-                    ScheduleTimedOutPressCleanup(keyboard, key, pressWasApplied);
+                    KeyboardInputMainThreadCleanup.ScheduleTimedOutPressCleanup(
+                        keyboard,
+                        key,
+                        pressWasApplied);
                 }
                 else if (pressWasApplied)
                 {
                     InputSimulationWaitOutcome releaseOutcome =
-                        await ReleaseKeyStateIfPossible(keyboard, key, CancellationToken.None).ConfigureAwait(false);
+                        await KeyboardInputMainThreadCleanup.ReleaseKeyStateIfPossible(
+                            keyboard,
+                            key,
+                            CancellationToken.None).ConfigureAwait(false);
                     if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
                     {
                         waitOutcome = InputSimulationWaitOutcome.TimedOut;
-                        ScheduleTimedOutPressCleanup(keyboard, key, false);
+                        KeyboardInputMainThreadCleanup.ScheduleTimedOutPressCleanup(keyboard, key, false);
                     }
                     else if (waitOutcome == InputSimulationWaitOutcome.Paused)
                     {
@@ -224,7 +228,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     else
                     {
                         KeyboardKeyState.UnregisterTransientKey(key);
-                        await FinalizePressOverlay(ct).ConfigureAwait(false);
+                        await KeyboardInputMainThreadCleanup.FinalizePressOverlay(ct).ConfigureAwait(false);
                     }
                 }
                 else
@@ -309,12 +313,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 InputSystem.onAfterUpdate -= keyDownEdgeMonitor;
                 if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
-                    ScheduleTimedOutHeldKeyCleanup(keyboard, key, keyName, keyDownApplied);
+                    KeyboardInputMainThreadCleanup.ScheduleTimedOutHeldKeyCleanup(
+                        keyboard,
+                        key,
+                        keyName,
+                        keyDownApplied);
                 }
                 else if (keyDownApplied && !committed)
                 {
                     InputSimulationWaitOutcome rollbackOutcome =
-                        await RollbackHeldKey(keyboard, key, keyName, CancellationToken.None).ConfigureAwait(false);
+                        await KeyboardInputMainThreadCleanup.RollbackHeldKey(
+                            keyboard,
+                            key,
+                            keyName,
+                            CancellationToken.None).ConfigureAwait(false);
                     if (rollbackOutcome == InputSimulationWaitOutcome.TimedOut)
                     {
                         waitOutcome = InputSimulationWaitOutcome.TimedOut;
@@ -366,11 +378,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             InputSimulationWaitOutcome releaseOutcome =
-                await ReleaseKeyStateIfPossible(keyboard, key, CancellationToken.None).ConfigureAwait(false);
+                await KeyboardInputMainThreadCleanup.ReleaseKeyStateIfPossible(
+                    keyboard,
+                    key,
+                    CancellationToken.None).ConfigureAwait(false);
 
             if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                ScheduleTimedOutHeldKeyCleanup(keyboard, key, keyName, false);
+                KeyboardInputMainThreadCleanup.ScheduleTimedOutHeldKeyCleanup(keyboard, key, keyName, false);
                 return KeyboardInputSimulationResponseFactory.TimedOutKeyResult(
                     UnityCliLoopKeyboardAction.KeyUp,
                     keyName);
@@ -413,145 +428,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return Key.Enter.ToString();
             }
             return keyName;
-        }
-
-        private static async Task FinalizePressOverlay(CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
-            if (ct.IsCancellationRequested)
-            {
-                SimulateKeyboardOverlayState.ClearPress();
-                return;
-            }
-
-            SimulateKeyboardOverlayState.ReleasePress();
-            await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
-                1,
-                UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
-                CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static async Task<InputSimulationWaitOutcome> RollbackHeldKey(
-            Keyboard keyboard,
-            Key key,
-            string keyName,
-            CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            InputSimulationWaitOutcome releaseOutcome =
-                await ReleaseKeyStateIfPossible(keyboard, key, ct).ConfigureAwait(false);
-            if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                ScheduleTimedOutHeldKeyCleanup(keyboard, key, keyName, false);
-                return releaseOutcome;
-            }
-
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            KeyboardKeyState.SetKeyUp(key);
-            SimulateKeyboardOverlayState.RemoveHeldKey(keyName);
-            return releaseOutcome;
-        }
-
-        private static async Task<InputSimulationWaitOutcome> ReleaseKeyStateIfPossible(
-            Keyboard keyboard,
-            Key key,
-            CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            if (!CanInjectKeyboardState(keyboard))
-            {
-                return InputSimulationWaitOutcome.Completed;
-            }
-
-            if (EditorApplication.isPaused)
-            {
-                ReleaseKeyStateImmediately(keyboard, key);
-                return InputSimulationWaitOutcome.Completed;
-            }
-
-            InputSimulationWaitOutcome releaseOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                () => KeyboardKeyState.SetKeyState(keyboard, key, false),
-                ct).ConfigureAwait(false);
-            if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
-            {
-                ScheduleReleaseKeyStateImmediately(keyboard, key);
-            }
-
-            return releaseOutcome;
-        }
-
-        private static void ScheduleReleaseKeyStateImmediately(Keyboard keyboard, Key key)
-        {
-            ReleaseKeyStateImmediatelyOnMainThreadAsync(keyboard, key, CancellationToken.None).Forget();
-        }
-
-        private static async Task ReleaseKeyStateImmediatelyOnMainThreadAsync(
-            Keyboard keyboard,
-            Key key,
-            CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            ReleaseKeyStateImmediately(keyboard, key);
-        }
-
-        private static void ReleaseKeyStateImmediately(Keyboard keyboard, Key key)
-        {
-            Debug.Assert(CanInjectKeyboardState(keyboard), "keyboard state can only be released while PlayMode has a keyboard");
-            if (!CanInjectKeyboardState(keyboard))
-            {
-                return;
-            }
-
-            KeyboardKeyState.SetKeyState(keyboard, key, false);
-            InputSystemUpdateHelper.RunExplicitUpdate(InputUpdateTypeResolver.Resolve());
-        }
-
-        private static void ScheduleTimedOutPressCleanup(Keyboard keyboard, Key key, bool pressWasApplied)
-        {
-            CleanupTimedOutPressAsync(keyboard, key, pressWasApplied, CancellationToken.None).Forget();
-        }
-
-        private static async Task CleanupTimedOutPressAsync(
-            Keyboard keyboard,
-            Key key,
-            bool pressWasApplied,
-            CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            if (pressWasApplied)
-            {
-                await ReleaseKeyStateIfPossible(keyboard, key, ct).ConfigureAwait(false);
-            }
-
-            KeyboardKeyState.UnregisterTransientKey(key);
-            SimulateKeyboardOverlayState.ClearPress();
-        }
-
-        private static void ScheduleTimedOutHeldKeyCleanup(Keyboard keyboard, Key key, string keyName, bool keyWasApplied)
-        {
-            CleanupTimedOutHeldKeyAsync(keyboard, key, keyName, keyWasApplied, CancellationToken.None).Forget();
-        }
-
-        private static async Task CleanupTimedOutHeldKeyAsync(
-            Keyboard keyboard,
-            Key key,
-            string keyName,
-            bool keyWasApplied,
-            CancellationToken ct)
-        {
-            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
-            if (keyWasApplied)
-            {
-                await ReleaseKeyStateIfPossible(keyboard, key, ct).ConfigureAwait(false);
-            }
-
-            KeyboardKeyState.SetKeyUp(key);
-            SimulateKeyboardOverlayState.RemoveHeldKey(keyName);
-        }
-
-        private static bool CanInjectKeyboardState(Keyboard keyboard)
-        {
-            return EditorApplication.isPlaying && keyboard != null;
         }
 
         // Runs inside InputSystem.onAfterUpdate. Editor updates are excluded because a press

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -237,12 +236,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (waitOutcome == InputSimulationWaitOutcome.Paused)
             {
-                return InterruptedKeyResult(UnityCliLoopKeyboardAction.Press, keyName, pressEdgeObserved);
+                return KeyboardInputSimulationResponseFactory.InterruptedKeyResult(
+                    UnityCliLoopKeyboardAction.Press,
+                    keyName,
+                    pressEdgeObserved);
             }
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                return TimedOutKeyResult(UnityCliLoopKeyboardAction.Press, keyName);
+                return KeyboardInputSimulationResponseFactory.TimedOutKeyResult(
+                    UnityCliLoopKeyboardAction.Press,
+                    keyName);
             }
 
             string durationText = duration > 0f ? $" for {InputSimulationDurationFormatter.FormatSeconds(duration)}s" : "";
@@ -320,12 +324,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (waitOutcome == InputSimulationWaitOutcome.Paused)
             {
-                return InterruptedKeyResult(UnityCliLoopKeyboardAction.KeyDown, keyName, pressEdgeObserved);
+                return KeyboardInputSimulationResponseFactory.InterruptedKeyResult(
+                    UnityCliLoopKeyboardAction.KeyDown,
+                    keyName,
+                    pressEdgeObserved);
             }
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                return TimedOutKeyResult(UnityCliLoopKeyboardAction.KeyDown, keyName);
+                return KeyboardInputSimulationResponseFactory.TimedOutKeyResult(
+                    UnityCliLoopKeyboardAction.KeyDown,
+                    keyName);
             }
 
             string keyDownEdgeText = pressEdgeObserved
@@ -362,7 +371,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (releaseOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 ScheduleTimedOutHeldKeyCleanup(keyboard, key, keyName, false);
-                return TimedOutKeyResult(UnityCliLoopKeyboardAction.KeyUp, keyName);
+                return KeyboardInputSimulationResponseFactory.TimedOutKeyResult(
+                    UnityCliLoopKeyboardAction.KeyUp,
+                    keyName);
             }
 
             await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
@@ -373,12 +384,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 .ConfigureAwait(false);
             if (waitOutcome == InputSimulationWaitOutcome.Paused)
             {
-                return InterruptedKeyResult(UnityCliLoopKeyboardAction.KeyUp, keyName, null);
+                return KeyboardInputSimulationResponseFactory.InterruptedKeyResult(
+                    UnityCliLoopKeyboardAction.KeyUp,
+                    keyName,
+                    null);
             }
 
             if (waitOutcome == InputSimulationWaitOutcome.TimedOut)
             {
-                return TimedOutKeyResult(UnityCliLoopKeyboardAction.KeyUp, keyName);
+                return KeyboardInputSimulationResponseFactory.TimedOutKeyResult(
+                    UnityCliLoopKeyboardAction.KeyUp,
+                    keyName);
             }
 
             return new SimulateKeyboardResponse
@@ -397,90 +413,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return Key.Enter.ToString();
             }
             return keyName;
-        }
-
-        // pressEdgeObserved stays nullable because KeyUp has no press edge to report;
-        // Press/KeyDown must pass their observation so pause-point interruptions (the
-        // most common E2E path) do not silently drop the field.
-        private static SimulateKeyboardResponse InterruptedKeyResult(
-            UnityCliLoopKeyboardAction action,
-            string keyName,
-            bool? pressEdgeObserved)
-        {
-            SimulateKeyboardResponse result = new()
-            {
-                Success = true,
-                Message = $"Keyboard input stopped because Unity paused during Pause Point inspection. Key '{keyName}' was released from Unity CLI Loop bookkeeping.",
-                Action = action.ToString(),
-                KeyName = keyName,
-                InterruptedByPausePoint = true,
-                PressEdgeObserved = pressEdgeObserved
-            };
-            AttachPausePointHit(result);
-            return result;
-        }
-
-        private static SimulateKeyboardResponse TimedOutKeyResult(
-            UnityCliLoopKeyboardAction action,
-            string keyName)
-        {
-            return new SimulateKeyboardResponse
-            {
-                Success = false,
-                Message = $"Keyboard input timed out while waiting for Unity Editor update. Key '{keyName}' cleanup is queued for the next Editor tick.",
-                Action = action.ToString(),
-                KeyName = keyName
-            };
-        }
-
-        private static void AttachPausePointHit(SimulateKeyboardResponse result)
-        {
-            if (result == null)
-            {
-                Debug.Assert(false, "result must not be null");
-                return;
-            }
-
-            UloopPausePointSnapshot? snapshot = UloopPausePointRegistry.GetLatestHitSnapshot();
-            if (snapshot == null)
-            {
-                return;
-            }
-
-            if (!snapshot.IsHit)
-            {
-                return;
-            }
-
-            string? snapshotId = snapshot.Id;
-            if (string.IsNullOrEmpty(snapshotId))
-            {
-                return;
-            }
-
-            result.PausePointId = snapshotId;
-            result.PausePointHitCount = snapshot.HitCount;
-            result.PausePointHits = CollectPausePointHits();
-        }
-
-        // One input can hit several markers in the same frame; the representative
-        // PausePointId alone forced agents into extra status calls to find the others.
-        private static List<UnityCliLoopPausePointHit> CollectPausePointHits()
-        {
-            List<UnityCliLoopPausePointHit> hits = new();
-            foreach (UloopPausePointSnapshot snapshot in UloopPausePointRegistry.GetHitSnapshots())
-            {
-                if (!snapshot.IsHit || string.IsNullOrEmpty(snapshot.Id))
-                {
-                    continue;
-                }
-                hits.Add(new UnityCliLoopPausePointHit
-                {
-                    Id = snapshot.Id,
-                    HitCount = snapshot.HitCount
-                });
-            }
-            return hits;
         }
 
         private static async Task FinalizePressOverlay(CancellationToken ct)


### PR DESCRIPTION
Refs: Refactor round 3 ToDo R3-1

## Summary
- Preserve keyboard simulation behavior while separating wire response construction and main-thread cleanup.
- Add synchronous characterization coverage for interrupted and timed-out keyboard responses.

## User Impact
- Keyboard press, key-down, and key-up behavior remains unchanged.
- The internal structure now matches the other input simulation tools, reducing risk in future maintenance.

## Changes
- Extract a stateless response factory with Pause Point evidence projection.
- Extract stateless keyboard state and overlay cleanup.
- Track the new async helper with the cancellation-token source guard.

## Verification
- Baseline PlayMode SimulateKeyboard tests: 37 passed.
- Unity compile: 0 errors, 0 warnings.
- StaticFacadeStateGuardTests: 20 passed.
- SimulateKeyboard and response factory PlayMode tests: 41 passed.
- Normalized move diff: implementation bodies preserved; residuals limited to signatures and direct dispatch qualification.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

