### PR TITLE
fix: UI drag simulation now keeps mouse position in sync during drags

### DIFF
--- a/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs
@@ -1,0 +1,222 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Collections;
+using System.Threading;
+using System.Threading.Tasks;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
+{
+    /// <summary>
+    /// Test fixture that verifies mouse UI drags keep Mouse.current aligned with the simulated pointer position.
+    /// </summary>
+    public class SimulateMouseUiInputSystemTests : InputTestFixture
+    {
+        private const float PositionTolerance = 0.01f;
+
+        private GameObject canvasGo = null!;
+        private GameObject eventSystemGo = null!;
+        private ExistingEventSystemDisableScope eventSystemDisableScope = null!;
+        private SimulateMouseUiTool tool = null!;
+        private SimulateMouseUiResponse lastResponse = null!;
+
+        public override void Setup()
+        {
+            base.Setup();
+
+            eventSystemDisableScope = new ExistingEventSystemDisableScope();
+
+            canvasGo = new GameObject("TestCanvas");
+            Canvas canvas = canvasGo.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvasGo.AddComponent<CanvasScaler>();
+            canvasGo.AddComponent<GraphicRaycaster>();
+
+            eventSystemGo = new GameObject("TestEventSystem");
+            eventSystemGo.AddComponent<EventSystem>();
+            eventSystemGo.AddComponent<StandaloneInputModule>();
+
+            tool = new SimulateMouseUiTool();
+            InputSystem.AddDevice<Mouse>();
+        }
+
+        public override void TearDown()
+        {
+            MouseDragState.Clear();
+            Object.DestroyImmediate(canvasGo);
+            Object.DestroyImmediate(eventSystemGo);
+            eventSystemDisableScope.Restore();
+            base.TearDown();
+        }
+
+        [UnityTest]
+        public IEnumerator DragOneShot_Should_UpdateMouseCurrentPositionToDragPosition()
+        {
+            // Verifies a one-shot UI drag keeps Mouse.current aligned with PointerEventData at the drag end.
+            MouseAwareDragTracker tracker = CreateDraggableElement(
+                "DragTarget", new Vector2(120f, 80f), new Vector2(200f, 100f));
+            yield return null;
+
+            Vector2 startScreenPosition = GetScreenPosition(tracker.gameObject);
+            Vector2 endScreenPosition = startScreenPosition + new Vector2(140f, -60f);
+            Vector2 startInputPosition = ScreenToInput(startScreenPosition);
+            Vector2 endInputPosition = ScreenToInput(endScreenPosition);
+            SetMousePosition(Vector2.zero);
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = MouseAction.Drag.ToString(),
+                ["fromX"] = startInputPosition.x,
+                ["fromY"] = startInputPosition.y,
+                ["x"] = endInputPosition.x,
+                ["y"] = endInputPosition.y,
+                ["dragSpeed"] = 0f
+            });
+
+            Assert.IsTrue(lastResponse.Success);
+            AssertPositionEquals(endScreenPosition, tracker.LastPointerPosition, "PointerEventData position should reach the drag end.");
+            AssertPositionEquals(endScreenPosition, tracker.LastMousePosition, "Mouse.current position should match PointerEventData during drag.");
+        }
+
+        [UnityTest]
+        public IEnumerator DragSplit_Should_UpdateMouseCurrentPositionOnEachDragStep()
+        {
+            // Verifies the incremental drag (DragStart/DragMove/DragEnd) path keeps Mouse.current aligned too,
+            // covering the InitiateDrag and InterpolateDragPosition sync points independently of one-shot drag.
+            MouseAwareDragTracker tracker = CreateDraggableElement(
+                "DragTarget", Vector2.zero, new Vector2(200f, 100f));
+            yield return null;
+
+            Vector2 startScreenPosition = GetScreenPosition(tracker.gameObject);
+            Vector2 moveScreenPosition = startScreenPosition + new Vector2(50f, 0f);
+            Vector2 endScreenPosition = startScreenPosition + new Vector2(100f, 0f);
+            Vector2 startInputPosition = ScreenToInput(startScreenPosition);
+            Vector2 moveInputPosition = ScreenToInput(moveScreenPosition);
+            Vector2 endInputPosition = ScreenToInput(endScreenPosition);
+            SetMousePosition(Vector2.zero);
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = MouseAction.DragStart.ToString(),
+                ["x"] = startInputPosition.x,
+                ["y"] = startInputPosition.y
+            });
+            Assert.IsTrue(lastResponse.Success);
+            AssertPositionEquals(startScreenPosition, GetMousePosition(), "Mouse.current position should match the drag start position.");
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = MouseAction.DragMove.ToString(),
+                ["x"] = moveInputPosition.x,
+                ["y"] = moveInputPosition.y,
+                ["dragSpeed"] = 0f
+            });
+            Assert.IsTrue(lastResponse.Success);
+            AssertPositionEquals(moveScreenPosition, GetMousePosition(), "Mouse.current position should match the drag move position.");
+
+            yield return RunTool(new JObject
+            {
+                ["action"] = MouseAction.DragEnd.ToString(),
+                ["x"] = endInputPosition.x,
+                ["y"] = endInputPosition.y,
+                ["dragSpeed"] = 0f
+            });
+            Assert.IsTrue(lastResponse.Success);
+            AssertPositionEquals(endScreenPosition, GetMousePosition(), "Mouse.current position should match the drag end position.");
+        }
+
+        private IEnumerator RunTool(JObject parameters)
+        {
+            Task<UnityCliLoopToolResponse> task = tool.ExecuteAsync(parameters, CancellationToken.None);
+            float timeoutAt = Time.realtimeSinceStartup + 5f;
+            yield return new WaitUntil(() =>
+                task.IsCompleted || Time.realtimeSinceStartup >= timeoutAt);
+            Assert.IsTrue(task.IsCompleted, "Tool execution timed out.");
+            Assert.IsFalse(task.IsFaulted, $"Tool execution should not fault: {task.Exception}");
+            lastResponse = (SimulateMouseUiResponse)task.Result;
+        }
+
+        private MouseAwareDragTracker CreateDraggableElement(
+            string name, Vector2 anchoredPosition, Vector2 sizeDelta)
+        {
+            GameObject go = new GameObject(name);
+            go.transform.SetParent(canvasGo.transform, false);
+            RectTransform rect = go.AddComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = anchoredPosition;
+            rect.sizeDelta = sizeDelta;
+            go.AddComponent<Image>();
+            return go.AddComponent<MouseAwareDragTracker>();
+        }
+
+        private Vector2 GetScreenPosition(GameObject go)
+        {
+            return (Vector2)go.GetComponent<RectTransform>().position;
+        }
+
+        private Vector2 ScreenToInput(Vector2 screenPosition)
+        {
+            float targetHeight = Handles.GetMainGameViewSize().y;
+            return new Vector2(screenPosition.x, targetHeight - screenPosition.y);
+        }
+
+        private void SetMousePosition(Vector2 position)
+        {
+            Mouse? currentMouse = Mouse.current;
+            Assert.IsNotNull(currentMouse, "Mouse.current should exist after adding a Mouse device.");
+            Set(currentMouse!.position, position);
+        }
+
+        private Vector2 GetMousePosition()
+        {
+            Mouse? currentMouse = Mouse.current;
+            Assert.IsNotNull(currentMouse, "Mouse.current should exist after adding a Mouse device.");
+            return currentMouse!.position.ReadValue();
+        }
+
+        private void AssertPositionEquals(Vector2 expected, Vector2 actual, string message)
+        {
+            float distance = Vector2.Distance(expected, actual);
+            Assert.LessOrEqual(distance, PositionTolerance, $"{message} Expected {expected}, got {actual}.");
+        }
+    }
+
+    /// <summary>
+    /// Test support type that records both PointerEventData and Mouse.current positions observed during a drag.
+    /// </summary>
+    public class MouseAwareDragTracker : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+    {
+        public Vector2 LastPointerPosition { get; private set; }
+        public Vector2 LastMousePosition { get; private set; }
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            Mouse? currentMouse = Mouse.current;
+            Assert.IsNotNull(currentMouse, "Mouse.current should exist for this test.");
+
+            LastPointerPosition = eventData.position;
+            LastMousePosition = currentMouse!.position.ReadValue();
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+        }
+    }
+}
+#endif

--- a/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs.meta
+++ b/Assets/Tests/PlayMode/SimulateMouseUiInputSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b16da86e84b144e7a2c869be8a6b7751
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/AssemblyInfo.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.ReplayInput.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Demo.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiDragEventExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiDragEventExecutor.cs
@@ -31,6 +31,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 pointerDrag = dragTarget,
                 rawPointerPress = raycastResult.gameObject
             };
+            MouseUiInputSystemSync.SyncMousePosition(screenPos);
 
             // Slider.OnPointerDown initializes m_Offset for handle positioning
             GameObject? pressTarget = ExecuteEvents.ExecuteHierarchy(
@@ -105,6 +106,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Vector2 previousPosition = pointerData.position;
                 pointerData.position = endPos;
                 pointerData.delta = endPos - previousPosition;
+                MouseUiInputSystemSync.SyncMousePosition(endPos);
                 ExecuteEvents.Execute(target, pointerData, ExecuteEvents.dragHandler);
 
                 SimulateMouseUiOverlayState.UpdatePosition(MouseUiCoordinateConverter.ScreenToInput(endPos));
@@ -131,6 +133,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 pointerData.position = currentPosition;
                 pointerData.delta = currentPosition - previousPosition;
 
+                MouseUiInputSystemSync.SyncMousePosition(currentPosition);
                 ExecuteEvents.Execute(target, pointerData, ExecuteEvents.dragHandler);
 
                 SimulateMouseUiOverlayState.UpdatePosition(MouseUiCoordinateConverter.ScreenToInput(currentPosition));

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiInputSystemSync.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiInputSystemSync.cs
@@ -1,0 +1,29 @@
+#nullable enable
+using UnityEngine;
+#if ULOOP_HAS_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Keeps Mouse.current aligned with the pointer position driven by mouse UI simulation.
+    /// </summary>
+    internal static class MouseUiInputSystemSync
+    {
+        // UI handlers can read Mouse.current alongside PointerEventData, so both paths must observe one position.
+        internal static void SyncMousePosition(Vector2 screenPos)
+        {
+#if ULOOP_HAS_INPUT_SYSTEM
+            Mouse? mouse = Mouse.current;
+            if (mouse == null)
+            {
+                return;
+            }
+
+            InputSystem.QueueDeltaStateEvent(mouse.position, screenPos);
+            InputSystemUpdateHelper.RunExplicitUpdate(InputUpdateTypeResolver.Resolve());
+#endif
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiInputSystemSync.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiInputSystemSync.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6e33ce94f024d3cb2f0e1240db6098d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPressActionExecutor.cs
@@ -24,6 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Vector2 inputPos = new(parameters.X, parameters.Y);
             Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
             PointerEventData pointerData = MouseUiPointerTargetResolver.CreatePointerPressData(eventSystem, screenPos, parameters.Button);
+            MouseUiInputSystemSync.SyncMousePosition(screenPos);
             ResolvedPointerTargets resolvedTargets =
                 MouseUiPointerTargetResolver.ResolvePressablePointerTargets(parameters, eventSystem, inputPos, screenPos, pointerData, MouseAction.Click);
             if (resolvedTargets.FailureResponse != null)
@@ -90,6 +91,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Vector2 inputPos = new(parameters.X, parameters.Y);
             Vector2 screenPos = MouseUiCoordinateConverter.InputToScreen(inputPos);
             PointerEventData pointerData = MouseUiPointerTargetResolver.CreatePointerPressData(eventSystem, screenPos, parameters.Button);
+            MouseUiInputSystemSync.SyncMousePosition(screenPos);
             ResolvedPointerTargets resolvedTargets =
                 MouseUiPointerTargetResolver.ResolvePressablePointerTargets(parameters, eventSystem, inputPos, screenPos, pointerData, MouseAction.LongPress);
             if (resolvedTargets.FailureResponse != null)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor.asmdef
@@ -8,7 +8,9 @@
         "GUID:a2d87883023de4cf59b7d1962d5dd8aa",
         "GUID:aa7cf56cc5f074e57ba35272b877e116",
         "GUID:c956a21f824994ef087b6de566690b3d",
-        "GUID:33fef506e6744f2982e8c13b1196f696"
+        "GUID:33fef506e6744f2982e8c13b1196f696",
+        "GUID:45d3617c96fa64d3e95383450e67f25a",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
     "includePlatforms": [
         "Editor"
@@ -19,6 +21,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "ULOOP_HAS_INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
## Summary
- UI mouse simulation (click, long-press, and drags) now keeps `Mouse.current` aligned with the simulated pointer position throughout the interaction.

## User Impact
- Previously, UI handlers that read `Mouse.current` directly (instead of only through `PointerEventData`) could observe a stale mouse position during simulated clicks and drags.
- After this fix, both paths stay consistent, so gameplay code depending on `Mouse.current` behaves correctly during simulated UI interactions.

## Changes
- Ports main branch commit fbe9cd45 (#1471) to v3-beta's split executor architecture (`MouseUiPressActionExecutor`, `MouseUiDragEventExecutor`).
- Adds `MouseUiInputSystemSync.SyncMousePosition`, reusing the existing `InputSystemUpdateHelper`/`InputUpdateTypeResolver` helpers from `Common/InputSystem`.
- Wires the sync call into the five coordinate-update sites: click, long-press, drag begin, and both branches of drag interpolation.

## Verification
- `dist/darwin-arm64/uloop compile`: success
- `dist/darwin-arm64/uloop run-tests --test-mode PlayMode`: 92/92 passed (including 2 new regression tests)
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode`: 1726 passed, 0 failed, 7 skipped (pre-existing, unrelated)

Refs: main commit fbe9cd45 (#1471), Stream B of the main→v3-beta port plan

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

