### PR TITLE
chore: simplify dynamic code response handling

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Characterizes dynamic-code response construction before factory extraction.
+    /// </summary>
+    [TestFixture]
+    public sealed class DynamicCodeExecutionResponseFactoryTests
+    {
+        /// <summary>
+        /// Verifies successful execution results preserve result, logs, and timings.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WhenSuccessful_MapsResultLogsAndTimings()
+        {
+            DynamicCodeExecutionResponseFactory factory = new();
+            ExecutionResult result = new()
+            {
+                Success = true,
+                Result = 42,
+                Logs = new List<string> { "execution log" },
+                Timings = new List<string> { "compile_ms=1" }
+            };
+
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Result, Is.EqualTo("42"));
+            Assert.That(response.Logs, Is.EqualTo(new[] { "execution log" }));
+            Assert.That(response.CompilationErrors, Is.Empty);
+            Assert.That(response.ErrorMessage, Is.Empty);
+            Assert.That(response.Timings, Is.EqualTo(new[] { "compile_ms=1" }));
+        }
+
+        /// <summary>
+        /// Verifies compilation failures expose deduplicated diagnostics, summary, hints, suggestions, and source context.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WhenCompilationFails_MapsStructuredDiagnostics()
+        {
+            DynamicCodeExecutionResponseFactory factory = new();
+            ExecutionResult result = new()
+            {
+                Success = false,
+                ErrorMessage = "Compilation error occurred",
+                UpdatedCode = "return MissingType.Value;",
+                CompilationErrors = new List<CompilationError>
+                {
+                    new CompilationError
+                    {
+                        ErrorCode = "CS0246",
+                        Message = "The type or namespace name 'MissingType' could not be found",
+                        Line = 1,
+                        Column = 8
+                    }
+                },
+                AmbiguousTypeCandidates = new Dictionary<string, List<string>>
+                {
+                    { "MissingType", new List<string> { "Namespace.One", "Namespace.Two" } }
+                }
+            };
+
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(
+                response.DiagnosticsSummary,
+                Is.EqualTo(
+                    "Errors: 1 unique (1 total). First at L1: CS0246 The type or namespace name 'MissingType' could not be found"));
+            Assert.That(response.Diagnostics, Has.Count.EqualTo(1));
+            Assert.That(response.CompilationErrors, Is.SameAs(response.Diagnostics));
+            Assert.That(
+                response.Diagnostics[0].Hint,
+                Is.EqualTo(
+                    "Auto-using resolution found multiple candidates for 'MissingType': Namespace.One, Namespace.Two. Use a fully-qualified name or add the correct using directive."));
+            Assert.That(
+                response.Diagnostics[0].Suggestions,
+                Is.EqualTo(new[] { "Use Namespace.One.MissingType", "Use Namespace.Two.MissingType" }));
+            Assert.That(response.Diagnostics[0].Context, Does.Contain("L1:return MissingType.Value;"));
+            Assert.That(response.Diagnostics[0].Context, Does.Contain("^"));
+            Assert.That(response.Logs, Contains.Item(response.DiagnosticsSummary));
+        }
+
+        /// <summary>
+        /// Verifies known compilation failures preserve friendly explanations, examples, and solutions.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WhenKnownFailureOccurs_AddsFriendlyGuidance()
+        {
+            DynamicCodeExecutionResponseFactory factory = new();
+            ExecutionResult result = new()
+            {
+                Success = false,
+                ErrorMessage = "Compilation error occurred",
+                CompilationErrors = new List<CompilationError>
+                {
+                    new CompilationError
+                    {
+                        ErrorCode = "CS8803",
+                        Message = "Top-level statements must precede namespace and type declarations."
+                    }
+                }
+            };
+
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+
+            Assert.That(response.ErrorMessage, Is.EqualTo("There is an issue with the code structure"));
+            Assert.That(
+                response.Logs,
+                Contains.Item(
+                    "Explanation: In the Dynamic Tool, class and namespace declarations are not required. Write Unity API processing directly."));
+            Assert.That(response.Logs, Contains.Item("Solutions:"));
+            Assert.That(response.Logs, Contains.Item("- Remove class definition and write only the code inside the method"));
+        }
+
+        /// <summary>
+        /// Verifies exceptions and auto-injected namespaces append their wire-visible log details.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WithExceptionAndInjectedNamespaces_AppendsLogDetails()
+        {
+            DynamicCodeExecutionResponseFactory factory = new();
+            ExecutionResult result = new()
+            {
+                Success = true,
+                Result = "ok",
+                Logs = new List<string> { "before" },
+                Exception = new InvalidOperationException("test exception"),
+                AutoInjectedNamespaces = new List<string> { "System.Linq", "UnityEngine" }
+            };
+
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+
+            Assert.That(response.Logs, Contains.Item("Exception: test exception"));
+            Assert.That(
+                response.Logs,
+                Contains.Item(
+                    "Performance hint: Auto-resolved 2 missing using directive(s): using System.Linq; using UnityEngine; — Include them in your code to skip auto-resolution and improve compilation speed."));
+        }
+
+        /// <summary>
+        /// Verifies cancelled results are recognized and mapped to the neutral cancellation response.
+        /// </summary>
+        [Test]
+        public void CancelledResult_WhenMapped_ReturnsNeutralCancellationResponse()
+        {
+            ExecutionResult result = new()
+            {
+                Success = false,
+                ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED
+            };
+
+            bool isCancelled = DynamicCodeExecutionResponseFactory.IsCancelledResult(result);
+            ExecuteDynamicCodeResponse response = DynamicCodeExecutionResponseFactory.CreateCancelledResponse();
+
+            Assert.That(isCancelled, Is.True);
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Result, Is.Empty);
+            Assert.That(response.Logs, Is.EqualTo(new[] { "Execution cancelled" }));
+            Assert.That(response.CompilationErrors, Is.Empty);
+            Assert.That(response.ErrorMessage, Is.EqualTo(UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED));
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45395290c32c4272b89e3da733881004
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Converts dynamic-code execution results into wire-visible tool responses.
+    /// </summary>
+    internal sealed class DynamicCodeExecutionResponseFactory
+    {
+        private readonly DynamicCodeFriendlyErrorConverter _friendlyErrorConverter;
+
+        internal DynamicCodeExecutionResponseFactory()
+        {
+            _friendlyErrorConverter = new DynamicCodeFriendlyErrorConverter();
+        }
+
+        internal static bool IsCancelledResult(ExecutionResult executionResult)
+        {
+            return executionResult != null
+                && !executionResult.Success
+                && string.Equals(
+                    executionResult.ErrorMessage,
+                    UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED,
+                    StringComparison.Ordinal);
+        }
+
+        internal static ExecuteDynamicCodeResponse CreateCancelledResponse()
+        {
+            return new ExecuteDynamicCodeResponse
+            {
+                Success = false,
+                Result = string.Empty,
+                Logs = new List<string> { "Execution cancelled" },
+                CompilationErrors = new List<CompilationErrorDto>(),
+                ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED
+            };
+        }
+
+        internal ExecuteDynamicCodeResponse ConvertExecutionResultToResponse(ExecutionResult result)
+        {
+            ExecuteDynamicCodeResponse response = new()            {
+                Success = result.Success,
+                Result = result.Result?.ToString() ?? string.Empty,
+                Logs = result.Logs ?? new List<string>(),
+                CompilationErrors = new List<CompilationErrorDto>(),
+                ErrorMessage = result.ErrorMessage ?? string.Empty,
+                Timings = result.Timings != null ? new List<string>(result.Timings) : new List<string>()
+            };
+
+            if (!result.Success)
+            {
+                ApplyFailureResponseDetails(response, result);
+            }
+
+            if (result.Exception != null)
+            {
+                ApplyExceptionResponseDetails(response, result.Exception);
+            }
+
+            if (result.AutoInjectedNamespaces != null && result.AutoInjectedNamespaces.Count > 0)
+            {
+                AddAutoInjectedNamespaceHint(response, result.AutoInjectedNamespaces);
+            }
+
+            return response;
+        }
+
+        private void ApplyFailureResponseDetails(
+            ExecuteDynamicCodeResponse response,
+            ExecutionResult result)
+        {
+            DynamicCodeFriendlyError friendlyError = _friendlyErrorConverter.Convert(result);
+            response.ErrorMessage = friendlyError.FriendlyMessage;
+            response.Logs = result.Logs != null ? new List<string>(result.Logs) : new List<string>();
+            AddFriendlyFailureDetails(response.Logs, friendlyError);
+            ApplyCompilationDiagnostics(response, result);
+            response.UpdatedCode = result.UpdatedCode ?? response.UpdatedCode;
+        }
+
+        private static void ApplyCompilationDiagnostics(
+            ExecuteDynamicCodeResponse response,
+            ExecutionResult result)
+        {
+            if (result.CompilationErrors?.Any() != true)
+            {
+                return;
+            }
+
+            response.Diagnostics = BuildDiagnostics(
+                result.CompilationErrors,
+                result.UpdatedCode,
+                result.AmbiguousTypeCandidates);
+            response.CompilationErrors = response.Diagnostics;
+            response.DiagnosticsSummary = CreateDiagnosticsSummary(response.Diagnostics);
+            response.Logs.Add(response.DiagnosticsSummary);
+        }
+
+        private static string CreateDiagnosticsSummary(List<CompilationErrorDto> diagnostics)
+        {
+            int total = diagnostics.Count;
+            int unique = diagnostics
+                .GroupBy(error => new { error.Line, error.Column, error.ErrorCode, error.Message })
+                .Count();
+            CompilationErrorDto first = diagnostics.First();
+            return $"Errors: {unique} unique ({total} total). First at L{first.Line}: {first.ErrorCode} {first.Message}";
+        }
+
+        private static void ApplyExceptionResponseDetails(
+            ExecuteDynamicCodeResponse response,
+            Exception exception)
+        {
+            response.Logs ??= new List<string>();
+            response.Logs.Add($"Exception: {exception.Message}");
+            if (!string.IsNullOrEmpty(exception.StackTrace))
+            {
+                response.Logs.Add($"Stack Trace: {exception.StackTrace}");
+            }
+        }
+
+        private static void AddAutoInjectedNamespaceHint(
+            ExecuteDynamicCodeResponse response,
+            List<string> autoInjectedNamespaces)
+        {
+            response.Logs ??= new List<string>();
+            string usingList = string.Join(" ", autoInjectedNamespaces.Select(ns => $"using {ns};"));
+            response.Logs.Add(
+                $"Performance hint: Auto-resolved {autoInjectedNamespaces.Count} missing using directive(s): "
+                + $"{usingList} — Include them in your code to skip auto-resolution and improve compilation speed.");
+        }
+
+        private static void AddFriendlyFailureDetails(
+            List<string> logs,
+            DynamicCodeFriendlyError friendlyError)
+        {
+            System.Diagnostics.Debug.Assert(logs != null, "logs must not be null");
+            System.Diagnostics.Debug.Assert(friendlyError != null, "friendlyError must not be null");
+
+            AddLogIfNotEmpty(logs, "Explanation: ", friendlyError.Explanation);
+            AddLogIfNotEmpty(logs, "Example: ", friendlyError.Example);
+
+            if (friendlyError.SuggestedSolutions.Count == 0)
+            {
+                return;
+            }
+
+            logs.Add("Solutions:");
+            foreach (string solution in friendlyError.SuggestedSolutions)
+            {
+                logs.Add("- " + solution);
+            }
+        }
+
+        private static void AddLogIfNotEmpty(List<string> logs, string prefix, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+
+            logs.Add(prefix + value);
+        }
+
+        private static List<CompilationErrorDto> BuildDiagnostics(
+            List<CompilationError> errors,
+            string updatedCode,
+            Dictionary<string, List<string>> ambiguousCandidates = null)
+        {
+            List<CompilationErrorDto> list = new();
+            string[] lines = string.IsNullOrEmpty(updatedCode)
+                ? Array.Empty<string>()
+                : updatedCode.Split(new[] { '\n' }, StringSplitOptions.None);
+
+            foreach (CompilationError error in errors)
+            {
+                (string hint, List<string> suggestions) = GetHintAndSuggestions(error, ambiguousCandidates);
+                string context = ExtractContext(lines, error.Line, error.Column);
+                list.Add(new CompilationErrorDto
+                {
+                    Line = error.Line,
+                    Column = error.Column,
+                    Message = error.Message,
+                    ErrorCode = error.ErrorCode,
+                    Hint = hint,
+                    Suggestions = suggestions,
+                    Context = context,
+                    PointerColumn = error.Column
+                });
+            }
+
+            return list
+                .GroupBy(diagnostic => new
+                {
+                    diagnostic.Line,
+                    diagnostic.Column,
+                    diagnostic.ErrorCode,
+                    diagnostic.Message
+                })
+                .Select(group => group.First())
+                .ToList();
+        }
+
+        private static (string hint, List<string> suggestions) GetHintAndSuggestions(
+            CompilationError error,
+            Dictionary<string, List<string>> ambiguousCandidates = null)
+        {
+            string hint = string.Empty;
+            List<string> suggestions = new();
+
+            switch (error.ErrorCode)
+            {
+                case "CS0246":
+                    string typeName = CompilationDiagnosticMessageParser.ExtractTypeNameFromMessage(error.Message);
+                    if (typeName != null
+                        && ambiguousCandidates != null
+                        && ambiguousCandidates.TryGetValue(typeName, out List<string> candidates))
+                    {
+                        string candidateList = string.Join(", ", candidates);
+                        hint = $"Auto-using resolution found multiple candidates for '{typeName}': {candidateList}. Use a fully-qualified name or add the correct using directive.";
+                        foreach (string ns in candidates)
+                        {
+                            suggestions.Add($"Use {ns}.{typeName}");
+                        }
+
+                        return (hint, suggestions);
+                    }
+
+                    hint = "Auto-using resolution was attempted but could not resolve this identifier. Use a fully-qualified name (e.g., UnityEngine.Mathf) or add the correct using directive.";
+                    suggestions.Add("Use fully-qualified name (e.g., UnityEngine.Mathf, System.Linq.Enumerable)");
+                    suggestions.Add("Add the appropriate using directive at the top of the snippet");
+                    return (hint, suggestions);
+
+                case "CS0103":
+                    string identifierName = CompilationDiagnosticMessageParser.ExtractTypeNameFromMessage(error.Message);
+                    if (identifierName != null
+                        && ambiguousCandidates != null
+                        && ambiguousCandidates.TryGetValue(identifierName, out List<string> identifierCandidates))
+                    {
+                        string candidateList = string.Join(", ", identifierCandidates);
+                        hint = $"Auto-using resolution found multiple candidates for '{identifierName}': {candidateList}. Use a fully-qualified name or add the correct using directive.";
+                        foreach (string ns in identifierCandidates)
+                        {
+                            suggestions.Add($"Use {ns}.{identifierName}");
+                        }
+
+                        return (hint, suggestions);
+                    }
+
+                    hint = "Identifier does not exist in the current context. Check spelling, declaration scope, and whether this should be a type name.";
+                    suggestions.Add("Declare the identifier before use");
+                    suggestions.Add("If this is a type name, use a fully-qualified name or add the correct using directive");
+                    return (hint, suggestions);
+
+                case "CS0104":
+                    hint = "Identifier is ambiguous; qualify explicitly (e.g., UnityEngine.Object).";
+                    suggestions.Add("Qualify with full namespace (e.g., UnityEngine.Object)");
+                    return (hint, suggestions);
+
+                default:
+                    return (hint, suggestions);
+            }
+        }
+
+        private static string ExtractContext(
+            string[] lines,
+            int lineNumber1Based,
+            int column1Based)
+        {
+            if (lines == null || lines.Length == 0 || lineNumber1Based <= 0 || lineNumber1Based > lines.Length)
+            {
+                return string.Empty;
+            }
+
+            int start = Math.Max(1, lineNumber1Based - 3);
+            int end = Math.Min(lines.Length, lineNumber1Based + 3);
+            StringBuilder sb = new();
+            for (int i = start; i <= end; i++)
+            {
+                string line = lines[i - 1].TrimEnd('\r');
+                string linePrefix = $"L{i}:";
+                sb.AppendLine(linePrefix + line);
+                if (i == lineNumber1Based)
+                {
+                    int caretPos = Math.Max(1, column1Based);
+                    sb.AppendLine(
+                        new string(' ', linePrefix.Length)
+                        + new string(' ', Math.Max(0, caretPos - 1))
+                        + "^");
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e6c1d830d6c48e0b8695c01e082dabd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,12 +15,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class ExecuteDynamicCodeUseCase : IExecuteDynamicCodeUseCase
     {
         private readonly IDynamicCodeExecutionRuntime _runtime;
-        private readonly DynamicCodeFriendlyErrorConverter _friendlyErrorConverter;
+        private readonly DynamicCodeExecutionResponseFactory _responseFactory;
 
         public ExecuteDynamicCodeUseCase(IDynamicCodeExecutionRuntime runtime)
         {
             _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
-            _friendlyErrorConverter = new DynamicCodeFriendlyErrorConverter();
+            _responseFactory = new DynamicCodeExecutionResponseFactory();
         }
 
         public async Task<ExecuteDynamicCodeResponse> ExecuteAsync(
@@ -60,9 +59,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     DynamicCodeForegroundWarmupState.MarkCompletedBySuccessfulExecution();
                 }
 
-                if (IsCancelledResult(finalResult))
+                if (DynamicCodeExecutionResponseFactory.IsCancelledResult(finalResult))
                 {
-                    ExecuteDynamicCodeResponse cancelledResponse = CreateCancelledResponse();
+                    ExecuteDynamicCodeResponse cancelledResponse =
+                        DynamicCodeExecutionResponseFactory.CreateCancelledResponse();
                     cancelledResponse.Logs = finalResult.Logs ?? cancelledResponse.Logs;
                     cancelledResponse.Timings = finalResult.Timings != null
                         ? new List<string>(finalResult.Timings)
@@ -71,7 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return cancelledResponse;
                 }
 
-                ExecuteDynamicCodeResponse response = ConvertExecutionResultToResponse(finalResult);
+                ExecuteDynamicCodeResponse response = _responseFactory.ConvertExecutionResultToResponse(finalResult);
                 response.EmitTimingsInJsonResponse = parameters.IncludeTimings;
                 // Why: domain-reload timeouts can complete while Unity's synchronization context is stalled.
                 bool domainReloadWaitRequired =
@@ -81,7 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             catch (OperationCanceledException)
             {
-                ExecuteDynamicCodeResponse response = CreateCancelledResponse();
+                ExecuteDynamicCodeResponse response = DynamicCodeExecutionResponseFactory.CreateCancelledResponse();
                 response.EmitTimingsInJsonResponse = parameters?.IncludeTimings ?? false;
                 return response;
             }
@@ -312,283 +312,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 && !parameters.CompileOnly
                 && executionResult != null
                 && executionResult.Success;
-        }
-
-        private static bool IsCancelledResult(ExecutionResult executionResult)
-        {
-            return executionResult != null
-                && !executionResult.Success
-                && string.Equals(
-                    executionResult.ErrorMessage,
-                    UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED,
-                    StringComparison.Ordinal);
-        }
-
-        private static ExecuteDynamicCodeResponse CreateCancelledResponse()
-        {
-            return new ExecuteDynamicCodeResponse
-            {
-                Success = false,
-                Result = string.Empty,
-                Logs = new List<string> { "Execution cancelled" },
-                CompilationErrors = new List<CompilationErrorDto>(),
-                ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED
-            };
-        }
-
-        private ExecuteDynamicCodeResponse ConvertExecutionResultToResponse(ExecutionResult result)
-        {
-            ExecuteDynamicCodeResponse response = new()            {
-                Success = result.Success,
-                Result = result.Result?.ToString() ?? string.Empty,
-                Logs = result.Logs ?? new List<string>(),
-                CompilationErrors = new List<CompilationErrorDto>(),
-                ErrorMessage = result.ErrorMessage ?? string.Empty,
-                Timings = result.Timings != null ? new List<string>(result.Timings) : new List<string>()
-            };
-
-            if (!result.Success)
-            {
-                ApplyFailureResponseDetails(response, result);
-            }
-
-            if (result.Exception != null)
-            {
-                ApplyExceptionResponseDetails(response, result.Exception);
-            }
-
-            if (result.AutoInjectedNamespaces != null && result.AutoInjectedNamespaces.Count > 0)
-            {
-                AddAutoInjectedNamespaceHint(response, result.AutoInjectedNamespaces);
-            }
-
-            return response;
-        }
-
-        private void ApplyFailureResponseDetails(
-            ExecuteDynamicCodeResponse response,
-            ExecutionResult result)
-        {
-            DynamicCodeFriendlyError friendlyError = _friendlyErrorConverter.Convert(result);
-            response.ErrorMessage = friendlyError.FriendlyMessage;
-            response.Logs = result.Logs != null ? new List<string>(result.Logs) : new List<string>();
-            AddFriendlyFailureDetails(response.Logs, friendlyError);
-            ApplyCompilationDiagnostics(response, result);
-            response.UpdatedCode = result.UpdatedCode ?? response.UpdatedCode;
-        }
-
-        private static void ApplyCompilationDiagnostics(
-            ExecuteDynamicCodeResponse response,
-            ExecutionResult result)
-        {
-            if (result.CompilationErrors?.Any() != true)
-            {
-                return;
-            }
-
-            response.Diagnostics = BuildDiagnostics(
-                result.CompilationErrors,
-                result.UpdatedCode,
-                result.AmbiguousTypeCandidates);
-            response.CompilationErrors = response.Diagnostics;
-            response.DiagnosticsSummary = CreateDiagnosticsSummary(response.Diagnostics);
-            response.Logs.Add(response.DiagnosticsSummary);
-        }
-
-        private static string CreateDiagnosticsSummary(List<CompilationErrorDto> diagnostics)
-        {
-            int total = diagnostics.Count;
-            int unique = diagnostics
-                .GroupBy(error => new { error.Line, error.Column, error.ErrorCode, error.Message })
-                .Count();
-            CompilationErrorDto first = diagnostics.First();
-            return $"Errors: {unique} unique ({total} total). First at L{first.Line}: {first.ErrorCode} {first.Message}";
-        }
-
-        private static void ApplyExceptionResponseDetails(
-            ExecuteDynamicCodeResponse response,
-            Exception exception)
-        {
-            response.Logs ??= new List<string>();
-            response.Logs.Add($"Exception: {exception.Message}");
-            if (!string.IsNullOrEmpty(exception.StackTrace))
-            {
-                response.Logs.Add($"Stack Trace: {exception.StackTrace}");
-            }
-        }
-
-        private static void AddAutoInjectedNamespaceHint(
-            ExecuteDynamicCodeResponse response,
-            List<string> autoInjectedNamespaces)
-        {
-            response.Logs ??= new List<string>();
-            string usingList = string.Join(" ", autoInjectedNamespaces.Select(ns => $"using {ns};"));
-            response.Logs.Add(
-                $"Performance hint: Auto-resolved {autoInjectedNamespaces.Count} missing using directive(s): "
-                + $"{usingList} — Include them in your code to skip auto-resolution and improve compilation speed.");
-        }
-
-        private static void AddFriendlyFailureDetails(
-            List<string> logs,
-            DynamicCodeFriendlyError friendlyError)
-        {
-            System.Diagnostics.Debug.Assert(logs != null, "logs must not be null");
-            System.Diagnostics.Debug.Assert(friendlyError != null, "friendlyError must not be null");
-
-            AddLogIfNotEmpty(logs, "Explanation: ", friendlyError.Explanation);
-            AddLogIfNotEmpty(logs, "Example: ", friendlyError.Example);
-
-            if (friendlyError.SuggestedSolutions.Count == 0)
-            {
-                return;
-            }
-
-            logs.Add("Solutions:");
-            foreach (string solution in friendlyError.SuggestedSolutions)
-            {
-                logs.Add("- " + solution);
-            }
-        }
-
-        private static void AddLogIfNotEmpty(List<string> logs, string prefix, string value)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                return;
-            }
-
-            logs.Add(prefix + value);
-        }
-
-        private static List<CompilationErrorDto> BuildDiagnostics(
-            List<CompilationError> errors,
-            string updatedCode,
-            Dictionary<string, List<string>> ambiguousCandidates = null)
-        {
-            List<CompilationErrorDto> list = new();
-            string[] lines = string.IsNullOrEmpty(updatedCode)
-                ? Array.Empty<string>()
-                : updatedCode.Split(new[] { '\n' }, StringSplitOptions.None);
-
-            foreach (CompilationError error in errors)
-            {
-                (string hint, List<string> suggestions) = GetHintAndSuggestions(error, ambiguousCandidates);
-                string context = ExtractContext(lines, error.Line, error.Column);
-                list.Add(new CompilationErrorDto
-                {
-                    Line = error.Line,
-                    Column = error.Column,
-                    Message = error.Message,
-                    ErrorCode = error.ErrorCode,
-                    Hint = hint,
-                    Suggestions = suggestions,
-                    Context = context,
-                    PointerColumn = error.Column
-                });
-            }
-
-            return list
-                .GroupBy(diagnostic => new
-                {
-                    diagnostic.Line,
-                    diagnostic.Column,
-                    diagnostic.ErrorCode,
-                    diagnostic.Message
-                })
-                .Select(group => group.First())
-                .ToList();
-        }
-
-        private static (string hint, List<string> suggestions) GetHintAndSuggestions(
-            CompilationError error,
-            Dictionary<string, List<string>> ambiguousCandidates = null)
-        {
-            string hint = string.Empty;
-            List<string> suggestions = new();
-
-            switch (error.ErrorCode)
-            {
-                case "CS0246":
-                    string typeName = CompilationDiagnosticMessageParser.ExtractTypeNameFromMessage(error.Message);
-                    if (typeName != null
-                        && ambiguousCandidates != null
-                        && ambiguousCandidates.TryGetValue(typeName, out List<string> candidates))
-                    {
-                        string candidateList = string.Join(", ", candidates);
-                        hint = $"Auto-using resolution found multiple candidates for '{typeName}': {candidateList}. Use a fully-qualified name or add the correct using directive.";
-                        foreach (string ns in candidates)
-                        {
-                            suggestions.Add($"Use {ns}.{typeName}");
-                        }
-
-                        return (hint, suggestions);
-                    }
-
-                    hint = "Auto-using resolution was attempted but could not resolve this identifier. Use a fully-qualified name (e.g., UnityEngine.Mathf) or add the correct using directive.";
-                    suggestions.Add("Use fully-qualified name (e.g., UnityEngine.Mathf, System.Linq.Enumerable)");
-                    suggestions.Add("Add the appropriate using directive at the top of the snippet");
-                    return (hint, suggestions);
-
-                case "CS0103":
-                    string identifierName = CompilationDiagnosticMessageParser.ExtractTypeNameFromMessage(error.Message);
-                    if (identifierName != null
-                        && ambiguousCandidates != null
-                        && ambiguousCandidates.TryGetValue(identifierName, out List<string> identifierCandidates))
-                    {
-                        string candidateList = string.Join(", ", identifierCandidates);
-                        hint = $"Auto-using resolution found multiple candidates for '{identifierName}': {candidateList}. Use a fully-qualified name or add the correct using directive.";
-                        foreach (string ns in identifierCandidates)
-                        {
-                            suggestions.Add($"Use {ns}.{identifierName}");
-                        }
-
-                        return (hint, suggestions);
-                    }
-
-                    hint = "Identifier does not exist in the current context. Check spelling, declaration scope, and whether this should be a type name.";
-                    suggestions.Add("Declare the identifier before use");
-                    suggestions.Add("If this is a type name, use a fully-qualified name or add the correct using directive");
-                    return (hint, suggestions);
-
-                case "CS0104":
-                    hint = "Identifier is ambiguous; qualify explicitly (e.g., UnityEngine.Object).";
-                    suggestions.Add("Qualify with full namespace (e.g., UnityEngine.Object)");
-                    return (hint, suggestions);
-
-                default:
-                    return (hint, suggestions);
-            }
-        }
-
-        private static string ExtractContext(
-            string[] lines,
-            int lineNumber1Based,
-            int column1Based)
-        {
-            if (lines == null || lines.Length == 0 || lineNumber1Based <= 0 || lineNumber1Based > lines.Length)
-            {
-                return string.Empty;
-            }
-
-            int start = Math.Max(1, lineNumber1Based - 3);
-            int end = Math.Min(lines.Length, lineNumber1Based + 3);
-            StringBuilder sb = new();
-            for (int i = start; i <= end; i++)
-            {
-                string line = lines[i - 1].TrimEnd('\r');
-                string linePrefix = $"L{i}:";
-                sb.AppendLine(linePrefix + line);
-                if (i == lineNumber1Based)
-                {
-                    int caretPos = Math.Max(1, column1Based);
-                    sb.AppendLine(
-                        new string(' ', linePrefix.Length)
-                        + new string(' ', Math.Max(0, caretPos - 1))
-                        + "^");
-                }
-            }
-
-            return sb.ToString();
         }
 
         private static string AppendReturnIfMissing(string originalCode)


### PR DESCRIPTION
Refs: Refactor round 3 ToDo R3-3

## Summary
- Preserve dynamic-code response fields and messages while isolating result-to-response conversion.
- Add direct synchronous coverage for success, diagnostics, friendly guidance, exceptions, namespace hints, and cancellation.

## User Impact
- Execute Dynamic Code responses, diagnostics, and cancellation behavior remain unchanged.
- Response construction now has one focused owner, reducing risk in future diagnostics changes.

## Changes
- Extract an instance response factory with an immutable friendly-error converter dependency.
- Delegate normal and cancelled response mapping from the use case.
- Keep real compile-and-run execution out of the new tests.

## Verification
- Baseline ExecuteDynamicCodeUseCaseTests: 22 passed.
- Red: 6 expected missing-factory compile errors.
- Unity compile: 0 errors, 0 warnings.
- New response factory tests: 5 passed.
- Response factory and use case tests: 27 passed.
- Normalized move diff: implementation bodies preserved; residuals limited to four factory dispatch replacements.
- IPC protocol version unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

