### PR TITLE
fix(dispatcher): Verify project runner archive attestation before extraction

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_download.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_download.go
@@ -139,6 +139,7 @@ func downloadDispatcherRealCLIForPin(ctx context.Context, cacheRoot string, pin 
 	archivePath := filepath.Join(tempDir, assetName)
 	checksumPath := archivePath + ".sha256"
 	assetURL := dispatcherReleaseAssetURL(pin.ProjectRunnerVersion, assetName)
+	releaseTag := sharedupdate.ProjectRunnerReleaseTag(pin.ProjectRunnerVersion)
 	clicore.WriteFormat(stderr, "uloop: downloading pinned project runner %s for %s...\n", pin.ProjectRunnerVersion, dispatcherPlatformName(goos, goarch))
 	if err := downloadDispatcherFile(ctx, assetURL, archivePath); err != nil {
 		return "", err
@@ -147,6 +148,9 @@ func downloadDispatcherRealCLIForPin(ctx context.Context, cacheRoot string, pin 
 		return "", err
 	}
 	if err := verifyDispatcherChecksum(archivePath, checksumPath); err != nil {
+		return "", err
+	}
+	if err := verifyReleaseAssetAttestation(ctx, releaseTag, assetURL, archivePath, attestationRunnerPublishWorkflowPath); err != nil {
 		return "", err
 	}
 

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -564,6 +565,8 @@ func TestDownloadDispatcherRealCLIWritesDownloadStatus(t *testing.T) {
 			}, nil
 		}),
 	}
+	restoreAttestation := stubAttestationVerifyPasses()
+	defer restoreAttestation()
 
 	var stderr bytes.Buffer
 	realCLIPath, err := downloadDispatcherRealCLIForPin(
@@ -582,6 +585,132 @@ func TestDownloadDispatcherRealCLIWritesDownloadStatus(t *testing.T) {
 	}
 	assertFileContent(t, realCLIPath, "real")
 	assertFileContent(t, dispatcherRealCLIReadyPath(realCLIPath), "ready\n")
+}
+
+func TestDownloadDispatcherRealCLIFailsClosedOnAttestationError(t *testing.T) {
+	// Verifies pinned project runners are rejected when the attestation verifier reports a mismatch, so a compromised release cannot install a runner even if its .sha256 lines up.
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "uloop-project-runner-darwin-arm64.tar.gz")
+	writeDispatcherTarGzArchive(t, archivePath, []dispatcherArchiveTestEntry{
+		{Name: "uloop-project-runner", Content: "real"},
+	})
+	archiveContent, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("failed to read archive: %v", err)
+	}
+	checksum := sha256.Sum256(archiveContent)
+	checksumContent := []byte(hex.EncodeToString(checksum[:]) + "  " + filepath.Base(archivePath) + "\n")
+
+	previousHTTPClient := dispatcherHTTPClient
+	defer func() {
+		dispatcherHTTPClient = previousHTTPClient
+	}()
+	dispatcherHTTPClient = &http.Client{
+		Transport: dispatcherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			content := []byte{}
+			statusCode := http.StatusNotFound
+			if strings.HasSuffix(request.URL.Path, "/uloop-project-runner-darwin-arm64.tar.gz") {
+				content = archiveContent
+				statusCode = http.StatusOK
+			}
+			if strings.HasSuffix(request.URL.Path, "/uloop-project-runner-darwin-arm64.tar.gz.sha256") {
+				content = checksumContent
+				statusCode = http.StatusOK
+			}
+			return &http.Response{
+				StatusCode: statusCode,
+				Status:     http.StatusText(statusCode),
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}),
+	}
+	restoreAttestation := stubAttestationVerifyReturns(fmt.Errorf("simulated runner attestation failure"))
+	defer restoreAttestation()
+
+	var stderr bytes.Buffer
+	_, err = downloadDispatcherRealCLIForPin(
+		context.Background(),
+		t.TempDir(),
+		dispatcherPin{ProjectRunnerVersion: "3.0.0-beta.88"},
+		"darwin",
+		"arm64",
+		&stderr)
+	if err == nil || !strings.Contains(err.Error(), "simulated runner attestation failure") {
+		t.Fatalf("expected attestation failure to fail closed, got %v", err)
+	}
+}
+
+func TestDownloadDispatcherRealCLIPassesRunnerIdentityToAttestation(t *testing.T) {
+	// Verifies the runner-publish workflow SAN and the project runner release tag are what get sent to the attestation hook (Fable 5 review — SAN must match .github/workflows/native-cli-publish.yml, tag must be uloop-project-runner-v<version>).
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "uloop-project-runner-darwin-arm64.tar.gz")
+	writeDispatcherTarGzArchive(t, archivePath, []dispatcherArchiveTestEntry{
+		{Name: "uloop-project-runner", Content: "real"},
+	})
+	archiveContent, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("failed to read archive: %v", err)
+	}
+	checksum := sha256.Sum256(archiveContent)
+	checksumContent := []byte(hex.EncodeToString(checksum[:]) + "  " + filepath.Base(archivePath) + "\n")
+
+	previousHTTPClient := dispatcherHTTPClient
+	defer func() {
+		dispatcherHTTPClient = previousHTTPClient
+	}()
+	dispatcherHTTPClient = &http.Client{
+		Transport: dispatcherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			content := []byte{}
+			statusCode := http.StatusNotFound
+			if strings.HasSuffix(request.URL.Path, "/uloop-project-runner-darwin-arm64.tar.gz") {
+				content = archiveContent
+				statusCode = http.StatusOK
+			}
+			if strings.HasSuffix(request.URL.Path, "/uloop-project-runner-darwin-arm64.tar.gz.sha256") {
+				content = checksumContent
+				statusCode = http.StatusOK
+			}
+			return &http.Response{
+				StatusCode: statusCode,
+				Status:     http.StatusText(statusCode),
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}),
+	}
+
+	var seenReleaseTag string
+	var seenAssetURL string
+	var seenWorkflowPath string
+	previous := verifyReleaseAssetAttestation
+	verifyReleaseAssetAttestation = func(_ context.Context, releaseTag string, assetURL string, _ string, workflowPath string) error {
+		seenReleaseTag = releaseTag
+		seenAssetURL = assetURL
+		seenWorkflowPath = workflowPath
+		return nil
+	}
+	defer func() {
+		verifyReleaseAssetAttestation = previous
+	}()
+
+	var stderr bytes.Buffer
+	if _, err := downloadDispatcherRealCLIForPin(
+		context.Background(),
+		t.TempDir(),
+		dispatcherPin{ProjectRunnerVersion: "3.0.0-beta.88"},
+		"darwin",
+		"arm64",
+		&stderr); err != nil {
+		t.Fatalf("downloadDispatcherRealCLIForPin failed: %v", err)
+	}
+	if seenReleaseTag != "uloop-project-runner-v3.0.0-beta.88" {
+		t.Fatalf("attestation hook received wrong release tag: %s", seenReleaseTag)
+	}
+	if !strings.HasSuffix(seenAssetURL, "/uloop-project-runner-v3.0.0-beta.88/uloop-project-runner-darwin-arm64.tar.gz") {
+		t.Fatalf("attestation hook received wrong asset URL: %s", seenAssetURL)
+	}
+	if seenWorkflowPath != attestationRunnerPublishWorkflowPath {
+		t.Fatalf("attestation hook received wrong workflow path: %s", seenWorkflowPath)
+	}
 }
 
 func TestInstallDownloadedDispatcherRealCLIKeepsExistingExecutable(t *testing.T) {


### PR DESCRIPTION
## Summary

The dispatcher project-runner download flow now requires a valid Sigstore attestation for each downloaded `uloop-project-runner-*.tar.gz` / `uloop-project-runner-*.zip` archive before it will extract and cache the runner binary.

This is Phase B3 of TODO 2 (`docs/plans/`). Phase B1 (PR #1670) added the verifier package; Phase B2 (PR #1671) wired the installer path. This PR reuses the shared verifier hook and identity constants from B2 with `attestationRunnerPublishWorkflowPath`.

## User Impact

**Before:** A compromised GitHub releases origin could serve a malicious `uloop-project-runner-*.tar.gz` + matching `.sha256`, and the dispatcher would happily extract and execute it — sha256 alone cannot prove authenticity when the checksum ships from the same origin as the archive.

**After:** The runner archive will not be extracted unless its `.sigstore.json` bundle cryptographically verifies against Sigstore's public-good trust anchor, the workflow identity matches `.github/workflows/native-cli-publish.yml` on an allowed ref (`refs/heads/v3-beta` or `refs/heads/main`), and the release tag's commit SHA matches the certificate's Source Repository Digest extension (OID 1.3.6.1.4.1.57264.1.13). Fail-closed on bundle-missing, network-failure, digest-mismatch, and identity-mismatch.

## Changes

- `downloadDispatcherRealCLIForPin` now calls `verifyReleaseAssetAttestation` with `attestationRunnerPublishWorkflowPath` after the sha256 check succeeds but before the archive is extracted.
- Existing `TestDownloadDispatcherRealCLIWritesDownloadStatus` stubs the attestation hook (unchanged behavior).
- Two new tests cover the runner integration: fail-closed on attestation error, and the exact `uloop-project-runner-v<version>` release tag + `native-cli-publish.yml` workflow path forwarded to the hook.

## Verification

- `scripts/check-go-cli.sh` — 0 lint issues across all Go modules
- `go test ./...` in `cli/dispatcher/` — all packages pass

## Follow-up

Phase B4 (dispatcher self-update archive verification via `ULOOP_EXPECTED_ARCHIVE_SHA256` from a verified in-toto statement) remains — see Obsidian spec line 68-71. The self-update path in `update.go` only attests the installer script; the archive that install.sh downloads is still same-origin-sha256-only, so TODO 2's acceptance criterion is not yet met on the self-update path. Runner downloads (this PR) do not have that gap because the dispatcher extracts the archive directly in Go.

Refs: `docs/plans/` spec, TODO 2 Phase B3

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

