### PR TITLE
fix(package): Reject PlayMode test runs while the Editor is paused

### DIFF
--- a/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
+++ b/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
@@ -86,5 +86,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 PlayModeToolPreflightService.FormatPausedMessage(SimulateMouseUiUseCase.PausedActionDescription),
                 Is.EqualTo("PlayMode is paused. Resume PlayMode before simulating UI input."));
         }
+
     }
 }

--- a/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
+++ b/Assets/Tests/Editor/TestExecutionStateValidationServiceTests.cs
@@ -70,6 +70,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Validate_WithPlayModeWhilePaused_ShouldReturnFailure()
+        {
+            // Verifies that PlayMode tests are rejected when Play Mode is paused.
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
+                isPlaying: true,
+                isPaused: true);
+
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, saveBeforeRun: false);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessage, Does.Contain("paused"));
+            Assert.That(result.ErrorMessage, Does.Contain("control-play-mode"));
+            Assert.That(result.ErrorMessage, Does.Contain("clear-pause-point"));
+        }
+
+        [Test]
+        public void Validate_WithEditModeWhilePaused_ShouldReturnPlayModeFailureNotPausedFailure()
+        {
+            // Verifies that the existing "cannot run during play mode" check takes precedence over the paused check for EditMode.
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
+                isPlaying: true,
+                isPaused: true);
+
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.EditMode, saveBeforeRun: false);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo("EditMode tests cannot run during play mode"));
+        }
+
+        [Test]
+        public void Validate_WithPlayModeWhilePlayingNotPaused_ShouldReturnSuccess()
+        {
+            // Verifies that PlayMode tests pass validation when playing but not paused.
+            TestExecutionStateValidationService service = new StubTestExecutionStateValidationService(
+                isPlaying: true,
+                isPaused: false);
+
+            ValidationResult result = service.Validate(UnityCliLoopTestMode.PlayMode, saveBeforeRun: false);
+
+            Assert.That(result.IsValid, Is.True);
+        }
+
+        [Test]
         public void Validate_WhenEditorHasUnsavedChangesAndSaveBeforeRunIsFalse_ShouldReturnFailure()
         {
             string[] unsavedEditorChanges =
@@ -134,6 +177,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private sealed class StubTestExecutionStateValidationService : TestExecutionStateValidationService
         {
             private readonly bool _isPlaying;
+            private readonly bool _isPaused;
             private readonly bool _isCompiling;
             private readonly bool _isUpdating;
             private readonly ValidationResult _saveResult;
@@ -144,6 +188,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             public StubTestExecutionStateValidationService(
                 bool isPlaying,
+                bool isPaused = false,
                 bool isCompiling = false,
                 bool isUpdating = false,
                 string[] unsavedEditorChanges = null,
@@ -151,6 +196,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 bool clearUnsavedChangesAfterSave = false)
             {
                 _isPlaying = isPlaying;
+                _isPaused = isPaused;
                 _isCompiling = isCompiling;
                 _isUpdating = isUpdating;
                 _unsavedEditorChanges = unsavedEditorChanges ?? new string[0];
@@ -159,6 +205,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             }
 
             protected override bool IsPlaying => _isPlaying;
+            protected override bool IsPaused => _isPaused;
             protected override bool IsCompiling => _isCompiling;
             protected override bool IsUpdating => _isUpdating;
             protected override string[] DetectUnsavedEditorChanges()

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -160,6 +160,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return successResponse;
         }
 
+        // Why these awaits do not use ConfigureAwait(false): StopPlayMode() clears isPaused
+        // before setting isPlaying=false, so by the time the poll loop's TimerDelay continuation
+        // is posted to UnitySynchronizationContext the pause is already lifted and the queue
+        // drains normally. Measured 2026-07-11: compile during pause self-resolved in ~5s.
         private async Task<bool> WaitForPlayModeExitAsync(CancellationToken ct)
         {
             int waitedMs = 0;

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -88,6 +88,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             // 2. Test execution
+            // Why these awaits do not use ConfigureAwait(false): the entry preflight rejects
+            // paused PlayMode, so the only remaining path where a pause could hang these awaits
+            // is a pause point hitting mid-test. In that case the Test Runner itself stalls and
+            // the hang is not solvable at the tool layer (see issue #1686).
             ct.ThrowIfCancellationRequested();
             SerializableTestResult result;
             if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
@@ -13,12 +13,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class TestExecutionStateValidationService
     {
+        private const string PlayModePausedMessage =
+            "PlayMode is paused. Tests cannot run while paused because tool continuations " +
+            "are not executed during pause, which would hang the test runner. " +
+            "Use control-play-mode --action Play to resume, " +
+            "or clear-pause-point --all if a pause point caused the pause.";
+
         private const string UnsavedEditorChangesFailureMessage =
             "Tests cannot run while the editor has unsaved scene or prefab changes. Save or discard these changes before running tests.";
         private const string UnsavedEditorChangesSaveFailureMessage =
             "Tests cannot save unsaved scene or prefab changes before running tests.";
 
         protected virtual bool IsPlaying => EditorApplication.isPlaying;
+        protected virtual bool IsPaused => EditorApplication.isPaused;
         protected virtual bool IsCompiling => EditorApplication.isCompiling;
         protected virtual bool IsUpdating => EditorApplication.isUpdating;
         protected virtual string[] DetectUnsavedEditorChanges()
@@ -45,6 +52,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (testMode == UnityCliLoopTestMode.EditMode && IsPlaying)
             {
                 return ValidationResult.Failure("EditMode tests cannot run during play mode");
+            }
+
+            if (testMode == UnityCliLoopTestMode.PlayMode && IsPaused)
+            {
+                return ValidationResult.Failure(PlayModePausedMessage);
             }
 
             if (saveBeforeRun)


### PR DESCRIPTION
## Summary

- Reject PlayMode test execution when Play Mode is paused, preventing tool hangs from
  UnitySynchronizationContext continuations that are never drained during pause
- Document why compile's `WaitForPlayModeExitAsync` is immune to this class of hang

Closes #1686

## Measurement data (Phase A)

| Scenario | Before fix | After fix |
|---|---|---|
| `compile` during pause | 5.089s, self-resolving (`StopPlayMode` clears `isPaused` first) | No change needed |
| `run-tests --test-mode EditMode` during pause | 0.07s, existing validation rejects | No change needed |
| `run-tests --test-mode PlayMode` during pause | Would reach plain awaits (potential hang) | **0.162s, preflight error** |

## Changes

- `TestExecutionStateValidationService`: Add `IsPaused` virtual property and PlayMode+paused guard
- `RunTestsUseCase`: Add why-comment on plain awaits (mid-test pause point hit is out of scope)
- `CompileUseCase`: Add why-comment on `WaitForPlayModeExitAsync` documenting self-resolution
- Tests: 3 new validation tests (paused rejection, EditMode precedence, not-paused passthrough)

## Test plan

- [x] `uloop compile` 0 errors / 0 warnings
- [x] TestExecutionStateValidationServiceTests 11/11 green
- [x] PlayModeToolPreflightServiceTests 8/8 green
- [x] Real repro: pause + PlayMode run-tests → 0.162s preflight error
- [x] Real repro: pause + compile → 5.089s self-resolution

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

