### PR TITLE
fix: Dynamic code snippets now recognize bare Object and Random calls consistently

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/AutoInjectedNamespacesTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/AutoInjectedNamespacesTests.cs
@@ -16,7 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -28,7 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -40,7 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             string body = "int x = 42;\nreturn x;";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -52,7 +52,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             string body = "StringBuilder sb = new StringBuilder();\nRegex r = new Regex(\"x\");\nreturn sb.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -65,7 +65,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             List<string> usings = new() { "using System.Text;" };
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
-            string wrappedSource = WrapperTemplate.Build(usings, "TestNs", "TestClass", body);
+            string wrappedSource = WrapperTemplate.Build(usings, System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
@@ -47,6 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void Prepare_WhenScriptUsesBareUnityObject_ShouldAddObjectAlias()
         {
+            // Verifies a bare "Object" call resolves to UnityEngine.Object via an injected alias.
             PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
                 "GameObject go = new GameObject(\"source\");\nObject.Instantiate(go);\nreturn null;",
                 DynamicCodeConstants.DEFAULT_NAMESPACE,
@@ -59,6 +60,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void Prepare_WhenObjectAliasAlreadyExists_ShouldNotAddDuplicateAlias()
         {
+            // Verifies the default Object alias is not injected a second time when the user already declared it.
             PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
                 "using Object = UnityEngine.Object;\nObject.Instantiate(new GameObject(\"source\"));\nreturn null;",
                 DynamicCodeConstants.DEFAULT_NAMESPACE,
@@ -73,6 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void Prepare_WhenCustomObjectAliasAlreadyExists_ShouldRespectUserAlias()
         {
+            // Verifies a user-defined "Object" alias to a different type is preserved, not overridden by the default.
             PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
                 "using Object = System.Object;\nreturn new Object();",
                 DynamicCodeConstants.DEFAULT_NAMESPACE,
@@ -87,6 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void Prepare_WhenVerbatimObjectAliasAlreadyExists_ShouldRespectUserAlias()
         {
+            // Verifies a verbatim "@Object" alias is detected so the default Object alias is skipped.
             PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
                 "using @Object = System.Object;\nreturn new @Object();",
                 DynamicCodeConstants.DEFAULT_NAMESPACE,
@@ -102,6 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void Prepare_WhenScriptUsesBareUnityRandom_ShouldAddRandomAlias()
         {
+            // Verifies a bare "Random" call resolves to UnityEngine.Random via an injected alias.
             PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
                 "int value = Random.Range(0, 10);\nreturn value;",
                 DynamicCodeConstants.DEFAULT_NAMESPACE,
@@ -114,6 +119,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void CountSubstring_WhenTargetIsEmpty_ShouldReturnZero()
         {
+            // Verifies the shared string-counting test helper treats an empty target as zero matches.
             int count = DynamicCodeTestStringUtility.CountSubstring("source", "");
 
             Assert.AreEqual(0, count);

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeSourcePreparerTests.cs
@@ -45,6 +45,81 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         [Test]
+        public void Prepare_WhenScriptUsesBareUnityObject_ShouldAddObjectAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "GameObject go = new GameObject(\"source\");\nObject.Instantiate(go);\nreturn null;",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            StringAssert.Contains("using Object = UnityEngine.Object;", prepared.PreparedSource);
+        }
+
+        [Test]
+        public void Prepare_WhenObjectAliasAlreadyExists_ShouldNotAddDuplicateAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "using Object = UnityEngine.Object;\nObject.Instantiate(new GameObject(\"source\"));\nreturn null;",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            Assert.AreEqual(
+                1,
+                DynamicCodeTestStringUtility.CountSubstring(prepared.PreparedSource, "using Object = UnityEngine.Object;"));
+        }
+
+        [Test]
+        public void Prepare_WhenCustomObjectAliasAlreadyExists_ShouldRespectUserAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "using Object = System.Object;\nreturn new Object();",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            Assert.AreEqual(
+                1,
+                DynamicCodeTestStringUtility.CountSubstring(prepared.PreparedSource, "using Object = "));
+        }
+
+        [Test]
+        public void Prepare_WhenVerbatimObjectAliasAlreadyExists_ShouldRespectUserAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "using @Object = System.Object;\nreturn new @Object();",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            StringAssert.Contains("using @Object = System.Object;", prepared.PreparedSource);
+            Assert.AreEqual(
+                0,
+                DynamicCodeTestStringUtility.CountSubstring(prepared.PreparedSource, "using Object = UnityEngine.Object;"));
+        }
+
+        [Test]
+        public void Prepare_WhenScriptUsesBareUnityRandom_ShouldAddRandomAlias()
+        {
+            PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(
+                "int value = Random.Range(0, 10);\nreturn value;",
+                DynamicCodeConstants.DEFAULT_NAMESPACE,
+                DynamicCodeConstants.DEFAULT_CLASS_NAME);
+
+            Assert.IsNotNull(prepared.PreparedSource);
+            StringAssert.Contains("using Random = UnityEngine.Random;", prepared.PreparedSource);
+        }
+
+        [Test]
+        public void CountSubstring_WhenTargetIsEmpty_ShouldReturnZero()
+        {
+            int count = DynamicCodeTestStringUtility.CountSubstring("source", "");
+
+            Assert.AreEqual(0, count);
+        }
+
+        [Test]
         public void Prepare_WhenInterpolatedStringExists_ShouldSkipLiteralHoisting()
         {
             PreparedDynamicCode prepared = DynamicCodeSourcePreparer.Prepare(

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs
@@ -1,0 +1,26 @@
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Shared string-counting helper for dynamic code source assertions.
+    /// </summary>
+    internal static class DynamicCodeTestStringUtility
+    {
+        public static int CountSubstring(string source, string target)
+        {
+            if (string.IsNullOrEmpty(target))
+            {
+                return 0;
+            }
+
+            int count = 0;
+            int index = 0;
+            while ((index = source.IndexOf(target, index, System.StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += target.Length;
+            }
+
+            return count;
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeTestStringUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4e47f270d1343898e09dad9cd8d2402
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Editor/DynamicCodeToolTests/PreUsingResolverTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/PreUsingResolverTests.cs
@@ -171,7 +171,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -184,7 +184,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -196,7 +196,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             List<string> usings = new() { "using System.Text;" };
             string body = "StringBuilder builder = new StringBuilder();\nreturn builder.ToString();";
-            string wrappedSource = WrapperTemplate.Build(usings, "TestNs", "TestClass", body);
+            string wrappedSource = WrapperTemplate.Build(usings, System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -209,7 +209,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             string body = "int x = 42;\nreturn x;";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -233,7 +233,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             string body = "StringBuilder sb = new StringBuilder();\nRegex r = new Regex(\"x\");\nreturn sb.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 
@@ -246,7 +246,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             string body = "System.Text.StringBuilder builder = new System.Text.StringBuilder();\nreturn builder.ToString();";
             string wrappedSource = WrapperTemplate.Build(
-                new List<string>(), "TestNs", "TestClass", body);
+                new List<string>(), System.Array.Empty<string>(), "TestNs", "TestClass", body);
 
             PreUsingResult result = PreUsingResolver.Resolve(wrappedSource, AssemblyTypeIndex.Instance);
 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperTests.cs
@@ -59,5 +59,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.IsTrue(result.HasTypeDeclaration);
             Assert.IsFalse(result.HasTopLevelStatements);
         }
+
+        [Test]
+        public void Analyze_WhenVerbatimUsingAlias_ShouldRecordNormalizedAliasName()
+        {
+            SourceShapeResult result = SourceShaper.Analyze(
+                "using @Object = System.Object;\nreturn new @Object();");
+
+            Assert.That(result.AliasedNames, Does.Contain("Object"));
+        }
+
+        [Test]
+        public void Analyze_WhenGlobalUsingAliasHasComments_ShouldRecordAliasName()
+        {
+            SourceShapeResult result = SourceShaper.Analyze(
+                "global /* comment */ using /* comment */ Random /* comment */ = UnityEngine.Random;\nreturn Random.Range(0, 1);");
+
+            Assert.That(result.AliasedNames, Does.Contain("Random"));
+        }
+
+        [Test]
+        public void Analyze_WhenUsingAliasHasComments_ShouldRecordAliasName()
+        {
+            SourceShapeResult result = SourceShaper.Analyze(
+                "using /* comment */ Object /* comment */ = UnityEngine.Object;\nreturn null;");
+
+            Assert.That(result.AliasedNames, Does.Contain("Object"));
+        }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SourceShaperTests.cs
@@ -63,6 +63,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void Analyze_WhenVerbatimUsingAlias_ShouldRecordNormalizedAliasName()
         {
+            // Verifies "using @Object = ..." records the alias name without the leading '@'.
             SourceShapeResult result = SourceShaper.Analyze(
                 "using @Object = System.Object;\nreturn new @Object();");
 
@@ -72,6 +73,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void Analyze_WhenGlobalUsingAliasHasComments_ShouldRecordAliasName()
         {
+            // Verifies comments between "global", "using", and the alias name do not block alias detection.
             SourceShapeResult result = SourceShaper.Analyze(
                 "global /* comment */ using /* comment */ Random /* comment */ = UnityEngine.Random;\nreturn Random.Range(0, 1);");
 
@@ -81,10 +83,23 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         [Test]
         public void Analyze_WhenUsingAliasHasComments_ShouldRecordAliasName()
         {
+            // Verifies comments between "using" and the alias name do not block alias detection.
             SourceShapeResult result = SourceShaper.Analyze(
                 "using /* comment */ Object /* comment */ = UnityEngine.Object;\nreturn null;");
 
             Assert.That(result.AliasedNames, Does.Contain("Object"));
+        }
+
+        [Test]
+        public void Analyze_WhenUsingVarHasCommentBeforeVar_ShouldTreatAsTopLevelStatement()
+        {
+            // Verifies a comment between "using" and "var" still resolves to a using-statement,
+            // not a using-directive (regression guard for the SkipWhitespaceAndComments fix).
+            SourceShapeResult result = SourceShaper.Analyze(
+                "using /* comment */ var scope = new System.IO.MemoryStream();\nreturn null;");
+
+            Assert.IsTrue(result.HasTopLevelStatements);
+            Assert.AreEqual(0, result.UsingDirectives.Count);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeSourcePreparer.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeSourcePreparer.cs
@@ -60,6 +60,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 : DynamicCodeLiteralHoister.Rewrite(body);
             string preparedSource = WrapperTemplate.Build(
                 shape.UsingDirectives,
+                shape.AliasedNames,
                 namespaceName,
                 className,
                 hoistedResult.RewrittenSource,

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
@@ -121,7 +121,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int braceDepth,
             SourceShapeResult result)
         {
-            int usingPos = SkipWhitespace(source, pos + 6);
+            int usingPos = SkipWhitespaceAndComments(source, pos + 6);
             if (!StartsWithKeyword(source, usingPos, "using"))
             {
                 return null;
@@ -137,8 +137,115 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SourceShapeResult result)
         {
             int semiEnd = FindSemicolon(source, segmentStart);
-            result.UsingDirectives.Add(source.Substring(segmentStart, semiEnd - segmentStart + 1).TrimEnd());
+            RegisterUsingDirective(result, source, segmentStart, semiEnd);
             return new SourceTopLevelStep(semiEnd + 1, braceDepth);
+        }
+
+        private static void RegisterUsingDirective(
+            SourceShapeResult result,
+            string source,
+            int segmentStart,
+            int semiEnd)
+        {
+            result.UsingDirectives.Add(source.Substring(segmentStart, semiEnd - segmentStart + 1).TrimEnd());
+
+            string aliasName = ExtractUsingAliasName(source, segmentStart, semiEnd);
+            if (!string.IsNullOrEmpty(aliasName))
+            {
+                result.AliasedNames.Add(aliasName);
+            }
+        }
+
+        // Recognizes "using Name = ...", "using @Name = ...", and their "global using" variants
+        // so WrapperTemplate can skip injecting a default alias the user's code already defines.
+        private static string ExtractUsingAliasName(string source, int segmentStart, int semiEnd)
+        {
+            int position = segmentStart;
+            if (StartsWithKeyword(source, position, "global"))
+            {
+                position = SkipWhitespaceAndComments(source, position + "global".Length);
+            }
+
+            if (!StartsWithKeyword(source, position, "using"))
+            {
+                return null;
+            }
+
+            position = SkipWhitespaceAndComments(source, position + "using".Length);
+            if (StartsWithKeyword(source, position, "static"))
+            {
+                return null;
+            }
+
+            (string Name, int EndPosition) aliasName = ReadAliasName(source, position, semiEnd);
+            if (aliasName.Name == null)
+            {
+                return null;
+            }
+
+            int equalsPosition = SkipWhitespaceAndComments(source, aliasName.EndPosition);
+            if (equalsPosition > semiEnd || source[equalsPosition] != '=')
+            {
+                return null;
+            }
+
+            return aliasName.Name;
+        }
+
+        private static (string Name, int EndPosition) ReadAliasName(string source, int position, int semiEnd)
+        {
+            int currentPosition = position;
+            if (currentPosition <= semiEnd && source[currentPosition] == '@')
+            {
+                currentPosition++;
+            }
+
+            if (currentPosition > semiEnd || !IsIdentifierStart(source[currentPosition]))
+            {
+                return (null, position);
+            }
+
+            int nameStart = currentPosition;
+            currentPosition++;
+            while (currentPosition <= semiEnd && IsIdentifierPart(source[currentPosition]))
+            {
+                currentPosition++;
+            }
+
+            return (source.Substring(nameStart, currentPosition - nameStart), currentPosition);
+        }
+
+        private static bool IsIdentifierStart(char value)
+        {
+            return char.IsLetter(value) || value == '_';
+        }
+
+        private static bool IsIdentifierPart(char value)
+        {
+            return char.IsLetterOrDigit(value) || value == '_';
+        }
+
+        private static int SkipWhitespaceAndComments(string source, int pos)
+        {
+            int current = SkipWhitespace(source, pos);
+            while (true)
+            {
+                if (TryMatchLineComment(source, current, out int afterLine))
+                {
+                    current = SkipWhitespace(source, afterLine);
+                    continue;
+                }
+
+                if (TryMatchBlockComment(source, current, out int afterBlock))
+                {
+                    current = SkipWhitespace(source, afterBlock);
+                    continue;
+                }
+
+                break;
+            }
+
+            return current;
         }
 
         private static SourceTopLevelStep? TryAnalyzeTopLevelDeclaration(
@@ -254,7 +361,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     : body + "\nreturn null;";
             }
 
-            return WrapperTemplate.Build(shape.UsingDirectives, namespaceName, className, body);
+            return WrapperTemplate.Build(shape.UsingDirectives, shape.AliasedNames, namespaceName, className, body);
         }
 
         internal static int SkipWhitespace(string s, int pos)
@@ -711,6 +818,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal sealed class SourceShapeResult
     {
         public List<string> UsingDirectives { get; } = new List<string>();
+        public HashSet<string> AliasedNames { get; } = new HashSet<string>(System.StringComparer.Ordinal);
         public bool HasNamespaceDeclaration { get; set; }
         public bool HasTypeDeclaration { get; set; }
         public bool HasTopLevelStatements { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SourceShaper.cs
@@ -100,7 +100,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             int segmentStart = pos;
-            int afterUsing = SkipWhitespace(source, pos + 5);
+            int afterUsing = SkipWhitespaceAndComments(source, pos + 5);
             if (StartsWithKeyword(source, afterUsing, "static"))
             {
                 return AddUsingDirectiveStep(source, segmentStart, braceDepth, result);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrapperTemplate.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrapperTemplate.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Text;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -12,13 +14,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal const string UserCodeStartMarker = "#line 1 \"user-snippet.cs\"";
         internal const string UserCodeEndMarker = "#line default";
 
+        private static readonly DefaultUsingAlias[] DefaultUsingAliases =
+        {
+            new("Object", "UnityEngine.Object"),
+            new("Random", "UnityEngine.Random"),
+        };
+
         public static string Build(
             IReadOnlyList<string> usingDirectives,
+            IReadOnlyCollection<string> aliasedNames,
             string namespaceName,
             string className,
             string body,
             IReadOnlyList<string> preambleLines = null)
         {
+            Debug.Assert(usingDirectives != null, "usingDirectives must not be null");
+            Debug.Assert(aliasedNames != null, "aliasedNames must not be null");
+
             StringBuilder sb = new();
 
             sb.AppendLine("#pragma warning disable CS0162");
@@ -30,10 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             sb.AppendLine("using System.Threading.Tasks;");
             sb.AppendLine("using UnityEngine;");
             sb.AppendLine("using UnityEditor;");
-            if (!HasObjectAlias(usingDirectives))
-            {
-                sb.AppendLine("using Object = UnityEngine.Object;");
-            }
+            AppendDefaultUsingAliases(sb, aliasedNames);
 
             foreach (string directive in usingDirectives)
             {
@@ -80,70 +89,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return sb.ToString();
         }
 
-        private static bool HasObjectAlias(IReadOnlyList<string> usingDirectives)
+        private static void AppendDefaultUsingAliases(
+            StringBuilder sb,
+            IReadOnlyCollection<string> aliasedNames)
         {
-            if (usingDirectives == null)
+            for (int index = 0; index < DefaultUsingAliases.Length; index++)
             {
-                return false;
-            }
-
-            for (int index = 0; index < usingDirectives.Count; index++)
-            {
-                string directive = usingDirectives[index]?.TrimStart();
-                if (string.IsNullOrEmpty(directive))
+                DefaultUsingAlias alias = DefaultUsingAliases[index];
+                if (aliasedNames.Contains(alias.Name))
                 {
                     continue;
                 }
 
-                if (IsObjectAliasDirective(directive))
-                {
-                    return true;
-                }
+                sb.AppendLine($"using {alias.Name} = {alias.TargetTypeName};");
             }
-
-            return false;
         }
 
-        private static bool IsObjectAliasDirective(string directive)
+        private readonly struct DefaultUsingAlias
         {
-            int usingPosition = 0;
-            if (SourceShaper.StartsWithKeyword(directive, usingPosition, "global"))
+            public string Name { get; }
+
+            public string TargetTypeName { get; }
+
+            public DefaultUsingAlias(string name, string targetTypeName)
             {
-                usingPosition = SkipWhitespaceAndComments(directive, usingPosition + "global".Length);
+                Name = name;
+                TargetTypeName = targetTypeName;
             }
-
-            if (!SourceShaper.StartsWithKeyword(directive, usingPosition, "using"))
-            {
-                return false;
-            }
-
-            int aliasStart = SkipWhitespaceAndComments(directive, usingPosition + "using".Length);
-            if (!SourceShaper.StartsWithKeyword(directive, aliasStart, "Object"))
-            {
-                return false;
-            }
-
-            int equalsPosition = SkipWhitespaceAndComments(directive, aliasStart + "Object".Length);
-            return equalsPosition < directive.Length && directive[equalsPosition] == '=';
-        }
-
-        private static int SkipWhitespaceAndComments(string source, int position)
-        {
-            int currentPosition = SourceShaper.SkipWhitespace(source, position);
-            while (IsCommentStart(source, currentPosition))
-            {
-                int nextPosition = SourceShaper.AdvanceOneTokenPublic(source, currentPosition);
-                currentPosition = SourceShaper.SkipWhitespace(source, nextPosition);
-            }
-
-            return currentPosition;
-        }
-
-        private static bool IsCommentStart(string source, int position)
-        {
-            return position + 1 < source.Length &&
-                   source[position] == '/' &&
-                   (source[position + 1] == '/' || source[position + 1] == '*');
         }
     }
 }


### PR DESCRIPTION
## Summary
- Dynamic code snippets that call `Random.Range(...)` without an explicit `using` now compile, matching the existing bare-`Object` support.
- The bare-alias detection now understands comments and `global using` forms, so a snippet's own custom alias is respected even when written unusually (e.g. `using @Object = ...;`, or with comments between tokens).

## User Impact
- Before: only bare `Object` calls were auto-resolved; a bare `Random.Range(...)` in dynamic code failed to compile unless the user added `using Random = UnityEngine.Random;` manually. A `global using` alias with a comment in between tokens was also missed.
- After: both `Object` and `Random` are auto-resolved when the snippet doesn't already alias them, and user-defined aliases (including verbatim/comment-containing forms) are correctly detected and respected.

## Changes
- `SourceShaper` now collects every using-alias name the snippet defines (`AliasedNames`), replacing the old ad-hoc string scan that only recognized "Object".
- `WrapperTemplate` injects default aliases (`Object`, `Random`) from a small table, skipping any name already in `AliasedNames`.
- Fixed a related gap where a comment between `global` and `using` caused the directive to be misclassified as a plain statement.
- Restored unit test coverage for this behavior at the preparer/shaper level (the previous coverage was removed in #1310 because it was execution-based and risked freezing the Editor; these new tests do not compile-and-run).

## Verification
- `dist/darwin-arm64/uloop compile` — 0 errors, 0 warnings
- `dist/darwin-arm64/uloop run-tests` (EditMode, full suite) — 1725 passed, 0 failed, 7 skipped (pre-existing skips)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

