### PR TITLE
chore: ship Sigstore attestation bundles alongside every release asset

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,6 +48,7 @@ jobs:
           scripts/test-notify-release-workflow-failure.sh
           scripts/test-native-cli-publish-workflow.sh
           scripts/test-dispatcher-publish-workflow.sh
+          scripts/test-distribute-attestation-bundles.sh
           scripts/test-install-release-filter.sh
 
       - name: Check IPC protocol reminder

--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -92,6 +92,7 @@ jobs:
         run: scripts/verify-dispatcher-release-assets.sh
 
       - name: Attest dispatcher release assets
+        id: attest
         if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
@@ -111,6 +112,15 @@ jobs:
               --repo "${GITHUB_REPOSITORY}" \
               --signer-workflow "${SIGNER_WORKFLOW}"
           done
+
+      - name: Distribute attestation bundles per asset
+        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          scripts/distribute-attestation-bundles.sh \
+            --bundle "${BUNDLE_PATH}" \
+            --release-dir dist/dispatcher-release
 
       - name: Upload dispatcher release assets artifact
         if: steps.release.outputs.publish == 'true'
@@ -214,6 +224,18 @@ jobs:
 
             if [ "${ASSET_SIZE}" -le 0 ]; then
               echo "Remote dispatcher release asset is empty: ${asset_name}" >&2
+              exit 1
+            fi
+
+            BUNDLE_NAME="${asset_name}.sigstore.json"
+            BUNDLE_SIZE=$(printf '%s' "${ASSETS_JSON}" | jq -r --arg name "${BUNDLE_NAME}" '.assets[] | select(.name == $name) | .size')
+            if [ -z "${BUNDLE_SIZE}" ] || [ "${BUNDLE_SIZE}" = "null" ]; then
+              echo "Missing remote dispatcher attestation bundle: ${BUNDLE_NAME}" >&2
+              exit 1
+            fi
+
+            if [ "${BUNDLE_SIZE}" -le 0 ]; then
+              echo "Remote dispatcher attestation bundle is empty: ${BUNDLE_NAME}" >&2
               exit 1
             fi
           done

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -97,6 +97,7 @@ jobs:
         run: scripts/verify-native-cli-release-assets.sh
 
       - name: Attest native CLI release assets
+        id: attest
         if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
@@ -116,6 +117,15 @@ jobs:
               --repo "${GITHUB_REPOSITORY}" \
               --signer-workflow "${SIGNER_WORKFLOW}"
           done
+
+      - name: Distribute attestation bundles per asset
+        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          scripts/distribute-attestation-bundles.sh \
+            --bundle "${BUNDLE_PATH}" \
+            --release-dir dist/release
 
       - name: Upload packaged release assets artifact
         if: steps.release.outputs.publish == 'true'
@@ -232,6 +242,18 @@ jobs:
 
             if [ "${ASSET_SIZE}" -le 0 ]; then
               echo "Remote release asset is empty: ${asset_name}" >&2
+              exit 1
+            fi
+
+            BUNDLE_NAME="${asset_name}.sigstore.json"
+            BUNDLE_SIZE=$(printf '%s' "${ASSETS_JSON}" | jq -r --arg name "${BUNDLE_NAME}" '.assets[] | select(.name == $name) | .size')
+            if [ -z "${BUNDLE_SIZE}" ] || [ "${BUNDLE_SIZE}" = "null" ]; then
+              echo "Missing remote native CLI attestation bundle: ${BUNDLE_NAME}" >&2
+              exit 1
+            fi
+
+            if [ "${BUNDLE_SIZE}" -le 0 ]; then
+              echo "Remote native CLI attestation bundle is empty: ${BUNDLE_NAME}" >&2
               exit 1
             fi
           done

--- a/scripts/distribute-attestation-bundles.sh
+++ b/scripts/distribute-attestation-bundles.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -eu
+
+# Copy the Sigstore attestation bundle produced by actions/attest to a per-asset
+# `<asset>.sigstore.json` file for every release asset in RELEASE_DIR. Every
+# asset gets an identical copy of the single bundle because actions/attest
+# emits one bundle that covers all matched subjects. Client verifiers only need
+# to match the target asset digest against the bundle's subject list.
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: distribute-attestation-bundles.sh --bundle <path> --release-dir <dir>
+USAGE
+  exit 2
+}
+
+BUNDLE_PATH=""
+RELEASE_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bundle)
+      BUNDLE_PATH="${2:-}"
+      shift 2
+      ;;
+    --release-dir)
+      RELEASE_DIR="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [ -z "$BUNDLE_PATH" ] || [ -z "$RELEASE_DIR" ]; then
+  usage
+fi
+
+if [ ! -s "$BUNDLE_PATH" ]; then
+  echo "Attestation bundle is missing or empty: $BUNDLE_PATH" >&2
+  exit 1
+fi
+
+if [ ! -d "$RELEASE_DIR" ]; then
+  echo "Release directory does not exist: $RELEASE_DIR" >&2
+  exit 1
+fi
+
+distributed_count=0
+for asset_path in "$RELEASE_DIR"/*; do
+  [ -f "$asset_path" ] || continue
+  case "$asset_path" in
+    *.sigstore.json) continue ;;
+  esac
+  cp "$BUNDLE_PATH" "$asset_path.sigstore.json"
+  distributed_count=$((distributed_count + 1))
+done
+
+if [ "$distributed_count" -eq 0 ]; then
+  echo "No release assets found under $RELEASE_DIR to attach attestations to." >&2
+  exit 1
+fi
+
+echo "Distributed attestation bundle to $distributed_count assets under $RELEASE_DIR."

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -102,6 +102,17 @@ test_package_release_sync_runs_after_dispatcher_publish() {
   assert_before "$WORKFLOW" "      - name: Publish draft dispatcher release" "      - name: Sync release-please package releases"
 }
 
+test_dispatcher_attestation_bundles_are_distributed_per_asset() {
+  assert_contains "$WORKFLOW" "      - name: Distribute attestation bundles per asset"
+  assert_contains "$WORKFLOW" "          scripts/distribute-attestation-bundles.sh \\"
+  assert_contains "$WORKFLOW" "            --bundle \"\${BUNDLE_PATH}\" \\"
+  assert_contains "$WORKFLOW" "            --release-dir dist/dispatcher-release"
+  assert_before "$WORKFLOW" "      - name: Verify dispatcher asset attestations" "      - name: Distribute attestation bundles per asset"
+  assert_before "$WORKFLOW" "      - name: Distribute attestation bundles per asset" "      - name: Upload dispatcher assets"
+  assert_contains "$WORKFLOW" "          BUNDLE_NAME=\"\${asset_name}.sigstore.json\""
+  assert_contains "$WORKFLOW" "              echo \"Missing remote dispatcher attestation bundle: \${BUNDLE_NAME}\" >&2"
+}
+
 test_dispatcher_resolver_is_used
 test_dispatcher_publish_is_serialized_by_branch
 test_dispatcher_assets_are_packaged_and_verified
@@ -110,3 +121,4 @@ test_existing_dispatcher_tag_target_is_checked
 test_dispatcher_draft_state_uses_runner_temp
 test_dispatcher_beta_releases_are_marked_prerelease
 test_package_release_sync_runs_after_dispatcher_publish
+test_dispatcher_attestation_bundles_are_distributed_per_asset

--- a/scripts/test-distribute-attestation-bundles.sh
+++ b/scripts/test-distribute-attestation-bundles.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -eu
+
+# Local test for distribute-attestation-bundles.sh. Runs the script with a
+# fake bundle and asserts every non-bundle asset gets a matching
+# `<asset>.sigstore.json` file.
+
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
+DISTRIBUTE="$SCRIPT_DIR/distribute-attestation-bundles.sh"
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+RELEASE_DIR="$TEST_DIR/release"
+mkdir -p "$RELEASE_DIR"
+touch "$RELEASE_DIR/asset-a.tar.gz"
+touch "$RELEASE_DIR/asset-a.tar.gz.sha256"
+touch "$RELEASE_DIR/asset-b.zip"
+touch "$RELEASE_DIR/asset-b.zip.sha256"
+
+BUNDLE_PATH="$TEST_DIR/attestation-bundle.sigstore"
+printf '{"fake":"bundle"}\n' > "$BUNDLE_PATH"
+
+"$DISTRIBUTE" --bundle "$BUNDLE_PATH" --release-dir "$RELEASE_DIR" >/dev/null
+
+for asset in asset-a.tar.gz asset-a.tar.gz.sha256 asset-b.zip asset-b.zip.sha256; do
+  bundle_copy="$RELEASE_DIR/$asset.sigstore.json"
+  if [ ! -s "$bundle_copy" ]; then
+    echo "FAIL: expected $bundle_copy to exist and be non-empty" >&2
+    exit 1
+  fi
+  if ! diff -q "$BUNDLE_PATH" "$bundle_copy" >/dev/null; then
+    echo "FAIL: $bundle_copy differs from source bundle" >&2
+    exit 1
+  fi
+done
+
+# Ensure sigstore.json files do not get their own .sigstore.json duplicates.
+for extra in $(find "$RELEASE_DIR" -maxdepth 1 -type f -name "*.sigstore.json.sigstore.json"); do
+  echo "FAIL: found double-suffix bundle $extra" >&2
+  exit 1
+done
+
+# Ensure the script fails when the bundle path is missing.
+if "$DISTRIBUTE" --bundle "$TEST_DIR/missing.sigstore" --release-dir "$RELEASE_DIR" >/dev/null 2>&1; then
+  echo "FAIL: expected failure for missing bundle" >&2
+  exit 1
+fi
+
+# Ensure the script fails when the release directory has no candidate assets.
+EMPTY_DIR="$TEST_DIR/empty"
+mkdir -p "$EMPTY_DIR"
+if "$DISTRIBUTE" --bundle "$BUNDLE_PATH" --release-dir "$EMPTY_DIR" >/dev/null 2>&1; then
+  echo "FAIL: expected failure for empty release directory" >&2
+  exit 1
+fi
+
+echo "OK distribute-attestation-bundles.sh"

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -73,8 +73,20 @@ test_release_please_is_dispatched_after_publish() {
   assert_before "$WORKFLOW" "      - name: Dispatch release-please after native CLI publish" "      - name: Sync release-please package releases"
 }
 
+test_native_cli_attestation_bundles_are_distributed_per_asset() {
+  assert_contains "$WORKFLOW" "      - name: Distribute attestation bundles per asset"
+  assert_contains "$WORKFLOW" "          scripts/distribute-attestation-bundles.sh \\"
+  assert_contains "$WORKFLOW" "            --bundle \"\${BUNDLE_PATH}\" \\"
+  assert_contains "$WORKFLOW" "            --release-dir dist/release"
+  assert_before "$WORKFLOW" "      - name: Verify native CLI asset attestations" "      - name: Distribute attestation bundles per asset"
+  assert_before "$WORKFLOW" "      - name: Distribute attestation bundles per asset" "      - name: Upload native CLI assets"
+  assert_contains "$WORKFLOW" "          BUNDLE_NAME=\"\${asset_name}.sigstore.json\""
+  assert_contains "$WORKFLOW" "              echo \"Missing remote native CLI attestation bundle: \${BUNDLE_NAME}\" >&2"
+}
+
 test_attestation_permissions
 test_go_is_available_for_package_release_sync
 test_release_assets_are_attested
 test_release_asset_attestations_are_verified
 test_release_please_is_dispatched_after_publish
+test_native_cli_attestation_bundles_are_distributed_per_asset


### PR DESCRIPTION
## Summary

- Every release asset now ships alongside its own `<asset>.sigstore.json` Sigstore attestation bundle. This lays the groundwork for the dispatcher self-update path to verify Sigstore attestations in follow-up PRs; client-side verification is intentionally out of scope for this change.

## User Impact

- No behaviour change for end users of the currently-released dispatcher and native CLI. Starting with the next release, GitHub releases include additional `install.sh.sigstore.json`, `uloop-dispatcher-*.tar.gz.sigstore.json`, `uloop-project-runner-*.tar.gz.sigstore.json`, and matching `.zip.sigstore.json` files. Existing download flows and `.sha256` verification are unchanged.
- Follow-up PRs will teach the dispatcher self-update path (`uloop update` and the 24h auto-check) to verify these bundles. Once that lands, a release that was tampered with by anyone who does not hold the GitHub Actions OIDC identity that signed the workflow run will cause auto-update to fail closed.

## Changes

- Add `scripts/distribute-attestation-bundles.sh`: a POSIX sh helper that copies the single Sigstore bundle emitted by `actions/attest` into a `<asset>.sigstore.json` file for every release asset in the release directory (skipping files that already end with `.sigstore.json`). Behaviour is covered by `scripts/test-distribute-attestation-bundles.sh`.
- Update `.github/workflows/dispatcher-publish.yml` and `.github/workflows/native-cli-publish.yml`:
    - Give the `actions/attest` step `id: attest` so its `bundle-path` output can be referenced.
    - Add a new `Distribute attestation bundles per asset` step immediately after `Verify ... asset attestations` and before `Upload ... assets`, which invokes the distribute script.
    - Extend the existing remote-release verification loops to assert that each expected `<asset>.sigstore.json` was actually uploaded and is non-empty.
- Update `scripts/test-dispatcher-publish-workflow.sh` and `scripts/test-native-cli-publish-workflow.sh` with structural assertions that the new distribute step exists, runs in the expected order (after verify, before upload), and that the remote-release loops check for bundle presence. A future refactor that drops the distribution or reorders it around upload will fail in CI instead of on the next release.
- Wire `scripts/test-distribute-attestation-bundles.sh` into `.github/workflows/build-and-test.yml` alongside the other release-automation shell helper tests.

## Verification

- `sh scripts/test-distribute-attestation-bundles.sh` → OK
- `sh scripts/test-dispatcher-publish-workflow.sh` → OK
- `sh scripts/test-native-cli-publish-workflow.sh` → OK

## Follow-ups (separate PRs)

- Confirm the dispatcher and native CLI publish workflows actually attach `.sigstore.json` files to every asset on the next real release.
- Backfill runbook: attach `.sigstore.json` bundles to every existing release (`dispatcher-v3.0.0` through the latest, plus `uloop-project-runner-v3.0.0-beta.*`) using `gh attestation download` and `gh release upload`.
- Client verifier package under `cli/dispatcher/internal/attestation/` plus integration into `update.go` and `dispatcher_download.go`, split into three follow-up PRs per the Obsidian TODO plan.

Refs: Obsidian TODO 2 (Phase A) — Release-asset signing / attestation verification.
