### PR TITLE
feat(package): Resolve source file and line to patch locations via portable PDBs

### DIFF
--- a/Assets/Tests/Editor/SourcePausePointResolver.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10d18ac3a0fa74f998bf605361941f5a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7551f7a8214794d3a84377968d678d11
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/AsyncMethodFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/AsyncMethodFixture.cs
@@ -1,0 +1,17 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointResolverTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
+{
+    internal sealed class AsyncMethodFixture
+    {
+        public async Task<int> ComputeAsync(int seed)
+        {
+            int doubled = seed * 2;
+            await Task.Yield();
+            int tripled = doubled + seed;
+            return tripled;
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/AsyncMethodFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/AsyncMethodFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 570fc2b00d9604567be0ceb6e64040e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/BranchingMethodFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/BranchingMethodFixture.cs
@@ -1,0 +1,23 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointResolverTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
+{
+    internal sealed class BranchingMethodFixture
+    {
+        public string Classify(int value)
+        {
+            // This comment line has no sequence point; resolving it rounds forward.
+            if (value < 0)
+            {
+                return "negative";
+            }
+
+            if (value == 0)
+            {
+                return "zero";
+            }
+
+            return "positive";
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/BranchingMethodFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/BranchingMethodFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e6ae435f07bd4667b5fde38ee31a9eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/CoroutineMethodFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/CoroutineMethodFixture.cs
@@ -1,0 +1,17 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointResolverTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+using System.Collections;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
+{
+    internal sealed class CoroutineMethodFixture
+    {
+        public IEnumerator CountUp(int start)
+        {
+            int current = start;
+            yield return current;
+            current = current + 1;
+            yield return current;
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/CoroutineMethodFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/CoroutineMethodFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ed660fce0eb4438fb201a6ea590699e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/LocalFunctionMethodFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/LocalFunctionMethodFixture.cs
@@ -1,0 +1,18 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointResolverTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
+{
+    internal sealed class LocalFunctionMethodFixture
+    {
+        public int Square(int value)
+        {
+            return Compute(value);
+
+            static int Compute(int x)
+            {
+                int squared = x * x;
+                return squared;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/LocalFunctionMethodFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/LocalFunctionMethodFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c15550f96e4db4c3daaaaec3375b0a22
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/NormalMethodFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/NormalMethodFixture.cs
@@ -1,0 +1,13 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointResolverTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
+{
+    internal sealed class NormalMethodFixture
+    {
+        public int Add(int left, int right)
+        {
+            int sum = left + right;
+            return sum;
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/NormalMethodFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/NormalMethodFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c0b3388f3b654c2a8161c0695d6f2b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/RefStructAndByRefFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/RefStructAndByRefFixture.cs
@@ -7,6 +7,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
         public int Value;
     }
 
+    internal ref struct GenericRefStruct<T>
+    {
+        public T Value;
+    }
+
     internal sealed class RefStructAndByRefFixture
     {
         // ref/out/in parameters and ref-struct/Span locals exist here specifically to verify
@@ -14,6 +19,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
         public int Combine(int value, ref int accumulator, out int doubled, in int multiplier)
         {
             CustomRefStruct customRefStruct = new CustomRefStruct { Value = value };
+            GenericRefStruct<int> genericRefStruct = new GenericRefStruct<int> { Value = value };
             System.Span<int> span = stackalloc int[1];
             int result = customRefStruct.Value * multiplier;
             doubled = result * 2;

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/RefStructAndByRefFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/RefStructAndByRefFixture.cs
@@ -1,0 +1,25 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointResolverTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
+{
+    internal ref struct CustomRefStruct
+    {
+        public int Value;
+    }
+
+    internal sealed class RefStructAndByRefFixture
+    {
+        // ref/out/in parameters and ref-struct/Span locals exist here specifically to verify
+        // the resolver excludes non-capturable locals and parameters.
+        public int Combine(int value, ref int accumulator, out int doubled, in int multiplier)
+        {
+            CustomRefStruct customRefStruct = new CustomRefStruct { Value = value };
+            System.Span<int> span = stackalloc int[1];
+            int result = customRefStruct.Value * multiplier;
+            doubled = result * 2;
+            accumulator += result;
+            span[0] = result;
+            return span[0];
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/RefStructAndByRefFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/RefStructAndByRefFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 746545906a1034258984f10c69399ee5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/TryFinallyMethodFixture.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/TryFinallyMethodFixture.cs
@@ -1,0 +1,24 @@
+// FROZEN FIXTURE: content and line numbers are asserted by SourcePausePointResolverTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.SourcePausePointResolverFixtures
+{
+    internal sealed class TryFinallyMethodFixture
+    {
+        public int Divide(int numerator, int denominator)
+        {
+            int result;
+            try
+            {
+                result = numerator / denominator;
+            }
+            finally
+            {
+                Console.WriteLine("Divide attempted.");
+            }
+
+            return result;
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/TryFinallyMethodFixture.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/Fixtures/TryFinallyMethodFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fe8731c68cad4244a4792c327d789e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointPathNormalizerTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointPathNormalizerTests.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies PDB document URL vs. project-relative path comparison across separator styles.
+    /// </summary>
+    [TestFixture]
+    public sealed class SourcePausePointPathNormalizerTests
+    {
+        [Test]
+        public void ToForwardSlashes_WhenPathContainsBackslashes_ReplacesThemWithForwardSlashes()
+        {
+            // Verifies backslash-separated Windows paths are normalized to forward slashes.
+            string result = SourcePausePointPathNormalizer.ToForwardSlashes(@"Assets\Scripts\Foo.cs");
+
+            Assert.That(result, Is.EqualTo("Assets/Scripts/Foo.cs"));
+        }
+
+        [Test]
+        public void PathsReferToSameFile_WhenPathsAreIdentical_ReturnsTrue()
+        {
+            // Verifies an exact project-relative match is recognized.
+            bool result = SourcePausePointPathNormalizer.PathsReferToSameFile(
+                "Assets/Scripts/Foo.cs", "Assets/Scripts/Foo.cs");
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void PathsReferToSameFile_WhenDocumentUrlIsAbsoluteWithBackslashes_ReturnsTrue()
+        {
+            // Verifies a Windows-style absolute PDB document URL still matches a relative input path.
+            bool result = SourcePausePointPathNormalizer.PathsReferToSameFile(
+                @"C:\Project\Assets\Scripts\Foo.cs", "Assets/Scripts/Foo.cs");
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void PathsReferToSameFile_WhenDocumentUrlIsAbsoluteWithForwardSlashes_ReturnsTrue()
+        {
+            // Verifies a Unix-style absolute PDB document URL still matches a relative input path.
+            bool result = SourcePausePointPathNormalizer.PathsReferToSameFile(
+                "/Users/dev/Project/Assets/Scripts/Foo.cs", "Assets/Scripts/Foo.cs");
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void PathsReferToSameFile_WhenDocumentUrlReferencesADifferentFile_ReturnsFalse()
+        {
+            // Verifies a document for an unrelated file is not treated as a match.
+            bool result = SourcePausePointPathNormalizer.PathsReferToSameFile(
+                "Assets/Scripts/Bar.cs", "Assets/Scripts/Foo.cs");
+
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointPathNormalizerTests.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointPathNormalizerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed46ef77889184a229183ed0ede0b4f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
@@ -1,0 +1,138 @@
+using System.Linq;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies file:line resolution against real compiled assemblies (frozen fixture scripts
+    /// under Fixtures/, read back from Library/ScriptAssemblies via portable PDBs).
+    /// </summary>
+    [TestFixture]
+    public sealed class SourcePausePointResolverTests
+    {
+        private const string FixturesDirectory = "Assets/Tests/Editor/SourcePausePointResolver/Fixtures/";
+
+        [Test]
+        public void Resolve_NormalMethod_ResolvesLineWithLocalsAndParameters()
+        {
+            // Verifies a plain statement resolves to its own line with its local and parameters.
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "NormalMethodFixture.cs", 10);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Resolution.ResolvedLine, Is.EqualTo(10));
+            Assert.That(result.Resolution.MethodDisplayName, Does.Contain("NormalMethodFixture").And.Contain("Add"));
+            Assert.That(result.Resolution.IsStatic, Is.False);
+            Assert.That(result.Resolution.Locals.Select(l => l.Name), Is.EquivalentTo(new[] { "sum" }));
+            Assert.That(result.Resolution.Locals.Single().TypeName, Is.EqualTo("System.Int32"));
+            Assert.That(result.Resolution.Parameters.Select(p => p.Name), Is.EqualTo(new[] { "left", "right" }));
+            Assert.That(result.Resolution.Parameters.Select(p => p.TypeName), Is.EqualTo(new[] { "System.Int32", "System.Int32" }));
+        }
+
+        [Test]
+        public void Resolve_BranchingMethod_WhenLineHasNoSequencePoint_RoundsForwardToNextLine()
+        {
+            // Verifies a comment-only line (no sequence point) rounds forward to the next statement.
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "BranchingMethodFixture.cs", 9);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Resolution.ResolvedLine, Is.EqualTo(10));
+            Assert.That(result.Resolution.MethodDisplayName, Does.Contain("Classify"));
+        }
+
+        [Test]
+        public void Resolve_TryFinallyMethod_InTryBlock_IncludesLocalDeclaredBeforeTry()
+        {
+            // Verifies a local declared in the method's root scope is visible inside a nested try block.
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "TryFinallyMethodFixture.cs", 14);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Resolution.ResolvedLine, Is.EqualTo(14));
+            Assert.That(result.Resolution.Locals.Select(l => l.Name), Does.Contain("result"));
+            Assert.That(result.Resolution.Parameters.Select(p => p.Name), Is.EqualTo(new[] { "numerator", "denominator" }));
+        }
+
+        [Test]
+        public void Resolve_TryFinallyMethod_InFinallyBlock_IncludesLocalDeclaredBeforeTry()
+        {
+            // Verifies a local declared in the method's root scope is visible inside the finally handler too.
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "TryFinallyMethodFixture.cs", 18);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Resolution.ResolvedLine, Is.EqualTo(18));
+            Assert.That(result.Resolution.Locals.Select(l => l.Name), Does.Contain("result"));
+        }
+
+        [Test]
+        public void Resolve_AsyncMethod_RedirectsToTheCompilerGeneratedStateMachineMoveNext()
+        {
+            // Verifies a line after 'await' resolves inside the state machine's MoveNext, not the async method itself.
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "AsyncMethodFixture.cs", 13);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Resolution.ResolvedLine, Is.EqualTo(13));
+            Assert.That(result.Resolution.MethodDisplayName, Does.Contain("ComputeAsync").And.Contain("MoveNext"));
+            Assert.That(result.Resolution.IsStatic, Is.False);
+        }
+
+        [Test]
+        public void Resolve_CoroutineMethod_RedirectsToTheCompilerGeneratedStateMachineMoveNext()
+        {
+            // Verifies a line after 'yield return' resolves inside the iterator state machine's MoveNext.
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "CoroutineMethodFixture.cs", 13);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Resolution.ResolvedLine, Is.EqualTo(13));
+            Assert.That(result.Resolution.MethodDisplayName, Does.Contain("CountUp").And.Contain("MoveNext"));
+            Assert.That(result.Resolution.IsStatic, Is.False);
+        }
+
+        [Test]
+        public void Resolve_LocalFunction_RedirectsToTheCompilerGeneratedLocalFunctionMethod()
+        {
+            // Verifies a line inside a static local function resolves to its own compiler-generated method, not the outer method.
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "LocalFunctionMethodFixture.cs", 13);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Resolution.ResolvedLine, Is.EqualTo(13));
+            Assert.That(result.Resolution.MethodDisplayName, Does.Contain("Compute"));
+            Assert.That(result.Resolution.IsStatic, Is.True);
+            Assert.That(result.Resolution.Locals.Select(l => l.Name), Is.EquivalentTo(new[] { "squared" }));
+            Assert.That(result.Resolution.Parameters.Select(p => p.Name), Is.EqualTo(new[] { "x" }));
+        }
+
+        [Test]
+        public void Resolve_WhenPathIsOutsideAnyScriptFolder_ReturnsScriptNotInAnyAssemblyFailure()
+        {
+            // Verifies a path outside Assets/Packages (no owning assembly) is reported with a specific
+            // failure reason instead of throwing. CompilationPipeline maps paths to assemblies by folder
+            // rule, not by file existence, so a path *inside* a known folder still resolves even if the
+            // file itself is missing (see Resolve_WhenLineIsBeyondAllSequencePoints_* below).
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                "NotAUnityScriptFolder/Foo.cs", 1);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.FailureReason, Is.EqualTo(SourcePausePointResolveFailureReason.ScriptNotInAnyAssembly));
+        }
+
+        [Test]
+        public void Resolve_WhenLineIsBeyondAllSequencePoints_ReturnsNoSequencePointFailure()
+        {
+            // Verifies a line past the end of the file's methods is reported with a specific failure reason.
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "NormalMethodFixture.cs", 9999);
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.FailureReason, Is.EqualTo(SourcePausePointResolveFailureReason.NoSequencePointOnOrAfterLine));
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
@@ -111,6 +111,19 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Resolve_RefStructAndByRefMethod_ExcludesNonCapturableLocalsAndParameters()
+        {
+            // Verifies ref-struct locals (user-defined and Span<T>) and ref/out/in parameters
+            // are excluded, since none of them can be boxed for capture.
+            SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
+                FixturesDirectory + "RefStructAndByRefFixture.cs", 22);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Resolution.Locals.Select(l => l.Name), Is.EquivalentTo(new[] { "result" }));
+            Assert.That(result.Resolution.Parameters.Select(p => p.Name), Is.EqualTo(new[] { "value" }));
+        }
+
+        [Test]
         public void Resolve_WhenPathIsOutsideAnyScriptFolder_ReturnsScriptNotInAnyAssemblyFailure()
         {
             // Verifies a path outside Assets/Packages (no owning assembly) is reported with a specific

--- a/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs
@@ -113,10 +113,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void Resolve_RefStructAndByRefMethod_ExcludesNonCapturableLocalsAndParameters()
         {
-            // Verifies ref-struct locals (user-defined and Span<T>) and ref/out/in parameters
-            // are excluded, since none of them can be boxed for capture.
+            // Verifies ref-struct locals (user-defined, generic user-defined, and Span<T>) and
+            // ref/out/in parameters are excluded, since none of them can be boxed for capture.
             SourcePausePointResolveResult result = SourcePausePointResolver.Resolve(
-                FixturesDirectory + "RefStructAndByRefFixture.cs", 22);
+                FixturesDirectory + "RefStructAndByRefFixture.cs", 28);
 
             Assert.That(result.Success, Is.True);
             Assert.That(result.Resolution.Locals.Select(l => l.Name), Is.EquivalentTo(new[] { "result" }));

--- a/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/SourcePausePointResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbd1614603737457d825f9ae7a0fcd5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointResolver/UnityCLILoop.Tests.Editor.SourcePausePointResolver.asmdef
+++ b/Assets/Tests/Editor/SourcePausePointResolver/UnityCLILoop.Tests.Editor.SourcePausePointResolver.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "UnityCLILoop.Tests.Editor.SourcePausePointResolver",
+    "rootNamespace": "io.github.hatayama.UnityCliLoop.Tests.Editor",
+    "references": [
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:94d8abc693f543a691a4645a5ff42e5c"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Editor/SourcePausePointResolver/UnityCLILoop.Tests.Editor.SourcePausePointResolver.asmdef.meta
+++ b/Assets/Tests/Editor/SourcePausePointResolver/UnityCLILoop.Tests.Editor.SourcePausePointResolver.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ca29a61d5863a4bab86eeb26502fac76
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointResolver")]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 370f810d00e884ba38a406c980fbf3a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -8,5 +8,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string ScriptAssembliesRelativeDirectory = "Library/ScriptAssemblies";
         public const string CompiledAssemblyExtension = ".dll";
         public const string DebugSymbolsExtension = ".pdb";
+        public const string IsByRefLikeAttributeFullName = "System.Runtime.CompilerServices.IsByRefLikeAttribute";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -1,0 +1,12 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Shared path and file-extension literals for resolving compiled script assemblies.
+    /// </summary>
+    internal static class SourcePausePointConstants
+    {
+        public const string ScriptAssembliesRelativeDirectory = "Library/ScriptAssemblies";
+        public const string CompiledAssemblyExtension = ".dll";
+        public const string DebugSymbolsExtension = ".pdb";
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d2f43dcd91d545129b7ba22576aaf98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointLocalVariable.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointLocalVariable.cs
@@ -1,0 +1,19 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// A named local variable in scope at a resolved instruction, keyed by its IL slot.
+    /// </summary>
+    internal sealed class SourcePausePointLocalVariable
+    {
+        public string Name { get; }
+        public int SlotIndex { get; }
+        public string TypeName { get; }
+
+        public SourcePausePointLocalVariable(string name, int slotIndex, string typeName)
+        {
+            Name = name;
+            SlotIndex = slotIndex;
+            TypeName = typeName;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointLocalVariable.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointLocalVariable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f636cd1f940274bf3bbc0b8e3d014d2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointParameter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointParameter.cs
@@ -1,0 +1,19 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// A method parameter, in declaration order (excludes the implicit "this").
+    /// </summary>
+    internal sealed class SourcePausePointParameter
+    {
+        public string Name { get; }
+        public int Index { get; }
+        public string TypeName { get; }
+
+        public SourcePausePointParameter(string name, int index, string typeName)
+        {
+            Name = name;
+            Index = index;
+            TypeName = typeName;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointParameter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointParameter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc2aec6b12a29470eabf7234edc03a30
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPathNormalizer.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPathNormalizer.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Compares a PDB sequence point's document URL against a project-relative script path,
+    /// tolerating separator and absolute-vs-relative differences across platforms.
+    /// </summary>
+    internal static class SourcePausePointPathNormalizer
+    {
+        public static string ToForwardSlashes(string path)
+        {
+            Debug.Assert(path != null, "path must not be null.");
+            return path.Replace('\\', '/');
+        }
+
+        public static bool PathsReferToSameFile(string documentUrl, string projectRelativePath)
+        {
+            Debug.Assert(documentUrl != null, "documentUrl must not be null.");
+            Debug.Assert(projectRelativePath != null, "projectRelativePath must not be null.");
+
+            string normalizedDocumentUrl = ToForwardSlashes(documentUrl);
+            string normalizedRelativePath = ToForwardSlashes(projectRelativePath);
+            StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (string.Equals(normalizedDocumentUrl, normalizedRelativePath, comparison))
+            {
+                return true;
+            }
+
+            return normalizedDocumentUrl.EndsWith("/" + normalizedRelativePath, comparison);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPathNormalizer.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPathNormalizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f6646ac70bfc4cc8b36dcea73f4b335
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolution.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public int MetadataToken { get; }
         public string MethodDisplayName { get; }
         public bool IsStatic { get; }
+        public bool IsDeclaringTypeValueType { get; }
         public int InstructionIndex { get; }
         public int IlOffset { get; }
         public int ResolvedLine { get; }
@@ -23,6 +24,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int metadataToken,
             string methodDisplayName,
             bool isStatic,
+            bool isDeclaringTypeValueType,
             int instructionIndex,
             int ilOffset,
             int resolvedLine,
@@ -33,6 +35,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MetadataToken = metadataToken;
             MethodDisplayName = methodDisplayName;
             IsStatic = isStatic;
+            IsDeclaringTypeValueType = isDeclaringTypeValueType;
             InstructionIndex = instructionIndex;
             IlOffset = ilOffset;
             ResolvedLine = resolvedLine;

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolution.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolution.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// A resolved patch location: the target method, its insertion point, and the
+    /// locals/parameters visible there.
+    /// </summary>
+    internal sealed class SourcePausePointResolution
+    {
+        public string AssemblyName { get; }
+        public int MetadataToken { get; }
+        public string MethodDisplayName { get; }
+        public bool IsStatic { get; }
+        public int InstructionIndex { get; }
+        public int IlOffset { get; }
+        public int ResolvedLine { get; }
+        public IReadOnlyList<SourcePausePointLocalVariable> Locals { get; }
+        public IReadOnlyList<SourcePausePointParameter> Parameters { get; }
+
+        public SourcePausePointResolution(
+            string assemblyName,
+            int metadataToken,
+            string methodDisplayName,
+            bool isStatic,
+            int instructionIndex,
+            int ilOffset,
+            int resolvedLine,
+            IReadOnlyList<SourcePausePointLocalVariable> locals,
+            IReadOnlyList<SourcePausePointParameter> parameters)
+        {
+            AssemblyName = assemblyName;
+            MetadataToken = metadataToken;
+            MethodDisplayName = methodDisplayName;
+            IsStatic = isStatic;
+            InstructionIndex = instructionIndex;
+            IlOffset = ilOffset;
+            ResolvedLine = resolvedLine;
+            Locals = locals;
+            Parameters = parameters;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolution.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolution.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 179cefdaa9b1245e396817df54ad77ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveFailureReason.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveFailureReason.cs
@@ -1,0 +1,14 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reasons a file:line lookup could not be resolved to a patchable instruction.
+    /// </summary>
+    internal enum SourcePausePointResolveFailureReason
+    {
+        None,
+        ScriptNotInAnyAssembly,
+        CompiledAssemblyNotFound,
+        SymbolsUnavailable,
+        NoSequencePointOnOrAfterLine
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveFailureReason.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveFailureReason.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd3908773e78d414fb4459f99788782b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveResult.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Outcome of a file:line resolve attempt. Never thrown; failures are carried as data
+    /// so callers can report a specific reason instead of an exception.
+    /// </summary>
+    internal sealed class SourcePausePointResolveResult
+    {
+        public bool Success { get; }
+        public SourcePausePointResolveFailureReason FailureReason { get; }
+        public string ErrorMessage { get; }
+        public SourcePausePointResolution Resolution { get; }
+
+        private SourcePausePointResolveResult(
+            bool success,
+            SourcePausePointResolveFailureReason failureReason,
+            string errorMessage,
+            SourcePausePointResolution resolution)
+        {
+            Success = success;
+            FailureReason = failureReason;
+            ErrorMessage = errorMessage;
+            Resolution = resolution;
+        }
+
+        public static SourcePausePointResolveResult SuccessResult(SourcePausePointResolution resolution)
+        {
+            Debug.Assert(resolution != null, "resolution must not be null for a success result.");
+            return new SourcePausePointResolveResult(true, SourcePausePointResolveFailureReason.None, string.Empty, resolution);
+        }
+
+        public static SourcePausePointResolveResult Failure(SourcePausePointResolveFailureReason reason, string errorMessage)
+        {
+            Debug.Assert(reason != SourcePausePointResolveFailureReason.None, "Failure requires a specific reason.");
+            return new SourcePausePointResolveResult(false, reason, errorMessage, null);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolveResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3fe55dfb7cfff4a0cbbea49c4a3e3d27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
@@ -284,13 +284,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return true;
             }
 
+            // A generic instance (e.g. MyRefStruct<int>) must be unwrapped to its open generic
+            // definition before the TypeDefinition check below, the same way the framework check
+            // above unwraps Span<T>/ReadOnlySpan<T>.
+            TypeReference elementType = type.IsGenericInstance ? type.GetElementType() : type;
+
             // Only inspect user-defined ref structs when the reference already points directly at
             // a TypeDefinition, i.e. it is declared in the very assembly being read. Resolving an
             // external TypeReference (e.g. any corlib value type such as System.Int32) requires
             // Mono.Cecil's assembly resolver to locate that assembly, which is not reliably
             // resolvable against the Unity Editor's Mono/.NET layout and would throw for ordinary
             // primitives that are not ref structs at all.
-            if (!(type is TypeDefinition typeDefinition) || !typeDefinition.IsValueType || !typeDefinition.HasCustomAttributes)
+            if (!(elementType is TypeDefinition typeDefinition) || !typeDefinition.IsValueType || !typeDefinition.HasCustomAttributes)
             {
                 return false;
             }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Collections.Generic;
+
+using UnityEditor.Compilation;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves a project-relative file:line into a patchable method, instruction index,
+    /// and the locals/parameters visible there, by reading the compiled assembly's portable PDB.
+    /// </summary>
+    internal static class SourcePausePointResolver
+    {
+        public static SourcePausePointResolveResult Resolve(string projectRelativeFilePath, int line)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(projectRelativeFilePath), "projectRelativeFilePath must not be null or empty.");
+            Debug.Assert(line > 0, "line must be a positive 1-based line number.");
+
+            string normalizedInputPath = SourcePausePointPathNormalizer.ToForwardSlashes(projectRelativeFilePath);
+
+            string rawAssemblyName = CompilationPipeline.GetAssemblyNameFromScriptPath(normalizedInputPath);
+            if (string.IsNullOrEmpty(rawAssemblyName))
+            {
+                return SourcePausePointResolveResult.Failure(
+                    SourcePausePointResolveFailureReason.ScriptNotInAnyAssembly,
+                    $"'{projectRelativeFilePath}' does not belong to any compiled assembly.");
+            }
+
+            // CompilationPipeline.GetAssemblyNameFromScriptPath returns the TargetAssembly's file name,
+            // which already carries a ".dll" suffix (see Unity's EditorBuildRules.TargetAssembly).
+            string assemblyName = Path.GetFileNameWithoutExtension(rawAssemblyName);
+
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string dllPath = Path.Combine(projectRoot, SourcePausePointConstants.ScriptAssembliesRelativeDirectory, assemblyName + SourcePausePointConstants.CompiledAssemblyExtension);
+            string pdbPath = Path.Combine(projectRoot, SourcePausePointConstants.ScriptAssembliesRelativeDirectory, assemblyName + SourcePausePointConstants.DebugSymbolsExtension);
+
+            if (!File.Exists(dllPath))
+            {
+                return SourcePausePointResolveResult.Failure(
+                    SourcePausePointResolveFailureReason.CompiledAssemblyNotFound,
+                    $"Compiled assembly not found at '{dllPath}'. Compile the project first.");
+            }
+
+            if (!File.Exists(pdbPath))
+            {
+                return SourcePausePointResolveResult.Failure(
+                    SourcePausePointResolveFailureReason.SymbolsUnavailable,
+                    $"Debug symbols not found at '{pdbPath}'. Ensure the project uses Debug code optimization.");
+            }
+
+            return ResolveFromCompiledAssembly(assemblyName, dllPath, pdbPath, normalizedInputPath, projectRelativeFilePath, line);
+        }
+
+        private static SourcePausePointResolveResult ResolveFromCompiledAssembly(
+            string assemblyName,
+            string dllPath,
+            string pdbPath,
+            string normalizedInputPath,
+            string originalInputPath,
+            int line)
+        {
+            using FileStream dllStream = File.Open(dllPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using FileStream pdbStream = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            ReaderParameters readerParameters = new ReaderParameters
+            {
+                InMemory = true,
+                ReadSymbols = true,
+                SymbolReaderProvider = new PortablePdbReaderProvider(),
+                SymbolStream = pdbStream
+            };
+
+            using AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(dllStream, readerParameters);
+
+            (MethodDefinition method, SequencePoint sequencePoint) = FindClosestSequencePointOnOrAfterLine(
+                assemblyDefinition.MainModule, normalizedInputPath, line);
+
+            if (method == null)
+            {
+                return SourcePausePointResolveResult.Failure(
+                    SourcePausePointResolveFailureReason.NoSequencePointOnOrAfterLine,
+                    $"No sequence point found on or after line {line} in '{originalInputPath}'.");
+            }
+
+            int instructionIndex = FindInstructionIndex(method.Body.Instructions, sequencePoint.Offset);
+            Debug.Assert(instructionIndex >= 0, "A sequence point's offset must correspond to an instruction in the same method body.");
+
+            List<SourcePausePointLocalVariable> locals = CollectCapturableLocals(method, sequencePoint.Offset);
+            List<SourcePausePointParameter> parameters = CollectParameters(method);
+
+            SourcePausePointResolution resolution = new SourcePausePointResolution(
+                assemblyName,
+                method.MetadataToken.ToInt32(),
+                method.FullName,
+                method.IsStatic,
+                instructionIndex,
+                sequencePoint.Offset,
+                sequencePoint.StartLine,
+                locals,
+                parameters);
+
+            return SourcePausePointResolveResult.SuccessResult(resolution);
+        }
+
+        private static (MethodDefinition method, SequencePoint sequencePoint) FindClosestSequencePointOnOrAfterLine(
+            ModuleDefinition module, string normalizedInputPath, int line)
+        {
+            MethodDefinition bestMethod = null;
+            SequencePoint bestSequencePoint = null;
+
+            foreach (MethodDefinition method in EnumerateMethods(module))
+            {
+                if (!method.HasBody)
+                {
+                    continue;
+                }
+
+                MethodDebugInformation debugInformation = method.DebugInformation;
+                if (debugInformation == null || !debugInformation.HasSequencePoints)
+                {
+                    continue;
+                }
+
+                foreach (SequencePoint sequencePoint in debugInformation.SequencePoints)
+                {
+                    if (sequencePoint.IsHidden || sequencePoint.StartLine < line)
+                    {
+                        continue;
+                    }
+
+                    if (!SourcePausePointPathNormalizer.PathsReferToSameFile(sequencePoint.Document.Url, normalizedInputPath))
+                    {
+                        continue;
+                    }
+
+                    if (bestSequencePoint == null || sequencePoint.StartLine < bestSequencePoint.StartLine)
+                    {
+                        bestMethod = method;
+                        bestSequencePoint = sequencePoint;
+                    }
+                }
+            }
+
+            return (bestMethod, bestSequencePoint);
+        }
+
+        private static IEnumerable<MethodDefinition> EnumerateMethods(ModuleDefinition module)
+        {
+            foreach (TypeDefinition type in module.Types)
+            {
+                foreach (MethodDefinition method in EnumerateMethods(type))
+                {
+                    yield return method;
+                }
+            }
+        }
+
+        private static IEnumerable<MethodDefinition> EnumerateMethods(TypeDefinition type)
+        {
+            foreach (MethodDefinition method in type.Methods)
+            {
+                yield return method;
+            }
+
+            foreach (TypeDefinition nestedType in type.NestedTypes)
+            {
+                foreach (MethodDefinition method in EnumerateMethods(nestedType))
+                {
+                    yield return method;
+                }
+            }
+        }
+
+        private static int FindInstructionIndex(Collection<Instruction> instructions, int offset)
+        {
+            for (int i = 0; i < instructions.Count; i++)
+            {
+                if (instructions[i].Offset == offset)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static List<SourcePausePointLocalVariable> CollectCapturableLocals(MethodDefinition method, int offset)
+        {
+            List<SourcePausePointLocalVariable> results = new List<SourcePausePointLocalVariable>();
+            ScopeDebugInformation rootScope = method.DebugInformation.Scope;
+            if (rootScope != null)
+            {
+                CollectInScopeVariables(rootScope, offset, method.Body.Variables, results);
+            }
+
+            return results;
+        }
+
+        private static void CollectInScopeVariables(
+            ScopeDebugInformation scope,
+            int offset,
+            Collection<VariableDefinition> methodVariables,
+            List<SourcePausePointLocalVariable> results)
+        {
+            if (!IsOffsetWithinScope(scope, offset))
+            {
+                return;
+            }
+
+            if (scope.HasVariables)
+            {
+                foreach (VariableDebugInformation variableDebugInformation in scope.Variables)
+                {
+                    AppendLocalIfCapturable(variableDebugInformation, methodVariables, results);
+                }
+            }
+
+            if (scope.HasScopes)
+            {
+                foreach (ScopeDebugInformation childScope in scope.Scopes)
+                {
+                    CollectInScopeVariables(childScope, offset, methodVariables, results);
+                }
+            }
+        }
+
+        private static bool IsOffsetWithinScope(ScopeDebugInformation scope, int offset)
+        {
+            if (offset < scope.Start.Offset)
+            {
+                return false;
+            }
+
+            return scope.End.IsEndOfMethod || offset < scope.End.Offset;
+        }
+
+        private static void AppendLocalIfCapturable(
+            VariableDebugInformation variableDebugInformation,
+            Collection<VariableDefinition> methodVariables,
+            List<SourcePausePointLocalVariable> results)
+        {
+            string name = variableDebugInformation.Name;
+            if (string.IsNullOrEmpty(name) || name.StartsWith("<", StringComparison.Ordinal))
+            {
+                // Unnamed or compiler-generated hoisted locals (e.g. "<>u__1") carry no source meaning to capture.
+                return;
+            }
+
+            int slotIndex = variableDebugInformation.Index;
+            if (slotIndex < 0 || slotIndex >= methodVariables.Count)
+            {
+                return;
+            }
+
+            TypeReference variableType = methodVariables[slotIndex].VariableType;
+            if (IsCaptureExcluded(variableType))
+            {
+                return;
+            }
+
+            results.Add(new SourcePausePointLocalVariable(name, slotIndex, variableType.FullName));
+        }
+
+        private static bool IsCaptureExcluded(TypeReference variableType)
+        {
+            // byref locals and pointers cannot be boxed; ref structs (Span<T> etc.) cannot be boxed either.
+            return variableType.IsByReference || variableType.IsPointer || IsKnownRefStructType(variableType);
+        }
+
+        private static bool IsKnownRefStructType(TypeReference variableType)
+        {
+            TypeReference elementType = variableType.IsGenericInstance ? variableType.GetElementType() : variableType;
+            return elementType.FullName == "System.Span`1" || elementType.FullName == "System.ReadOnlySpan`1";
+        }
+
+        private static List<SourcePausePointParameter> CollectParameters(MethodDefinition method)
+        {
+            List<SourcePausePointParameter> parameters = new List<SourcePausePointParameter>();
+            foreach (ParameterDefinition parameter in method.Parameters)
+            {
+                parameters.Add(new SourcePausePointParameter(parameter.Name, parameter.Index, parameter.ParameterType.FullName));
+            }
+
+            return parameters;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs
@@ -101,6 +101,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 method.MetadataToken.ToInt32(),
                 method.FullName,
                 method.IsStatic,
+                method.DeclaringType.IsValueType,
                 instructionIndex,
                 sequencePoint.Offset,
                 sequencePoint.StartLine,
@@ -116,7 +117,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             MethodDefinition bestMethod = null;
             SequencePoint bestSequencePoint = null;
 
-            foreach (MethodDefinition method in EnumerateMethods(module))
+            foreach (MethodDefinition method in EnumerateMethodsInModule(module))
             {
                 if (!method.HasBody)
                 {
@@ -152,18 +153,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return (bestMethod, bestSequencePoint);
         }
 
-        private static IEnumerable<MethodDefinition> EnumerateMethods(ModuleDefinition module)
+        private static IEnumerable<MethodDefinition> EnumerateMethodsInModule(ModuleDefinition module)
         {
             foreach (TypeDefinition type in module.Types)
             {
-                foreach (MethodDefinition method in EnumerateMethods(type))
+                foreach (MethodDefinition method in EnumerateMethodsInType(type))
                 {
                     yield return method;
                 }
             }
         }
 
-        private static IEnumerable<MethodDefinition> EnumerateMethods(TypeDefinition type)
+        private static IEnumerable<MethodDefinition> EnumerateMethodsInType(TypeDefinition type)
         {
             foreach (MethodDefinition method in type.Methods)
             {
@@ -172,7 +173,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             foreach (TypeDefinition nestedType in type.NestedTypes)
             {
-                foreach (MethodDefinition method in EnumerateMethods(nestedType))
+                foreach (MethodDefinition method in EnumerateMethodsInType(nestedType))
                 {
                     yield return method;
                 }
@@ -269,15 +270,47 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             results.Add(new SourcePausePointLocalVariable(name, slotIndex, variableType.FullName));
         }
 
-        private static bool IsCaptureExcluded(TypeReference variableType)
+        private static bool IsCaptureExcluded(TypeReference type)
         {
-            // byref locals and pointers cannot be boxed; ref structs (Span<T> etc.) cannot be boxed either.
-            return variableType.IsByReference || variableType.IsPointer || IsKnownRefStructType(variableType);
+            // byref locals/parameters (ref, out, in) and pointers cannot be boxed; ref structs
+            // (Span<T>, and any user-defined "ref struct") cannot be boxed either.
+            return type.IsByReference || type.IsPointer || IsRefStructType(type);
         }
 
-        private static bool IsKnownRefStructType(TypeReference variableType)
+        private static bool IsRefStructType(TypeReference type)
         {
-            TypeReference elementType = variableType.IsGenericInstance ? variableType.GetElementType() : variableType;
+            if (IsKnownFrameworkRefStructType(type))
+            {
+                return true;
+            }
+
+            // Only inspect user-defined ref structs when the reference already points directly at
+            // a TypeDefinition, i.e. it is declared in the very assembly being read. Resolving an
+            // external TypeReference (e.g. any corlib value type such as System.Int32) requires
+            // Mono.Cecil's assembly resolver to locate that assembly, which is not reliably
+            // resolvable against the Unity Editor's Mono/.NET layout and would throw for ordinary
+            // primitives that are not ref structs at all.
+            if (!(type is TypeDefinition typeDefinition) || !typeDefinition.IsValueType || !typeDefinition.HasCustomAttributes)
+            {
+                return false;
+            }
+
+            foreach (CustomAttribute attribute in typeDefinition.CustomAttributes)
+            {
+                if (attribute.AttributeType.FullName == SourcePausePointConstants.IsByRefLikeAttributeFullName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsKnownFrameworkRefStructType(TypeReference type)
+        {
+            // Span<T>/ReadOnlySpan<T> are ref structs defined in corlib; checking their FullName
+            // avoids forcing assembly resolution for a framework type on the hot path.
+            TypeReference elementType = type.IsGenericInstance ? type.GetElementType() : type;
             return elementType.FullName == "System.Span`1" || elementType.FullName == "System.ReadOnlySpan`1";
         }
 
@@ -286,6 +319,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             List<SourcePausePointParameter> parameters = new List<SourcePausePointParameter>();
             foreach (ParameterDefinition parameter in method.Parameters)
             {
+                if (IsCaptureExcluded(parameter.ParameterType))
+                {
+                    continue;
+                }
+
                 parameters.Add(new SourcePausePointParameter(parameter.Name, parameter.Index, parameter.ParameterType.FullName));
             }
 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: caeccbff2206446b98d07f44f7b14413
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Refs: uloop Source Pause Point 実行計画 (Obsidian) — PR 2 / Phase 2

## Summary
- Internal building block for the upcoming `--file`/`--line` pause point feature: given a project-relative script path and a line number, resolve which compiled method/instruction to patch and which locals/parameters are in scope there.
- No user-facing behavior yet — this PR has no callers. It lands ahead of the Harmony patcher (PR 4) and the tool wiring (PR 5), per the plan's PR breakdown.

## User Impact
- None yet. This is pure internal infrastructure; `enable-pause-point --file/--line` is not wired up until PR 5.

## Changes
- `SourcePausePointResolver`: reads the target script's compiled assembly (`Library/ScriptAssemblies/*.dll` + portable `.pdb`) via Mono.Cecil and finds the closest sequence point on or after the requested line (rounding forward, skipping hidden sequence points), searching nested compiler-generated types so async methods / iterators / local functions resolve into their real `MoveNext`/local-function body instead of the outer declared method.
- Returns a Result-style DTO (`SourcePausePointResolveResult` / `SourcePausePointResolution`) instead of throwing; distinguishes "script not in any assembly", "compiled assembly not found", "symbols unavailable", and "no sequence point on or after line" failures.
- Locals are collected by walking the PDB's lexical scope tree at the resolved IL offset (so a local declared in the method's root scope is correctly visible inside a nested `try`/`finally`), excluding unnamed/compiler-generated locals and byref/pointer/ref-struct (`Span<T>`/`ReadOnlySpan<T>`) locals that cannot be boxed for capture.
- `SourcePausePointPathNormalizer` compares a PDB document URL against the project-relative input path tolerating separator and absolute-vs-relative differences (Windows Compatibility Guardrails).
- Frozen fixture scripts (normal statement, branching, try/finally, async, iterator/coroutine, local function) under a new isolated test assembly, asserting against real compiled output.

## Verification
- `dist/darwin-arm64/uloop compile` — 0 errors, 0 warnings
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode` (full suite) — 1800 passed, 0 failed, 7 skipped (pre-existing)
- New Resolver + path-normalizer tests (14 total) all green

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

