### PR TITLE
feat: Screenshot tool can now annotate 3D physics raycast candidates

### DIFF
--- a/.agents/skills/uloop-screenshot/SKILL.md
+++ b/.agents/skills/uloop-screenshot/SKILL.md
@@ -79,9 +79,10 @@ Returns JSON with:
   - `FileSizeBytes`: Size of the saved file in bytes
   - `Width`: Captured image width in pixels
   - `Height`: Captured image height in pixels
-  - `CoordinateSystem`: `"gameView"` or `"window"`
+  - `ImageCoordinateSystem`: `"top-left-game-view"` or `"top-left-window"`
   - `ResolutionScale`: Resolution scale used for capture
-  - `YOffset`: Y offset used for gameView coordinate conversion
+  - `ImageToInputOffsetY`: Y offset used for top-left-game-view coordinate conversion
+  - `ScreenshotToInputFormula`: Formula converting raw image pixels to simulate-mouse input coordinates
   - `AnnotatedElements`: Array of annotated UI element metadata. Empty unless `--annotate-elements` is used.
 
 For `AnnotatedElements` fields and gameView coordinate conversion, read [references/annotated-elements.md](references/annotated-elements.md) before using screenshot coordinates with mouse simulation tools.

--- a/.agents/skills/uloop-screenshot/references/annotated-elements.md
+++ b/.agents/skills/uloop-screenshot/references/annotated-elements.md
@@ -18,18 +18,18 @@ Read this when using `uloop screenshot --capture-mode rendering --annotate-eleme
 
 ## Coordinate Conversion
 
-When `CoordinateSystem` is `"gameView"`, convert image pixel coordinates to simulate-mouse coordinates:
+When `ImageCoordinateSystem` is `"top-left-game-view"`, convert image pixel coordinates to simulate-mouse coordinates using `ScreenshotToInputFormula`:
 
 ```text
-sim_x = image_x / ResolutionScale
-sim_y = image_y / ResolutionScale + YOffset
+simulate_mouse_x = image_x / resolutionScale
+simulate_mouse_y = image_y / resolutionScale + imageToInputOffsetY
 ```
 
 When `ResolutionScale` is `1.0`, this simplifies to:
 
 ```text
-sim_x = image_x
-sim_y = image_y + YOffset
+simulate_mouse_x = image_x
+simulate_mouse_y = image_y + imageToInputOffsetY
 ```
 
 ## Annotation Readability

--- a/.claude/skills/uloop-screenshot/SKILL.md
+++ b/.claude/skills/uloop-screenshot/SKILL.md
@@ -79,9 +79,10 @@ Returns JSON with:
   - `FileSizeBytes`: Size of the saved file in bytes
   - `Width`: Captured image width in pixels
   - `Height`: Captured image height in pixels
-  - `CoordinateSystem`: `"gameView"` or `"window"`
+  - `ImageCoordinateSystem`: `"top-left-game-view"` or `"top-left-window"`
   - `ResolutionScale`: Resolution scale used for capture
-  - `YOffset`: Y offset used for gameView coordinate conversion
+  - `ImageToInputOffsetY`: Y offset used for top-left-game-view coordinate conversion
+  - `ScreenshotToInputFormula`: Formula converting raw image pixels to simulate-mouse input coordinates
   - `AnnotatedElements`: Array of annotated UI element metadata. Empty unless `--annotate-elements` is used.
 
 For `AnnotatedElements` fields and gameView coordinate conversion, read [references/annotated-elements.md](references/annotated-elements.md) before using screenshot coordinates with mouse simulation tools.

--- a/.claude/skills/uloop-screenshot/references/annotated-elements.md
+++ b/.claude/skills/uloop-screenshot/references/annotated-elements.md
@@ -18,18 +18,18 @@ Read this when using `uloop screenshot --capture-mode rendering --annotate-eleme
 
 ## Coordinate Conversion
 
-When `CoordinateSystem` is `"gameView"`, convert image pixel coordinates to simulate-mouse coordinates:
+When `ImageCoordinateSystem` is `"top-left-game-view"`, convert image pixel coordinates to simulate-mouse coordinates using `ScreenshotToInputFormula`:
 
 ```text
-sim_x = image_x / ResolutionScale
-sim_y = image_y / ResolutionScale + YOffset
+simulate_mouse_x = image_x / resolutionScale
+simulate_mouse_y = image_y / resolutionScale + imageToInputOffsetY
 ```
 
 When `ResolutionScale` is `1.0`, this simplifies to:
 
 ```text
-sim_x = image_x
-sim_y = image_y + YOffset
+simulate_mouse_x = image_x
+simulate_mouse_y = image_y + imageToInputOffsetY
 ```
 
 ## Annotation Readability

--- a/Assets/Tests/Editor/EditorWindowCaptureUtilityTests.cs
+++ b/Assets/Tests/Editor/EditorWindowCaptureUtilityTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies Editor Window Capture Utility coordinate calculations.
+    /// </summary>
+    public class EditorWindowCaptureUtilityTests
+    {
+        [Test]
+        public void CalculateImageToInputOffsetY_WhenRenderTextureIsShorterThanGameView_ShouldReturnTopOffset()
+        {
+            // Tests that a RenderTexture shorter than the Game View yields a positive top offset.
+            Vector2 gameViewSize = new(1768f, 1383f);
+
+            int offsetY = EditorWindowCaptureUtility.CalculateImageToInputOffsetY(gameViewSize, 1080);
+
+            Assert.That(offsetY, Is.EqualTo(303));
+        }
+
+        [Test]
+        public void CalculateImageToInputOffsetY_WhenRenderTextureMatchesGameView_ShouldReturnZero()
+        {
+            // Tests that a RenderTexture matching the Game View height yields a zero offset.
+            Vector2 gameViewSize = new(1920f, 1080f);
+
+            int offsetY = EditorWindowCaptureUtility.CalculateImageToInputOffsetY(gameViewSize, 1080);
+
+            Assert.That(offsetY, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void CreateUnavailableGameRenderingImageInfo_WhenRenderTextureIsMissing_ShouldUseGameViewSizeAndZeroOffset()
+        {
+            // Tests that the fallback info reuses the Game View size for both sizes with a zero offset.
+            Vector2 gameViewSize = new(1768f, 1383f);
+
+            GameRenderingImageInfo renderingImageInfo =
+                EditorWindowCaptureUtility.CreateUnavailableGameRenderingImageInfo(gameViewSize);
+
+            Assert.That(renderingImageInfo.GameViewSize, Is.EqualTo(gameViewSize));
+            Assert.That(renderingImageInfo.RenderingImageSize, Is.EqualTo(gameViewSize));
+            Assert.That(renderingImageInfo.ImageToInputOffsetY, Is.EqualTo(0));
+        }
+    }
+}

--- a/Assets/Tests/Editor/EditorWindowCaptureUtilityTests.cs.meta
+++ b/Assets/Tests/Editor/EditorWindowCaptureUtilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35f4b508a887640c298e8e5c79f9eb2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ScreenshotUseCaseTests.cs
+++ b/Assets/Tests/Editor/ScreenshotUseCaseTests.cs
@@ -1,0 +1,94 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies Screenshot Use Case parameter validation.
+    /// </summary>
+    public class ScreenshotUseCaseTests
+    {
+        [Test]
+        public void ExecuteAsync_WhenRaycastLayerMaskIsSetWithoutRaycastGrid_ShouldThrowValidationException()
+        {
+            // Tests that setting RaycastLayerMask without AnnotateRaycastGrid fails validation.
+            JObject parameters = new JObject
+            {
+                ["RaycastLayerMask"] = "Default"
+            };
+
+            UnityCliLoopToolParameterValidationException? exception =
+                Assert.ThrowsAsync<UnityCliLoopToolParameterValidationException>(
+                    async () => await ExecuteScreenshot(parameters));
+
+            Assert.That(exception!.Message, Does.Contain("RaycastLayerMask requires AnnotateRaycastGrid=true"));
+        }
+
+        [Test]
+        public void ExecuteAsync_WhenElementsOnlyHasNoAnnotationMode_ShouldThrowValidationException()
+        {
+            // Tests that ElementsOnly without AnnotateElements or AnnotateRaycastGrid fails validation.
+            JObject parameters = new JObject
+            {
+                ["CaptureMode"] = "rendering",
+                ["ElementsOnly"] = true
+            };
+
+            UnityCliLoopToolParameterValidationException? exception =
+                Assert.ThrowsAsync<UnityCliLoopToolParameterValidationException>(
+                    async () => await ExecuteScreenshot(parameters));
+
+            Assert.That(
+                exception!.Message,
+                Does.Contain("ElementsOnly requires AnnotateElements=true or AnnotateRaycastGrid=true"));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenElementsOnlyUsesRaycastGrid_ShouldPassValidation()
+        {
+            // Tests that ElementsOnly combined with AnnotateRaycastGrid passes validation
+            // (PlayMode is unavailable in EditMode, so capture itself no-ops after validation).
+            JObject parameters = new JObject
+            {
+                ["CaptureMode"] = "rendering",
+                ["AnnotateRaycastGrid"] = true,
+                ["ElementsOnly"] = true
+            };
+
+            UnityCliLoopToolResponse response = await ExecuteScreenshot(parameters);
+
+            Assert.That(response, Is.InstanceOf<ScreenshotResponse>());
+        }
+
+        [Test]
+        public void ExecuteAsync_WhenRaycastLayerMaskContainsUnknownLayer_ShouldThrowValidationException()
+        {
+            // Tests that an unrecognized layer name in RaycastLayerMask fails validation with the layer name in the message.
+            JObject parameters = new JObject
+            {
+                ["CaptureMode"] = "rendering",
+                ["AnnotateRaycastGrid"] = true,
+                ["RaycastLayerMask"] = "MissingLayerForTest"
+            };
+
+            UnityCliLoopToolParameterValidationException? exception =
+                Assert.ThrowsAsync<UnityCliLoopToolParameterValidationException>(
+                    async () => await ExecuteScreenshot(parameters));
+
+            Assert.That(exception!.Message, Does.Contain("unknown layer name"));
+            Assert.That(exception!.Message, Does.Contain("MissingLayerForTest"));
+        }
+
+        private static async Task<UnityCliLoopToolResponse> ExecuteScreenshot(JObject parameters)
+        {
+            ScreenshotTool tool = new();
+            return await tool.ExecuteAsync(parameters, CancellationToken.None);
+        }
+    }
+}

--- a/Assets/Tests/Editor/ScreenshotUseCaseTests.cs.meta
+++ b/Assets/Tests/Editor/ScreenshotUseCaseTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70bf64f00f65845479f85cb7f12d3d3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/UIElementAnnotatorTests.cs
+++ b/Assets/Tests/Editor/UIElementAnnotatorTests.cs
@@ -78,6 +78,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(outlineColor, Is.EqualTo(new Color(0f, 0f, 0f, 0.95f)));
         }
 
+        /// <summary>
+        /// Verifies that converting a top-left outline segment to screen space flips its Y coordinates.
+        /// </summary>
+        [Test]
+        public void ConvertTopLeftOutlineSegmentToScreenSegment_ShouldFlipYForCanvasSpace()
+        {
+            RaycastOutlineSegment inputSegment = new(10f, 20f, 30f, 20f);
+
+            RaycastOutlineSegment screenSegment =
+                UIElementAnnotator.ConvertTopLeftOutlineSegmentToScreenSegment(inputSegment, 100f);
+
+            Assert.That(screenSegment.StartX, Is.EqualTo(10f));
+            Assert.That(screenSegment.StartY, Is.EqualTo(80f));
+            Assert.That(screenSegment.EndX, Is.EqualTo(30f));
+            Assert.That(screenSegment.EndY, Is.EqualTo(80f));
+        }
+
+        /// <summary>
+        /// Verifies that a horizontal outline segment's rect extends both endpoints by half the thickness.
+        /// </summary>
+        [Test]
+        public void CalculateOutlineSegmentRect_WhenHorizontalSegment_ShouldExtendBothEndpoints()
+        {
+            RaycastOutlineSegment segment = new(10f, 20f, 30f, 20f);
+
+            Rect rect = UIElementAnnotator.CalculateOutlineSegmentRect(segment, 4f);
+
+            Assert.That(rect, Is.EqualTo(new Rect(8f, 18f, 24f, 4f)));
+        }
+
+        /// <summary>
+        /// Verifies that a vertical outline segment's rect extends both endpoints by half the thickness.
+        /// </summary>
+        [Test]
+        public void CalculateOutlineSegmentRect_WhenVerticalSegment_ShouldExtendBothEndpoints()
+        {
+            RaycastOutlineSegment segment = new(10f, 20f, 10f, 50f);
+
+            Rect rect = UIElementAnnotator.CalculateOutlineSegmentRect(segment, 4f);
+
+            Assert.That(rect, Is.EqualTo(new Rect(8f, 18f, 4f, 34f)));
+        }
+
         [Test]
         public void CalculateBorderEdgeRects_WhenBoundsAreProvided_ShouldPlaceEdgesInsideTheBounds()
         {

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureService.cs
@@ -37,15 +37,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return EditorWindowCaptureUtility.GetOpenWindowNames();
         }
 
-        public Task<(Texture2D? texture, int yOffset, bool timedOut)> CaptureGameRenderingAsync(
+        public async Task<(Texture2D? texture, int yOffset, bool timedOut)> CaptureGameRenderingAsync(
             float resolutionScale,
             int timeoutMilliseconds,
             CancellationToken ct)
         {
-            return EditorWindowCaptureUtility.CaptureGameRenderingAsync(
-                resolutionScale,
-                timeoutMilliseconds,
-                ct);
+            (Texture2D? texture, GameRenderingImageInfo renderingImageInfo, bool timedOut) =
+                await EditorWindowCaptureUtility.CaptureGameRenderingAsync(
+                    resolutionScale,
+                    null,
+                    timeoutMilliseconds,
+                    ct).ConfigureAwait(false);
+            return (texture, renderingImageInfo.ImageToInputOffsetY, timedOut);
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 
-using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.InternalAPIBridge;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -165,11 +164,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         // Captures game rendering by reading GameView's composited RenderTexture (PlayMode only).
         // Contains all cameras + Screen Space Overlay Canvas, without tab bar or borders.
-        // Coordinate mapping to simulate-mouse:
-        //   sim_x = image_x / resolutionScale, sim_y = image_y / resolutionScale + YOffset
-        // where YOffset = Screen.height - RenderTexture.height (returned in the tuple).
-        public static async Task<(Texture2D? texture, int yOffset, bool timedOut)> CaptureGameRenderingAsync(
+        internal static async Task<(Texture2D? texture, GameRenderingImageInfo renderingImageInfo, bool timedOut)> CaptureGameRenderingAsync(
             float resolutionScale,
+            GameRenderingImageInfo? renderingImageInfo,
             int frameWaitTimeoutMilliseconds,
             CancellationToken ct)
         {
@@ -184,7 +181,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ct).ConfigureAwait(false);
             if (!framesReady)
             {
-                return (null, 0, true);
+                return (null, default, true);
             }
 
             await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
@@ -193,10 +190,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (rt == null)
             {
                 Debug.LogWarning("[EditorWindowCaptureUtility] GameView RenderTexture is not available");
-                return (null, 0, false);
+                GameRenderingImageInfo unavailableInfo = renderingImageInfo ??
+                    CreateUnavailableGameRenderingImageInfo(Handles.GetMainGameViewSize());
+                return (null, unavailableInfo, false);
             }
 
-            int yOffset = (int)Handles.GetMainGameViewSize().y - rt.height;
+            // GameView RenderTexture can be shorter than the full input area, so raw image Y needs this offset.
+            GameRenderingImageInfo captureInfo = renderingImageInfo ??
+                CreateGameRenderingImageInfo(Handles.GetMainGameViewSize(), rt.width, rt.height);
 
             // RenderTexture uses bottom-left origin; flip vertically for standard top-left image format
             RenderTextureDescriptor flipDescriptor = new(rt.width, rt.height, rt.format, 0);
@@ -231,7 +232,63 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 texture = ApplyResolutionScaling(texture, resolutionScale);
             }
 
-            return (texture, yOffset, false);
+            return (texture, captureInfo, false);
+        }
+
+        // Raycast-grid annotations must use the same settled RenderTexture geometry as the PNG capture path.
+        internal static async Task<(GameRenderingImageInfo renderingImageInfo, bool timedOut)> GetGameRenderingImageInfoAsync(
+            int frameWaitTimeoutMilliseconds,
+            CancellationToken ct)
+        {
+            Debug.Assert(UnityEditor.EditorApplication.isPlaying, "GetGameRenderingImageInfoAsync requires PlayMode");
+
+            SynchronizationContext editorContext =
+                CapturedEditorSynchronizationContext.RequireCurrent("raycast grid rendering info capture");
+            bool framesReady = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                2,
+                frameWaitTimeoutMilliseconds,
+                ct).ConfigureAwait(false);
+            if (!framesReady)
+            {
+                return (default, true);
+            }
+
+            await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+
+            Vector2 gameViewSize = Handles.GetMainGameViewSize();
+            RenderTexture rt = GameViewBridge.GetRenderTexture();
+            if (rt == null)
+            {
+                return (CreateUnavailableGameRenderingImageInfo(gameViewSize), false);
+            }
+
+            return (CreateGameRenderingImageInfo(gameViewSize, rt.width, rt.height), false);
+        }
+
+        internal static GameRenderingImageInfo CreateUnavailableGameRenderingImageInfo(Vector2 gameViewSize)
+        {
+            return new GameRenderingImageInfo(gameViewSize, gameViewSize, 0);
+        }
+
+        private static GameRenderingImageInfo CreateGameRenderingImageInfo(
+            Vector2 gameViewSize,
+            int renderTextureWidth,
+            int renderTextureHeight)
+        {
+            Vector2 renderingImageSize = new(renderTextureWidth, renderTextureHeight);
+            int imageToInputOffsetY = CalculateImageToInputOffsetY(gameViewSize, renderTextureHeight);
+            return new GameRenderingImageInfo(gameViewSize, renderingImageSize, imageToInputOffsetY);
+        }
+
+        /// <summary>
+        /// Calculates the Y offset from rendering screenshot image space to Game View input space.
+        /// </summary>
+        internal static int CalculateImageToInputOffsetY(Vector2 gameViewSize, int renderTextureHeight)
+        {
+            Debug.Assert(gameViewSize.y >= 0f, "Game View height must not be negative.");
+            Debug.Assert(renderTextureHeight >= 0, "RenderTexture height must not be negative.");
+
+            return Mathf.RoundToInt(gameViewSize.y) - renderTextureHeight;
         }
 
         private static Texture2D ApplyResolutionScaling(Texture2D originalTexture, float scale)
@@ -297,6 +354,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return MainThreadSwitcher.SwitchToMainThread(ct);
+        }
+    }
+
+    /// <summary>
+    /// Describes the Game View geometry used to map rendering screenshots back to input coordinates.
+    /// </summary>
+    internal readonly struct GameRenderingImageInfo
+    {
+        public readonly Vector2 GameViewSize;
+        public readonly Vector2 RenderingImageSize;
+        public readonly int ImageToInputOffsetY;
+
+        public GameRenderingImageInfo(
+            Vector2 gameViewSize,
+            Vector2 renderingImageSize,
+            int imageToInputOffsetY)
+        {
+            GameViewSize = gameViewSize;
+            RenderingImageSize = renderingImageSize;
+            ImageToInputOffsetY = imageToInputOffsetY;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -182,7 +182,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 DestroyAnnotationOverlay(annotationOverlay, editorContext);
             }
 
-            UIElementAnnotator.ConvertToSimCoordinates(annotatedElements, Mathf.RoundToInt(gameViewSize.y));
+            // Uses the settled capture-time size, not the pre-capture gameViewSize sample, so annotated
+            // element coordinates stay consistent with the GameViewWidth/Height this response reports.
+            UIElementAnnotator.ConvertToSimCoordinates(annotatedElements, Mathf.RoundToInt(captureRenderingInfo.GameViewSize.y));
             List<UIElementInfo> responseAnnotatedElements =
                 CreateResponseAnnotatedElements(annotatedElements, physicsColliderElements);
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -61,6 +61,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             List<UIElementInfo> annotatedElements = new();
+            List<UIElementInfo> physicsColliderElements = new();
+            Vector2 gameViewSize = GameViewCoordinateUtility.GetMainGameViewSize();
+            List<RaycastGridPointInfo> raycastGridPoints = new();
+            List<RaycastLayerSummaryInfo> raycastLayerSummaries = new();
+            List<UIElementInfo> raycastGridOverlayElements = new();
+            GameRenderingImageInfo? raycastGridRenderingInfo = null;
 
             if (request.AnnotateElements)
             {
@@ -68,12 +74,57 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 UIElementAnnotator.AssignLabels(annotatedElements);
             }
 
+            if (request.AnnotateRaycastGrid)
+            {
+                GameRenderingImageInfo renderingImageInfo;
+                bool gridInfoTimedOut;
+                (renderingImageInfo, gridInfoTimedOut) = await EditorWindowCaptureUtility.GetGameRenderingImageInfoAsync(
+                    UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
+                    ct).ConfigureAwait(false);
+                if (gridInfoTimedOut)
+                {
+                    return CreateTimedOutResult(
+                        "raycast grid rendering info capture",
+                        correlationId,
+                        new List<ScreenshotInfo>());
+                }
+
+                await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
+
+                raycastGridRenderingInfo = renderingImageInfo;
+                gameViewSize = renderingImageInfo.GameViewSize;
+                RaycastLayerMaskResolution raycastLayerMaskResolution = ResolveRaycastLayerMask(request);
+
+                if (raycastLayerMaskResolution.HasLayerNames)
+                {
+                    physicsColliderElements = RaycastGridAnnotator.CollectPhysicsColliderElements(
+                        renderingImageInfo.RenderingImageSize,
+                        renderingImageInfo.ImageToInputOffsetY,
+                        raycastLayerMaskResolution.Mask);
+                }
+                else
+                {
+                    raycastGridPoints = RaycastGridAnnotator.CollectRaycastGridPoints(
+                        renderingImageInfo.RenderingImageSize,
+                        renderingImageInfo.ImageToInputOffsetY);
+                    raycastLayerSummaries = RaycastGridAnnotator.CollectRaycastLayerSummaries(
+                        renderingImageInfo.RenderingImageSize,
+                        renderingImageInfo.ImageToInputOffsetY);
+                    raycastGridOverlayElements = RaycastGridAnnotator.CreateOverlayElements(raycastGridPoints);
+                }
+            }
+
             if (request.ElementsOnly)
             {
-                UIElementAnnotator.ConvertToSimCoordinates(annotatedElements, (int)Handles.GetMainGameViewSize().y);
-                ScreenshotInfo elementsOnlyInfo = new();
-                elementsOnlyInfo.CoordinateSystem = UnityCliLoopScreenshotCoordinateSystem.GameView;
-                elementsOnlyInfo.AnnotatedElements = annotatedElements;
+                UIElementAnnotator.ConvertToSimCoordinates(annotatedElements, Mathf.RoundToInt(gameViewSize.y));
+                List<UIElementInfo> elementsOnlyAnnotatedElements =
+                    CreateResponseAnnotatedElements(annotatedElements, physicsColliderElements);
+                ScreenshotInfo elementsOnlyInfo = new() { ResolutionScale = request.ResolutionScale };
+                int elementsOnlyImageToInputOffsetY = raycastGridRenderingInfo?.ImageToInputOffsetY ?? 0;
+                ApplyRenderingCoordinateMetadata(elementsOnlyInfo, gameViewSize, elementsOnlyImageToInputOffsetY);
+                elementsOnlyInfo.AnnotatedElements = elementsOnlyAnnotatedElements;
+                elementsOnlyInfo.RaycastGridPoints = raycastGridPoints;
+                elementsOnlyInfo.RaycastLayerSummaries = raycastLayerSummaries;
                 return new ScreenshotResponse
                 {
                     Screenshots = new List<ScreenshotInfo> { elementsOnlyInfo }
@@ -82,14 +133,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             GameObject annotationOverlay = null;
             Texture2D texture;
-            int yOffset;
-            bool timedOut;
+            GameRenderingImageInfo captureRenderingInfo;
+            bool captureTimedOut;
             try
             {
-                if (request.AnnotateElements)
+                if (request.AnnotateElements || request.AnnotateRaycastGrid)
                 {
+                    List<UIElementInfo> overlayElements = new(annotatedElements);
+                    overlayElements.AddRange(raycastGridOverlayElements);
+                    overlayElements.AddRange(physicsColliderElements);
                     annotationOverlay = UIElementAnnotator.CreateAnnotationOverlay(
-                        annotatedElements,
+                        overlayElements,
                         request.ResolutionScale);
                     Canvas.ForceUpdateCanvases();
                     // Chained CLI calls can read the previous GameView RT before overlay rendering catches up.
@@ -108,11 +162,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     await CapturedEditorSynchronizationContext.SwitchTo(editorContext, ct);
                 }
 
-                (texture, yOffset, timedOut) = await EditorWindowCaptureUtility.CaptureGameRenderingAsync(
+                (texture, captureRenderingInfo, captureTimedOut) = await EditorWindowCaptureUtility.CaptureGameRenderingAsync(
                     request.ResolutionScale,
+                    raycastGridRenderingInfo,
                     UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS,
                     ct).ConfigureAwait(false);
-                if (timedOut)
+                if (captureTimedOut)
                 {
                     return CreateTimedOutResult(
                         "GameView rendering capture",
@@ -127,7 +182,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 DestroyAnnotationOverlay(annotationOverlay, editorContext);
             }
 
-            UIElementAnnotator.ConvertToSimCoordinates(annotatedElements, (int)Handles.GetMainGameViewSize().y);
+            UIElementAnnotator.ConvertToSimCoordinates(annotatedElements, Mathf.RoundToInt(gameViewSize.y));
+            List<UIElementInfo> responseAnnotatedElements =
+                CreateResponseAnnotatedElements(annotatedElements, physicsColliderElements);
 
             if (texture == null)
             {
@@ -158,11 +215,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     FileSizeBytes = savedFileInfo.Length,
                     Width = width,
                     Height = height,
-                    CoordinateSystem = UnityCliLoopScreenshotCoordinateSystem.GameView,
                     ResolutionScale = request.ResolutionScale,
-                    YOffset = yOffset,
-                    AnnotatedElements = annotatedElements,
                 };
+                ApplyRenderingCoordinateMetadata(info, captureRenderingInfo.GameViewSize, captureRenderingInfo.ImageToInputOffsetY);
+                info.AnnotatedElements = responseAnnotatedElements;
+                info.RaycastGridPoints = raycastGridPoints;
+                info.RaycastLayerSummaries = raycastLayerSummaries;
                 screenshots.Add(info);
             }
             catch (Exception ex)
@@ -250,13 +308,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     SaveTextureAsPng(texture, savedPath);
 
                     FileInfo savedFileInfo = new(savedPath);
-                    screenshots.Add(new ScreenshotInfo
+                    ScreenshotInfo info = new()
                     {
                         ImagePath = savedPath,
                         FileSizeBytes = savedFileInfo.Length,
                         Width = width,
                         Height = height,
-                    });
+                    };
+                    ApplyWindowCoordinateMetadata(info);
+                    screenshots.Add(info);
                 }
                 catch (Exception ex)
                 {
@@ -324,6 +384,35 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             editorContext.Post(_ => UIElementAnnotator.DestroyAnnotationOverlay(annotationOverlay), null);
         }
 
+        private static void ApplyRenderingCoordinateMetadata(
+            ScreenshotInfo info,
+            Vector2 gameViewSize,
+            int imageToInputOffsetY = 0)
+        {
+            info.ImageCoordinateSystem = UnityCliLoopConstants.COORDINATE_SYSTEM_TOP_LEFT_GAME_VIEW;
+            info.GameViewWidth = gameViewSize.x;
+            info.GameViewHeight = gameViewSize.y;
+            info.ImageToInputOffsetY = imageToInputOffsetY;
+            info.ScreenshotToInputFormula = UnityCliLoopConstants.SCREENSHOT_RENDERING_TO_INPUT_FORMULA;
+            info.UnityInputFormula = UnityCliLoopConstants.COORDINATE_CONVERSION_FORMULA_GAME_VIEW_INPUT_TO_UNITY;
+        }
+
+        private static void ApplyWindowCoordinateMetadata(ScreenshotInfo info)
+        {
+            info.ImageCoordinateSystem = UnityCliLoopConstants.COORDINATE_SYSTEM_TOP_LEFT_WINDOW;
+            info.ScreenshotToInputFormula = UnityCliLoopConstants.SCREENSHOT_WINDOW_TO_INPUT_FORMULA_UNAVAILABLE;
+            info.UnityInputFormula = "";
+        }
+
+        private static List<UIElementInfo> CreateResponseAnnotatedElements(
+            List<UIElementInfo> uiElements,
+            List<UIElementInfo> physicsColliderElements)
+        {
+            List<UIElementInfo> responseElements = new(uiElements);
+            responseElements.AddRange(physicsColliderElements);
+            return responseElements;
+        }
+
         private void ValidateParameters(ScreenshotSchema request)
         {
             if (request.CaptureMode != CaptureMode.rendering &&
@@ -338,7 +427,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     $"ResolutionScale must be between 0.1 and 1.0, got: {request.ResolutionScale}");
             }
 
-            // AnnotateElements and ElementsOnly rely on PlayMode rendering pipeline
+            // AnnotateElements, ElementsOnly, and AnnotateRaycastGrid rely on PlayMode rendering pipeline
             if (request.CaptureMode != CaptureMode.rendering)
             {
                 if (request.AnnotateElements)
@@ -350,12 +439,75 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     throw new UnityCliLoopToolParameterValidationException("ElementsOnly is only supported when CaptureMode=rendering");
                 }
+
+                if (request.AnnotateRaycastGrid)
+                {
+                    throw new UnityCliLoopToolParameterValidationException("AnnotateRaycastGrid is only supported when CaptureMode=rendering");
+                }
             }
 
-            if (request.ElementsOnly && !request.AnnotateElements)
+            if (request.ElementsOnly &&
+                !request.AnnotateElements &&
+                !request.AnnotateRaycastGrid)
             {
-                throw new UnityCliLoopToolParameterValidationException("ElementsOnly requires AnnotateElements=true");
+                throw new UnityCliLoopToolParameterValidationException(
+                    "ElementsOnly requires AnnotateElements=true or AnnotateRaycastGrid=true");
             }
+
+            RaycastLayerMaskResolution raycastLayerMaskResolution = ResolveRaycastLayerMask(request);
+            if (raycastLayerMaskResolution.HasLayerNames && !request.AnnotateRaycastGrid)
+            {
+                throw new UnityCliLoopToolParameterValidationException(
+                    "RaycastLayerMask requires AnnotateRaycastGrid=true");
+            }
+
+            if (!raycastLayerMaskResolution.IsValid)
+            {
+                throw new UnityCliLoopToolParameterValidationException(
+                    CreateInvalidRaycastLayerMaskMessage(raycastLayerMaskResolution));
+            }
+        }
+
+        private static RaycastLayerMaskResolution ResolveRaycastLayerMask(ScreenshotSchema request)
+        {
+            string raycastLayerMask = request.RaycastLayerMask ?? "";
+            return RaycastLayerMaskResolver.Resolve(
+                raycastLayerMask,
+                GetAvailableLayerDefinitions());
+        }
+
+        private static List<RaycastLayerDefinition> GetAvailableLayerDefinitions()
+        {
+            List<RaycastLayerDefinition> layerDefinitions = new();
+            for (int layerIndex = 0; layerIndex <= 31; layerIndex++)
+            {
+                string layerName = LayerMask.LayerToName(layerIndex);
+                if (string.IsNullOrEmpty(layerName))
+                {
+                    continue;
+                }
+
+                layerDefinitions.Add(new RaycastLayerDefinition
+                {
+                    Name = layerName,
+                    Index = layerIndex
+                });
+            }
+
+            return layerDefinitions;
+        }
+
+        private static string CreateInvalidRaycastLayerMaskMessage(
+            RaycastLayerMaskResolution raycastLayerMaskResolution)
+        {
+            string invalidLayerNames = string.Join(", ", raycastLayerMaskResolution.InvalidLayerNames);
+            string validLayerNames = string.Join(", ", raycastLayerMaskResolution.ValidLayerNames);
+            if (string.IsNullOrEmpty(validLayerNames))
+            {
+                validLayerNames = "(none)";
+            }
+
+            return $"RaycastLayerMask contains unknown layer name(s): {invalidLayerNames}. Valid layers: {validLayerNames}";
         }
 
         private string EnsureOutputDirectoryExists(string outputDirectory)

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
@@ -79,9 +79,10 @@ Returns JSON with:
   - `FileSizeBytes`: Size of the saved file in bytes
   - `Width`: Captured image width in pixels
   - `Height`: Captured image height in pixels
-  - `CoordinateSystem`: `"gameView"` or `"window"`
+  - `ImageCoordinateSystem`: `"top-left-game-view"` or `"top-left-window"`
   - `ResolutionScale`: Resolution scale used for capture
-  - `YOffset`: Y offset used for gameView coordinate conversion
+  - `ImageToInputOffsetY`: Y offset used for top-left-game-view coordinate conversion
+  - `ScreenshotToInputFormula`: Formula converting raw image pixels to simulate-mouse input coordinates
   - `AnnotatedElements`: Array of annotated UI element metadata. Empty unless `--annotate-elements` is used.
 
 For `AnnotatedElements` fields and gameView coordinate conversion, read [references/annotated-elements.md](references/annotated-elements.md) before using screenshot coordinates with mouse simulation tools.

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/references/annotated-elements.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/references/annotated-elements.md
@@ -18,18 +18,18 @@ Read this when using `uloop screenshot --capture-mode rendering --annotate-eleme
 
 ## Coordinate Conversion
 
-When `CoordinateSystem` is `"gameView"`, convert image pixel coordinates to simulate-mouse coordinates:
+When `ImageCoordinateSystem` is `"top-left-game-view"`, convert image pixel coordinates to simulate-mouse coordinates using `ScreenshotToInputFormula`:
 
 ```text
-sim_x = image_x / ResolutionScale
-sim_y = image_y / ResolutionScale + YOffset
+simulate_mouse_x = image_x / resolutionScale
+simulate_mouse_y = image_y / resolutionScale + imageToInputOffsetY
 ```
 
 When `ResolutionScale` is `1.0`, this simplifies to:
 
 ```text
-sim_x = image_x
-sim_y = image_y + YOffset
+simulate_mouse_x = image_x
+simulate_mouse_y = image_y + imageToInputOffsetY
 ```
 
 ## Annotation Readability

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UIElementAnnotator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UIElementAnnotator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -58,9 +59,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             List<UIElementInfo> elements = new();
             HashSet<GameObject> processedObjects = new();
+            UiRaycastHelper.RaycastContext? raycastContext = CreateRaycastContextForCurrentEventSystem();
 
-            CollectSelectables(elements, processedObjects);
-            CollectEventHandlers(elements, processedObjects);
+            CollectSelectables(elements, processedObjects, raycastContext);
+            CollectEventHandlers(elements, processedObjects, raycastContext);
 
             return elements;
         }
@@ -117,10 +119,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             canvas.sortingOrder = OVERLAY_SORT_ORDER;
 
             Font font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            List<AnnotationDrawInfo> drawInfos = new(elements.Count);
+            float physicsAnnotationScreenHeight = CalculatePhysicsAnnotationScreenHeight(elements);
 
             foreach (UIElementInfo element in elements)
             {
-                CreateAnnotationForElement(root.transform, element, font, borderMetrics);
+                drawInfos.Add(CreateAnnotationDrawInfo(element, physicsAnnotationScreenHeight));
+            }
+
+            foreach (AnnotationDrawInfo drawInfo in drawInfos)
+            {
+                CreateAnnotationBorderForElement(root.transform, drawInfo, borderMetrics);
+            }
+
+            foreach (AnnotationDrawInfo drawInfo in drawInfos)
+            {
+                CreateAnnotationLabelForElement(root.transform, drawInfo, font, borderMetrics);
             }
 
             return root;
@@ -134,7 +148,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static void CollectSelectables(List<UIElementInfo> elements, HashSet<GameObject> processedObjects)
+        private static void CollectSelectables(
+            List<UIElementInfo> elements,
+            HashSet<GameObject> processedObjects,
+            UiRaycastHelper.RaycastContext? raycastContext)
         {
             Selectable[] selectables = Selectable.allSelectablesArray;
             foreach (Selectable selectable in selectables)
@@ -147,13 +164,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 processedObjects.Add(selectable.gameObject);
 
                 string type = ClassifySelectable(selectable);
-                AddElementInfo(elements, selectable.gameObject, selectable.name, type);
+                AddElementInfo(elements, selectable.gameObject, selectable.name, type, raycastContext);
             }
         }
 
         // Collects non-Selectable MonoBehaviours that implement pointer/drag event interfaces.
         // Priority: IDragHandler > IDropHandler > IPointerClickHandler > IPointerDownHandler
-        private static void CollectEventHandlers(List<UIElementInfo> elements, HashSet<GameObject> processedObjects)
+        private static void CollectEventHandlers(
+            List<UIElementInfo> elements,
+            HashSet<GameObject> processedObjects,
+            UiRaycastHelper.RaycastContext? raycastContext)
         {
             MonoBehaviour[] allBehaviours = Object.FindObjectsOfType<MonoBehaviour>();
             foreach (MonoBehaviour behaviour in allBehaviours)
@@ -168,18 +188,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                string type = ClassifyEventHandler(behaviour);
+                string? type = ClassifyEventHandler(behaviour);
                 if (type == null)
                 {
                     continue;
                 }
 
                 processedObjects.Add(behaviour.gameObject);
-                AddElementInfo(elements, behaviour.gameObject, behaviour.name, type);
+                AddElementInfo(elements, behaviour.gameObject, behaviour.name, type, raycastContext);
             }
         }
 
-        private static string ClassifyEventHandler(MonoBehaviour behaviour)
+        private static string? ClassifyEventHandler(MonoBehaviour behaviour)
         {
             if (behaviour is IDragHandler) return "Draggable";
             if (behaviour is IDropHandler) return "DropTarget";
@@ -204,11 +224,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Reusable buffers to avoid per-element allocations in AddElementInfo → GetScreenCorners
         private static readonly Vector3[] SharedWorldCorners = new Vector3[4];
         private static readonly Vector2[] SharedScreenCorners = new Vector2[4];
-        private static readonly List<RaycastResult> SharedRaycastResults = new List<RaycastResult>();
-        private static PointerEventData SharedPointerEventData;
-        private static EventSystem SharedPointerEventSystem;
 
-        private static void AddElementInfo(List<UIElementInfo> elements, GameObject go, string name, string type)
+        private static void AddElementInfo(
+            List<UIElementInfo> elements,
+            GameObject go,
+            string name,
+            string type,
+            UiRaycastHelper.RaycastContext? raycastContext)
         {
             RectTransform rectTransform = go.GetComponent<RectTransform>();
             if (rectTransform == null)
@@ -241,7 +263,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             float centerX = (minX + maxX) / 2f;
             float centerY = (minY + maxY) / 2f;
 
-            if (!IsRaycastReachable(go, centerX, centerY))
+            if (!IsRaycastReachable(go, centerX, centerY, raycastContext))
             {
                 return;
             }
@@ -266,50 +288,44 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static bool HasActiveGraphicRaycaster(Canvas canvas)
         {
             GraphicRaycaster raycaster = canvas.GetComponent<GraphicRaycaster>();
-            return raycaster != null && raycaster.isActiveAndEnabled;
+            return canvas.isActiveAndEnabled && raycaster != null && raycaster.isActiveAndEnabled;
         }
 
-        // simulate-mouse uses EventSystem.RaycastAll, so only advertise elements whose
-        // center point is actually hittable. Skips the check when no EventSystem exists
-        // (e.g. annotation-only scenes without interaction).
-        private static bool IsRaycastReachable(GameObject go, float centerX, float centerY)
+        // Uses the same raycast path as simulate-mouse so annotations match UI input behavior.
+        // Skips the check when no EventSystem exists, such as annotation-only scenes without interaction.
+        private static bool IsRaycastReachable(
+            GameObject go,
+            float centerX,
+            float centerY,
+            UiRaycastHelper.RaycastContext? raycastContext)
         {
-            EventSystem eventSystem = EventSystem.current;
-            if (eventSystem == null)
+            if (raycastContext == null)
             {
                 return true;
             }
 
-            if (SharedPointerEventData == null || SharedPointerEventSystem != eventSystem)
+            RaycastResult? raycastResult = raycastContext.Raycast(new Vector2(centerX, centerY));
+            if (raycastResult == null)
             {
-                SharedPointerEventData = new PointerEventData(eventSystem);
-                SharedPointerEventSystem = eventSystem;
+                return false;
             }
-            SharedPointerEventData.position = new Vector2(centerX, centerY);
-
-            SharedRaycastResults.Clear();
-            eventSystem.RaycastAll(SharedPointerEventData, SharedRaycastResults);
 
             Transform targetTransform = go.transform;
-            foreach (RaycastResult raycastResult in SharedRaycastResults)
+            Transform hitTransform = raycastResult.Value.gameObject.transform;
+            return hitTransform == targetTransform || hitTransform.IsChildOf(targetTransform);
+        }
+
+        // Reuses one raycast context while collecting annotations because a screenshot can
+        // test many UI elements in one frame.
+        private static UiRaycastHelper.RaycastContext? CreateRaycastContextForCurrentEventSystem()
+        {
+            EventSystem eventSystem = EventSystem.current;
+            if (eventSystem == null)
             {
-                Transform hitTransform = raycastResult.gameObject.transform;
-                if (hitTransform == targetTransform || hitTransform.IsChildOf(targetTransform))
-                {
-                    return true;
-                }
+                return null;
             }
 
-            // EventSystem clips at Screen.width/height which can be smaller than the
-            // Canvas layout space (Game view target resolution). Check Canvas space directly.
-            RectTransform rectTransform = go.GetComponent<RectTransform>();
-            if (rectTransform != null)
-            {
-                return RectTransformUtility.RectangleContainsScreenPoint(
-                    rectTransform, new Vector2(centerX, centerY), null);
-            }
-
-            return false;
+            return new UiRaycastHelper.RaycastContext(eventSystem);
         }
 
         // Writes 4 corners into SharedScreenCorners in screen pixel coordinates (bottom-left origin).
@@ -359,51 +375,169 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return true;
         }
 
-        private static void CreateAnnotationForElement(
+        private static void CreateAnnotationBorderForElement(
             Transform parent,
-            UIElementInfo element,
-            Font font,
+            AnnotationDrawInfo drawInfo,
             AnnotationBorderMetrics borderMetrics)
         {
-            float screenMinX = element.BoundsMinX;
-            float screenMaxX = element.BoundsMaxX;
-            float screenMinY = element.BoundsMinY;
-            float screenMaxY = element.BoundsMaxY;
-
-            Color color = GetAnnotationColorForElement(element);
-            Color contrastColor = GetContrastingTextColor(color);
-            AnnotationBorderColors borderColors = GetAnnotationBorderColors(color);
+            if (drawInfo.OutlineSegments.Count > 0)
+            {
+                CreateAnnotationOutlineForElement(parent, drawInfo, borderMetrics);
+                return;
+            }
 
             CreateBorder(
                 parent,
                 "LightOuter",
-                screenMinX - borderMetrics.OuterOffset,
-                screenMinY - borderMetrics.OuterOffset,
-                screenMaxX + borderMetrics.OuterOffset,
-                screenMaxY + borderMetrics.OuterOffset,
+                drawInfo.ScreenMinX - borderMetrics.OuterOffset,
+                drawInfo.ScreenMinY - borderMetrics.OuterOffset,
+                drawInfo.ScreenMaxX + borderMetrics.OuterOffset,
+                drawInfo.ScreenMaxY + borderMetrics.OuterOffset,
                 borderMetrics.NeutralThickness,
-                borderColors.Outer);
+                drawInfo.BorderColors.Outer);
             CreateBorder(
                 parent,
                 "ColorMiddle",
-                screenMinX - borderMetrics.ColorOffset,
-                screenMinY - borderMetrics.ColorOffset,
-                screenMaxX + borderMetrics.ColorOffset,
-                screenMaxY + borderMetrics.ColorOffset,
+                drawInfo.ScreenMinX - borderMetrics.ColorOffset,
+                drawInfo.ScreenMinY - borderMetrics.ColorOffset,
+                drawInfo.ScreenMaxX + borderMetrics.ColorOffset,
+                drawInfo.ScreenMaxY + borderMetrics.ColorOffset,
                 borderMetrics.ColorThickness,
-                borderColors.Middle);
-            CreateBorder(parent, "DarkInner", screenMinX, screenMinY, screenMaxX, screenMaxY, borderMetrics.NeutralThickness, borderColors.Inner);
+                drawInfo.BorderColors.Middle);
+            CreateBorder(
+                parent,
+                "DarkInner",
+                drawInfo.ScreenMinX,
+                drawInfo.ScreenMinY,
+                drawInfo.ScreenMaxX,
+                drawInfo.ScreenMaxY,
+                borderMetrics.NeutralThickness,
+                drawInfo.BorderColors.Inner);
+        }
 
-            string labelText = CreateDisplayLabel(element);
+        private static void CreateAnnotationOutlineForElement(
+            Transform parent,
+            AnnotationDrawInfo drawInfo,
+            AnnotationBorderMetrics borderMetrics)
+        {
+            float outerThickness = borderMetrics.ColorThickness + borderMetrics.NeutralThickness * 2f;
+            CreateOutline(
+                parent,
+                "LightOuter",
+                drawInfo.OutlineSegments,
+                outerThickness,
+                drawInfo.BorderColors.Outer);
+            CreateOutline(
+                parent,
+                "ColorMiddle",
+                drawInfo.OutlineSegments,
+                borderMetrics.ColorThickness,
+                drawInfo.BorderColors.Middle);
+            CreateOutline(
+                parent,
+                "DarkInner",
+                drawInfo.OutlineSegments,
+                borderMetrics.NeutralThickness,
+                drawInfo.BorderColors.Inner);
+        }
+
+        private static void CreateAnnotationLabelForElement(
+            Transform parent,
+            AnnotationDrawInfo drawInfo,
+            Font font,
+            AnnotationBorderMetrics borderMetrics)
+        {
             CreateLabel(
                 parent,
-                labelText,
-                screenMinX,
-                screenMaxY + borderMetrics.OuterOffset + borderMetrics.LabelOutlineDistance + borderMetrics.LabelToBorderGap,
-                color,
-                contrastColor,
+                drawInfo.DisplayLabel,
+                drawInfo.ScreenMinX,
+                drawInfo.ScreenMaxY + borderMetrics.OuterOffset + borderMetrics.LabelOutlineDistance + borderMetrics.LabelToBorderGap,
+                drawInfo.Color,
+                drawInfo.ContrastColor,
                 font,
                 borderMetrics.LabelOutlineDistance);
+        }
+
+        private static AnnotationDrawInfo CreateAnnotationDrawInfo(
+            UIElementInfo element,
+            float physicsAnnotationScreenHeight)
+        {
+            Color color = GetAnnotationColorForElement(element);
+            Color contrastColor = GetContrastingTextColor(color);
+            AnnotationBorderColors borderColors = GetAnnotationBorderColors(color);
+            string displayLabel = CreateDisplayLabel(element);
+            float screenMinX = element.BoundsMinX;
+            float screenMinY = element.BoundsMinY;
+            float screenMaxX = element.BoundsMaxX;
+            float screenMaxY = element.BoundsMaxY;
+            List<RaycastOutlineSegment> outlineSegments = element.RaycastOutlineSegments;
+
+            if (IsPhysicsColliderElement(element))
+            {
+                Debug.Assert(
+                    physicsAnnotationScreenHeight >= 0f,
+                    "Physics collider annotations require a non-negative Game View height.");
+                screenMinY = physicsAnnotationScreenHeight - element.BoundsMaxY;
+                screenMaxY = physicsAnnotationScreenHeight - element.BoundsMinY;
+                outlineSegments = ConvertTopLeftOutlineSegmentsToScreenSegments(
+                    element.RaycastOutlineSegments,
+                    physicsAnnotationScreenHeight);
+            }
+
+            return new AnnotationDrawInfo(
+                screenMinX,
+                screenMinY,
+                screenMaxX,
+                screenMaxY,
+                color,
+                contrastColor,
+                borderColors,
+                displayLabel,
+                outlineSegments);
+        }
+
+        private static float CalculatePhysicsAnnotationScreenHeight(List<UIElementInfo> elements)
+        {
+            foreach (UIElementInfo element in elements)
+            {
+                if (!IsPhysicsColliderElement(element))
+                {
+                    continue;
+                }
+
+                return GameViewCoordinateUtility.GetMainGameViewSize().y;
+            }
+
+            return 0f;
+        }
+
+        private static bool IsPhysicsColliderElement(UIElementInfo element)
+        {
+            return element.Type == "PhysicsCollider";
+        }
+
+        private static List<RaycastOutlineSegment> ConvertTopLeftOutlineSegmentsToScreenSegments(
+            List<RaycastOutlineSegment> outlineSegments,
+            float screenHeight)
+        {
+            List<RaycastOutlineSegment> screenSegments = new(outlineSegments.Count);
+            foreach (RaycastOutlineSegment segment in outlineSegments)
+            {
+                screenSegments.Add(ConvertTopLeftOutlineSegmentToScreenSegment(segment, screenHeight));
+            }
+
+            return screenSegments;
+        }
+
+        internal static RaycastOutlineSegment ConvertTopLeftOutlineSegmentToScreenSegment(
+            RaycastOutlineSegment segment,
+            float screenHeight)
+        {
+            return new RaycastOutlineSegment(
+                segment.StartX,
+                screenHeight - segment.StartY,
+                segment.EndX,
+                screenHeight - segment.EndY);
         }
 
         private static void CreateBorder(
@@ -417,6 +551,39 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CreateBorderEdge(parent, $"{name}_Bottom", borderEdgeRects.Bottom, color);
             CreateBorderEdge(parent, $"{name}_Left", borderEdgeRects.Left, color);
             CreateBorderEdge(parent, $"{name}_Right", borderEdgeRects.Right, color);
+        }
+
+        private static void CreateOutline(
+            Transform parent,
+            string name,
+            List<RaycastOutlineSegment> outlineSegments,
+            float thickness,
+            Color color)
+        {
+            for (int i = 0; i < outlineSegments.Count; i++)
+            {
+                Rect rect = CalculateOutlineSegmentRect(outlineSegments[i], thickness);
+                CreateBorderEdge(parent, $"{name}_Outline_{i}", rect, color);
+            }
+        }
+
+        internal static Rect CalculateOutlineSegmentRect(RaycastOutlineSegment segment, float thickness)
+        {
+            Debug.Assert(thickness >= 0f, "Outline thickness must not be negative.");
+            bool horizontal = Mathf.Approximately(segment.StartY, segment.EndY);
+            bool vertical = Mathf.Approximately(segment.StartX, segment.EndX);
+            Debug.Assert(horizontal || vertical, "Raycast outline segments must be axis-aligned.");
+
+            if (horizontal)
+            {
+                float minX = Mathf.Min(segment.StartX, segment.EndX) - thickness / 2f;
+                float width = Mathf.Abs(segment.EndX - segment.StartX) + thickness;
+                return new Rect(minX, segment.StartY - thickness / 2f, width, thickness);
+            }
+
+            float minY = Mathf.Min(segment.StartY, segment.EndY) - thickness / 2f;
+            float height = Mathf.Abs(segment.EndY - segment.StartY) + thickness;
+            return new Rect(segment.StartX - thickness / 2f, minY, thickness, height);
         }
 
         internal static BorderEdgeRects CalculateBorderEdgeRects(
@@ -511,7 +678,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(element != null, "UIElementInfo must not be null.");
 
-            int labelIndex = GetLabelIndex(element.Label);
+            int labelIndex = GetLabelIndex(element!.Label);
             if (labelIndex < 0)
             {
                 return FALLBACK_COLOR;
@@ -589,7 +756,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(element != null, "UIElementInfo must not be null.");
 
-            string interaction = element.Interaction;
+            string interaction = element!.Interaction;
             if (string.IsNullOrEmpty(interaction))
             {
                 interaction = GetInteractionForType(element.Type);
@@ -657,6 +824,41 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Inner = inner;
                 Middle = middle;
                 Outer = outer;
+            }
+        }
+
+        private readonly struct AnnotationDrawInfo
+        {
+            public readonly float ScreenMinX;
+            public readonly float ScreenMinY;
+            public readonly float ScreenMaxX;
+            public readonly float ScreenMaxY;
+            public readonly Color Color;
+            public readonly Color ContrastColor;
+            public readonly AnnotationBorderColors BorderColors;
+            public readonly string DisplayLabel;
+            public readonly List<RaycastOutlineSegment> OutlineSegments;
+
+            public AnnotationDrawInfo(
+                float screenMinX,
+                float screenMinY,
+                float screenMaxX,
+                float screenMaxY,
+                Color color,
+                Color contrastColor,
+                AnnotationBorderColors borderColors,
+                string displayLabel,
+                List<RaycastOutlineSegment> outlineSegments)
+            {
+                ScreenMinX = screenMinX;
+                ScreenMinY = screenMinY;
+                ScreenMaxX = screenMaxX;
+                ScreenMaxY = screenMaxY;
+                Color = color;
+                ContrastColor = contrastColor;
+                BorderColors = borderColors;
+                DisplayLabel = displayLabel;
+                OutlineSegments = outlineSegments;
             }
         }
 

--- a/Packages/src/Editor/ToolContracts/ScreenshotResponse.cs
+++ b/Packages/src/Editor/ToolContracts/ScreenshotResponse.cs
@@ -2,8 +2,6 @@
 
 using System.Collections.Generic;
 
-using io.github.hatayama.UnityCliLoop.ToolContracts;
-
 namespace io.github.hatayama.UnityCliLoop.ToolContracts
 {
     /// <summary>
@@ -15,20 +13,20 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public long FileSizeBytes { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
-
-        // "gameView": image from game RenderTexture. Convert to simulate-mouse coords:
-        //   sim_x = image_x / ResolutionScale
-        //   sim_y = image_y / ResolutionScale + YOffset
-        // "window": EditorWindow capture including toolbar
-        public string CoordinateSystem { get; set; } = UnityCliLoopScreenshotCoordinateSystem.Window;
-
+        public string ImageCoordinateSystem { get; set; } = UnityCliLoopConstants.COORDINATE_SYSTEM_TOP_LEFT_WINDOW;
         public float ResolutionScale { get; set; } = 1.0f;
 
         // Y offset to add to image pixel Y to get simulate-mouse Y coordinate.
-        // Only meaningful when CoordinateSystem == "gameView".
-        public int YOffset { get; set; }
+        // Only meaningful when ImageCoordinateSystem is the Game View system.
+        public int ImageToInputOffsetY { get; set; }
 
+        public float GameViewWidth { get; set; }
+        public float GameViewHeight { get; set; }
+        public string ScreenshotToInputFormula { get; set; } = UnityCliLoopConstants.SCREENSHOT_WINDOW_TO_INPUT_FORMULA_UNAVAILABLE;
+        public string UnityInputFormula { get; set; } = "";
         public List<UIElementInfo> AnnotatedElements { get; set; } = new List<UIElementInfo>();
+        public List<RaycastGridPointInfo> RaycastGridPoints { get; set; } = new List<RaycastGridPointInfo>();
+        public List<RaycastLayerSummaryInfo> RaycastLayerSummaries { get; set; } = new List<RaycastLayerSummaryInfo>();
     }
 
     /// <summary>

--- a/Packages/src/Editor/ToolContracts/ScreenshotSchema.cs
+++ b/Packages/src/Editor/ToolContracts/ScreenshotSchema.cs
@@ -1,6 +1,3 @@
-
-using io.github.hatayama.UnityCliLoop.ToolContracts;
-
 namespace io.github.hatayama.UnityCliLoop.ToolContracts
 {
     /// <summary>
@@ -15,5 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public CaptureMode CaptureMode { get; set; } = CaptureMode.window;
         public bool AnnotateElements { get; set; } = false;
         public bool ElementsOnly { get; set; } = false;
+        public bool AnnotateRaycastGrid { get; set; } = false;
+        public string RaycastLayerMask { get; set; } = "";
     }
 }

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -93,6 +93,13 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string COORDINATE_CONVERSION_FORMULA_GAME_VIEW_INPUT_TO_UNITY =
             "unity_x = input_x; unity_y = gameViewHeight - input_y";
 
+        // Screenshot tool coordinate constants
+        public const string COORDINATE_SYSTEM_TOP_LEFT_WINDOW = "top-left-window";
+        public const string SCREENSHOT_RENDERING_TO_INPUT_FORMULA =
+            "simulate_mouse_x = image_x / resolutionScale; simulate_mouse_y = image_y / resolutionScale + imageToInputOffsetY";
+        public const string SCREENSHOT_WINDOW_TO_INPUT_FORMULA_UNAVAILABLE =
+            "unavailable: window screenshots include Unity Editor chrome; use capture-mode rendering for mouse input coordinates";
+
         public const int CORRELATION_ID_LENGTH = 8;
         public const string GUID_FORMAT_NO_HYPHENS = "N";
         

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopScreenshotTypes.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopScreenshotTypes.cs
@@ -12,13 +12,4 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         window = 0,
         rendering = 1
     }
-
-    /// <summary>
-    /// Provides Unity CLI Loop Screenshot Coordinate System behavior for Unity CLI Loop.
-    /// </summary>
-    public static class UnityCliLoopScreenshotCoordinateSystem
-    {
-        public const string Window = "window";
-        public const string GameView = "gameView";
-    }
 }

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -252,7 +252,7 @@
           },
           "CaptureMode": {
             "type": "string",
-            "description": "Capture mode: window=capture EditorWindow including toolbar, rendering=capture game rendering only (PlayMode required). Response includes CoordinateSystem ('gameView' or 'window'), ResolutionScale, and YOffset. For gameView: sim_x = image_x / ResolutionScale, sim_y = image_y / ResolutionScale + YOffset.",
+            "description": "Capture mode: window=capture EditorWindow including toolbar, rendering=capture game rendering only (PlayMode required). Rendering screenshots return ScreenshotToInputFormula for converting raw image pixels before calling simulate-mouse-input or raycast.",
             "enum": [
               "window",
               "rendering"
@@ -266,8 +266,18 @@
           },
           "ElementsOnly": {
             "type": "boolean",
-            "description": "Return only annotated element JSON without capturing a screenshot image. Requires AnnotateElements=true and CaptureMode=rendering in PlayMode.",
+            "description": "Return only annotation JSON without capturing a screenshot image. Requires AnnotateElements=true or AnnotateRaycastGrid=true, and CaptureMode=rendering in PlayMode.",
             "default": false
+          },
+          "AnnotateRaycastGrid": {
+            "type": "boolean",
+            "description": "Annotate 3D physics raycast candidate points on rendering screenshots. Uses Camera.main, Camera.main.cullingMask visibility, and the same top-left Game View coordinates as simulate-mouse-input.",
+            "default": false
+          },
+          "RaycastLayerMask": {
+            "type": "string",
+            "description": "Comma-separated physics layer names used by AnnotateRaycastGrid. Hits are limited to layers also visible to Camera.main.cullingMask. When set, returns clustered PhysicsCollider entries in AnnotatedElements instead of the coarse grid points.",
+            "default": ""
           }
         }
       }


### PR DESCRIPTION
## Summary
- The screenshot tool can now annotate 3D physics raycast candidate points (or clustered colliders when a layer filter is given) directly on rendering-mode screenshots, in addition to the existing UI element annotation.
- Rendering screenshots return a ready-to-use formula (`ScreenshotToInputFormula`) for converting image pixels into simulate-mouse-input/raycast coordinates, removing the need to reverse-engineer the previous `CoordinateSystem`/`YOffset` fields.

## User Impact
- Before: only UI elements could be annotated on a screenshot, and callers had to compute the mouse-input Y offset themselves from `CoordinateSystem`/`YOffset`.
- After: passing `AnnotateRaycastGrid=true` overlays a 5x5 grid of physics raycast hits (or, with `RaycastLayerMask` set, clustered outlines of the actual hit colliders) on the screenshot, and the response includes the exact formula plus Game View size needed to drive `simulate-mouse-input`/`raycast` from the image.

## Changes
- `ScreenshotSchema`/`ScreenshotResponse` gained `AnnotateRaycastGrid`, `RaycastLayerMask`, `GameViewWidth`/`Height`, `ScreenshotToInputFormula`, `UnityInputFormula`, `RaycastGridPoints`, and `RaycastLayerSummaries`. `CoordinateSystem`/`YOffset` were renamed to `ImageCoordinateSystem`/`ImageToInputOffsetY`.
- `EditorWindowCaptureUtility` now shares a `GameRenderingImageInfo` struct between the raycast-grid path and the PNG capture path so both reuse the same settled RenderTexture geometry, while keeping the existing frame-wait timeout safety net.
- `UIElementAnnotator` now shares one `UiRaycastHelper.RaycastContext` while collecting elements (replacing an ad-hoc per-call raycast check) and draws physics-collider outlines in a separate pass from box borders/labels.
- `ScreenshotUseCase` wires raycast-grid collection into rendering capture with matching parameter validation, and `default-tools.json`'s `screenshot` entry was updated in the same change (required immediately by `DefaultToolsCatalogDriftTests`).

## Verification
- `uloop compile` — 0 errors, 0 warnings
- Full EditMode suite — 1774 passed, 0 failed (7 pre-existing skips)
- PlayMode regression (`SimulateMouseUiTests`, `SimulateMouseUiInputSystemTests`, `InputReplayVerificationE2ETests`) — all passed, confirming no behavior change for existing `UiRaycastHelper` callers

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

