### PR TITLE
chore: Document the raycast tool and 3D collider annotation fields

### DIFF
--- a/.agents/skills/uloop-screenshot/references/annotated-elements.md
+++ b/.agents/skills/uloop-screenshot/references/annotated-elements.md
@@ -1,36 +1,73 @@
 # Annotated Elements and Coordinates
 
-Read this when using `uloop screenshot --capture-mode rendering --annotate-elements` to find coordinates for `simulate-mouse-ui` or `simulate-mouse-input`.
+Read this when using `uloop screenshot --capture-mode rendering --annotate-elements true` or clustered `--annotate-raycast-grid true --raycast-layer-mask <layers>` output to find coordinates for `simulate-mouse-ui`, `simulate-mouse-input`, or `raycast`.
 
 ## AnnotatedElements Fields
 
-`AnnotatedElements` is empty unless `--annotate-elements` is used. Entries are sorted by z-order, frontmost first. Each item contains:
+`AnnotatedElements` is empty unless `--annotate-elements true` is used, or unless `--annotate-raycast-grid true --raycast-layer-mask <layers>` adds clustered 3D collider candidates. UI entries are sorted by z-order, frontmost first. Each item contains:
 
 - `Label`: Index label in JSON (`A` = frontmost, `B` = next, ...). Screenshot labels also include the interaction hint, such as `A / CLICK` or `B / DRAG`.
 - `Name`: Element name
 - `Path`: Hierarchy path from the scene root, for example `Canvas/Panel/Button`. Use this as `simulate-mouse-ui --target-path` when bypassing raycast blockers.
-- `Type`: Element type (`Button`, `Toggle`, `Slider`, `Dropdown`, `InputField`, `Scrollbar`, `Draggable`, `DropTarget`, `Selectable`)
-- `Interaction`: Derived interaction category (`Click`, `Drag`, `Drop`, `Text`). Use this to choose between `simulate-mouse-ui --action Click` and drag actions.
-- `SimX`, `SimY`: Center position in simulate-mouse coordinates. Use these directly with `--x` and `--y`.
-- `BoundsMinX`, `BoundsMinY`, `BoundsMaxX`, `BoundsMaxY`: Bounding box in simulate-mouse coordinates
+- `Type`: Element type (`Button`, `Toggle`, `Slider`, `Dropdown`, `InputField`, `Scrollbar`, `Draggable`, `DropTarget`, `Selectable`, `PhysicsCollider`)
+- `Interaction`: Derived interaction category (`Click`, `Drag`, `Drop`, `Text`) or `Raycast` for clustered physics collider entries. Use this to choose between `simulate-mouse-ui --action Click`, drag actions, or `simulate-mouse-input`/`raycast`.
+- `Layer`: Physics layer name for `PhysicsCollider` entries. Empty for UI entries.
+- `Components`: Collider and MonoBehaviour component type names from the hit GameObject for `PhysicsCollider` entries. Empty for UI entries.
+- `SimX`, `SimY`: Target click position in top-left Game View coordinates. For UI entries this is the element center; for `PhysicsCollider` entries this is a representative sampled hit. Use these directly with `simulate-mouse-ui --x/--y`, `simulate-mouse-input --x/--y`, or `raycast --x/--y`.
+- `BoundsMinX`, `BoundsMinY`, `BoundsMaxX`, `BoundsMaxY`: Bounding box in the same coordinates as `SimX/SimY`. For `PhysicsCollider` entries, this is the axis-aligned sampled-cell coverage box from reachable raycast hits, not a guarantee that every interior point is clickable.
 - `SortingOrder`: Canvas sorting order. Higher values are in front.
 - `SiblingIndex`: Transform sibling index under the element's direct parent. Do not use it as a reliable z-order signal across nested UI hierarchies.
 
+## RaycastGridPoints Fields
+
+`RaycastGridPoints` is populated when `--annotate-raycast-grid true` is used without `--raycast-layer-mask`. It is a coarse 5x5 grid preview of what each sample point would hit.
+
+- `Label`: Grid point label
+- `Hit`: Whether the raycast hit a collider
+- `InputX`, `InputY`: Top-left Game View coordinates for this sample point. Pass directly to `simulate-mouse-input --x/--y` or `raycast --x/--y`.
+- `InjectedUnityPositionX`, `InjectedUnityPositionY`: The same point converted to bottom-left Unity coordinates (what `Mouse.current.position` would read)
+- `HitGameObjectName`, `HitGameObjectPath`: Identifies the hit object when `Hit` is true, null otherwise
+- `HitLayer`, `HitLayerIndex`: Physics layer of the hit object, null otherwise
+- `Distance`: Distance from `Camera.main` to the hit point, null otherwise
+
+## RaycastLayerSummaries Fields
+
+`RaycastLayerSummaries` is populated when `--annotate-raycast-grid true` is used without `--raycast-layer-mask`. It is built from dense raycast samples, while `RaycastGridPoints` remains the coarse 5x5 annotated grid.
+
+- `Layer`: Physics layer name to pass to `--raycast-layer-mask`
+- `LayerIndex`: Unity physics layer index
+- `HitCount`: Dense raycast hit count for the layer
+- `RepresentativeObjectPath`: Hierarchy path for the object with the most hits on that layer. Ties are resolved alphabetically by path.
+
+Entries are sorted by `HitCount` descending, then `LayerIndex` ascending.
+
 ## Coordinate Conversion
 
-When `ImageCoordinateSystem` is `"top-left-game-view"`, convert image pixel coordinates to simulate-mouse coordinates using `ScreenshotToInputFormula`:
+When `ImageCoordinateSystem` is `"top-left-game-view"`, convert raw image pixel coordinates from `screenshot --capture-mode rendering` with the formula returned in `ScreenshotToInputFormula`:
 
 ```text
 simulate_mouse_x = image_x / resolutionScale
 simulate_mouse_y = image_y / resolutionScale + imageToInputOffsetY
 ```
 
-When `ResolutionScale` is `1.0`, this simplifies to:
+When `ResolutionScale` is `1.0` and `imageToInputOffsetY` is `0` for rendering captures, raw image pixel coordinates already match mouse-input coordinates. `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` are already mouse-input coordinates in that mode, so pass those values directly.
+
+For `PhysicsCollider` entries, `SimX/SimY` is a real sampled raycast hit nearest to the reachable cluster centroid. This avoids synthetic center points that may fall into empty space for L-shaped or ring-shaped collider coverage. Always use `SimX/SimY` for clicking; use `BoundsMinX/Y` and `BoundsMaxX/Y` only as a sampled coverage guide.
+
+`--raycast-layer-mask` filters by the requested physics layers and `Camera.main.cullingMask`. A layer that is requested but hidden from the active camera is treated as not visible and will not produce `PhysicsCollider` entries.
+
+For clustered `PhysicsCollider` entries, points where the frontmost EventSystem hit comes from a `GraphicRaycaster` UI element are treated as covered by UI. This includes world-space Canvas UI. `PhysicsRaycaster` and other non-uGUI hits are not treated as UI occlusion. Bounds, screenshot outlines, and `SimX/SimY` are derived from the remaining reachable samples; if every sampled hit in that collider cluster is covered, the collider is omitted from `AnnotatedElements`.
+
+`PhysicsCollider` bounds expand each reachable sample by half the dense raycast sampling step in X and Y, then clamp the result to the captured Game View area. The screenshot overlay draws only the outer edges of those reachable sample cells, so angled, L-shaped, separated, and partially UI-covered hit regions do not become one large rectangle. `BoundsMinX/Y` and `BoundsMaxX/Y` are still an axis-aligned bbox for JSON consumers, may extend up to half a sample step past the visible collider edge, and do not guarantee that every interior point is clickable.
+
+`simulate-mouse-input` and `raycast` convert internally to Unity Input System coordinates:
 
 ```text
-simulate_mouse_x = image_x
-simulate_mouse_y = image_y + imageToInputOffsetY
+unity_x = input_x
+unity_y = gameViewHeight - input_y
 ```
+
+Do not flip Y in the caller.
 
 ## Annotation Readability
 

--- a/.claude/skills/uloop-screenshot/references/annotated-elements.md
+++ b/.claude/skills/uloop-screenshot/references/annotated-elements.md
@@ -1,36 +1,73 @@
 # Annotated Elements and Coordinates
 
-Read this when using `uloop screenshot --capture-mode rendering --annotate-elements` to find coordinates for `simulate-mouse-ui` or `simulate-mouse-input`.
+Read this when using `uloop screenshot --capture-mode rendering --annotate-elements true` or clustered `--annotate-raycast-grid true --raycast-layer-mask <layers>` output to find coordinates for `simulate-mouse-ui`, `simulate-mouse-input`, or `raycast`.
 
 ## AnnotatedElements Fields
 
-`AnnotatedElements` is empty unless `--annotate-elements` is used. Entries are sorted by z-order, frontmost first. Each item contains:
+`AnnotatedElements` is empty unless `--annotate-elements true` is used, or unless `--annotate-raycast-grid true --raycast-layer-mask <layers>` adds clustered 3D collider candidates. UI entries are sorted by z-order, frontmost first. Each item contains:
 
 - `Label`: Index label in JSON (`A` = frontmost, `B` = next, ...). Screenshot labels also include the interaction hint, such as `A / CLICK` or `B / DRAG`.
 - `Name`: Element name
 - `Path`: Hierarchy path from the scene root, for example `Canvas/Panel/Button`. Use this as `simulate-mouse-ui --target-path` when bypassing raycast blockers.
-- `Type`: Element type (`Button`, `Toggle`, `Slider`, `Dropdown`, `InputField`, `Scrollbar`, `Draggable`, `DropTarget`, `Selectable`)
-- `Interaction`: Derived interaction category (`Click`, `Drag`, `Drop`, `Text`). Use this to choose between `simulate-mouse-ui --action Click` and drag actions.
-- `SimX`, `SimY`: Center position in simulate-mouse coordinates. Use these directly with `--x` and `--y`.
-- `BoundsMinX`, `BoundsMinY`, `BoundsMaxX`, `BoundsMaxY`: Bounding box in simulate-mouse coordinates
+- `Type`: Element type (`Button`, `Toggle`, `Slider`, `Dropdown`, `InputField`, `Scrollbar`, `Draggable`, `DropTarget`, `Selectable`, `PhysicsCollider`)
+- `Interaction`: Derived interaction category (`Click`, `Drag`, `Drop`, `Text`) or `Raycast` for clustered physics collider entries. Use this to choose between `simulate-mouse-ui --action Click`, drag actions, or `simulate-mouse-input`/`raycast`.
+- `Layer`: Physics layer name for `PhysicsCollider` entries. Empty for UI entries.
+- `Components`: Collider and MonoBehaviour component type names from the hit GameObject for `PhysicsCollider` entries. Empty for UI entries.
+- `SimX`, `SimY`: Target click position in top-left Game View coordinates. For UI entries this is the element center; for `PhysicsCollider` entries this is a representative sampled hit. Use these directly with `simulate-mouse-ui --x/--y`, `simulate-mouse-input --x/--y`, or `raycast --x/--y`.
+- `BoundsMinX`, `BoundsMinY`, `BoundsMaxX`, `BoundsMaxY`: Bounding box in the same coordinates as `SimX/SimY`. For `PhysicsCollider` entries, this is the axis-aligned sampled-cell coverage box from reachable raycast hits, not a guarantee that every interior point is clickable.
 - `SortingOrder`: Canvas sorting order. Higher values are in front.
 - `SiblingIndex`: Transform sibling index under the element's direct parent. Do not use it as a reliable z-order signal across nested UI hierarchies.
 
+## RaycastGridPoints Fields
+
+`RaycastGridPoints` is populated when `--annotate-raycast-grid true` is used without `--raycast-layer-mask`. It is a coarse 5x5 grid preview of what each sample point would hit.
+
+- `Label`: Grid point label
+- `Hit`: Whether the raycast hit a collider
+- `InputX`, `InputY`: Top-left Game View coordinates for this sample point. Pass directly to `simulate-mouse-input --x/--y` or `raycast --x/--y`.
+- `InjectedUnityPositionX`, `InjectedUnityPositionY`: The same point converted to bottom-left Unity coordinates (what `Mouse.current.position` would read)
+- `HitGameObjectName`, `HitGameObjectPath`: Identifies the hit object when `Hit` is true, null otherwise
+- `HitLayer`, `HitLayerIndex`: Physics layer of the hit object, null otherwise
+- `Distance`: Distance from `Camera.main` to the hit point, null otherwise
+
+## RaycastLayerSummaries Fields
+
+`RaycastLayerSummaries` is populated when `--annotate-raycast-grid true` is used without `--raycast-layer-mask`. It is built from dense raycast samples, while `RaycastGridPoints` remains the coarse 5x5 annotated grid.
+
+- `Layer`: Physics layer name to pass to `--raycast-layer-mask`
+- `LayerIndex`: Unity physics layer index
+- `HitCount`: Dense raycast hit count for the layer
+- `RepresentativeObjectPath`: Hierarchy path for the object with the most hits on that layer. Ties are resolved alphabetically by path.
+
+Entries are sorted by `HitCount` descending, then `LayerIndex` ascending.
+
 ## Coordinate Conversion
 
-When `ImageCoordinateSystem` is `"top-left-game-view"`, convert image pixel coordinates to simulate-mouse coordinates using `ScreenshotToInputFormula`:
+When `ImageCoordinateSystem` is `"top-left-game-view"`, convert raw image pixel coordinates from `screenshot --capture-mode rendering` with the formula returned in `ScreenshotToInputFormula`:
 
 ```text
 simulate_mouse_x = image_x / resolutionScale
 simulate_mouse_y = image_y / resolutionScale + imageToInputOffsetY
 ```
 
-When `ResolutionScale` is `1.0`, this simplifies to:
+When `ResolutionScale` is `1.0` and `imageToInputOffsetY` is `0` for rendering captures, raw image pixel coordinates already match mouse-input coordinates. `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` are already mouse-input coordinates in that mode, so pass those values directly.
+
+For `PhysicsCollider` entries, `SimX/SimY` is a real sampled raycast hit nearest to the reachable cluster centroid. This avoids synthetic center points that may fall into empty space for L-shaped or ring-shaped collider coverage. Always use `SimX/SimY` for clicking; use `BoundsMinX/Y` and `BoundsMaxX/Y` only as a sampled coverage guide.
+
+`--raycast-layer-mask` filters by the requested physics layers and `Camera.main.cullingMask`. A layer that is requested but hidden from the active camera is treated as not visible and will not produce `PhysicsCollider` entries.
+
+For clustered `PhysicsCollider` entries, points where the frontmost EventSystem hit comes from a `GraphicRaycaster` UI element are treated as covered by UI. This includes world-space Canvas UI. `PhysicsRaycaster` and other non-uGUI hits are not treated as UI occlusion. Bounds, screenshot outlines, and `SimX/SimY` are derived from the remaining reachable samples; if every sampled hit in that collider cluster is covered, the collider is omitted from `AnnotatedElements`.
+
+`PhysicsCollider` bounds expand each reachable sample by half the dense raycast sampling step in X and Y, then clamp the result to the captured Game View area. The screenshot overlay draws only the outer edges of those reachable sample cells, so angled, L-shaped, separated, and partially UI-covered hit regions do not become one large rectangle. `BoundsMinX/Y` and `BoundsMaxX/Y` are still an axis-aligned bbox for JSON consumers, may extend up to half a sample step past the visible collider edge, and do not guarantee that every interior point is clickable.
+
+`simulate-mouse-input` and `raycast` convert internally to Unity Input System coordinates:
 
 ```text
-simulate_mouse_x = image_x
-simulate_mouse_y = image_y + imageToInputOffsetY
+unity_x = input_x
+unity_y = gameViewHeight - input_y
 ```
+
+Do not flip Y in the caller.
 
 ## Annotation Readability
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/references/annotated-elements.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/references/annotated-elements.md
@@ -1,36 +1,73 @@
 # Annotated Elements and Coordinates
 
-Read this when using `uloop screenshot --capture-mode rendering --annotate-elements` to find coordinates for `simulate-mouse-ui` or `simulate-mouse-input`.
+Read this when using `uloop screenshot --capture-mode rendering --annotate-elements true` or clustered `--annotate-raycast-grid true --raycast-layer-mask <layers>` output to find coordinates for `simulate-mouse-ui`, `simulate-mouse-input`, or `raycast`.
 
 ## AnnotatedElements Fields
 
-`AnnotatedElements` is empty unless `--annotate-elements` is used. Entries are sorted by z-order, frontmost first. Each item contains:
+`AnnotatedElements` is empty unless `--annotate-elements true` is used, or unless `--annotate-raycast-grid true --raycast-layer-mask <layers>` adds clustered 3D collider candidates. UI entries are sorted by z-order, frontmost first. Each item contains:
 
 - `Label`: Index label in JSON (`A` = frontmost, `B` = next, ...). Screenshot labels also include the interaction hint, such as `A / CLICK` or `B / DRAG`.
 - `Name`: Element name
 - `Path`: Hierarchy path from the scene root, for example `Canvas/Panel/Button`. Use this as `simulate-mouse-ui --target-path` when bypassing raycast blockers.
-- `Type`: Element type (`Button`, `Toggle`, `Slider`, `Dropdown`, `InputField`, `Scrollbar`, `Draggable`, `DropTarget`, `Selectable`)
-- `Interaction`: Derived interaction category (`Click`, `Drag`, `Drop`, `Text`). Use this to choose between `simulate-mouse-ui --action Click` and drag actions.
-- `SimX`, `SimY`: Center position in simulate-mouse coordinates. Use these directly with `--x` and `--y`.
-- `BoundsMinX`, `BoundsMinY`, `BoundsMaxX`, `BoundsMaxY`: Bounding box in simulate-mouse coordinates
+- `Type`: Element type (`Button`, `Toggle`, `Slider`, `Dropdown`, `InputField`, `Scrollbar`, `Draggable`, `DropTarget`, `Selectable`, `PhysicsCollider`)
+- `Interaction`: Derived interaction category (`Click`, `Drag`, `Drop`, `Text`) or `Raycast` for clustered physics collider entries. Use this to choose between `simulate-mouse-ui --action Click`, drag actions, or `simulate-mouse-input`/`raycast`.
+- `Layer`: Physics layer name for `PhysicsCollider` entries. Empty for UI entries.
+- `Components`: Collider and MonoBehaviour component type names from the hit GameObject for `PhysicsCollider` entries. Empty for UI entries.
+- `SimX`, `SimY`: Target click position in top-left Game View coordinates. For UI entries this is the element center; for `PhysicsCollider` entries this is a representative sampled hit. Use these directly with `simulate-mouse-ui --x/--y`, `simulate-mouse-input --x/--y`, or `raycast --x/--y`.
+- `BoundsMinX`, `BoundsMinY`, `BoundsMaxX`, `BoundsMaxY`: Bounding box in the same coordinates as `SimX/SimY`. For `PhysicsCollider` entries, this is the axis-aligned sampled-cell coverage box from reachable raycast hits, not a guarantee that every interior point is clickable.
 - `SortingOrder`: Canvas sorting order. Higher values are in front.
 - `SiblingIndex`: Transform sibling index under the element's direct parent. Do not use it as a reliable z-order signal across nested UI hierarchies.
 
+## RaycastGridPoints Fields
+
+`RaycastGridPoints` is populated when `--annotate-raycast-grid true` is used without `--raycast-layer-mask`. It is a coarse 5x5 grid preview of what each sample point would hit.
+
+- `Label`: Grid point label
+- `Hit`: Whether the raycast hit a collider
+- `InputX`, `InputY`: Top-left Game View coordinates for this sample point. Pass directly to `simulate-mouse-input --x/--y` or `raycast --x/--y`.
+- `InjectedUnityPositionX`, `InjectedUnityPositionY`: The same point converted to bottom-left Unity coordinates (what `Mouse.current.position` would read)
+- `HitGameObjectName`, `HitGameObjectPath`: Identifies the hit object when `Hit` is true, null otherwise
+- `HitLayer`, `HitLayerIndex`: Physics layer of the hit object, null otherwise
+- `Distance`: Distance from `Camera.main` to the hit point, null otherwise
+
+## RaycastLayerSummaries Fields
+
+`RaycastLayerSummaries` is populated when `--annotate-raycast-grid true` is used without `--raycast-layer-mask`. It is built from dense raycast samples, while `RaycastGridPoints` remains the coarse 5x5 annotated grid.
+
+- `Layer`: Physics layer name to pass to `--raycast-layer-mask`
+- `LayerIndex`: Unity physics layer index
+- `HitCount`: Dense raycast hit count for the layer
+- `RepresentativeObjectPath`: Hierarchy path for the object with the most hits on that layer. Ties are resolved alphabetically by path.
+
+Entries are sorted by `HitCount` descending, then `LayerIndex` ascending.
+
 ## Coordinate Conversion
 
-When `ImageCoordinateSystem` is `"top-left-game-view"`, convert image pixel coordinates to simulate-mouse coordinates using `ScreenshotToInputFormula`:
+When `ImageCoordinateSystem` is `"top-left-game-view"`, convert raw image pixel coordinates from `screenshot --capture-mode rendering` with the formula returned in `ScreenshotToInputFormula`:
 
 ```text
 simulate_mouse_x = image_x / resolutionScale
 simulate_mouse_y = image_y / resolutionScale + imageToInputOffsetY
 ```
 
-When `ResolutionScale` is `1.0`, this simplifies to:
+When `ResolutionScale` is `1.0` and `imageToInputOffsetY` is `0` for rendering captures, raw image pixel coordinates already match mouse-input coordinates. `AnnotatedElements[].SimX/SimY` and `RaycastGridPoints[].InputX/InputY` are already mouse-input coordinates in that mode, so pass those values directly.
+
+For `PhysicsCollider` entries, `SimX/SimY` is a real sampled raycast hit nearest to the reachable cluster centroid. This avoids synthetic center points that may fall into empty space for L-shaped or ring-shaped collider coverage. Always use `SimX/SimY` for clicking; use `BoundsMinX/Y` and `BoundsMaxX/Y` only as a sampled coverage guide.
+
+`--raycast-layer-mask` filters by the requested physics layers and `Camera.main.cullingMask`. A layer that is requested but hidden from the active camera is treated as not visible and will not produce `PhysicsCollider` entries.
+
+For clustered `PhysicsCollider` entries, points where the frontmost EventSystem hit comes from a `GraphicRaycaster` UI element are treated as covered by UI. This includes world-space Canvas UI. `PhysicsRaycaster` and other non-uGUI hits are not treated as UI occlusion. Bounds, screenshot outlines, and `SimX/SimY` are derived from the remaining reachable samples; if every sampled hit in that collider cluster is covered, the collider is omitted from `AnnotatedElements`.
+
+`PhysicsCollider` bounds expand each reachable sample by half the dense raycast sampling step in X and Y, then clamp the result to the captured Game View area. The screenshot overlay draws only the outer edges of those reachable sample cells, so angled, L-shaped, separated, and partially UI-covered hit regions do not become one large rectangle. `BoundsMinX/Y` and `BoundsMaxX/Y` are still an axis-aligned bbox for JSON consumers, may extend up to half a sample step past the visible collider edge, and do not guarantee that every interior point is clickable.
+
+`simulate-mouse-input` and `raycast` convert internally to Unity Input System coordinates:
 
 ```text
-simulate_mouse_x = image_x
-simulate_mouse_y = image_y + imageToInputOffsetY
+unity_x = input_x
+unity_y = gameViewHeight - input_y
 ```
+
+Do not flip Y in the caller.
 
 ## Annotation Readability
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ That's it! After installing Skills, LLM tools can automatically handle instructi
 
 
 <details>
-<summary>All 16 Bundled Skills</summary>
+<summary>All 17 Bundled Skills</summary>
 
 - `/uloop-launch` - Launch Unity with correct version
 - `/uloop-compile` - Execute compilation
@@ -179,6 +179,7 @@ That's it! After installing Skills, LLM tools can automatically handle instructi
 - `/uloop-get-hierarchy` - Get scene hierarchy
 - `/uloop-find-game-objects` - Find GameObjects
 - `/uloop-screenshot` - Capture EditorWindow
+- `/uloop-raycast` - Check what a Game View coordinate hits in 3D physics
 - `/uloop-simulate-mouse-ui` - Simulate mouse click, long-press, and drag on PlayMode UI elements
 - `/uloop-simulate-mouse-input` - Simulate mouse input in PlayMode via Input System
 - `/uloop-simulate-keyboard` - Simulate keyboard input in PlayMode via Input System
@@ -343,8 +344,10 @@ Great for keeping visual feedback in sync after other apps steal focus. (Linux i
 Take a screenshot of any EditorWindow as a PNG. Specify the window name (the text displayed in the title bar/tab) to capture.
 When multiple windows of the same type are open (e.g., 3 Inspector windows), all windows are saved with numbered filenames.
 Supports three matching modes: `exact` (default), `prefix`, and `contains` - all case-insensitive.
+Use `CaptureMode: rendering` when you need coordinates for `simulate-mouse-input`, `simulate-mouse-ui`, or `raycast`; convert raw image pixels with `ScreenshotToInputFormula`, or pass annotated `SimX/SimY` and raycast-grid `InputX/InputY` values directly.
 ```text
 → screenshot (WindowName: "Console")
+→ screenshot (CaptureMode: rendering, AnnotateRaycastGrid: true)
 → Save Console window state as PNG
 → Provide visual feedback to AI
 ```
@@ -393,6 +396,8 @@ https://github.com/user-attachments/assets/c7ee9103-c282-4f90-8b01-64bb17400f3e
 ### 12. simulate-mouse-input - Simulate Mouse Input in PlayMode via Input System
 Simulate mouse input in PlayMode via Input System. Injects button clicks, mouse delta, and scroll wheel directly into `Mouse.current` for game logic that reads Input System. Unlike `simulate-mouse-ui` which fires EventSystem pointer events for uGUI, this tool targets game logic that reads `Mouse.current` directly. This tool is available only when the Input System package is installed, and Active Input Handling must be set to `Input System Package (New)` or `Both` in Player Settings.
 
+Click and LongPress coordinates use the same top-left Game View coordinates as `screenshot --capture-mode rendering`; do not flip Y before calling the tool.
+
 Supports 5 actions: Click, LongPress, MoveDelta, SmoothDelta, Scroll.
 
 ```text
@@ -404,7 +409,16 @@ Supports 5 actions: Click, LongPress, MoveDelta, SmoothDelta, Scroll.
 → simulate-mouse-input (Action: SmoothDelta, DeltaX: 300, DeltaY: 0, Duration: 0.5)
 ```
 
-### 13. simulate-keyboard - Simulate Keyboard Input in PlayMode
+### 13. raycast - Check a 3D Physics Hit at a Game View Coordinate
+Raycast from `Camera.main` through a top-left Game View coordinate. Use this before gameplay clicks when you need to confirm which 3D object a screenshot coordinate will hit.
+
+```text
+→ screenshot (CaptureMode: rendering, AnnotateRaycastGrid: true)
+→ raycast (X: 960, Y: 540)
+→ simulate-mouse-input (Action: Click, X: 960, Y: 540)
+```
+
+### 14. simulate-keyboard - Simulate Keyboard Input in PlayMode
 Simulate keyboard key input in PlayMode via Input System. Supports single key taps, sustained holds, and multi-key combinations (e.g. Shift+W for sprinting). This tool is available only when the Input System package is installed, and Active Input Handling must be set to `Input System Package (New)` or `Both` in Player Settings. Game code must read input via Input System API (e.g. `Keyboard.current[Key.W].isPressed`), not legacy `Input.GetKey()`.
 
 Supports 3 actions: Press (one-shot tap or timed hold), KeyDown (hold key down), KeyUp (release held key). Use Press for edge-triggered gameplay such as `Keyboard.current.spaceKey.wasPressedThisFrame`; KeyDown emits only one initial press edge and then becomes held state, so use KeyDown/KeyUp only when the test intentionally needs a held key.
@@ -419,7 +433,7 @@ Supports 3 actions: Press (one-shot tap or timed hold), KeyDown (hold key down),
 → simulate-keyboard (Action: KeyUp, Key: LeftShift)
 ```
 
-### 14. record-input - Record Input During PlayMode
+### 15. record-input - Record Input During PlayMode
 Record keyboard and mouse input during PlayMode frame-by-frame into a JSON file. Captures key presses, mouse movement, clicks, and scroll events via Input System device state diffing. This tool is available only when the Input System package is installed.
 
 ```text
@@ -429,7 +443,7 @@ Record keyboard and mouse input during PlayMode frame-by-frame into a JSON file.
 → JSON file saved to .uloop/outputs/InputRecordings/
 ```
 
-### 15. replay-input - Replay Recorded Input During PlayMode
+### 16. replay-input - Replay Recorded Input During PlayMode
 Replay recorded keyboard and mouse input during PlayMode. Loads a JSON recording and injects input frame-by-frame via Input System. Supports looping and progress monitoring. This tool is available only when the Input System package is installed.
 
 ```text


### PR DESCRIPTION
## Summary
- README.md now lists the `raycast` tool and mentions its Game View coordinate flow alongside `screenshot`/`simulate-mouse-input`.
- The screenshot skill's `annotated-elements.md` reference now documents `RaycastGridPoints`, `RaycastLayerSummaries`, and `PhysicsCollider` annotation fields added by the raycast grid annotation work (C2/C3), which were previously undocumented.

## User Impact
- Before: agents reading README.md or the screenshot skill docs had no discoverable path to the `raycast` tool, and had no documented field reference for the 3D collider candidates that `screenshot --annotate-raycast-grid` already returns.
- After: both docs describe the raycast workflow (`screenshot --annotate-raycast-grid` → `raycast` → `simulate-mouse-input`) and every response field an agent needs to use it correctly.

## Changes
- `README.md`: added a numbered `raycast` tool section (renumbering `simulate-keyboard`/`record-input`/`replay-input`), a Bundled Skills entry, and short coordinate-flow notes on the `screenshot` and `simulate-mouse-input` sections.
- `Packages/src/Editor/FirstPartyTools/Screenshot/Skill/references/annotated-elements.md` (+ regenerated `.claude`/`.agents` copies): documented `RaycastGridPoints` and `RaycastLayerSummaries` fields, `PhysicsCollider` entries in `AnnotatedElements` (`Layer`/`Components`), and the Unity Input System Y-flip conversion, ported from main's equivalent doc and adapted to v3-beta's existing field names.

This completes the remaining scope of the C5 catalog/skill/doc sync step in the main→v3-beta port; `default-tools.json` and the other tool skill docs were already synced incidentally during the C1–C4 ports.

## Verification
- `uloop compile` → 0 errors, 0 warnings
- `uloop run-tests --filter-type exact --filter-value io.github.hatayama.UnityCliLoop.Tests.Editor.DefaultToolsCatalogDriftTests --test-mode EditMode` → Passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

