### PR TITLE
chore: simplify dynamic code missing-return recovery

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeMissingReturnRetryPolicyTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeMissingReturnRetryPolicyTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Characterizes missing-return retry decisions and transformations before policy extraction.
+    /// </summary>
+    [TestFixture]
+    public sealed class DynamicCodeMissingReturnRetryPolicyTests
+    {
+        /// <summary>
+        /// Verifies compiler codes and log fallbacks identify only missing-return failures.
+        /// </summary>
+        [Test]
+        public void LooksLikeMissingReturn_WithCompilerAndLogSignals_RecognizesSupportedPatterns()
+        {
+            ExecutionResult compilerResult = new()
+            {
+                CompilationErrors = new List<CompilationError>
+                {
+                    new CompilationError { ErrorCode = "CS0161" }
+                }
+            };
+            ExecutionResult logResult = new()
+            {
+                Logs = new List<string> { "CS0127: Since the method returns void" }
+            };
+            ExecutionResult unrelatedResult = new()
+            {
+                Logs = new List<string> { "CS0103: The name does not exist" }
+            };
+
+            Assert.That(DynamicCodeMissingReturnRetryPolicy.LooksLikeMissingReturn(compilerResult), Is.True);
+            Assert.That(DynamicCodeMissingReturnRetryPolicy.LooksLikeMissingReturn(logResult), Is.True);
+            Assert.That(DynamicCodeMissingReturnRetryPolicy.LooksLikeMissingReturn(unrelatedResult), Is.False);
+        }
+
+        /// <summary>
+        /// Verifies retries remain limited to script-style top-level snippets.
+        /// </summary>
+        [TestCase("int value = 1;", true)]
+        [TestCase("namespace Sample { class Value {} }", false)]
+        [TestCase("public class Value { public int Run() => 1; }", false)]
+        public void CanRetryMissingReturn_WithSourceShape_ReturnsExpectedDecision(
+            string code,
+            bool expected)
+        {
+            bool actual = DynamicCodeMissingReturnRetryPolicy.CanRetryMissingReturn(code);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// Verifies return insertion preserves existing semicolons and appends the exact fallback statement.
+        /// </summary>
+        [TestCase("int value = 1", "int value = 1;\nreturn null;")]
+        [TestCase("int value = 1;", "int value = 1;\nreturn null;")]
+        [TestCase("int value = 1;  ", "int value = 1;  \nreturn null;")]
+        public void AppendReturnIfMissing_WithCode_AppendsExactFallback(
+            string code,
+            string expected)
+        {
+            string actual = DynamicCodeMissingReturnRetryPolicy.AppendReturnIfMissing(code);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// Verifies original and retry logs retain their order without mutating the original list.
+        /// </summary>
+        [Test]
+        public void MergeLogs_WithOriginalAndRetryLogs_PreservesOrderAndInputs()
+        {
+            List<string> originalLogs = new() { "initial-1", "initial-2" };
+            List<string> retryLogs = new() { "retry-1", "retry-2" };
+
+            List<string> mergedLogs = DynamicCodeMissingReturnRetryPolicy.MergeLogs(originalLogs, retryLogs);
+            List<string> retryOnlyLogs = DynamicCodeMissingReturnRetryPolicy.MergeLogs(null, retryLogs);
+            List<string> originalOnlyLogs = DynamicCodeMissingReturnRetryPolicy.MergeLogs(originalLogs, null);
+
+            Assert.That(mergedLogs, Is.EqualTo(new[] { "initial-1", "initial-2", "retry-1", "retry-2" }));
+            Assert.That(retryOnlyLogs, Is.EqualTo(retryLogs));
+            Assert.That(originalOnlyLogs, Is.EqualTo(originalLogs));
+            Assert.That(originalLogs, Is.EqualTo(new[] { "initial-1", "initial-2" }));
+        }
+
+        /// <summary>
+        /// Verifies successful initial results bypass the retry delegate.
+        /// </summary>
+        [Test]
+        public async Task RetryMissingReturnIfNeeded_WhenInitialResultSucceeds_DoesNotInvokeDelegate()
+        {
+            ExecutionResult initialResult = new() { Success = true, Result = "done" };
+            int invocationCount = 0;
+            Func<string, CancellationToken, Task<ExecutionResult>> executeRetryAsync = (code, ct) =>
+            {
+                invocationCount++;
+                return Task.FromResult(new ExecutionResult { Success = true });
+            };
+
+            ExecutionResult result = await DynamicCodeMissingReturnRetryPolicy.RetryMissingReturnIfNeeded(
+                initialResult,
+                "return 1;",
+                executeRetryAsync,
+                CancellationToken.None);
+
+            Assert.That(result, Is.SameAs(initialResult));
+            Assert.That(invocationCount, Is.Zero);
+        }
+
+        /// <summary>
+        /// Verifies retry execution receives appended code and failed retry logs follow original logs.
+        /// </summary>
+        [Test]
+        public async Task RetryMissingReturnIfNeeded_WhenRetryFails_PassesCodeAndMergesLogs()
+        {
+            ExecutionResult initialResult = new()
+            {
+                Success = false,
+                CompilationErrors = new List<CompilationError>
+                {
+                    new CompilationError { ErrorCode = "CS0161" }
+                },
+                Logs = new List<string> { "initial failure" }
+            };
+            ExecutionResult retryResult = new()
+            {
+                Success = false,
+                Logs = new List<string> { "retry failure" }
+            };
+            string capturedCode = null;
+            Func<string, CancellationToken, Task<ExecutionResult>> executeRetryAsync = (code, ct) =>
+            {
+                capturedCode = code;
+                return Task.FromResult(retryResult);
+            };
+
+            ExecutionResult result = await DynamicCodeMissingReturnRetryPolicy.RetryMissingReturnIfNeeded(
+                initialResult,
+                "int value = 1",
+                executeRetryAsync,
+                CancellationToken.None);
+
+            Assert.That(result, Is.SameAs(retryResult));
+            Assert.That(capturedCode, Is.EqualTo("int value = 1;\nreturn null;"));
+            Assert.That(result.Logs, Is.EqualTo(new[] { "initial failure", "retry failure" }));
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeMissingReturnRetryPolicyTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeMissingReturnRetryPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ac137311d0742539d4599d7a6fe1542
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -67,7 +67,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputMotionActionExecutor.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputMainThreadCleanup.cs",
-            "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs"
+            "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs",
+            "Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeMissingReturnRetryPolicy.cs"
         };
 
         private static readonly Dictionary<string, string[]> OverloadGuardMethodsByPath = new Dictionary<string, string[]>
@@ -323,13 +324,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Tests that timeout-sensitive dynamic-code awaits do not capture Unity's synchronization context.
             string source = ReadSourceFile(
                 "Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs");
+            string retryPolicySource = ReadSourceFile(
+                "Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeMissingReturnRetryPolicy.cs");
 
             Assert.That(source, Does.Contain("await WarmForegroundExecutionPathIfNeededAsync(parameters, cancellationToken)\n                    .ConfigureAwait(false);"));
             Assert.That(source, Does.Contain("await ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false);"));
-            Assert.That(source, Does.Contain("await RetryMissingReturnIfNeeded(\n                    executionResult,"));
+            Assert.That(source, Does.Contain("await DynamicCodeMissingReturnRetryPolicy.RetryMissingReturnIfNeeded(\n                    executionResult,"));
             Assert.That(source, Does.Contain("cancellationToken).ConfigureAwait(false);"));
             Assert.That(source, Does.Contain("await _runtime.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);"));
             Assert.That(source, Does.Contain("await _runtime.TryExecuteIfIdleAsync(\n                request,\n                cancellationToken).ConfigureAwait(false);"));
+            Assert.That(
+                retryPolicySource,
+                Does.Contain("await executeRetryAsync(codeWithReturn, ct)\n                .ConfigureAwait(false);"));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeMissingReturnRetryPolicy.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeMissingReturnRetryPolicy.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Decides when missing-return failures can be retried and combines retry results.
+    /// </summary>
+    internal static class DynamicCodeMissingReturnRetryPolicy
+    {
+        internal static async Task<ExecutionResult> RetryMissingReturnIfNeeded(
+            ExecutionResult executionResult,
+            string originalCode,
+            Func<string, CancellationToken, Task<ExecutionResult>> executeRetryAsync,
+            CancellationToken ct)
+        {
+            if (executionResult.Success)
+            {
+                return executionResult;
+            }
+
+            bool looksLikeMissingReturn = LooksLikeMissingReturn(executionResult);
+            if (!looksLikeMissingReturn || !CanRetryMissingReturn(originalCode))
+            {
+                return executionResult;
+            }
+
+            string codeWithReturn = AppendReturnIfMissing(originalCode);
+            ExecutionResult retryResult = await executeRetryAsync(codeWithReturn, ct)
+                .ConfigureAwait(false);
+            if (retryResult.Success)
+            {
+                return retryResult;
+            }
+
+            if (retryResult.Logs?.Any() == true)
+            {
+                retryResult.Logs = MergeLogs(executionResult.Logs, retryResult.Logs);
+            }
+            else
+            {
+                retryResult.Logs = CloneLogs(executionResult.Logs);
+            }
+
+            return retryResult;
+        }
+
+        internal static List<string> MergeLogs(List<string> originalLogs, List<string> retryLogs)
+        {
+            List<string> mergedLogs = CloneLogs(originalLogs);
+            if (retryLogs == null || retryLogs.Count == 0)
+            {
+                return mergedLogs;
+            }
+
+            if (mergedLogs == null)
+            {
+                return new List<string>(retryLogs);
+            }
+
+            mergedLogs.AddRange(retryLogs);
+            return mergedLogs;
+        }
+
+        private static List<string> CloneLogs(List<string> logs)
+        {
+            return logs == null ? null : new List<string>(logs);
+        }
+
+        internal static bool LooksLikeMissingReturn(ExecutionResult executionResult)
+        {
+            if (executionResult.CompilationErrors?.Any() == true)
+            {
+                return executionResult.CompilationErrors.Any(error =>
+                    error.ErrorCode == "CS0161" || error.ErrorCode == "CS0127");
+            }
+
+            if (executionResult.Logs?.Any() == true)
+            {
+                return executionResult.Logs.Any(log =>
+                    log.Contains("CS0161") ||
+                    log.Contains("CS0127") ||
+                    log.Contains("must return a value"));
+            }
+
+            return false;
+        }
+
+        internal static bool CanRetryMissingReturn(string originalCode)
+        {
+            SourceShapeResult shape = SourceShaper.Analyze(originalCode ?? string.Empty);
+            return shape.HasTopLevelStatements
+                   && !shape.HasNamespaceDeclaration
+                   && !shape.HasTypeDeclaration;
+        }
+
+        internal static string AppendReturnIfMissing(string originalCode)
+        {
+            string code = originalCode ?? string.Empty;
+            string trimmed = code.TrimEnd();
+            bool endsWithSemicolon = trimmed.EndsWith(";");
+            string builder = endsWithSemicolon ? code : code + ";";
+            return builder + "\nreturn null;";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeMissingReturnRetryPolicy.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeMissingReturnRetryPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c0df45cb871405c839dde0e3bfec91c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -46,12 +46,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     .ConfigureAwait(false);
                 ExecutionResult executionResult = await ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
-                ExecutionResult finalResult = await RetryMissingReturnIfNeeded(
+                ExecutionResult finalResult = await DynamicCodeMissingReturnRetryPolicy.RetryMissingReturnIfNeeded(
                     executionResult,
                     originalCode,
-                    parametersArray,
-                    parameters.CompileOnly,
-                    parameters.YieldToForegroundRequests,
+                    (string retryCode, CancellationToken ct) => ExecuteRequestAsync(
+                        CreateExecutionRequest(
+                            retryCode,
+                            parametersArray,
+                            parameters.CompileOnly,
+                            parameters.YieldToForegroundRequests),
+                        ct),
                     cancellationToken).ConfigureAwait(false);
 
                 if (ShouldMarkExecutionPathWarm(parameters, finalResult))
@@ -130,99 +134,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 CompileOnly = compileOnly,
                 YieldToForegroundRequests = yieldToForegroundRequests
             };
-        }
-
-        private async Task<ExecutionResult> RetryMissingReturnIfNeeded(
-            ExecutionResult executionResult,
-            string originalCode,
-            object[] parameters,
-            bool compileOnly,
-            bool yieldToForegroundRequests,
-            CancellationToken cancellationToken)
-        {
-            if (executionResult.Success)
-            {
-                return executionResult;
-            }
-
-            bool looksLikeMissingReturn = LooksLikeMissingReturn(executionResult);
-            if (!looksLikeMissingReturn || !CanRetryMissingReturn(originalCode))
-            {
-                return executionResult;
-            }
-
-            string codeWithReturn = AppendReturnIfMissing(originalCode);
-            DynamicCodeExecutionRequest retryRequest = CreateExecutionRequest(
-                codeWithReturn,
-                parameters,
-                compileOnly,
-                yieldToForegroundRequests);
-            ExecutionResult retryResult = await ExecuteRequestAsync(retryRequest, cancellationToken)
-                .ConfigureAwait(false);
-            if (retryResult.Success)
-            {
-                return retryResult;
-            }
-
-            if (retryResult.Logs?.Any() == true)
-            {
-                retryResult.Logs = MergeLogs(executionResult.Logs, retryResult.Logs);
-            }
-            else
-            {
-                retryResult.Logs = CloneLogs(executionResult.Logs);
-            }
-
-            return retryResult;
-        }
-
-        private static List<string> MergeLogs(List<string> originalLogs, List<string> retryLogs)
-        {
-            List<string> mergedLogs = CloneLogs(originalLogs);
-            if (retryLogs == null || retryLogs.Count == 0)
-            {
-                return mergedLogs;
-            }
-
-            if (mergedLogs == null)
-            {
-                return new List<string>(retryLogs);
-            }
-
-            mergedLogs.AddRange(retryLogs);
-            return mergedLogs;
-        }
-
-        private static List<string> CloneLogs(List<string> logs)
-        {
-            return logs == null ? null : new List<string>(logs);
-        }
-
-        private static bool LooksLikeMissingReturn(ExecutionResult executionResult)
-        {
-            if (executionResult.CompilationErrors?.Any() == true)
-            {
-                return executionResult.CompilationErrors.Any(error =>
-                    error.ErrorCode == "CS0161" || error.ErrorCode == "CS0127");
-            }
-
-            if (executionResult.Logs?.Any() == true)
-            {
-                return executionResult.Logs.Any(log =>
-                    log.Contains("CS0161") ||
-                    log.Contains("CS0127") ||
-                    log.Contains("must return a value"));
-            }
-
-            return false;
-        }
-
-        private static bool CanRetryMissingReturn(string originalCode)
-        {
-            SourceShapeResult shape = SourceShaper.Analyze(originalCode ?? string.Empty);
-            return shape.HasTopLevelStatements
-                   && !shape.HasNamespaceDeclaration
-                   && !shape.HasTypeDeclaration;
         }
 
         private async Task<ExecutionResult> ExecuteRequestAsync(
@@ -314,13 +225,5 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 && executionResult.Success;
         }
 
-        private static string AppendReturnIfMissing(string originalCode)
-        {
-            string code = originalCode ?? string.Empty;
-            string trimmed = code.TrimEnd();
-            bool endsWithSemicolon = trimmed.EndsWith(";");
-            string builder = endsWithSemicolon ? code : code + ";";
-            return builder + "\nreturn null;";
-        }
     }
 }


### PR DESCRIPTION
Refs: Refactor round 3 ToDo R3-4

## Summary
- Preserve missing-return recovery while moving retry decisions and transformations into one policy.
- Add direct coverage for compiler signals, source-shape eligibility, code rewriting, delegate short-circuiting, and log ordering.

## User Impact
- Optional-return recovery behavior remains unchanged.
- The use case is now a focused 229-line orchestrator with retry policy owned separately.

## Changes
- Extract a stateless missing-return retry policy.
- Inject a non-async retry delegate that keeps request creation and runtime execution in the use case.
- Track the new async policy and its ConfigureAwait behavior with source guards.

## Verification
- Baseline dynamic-code tests: 27 passed.
- Red: 10 expected missing-policy compile errors.
- Unity compile: 0 errors, 0 warnings.
- New retry policy tests: 10 passed.
- StaticFacadeStateGuardTests: 20 passed.
- Head dynamic-code tests: 37 passed.
- Normalized move diff: pure logic bodies preserved; 12 residual lines are the approved delegate-boundary adaptation for the old signature, call site, request construction, and execution call.
- IPC protocol version unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

