### PR TITLE
docs: Document pin-driven runner downgrade risk

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,13 +17,18 @@ When reporting a vulnerability, please include:
 
 ### Untrusted Unity projects can drive the runner version
 
-`uloop` reads `Packages/src/project-runner-pin.json` (which
-`CliPinSynchronizer` mirrors byte-identically to
-`.uloop/project-runner-pin.json`) from the current Unity project to decide
-which project-runner release to download and execute. The pin is
+At runtime `uloop` looks up the project-runner pin from the current
+Unity project to decide which project-runner release to download and
+execute. The read order is `.uloop/project-runner-pin.json` first, then
+a fallback to `Packages/src/project-runner-pin.json`, and finally the
+installed package copy under `Packages/<package>/`. The authoring source
+is `Packages/src/project-runner-pin.json`; `CliPinSynchronizer` copies
+it byte-identically to `.uloop/project-runner-pin.json` when Unity
+opens the project, so the runtime lookup usually resolves inside
+`.uloop/` before the source ever gets consulted. The pin is
 project-local data: opening or cloning a third-party Unity project and
-running `uloop` inside it means the project's pin controls which release
-`uloop` will pull down and launch.
+running `uloop` inside it means the project's pin controls which
+release `uloop` will pull down and launch.
 
 Concrete implications:
 
@@ -44,10 +49,14 @@ Guidance:
 
 - Only run `uloop` inside Unity projects whose maintainers you trust to
   choose your runner version.
-- When auditing a third-party project, inspect the source pin at
-  `Packages/src/project-runner-pin.json` (and its mirror at
-  `.uloop/project-runner-pin.json` if only that path is present)
-  before running any `uloop` command in it.
+- When auditing a third-party project, inspect **both**
+  `.uloop/project-runner-pin.json` and
+  `Packages/src/project-runner-pin.json` before running any `uloop`
+  command in it. The two files must be byte-identical — any divergence
+  is itself a red flag, because the runtime path (`.uloop/`) is what
+  actually decides which release runs, and a mismatched source
+  (`Packages/src/`) means the mirror step never completed or was
+  bypassed.
 - `ULOOP_DISABLE_SELF_UPDATE=1` is still worth setting in one-off audit
   environments because it prevents the dispatcher from silently
   upgrading itself while you are investigating, but treat it as a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,3 +12,41 @@ When reporting a vulnerability, please include:
 - Steps to reproduce the issue
 - Potential impact
 - Any suggested fixes, if available
+
+## Trust Model and Known Risks
+
+### Untrusted Unity projects can drive the runner version
+
+`uloop` reads `.uloop/project-runner-pin.json` (or the mirrored
+`Packages/src/project-runner-pin.json`) from the current Unity project to
+decide which project-runner release to download and execute. The pin is
+project-local data: opening or cloning a third-party Unity project and
+running `uloop` inside it means the project's pin controls which release
+`uloop` will pull down and launch.
+
+Concrete implications:
+
+- A hostile project can pin the runner to a known-vulnerable published
+  release and downgrade you to it. `uloop` verifies the release's Sigstore
+  attestation before extracting the archive, so an attacker cannot forge a
+  new asset — but they *can* select an older asset the project owns.
+- Setting `ULOOP_DISABLE_SELF_UPDATE=1` only disables the dispatcher's own
+  auto-update. It does not disable pin-driven runner selection, because the
+  runner version is part of the project contract, not the dispatcher's
+  update policy.
+- Attestation verification (`Sigstore` bundles) rules out unpublished
+  binaries: an attacker cannot make `uloop` execute an archive that was
+  not built and signed by the official release workflow.
+
+Guidance:
+
+- Only run `uloop` inside Unity projects whose maintainers you trust to
+  choose your runner version.
+- When auditing a third-party project, inspect
+  `.uloop/project-runner-pin.json` and
+  `Packages/src/project-runner-pin.json` before running any `uloop`
+  command in it.
+- `ULOOP_DISABLE_SELF_UPDATE=1` is still worth setting in one-off audit
+  environments because it prevents the dispatcher from silently
+  upgrading itself while you are investigating, but treat it as a
+  layered defense, not a substitute for reading the pin.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,9 +17,10 @@ When reporting a vulnerability, please include:
 
 ### Untrusted Unity projects can drive the runner version
 
-`uloop` reads `.uloop/project-runner-pin.json` (or the mirrored
-`Packages/src/project-runner-pin.json`) from the current Unity project to
-decide which project-runner release to download and execute. The pin is
+`uloop` reads `Packages/src/project-runner-pin.json` (which
+`CliPinSynchronizer` mirrors byte-identically to
+`.uloop/project-runner-pin.json`) from the current Unity project to decide
+which project-runner release to download and execute. The pin is
 project-local data: opening or cloning a third-party Unity project and
 running `uloop` inside it means the project's pin controls which release
 `uloop` will pull down and launch.
@@ -29,7 +30,8 @@ Concrete implications:
 - A hostile project can pin the runner to a known-vulnerable published
   release and downgrade you to it. `uloop` verifies the release's Sigstore
   attestation before extracting the archive, so an attacker cannot forge a
-  new asset — but they *can* select an older asset the project owns.
+  new asset — but they *can* select an older release already published by
+  this repository.
 - Setting `ULOOP_DISABLE_SELF_UPDATE=1` only disables the dispatcher's own
   auto-update. It does not disable pin-driven runner selection, because the
   runner version is part of the project contract, not the dispatcher's
@@ -42,10 +44,10 @@ Guidance:
 
 - Only run `uloop` inside Unity projects whose maintainers you trust to
   choose your runner version.
-- When auditing a third-party project, inspect
-  `.uloop/project-runner-pin.json` and
-  `Packages/src/project-runner-pin.json` before running any `uloop`
-  command in it.
+- When auditing a third-party project, inspect the source pin at
+  `Packages/src/project-runner-pin.json` (and its mirror at
+  `.uloop/project-runner-pin.json` if only that path is present)
+  before running any `uloop` command in it.
 - `ULOOP_DISABLE_SELF_UPDATE=1` is still worth setting in one-off audit
   environments because it prevents the dispatcher from silently
   upgrading itself while you are investigating, but treat it as a


### PR DESCRIPTION
## Summary
- Explain in `SECURITY.md` that a hostile Unity project's runner pin can downgrade `uloop` to an older, already-signed release.
- Clarify that `ULOOP_DISABLE_SELF_UPDATE=1` only stops the dispatcher's own auto-update — it does not block pin-driven runner selection.

## User Impact
- Reviewers auditing a third-party Unity project now have written guidance on why `uloop` may still fetch an older runner even though every binary is Sigstore-attested: attestation rules out forged binaries, not selection of an older signed one. The doc points them at the exact pin files to inspect before running any `uloop` command.

## Changes
- `SECURITY.md`: add a "Trust Model and Known Risks" section covering the pin-driven runner selection boundary, the limits of `ULOOP_DISABLE_SELF_UPDATE`, and concrete inspection guidance.

## Verification
- Docs-only change — nothing to run. Verified the doc lists both pin file paths (`.uloop/project-runner-pin.json` and `Packages/src/project-runner-pin.json`) that `dispatcher_pin.go` actually reads.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

