### PR TITLE
fix(package): Update stale pause point guidance in tool skills

### DIFF
--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -11,7 +11,7 @@ Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-c
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
-This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, add a focused `Debug.Log` immediately before `UloopPausePoint.Pause("<id>")`, then run `get-logs --search-text <id>` while Unity is paused. Do not replace that log read with execute-dynamic-code.
+This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, enable a source pause point on that line instead (`uloop enable-pause-point --file <file> --line <line>`, see the `uloop-wait-for-pause-point` skill): the hit response's `CapturedVariables` already contains the locals, parameters, and instance fields at that line, with no code edit or recompile. Do not try to reconstruct those values with execute-dynamic-code.
 
 ## Workflow
 

--- a/.agents/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.agents/skills/uloop-simulate-keyboard/SKILL.md
@@ -45,7 +45,7 @@ If a successful `Press` or `KeyDown` leaves `Keyboard.current.<key>.isPressed` t
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Place markers after the app consumed the key, not immediately after `simulate-keyboard`.
+For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the key is safe: when the pause lands mid-command, `simulate-keyboard` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the key when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker. `PressEdgeObserved` is still reported on pause-point interruptions.
 
@@ -92,8 +92,8 @@ Returns JSON with:
 - `Action` (string): The `--action` value that was applied (`Press`, `KeyDown`, or `KeyUp`)
 - `KeyName` (string, nullable): The key that was acted on; may be `null` when the action could not resolve a key
 - `InterruptedByPausePoint` (boolean): True when Unity paused during Pause Point inspection and the input bookkeeping was safely released
-- `PausePointId` (string, nullable): The marker id when a `UloopPausePoint.Pause` marker caused the interruption
-- `PausePointHitCount` (integer, nullable): The marker hit count when a `UloopPausePoint.Pause` marker caused the interruption
+- `PausePointId` (string, nullable): The derived `<file>:<line>` pause point id that caused the interruption (the `Id` returned by `enable-pause-point`)
+- `PausePointHitCount` (integer, nullable): The hit count for that pause point when it caused the interruption
 - `PausePointHits` (array, nullable): Every marker hit during this input as `{Id, HitCount}` entries, in hit order. Read this when one input may trigger several markers; `PausePointId` only names the latest one
 - `PressEdgeObserved` (boolean, nullable): For `Press` and `KeyDown`, whether the press edge (`wasPressedThisFrame`) was actually visible inside a gameplay input update. `false` means the CLI succeeded but gameplay polling most likely missed the edge (e.g. the press was consumed by an editor-only input update) — retry the input or verify with a focused log instead of trusting `Success` alone. `null` only for `KeyUp` and for timed-out responses; pause-point interruptions still report the observed value
 

--- a/.agents/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-input/SKILL.md
@@ -50,10 +50,10 @@ uloop simulate-mouse-input --action <action> [options]
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Place markers after the app consumed the mouse input, not immediately after `simulate-mouse-input`.
+For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the mouse input is safe: when the pause lands mid-command, `simulate-mouse-input` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the input when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker.
-- Remove temporary pause-point/log instrumentation before final validation when it was added only for inspection.
+- Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.
 
 ### Global Options (optional)
 
@@ -135,8 +135,8 @@ Returns JSON with:
 - `InjectedUnityPositionX` / `InjectedUnityPositionY`: Coordinates injected into `Mouse.current.position`
 - `CoordinateConversionFormula`: Conversion formula used by the tool
 - `InterruptedByPausePoint`: True when Unity paused during Pause Point inspection and the input bookkeeping was safely released
-- `PausePointId`: The id from `UloopPausePoint.Pause("<id>")` when it caused the interruption
-- `PausePointHitCount`: The hit count for that `UloopPausePoint.Pause("<id>")`
+- `PausePointId`: The derived `<file>:<line>` pause point id that caused the interruption (the `Id` returned by `enable-pause-point`)
+- `PausePointHitCount`: The hit count for that pause point when it caused the interruption
 - `PausePointHits` (array, nullable): Every marker hit during this input as `{Id, HitCount}` entries, in hit order. Read this when one input may trigger several markers; `PausePointId` only names the latest one
 
 Verify visual outcome with a follow-up screenshot.

--- a/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -76,9 +76,10 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 
 ## Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this UI input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Place markers after the app consumed the UI event, not immediately after `simulate-mouse-ui`.
+For standard frame proof when this UI input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the UI event is safe: when the pause lands mid-command, `simulate-mouse-ui` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the event when you want the settled result state rather than the input-handling moment.
 
-- Remove temporary pause-point/log instrumentation before final validation when it was added only for inspection.
+- If `InterruptedByPausePoint: true`, Unity is paused and `Success: true` only means the command ended cleanly. Read `Message` first: it states whether the pointer event was already dispatched before the pause (only the overlay animation was interrupted) or the pause landed first (no pointer event was fired).
+- Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.
 
 ## Examples
 
@@ -133,6 +134,10 @@ Returns JSON with:
 - `PositionY`: Target Y coordinate that was used
 - `EndPositionX`: Drag end X coordinate (nullable float; populated for drag actions only)
 - `EndPositionY`: Drag end Y coordinate (nullable float; populated for drag actions only)
+- `InterruptedByPausePoint`: True when Unity paused during Pause Point inspection and the command returned early instead of running to completion. `Message` states whether the pointer event was already dispatched before the pause
+- `PausePointId`: The derived `<file>:<line>` pause point id that caused the interruption (nullable string; the `Id` returned by `enable-pause-point`)
+- `PausePointHitCount`: The hit count for that pause point when it caused the interruption (nullable integer)
+- `PausePointHits`: Every marker hit during this input as `{Id, HitCount}` entries, in hit order (nullable array). Read this when one input may trigger several markers; `PausePointId` only names the latest one
 
 Verify the visual outcome with a follow-up `uloop screenshot --capture-mode rendering --annotate-elements`.
 

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -11,7 +11,7 @@ Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-c
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
-This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, add a focused `Debug.Log` immediately before `UloopPausePoint.Pause("<id>")`, then run `get-logs --search-text <id>` while Unity is paused. Do not replace that log read with execute-dynamic-code.
+This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, enable a source pause point on that line instead (`uloop enable-pause-point --file <file> --line <line>`, see the `uloop-wait-for-pause-point` skill): the hit response's `CapturedVariables` already contains the locals, parameters, and instance fields at that line, with no code edit or recompile. Do not try to reconstruct those values with execute-dynamic-code.
 
 ## Workflow
 

--- a/.claude/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.claude/skills/uloop-simulate-keyboard/SKILL.md
@@ -45,7 +45,7 @@ If a successful `Press` or `KeyDown` leaves `Keyboard.current.<key>.isPressed` t
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Place markers after the app consumed the key, not immediately after `simulate-keyboard`.
+For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the key is safe: when the pause lands mid-command, `simulate-keyboard` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the key when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker. `PressEdgeObserved` is still reported on pause-point interruptions.
 
@@ -92,8 +92,8 @@ Returns JSON with:
 - `Action` (string): The `--action` value that was applied (`Press`, `KeyDown`, or `KeyUp`)
 - `KeyName` (string, nullable): The key that was acted on; may be `null` when the action could not resolve a key
 - `InterruptedByPausePoint` (boolean): True when Unity paused during Pause Point inspection and the input bookkeeping was safely released
-- `PausePointId` (string, nullable): The marker id when a `UloopPausePoint.Pause` marker caused the interruption
-- `PausePointHitCount` (integer, nullable): The marker hit count when a `UloopPausePoint.Pause` marker caused the interruption
+- `PausePointId` (string, nullable): The derived `<file>:<line>` pause point id that caused the interruption (the `Id` returned by `enable-pause-point`)
+- `PausePointHitCount` (integer, nullable): The hit count for that pause point when it caused the interruption
 - `PausePointHits` (array, nullable): Every marker hit during this input as `{Id, HitCount}` entries, in hit order. Read this when one input may trigger several markers; `PausePointId` only names the latest one
 - `PressEdgeObserved` (boolean, nullable): For `Press` and `KeyDown`, whether the press edge (`wasPressedThisFrame`) was actually visible inside a gameplay input update. `false` means the CLI succeeded but gameplay polling most likely missed the edge (e.g. the press was consumed by an editor-only input update) — retry the input or verify with a focused log instead of trusting `Success` alone. `null` only for `KeyUp` and for timed-out responses; pause-point interruptions still report the observed value
 

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -50,10 +50,10 @@ uloop simulate-mouse-input --action <action> [options]
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Place markers after the app consumed the mouse input, not immediately after `simulate-mouse-input`.
+For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the mouse input is safe: when the pause lands mid-command, `simulate-mouse-input` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the input when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker.
-- Remove temporary pause-point/log instrumentation before final validation when it was added only for inspection.
+- Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.
 
 ### Global Options (optional)
 
@@ -135,8 +135,8 @@ Returns JSON with:
 - `InjectedUnityPositionX` / `InjectedUnityPositionY`: Coordinates injected into `Mouse.current.position`
 - `CoordinateConversionFormula`: Conversion formula used by the tool
 - `InterruptedByPausePoint`: True when Unity paused during Pause Point inspection and the input bookkeeping was safely released
-- `PausePointId`: The id from `UloopPausePoint.Pause("<id>")` when it caused the interruption
-- `PausePointHitCount`: The hit count for that `UloopPausePoint.Pause("<id>")`
+- `PausePointId`: The derived `<file>:<line>` pause point id that caused the interruption (the `Id` returned by `enable-pause-point`)
+- `PausePointHitCount`: The hit count for that pause point when it caused the interruption
 - `PausePointHits` (array, nullable): Every marker hit during this input as `{Id, HitCount}` entries, in hit order. Read this when one input may trigger several markers; `PausePointId` only names the latest one
 
 Verify visual outcome with a follow-up screenshot.

--- a/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -76,9 +76,10 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 
 ## Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this UI input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Place markers after the app consumed the UI event, not immediately after `simulate-mouse-ui`.
+For standard frame proof when this UI input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the UI event is safe: when the pause lands mid-command, `simulate-mouse-ui` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the event when you want the settled result state rather than the input-handling moment.
 
-- Remove temporary pause-point/log instrumentation before final validation when it was added only for inspection.
+- If `InterruptedByPausePoint: true`, Unity is paused and `Success: true` only means the command ended cleanly. Read `Message` first: it states whether the pointer event was already dispatched before the pause (only the overlay animation was interrupted) or the pause landed first (no pointer event was fired).
+- Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.
 
 ## Examples
 
@@ -133,6 +134,10 @@ Returns JSON with:
 - `PositionY`: Target Y coordinate that was used
 - `EndPositionX`: Drag end X coordinate (nullable float; populated for drag actions only)
 - `EndPositionY`: Drag end Y coordinate (nullable float; populated for drag actions only)
+- `InterruptedByPausePoint`: True when Unity paused during Pause Point inspection and the command returned early instead of running to completion. `Message` states whether the pointer event was already dispatched before the pause
+- `PausePointId`: The derived `<file>:<line>` pause point id that caused the interruption (nullable string; the `Id` returned by `enable-pause-point`)
+- `PausePointHitCount`: The hit count for that pause point when it caused the interruption (nullable integer)
+- `PausePointHits`: Every marker hit during this input as `{Id, HitCount}` entries, in hit order (nullable array). Read this when one input may trigger several markers; `PausePointId` only names the latest one
 
 Verify the visual outcome with a follow-up `uloop screenshot --capture-mode rendering --annotate-elements`.
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -11,7 +11,7 @@ Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-c
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
-This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, add a focused `Debug.Log` immediately before `UloopPausePoint.Pause("<id>")`, then run `get-logs --search-text <id>` while Unity is paused. Do not replace that log read with execute-dynamic-code.
+This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, enable a source pause point on that line instead (`uloop enable-pause-point --file <file> --line <line>`, see the `uloop-wait-for-pause-point` skill): the hit response's `CapturedVariables` already contains the locals, parameters, and instance fields at that line, with no code edit or recompile. Do not try to reconstruct those values with execute-dynamic-code.
 
 ## Workflow
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
@@ -45,7 +45,7 @@ If a successful `Press` or `KeyDown` leaves `Keyboard.current.<key>.isPressed` t
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Place markers after the app consumed the key, not immediately after `simulate-keyboard`.
+For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the key is safe: when the pause lands mid-command, `simulate-keyboard` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the key when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker. `PressEdgeObserved` is still reported on pause-point interruptions.
 
@@ -92,8 +92,8 @@ Returns JSON with:
 - `Action` (string): The `--action` value that was applied (`Press`, `KeyDown`, or `KeyUp`)
 - `KeyName` (string, nullable): The key that was acted on; may be `null` when the action could not resolve a key
 - `InterruptedByPausePoint` (boolean): True when Unity paused during Pause Point inspection and the input bookkeeping was safely released
-- `PausePointId` (string, nullable): The marker id when a `UloopPausePoint.Pause` marker caused the interruption
-- `PausePointHitCount` (integer, nullable): The marker hit count when a `UloopPausePoint.Pause` marker caused the interruption
+- `PausePointId` (string, nullable): The derived `<file>:<line>` pause point id that caused the interruption (the `Id` returned by `enable-pause-point`)
+- `PausePointHitCount` (integer, nullable): The hit count for that pause point when it caused the interruption
 - `PausePointHits` (array, nullable): Every marker hit during this input as `{Id, HitCount}` entries, in hit order. Read this when one input may trigger several markers; `PausePointId` only names the latest one
 - `PressEdgeObserved` (boolean, nullable): For `Press` and `KeyDown`, whether the press edge (`wasPressedThisFrame`) was actually visible inside a gameplay input update. `false` means the CLI succeeded but gameplay polling most likely missed the edge (e.g. the press was consumed by an editor-only input update) — retry the input or verify with a focused log instead of trusting `Success` alone. `null` only for `KeyUp` and for timed-out responses; pause-point interruptions still report the observed value
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
@@ -50,10 +50,10 @@ uloop simulate-mouse-input --action <action> [options]
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Place markers after the app consumed the mouse input, not immediately after `simulate-mouse-input`.
+For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the mouse input is safe: when the pause lands mid-command, `simulate-mouse-input` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the input when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker.
-- Remove temporary pause-point/log instrumentation before final validation when it was added only for inspection.
+- Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.
 
 ### Global Options (optional)
 
@@ -135,8 +135,8 @@ Returns JSON with:
 - `InjectedUnityPositionX` / `InjectedUnityPositionY`: Coordinates injected into `Mouse.current.position`
 - `CoordinateConversionFormula`: Conversion formula used by the tool
 - `InterruptedByPausePoint`: True when Unity paused during Pause Point inspection and the input bookkeeping was safely released
-- `PausePointId`: The id from `UloopPausePoint.Pause("<id>")` when it caused the interruption
-- `PausePointHitCount`: The hit count for that `UloopPausePoint.Pause("<id>")`
+- `PausePointId`: The derived `<file>:<line>` pause point id that caused the interruption (the `Id` returned by `enable-pause-point`)
+- `PausePointHitCount`: The hit count for that pause point when it caused the interruption
 - `PausePointHits` (array, nullable): Every marker hit during this input as `{Id, HitCount}` entries, in hit order. Read this when one input may trigger several markers; `PausePointId` only names the latest one
 
 Verify visual outcome with a follow-up screenshot.

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
@@ -76,9 +76,10 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 
 ## Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this UI input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Place markers after the app consumed the UI event, not immediately after `simulate-mouse-ui`.
+For standard frame proof when this UI input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the UI event is safe: when the pause lands mid-command, `simulate-mouse-ui` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the event when you want the settled result state rather than the input-handling moment.
 
-- Remove temporary pause-point/log instrumentation before final validation when it was added only for inspection.
+- If `InterruptedByPausePoint: true`, Unity is paused and `Success: true` only means the command ended cleanly. Read `Message` first: it states whether the pointer event was already dispatched before the pause (only the overlay animation was interrupted) or the pause landed first (no pointer event was fired).
+- Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.
 
 ## Examples
 
@@ -133,6 +134,10 @@ Returns JSON with:
 - `PositionY`: Target Y coordinate that was used
 - `EndPositionX`: Drag end X coordinate (nullable float; populated for drag actions only)
 - `EndPositionY`: Drag end Y coordinate (nullable float; populated for drag actions only)
+- `InterruptedByPausePoint`: True when Unity paused during Pause Point inspection and the command returned early instead of running to completion. `Message` states whether the pointer event was already dispatched before the pause
+- `PausePointId`: The derived `<file>:<line>` pause point id that caused the interruption (nullable string; the `Id` returned by `enable-pause-point`)
+- `PausePointHitCount`: The hit count for that pause point when it caused the interruption (nullable integer)
+- `PausePointHits`: Every marker hit during this input as `{Id, HitCount}` entries, in hit order (nullable array). Read this when one input may trigger several markers; `PausePointId` only names the latest one
 
 Verify the visual outcome with a follow-up `uloop screenshot --capture-mode rendering --annotate-elements`.
 


### PR DESCRIPTION
## Summary

- Align four tool skills with the source pause point workflow (`enable-pause-point --file/--line` + `CapturedVariables`) shipped in #1684 / #1685
- Remove the last skill-level mentions of the emergency-only handwritten-marker API (`UloopPausePoint.Pause`), which must only be surfaced through patch-failure hints

## Changes

- **execute-dynamic-code**: the "add a Debug.Log before `UloopPausePoint.Pause()` and read it back via get-logs" workflow for method locals is replaced with enabling a source pause point and reading `CapturedVariables` from the hit response (no code edit or recompile)
- **simulate-keyboard / simulate-mouse-input**: `PausePointId` / `PausePointHitCount` output docs now describe the derived `<file>:<line>` id returned by `enable-pause-point` instead of `UloopPausePoint.Pause()`
- **simulate-mouse-ui**: documents the `InterruptedByPausePoint` / `PausePointId` / `PausePointHitCount` / `PausePointHits` response fields added in #1685 (keyboard and mouse-input already documented them) and the `Message` dispatch-state contract (whether the pointer event fired before the pause)
- All three input skills: "place markers ..., not immediately after `simulate-*`" is replaced with the Line Placement guidance that mid-command pauses are safe and return promptly; "remove temporary pause-point/log instrumentation" becomes "clear pause points"
- `.claude/` and `.agents/` copies regenerated via `uloop skills install --claude --agents`, byte-identical to sources

## Test plan

- [x] Regeneration: 4 updated / 15 skipped per location; `cmp` confirms all copies byte-identical to sources
- [x] `grep` confirms zero `UloopPausePoint` mentions remain across all skill sources
- [x] Body-only markdown edits — no C# or skill frontmatter changes (compile and skill layout tests unaffected)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

