### PR TITLE
fix: Mouse click and long-press coordinates now match the Game View's actual resolution

### DIFF
--- a/.agents/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-input/SKILL.md
@@ -12,7 +12,7 @@ Simulate mouse input via Input System in Unity PlayMode.
 ## Workflow
 
 1. Ensure Unity is in PlayMode (use `uloop control-play-mode --action Play` if not)
-2. For Click/LongPress: determine the target screen position (use `uloop screenshot` to find coordinates)
+2. For Click/LongPress: determine the target Game View input position from annotated `SimX`/`SimY`, raycast-grid `InputX`/`InputY`, or raw image pixels converted with `ScreenshotToInputFormula`
 3. Execute the needed `uloop simulate-mouse-input` commands
 4. Inspect the result with the lightest useful evidence: runtime state, logs, or a screenshot
 5. When this input verifies a state transition, use Pause Point inspection from the section below as the standard frame proof
@@ -29,8 +29,8 @@ uloop simulate-mouse-input --action <action> [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--action` | enum | `Click` | `Click`, `LongPress`, `MoveDelta`, `SmoothDelta`, `Scroll` |
-| `--x` | number | `0` | Target X position (origin: top-left). Used by Click and LongPress. |
-| `--y` | number | `0` | Target Y position (origin: top-left). Used by Click and LongPress. |
+| `--x` | number | `0` | Target X position in Game View pixels (origin: top-left). Used by Click and LongPress. Use `AnnotatedElements[].SimX`, `RaycastGridPoints[].InputX`, or raw image pixels converted with `ScreenshotToInputFormula`. |
+| `--y` | number | `0` | Target Y position in Game View pixels (origin: top-left). Used by Click and LongPress. Use `AnnotatedElements[].SimY`, `RaycastGridPoints[].InputY`, or raw image pixels converted with `ScreenshotToInputFormula`. |
 | `--button` | enum | `Left` | Mouse button: `Left`, `Right`, `Middle`. Used by Click and LongPress. |
 | `--duration` | number | `0` | Hold duration for LongPress, or interpolation duration for SmoothDelta (seconds). For Click, 0 = one-shot tap. |
 | `--delta-x` | number | `0` | Delta X in pixels for MoveDelta/SmoothDelta. Positive = right. |
@@ -77,7 +77,7 @@ All rows below assume the New Input System is installed.
 ## Examples
 
 ```bash
-# Left-click at screen center for runtime input
+# Left-click at the Game View center for runtime input
 uloop simulate-mouse-input --action Click --x 400 --y 300
 
 # Right-click at screen center
@@ -99,6 +99,20 @@ uloop simulate-mouse-input --action Scroll --scroll-y -120
 uloop simulate-mouse-input --action SmoothDelta --delta-x 300 --delta-y 0 --duration 0.5
 ```
 
+## Coordinate System
+
+- `--x` / `--y` use **top-left Game View coordinates**.
+- Raw image pixels from `uloop screenshot --capture-mode rendering` must be converted with `ScreenshotToInputFormula`.
+- `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` can be passed directly to this tool.
+- Do not flip Y in the caller. The tool converts internally for Unity Input System:
+
+```text
+unity_x = input_x
+unity_y = gameViewHeight - input_y
+```
+
+- `Mouse.current.position` uses bottom-left Unity coordinates, so the value read inside Unity may show the converted Y.
+
 ## Prerequisites
 
 - Unity must be in **PlayMode**
@@ -113,8 +127,13 @@ Returns JSON with:
 - `Message`: Status message
 - `Action`: Echoes which action was executed (`Click`, `LongPress`, `MoveDelta`, `SmoothDelta`, or `Scroll`)
 - `Button`: Which button was used (nullable string; populated for `Click` / `LongPress`, null otherwise)
-- `PositionX`: Target X coordinate (nullable float; populated for `Click` / `LongPress`)
-- `PositionY`: Target Y coordinate (nullable float; populated for `Click` / `LongPress`)
+- `PositionX` / `PositionY`: Target top-left Game View coordinates (nullable float; populated for `Click` / `LongPress`)
+- `InputCoordinateSystem`: `"top-left-game-view"` for click/long-press coordinates
+- `UnityCoordinateSystem`: `"bottom-left-game-view"` for the injected `Mouse.current.position`
+- `GameViewWidth` / `GameViewHeight`: Game View size used for conversion
+- `InputPositionX` / `InputPositionY`: Coordinates received from the caller
+- `InjectedUnityPositionX` / `InjectedUnityPositionY`: Coordinates injected into `Mouse.current.position`
+- `CoordinateConversionFormula`: Conversion formula used by the tool
 - `InterruptedByPausePoint`: True when Unity paused during Pause Point inspection and the input bookkeeping was safely released
 - `PausePointId`: The id from `UloopPausePoint.Pause("<id>")` when it caused the interruption
 - `PausePointHitCount`: The hit count for that `UloopPausePoint.Pause("<id>")`

--- a/.agents/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-input/SKILL.md
@@ -77,10 +77,10 @@ All rows below assume the New Input System is installed.
 ## Examples
 
 ```bash
-# Left-click at the Game View center for runtime input
+# Left-click at a representative Game View point for runtime input
 uloop simulate-mouse-input --action Click --x 400 --y 300
 
-# Right-click at screen center
+# Right-click at a representative Game View point
 uloop simulate-mouse-input --action Click --x 400 --y 300 --button Right
 
 # Hold left-click for 2 seconds

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -12,7 +12,7 @@ Simulate mouse input via Input System in Unity PlayMode.
 ## Workflow
 
 1. Ensure Unity is in PlayMode (use `uloop control-play-mode --action Play` if not)
-2. For Click/LongPress: determine the target screen position (use `uloop screenshot` to find coordinates)
+2. For Click/LongPress: determine the target Game View input position from annotated `SimX`/`SimY`, raycast-grid `InputX`/`InputY`, or raw image pixels converted with `ScreenshotToInputFormula`
 3. Execute the needed `uloop simulate-mouse-input` commands
 4. Inspect the result with the lightest useful evidence: runtime state, logs, or a screenshot
 5. When this input verifies a state transition, use Pause Point inspection from the section below as the standard frame proof
@@ -29,8 +29,8 @@ uloop simulate-mouse-input --action <action> [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--action` | enum | `Click` | `Click`, `LongPress`, `MoveDelta`, `SmoothDelta`, `Scroll` |
-| `--x` | number | `0` | Target X position (origin: top-left). Used by Click and LongPress. |
-| `--y` | number | `0` | Target Y position (origin: top-left). Used by Click and LongPress. |
+| `--x` | number | `0` | Target X position in Game View pixels (origin: top-left). Used by Click and LongPress. Use `AnnotatedElements[].SimX`, `RaycastGridPoints[].InputX`, or raw image pixels converted with `ScreenshotToInputFormula`. |
+| `--y` | number | `0` | Target Y position in Game View pixels (origin: top-left). Used by Click and LongPress. Use `AnnotatedElements[].SimY`, `RaycastGridPoints[].InputY`, or raw image pixels converted with `ScreenshotToInputFormula`. |
 | `--button` | enum | `Left` | Mouse button: `Left`, `Right`, `Middle`. Used by Click and LongPress. |
 | `--duration` | number | `0` | Hold duration for LongPress, or interpolation duration for SmoothDelta (seconds). For Click, 0 = one-shot tap. |
 | `--delta-x` | number | `0` | Delta X in pixels for MoveDelta/SmoothDelta. Positive = right. |
@@ -77,7 +77,7 @@ All rows below assume the New Input System is installed.
 ## Examples
 
 ```bash
-# Left-click at screen center for runtime input
+# Left-click at the Game View center for runtime input
 uloop simulate-mouse-input --action Click --x 400 --y 300
 
 # Right-click at screen center
@@ -99,6 +99,20 @@ uloop simulate-mouse-input --action Scroll --scroll-y -120
 uloop simulate-mouse-input --action SmoothDelta --delta-x 300 --delta-y 0 --duration 0.5
 ```
 
+## Coordinate System
+
+- `--x` / `--y` use **top-left Game View coordinates**.
+- Raw image pixels from `uloop screenshot --capture-mode rendering` must be converted with `ScreenshotToInputFormula`.
+- `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` can be passed directly to this tool.
+- Do not flip Y in the caller. The tool converts internally for Unity Input System:
+
+```text
+unity_x = input_x
+unity_y = gameViewHeight - input_y
+```
+
+- `Mouse.current.position` uses bottom-left Unity coordinates, so the value read inside Unity may show the converted Y.
+
 ## Prerequisites
 
 - Unity must be in **PlayMode**
@@ -113,8 +127,13 @@ Returns JSON with:
 - `Message`: Status message
 - `Action`: Echoes which action was executed (`Click`, `LongPress`, `MoveDelta`, `SmoothDelta`, or `Scroll`)
 - `Button`: Which button was used (nullable string; populated for `Click` / `LongPress`, null otherwise)
-- `PositionX`: Target X coordinate (nullable float; populated for `Click` / `LongPress`)
-- `PositionY`: Target Y coordinate (nullable float; populated for `Click` / `LongPress`)
+- `PositionX` / `PositionY`: Target top-left Game View coordinates (nullable float; populated for `Click` / `LongPress`)
+- `InputCoordinateSystem`: `"top-left-game-view"` for click/long-press coordinates
+- `UnityCoordinateSystem`: `"bottom-left-game-view"` for the injected `Mouse.current.position`
+- `GameViewWidth` / `GameViewHeight`: Game View size used for conversion
+- `InputPositionX` / `InputPositionY`: Coordinates received from the caller
+- `InjectedUnityPositionX` / `InjectedUnityPositionY`: Coordinates injected into `Mouse.current.position`
+- `CoordinateConversionFormula`: Conversion formula used by the tool
 - `InterruptedByPausePoint`: True when Unity paused during Pause Point inspection and the input bookkeeping was safely released
 - `PausePointId`: The id from `UloopPausePoint.Pause("<id>")` when it caused the interruption
 - `PausePointHitCount`: The hit count for that `UloopPausePoint.Pause("<id>")`

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -77,10 +77,10 @@ All rows below assume the New Input System is installed.
 ## Examples
 
 ```bash
-# Left-click at the Game View center for runtime input
+# Left-click at a representative Game View point for runtime input
 uloop simulate-mouse-input --action Click --x 400 --y 300
 
-# Right-click at screen center
+# Right-click at a representative Game View point
 uloop simulate-mouse-input --action Click --x 400 --y 300 --button Right
 
 # Hold left-click for 2 seconds

--- a/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
@@ -68,6 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.Greater(mouseUpdateFramePressObserver.LeftButtonPressedUpdateCount, 0, "Click should be visible to MonoBehaviour.Update via wasPressedThisFrame");
             // After click completes, button should be released
             Assert.IsFalse(mouse.leftButton.isPressed, "Left button should be released after click");
+            AssertCoordinateMetadata(400f, 300f);
         }
 
         [UnityTest]
@@ -193,6 +194,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             Assert.AreEqual("LongPress", lastResponse.Action);
             // After long press completes, button should be released
             Assert.IsFalse(mouse.leftButton.isPressed, "Button should be released after long press");
+            AssertCoordinateMetadata(400f, 300f);
         }
 
         [UnityTest]
@@ -373,6 +375,29 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
                 task.IsCompleted || Time.realtimeSinceStartup >= timeoutAt);
             Assert.IsTrue(task.IsCompleted, "Tool execution timed out.");
             Assert.IsFalse(task.IsFaulted, $"Tool execution should not fault: {task.Exception}");
+        }
+
+        private void AssertCoordinateMetadata(float inputX, float inputY)
+        {
+            Vector2 inputPosition = new(inputX, inputY);
+            Vector2 gameViewSize = GameViewCoordinateUtility.GetMainGameViewSize();
+            GameViewCoordinateConversion expected = GameViewCoordinateUtility.ConvertInputToUnity(inputPosition, gameViewSize);
+
+            Assert.AreEqual(UnityCliLoopConstants.COORDINATE_SYSTEM_TOP_LEFT_GAME_VIEW, lastResponse.InputCoordinateSystem);
+            Assert.AreEqual(UnityCliLoopConstants.COORDINATE_SYSTEM_BOTTOM_LEFT_GAME_VIEW, lastResponse.UnityCoordinateSystem);
+            Assert.AreEqual(UnityCliLoopConstants.COORDINATE_CONVERSION_FORMULA_GAME_VIEW_INPUT_TO_UNITY, lastResponse.CoordinateConversionFormula);
+            Assert.IsTrue(lastResponse.GameViewWidth.HasValue);
+            Assert.IsTrue(lastResponse.GameViewHeight.HasValue);
+            Assert.IsTrue(lastResponse.InputPositionX.HasValue);
+            Assert.IsTrue(lastResponse.InputPositionY.HasValue);
+            Assert.IsTrue(lastResponse.InjectedUnityPositionX.HasValue);
+            Assert.IsTrue(lastResponse.InjectedUnityPositionY.HasValue);
+            Assert.AreEqual(expected.GameViewSize.x, lastResponse.GameViewWidth!.Value);
+            Assert.AreEqual(expected.GameViewSize.y, lastResponse.GameViewHeight!.Value);
+            Assert.AreEqual(expected.InputPosition.x, lastResponse.InputPositionX!.Value);
+            Assert.AreEqual(expected.InputPosition.y, lastResponse.InputPositionY!.Value);
+            Assert.AreEqual(expected.InjectedUnityPosition.x, lastResponse.InjectedUnityPositionX!.Value);
+            Assert.AreEqual(expected.InjectedUnityPosition.y, lastResponse.InjectedUnityPositionY!.Value);
         }
 
         /// <summary>

--- a/Assets/Tests/PlayMode/UnityCLILoop.Tests.PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/UnityCLILoop.Tests.PlayMode.asmdef
@@ -24,7 +24,8 @@
         "GUID:2bafac87e7f4b9b418d9448d219b01ab",
         "GUID:75469ad4d38634e559750d17036d5f7c",
         "GUID:dc04f38471c3a459fb4d31124ee9127d",
-        "GUID:6399a27a6ac3945be87994ba344509be"
+        "GUID:6399a27a6ac3945be87994ba344509be",
+        "GUID:96b8d4624fb74ea2849fed17e7ad69d3"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/src/Editor/FirstPartyTools/Common/GameView/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/GameView/AssemblyInfo.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Raycast.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Screenshot.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Demo.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputPressActionExecutor.cs
@@ -16,12 +16,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class MouseInputPressActionExecutor
     {
-        // Input coordinates use top-left origin; Unity Screen space uses bottom-left origin.
-        // Uses Screen.height (runtime resolution) because Mouse.current.position is in
-        // runtime screen space, not the editor Game view target resolution.
-        private static Vector2 InputToScreen(Vector2 inputPos)
+        // Uses the Game View's target resolution (not the runtime window's Screen.height) so the
+        // Y-flip matches what a `screenshot --capture-mode rendering` image represents.
+        private static GameViewCoordinateConversion ConvertInputToUnity(Vector2 inputPos)
         {
-            return new Vector2(inputPos.x, Screen.height - inputPos.y);
+            Vector2 gameViewSize = GameViewCoordinateUtility.GetMainGameViewSize();
+            return GameViewCoordinateUtility.ConvertInputToUnity(inputPos, gameViewSize);
         }
 
         internal static async Task<SimulateMouseInputResponse> ExecuteClick(
@@ -38,13 +38,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Vector2 inputPos = new(request.X, request.Y);
-            Vector2 screenPos = InputToScreen(inputPos);
+            GameViewCoordinateConversion conversion = ConvertInputToUnity(inputPos);
             RuntimeMouseButton button = ToRuntimeMouseButton(request.Button);
             string buttonName = button.ToString();
 
             // Set mouse position before clicking
             InputSimulationWaitOutcome positionOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                () => MouseInputState.SetPositionState(mouse, screenPos), ct).ConfigureAwait(false);
+                () => MouseInputState.SetPositionState(mouse, conversion.InjectedUnityPosition), ct).ConfigureAwait(false);
             if (positionOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 return MouseInputSimulationResponseFactory.TimedOutButtonResult(
@@ -132,15 +132,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string durationText = request.Duration > 0f ? $" for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s" : "";
-            return new SimulateMouseInputResponse
-            {
-                Success = true,
-                Message = $"Clicked {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}){durationText}",
-                Action = UnityCliLoopMouseInputAction.Click.ToString(),
-                Button = buttonName,
-                PositionX = inputPos.x,
-                PositionY = inputPos.y
-            };
+            return MouseInputSimulationResponseFactory.SuccessButtonResult(
+                UnityCliLoopMouseInputAction.Click,
+                $"Clicked {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}){durationText}",
+                buttonName,
+                inputPos,
+                conversion);
         }
 
         internal static async Task<SimulateMouseInputResponse> ExecuteLongPress(
@@ -157,13 +154,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Vector2 inputPos = new(request.X, request.Y);
-            Vector2 screenPos = InputToScreen(inputPos);
+            GameViewCoordinateConversion conversion = ConvertInputToUnity(inputPos);
             RuntimeMouseButton button = ToRuntimeMouseButton(request.Button);
             string buttonName = button.ToString();
 
             // Set mouse position before pressing
             InputSimulationWaitOutcome positionOutcome = await InputSystemUpdateHelper.ApplyOnNextConfiguredUpdate(
-                () => MouseInputState.SetPositionState(mouse, screenPos), ct).ConfigureAwait(false);
+                () => MouseInputState.SetPositionState(mouse, conversion.InjectedUnityPosition), ct).ConfigureAwait(false);
             if (positionOutcome == InputSimulationWaitOutcome.TimedOut)
             {
                 return MouseInputSimulationResponseFactory.TimedOutButtonResult(
@@ -253,15 +250,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     inputPos);
             }
 
-            return new SimulateMouseInputResponse
-            {
-                Success = true,
-                Message = $"Long-pressed {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}) for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s",
-                Action = UnityCliLoopMouseInputAction.LongPress.ToString(),
-                Button = buttonName,
-                PositionX = inputPos.x,
-                PositionY = inputPos.y
-            };
+            return MouseInputSimulationResponseFactory.SuccessButtonResult(
+                UnityCliLoopMouseInputAction.LongPress,
+                $"Long-pressed {buttonName} at ({inputPos.x:F1}, {inputPos.y:F1}) for {InputSimulationDurationFormatter.FormatSeconds(request.Duration)}s",
+                buttonName,
+                inputPos,
+                conversion);
         }
 
         private static RuntimeMouseButton ToRuntimeMouseButton(UnityCliLoopMouseButton button)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/MouseInputSimulationResponseFactory.cs
@@ -13,6 +13,35 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal static class MouseInputSimulationResponseFactory
     {
+        // Echoes the full conversion so callers can verify the Y-flip math against a
+        // screenshot instead of trusting a hidden Screen.height-based flip.
+        internal static SimulateMouseInputResponse SuccessButtonResult(
+            UnityCliLoopMouseInputAction action,
+            string message,
+            string buttonName,
+            Vector2 inputPos,
+            GameViewCoordinateConversion conversion)
+        {
+            return new SimulateMouseInputResponse
+            {
+                Success = true,
+                Message = message,
+                Action = action.ToString(),
+                Button = buttonName,
+                PositionX = inputPos.x,
+                PositionY = inputPos.y,
+                InputCoordinateSystem = UnityCliLoopConstants.COORDINATE_SYSTEM_TOP_LEFT_GAME_VIEW,
+                UnityCoordinateSystem = UnityCliLoopConstants.COORDINATE_SYSTEM_BOTTOM_LEFT_GAME_VIEW,
+                GameViewWidth = conversion.GameViewSize.x,
+                GameViewHeight = conversion.GameViewSize.y,
+                InputPositionX = conversion.InputPosition.x,
+                InputPositionY = conversion.InputPosition.y,
+                InjectedUnityPositionX = conversion.InjectedUnityPosition.x,
+                InjectedUnityPositionY = conversion.InjectedUnityPosition.y,
+                CoordinateConversionFormula = UnityCliLoopConstants.COORDINATE_CONVERSION_FORMULA_GAME_VIEW_INPUT_TO_UNITY
+            };
+        }
+
         internal static SimulateMouseInputResponse InterruptedButtonResult(
             UnityCliLoopMouseInputAction action,
             string buttonName,

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputResponse.cs
@@ -17,6 +17,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string? Button { get; set; }
         public float? PositionX { get; set; }
         public float? PositionY { get; set; }
+        public string InputCoordinateSystem { get; set; } = "";
+        public string UnityCoordinateSystem { get; set; } = "";
+        public float? GameViewWidth { get; set; }
+        public float? GameViewHeight { get; set; }
+        public float? InputPositionX { get; set; }
+        public float? InputPositionY { get; set; }
+        public float? InjectedUnityPositionX { get; set; }
+        public float? InjectedUnityPositionY { get; set; }
+        public string CoordinateConversionFormula { get; set; } = "";
         public bool InterruptedByPausePoint { get; set; }
         public string? PausePointId { get; set; }
         public int? PausePointHitCount { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
@@ -12,7 +12,7 @@ Simulate mouse input via Input System in Unity PlayMode.
 ## Workflow
 
 1. Ensure Unity is in PlayMode (use `uloop control-play-mode --action Play` if not)
-2. For Click/LongPress: determine the target screen position (use `uloop screenshot` to find coordinates)
+2. For Click/LongPress: determine the target Game View input position from annotated `SimX`/`SimY`, raycast-grid `InputX`/`InputY`, or raw image pixels converted with `ScreenshotToInputFormula`
 3. Execute the needed `uloop simulate-mouse-input` commands
 4. Inspect the result with the lightest useful evidence: runtime state, logs, or a screenshot
 5. When this input verifies a state transition, use Pause Point inspection from the section below as the standard frame proof
@@ -29,8 +29,8 @@ uloop simulate-mouse-input --action <action> [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--action` | enum | `Click` | `Click`, `LongPress`, `MoveDelta`, `SmoothDelta`, `Scroll` |
-| `--x` | number | `0` | Target X position (origin: top-left). Used by Click and LongPress. |
-| `--y` | number | `0` | Target Y position (origin: top-left). Used by Click and LongPress. |
+| `--x` | number | `0` | Target X position in Game View pixels (origin: top-left). Used by Click and LongPress. Use `AnnotatedElements[].SimX`, `RaycastGridPoints[].InputX`, or raw image pixels converted with `ScreenshotToInputFormula`. |
+| `--y` | number | `0` | Target Y position in Game View pixels (origin: top-left). Used by Click and LongPress. Use `AnnotatedElements[].SimY`, `RaycastGridPoints[].InputY`, or raw image pixels converted with `ScreenshotToInputFormula`. |
 | `--button` | enum | `Left` | Mouse button: `Left`, `Right`, `Middle`. Used by Click and LongPress. |
 | `--duration` | number | `0` | Hold duration for LongPress, or interpolation duration for SmoothDelta (seconds). For Click, 0 = one-shot tap. |
 | `--delta-x` | number | `0` | Delta X in pixels for MoveDelta/SmoothDelta. Positive = right. |
@@ -77,7 +77,7 @@ All rows below assume the New Input System is installed.
 ## Examples
 
 ```bash
-# Left-click at screen center for runtime input
+# Left-click at the Game View center for runtime input
 uloop simulate-mouse-input --action Click --x 400 --y 300
 
 # Right-click at screen center
@@ -99,6 +99,20 @@ uloop simulate-mouse-input --action Scroll --scroll-y -120
 uloop simulate-mouse-input --action SmoothDelta --delta-x 300 --delta-y 0 --duration 0.5
 ```
 
+## Coordinate System
+
+- `--x` / `--y` use **top-left Game View coordinates**.
+- Raw image pixels from `uloop screenshot --capture-mode rendering` must be converted with `ScreenshotToInputFormula`.
+- `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` can be passed directly to this tool.
+- Do not flip Y in the caller. The tool converts internally for Unity Input System:
+
+```text
+unity_x = input_x
+unity_y = gameViewHeight - input_y
+```
+
+- `Mouse.current.position` uses bottom-left Unity coordinates, so the value read inside Unity may show the converted Y.
+
 ## Prerequisites
 
 - Unity must be in **PlayMode**
@@ -113,8 +127,13 @@ Returns JSON with:
 - `Message`: Status message
 - `Action`: Echoes which action was executed (`Click`, `LongPress`, `MoveDelta`, `SmoothDelta`, or `Scroll`)
 - `Button`: Which button was used (nullable string; populated for `Click` / `LongPress`, null otherwise)
-- `PositionX`: Target X coordinate (nullable float; populated for `Click` / `LongPress`)
-- `PositionY`: Target Y coordinate (nullable float; populated for `Click` / `LongPress`)
+- `PositionX` / `PositionY`: Target top-left Game View coordinates (nullable float; populated for `Click` / `LongPress`)
+- `InputCoordinateSystem`: `"top-left-game-view"` for click/long-press coordinates
+- `UnityCoordinateSystem`: `"bottom-left-game-view"` for the injected `Mouse.current.position`
+- `GameViewWidth` / `GameViewHeight`: Game View size used for conversion
+- `InputPositionX` / `InputPositionY`: Coordinates received from the caller
+- `InjectedUnityPositionX` / `InjectedUnityPositionY`: Coordinates injected into `Mouse.current.position`
+- `CoordinateConversionFormula`: Conversion formula used by the tool
 - `InterruptedByPausePoint`: True when Unity paused during Pause Point inspection and the input bookkeeping was safely released
 - `PausePointId`: The id from `UloopPausePoint.Pause("<id>")` when it caused the interruption
 - `PausePointHitCount`: The hit count for that `UloopPausePoint.Pause("<id>")`

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
@@ -77,10 +77,10 @@ All rows below assume the New Input System is installed.
 ## Examples
 
 ```bash
-# Left-click at the Game View center for runtime input
+# Left-click at a representative Game View point for runtime input
 uloop simulate-mouse-input --action Click --x 400 --y 300
 
-# Right-click at screen center
+# Right-click at a representative Game View point
 uloop simulate-mouse-input --action Click --x 400 --y 300 --button Right
 
 # Hold left-click for 2 seconds

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor.asmdef
@@ -9,7 +9,8 @@
         "GUID:aa7cf56cc5f074e57ba35272b877e116",
         "GUID:c956a21f824994ef087b6de566690b3d",
         "GUID:75469ad4d38634e559750d17036d5f7c",
-        "GUID:33fef506e6744f2982e8c13b1196f696"
+        "GUID:33fef506e6744f2982e8c13b1196f696",
+        "GUID:96b8d4624fb74ea2849fed17e7ad69d3"
     ],
     "includePlatforms": [
         "Editor"

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -470,12 +470,12 @@
           },
           "X": {
             "type": "number",
-            "description": "Target X position in screen pixels (origin: top-left). Used by Click and LongPress.",
+            "description": "Target X position in Game View pixels (origin: top-left). Used by Click and LongPress. Use AnnotatedElements[].SimX, RaycastGridPoints[].InputX, or raw image pixels converted with ScreenshotToInputFormula.",
             "default": 0
           },
           "Y": {
             "type": "number",
-            "description": "Target Y position in screen pixels (origin: top-left). Used by Click and LongPress.",
+            "description": "Target Y position in Game View pixels (origin: top-left). Used by Click and LongPress. Use AnnotatedElements[].SimY, RaycastGridPoints[].InputY, or raw image pixels converted with ScreenshotToInputFormula.",
             "default": 0
           },
           "Button": {


### PR DESCRIPTION
## Summary
- `simulate-mouse-input`'s click/long-press coordinates now align with the Game View's target resolution instead of the runtime window's pixel size, so injected clicks land where a `screenshot --capture-mode rendering` image says they should.
- The response now echoes the full coordinate conversion (Game View size, input position, injected position, formula) so callers can verify the math themselves.

## User Impact
- Before: when the Game View was resized or docked at a different pixel size than its target resolution, `simulate-mouse-input` could inject clicks at the wrong Y position relative to a screenshot taken with `--capture-mode rendering`.
- After: both tools derive coordinates from the same Game View target resolution, so screenshot-driven coordinates and injected input stay consistent.

## Changes
- `MouseInputPressActionExecutor`: replaced the `Screen.height`-based Y-flip with `GameViewCoordinateUtility.ConvertInputToUnity` (the same utility already used by the raycast/screenshot tools).
- `SimulateMouseInputResponse`: added coordinate-system/conversion metadata fields (Game View size, input position, injected Unity position, conversion formula).
- `MouseInputSimulationResponseFactory`: added a success-result builder that populates the new metadata.
- Wired `InternalsVisibleTo`/asmdef references so `SimulateMouseInput.Editor` and `Tests.PlayMode` can use the shared `GameViewCoordinateUtility`.
- `simulate-mouse-ui` required no change — it already used `Handles.GetMainGameViewSize()`.

Ported from origin/main's `c81f6b0b` (mouse-coordinate portion only; the raycast/screenshot portions of that commit were already ported as C1–C3).

## Verification
- `uloop compile`: 0 errors, 0 warnings
- `uloop run-tests` (PlayMode, `SimulateMouseInputTests|SimulateMouseUi.*Tests`): 46/46 passed
- `uloop run-tests` (EditMode, full suite): 1774/1774 passed, 7 pre-existing skips
- `uloop run-tests` (PlayMode, full suite): 92/92 passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

