### PR TITLE
fix(dispatcher): Verify dispatcher archive attestation before installer runs

### DIFF
--- a/cli/dispatcher/internal/attestation/verifier.go
+++ b/cli/dispatcher/internal/attestation/verifier.go
@@ -115,6 +115,94 @@ func Verify(trustedMaterial root.TrustedMaterial, opts VerifyOptions) error {
 	return nil
 }
 
+// SubjectsOptions parameterizes VerifySubjects. Unlike VerifyOptions there is
+// no AssetDigest — the whole point of VerifySubjects is to obtain the digests
+// of the release's assets from the verified statement, so the caller does not
+// know them ahead of time.
+type SubjectsOptions struct {
+	BundleData        []byte
+	ExpectedCommitSHA string
+	Identity          Identity
+}
+
+// VerifySubjects performs full Sigstore verification of the bundle (signature,
+// transparency log, integrated timestamps, SCT, certificate identity, source
+// repository digest binding) and returns a map of subject filename → lowercase
+// hex-encoded SHA-256 digest extracted from the verified in-toto statement.
+//
+// This is the "manifest" surface B4 uses: the dispatcher pins a set of trusted
+// archive digests here, then hands the manifest to install.sh so the shell
+// script can compare against a digest that is cryptographically bound to the
+// release commit, rather than the sibling `.sha256` file which ships from the
+// same origin as the archive and thus offers no authenticity guarantee.
+//
+// The sigstore-go policy option is called WithoutArtifactUnsafe — the name is
+// alarming but correct here: verification without a caller-provided artifact
+// is unsafe when the caller then uses the certificate for something else
+// (e.g. claiming a local file is trusted). Here the "artifact" IS the subject
+// list we return, and callers must not skip the second-stage digest comparison
+// against the specific asset they downloaded. Verify() still enforces artifact
+// binding for the installer script path.
+func VerifySubjects(trustedMaterial root.TrustedMaterial, opts SubjectsOptions) (map[string]string, error) {
+	if len(opts.BundleData) == 0 {
+		return nil, fmt.Errorf("%w: BundleData required", ErrVerificationFailed)
+	}
+	if !isHexCommitSHA(opts.ExpectedCommitSHA) {
+		return nil, fmt.Errorf("%w: ExpectedCommitSHA must be 40-char hex", ErrVerificationFailed)
+	}
+	if opts.Identity.Repository == "" || opts.Identity.WorkflowPath == "" || len(opts.Identity.Refs) == 0 {
+		return nil, fmt.Errorf("%w: Identity.Repository, WorkflowPath, and at least one Ref required", ErrVerificationFailed)
+	}
+
+	var b bundle.Bundle
+	if err := b.UnmarshalJSON(opts.BundleData); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrMalformedBundle, err)
+	}
+
+	verifier, err := verify.NewVerifier(trustedMaterial,
+		verify.WithTransparencyLog(1),
+		verify.WithIntegratedTimestamps(1),
+		verify.WithSignedCertificateTimestamps(1))
+	if err != nil {
+		return nil, fmt.Errorf("%w: build verifier: %v", ErrVerificationFailed, err)
+	}
+
+	identities, err := buildCertificateIdentities(opts.Identity, opts.ExpectedCommitSHA)
+	if err != nil {
+		return nil, fmt.Errorf("%w: build identities: %v", ErrVerificationFailed, err)
+	}
+
+	policyOpts := make([]verify.PolicyOption, 0, len(identities))
+	for _, id := range identities {
+		policyOpts = append(policyOpts, verify.WithCertificateIdentity(id))
+	}
+
+	policy := verify.NewPolicy(verify.WithoutArtifactUnsafe(), policyOpts...)
+
+	result, err := verifier.Verify(&b, policy)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrVerificationFailed, err)
+	}
+	if result == nil || result.Statement == nil {
+		return nil, fmt.Errorf("%w: verified bundle had no statement", ErrVerificationFailed)
+	}
+	subjects := make(map[string]string, len(result.Statement.Subject))
+	for _, subject := range result.Statement.Subject {
+		if subject == nil {
+			continue
+		}
+		hex, ok := subject.Digest["sha256"]
+		if !ok || hex == "" {
+			continue
+		}
+		subjects[subject.Name] = hex
+	}
+	if len(subjects) == 0 {
+		return nil, fmt.Errorf("%w: verified bundle had no sha256 subjects", ErrVerificationFailed)
+	}
+	return subjects, nil
+}
+
 func (o VerifyOptions) validate() error {
 	if o.AssetDigest == "" {
 		return fmt.Errorf("%w: AssetDigest required", ErrVerificationFailed)

--- a/cli/dispatcher/internal/attestation/verifier_test.go
+++ b/cli/dispatcher/internal/attestation/verifier_test.go
@@ -70,6 +70,80 @@ func TestVerify_HappyPath(t *testing.T) {
 	}
 }
 
+// Verifies VerifySubjects returns the release's per-asset SHA-256 digests when the bundle is valid.
+func TestVerifySubjects_HappyPath(t *testing.T) {
+	f := loadHappyFixture(t)
+	trusted, err := LoadEmbeddedTrustedMaterial()
+	if err != nil {
+		t.Fatalf("load trusted root: %v", err)
+	}
+	subjects, err := VerifySubjects(trusted, SubjectsOptions{
+		BundleData:        f.bundle,
+		ExpectedCommitSHA: f.commitSHA,
+		Identity:          f.identity,
+	})
+	if err != nil {
+		t.Fatalf("expected VerifySubjects to succeed, got: %v", err)
+	}
+	if len(subjects) == 0 {
+		t.Fatal("expected at least one subject digest")
+	}
+	// The fixture digest belongs to the arm64 archive subject — confirm the map includes it.
+	found := false
+	for name, hex := range subjects {
+		if hex == f.digest {
+			if !strings.Contains(name, "arm64") {
+				t.Fatalf("expected arm64-shaped subject name for the fixture digest, got %q", name)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected fixture digest %s to appear in subjects map: %v", f.digest, subjects)
+	}
+}
+
+// Verifies VerifySubjects fail-closed when the certificate's Source Repository Digest differs from ExpectedCommitSHA.
+func TestVerifySubjects_CommitMismatchFailsClosed(t *testing.T) {
+	f := loadHappyFixture(t)
+	trusted, err := LoadEmbeddedTrustedMaterial()
+	if err != nil {
+		t.Fatalf("load trusted root: %v", err)
+	}
+	badCommit := "1111111111111111111111111111111111111111"
+	_, err = VerifySubjects(trusted, SubjectsOptions{
+		BundleData:        f.bundle,
+		ExpectedCommitSHA: badCommit,
+		Identity:          f.identity,
+	})
+	if err == nil {
+		t.Fatal("expected commit SHA mismatch to fail, got nil")
+	}
+	if !errors.Is(err, ErrVerificationFailed) {
+		t.Fatalf("expected ErrVerificationFailed, got %v", err)
+	}
+}
+
+// Verifies VerifySubjects rejects bundles it cannot parse as Sigstore JSON.
+func TestVerifySubjects_MalformedBundleFailsClosed(t *testing.T) {
+	f := loadHappyFixture(t)
+	trusted, err := LoadEmbeddedTrustedMaterial()
+	if err != nil {
+		t.Fatalf("load trusted root: %v", err)
+	}
+	_, err = VerifySubjects(trusted, SubjectsOptions{
+		BundleData:        []byte("{not-a-bundle}"),
+		ExpectedCommitSHA: f.commitSHA,
+		Identity:          f.identity,
+	})
+	if err == nil {
+		t.Fatal("expected malformed bundle to fail, got nil")
+	}
+	if !errors.Is(err, ErrMalformedBundle) {
+		t.Fatalf("expected ErrMalformedBundle, got %v", err)
+	}
+}
+
 // Verifies fail-closed when the local asset digest is not one of the bundle's subjects.
 func TestVerify_DigestMismatch(t *testing.T) {
 	f := loadHappyFixture(t)

--- a/cli/dispatcher/internal/dispatcher/attestation_release.go
+++ b/cli/dispatcher/internal/dispatcher/attestation_release.go
@@ -1,0 +1,210 @@
+package dispatcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/attestation"
+	sharedupdate "github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
+)
+
+const (
+	dispatcherReleasesAPIPathTemplate = "/repos/%s/releases?per_page=100&page=%d"
+	dispatcherReleaseAPIMaxPages      = 10
+	dispatcherReleaseTagPrefix        = "dispatcher-v"
+	betaVersionMarker                 = "-beta."
+	updateArchiveManifestEnvName      = "ULOOP_ARCHIVE_MANIFEST"
+)
+
+// dispatcherAPIBaseURL is mutable so tests can point it at an httptest server.
+// Production callers must not touch it.
+var dispatcherAPIBaseURL = "https://api.github.com"
+
+func dispatcherAPIBase() string { return dispatcherAPIBaseURL }
+
+// fetchAttestationSubjectManifestFunc is the indirection tests use to stub the
+// full network + Sigstore verify pipeline. Production callers must not reassign
+// this outside the dispatcher package.
+var fetchAttestationSubjectManifestFunc = fetchAttestationSubjectManifest
+
+// resolveUpdateTargetVersionFunc is the indirection tests use to stub the
+// GitHub /releases enumeration + channel-filter step. Production callers must
+// not reassign this outside the dispatcher package.
+var resolveUpdateTargetVersionFunc = resolveUpdateTargetVersion
+
+type githubReleaseListEntry struct {
+	TagName    string `json:"tag_name"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+// resolveDispatcherLatestReleaseTag returns the release tag the update flow
+// should target when the caller asks for latest / latest-beta. wantBeta=true
+// picks the newest prerelease dispatcher tag containing "-beta."; wantBeta=false
+// picks the newest non-prerelease dispatcher tag. The filter mirrors
+// scripts/install.sh's release-selection logic so a dispatcher-side resolve and
+// a script-side resolve always converge on the same tag.
+//
+// This resolve must happen dispatcher-side (not inside install.sh) so the
+// attestation verifier can bind manifests + installer verification to a
+// concrete tag rather than the /releases/latest endpoint — which in this repo
+// silently returns the wrong (mixed package/dispatcher/runner) release.
+func resolveDispatcherLatestReleaseTag(ctx context.Context, wantBeta bool) (string, error) {
+	for page := 1; page <= dispatcherReleaseAPIMaxPages; page++ {
+		entries, err := fetchDispatcherReleasePage(ctx, page)
+		if err != nil {
+			return "", err
+		}
+		if len(entries) == 0 {
+			break
+		}
+		for _, entry := range entries {
+			if entry.Draft {
+				continue
+			}
+			if !strings.HasPrefix(entry.TagName, dispatcherReleaseTagPrefix) {
+				continue
+			}
+			if wantBeta {
+				if !entry.Prerelease || !strings.Contains(strings.ToLower(entry.TagName), betaVersionMarker) {
+					continue
+				}
+			} else {
+				if entry.Prerelease {
+					continue
+				}
+			}
+			return entry.TagName, nil
+		}
+		if len(entries) < 100 {
+			break
+		}
+	}
+	channel := "stable"
+	if wantBeta {
+		channel = "beta"
+	}
+	return "", fmt.Errorf("no %s dispatcher release available", channel)
+}
+
+func fetchDispatcherReleasePage(ctx context.Context, page int) ([]githubReleaseListEntry, error) {
+	url := dispatcherAPIBase() + fmt.Sprintf(dispatcherReleasesAPIPathTemplate, dispatcherReleaseRepository, page)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token := lookupGitHubAPIToken(); token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	response, err := dispatcherHTTPClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, response.Body)
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, fmt.Errorf("list releases: status %s", response.Status)
+	}
+	var entries []githubReleaseListEntry
+	if err := json.NewDecoder(response.Body).Decode(&entries); err != nil {
+		return nil, fmt.Errorf("decode releases: %v", err)
+	}
+	return entries, nil
+}
+
+// resolveUpdateTargetVersion promotes an implicit "latest" self-update request
+// into an explicit target version. If TargetVersion is already set, it is
+// returned untouched so tryHandleUpdateRequest's --to-version path still works.
+// Otherwise the newest dispatcher release matching the caller's channel
+// (stable vs beta, chosen by CurrentVersion) is resolved to a concrete
+// version string like "3.0.1-beta.12".
+func resolveUpdateTargetVersion(ctx context.Context, options sharedupdate.Options) (sharedupdate.Options, error) {
+	if options.TargetVersion != "" {
+		return options, nil
+	}
+	wantBeta := sharedupdate.IsBetaVersion(options.CurrentVersion)
+	tag, err := resolveDispatcherLatestReleaseTag(ctx, wantBeta)
+	if err != nil {
+		return options, err
+	}
+	options.TargetVersion = strings.TrimPrefix(tag, dispatcherReleaseTagPrefix)
+	return options, nil
+}
+
+// fetchAttestationSubjectManifest fetches and verifies the release's
+// attestation bundle and returns a sha256sum-style manifest string mapping
+// each release asset filename to its verified SHA-256 digest.
+//
+// The returned string has one line per subject in the format
+// "<digest>  <filename>\n" so install.sh / install.ps1 can look up the asset
+// name they downloaded and enforce the digest without inheriting any Go-side
+// GOOS/GOARCH prediction that could diverge from the shell's uname-based
+// detection (e.g. Rosetta running an amd64 dispatcher inside an arm64 host).
+func fetchAttestationSubjectManifest(ctx context.Context, releaseTag string) (string, error) {
+	if releaseTag == "" {
+		return "", fmt.Errorf("%w: releaseTag required to fetch subject manifest", attestation.ErrVerificationFailed)
+	}
+	assetURL := dispatcherReleaseBaseURL + "/" + releaseTag + "/" + sharedupdate.PosixScriptName
+	bundleData, err := attestation.FetchBundle(ctx, assetURL+".sigstore.json")
+	if err != nil {
+		return "", err
+	}
+	commitSHA, err := attestation.FetchTagCommitSHA(ctx, dispatcherReleaseRepository, releaseTag)
+	if err != nil {
+		return "", err
+	}
+	trustedMaterial, err := attestation.LoadEmbeddedTrustedMaterial()
+	if err != nil {
+		return "", fmt.Errorf("%w: load embedded trusted root: %v", attestation.ErrVerificationFailed, err)
+	}
+	subjects, err := attestation.VerifySubjects(trustedMaterial, attestation.SubjectsOptions{
+		BundleData:        bundleData,
+		ExpectedCommitSHA: commitSHA,
+		Identity: attestation.Identity{
+			Repository:   dispatcherReleaseRepository,
+			WorkflowPath: attestationDispatcherPublishWorkflowPath,
+			Refs:         attestationAllowedRefs,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	var builder strings.Builder
+	for name, digest := range subjects {
+		if name == "" || digest == "" {
+			continue
+		}
+		if strings.ContainsAny(name, "\n\r") {
+			continue
+		}
+		builder.WriteString(digest)
+		builder.WriteString("  ")
+		builder.WriteString(name)
+		builder.WriteByte('\n')
+	}
+	if builder.Len() == 0 {
+		return "", fmt.Errorf("%w: subject manifest was empty after filtering", attestation.ErrVerificationFailed)
+	}
+	return builder.String(), nil
+}
+
+// lookupGitHubAPIToken reads the ambient GitHub token from the environment.
+// GITHUB_TOKEN wins over GH_TOKEN so CI environments that set both behave
+// consistently with attestation.setAuthorizationIfAvailable in fetcher.go.
+func lookupGitHubAPIToken() string {
+	for _, env := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		if value := os.Getenv(env); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/cli/dispatcher/internal/dispatcher/attestation_release_test.go
+++ b/cli/dispatcher/internal/dispatcher/attestation_release_test.go
@@ -1,0 +1,126 @@
+package dispatcher
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sharedupdate "github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
+)
+
+// Verifies latest-beta selection ignores stable releases, non-dispatcher tags,
+// draft releases, and non-beta prereleases so a dispatcher on a beta channel
+// cannot silently resolve to a stable-only tag it would then attest against.
+func TestResolveDispatcherLatestReleaseTagBetaChannelSkipsUnmatchedEntries(t *testing.T) {
+	entriesPage := []githubReleaseListEntry{
+		{TagName: "dispatcher-v3.0.1-beta.12", Prerelease: true, Draft: false},
+		{TagName: "dispatcher-v3.0.0", Prerelease: false, Draft: false},
+		{TagName: "uloop-project-runner-v0.9.0-beta.4", Prerelease: true, Draft: false},
+		{TagName: "dispatcher-v3.0.2-beta.1", Prerelease: true, Draft: true},
+		{TagName: "dispatcher-v3.0.0-rc.1", Prerelease: true, Draft: false},
+	}
+	server, restoreBase := installReleaseListServer(t, entriesPage)
+	defer server.Close()
+	defer restoreBase()
+
+	tag, err := resolveDispatcherLatestReleaseTag(context.Background(), true)
+	if err != nil {
+		t.Fatalf("resolveDispatcherLatestReleaseTag failed: %v", err)
+	}
+	if tag != "dispatcher-v3.0.1-beta.12" {
+		t.Fatalf("unexpected beta tag: %s", tag)
+	}
+}
+
+// Verifies stable-channel resolution rejects prereleases and only accepts a
+// dispatcher-v tag that is not marked prerelease.
+func TestResolveDispatcherLatestReleaseTagStableChannelSkipsPrereleases(t *testing.T) {
+	entriesPage := []githubReleaseListEntry{
+		{TagName: "dispatcher-v3.0.1-beta.12", Prerelease: true},
+		{TagName: "dispatcher-v3.0.0", Prerelease: false},
+		{TagName: "uloop-project-runner-v0.9.0", Prerelease: false},
+	}
+	server, restoreBase := installReleaseListServer(t, entriesPage)
+	defer server.Close()
+	defer restoreBase()
+
+	tag, err := resolveDispatcherLatestReleaseTag(context.Background(), false)
+	if err != nil {
+		t.Fatalf("resolveDispatcherLatestReleaseTag failed: %v", err)
+	}
+	if tag != "dispatcher-v3.0.0" {
+		t.Fatalf("unexpected stable tag: %s", tag)
+	}
+}
+
+// Verifies a channel with no matching release returns an error rather than
+// silently falling back — attestation flows must fail closed on an unmet
+// selector rather than downgrade to the wrong channel.
+func TestResolveDispatcherLatestReleaseTagFailsWhenChannelEmpty(t *testing.T) {
+	entriesPage := []githubReleaseListEntry{
+		{TagName: "dispatcher-v3.0.0", Prerelease: false},
+	}
+	server, restoreBase := installReleaseListServer(t, entriesPage)
+	defer server.Close()
+	defer restoreBase()
+
+	if _, err := resolveDispatcherLatestReleaseTag(context.Background(), true); err == nil {
+		t.Fatal("expected beta resolution to fail when no beta release exists")
+	}
+}
+
+// Verifies resolveUpdateTargetVersion respects an already-populated
+// TargetVersion so tryHandleUpdateRequest's --to-version path is untouched.
+func TestResolveUpdateTargetVersionKeepsExplicitTarget(t *testing.T) {
+	options, err := resolveUpdateTargetVersion(context.Background(), sharedupdate.Options{
+		CurrentVersion: "3.0.0-beta.10",
+		TargetVersion:  "3.0.0-beta.7",
+	})
+	if err != nil {
+		t.Fatalf("resolveUpdateTargetVersion failed: %v", err)
+	}
+	if options.TargetVersion != "3.0.0-beta.7" {
+		t.Fatalf("explicit target was overwritten: %s", options.TargetVersion)
+	}
+}
+
+// Verifies resolveUpdateTargetVersion picks the beta channel when the caller
+// is currently running a beta build.
+func TestResolveUpdateTargetVersionPromotesLatestForBetaChannel(t *testing.T) {
+	entriesPage := []githubReleaseListEntry{
+		{TagName: "dispatcher-v3.0.1-beta.5", Prerelease: true},
+	}
+	server, restoreBase := installReleaseListServer(t, entriesPage)
+	defer server.Close()
+	defer restoreBase()
+
+	options, err := resolveUpdateTargetVersion(context.Background(), sharedupdate.Options{
+		CurrentVersion: "3.0.0-beta.1",
+	})
+	if err != nil {
+		t.Fatalf("resolveUpdateTargetVersion failed: %v", err)
+	}
+	if options.TargetVersion != "3.0.1-beta.5" {
+		t.Fatalf("unexpected resolved target: %s", options.TargetVersion)
+	}
+}
+
+func installReleaseListServer(t *testing.T, entries []githubReleaseListEntry) (*httptest.Server, func()) {
+	t.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			_ = json.NewEncoder(w).Encode([]githubReleaseListEntry{})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+	server := httptest.NewServer(handler)
+	previousBase := dispatcherAPIBaseURL
+	dispatcherAPIBaseURL = server.URL
+	return server, func() {
+		dispatcherAPIBaseURL = previousBase
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_bootstrap_routing_test.go
@@ -66,9 +66,13 @@ func TestRunDispatcherUpdateRunsInDispatcherProcess(t *testing.T) {
 
 	previousRun := updateRunCommand
 	previousReader := dispatcherReadInstalledVersion
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousManifest := fetchAttestationSubjectManifestFunc
 	defer func() {
 		updateRunCommand = previousRun
 		dispatcherReadInstalledVersion = previousReader
+		resolveUpdateTargetVersionFunc = previousResolver
+		fetchAttestationSubjectManifestFunc = previousManifest
 	}()
 	updateExecuted := false
 	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
@@ -77,6 +81,15 @@ func TestRunDispatcherUpdateRunsInDispatcherProcess(t *testing.T) {
 	}
 	dispatcherReadInstalledVersion = func(context.Context) (string, error) {
 		return dispatcherVersion, nil
+	}
+	resolveUpdateTargetVersionFunc = func(ctx context.Context, options update.Options) (update.Options, error) {
+		if options.TargetVersion == "" {
+			options.TargetVersion = dispatcherVersion
+		}
+		return options, nil
+	}
+	fetchAttestationSubjectManifestFunc = func(ctx context.Context, tag string) (string, error) {
+		return "deadbeef  install.sh\n", nil
 	}
 
 	var stdout bytes.Buffer

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -375,9 +375,13 @@ func markDispatcherSelfUpdateCheckedWithDeps(deps dispatcherRunDeps) {
 }
 
 func runDispatcherUpdateCommand(ctx context.Context) error {
-	command, err := sharedupdate.CommandForOS(runtime.GOOS, sharedupdate.Options{
+	resolved, err := resolveUpdateTargetVersionFunc(ctx, sharedupdate.Options{
 		CurrentVersion: dispatcherVersion,
 	})
+	if err != nil {
+		return err
+	}
+	command, err := sharedupdate.CommandForOS(runtime.GOOS, resolved)
 	if err != nil {
 		return err
 	}

--- a/cli/dispatcher/internal/dispatcher/update.go
+++ b/cli/dispatcher/internal/dispatcher/update.go
@@ -39,10 +39,15 @@ func tryHandleUpdateRequest(ctx context.Context, args []string, stdout io.Writer
 		return true, 1
 	}
 
-	updateCommand, err := update.CommandForOS(runtime.GOOS, update.Options{
+	resolvedOptions, err := resolveUpdateTargetVersionFunc(ctx, update.Options{
 		CurrentVersion: dispatcherVersion,
 		TargetVersion:  options.targetVersion,
 	})
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: clicore.UpdateCommandName})
+		return true, 1
+	}
+	updateCommand, err := update.CommandForOS(runtime.GOOS, resolvedOptions)
 	if err != nil {
 		clierrors.WriteClassifiedError(stderr, wrapUnsupportedPlatformError(err), clierrors.ErrorContext{Command: clicore.UpdateCommandName})
 		return true, 1
@@ -97,11 +102,18 @@ func runUpdateCommand(ctx context.Context, updateCommand update.Command, stdout 
 		return err
 	}
 
+	manifest, err := fetchAttestationSubjectManifestFunc(ctx, updateCommand.ReleaseTag)
+	if err != nil {
+		return err
+	}
+
 	args := updateExecutionArgs(updateCommand, installerPath)
 	command := exec.CommandContext(ctx, updateCommand.Name, args...)
 	command.Stdout = stdout
 	command.Stderr = stderr
-	command.Env = append(os.Environ(), updateCommand.Env...)
+	env := append(os.Environ(), updateCommand.Env...)
+	env = append(env, updateArchiveManifestEnvName+"="+manifest)
+	command.Env = env
 	return command.Run()
 }
 

--- a/cli/dispatcher/internal/dispatcher/update_test.go
+++ b/cli/dispatcher/internal/dispatcher/update_test.go
@@ -398,15 +398,28 @@ func stubManualUpdateHooks(t *testing.T, updatedVersion string) func() {
 	t.Helper()
 	previousRunner := updateRunCommand
 	previousReader := dispatcherReadInstalledVersion
+	previousResolver := resolveUpdateTargetVersionFunc
+	previousManifest := fetchAttestationSubjectManifestFunc
 	updateRunCommand = func(context.Context, update.Command, io.Writer, io.Writer) error {
 		return nil
 	}
 	dispatcherReadInstalledVersion = func(context.Context) (string, error) {
 		return updatedVersion, nil
 	}
+	resolveUpdateTargetVersionFunc = func(ctx context.Context, options update.Options) (update.Options, error) {
+		if options.TargetVersion == "" {
+			options.TargetVersion = "9.9.9"
+		}
+		return options, nil
+	}
+	fetchAttestationSubjectManifestFunc = func(ctx context.Context, tag string) (string, error) {
+		return "deadbeef  install.sh\n", nil
+	}
 	return func() {
 		updateRunCommand = previousRunner
 		dispatcherReadInstalledVersion = previousReader
+		resolveUpdateTargetVersionFunc = previousResolver
+		fetchAttestationSubjectManifestFunc = previousManifest
 	}
 }
 

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "c1b345cfb13b50c52c529f4746a4b481ddbd0615"
+  "sharedInputsHash": "4cf6c7f5a03b5a1d2d0046ed035ddc4db5158516"
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -484,6 +484,30 @@ try {
         throw "Checksum mismatch for $AssetName"
     }
 
+    # Why: when the dispatcher self-update path invokes this script it passes an
+    # ULOOP_ARCHIVE_MANIFEST env whose "<digest>  <filename>" lines came from a
+    # Sigstore attestation bundle verified against the release commit SHA.
+    # Enforcing the manifest entry stops a swapped archive from being blessed by
+    # a compromised same-origin .sha256. Missing env = README bootstrap; skip
+    # instead of hard-failing so a first-time curl|iex install still works.
+    $Manifest = [Environment]::GetEnvironmentVariable("ULOOP_ARCHIVE_MANIFEST")
+    if (-not [string]::IsNullOrEmpty($Manifest)) {
+        $ManifestHash = $null
+        foreach ($Line in ($Manifest -split "`r?`n")) {
+            $Parts = $Line -split '\s+', 2
+            if ($Parts.Length -eq 2 -and $Parts[1].Trim() -eq $AssetName) {
+                $ManifestHash = $Parts[0].Trim().ToLowerInvariant()
+                break
+            }
+        }
+        if ([string]::IsNullOrEmpty($ManifestHash)) {
+            throw "Attestation manifest has no entry for $AssetName"
+        }
+        if ($ManifestHash -ne $ActualHash) {
+            throw "Attestation manifest hash mismatch for $AssetName"
+        }
+    }
+
     Expand-UloopArchive -ArchivePath $ArchivePath -DestinationPath $TempDir
 
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -413,33 +413,72 @@ tmp_dir=$(mktemp -d)
 staged_uloop_path=""
 trap 'rm -rf "$tmp_dir"; if [ -n "$staged_uloop_path" ]; then rm -f "$staged_uloop_path"; fi' EXIT
 
-verify_checksum() {
+compute_asset_sha256() {
+  # Why: install.sh runs on macOS (shasum) and MINGW/MSYS (sha256sum). We do the
+  # computation once here so both the same-origin .sha256 check and the trusted
+  # manifest check share one hex string.
   if command -v sha256sum >/dev/null 2>&1; then
-    (
-      cd "$tmp_dir"
-      sha256sum -c "$asset_name.sha256"
-    )
+    sha256sum "$tmp_dir/$asset_name" | awk '{print $1}'
     return
   fi
-
   if command -v shasum >/dev/null 2>&1; then
-    expected_hash=$(awk '{print $1}' "$tmp_dir/$asset_name.sha256")
-    actual_hash=$(shasum -a 256 "$tmp_dir/$asset_name" | awk '{print $1}')
-    if [ "$expected_hash" != "$actual_hash" ]; then
-      echo "Checksum mismatch for $asset_name" >&2
-      exit 1
-    fi
+    shasum -a 256 "$tmp_dir/$asset_name" | awk '{print $1}'
     return
   fi
-
   echo "sha256sum or shasum is required to verify $asset_name" >&2
   exit 1
+}
+
+verify_checksum() {
+  actual_hash=$(compute_asset_sha256)
+  expected_hash=$(awk '{print $1}' "$tmp_dir/$asset_name.sha256")
+  if [ -z "$expected_hash" ]; then
+    echo "Missing checksum entry for $asset_name" >&2
+    exit 1
+  fi
+  if [ "$expected_hash" != "$actual_hash" ]; then
+    echo "Checksum mismatch for $asset_name" >&2
+    exit 1
+  fi
+}
+
+verify_archive_attestation_manifest() {
+  # Why: when the dispatcher self-update path invokes this script it passes an
+  # ULOOP_ARCHIVE_MANIFEST env carrying "<digest>  <filename>" lines that were
+  # extracted from a Sigstore attestation bundle already verified against the
+  # release commit SHA. Enforce that the digest we just computed matches the
+  # entry for our asset_name so a compromised same-origin .sha256 file alone
+  # cannot bless a swapped archive. When the env is unset (README curl|sh
+  # bootstrap), we skip: bootstrap trust rests on TLS + repo ownership, and
+  # promoting that missing-manifest path to a hard failure would break every
+  # first-time install.
+  if [ -z "${ULOOP_ARCHIVE_MANIFEST:-}" ]; then
+    return
+  fi
+  manifest_hash=$(
+    printf '%s\n' "$ULOOP_ARCHIVE_MANIFEST" | awk -v name="$asset_name" '
+      $2 == name { print $1; found = 1; exit }
+      END { if (!found) exit 1 }
+    '
+  ) || {
+    echo "Attestation manifest has no entry for $asset_name" >&2
+    exit 1
+  }
+  if [ -z "$manifest_hash" ]; then
+    echo "Attestation manifest entry for $asset_name is empty" >&2
+    exit 1
+  fi
+  if [ "$manifest_hash" != "$actual_hash" ]; then
+    echo "Attestation manifest hash mismatch for $asset_name" >&2
+    exit 1
+  fi
 }
 
 mkdir -p "$INSTALL_DIR"
 curl -fsSL "$download_url" -o "$tmp_dir/$asset_name"
 curl -fsSL "$checksum_url" -o "$tmp_dir/$asset_name.sha256"
 verify_checksum
+verify_archive_attestation_manifest
 extract_asset
 staged_uloop_path="$INSTALL_DIR/.uloop-install-$$"
 if [ "$installed_command_name" = "uloop.exe" ]; then

--- a/scripts/test-install-archive-manifest.sh
+++ b/scripts/test-install-archive-manifest.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Verifies install.sh's ULOOP_ARCHIVE_MANIFEST verification handles a matching
+# digest, a mismatch, a missing entry, and an unset env consistently. Locks in
+# the exact POSIX-sh semantics so a later refactor cannot silently regress the
+# defense-in-depth over the same-origin .sha256 file.
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+INSTALL_SCRIPT="$ROOT_DIR/scripts/install.sh"
+
+if ! command -v awk >/dev/null 2>&1; then
+  echo "awk is required for this test" >&2
+  exit 1
+fi
+
+# Extract the two functions from install.sh so the test does not have to
+# re-run the entire installer top-to-bottom (which would try to reach
+# api.github.com and mutate $HOME/.local/bin).
+extract_function() {
+  name=$1
+  awk -v want="$name" '
+    $0 ~ ("^" want "\\(\\)") { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { exit }
+  ' "$INSTALL_SCRIPT"
+}
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT INT HUP TERM
+
+tmp_dir="$TMP_DIR"
+asset_name="uloop-dispatcher-darwin-arm64.zip"
+printf 'archive payload\n' > "$tmp_dir/$asset_name"
+
+# Compute the reference digest with whichever sha tool we have available.
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_hash=$(sha256sum "$tmp_dir/$asset_name" | awk '{print $1}')
+else
+  actual_hash=$(shasum -a 256 "$tmp_dir/$asset_name" | awk '{print $1}')
+fi
+
+# Source the two helpers extracted from install.sh so tests exercise the real
+# implementations, not a copy that could drift.
+eval "$(extract_function compute_asset_sha256)"
+eval "$(extract_function verify_archive_attestation_manifest)"
+
+expect_pass() {
+  label=$1
+  # Why: verify_archive_attestation_manifest uses `exit 1` on failure, so it
+  # must run in a subshell to prevent the test harness itself from exiting.
+  if ! (verify_archive_attestation_manifest) 2>/dev/null; then
+    echo "FAIL: $label — expected pass but got failure" >&2
+    exit 1
+  fi
+}
+
+expect_fail() {
+  label=$1
+  if (verify_archive_attestation_manifest) 2>/dev/null; then
+    echo "FAIL: $label — expected failure but got pass" >&2
+    exit 1
+  fi
+}
+
+# 1. Unset env: manifest check must skip silently so a first-time README
+#    bootstrap install (curl | sh) keeps working.
+unset ULOOP_ARCHIVE_MANIFEST || true
+expect_pass "unset manifest skips silently"
+
+# 2. Matching manifest entry: accept and continue.
+ULOOP_ARCHIVE_MANIFEST="$actual_hash  $asset_name
+0000000000000000000000000000000000000000000000000000000000000000  install.sh"
+export ULOOP_ARCHIVE_MANIFEST
+expect_pass "matching manifest digest accepted"
+
+# 3. Mismatched digest: reject.
+ULOOP_ARCHIVE_MANIFEST="0000000000000000000000000000000000000000000000000000000000000000  $asset_name"
+export ULOOP_ARCHIVE_MANIFEST
+expect_fail "mismatched manifest digest rejected"
+
+# 4. Missing asset entry: reject rather than silently pass, otherwise a
+#    tampered filename could bypass the check by omitting itself from the
+#    manifest.
+ULOOP_ARCHIVE_MANIFEST="1111111111111111111111111111111111111111111111111111111111111111  install.sh"
+export ULOOP_ARCHIVE_MANIFEST
+expect_fail "missing manifest entry for asset_name rejected"
+
+echo "OK"

--- a/scripts/test-install-release-filter.sh
+++ b/scripts/test-install-release-filter.sh
@@ -191,6 +191,17 @@ if [ "$1" = "-c" ]; then
   exit 0
 fi
 
+# install.sh now computes the digest with `sha256sum <path>` and compares
+# against the parsed .sha256 file so the same hash string is available for
+# both the same-origin check and the attestation-manifest cross-check. The
+# .sha256 fixtures written above use the literal "fakehash", so emit that
+# whenever a single-file digest is requested. Any other invocation shape is
+# unexpected and should fail loud.
+if [ "$#" -ge 1 ] && [ -f "$1" ]; then
+  printf 'fakehash  %s\n' "$1"
+  exit 0
+fi
+
 echo "unexpected sha256sum arguments: $*" >&2
 exit 1
 MOCK_SHA256SUM


### PR DESCRIPTION
## Summary
- Dispatcher self-update now binds the installed archive to a Sigstore attestation, not just the same-origin `.sha256`.
- Archive attestation is verified before the archive is trusted, layering on top of the existing installer-script check (B2) and runner-archive check (B3).

## User Impact
- Before: `uloop update` and the auto-update path trusted the archive when its bytes matched the sibling `.sha256`. An attacker who could tamper with a release asset could rewrite the archive and its `.sha256` together and pass verification.
- After: the dispatcher resolves the target release tag, fetches the Sigstore bundle, and hands a verified digest manifest to `install.sh` / `install.ps1`. The installer scripts refuse to extract an archive whose sha256 does not match the manifest entry for its filename.
- The README `curl | sh` bootstrap path is unchanged: when `ULOOP_ARCHIVE_MANIFEST` is unset, the installer scripts continue to rely on the `.sha256` file (bootstrap trust remains rooted in TLS + repo ownership, as documented in the security TODO).

## Changes
- `cli/dispatcher/internal/attestation/verifier.go`: add `VerifySubjects` which runs full Sigstore verification (signature, transparency log, integrated timestamps, SCT, cert identity, source-repo digest binding) and returns the verified subject-digest map, without a caller-supplied artifact digest.
- `cli/dispatcher/internal/dispatcher/attestation_release.go`: paginated `/releases` enumeration with `dispatcher-v` + channel filtering that mirrors `install.sh`'s selector so dispatcher-side and script-side resolution converge on the same tag; `fetchAttestationSubjectManifest` builds a `sha256sum`-style manifest from the verified statement.
- `cli/dispatcher/internal/dispatcher/update.go` & `run_dispatcher.go`: pre-resolve latest → concrete target version before `CommandForOS`; append `ULOOP_ARCHIVE_MANIFEST` env to the installer command after the installer script's own attestation passes.
- `scripts/install.sh` & `scripts/install.ps1`: consume `ULOOP_ARCHIVE_MANIFEST`; fail closed when the manifest is set but has no entry for the asset or the digest mismatches; skip when the env is unset so first-time installs still work.
- Tests: unit tests for the channel filter, the resolver, and the shell manifest verification (`scripts/test-install-archive-manifest.sh`).

## Verification
- `scripts/check-go-cli.sh` — pass (fmt, vet, lint, tests, dist rebuild)
- `sh scripts/test-install-archive-manifest.sh` — pass (matched digest, mismatched digest, missing entry, unset env)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

