### PR TITLE
feat: Enable pause points by source file and line

### DIFF
--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies the Unity pause-point-status response (including captured
+    /// variables) stays aligned with the shared Go CLI contract.
+    /// </summary>
+    public sealed class PausePointStatusResponseContractTests
+    {
+        private const string SharedContractPath = "tests/contracts/pause_point_status_response_contract.json";
+
+        [Test]
+        public void PausePointStatusResponse_WhenSerialized_MatchesSharedContractFieldShape()
+        {
+            // Verifies C# does not add, remove, or rename fields (including CapturedVariables) without
+            // updating the shared CLI contract.
+            JObject expected = ReadSharedContractFieldShape();
+            PausePointStatusResponse response = new()
+            {
+                Id = "Assets/Scripts/Enemy.cs:42",
+                Status = "Hit",
+                IsEnabled = true,
+                IsHit = true,
+                HitCount = 1,
+                TimeoutSeconds = 30,
+                Expired = false,
+                EnabledAtUtc = "2026-06-03T00:00:00.0000000Z",
+                ElapsedSinceEnabledMilliseconds = 1200,
+                RemainingMilliseconds = 28800,
+                Generation = 3,
+                EditorState = new PausePointStatusEditorState
+                {
+                    IsPlaying = true,
+                    IsPaused = true,
+                    CapturedAt = "PausePointHit"
+                },
+                FirstHitAtUtc = "2026-06-03T00:00:01.0000000Z",
+                LastHitAtUtc = "2026-06-03T00:00:01.0000000Z",
+                FirstHitSequence = 1,
+                LastHitSequence = 1,
+                Message = "Pause point hit.",
+                RecommendedNextAction = "Clear this marker, then re-enable it with the same Id and TimeoutSeconds values.",
+                CapturedVariables = new List<PausePointStatusCapturedVariable>
+                {
+                    new()
+                    {
+                        Name = "target",
+                        Scope = "InstanceField",
+                        TypeName = "UnityEngine.GameObject",
+                        Value = "Enemy",
+                        UnityObjectKind = "SceneObject",
+                        UnityObjectPath = "MainScene:/Root/Enemy",
+                        UnityObjectInstanceId = -1234
+                    }
+                },
+                CapturedVariablesTruncated = true
+            };
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+            JObject actual = NormalizeFieldShape(JObject.Parse(json));
+
+            Assert.That(JToken.DeepEquals(actual, expected), Is.True, $"Expected {expected} but got {actual}");
+        }
+
+        private static JObject ReadSharedContractFieldShape()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedContractPath));
+            return NormalizeFieldShape(JObject.Parse(json));
+        }
+
+        private static JObject NormalizeFieldShape(JObject value)
+        {
+            JObject shape = new();
+            foreach (JProperty property in value.Properties())
+            {
+                shape[property.Name] = NormalizeTokenFieldShape(property.Value);
+            }
+            return shape;
+        }
+
+        private static JToken NormalizeTokenFieldShape(JToken value)
+        {
+            if (value is JObject objectValue)
+            {
+                return NormalizeFieldShape(objectValue);
+            }
+
+            if (value is JArray arrayValue)
+            {
+                JArray arrayShape = new();
+                if (arrayValue.Count > 0)
+                {
+                    arrayShape.Add(NormalizeTokenFieldShape(arrayValue[0]));
+                }
+                return arrayShape;
+            }
+
+            return new JValue(NormalizeScalarType(value.Type));
+        }
+
+        private static string NormalizeScalarType(JTokenType type)
+        {
+            return type switch
+            {
+                JTokenType.Boolean => "boolean",
+                JTokenType.Float => "number",
+                JTokenType.Integer => "number",
+                JTokenType.Null => "null",
+                JTokenType.String => "string",
+                _ => "unknown"
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs.meta
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7810f9394bc7741588a05981aec61339
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -10,6 +11,7 @@ using UnityEditor;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.Tests.PausePointToolsFixtures;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -474,12 +476,132 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Warning, Is.Empty);
         }
 
+        // NOTE: Enabling by File/Line is rejected in Debug-only when
+        // CompilationPipeline.codeOptimization == CodeOptimization.Release. There is no seam to
+        // fake that Editor-global static property in an EditMode test, and flipping it for real
+        // would trigger a recompilation mid-test (forbidden by this repo's Unity Freeze Prevention
+        // guardrails). This branch is verified manually/E2E instead (see PR 6).
+
+        [Test]
+        public async Task Enable_WhenFileAndLineResolveToRealMethod_PatchesAndCapturesVariablesOnHit()
+        {
+            // Verifies the File/Line path resolves a real fixture method, patches it via Harmony
+            // through the full public tool surface, and a subsequent call to the patched method
+            // hits the registry with its locals, parameters, and instance field captured.
+            PausePointResponse response = await EnablePausePointByFileLineAsync(FixtureFilePath, FixtureLine);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Id, Is.EqualTo($"{FixtureFilePath}:{FixtureLine}"));
+            Assert.That(response.ResolvedLine, Is.EqualTo(FixtureLine));
+            Assert.That(response.ResolvedMethod, Does.Contain("Add"));
+
+            EnableBySourceLocationFixture fixture = new();
+            int sum = fixture.Add(2, 3);
+
+            Assert.That(sum, Is.EqualTo(5));
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus(response.Id);
+            Assert.That(snapshot.IsHit, Is.True);
+            Assert.That(
+                snapshot.CapturedVariables.Select(v => v.Name),
+                Is.EquivalentTo(new[] { "left", "right", "sum", "Tag" }));
+        }
+
+        [Test]
+        public async Task Enable_WhenIdAndFileBothProvided_ReturnsValidationFailureResponse()
+        {
+            // Verifies Id and File/Line are mutually exclusive.
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["file"] = FixtureFilePath,
+                ["line"] = FixtureLine,
+                ["timeoutSeconds"] = 30
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("Specify either Id or File and Line, not both."));
+        }
+
+        [Test]
+        public async Task Enable_WhenFileProvidedWithoutLine_ReturnsValidationFailureResponse()
+        {
+            // Verifies File requires Line to be provided together.
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["file"] = FixtureFilePath,
+                ["timeoutSeconds"] = 30
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("File and Line must both be provided together."));
+        }
+
+        [Test]
+        public async Task Enable_WhenLineProvidedWithoutFile_ReturnsValidationFailureResponse()
+        {
+            // Verifies Line requires File to be provided together.
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["line"] = FixtureLine,
+                ["timeoutSeconds"] = 30
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("File and Line must both be provided together."));
+        }
+
+        [Test]
+        public async Task Enable_WhenLineHasNoSequencePoint_ReturnsResolverErrorAsValidationFailure()
+        {
+            // Verifies a line with no sequence point on or after it (deliberately far past the
+            // fixture file's end) surfaces the Resolver's error message as a Success=false
+            // response instead of throwing.
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["file"] = FixtureFilePath,
+                ["line"] = 9999,
+                ["timeoutSeconds"] = 30
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Does.Contain("No sequence point found on or after line"));
+        }
+
+        private const string FixtureFilePath = "Assets/Tests/Editor/PausePointToolsFixture.cs";
+        private const int FixtureLine = 12;
+
         private static async Task<PausePointResponse> EnablePausePointAsync(string id)
         {
             EnablePausePointTool tool = new();
             JObject parameters = new()
             {
                 ["id"] = id,
+                ["timeoutSeconds"] = 30
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+            return response;
+        }
+
+        private static async Task<PausePointResponse> EnablePausePointByFileLineAsync(string file, int line)
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["file"] = file,
+                ["line"] = line,
                 ["timeoutSeconds"] = 30
             };
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -41,6 +41,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             EditorSettings.enterPlayModeOptionsEnabled = _originalEnterPlayModeOptionsEnabled;
             EditorSettings.enterPlayModeOptions = _originalEnterPlayModeOptions;
+            // Tests that enable pause points by File/Line leave a Harmony transpiler attached to
+            // the fixture method; clear it so later tests re-patch cleanly instead of hitting the
+            // Patcher's "already patched" no-op path against a previous test's ledger entry.
+            SourcePausePointPatcher.UnpatchAll();
             UloopPausePointRegistry.ResetForTests();
         }
 
@@ -579,8 +583,95 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Message, Does.Contain("No sequence point found on or after line"));
         }
 
+        [Test]
+        public async Task Clear_WhenSpecificIdCleared_CallsPatcherUnpatchSoTheIdCanBeFreshlyRePatched()
+        {
+            // Verifies PausePointUseCase.Clear actually calls SourcePausePointPatcher.Unpatch (not
+            // just the registry): after clearing, re-Patch-ing the same id with a deliberately
+            // stale Mvid must reach the Patcher's stale-assembly gate again, which only runs when
+            // the id is no longer in the Patcher's ledger (an "already patched" id short-circuits
+            // before that gate ever runs, per SourcePausePointPatcherTests coverage from PR 4).
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(FixtureFilePath, FixtureLine);
+            Assert.That(resolveResult.Success, Is.True);
+            string id = $"{FixtureFilePath}:{FixtureLine}";
+
+            UloopPausePointRegistry.Enable(id, 30);
+            Assert.That(SourcePausePointPatcher.Patch(id, resolveResult.Resolution).Success, Is.True);
+
+            ClearPausePointTool clearTool = new();
+            JObject clearParameters = new() { ["id"] = id, ["all"] = false };
+            await clearTool.ExecuteAsync(clearParameters, CancellationToken.None);
+
+            SourcePausePointPatchResult rePatchResult = SourcePausePointPatcher.Patch(id, WithStaleMvid(resolveResult.Resolution));
+
+            Assert.That(rePatchResult.Success, Is.False);
+            Assert.That(rePatchResult.FailureReason, Is.EqualTo(SourcePausePointPatchFailureReason.StaleAssembly));
+        }
+
+        [Test]
+        public async Task ClearAll_WhenSourcePausePointsExist_CallsPatcherUnpatchAllSoIdsCanBeFreshlyRePatched()
+        {
+            // Verifies PausePointUseCase.Clear(All) calls SourcePausePointPatcher.UnpatchAll,
+            // using the same stale-Mvid gate signal as the --id case above to prove the ledger
+            // entry was actually removed rather than only clearing the registry.
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(FixtureFilePath, FixtureLine);
+            Assert.That(resolveResult.Success, Is.True);
+            string id = $"{FixtureFilePath}:{FixtureLine}";
+
+            UloopPausePointRegistry.Enable(id, 30);
+            Assert.That(SourcePausePointPatcher.Patch(id, resolveResult.Resolution).Success, Is.True);
+
+            ClearPausePointTool clearTool = new();
+            JObject clearParameters = new() { ["all"] = true };
+            await clearTool.ExecuteAsync(clearParameters, CancellationToken.None);
+
+            SourcePausePointPatchResult rePatchResult = SourcePausePointPatcher.Patch(id, WithStaleMvid(resolveResult.Resolution));
+
+            Assert.That(rePatchResult.Success, Is.False);
+            Assert.That(rePatchResult.FailureReason, Is.EqualTo(SourcePausePointPatchFailureReason.StaleAssembly));
+        }
+
+        [Test]
+        public void PausePointStatusBridgeCommand_Clear_CallsPatcherUnpatchSoTheIdCanBeFreshlyRePatched()
+        {
+            // Verifies the CLI bridge's Clear (the path Go's wait-for-pause-point timeout
+            // auto-clear and clear-pause-point-status hit) also calls
+            // SourcePausePointPatcher.Unpatch, using the same stale-Mvid gate signal as the tool
+            // tests above to prove the ledger entry was actually removed.
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(FixtureFilePath, FixtureLine);
+            Assert.That(resolveResult.Success, Is.True);
+            string id = $"{FixtureFilePath}:{FixtureLine}";
+
+            UloopPausePointRegistry.Enable(id, 30);
+            Assert.That(SourcePausePointPatcher.Patch(id, resolveResult.Resolution).Success, Is.True);
+
+            JObject bridgeParameters = new() { ["Id"] = id };
+            PausePointStatusBridgeCommand.Clear(bridgeParameters);
+
+            SourcePausePointPatchResult rePatchResult = SourcePausePointPatcher.Patch(id, WithStaleMvid(resolveResult.Resolution));
+
+            Assert.That(rePatchResult.Success, Is.False);
+            Assert.That(rePatchResult.FailureReason, Is.EqualTo(SourcePausePointPatchFailureReason.StaleAssembly));
+        }
+
         private const string FixtureFilePath = "Assets/Tests/Editor/PausePointToolsFixture.cs";
         private const int FixtureLine = 12;
+
+        private static SourcePausePointResolution WithStaleMvid(SourcePausePointResolution resolution)
+        {
+            return new SourcePausePointResolution(
+                resolution.AssemblyName,
+                Guid.NewGuid().ToString(),
+                resolution.MetadataToken,
+                resolution.MethodDisplayName,
+                resolution.IsStatic,
+                resolution.IsDeclaringTypeValueType,
+                resolution.InstructionIndex,
+                resolution.IlOffset,
+                resolution.ResolvedLine,
+                resolution.Locals,
+                resolution.Parameters);
+        }
 
         private static async Task<PausePointResponse> EnablePausePointAsync(string id)
         {

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -306,6 +306,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void PausePointStatusBridge_WhenPausePointHitWithCapturedVariables_ReturnsCapturedVariables()
+        {
+            // Verifies the CLI status bridge surfaces captured variables and the truncated flag
+            // from the registry snapshot, not just the marker/hit bookkeeping fields.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopCapturedVariable[] capturedVariables =
+            {
+                new("speed", UloopCapturedVariableScope.Local, "System.Int32", "5", string.Empty, string.Empty, 0)
+            };
+            UloopPausePointRegistry.HitWithCapturedVariables("jump", capturedVariables, true);
+            JObject parameters = new() { ["id"] = "jump" };
+
+            PausePointStatusResponse response = PausePointStatusBridgeCommand.Execute(parameters);
+
+            Assert.That(response.CapturedVariablesTruncated, Is.True);
+            Assert.That(response.CapturedVariables.Select(v => v.Name), Is.EquivalentTo(new[] { "speed" }));
+            Assert.That(response.CapturedVariables[0].Value, Is.EqualTo("5"));
+        }
+
+        [Test]
         public void Enable_WhenSamePausePointWasHit_ClearsLatestHitSnapshot()
         {
             // Verifies re-enabling a marker does not leave stale hit details for input tools.

--- a/Assets/Tests/Editor/PausePointToolsFixture.cs
+++ b/Assets/Tests/Editor/PausePointToolsFixture.cs
@@ -1,0 +1,15 @@
+// FROZEN FIXTURE: content and line numbers are asserted by PausePointTests.
+// Do not reformat or edit this file; add a new fixture file instead.
+namespace io.github.hatayama.UnityCliLoop.Tests.PausePointToolsFixtures
+{
+    internal sealed class EnableBySourceLocationFixture
+    {
+        public string Tag = "source-fixture-instance";
+
+        public int Add(int left, int right)
+        {
+            int sum = left + right;
+            return sum;
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointToolsFixture.cs.meta
+++ b/Assets/Tests/Editor/PausePointToolsFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41dd106203c1f42f0a3fc84e8dc90c55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
@@ -3,3 +3,8 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointResolver")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointCapture")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointPatcher")]
+// PausePointStatusBridgeCommand.Clear (Infrastructure) unpatches source pause points on clear;
+// PausePointTests (Tests.Editor) exercises the Resolver/Patcher pipeline end-to-end and needs
+// SourcePausePointPatcher visibility to prove Unpatch actually detaches the ledger entry.
+[assembly: InternalsVisibleTo("UnityCLILoop.Infrastructure")]
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/AssemblyInfo.cs
@@ -3,8 +3,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointResolver")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointCapture")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor.SourcePausePointPatcher")]
-// PausePointStatusBridgeCommand.Clear (Infrastructure) unpatches source pause points on clear;
 // PausePointTests (Tests.Editor) exercises the Resolver/Patcher pipeline end-to-end and needs
 // SourcePausePointPatcher visibility to prove Unpatch actually detaches the ledger entry.
-[assembly: InternalsVisibleTo("UnityCLILoop.Infrastructure")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -207,7 +207,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (parameters.All)
             {
-                SourcePausePointPatcher.UnpatchAll();
+                // Registry.ClearAll unpatches any source pause points via the hook
+                // SourcePausePointPatcher wires into it; this use case never references the
+                // Patcher directly.
                 UloopPausePointClearAllResult clearAllResult = UloopPausePointRegistry.ClearAll();
                 return PausePointResponse.FromClearAll(clearAllResult);
             }
@@ -218,7 +220,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return CreateValidationFailure(idError);
             }
 
-            SourcePausePointPatcher.Unpatch(parameters.Id);
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(parameters.Id);
             return PausePointResponse.FromSnapshot(snapshot);
         }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -207,6 +207,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (parameters.All)
             {
+                SourcePausePointPatcher.UnpatchAll();
                 UloopPausePointClearAllResult clearAllResult = UloopPausePointRegistry.ClearAll();
                 return PausePointResponse.FromClearAll(clearAllResult);
             }
@@ -217,6 +218,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return CreateValidationFailure(idError);
             }
 
+            SourcePausePointPatcher.Unpatch(parameters.Id);
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(parameters.Id);
             return PausePointResponse.FromSnapshot(snapshot);
         }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
+using UnityEditor.Compilation;
 
 using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -9,11 +10,17 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Parameters for enabling one named pause point marker.
+    /// Parameters for enabling one pause point, either by a hand-written marker id or by
+    /// resolving a source file:line to a patch location. Exactly one of "Id" or "File"+"Line"
+    /// must be provided.
     /// </summary>
     public class EnablePausePointSchema : UnityCliLoopToolSchema
     {
         public string Id { get; set; } = string.Empty;
+
+        public string File { get; set; } = string.Empty;
+
+        public int Line { get; set; }
 
         public int TimeoutSeconds { get; set; } = UloopPausePointRegistry.DefaultTimeoutSeconds;
     }
@@ -37,6 +44,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Only explicit validation failures set this to false.
         public bool Success { get; set; } = true;
         public string Id { get; set; } = string.Empty;
+        public int ResolvedLine { get; set; }
+        public string ResolvedMethod { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
         public bool IsEnabled { get; set; }
         public bool IsHit { get; set; }
@@ -172,15 +181,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public PausePointResponse Enable(EnablePausePointSchema parameters)
         {
-            string idError = ValidateId(parameters.Id);
-            if (idError != null)
+            string modeError = ValidateEnableMode(parameters);
+            if (modeError != null)
             {
-                return CreateValidationFailure(idError);
+                return CreateValidationFailure(modeError);
             }
 
             if (parameters.TimeoutSeconds <= 0)
             {
                 return CreateValidationFailure("TimeoutSeconds must be greater than zero.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(parameters.File))
+            {
+                return EnableBySourceLocation(parameters);
             }
 
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(parameters.Id, parameters.TimeoutSeconds);
@@ -205,6 +219,89 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(parameters.Id);
             return PausePointResponse.FromSnapshot(snapshot);
+        }
+
+        // Resolves File:Line to a patch location via the Resolver, patches it via Harmony, then
+        // arms the same registry state machine the Id path uses, keyed by the derived source id.
+        private static PausePointResponse EnableBySourceLocation(EnablePausePointSchema parameters)
+        {
+            if (CompilationPipeline.codeOptimization == CodeOptimization.Release)
+            {
+                return CreateValidationFailure(SourcePausePointConstants.ReleaseCodeOptimizationRejectionMessage);
+            }
+
+            SourcePausePointResolveResult resolveResult = SourcePausePointResolver.Resolve(parameters.File, parameters.Line);
+            if (!resolveResult.Success)
+            {
+                return CreateValidationFailure(resolveResult.ErrorMessage);
+            }
+
+            string id = BuildSourcePausePointId(parameters.File, parameters.Line);
+            SourcePausePointPatchResult patchResult = SourcePausePointPatcher.Patch(id, resolveResult.Resolution);
+            if (!patchResult.Success)
+            {
+                return new PausePointResponse
+                {
+                    Success = false,
+                    Message = patchResult.ErrorMessage,
+                    RecommendedNextAction = patchResult.Hint
+                };
+            }
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(id, parameters.TimeoutSeconds);
+            PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
+            response.ResolvedLine = resolveResult.Resolution.ResolvedLine;
+            response.ResolvedMethod = resolveResult.Resolution.MethodDisplayName;
+            response.Warning = MergeWarnings(CreateEnableWarning(), patchResult.Warning);
+            return response;
+        }
+
+        // The derived id must use the originally requested file/line (not the resolved/rounded
+        // line) so repeated calls at the same requested location stay idempotent.
+        private static string BuildSourcePausePointId(string file, int line)
+        {
+            return SourcePausePointPathNormalizer.ToForwardSlashes(file) + ":" + line;
+        }
+
+        private static string MergeWarnings(string first, string second)
+        {
+            if (string.IsNullOrEmpty(first))
+            {
+                return second;
+            }
+
+            if (string.IsNullOrEmpty(second))
+            {
+                return first;
+            }
+
+            return first + " " + second;
+        }
+
+        // Returns an error message when the Id/File/Line combination fails validation, or null
+        // when exactly one of "Id" or "File"+"Line" is provided.
+        private static string ValidateEnableMode(EnablePausePointSchema parameters)
+        {
+            bool hasId = !string.IsNullOrWhiteSpace(parameters.Id);
+            bool hasFile = !string.IsNullOrWhiteSpace(parameters.File);
+            bool hasLine = parameters.Line > 0;
+
+            if (hasId && (hasFile || hasLine))
+            {
+                return "Specify either Id or File and Line, not both.";
+            }
+
+            if (!hasId && !hasFile && !hasLine)
+            {
+                return "Id must not be null or empty.";
+            }
+
+            if (!hasId && hasFile != hasLine)
+            {
+                return "File and Line must both be provided together.";
+            }
+
+            return null;
         }
 
         // Returns an error message when id fails validation, or null when it is valid.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -43,5 +43,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const string RefStructInstanceNotCapturedWarning =
             "The declaring type is a ref struct; this-instance fields are not captured "
             + "(locals and parameters are still captured normally).";
+
+        // Release code optimization strips most sequence points and hoists/elides locals, so the
+        // Resolver's PDB-driven lookup cannot reliably find a patch location; rejecting up front
+        // avoids patching the wrong instruction instead of failing later in a confusing way.
+        public const string ReleaseCodeOptimizationRejectionMessage =
+            "Enabling a pause point by file and line requires Debug code optimization. The project "
+            + "is currently set to Release; switch the Editor's Code Optimization mode to Debug "
+            + "(the bug icon in the main toolbar) and recompile, then retry.";
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointPatcher.cs
@@ -32,6 +32,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static readonly Dictionary<MethodBase, List<SourcePausePointPatchInjection>> InjectionsByMethod = new();
         private static readonly Dictionary<string, MethodBase> MethodById = new();
 
+        // The registry lives in a Runtime assembly this Editor-only tool assembly may depend on,
+        // but not the reverse (patching is an outer/implementation concern the registry's inner
+        // layer must not know about). Wiring these hooks here - rather than having every Clear
+        // caller reference this class directly - lets the Infrastructure CLI bridge call
+        // UloopPausePointRegistry.Clear/ClearAll without ever referencing this assembly.
+        static SourcePausePointPatcher()
+        {
+            UloopPausePointRegistry.OnCleared = Unpatch;
+            UloopPausePointRegistry.OnClearedAll = UnpatchAll;
+        }
+
         public static SourcePausePointPatchResult Patch(string id, SourcePausePointResolution resolution)
         {
             Debug.Assert(!string.IsNullOrEmpty(id), "id must not be null or empty.");

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using Newtonsoft.Json.Linq;
 
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -23,6 +24,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public static PausePointStatusResponse Clear(JToken paramsToken)
         {
             string id = ReadId(paramsToken);
+            // This is the path the Go CLI's wait-for-pause-point timeout auto-clear and
+            // clear-pause-point-status hit; a source pause point left un-unpatched here would keep
+            // its Harmony injection attached (inert but never cleaned up) after the marker itself
+            // reports Cleared.
+            SourcePausePointPatcher.Unpatch(id);
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(id);
             return PausePointStatusResponse.FromSnapshot(snapshot);
         }

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 
 using io.github.hatayama.UnityCliLoop.Runtime;
@@ -66,6 +68,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public int LastHitSequence { get; set; }
         public string Message { get; set; } = string.Empty;
         public string RecommendedNextAction { get; set; } = string.Empty;
+        public IReadOnlyList<PausePointStatusCapturedVariable> CapturedVariables { get; set; } =
+            Array.Empty<PausePointStatusCapturedVariable>();
+        public bool CapturedVariablesTruncated { get; set; }
 
         internal static PausePointStatusResponse FromSnapshot(UloopPausePointSnapshot snapshot)
         {
@@ -93,7 +98,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 FirstHitSequence = snapshot.FirstHitSequence,
                 LastHitSequence = snapshot.LastHitSequence,
                 Message = snapshot.Message,
-                RecommendedNextAction = snapshot.RecommendedNextAction
+                RecommendedNextAction = snapshot.RecommendedNextAction,
+                CapturedVariables = snapshot.CapturedVariables
+                    .Select(PausePointStatusCapturedVariable.FromCapturedVariable)
+                    .ToList(),
+                CapturedVariablesTruncated = snapshot.CapturedVariablesTruncated
             };
         }
     }
@@ -119,6 +128,40 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 IsPlaying = snapshot.IsPlaying,
                 IsPaused = snapshot.IsPaused,
                 CapturedAt = snapshot.CapturedAt
+            };
+        }
+    }
+
+    /// <summary>
+    /// One variable captured at a source pause point, mirroring Runtime.UloopCapturedVariable's
+    /// fields for the CLI polling bridge response.
+    /// </summary>
+    public class PausePointStatusCapturedVariable
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Scope { get; set; } = string.Empty;
+        public string TypeName { get; set; } = string.Empty;
+        public string Value { get; set; } = string.Empty;
+        public string UnityObjectKind { get; set; } = string.Empty;
+        public string UnityObjectPath { get; set; } = string.Empty;
+        public int UnityObjectInstanceId { get; set; }
+
+        internal static PausePointStatusCapturedVariable FromCapturedVariable(UloopCapturedVariable capturedVariable)
+        {
+            if (capturedVariable == null)
+            {
+                throw new ArgumentNullException(nameof(capturedVariable));
+            }
+
+            return new PausePointStatusCapturedVariable
+            {
+                Name = capturedVariable.Name,
+                Scope = capturedVariable.Scope,
+                TypeName = capturedVariable.TypeName,
+                Value = capturedVariable.Value,
+                UnityObjectKind = capturedVariable.UnityObjectKind,
+                UnityObjectPath = capturedVariable.UnityObjectPath,
+                UnityObjectInstanceId = capturedVariable.UnityObjectInstanceId
             };
         }
     }

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -1,7 +1,6 @@
 using System;
 using Newtonsoft.Json.Linq;
 
-using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -24,11 +23,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public static PausePointStatusResponse Clear(JToken paramsToken)
         {
             string id = ReadId(paramsToken);
-            // This is the path the Go CLI's wait-for-pause-point timeout auto-clear and
-            // clear-pause-point-status hit; a source pause point left un-unpatched here would keep
-            // its Harmony injection attached (inert but never cleaned up) after the marker itself
-            // reports Cleared.
-            SourcePausePointPatcher.Unpatch(id);
+            // Registry.Clear unpatches any source pause point via the hook
+            // SourcePausePointPatcher wires into it, so this bridge - which must not reference
+            // that Editor-only tool assembly directly - never leaves a Harmony injection attached
+            // after the marker itself reports Cleared.
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear(id);
             return PausePointStatusResponse.FromSnapshot(snapshot);
         }

--- a/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
+++ b/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
@@ -6,7 +6,8 @@
         "GUID:5c4588558a3624eacbce0f50007cf1eb",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
-        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d",
+        "GUID:94d8abc693f543a691a4645a5ff42e5c"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
+++ b/Packages/src/Editor/Infrastructure/UnityCLILoop.Infrastructure.asmdef
@@ -6,8 +6,7 @@
         "GUID:5c4588558a3624eacbce0f50007cf1eb",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
         "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
-        "GUID:527f26a36b5043c2bd4d4036d04cd76d",
-        "GUID:94d8abc693f543a691a4645a5ff42e5c"
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -26,6 +26,15 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         // not just the latest hit, to report every marker that interrupted them.
         private static readonly List<UloopPausePointSnapshot> _hitSnapshots = new();
 
+        // Source pause points are patched into IL by an Editor-only tool assembly this Runtime
+        // assembly must not reference directly (patching is an outer/implementation concern; this
+        // registry is the inner layer). That tool assembly wires its own Unpatch/UnpatchAll into
+        // these hooks the first time it patches a method, so every Clear/ClearAll caller -
+        // including the Infrastructure CLI bridge, which also must not reference the tool
+        // assembly - removes the underlying Harmony patch without knowing it exists.
+        public static Action<string> OnCleared { get; set; }
+        public static Action OnClearedAll { get; set; }
+
         public static UloopPausePointSnapshot Enable(string id, int timeoutSeconds)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(id), "id must not be null or empty");
@@ -42,6 +51,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public static UloopPausePointSnapshot Clear(string id)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(id), "id must not be null or empty");
+
+            OnCleared?.Invoke(id);
 
             DateTime now = NowUtc();
             if (!Entries.ContainsKey(id))
@@ -66,6 +77,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         public static UloopPausePointClearAllResult ClearAll()
         {
+            OnClearedAll?.Invoke();
+
             DateTime now = NowUtc();
             int clearedCount = 0;
             foreach (UloopPausePointEntry entry in Entries.Values)

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -340,13 +340,21 @@
     },
     {
       "name": "enable-pause-point",
-      "description": "Enable a named UloopPausePoint.Pause marker so Unity pauses when that code path is reached",
+      "description": "Enable a pause point so Unity pauses when that code path is reached, either by a named UloopPausePoint.Pause marker (Id) or by resolving a source file and line (File+Line)",
       "inputSchema": {
         "type": "object",
         "properties": {
           "Id": {
             "type": "string",
-            "description": "Named pause point id passed to UloopPausePoint.Pause"
+            "description": "Named pause point id passed to UloopPausePoint.Pause. Mutually exclusive with File/Line"
+          },
+          "File": {
+            "type": "string",
+            "description": "Project-relative source file path to patch a pause point into. Requires Line; mutually exclusive with Id"
+          },
+          "Line": {
+            "type": "integer",
+            "description": "1-based source line to resolve within File. Requires File; mutually exclusive with Id"
           },
           "TimeoutSeconds": {
             "type": "integer",

--- a/cli/project-runner/internal/projectrunner/pause_point_status_response_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_status_response_contract_test.go
@@ -1,0 +1,44 @@
+package projectrunner
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+const pausePointStatusResponseContractPath = "tests/contracts/pause_point_status_response_contract.json"
+
+// Verifies the Go pausePointStatusResponse DTO preserves every field in the shared Unity
+// PausePointStatusResponse contract, including the CapturedVariables/CapturedVariablesTruncated
+// fields introduced for source file:line pause points.
+func TestPausePointStatusResponseMatchesSharedContract(t *testing.T) {
+	fixture := readPausePointStatusResponseContract(t)
+
+	var response pausePointStatusResponse
+	if err := json.Unmarshal(fixture, &response); err != nil {
+		t.Fatalf("failed to unmarshal shared pause point status response contract: %v", err)
+	}
+
+	roundTripped, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("failed to marshal Go pause point status response: %v", err)
+	}
+
+	expected := readJSONFieldShape(t, fixture)
+	actual := readJSONFieldShape(t, roundTripped)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("pause point status response field shape drifted\nexpected: %#v\nactual:   %#v", expected, actual)
+	}
+}
+
+func readPausePointStatusResponseContract(t *testing.T) []byte {
+	t.Helper()
+
+	path := findRepoRelativeFile(t, pausePointStatusResponseContractPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read shared pause point status response contract: %v", err)
+	}
+	return data
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -46,30 +46,45 @@ type pausePointStatusOptions struct {
 }
 
 type pausePointStatusResponse struct {
-	Id                              string                `json:"Id"`
-	Status                          string                `json:"Status"`
-	IsEnabled                       bool                  `json:"IsEnabled"`
-	IsHit                           bool                  `json:"IsHit"`
-	HitCount                        int                   `json:"HitCount"`
-	TimeoutSeconds                  int                   `json:"TimeoutSeconds"`
-	Expired                         bool                  `json:"Expired"`
-	EnabledAtUtc                    string                `json:"EnabledAtUtc"`
-	ElapsedSinceEnabledMilliseconds int64                 `json:"ElapsedSinceEnabledMilliseconds"`
-	RemainingMilliseconds           int64                 `json:"RemainingMilliseconds"`
-	Generation                      int                   `json:"Generation"`
-	EditorState                     pausePointEditorState `json:"EditorState"`
-	FirstHitAtUtc                   string                `json:"FirstHitAtUtc"`
-	LastHitAtUtc                    string                `json:"LastHitAtUtc"`
-	FirstHitSequence                int                   `json:"FirstHitSequence"`
-	LastHitSequence                 int                   `json:"LastHitSequence"`
-	Message                         string                `json:"Message"`
-	RecommendedNextAction           string                `json:"RecommendedNextAction"`
+	Id                              string                       `json:"Id"`
+	Status                          string                       `json:"Status"`
+	IsEnabled                       bool                         `json:"IsEnabled"`
+	IsHit                           bool                         `json:"IsHit"`
+	HitCount                        int                          `json:"HitCount"`
+	TimeoutSeconds                  int                          `json:"TimeoutSeconds"`
+	Expired                         bool                         `json:"Expired"`
+	EnabledAtUtc                    string                       `json:"EnabledAtUtc"`
+	ElapsedSinceEnabledMilliseconds int64                        `json:"ElapsedSinceEnabledMilliseconds"`
+	RemainingMilliseconds           int64                        `json:"RemainingMilliseconds"`
+	Generation                      int                          `json:"Generation"`
+	EditorState                     pausePointEditorState        `json:"EditorState"`
+	FirstHitAtUtc                   string                       `json:"FirstHitAtUtc"`
+	LastHitAtUtc                    string                       `json:"LastHitAtUtc"`
+	FirstHitSequence                int                          `json:"FirstHitSequence"`
+	LastHitSequence                 int                          `json:"LastHitSequence"`
+	Message                         string                       `json:"Message"`
+	RecommendedNextAction           string                       `json:"RecommendedNextAction"`
+	CapturedVariables               []pausePointCapturedVariable `json:"CapturedVariables"`
+	CapturedVariablesTruncated      bool                         `json:"CapturedVariablesTruncated"`
 }
 
 type pausePointEditorState struct {
 	IsPlaying  bool   `json:"IsPlaying"`
 	IsPaused   bool   `json:"IsPaused"`
 	CapturedAt string `json:"CapturedAt"`
+}
+
+// pausePointCapturedVariable mirrors the flat Unity-side
+// PausePointStatusCapturedVariable/UloopCapturedVariable DTO field-for-field: one variable
+// captured at a source pause point (a local, a parameter, or a `this` instance field).
+type pausePointCapturedVariable struct {
+	Name                  string `json:"Name"`
+	Scope                 string `json:"Scope"`
+	TypeName              string `json:"TypeName"`
+	Value                 string `json:"Value"`
+	UnityObjectKind       string `json:"UnityObjectKind"`
+	UnityObjectPath       string `json:"UnityObjectPath"`
+	UnityObjectInstanceId int    `json:"UnityObjectInstanceId"`
 }
 
 type pausePointWaitState string

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -920,6 +921,115 @@ func TestRunPausePointStatusReturnsCurrentStatus(t *testing.T) {
 	}
 	if response.RecommendedNextAction != "Clear this marker, then re-enable it with the same Id and TimeoutSeconds values." {
 		t.Fatalf("recommendedNextAction mismatch: %#v", response)
+	}
+}
+
+// Verifies pause-point-status passes captured variables and the truncated flag through to stdout.
+func TestRunPausePointStatusReturnsCapturedVariables(t *testing.T) {
+	originalQuery := queryPausePointStatus
+	defer func() {
+		queryPausePointStatus = originalQuery
+	}()
+
+	queryPausePointStatus = func(
+		ctx context.Context,
+		connection unityipc.Connection,
+		id string,
+	) (pausePointStatusResponse, error) {
+		return pausePointStatusResponse{
+			Id:        id,
+			Status:    pausePointStatusHit,
+			IsEnabled: true,
+			IsHit:     true,
+			CapturedVariables: []pausePointCapturedVariable{
+				{
+					Name:     "speed",
+					Scope:    "Local",
+					TypeName: "System.Int32",
+					Value:    "5",
+				},
+				{
+					Name:                  "enemy",
+					Scope:                 "InstanceField",
+					TypeName:              "UnityEngine.GameObject",
+					Value:                 "Enemy",
+					UnityObjectKind:       "SceneObject",
+					UnityObjectPath:       "MainScene:/Root/Enemy",
+					UnityObjectInstanceId: -1234,
+				},
+			},
+			CapturedVariablesTruncated: true,
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPausePointStatusCommand(
+		context.Background(),
+		unityipc.Connection{ProjectRoot: "/tmp/MyProject"},
+		[]string{"--id", "jump"},
+		&stdout,
+		&stderr)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d with stderr %s", code, stderr.String())
+	}
+	var response pausePointStatusResponse
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if !response.CapturedVariablesTruncated {
+		t.Fatalf("expected CapturedVariablesTruncated to be true: %#v", response)
+	}
+	if len(response.CapturedVariables) != 2 {
+		t.Fatalf("expected 2 captured variables, got %#v", response.CapturedVariables)
+	}
+	if response.CapturedVariables[0].Name != "speed" || response.CapturedVariables[0].Value != "5" {
+		t.Fatalf("first captured variable mismatch: %#v", response.CapturedVariables[0])
+	}
+	second := response.CapturedVariables[1]
+	if second.Name != "enemy" || second.UnityObjectKind != "SceneObject" ||
+		second.UnityObjectPath != "MainScene:/Root/Enemy" || second.UnityObjectInstanceId != -1234 {
+		t.Fatalf("second captured variable mismatch: %#v", second)
+	}
+}
+
+// Verifies pausePointCapturedVariable round-trips through JSON without losing or reordering fields.
+func TestPausePointStatusResponseCapturedVariablesJSONRoundTrip(t *testing.T) {
+	original := pausePointStatusResponse{
+		Id:     "jump",
+		Status: pausePointStatusHit,
+		CapturedVariables: []pausePointCapturedVariable{
+			{
+				Name:                  "speed",
+				Scope:                 "Local",
+				TypeName:              "System.Int32",
+				Value:                 "5",
+				UnityObjectKind:       "SceneObject",
+				UnityObjectPath:       "MainScene:/Root/Enemy",
+				UnityObjectInstanceId: -1234,
+			},
+		},
+		CapturedVariablesTruncated: true,
+	}
+
+	marshaled, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var roundTripped pausePointStatusResponse
+	if err := json.Unmarshal(marshaled, &roundTripped); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(original.CapturedVariables, roundTripped.CapturedVariables) {
+		t.Fatalf("captured variables mismatch after round trip: got %#v, want %#v",
+			roundTripped.CapturedVariables, original.CapturedVariables)
+	}
+	if original.CapturedVariablesTruncated != roundTripped.CapturedVariablesTruncated {
+		t.Fatalf("capturedVariablesTruncated mismatch after round trip: got %v, want %v",
+			roundTripped.CapturedVariablesTruncated, original.CapturedVariablesTruncated)
 	}
 }
 

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -1,0 +1,36 @@
+{
+  "Id": "Assets/Scripts/Enemy.cs:42",
+  "Status": "Hit",
+  "IsEnabled": true,
+  "IsHit": true,
+  "HitCount": 1,
+  "TimeoutSeconds": 30,
+  "Expired": false,
+  "EnabledAtUtc": "2026-06-03T00:00:00.0000000Z",
+  "ElapsedSinceEnabledMilliseconds": 1200,
+  "RemainingMilliseconds": 28800,
+  "Generation": 3,
+  "EditorState": {
+    "IsPlaying": true,
+    "IsPaused": true,
+    "CapturedAt": "PausePointHit"
+  },
+  "FirstHitAtUtc": "2026-06-03T00:00:01.0000000Z",
+  "LastHitAtUtc": "2026-06-03T00:00:01.0000000Z",
+  "FirstHitSequence": 1,
+  "LastHitSequence": 1,
+  "Message": "Pause point hit.",
+  "RecommendedNextAction": "Clear this marker, then re-enable it with the same Id and TimeoutSeconds values.",
+  "CapturedVariables": [
+    {
+      "Name": "target",
+      "Scope": "InstanceField",
+      "TypeName": "UnityEngine.GameObject",
+      "Value": "Enemy",
+      "UnityObjectKind": "SceneObject",
+      "UnityObjectPath": "MainScene:/Root/Enemy",
+      "UnityObjectInstanceId": -1234
+    }
+  ],
+  "CapturedVariablesTruncated": true
+}


### PR DESCRIPTION
## Summary
- `enable-pause-point` now accepts `File`+`Line` in addition to the existing `Id` marker mode, resolving a source location and patching a pause point into it without any source edit.
- Clearing a source pause point (single or `ClearAll`) automatically removes the underlying Harmony patch, so no injected instrumentation is left behind after the marker reports Cleared.
- When a pause point hits, the response now includes `CapturedVariables` (locals, parameters, and instance fields captured at that line) and a `CapturedVariablesTruncated` flag.

## User Impact
- AI agents can now pause execution at any source line (e.g. `enable-pause-point --file Assets/Scripts/Enemy.cs --line 42`) instead of requiring a hand-written `UloopPausePoint.Pause("id")` marker in code.
- Pausing at a Release-optimized build is rejected up front with a clear message to switch the Editor to Debug code optimization, instead of silently patching the wrong instruction.
- Waiting on a pause point (`wait-for-pause-point`) now surfaces captured variable values directly in the response, so agents can inspect state at the pause point without a separate step.

## Changes
- `PausePointTools.EnablePausePointSchema`/`PausePointUseCase.Enable`: validates that exactly one of `Id` or `File`+`Line` is provided, rejects Release code optimization for the source-line path, resolves the location via the existing Resolver, patches via `SourcePausePointPatcher`, and merges any resolver/patcher warning with the existing enable warning.
- `UloopPausePointRegistry` gains `OnCleared`/`OnClearedAll` hooks invoked from `Clear`/`ClearAll`; `SourcePausePointPatcher"'s static constructor wires `Unpatch`/`UnpatchAll` into these hooks. This keeps the onion-architecture dependency direction intact: the Runtime registry and Infrastructure bridge never reference the Editor-only patching assembly directly.
- `PausePointStatusBridgeCommand`/Go `pause_point_wait.go`: both response DTOs gain `CapturedVariables`/`CapturedVariablesTruncated`, backed by a new shared JSON contract fixture (`tests/contracts/pause_point_status_response_contract.json`) with matching Go and C# field-shape tests.
- `default-tools.json`: `enable-pause-point`'s schema documents the new `File`/`Line` properties as mutually exclusive with `Id`.

## Verification
- `uloop compile` — 0 errors, 0 warnings
- `uloop run-tests --filter-value "PausePoint"` — 98/98 passed
- `scripts/check-go-cli.sh` — all green (fmt, vet, lint, tests, build)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

