### PR TITLE
Extract server recovery/bind-retry flow into UnityCliLoopServerRecoveryExecutor

### DIFF
--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -68,7 +68,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputMainThreadCleanup.cs",
             "Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs",
-            "Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeMissingReturnRetryPolicy.cs"
+            "Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeMissingReturnRetryPolicy.cs",
+            "Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryExecutor.cs"
         };
 
         private static readonly Dictionary<string, string[]> OverloadGuardMethodsByPath = new Dictionary<string, string[]>

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerController.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Net.Sockets;
 using UnityEditor;
-using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.Domain;
@@ -38,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         private readonly UnityCliLoopServerRecoveryTrackingService _recoveryTrackingService;
         private readonly IUnityCliLoopServerDomainReloadLifecycle _domainReloadLifecycle;
         private IUnityCliLoopServerInstance _bridgeServer;
-        private readonly SemaphoreSlim _startupSemaphore = new SemaphoreSlim(1, 1);
+        private readonly UnityCliLoopServerRecoveryExecutor _recoveryExecutor;
 
         internal UnityCliLoopServerControllerService(
             IUnityCliLoopServerInstanceFactory serverInstanceFactory,
@@ -82,9 +80,18 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             _startupProtectionService = startupProtectionService ?? throw new ArgumentNullException(nameof(startupProtectionService));
             _recoveryTrackingService = recoveryTrackingService ?? throw new ArgumentNullException(nameof(recoveryTrackingService));
             _domainReloadLifecycle = domainReloadLifecycle ?? throw new ArgumentNullException(nameof(domainReloadLifecycle));
+
+            _recoveryExecutor = new UnityCliLoopServerRecoveryExecutor(
+                serverInstanceFactory,
+                readinessService,
+                startupProtectionService,
+                sessionFlagsRepository,
+                toolRegistrarService,
+                () => _bridgeServer,
+                server => _bridgeServer = server);
         }
 
-        private bool IsBackgroundUnityProcess()
+        internal static bool IsBackgroundUnityProcess()
         {
             bool isAssetImportWorker = AssetDatabase.IsAssetImportWorkerProcess();
             return isAssetImportWorker;
@@ -363,158 +370,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         /// Centralized, coalesced recovery start.
         /// Attempts recovery on the project IPC endpoint for up to 5 seconds.
         /// </summary>
-        public async Task StartRecoveryIfNeededAsync(bool isAfterCompile, CancellationToken cancellationToken)
+        public Task StartRecoveryIfNeededAsync(bool isAfterCompile, CancellationToken cancellationToken)
         {
-            if (IsBackgroundUnityProcess())
-            {
-                VibeLogger.LogInfo("server_start_ignored", "background_process");
-                return;
-            }
-
-            if (_startupProtectionService.IsStartupProtectionActive())
-            {
-                VibeLogger.LogInfo("server_start_ignored", "startup_protection_active");
-                if (_bridgeServer?.IsRunning == true)
-                {
-                    await _readinessService.MarkServerReadyAsync("startup-protection-active", cancellationToken);
-                    return;
-                }
-
-                return;
-            }
-
-            VibeLogger.LogInfo("startup_request", "transport=project_ipc");
-
-            await _startupSemaphore.WaitAsync(cancellationToken);
-            try
-            {
-                // If any server is already running, ignore this request to prevent double-binding
-                if (_bridgeServer != null && _bridgeServer.IsRunning)
-                {
-                    VibeLogger.LogInfo("server_start_ignored", $"already_running endpoint={_bridgeServer.Endpoint}");
-                    await _readinessService.MarkServerReadyAsync("already-running", cancellationToken);
-                    return;
-                }
-
-                // Ensure previous instance is fully disposed before trying to bind a new one
-                if (_bridgeServer != null)
-                {
-                    try
-                    {
-                        _bridgeServer.Dispose();
-                        VibeLogger.LogInfo("server_disposed_before_bind", "disposed previous server instance");
-                    }
-                    catch (Exception ex)
-                    {
-                        VibeLogger.LogWarning("server_dispose_failed", ex.Message);
-                    }
-                    finally
-                    {
-                        _bridgeServer = null;
-                    }
-                }
-
-                bool started = await TryBindWithWaitAsync(
-                    5000,
-                    250,
-                    cancellationToken);
-
-                if (!started)
-                {
-                    // Ensure session reflects stopped state on failure
-                    _sessionFlagsRepository.ClearServerSession();
-                    _sessionFlagsRepository.ClearReconnectingFlags();
-                    string message = "Unity CLI Loop server recovery failed because the project IPC endpoint could not be bound within 5000ms.";
-                    Debug.LogError($"[{UnityCliLoopConstants.PROJECT_NAME}] {message}");
-                    throw new InvalidOperationException(message);
-                }
-
-                // Mark running and update settings
-                SaveRunningServerState();
-
-                // Clear reconnection-related flags on successful recovery
-                _sessionFlagsRepository.ClearReconnectingFlags();
-                _sessionFlagsRepository.ClearPostCompileReconnectingUI();
-                _toolRegistrarService.WarmupRegistry();
-                await _readinessService.MarkServerReadyAsync("server-recovery", cancellationToken);
-
-                _startupProtectionService.ActivateStartupProtection(5000);
-            }
-            finally
-            {
-                _startupSemaphore.Release();
-            }
-        }
-
-        private async Task<bool> TryBindWithWaitAsync(
-            int maxWaitMs,
-            int stepMs,
-            CancellationToken cancellationToken)
-        {
-            int remainingMs = maxWaitMs;
-            while (true)
-            {
-                VibeLogger.LogInfo("binding_attempt", "transport=project_ipc");
-                IUnityCliLoopServerInstance server = null;
-                try
-                {
-                    // Defensive: dispose any non-running stale instance before creating a new one
-                    if (_bridgeServer != null && !_bridgeServer.IsRunning)
-                    {
-                        try
-                        {
-                            _bridgeServer.Dispose();
-                            VibeLogger.LogInfo("server_disposed_before_bind", "disposed stale instance");
-                        }
-                        catch (Exception ex)
-                        {
-                            VibeLogger.LogWarning("server_dispose_failed", ex.Message);
-                        }
-                        finally
-                        {
-                            _bridgeServer = null;
-                        }
-                    }
-
-                    server = _serverInstanceFactory.Create();
-                    server.StartServer();
-                    _bridgeServer = server;
-                    VibeLogger.LogInfo(
-                        "binding_success",
-                        "Unity CLI Loop server bound the project IPC endpoint.",
-                        new { endpoint = server.Endpoint });
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Ensure partially created server is cleaned up on failure
-                    server?.Dispose();
-                    // Unwrap SocketException details if present
-                    SocketException sockEx = ex as SocketException;
-                    if (ex is InvalidOperationException && ex.InnerException is SocketException innerSock)
-                    {
-                        sockEx = innerSock;
-                    }
-
-                    if (sockEx != null)
-                    {
-                        VibeLogger.LogWarning("binding_failed", $"target=project_ipc code={sockEx.SocketErrorCode} hresult={sockEx.HResult} native={sockEx.ErrorCode}");
-                    }
-                    else
-                    {
-                        VibeLogger.LogWarning("binding_failed", $"target=project_ipc code=Unknown hresult={ex.HResult}");
-                    }
-
-                    if (remainingMs <= 0)
-                    {
-                        return false;
-                    }
-
-                    int delay = stepMs <= 0 ? remainingMs : Math.Min(stepMs, remainingMs);
-                    await TimerDelay.Wait(delay, cancellationToken);
-                    remainingMs -= delay;
-                }
-            }
+            return _recoveryExecutor.StartRecoveryIfNeededAsync(isAfterCompile, cancellationToken);
         }
 
         private void SaveRunningServerState()

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryExecutor.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryExecutor.cs
@@ -40,13 +40,13 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             System.Diagnostics.Debug.Assert(getBridgeServer != null, "getBridgeServer must not be null");
             System.Diagnostics.Debug.Assert(setBridgeServer != null, "setBridgeServer must not be null");
 
-            _serverInstanceFactory = serverInstanceFactory ?? throw new ArgumentNullException(nameof(serverInstanceFactory));
-            _readinessService = readinessService ?? throw new ArgumentNullException(nameof(readinessService));
-            _startupProtectionService = startupProtectionService ?? throw new ArgumentNullException(nameof(startupProtectionService));
-            _sessionFlagsRepository = sessionFlagsRepository ?? throw new ArgumentNullException(nameof(sessionFlagsRepository));
-            _toolRegistrarService = toolRegistrarService ?? throw new ArgumentNullException(nameof(toolRegistrarService));
-            _getBridgeServer = getBridgeServer ?? throw new ArgumentNullException(nameof(getBridgeServer));
-            _setBridgeServer = setBridgeServer ?? throw new ArgumentNullException(nameof(setBridgeServer));
+            _serverInstanceFactory = serverInstanceFactory;
+            _readinessService = readinessService;
+            _startupProtectionService = startupProtectionService;
+            _sessionFlagsRepository = sessionFlagsRepository;
+            _toolRegistrarService = toolRegistrarService;
+            _getBridgeServer = getBridgeServer;
+            _setBridgeServer = setBridgeServer;
         }
 
         /// <summary>

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryExecutor.cs
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryExecutor.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Executes the coalesced, bind-retry recovery flow that (re)binds the project IPC endpoint.
+    /// </summary>
+    internal sealed class UnityCliLoopServerRecoveryExecutor
+    {
+        private readonly IUnityCliLoopServerInstanceFactory _serverInstanceFactory;
+        private readonly UnityCliLoopServerReadinessService _readinessService;
+        private readonly UnityCliLoopServerStartupProtectionService _startupProtectionService;
+        private readonly ISessionFlagsRepository _sessionFlagsRepository;
+        private readonly UnityCliLoopToolRegistrarService _toolRegistrarService;
+        private readonly Func<IUnityCliLoopServerInstance> _getBridgeServer;
+        private readonly Action<IUnityCliLoopServerInstance> _setBridgeServer;
+        private readonly SemaphoreSlim _startupSemaphore = new SemaphoreSlim(1, 1);
+
+        internal UnityCliLoopServerRecoveryExecutor(
+            IUnityCliLoopServerInstanceFactory serverInstanceFactory,
+            UnityCliLoopServerReadinessService readinessService,
+            UnityCliLoopServerStartupProtectionService startupProtectionService,
+            ISessionFlagsRepository sessionFlagsRepository,
+            UnityCliLoopToolRegistrarService toolRegistrarService,
+            Func<IUnityCliLoopServerInstance> getBridgeServer,
+            Action<IUnityCliLoopServerInstance> setBridgeServer)
+        {
+            System.Diagnostics.Debug.Assert(serverInstanceFactory != null, "serverInstanceFactory must not be null");
+            System.Diagnostics.Debug.Assert(readinessService != null, "readinessService must not be null");
+            System.Diagnostics.Debug.Assert(startupProtectionService != null, "startupProtectionService must not be null");
+            System.Diagnostics.Debug.Assert(sessionFlagsRepository != null, "sessionFlagsRepository must not be null");
+            System.Diagnostics.Debug.Assert(toolRegistrarService != null, "toolRegistrarService must not be null");
+            System.Diagnostics.Debug.Assert(getBridgeServer != null, "getBridgeServer must not be null");
+            System.Diagnostics.Debug.Assert(setBridgeServer != null, "setBridgeServer must not be null");
+
+            _serverInstanceFactory = serverInstanceFactory ?? throw new ArgumentNullException(nameof(serverInstanceFactory));
+            _readinessService = readinessService ?? throw new ArgumentNullException(nameof(readinessService));
+            _startupProtectionService = startupProtectionService ?? throw new ArgumentNullException(nameof(startupProtectionService));
+            _sessionFlagsRepository = sessionFlagsRepository ?? throw new ArgumentNullException(nameof(sessionFlagsRepository));
+            _toolRegistrarService = toolRegistrarService ?? throw new ArgumentNullException(nameof(toolRegistrarService));
+            _getBridgeServer = getBridgeServer ?? throw new ArgumentNullException(nameof(getBridgeServer));
+            _setBridgeServer = setBridgeServer ?? throw new ArgumentNullException(nameof(setBridgeServer));
+        }
+
+        /// <summary>
+        /// Centralized, coalesced recovery start.
+        /// Attempts recovery on the project IPC endpoint for up to 5 seconds.
+        /// </summary>
+        internal async Task StartRecoveryIfNeededAsync(bool isAfterCompile, CancellationToken ct)
+        {
+            if (UnityCliLoopServerControllerService.IsBackgroundUnityProcess())
+            {
+                VibeLogger.LogInfo("server_start_ignored", "background_process");
+                return;
+            }
+
+            if (_startupProtectionService.IsStartupProtectionActive())
+            {
+                VibeLogger.LogInfo("server_start_ignored", "startup_protection_active");
+                if (_getBridgeServer()?.IsRunning == true)
+                {
+                    await _readinessService.MarkServerReadyAsync("startup-protection-active", ct);
+                    return;
+                }
+
+                return;
+            }
+
+            VibeLogger.LogInfo("startup_request", "transport=project_ipc");
+
+            await _startupSemaphore.WaitAsync(ct);
+            try
+            {
+                // If any server is already running, ignore this request to prevent double-binding
+                if (_getBridgeServer() != null && _getBridgeServer().IsRunning)
+                {
+                    VibeLogger.LogInfo("server_start_ignored", $"already_running endpoint={_getBridgeServer().Endpoint}");
+                    await _readinessService.MarkServerReadyAsync("already-running", ct);
+                    return;
+                }
+
+                // Ensure previous instance is fully disposed before trying to bind a new one
+                if (_getBridgeServer() != null)
+                {
+                    try
+                    {
+                        _getBridgeServer().Dispose();
+                        VibeLogger.LogInfo("server_disposed_before_bind", "disposed previous server instance");
+                    }
+                    catch (Exception ex)
+                    {
+                        VibeLogger.LogWarning("server_dispose_failed", ex.Message);
+                    }
+                    finally
+                    {
+                        _setBridgeServer(null);
+                    }
+                }
+
+                bool started = await TryBindWithWaitAsync(
+                    5000,
+                    250,
+                    ct);
+
+                if (!started)
+                {
+                    // Ensure session reflects stopped state on failure
+                    _sessionFlagsRepository.ClearServerSession();
+                    _sessionFlagsRepository.ClearReconnectingFlags();
+                    string message = "Unity CLI Loop server recovery failed because the project IPC endpoint could not be bound within 5000ms.";
+                    UnityEngine.Debug.LogError($"[{UnityCliLoopConstants.PROJECT_NAME}] {message}");
+                    throw new InvalidOperationException(message);
+                }
+
+                // Mark running and update settings
+                _sessionFlagsRepository.MarkServerStarted();
+
+                // Clear reconnection-related flags on successful recovery
+                _sessionFlagsRepository.ClearReconnectingFlags();
+                _sessionFlagsRepository.ClearPostCompileReconnectingUI();
+                _toolRegistrarService.WarmupRegistry();
+                await _readinessService.MarkServerReadyAsync("server-recovery", ct);
+
+                _startupProtectionService.ActivateStartupProtection(5000);
+            }
+            finally
+            {
+                _startupSemaphore.Release();
+            }
+        }
+
+        private async Task<bool> TryBindWithWaitAsync(
+            int maxWaitMs,
+            int stepMs,
+            CancellationToken ct)
+        {
+            int remainingMs = maxWaitMs;
+            while (true)
+            {
+                VibeLogger.LogInfo("binding_attempt", "transport=project_ipc");
+                IUnityCliLoopServerInstance server = null;
+                try
+                {
+                    // Defensive: dispose any non-running stale instance before creating a new one
+                    if (_getBridgeServer() != null && !_getBridgeServer().IsRunning)
+                    {
+                        try
+                        {
+                            _getBridgeServer().Dispose();
+                            VibeLogger.LogInfo("server_disposed_before_bind", "disposed stale instance");
+                        }
+                        catch (Exception ex)
+                        {
+                            VibeLogger.LogWarning("server_dispose_failed", ex.Message);
+                        }
+                        finally
+                        {
+                            _setBridgeServer(null);
+                        }
+                    }
+
+                    server = _serverInstanceFactory.Create();
+                    server.StartServer();
+                    _setBridgeServer(server);
+                    VibeLogger.LogInfo(
+                        "binding_success",
+                        "Unity CLI Loop server bound the project IPC endpoint.",
+                        new { endpoint = server.Endpoint });
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    // Ensure partially created server is cleaned up on failure
+                    server?.Dispose();
+                    // Unwrap SocketException details if present
+                    SocketException sockEx = ex as SocketException;
+                    if (ex is InvalidOperationException && ex.InnerException is SocketException innerSock)
+                    {
+                        sockEx = innerSock;
+                    }
+
+                    if (sockEx != null)
+                    {
+                        VibeLogger.LogWarning("binding_failed", $"target=project_ipc code={sockEx.SocketErrorCode} hresult={sockEx.HResult} native={sockEx.ErrorCode}");
+                    }
+                    else
+                    {
+                        VibeLogger.LogWarning("binding_failed", $"target=project_ipc code=Unknown hresult={ex.HResult}");
+                    }
+
+                    if (remainingMs <= 0)
+                    {
+                        return false;
+                    }
+
+                    int delay = stepMs <= 0 ? remainingMs : Math.Min(stepMs, remainingMs);
+                    await TimerDelay.Wait(delay, ct);
+                    remainingMs -= delay;
+                }
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryExecutor.cs.meta
+++ b/Packages/src/Editor/Infrastructure/Server/UnityCliLoopServerRecoveryExecutor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea3e506a5a0d482baa7f384c2d29c876
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Refs: R3-8 in the Unity CLI Loop Phase 2/3 refactor ToDo

## Summary
- `UnityCliLoopServerControllerService` mixed IPC lifecycle orchestration (start/stop/domain-reload handling) with the coalesced recovery/bind-retry algorithm (`StartRecoveryIfNeededAsync` + `TryBindWithWaitAsync`, ~150 lines).
- Extracted both methods into a new `internal sealed class UnityCliLoopServerRecoveryExecutor`, constructed once in the controller's constructor and wired via a thin one-line delegating wrapper.
- The only genuinely shared mutable state, `_bridgeServer`, is bridged with a `Func<IUnityCliLoopServerInstance> getBridgeServer` / `Action<IUnityCliLoopServerInstance> setBridgeServer` pair — everything else the executor needs was already an injected interface, so no other bridging was required.
- `IsBackgroundUnityProcess()` was promoted from `private` to `internal static` (it has zero instance-state dependencies — it only calls the static `AssetDatabase.IsAssetImportWorkerProcess()`), letting the executor call it directly without duplication or another delegate.
- `cancellationToken` parameter renamed to `ct` in the moved methods per project convention.

## Verification
- Pure-move check: normalized two-way diff (`sort -u` + `comm -23`/`comm -13`) between the pre-move file and the combined post-move files shows only the pre-approved adaptations (ct rename, `_bridgeServer` → delegate calls, `IsBackgroundUnityProcess` static-ization, and the new executor's DI wiring/wrapper) — no unrelated logic changes.
- `uloop compile` — 0 errors / 0 warnings.
- `uloop run-tests --filter-value 'UnityCliLoopServerControllerRecoveryTests'` — 23/23 pass, test file unmodified (public constructor signature of `UnityCliLoopServerControllerService` preserved, so the existing tests exercise the new code path unchanged).

## Test plan
- [x] `uloop compile` clean
- [x] `UnityCliLoopServerControllerRecoveryTests` 23/23 pass unmodified
- [x] Normalized diff confirms byte-equal behavior modulo approved adaptations

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

