### PR TITLE
fix(package): Clear active pause points before running tests

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -12,7 +12,7 @@ Before running tests, run `uloop compile` first if you created, deleted, renamed
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
-Active pause points are automatically cleared (including Harmony unpatching) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
+Active pause points are automatically cleared (the underlying code patches are removed as well) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
 
 `NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
 

--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -12,6 +12,8 @@ Before running tests, run `uloop compile` first if you created, deleted, renamed
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
+Active pause points are automatically cleared (including Harmony unpatching) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
+
 `NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
 
 ## Usage
@@ -70,6 +72,7 @@ Returns JSON with:
 - `FailedCount` (number): Failed tests
 - `SkippedCount` (number): Skipped tests
 - `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
+- `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 
 ### XML Result File
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -12,7 +12,7 @@ Before running tests, run `uloop compile` first if you created, deleted, renamed
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
-Active pause points are automatically cleared (including Harmony unpatching) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
+Active pause points are automatically cleared (the underlying code patches are removed as well) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
 
 `NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -12,6 +12,8 @@ Before running tests, run `uloop compile` first if you created, deleted, renamed
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
+Active pause points are automatically cleared (including Harmony unpatching) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
+
 `NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
 
 ## Usage
@@ -70,6 +72,7 @@ Returns JSON with:
 - `FailedCount` (number): Failed tests
 - `SkippedCount` (number): Skipped tests
 - `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
+- `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 
 ### XML Result File
 

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -379,6 +379,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.ClearedPausePointIds, Is.Null);
         }
 
+        [Test]
+        public async Task ExecuteAsync_WithUnsupportedFilterType_ShouldNotClearPausePoints()
+        {
+            // Verifies filter creation failure does not silently clear active pause points.
+            bool clearCalled = false;
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                clearActivePausePoints: () =>
+                {
+                    clearCalled = true;
+                    return new[] { "file.cs:10" };
+                },
+                waitForTestRunnerCleanupAsync: NoCleanupWait
+            );
+            RunTestsSchema parameters = new()
+            {
+                TestMode = UnityCliLoopTestMode.EditMode,
+                FilterType = (TestFilterType)999,
+                FilterValue = "value"
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(clearCalled, Is.False);
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.ClearedPausePointIds, Is.Null);
+        }
+
         private static Task NoCleanupWait(CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -23,7 +23,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                NoCleanupWait
+                waitForTestRunnerCleanupAsync: NoCleanupWait
             );
             RunTestsSchema parameters = new()
             {
@@ -58,7 +58,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                NoCleanupWait
+                waitForTestRunnerCleanupAsync: NoCleanupWait
             );
             RunTestsSchema parameters = new()
             {
@@ -83,7 +83,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                NoCleanupWait
+                waitForTestRunnerCleanupAsync: NoCleanupWait
             );
             RunTestsSchema parameters = new();
 
@@ -107,7 +107,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                NoCleanupWait
+                waitForTestRunnerCleanupAsync: NoCleanupWait
             );
             RunTestsSchema parameters = new()
             {
@@ -155,7 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                NoCleanupWait
+                waitForTestRunnerCleanupAsync: NoCleanupWait
             );
             RunTestsSchema parameters = new()
             {
@@ -186,7 +186,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                NoCleanupWait
+                waitForTestRunnerCleanupAsync: NoCleanupWait
             );
             RunTestsSchema parameters = new()
             {
@@ -214,7 +214,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                ct =>
+                waitForTestRunnerCleanupAsync: ct =>
                 {
                     ct.ThrowIfCancellationRequested();
                     cleanupWaitCount++;
@@ -241,7 +241,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                ct =>
+                waitForTestRunnerCleanupAsync: ct =>
                 {
                     ct.ThrowIfCancellationRequested();
                     cleanupWaitCount++;
@@ -270,7 +270,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new TestFilterCreationService(),
                 executionService,
                 validationService,
-                ct =>
+                waitForTestRunnerCleanupAsync: ct =>
                 {
                     ct.ThrowIfCancellationRequested();
                     cleanupWaitCount++;
@@ -283,6 +283,100 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(cleanupWaitCount, Is.EqualTo(0));
             Assert.That(executionService.WasCalled, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_AfterValidationPasses_ShouldClearActivePausePoints()
+        {
+            // Verifies pause points are cleared after validation succeeds but before test execution.
+            bool clearCalled = false;
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                clearActivePausePoints: () =>
+                {
+                    clearCalled = true;
+                    return new[] { "file.cs:10" };
+                },
+                waitForTestRunnerCleanupAsync: NoCleanupWait
+            );
+            RunTestsSchema parameters = new();
+
+            await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(clearCalled, Is.True);
+            Assert.That(executionService.WasCalled, Is.True);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenValidationFails_ShouldNotClearPausePoints()
+        {
+            // Verifies rejected calls produce zero side effects on pause point state.
+            bool clearCalled = false;
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(
+                ValidationResult.Failure("EditMode tests cannot run during play mode"));
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                clearActivePausePoints: () =>
+                {
+                    clearCalled = true;
+                    return new[] { "file.cs:10" };
+                },
+                waitForTestRunnerCleanupAsync: NoCleanupWait
+            );
+            RunTestsSchema parameters = new();
+
+            await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(clearCalled, Is.False);
+            Assert.That(executionService.WasCalled, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenPausePointsCleared_ShouldReportClearedIdsInResponse()
+        {
+            // Verifies cleared pause point IDs appear in the response for agent transparency.
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                clearActivePausePoints: () => new[] { "Assets/Scripts/Foo.cs:42", "my-custom-marker" },
+                waitForTestRunnerCleanupAsync: NoCleanupWait
+            );
+            RunTestsSchema parameters = new();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.ClearedPausePointIds, Is.Not.Null);
+            Assert.That(response.ClearedPausePointIds, Is.EqualTo(new[] { "Assets/Scripts/Foo.cs:42", "my-custom-marker" }));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenNoPausePointsActive_ShouldNotReportClearedIds()
+        {
+            // Verifies ClearedPausePointIds stays null when no markers were armed.
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                clearActivePausePoints: () => null,
+                waitForTestRunnerCleanupAsync: NoCleanupWait
+            );
+            RunTestsSchema parameters = new();
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.ClearedPausePointIds, Is.Null);
         }
 
         private static Task NoCleanupWait(CancellationToken ct)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
@@ -77,6 +78,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Path to XML result file (if saved)
         /// </summary>
         public string XmlPath { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string[] ClearedPausePointIds { get; set; }
 
         /// <summary>
         /// Create a new RunTestsResponse. Every field is required so classification decisions

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -79,6 +79,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public string XmlPath { get; set; }
 
+        /// <summary>
+        /// IDs of pause points that were cleared before test execution, or null when none were active
+        /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string[] ClearedPausePointIds { get; set; }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -18,6 +19,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly TestExecutionService _executionService;
         private readonly TestExecutionStateValidationService _validationService;
         private readonly RunTestsNoTestsDiagnosticService _noTestsDiagnosticService;
+        private readonly Func<string[]> _clearActivePausePoints;
         private readonly Func<CancellationToken, Task> _waitForTestRunnerCleanupAsync;
         private const int TestRunnerCleanupFallbackDelayMilliseconds = 3000;
 
@@ -33,6 +35,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             TestFilterCreationService filterService,
             TestExecutionService executionService,
             TestExecutionStateValidationService validationService,
+            Func<string[]> clearActivePausePoints = null,
             Func<CancellationToken, Task> waitForTestRunnerCleanupAsync = null)
         {
             Debug.Assert(filterService != null, "filterService must not be null");
@@ -42,6 +45,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _executionService = executionService;
             _validationService = validationService;
             _noTestsDiagnosticService = new RunTestsNoTestsDiagnosticService();
+            _clearActivePausePoints = clearActivePausePoints ?? ClearActivePausePointsDefault;
             _waitForTestRunnerCleanupAsync = waitForTestRunnerCleanupAsync ?? WaitForTestRunnerCleanupAsync;
         }
 
@@ -75,6 +79,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return CreateFailureResponse(validation.ErrorMessage);
             }
 
+            string[] clearedPausePointIds = _clearActivePausePoints();
+
             // 1. Test filter creation
             TestExecutionFilter filter = null;
             if (parameters.FilterType != TestFilterType.all)
@@ -88,10 +94,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             // 2. Test execution
-            // Why these awaits do not use ConfigureAwait(false): the entry preflight rejects
-            // paused PlayMode, so the only remaining path where a pause could hang these awaits
-            // is a pause point hitting mid-test. In that case the Test Runner itself stalls and
-            // the hang is not solvable at the tool layer (see issue #1686).
+            // Why these awaits do not use ConfigureAwait(false): the entry clears all active
+            // pause points and the server is single-flight (BUSY rejects concurrent commands),
+            // so no CLI-originated pause can fire during test execution. The only remaining
+            // pause source is a human manually pausing via the Editor UI, which is native
+            // Unity behavior and out of scope.
             ct.ThrowIfCancellationRequested();
             SerializableTestResult result;
             if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)
@@ -119,6 +126,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 hasFailures: result.hasFailures,
                 noTestsFound: result.noTestsFound,
                 noTestsFoundExplanation: result.noTestsFoundExplanation);
+            if (clearedPausePointIds != null && clearedPausePointIds.Length > 0)
+            {
+                response.ClearedPausePointIds = clearedPausePointIds;
+            }
             response.Message = RunTestsNoTestsDiagnosticService.AppendDiagnosticsOrOriginalMessage(
                 response.Message,
                 () => _noTestsDiagnosticService.AppendDiagnosticsIfNeeded(
@@ -149,6 +160,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 hasFailures: false,
                 noTestsFound: false,
                 noTestsFoundExplanation: string.Empty);
+        }
+
+        private static string[] ClearActivePausePointsDefault()
+        {
+            UloopPausePointClearAllResult result = UloopPausePointRegistry.ClearAll();
+            if (result.ClearedCount == 0)
+            {
+                return null;
+            }
+            return result.ClearedIds;
         }
 
         private static async Task WaitForTestRunnerCleanupAsync(CancellationToken ct)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -79,8 +79,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return CreateFailureResponse(validation.ErrorMessage);
             }
 
-            string[] clearedPausePointIds = _clearActivePausePoints();
-
             // 1. Test filter creation
             TestExecutionFilter filter = null;
             if (parameters.FilterType != TestFilterType.all)
@@ -92,6 +90,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
                 filter = createdFilter;
             }
+
+            string[] clearedPausePointIds = _clearActivePausePoints();
 
             // 2. Test execution
             // Why these awaits do not use ConfigureAwait(false): the entry clears all active

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -12,7 +12,7 @@ Before running tests, run `uloop compile` first if you created, deleted, renamed
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
-Active pause points are automatically cleared (including Harmony unpatching) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
+Active pause points are automatically cleared (the underlying code patches are removed as well) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
 
 `NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -12,6 +12,8 @@ Before running tests, run `uloop compile` first if you created, deleted, renamed
 
 Before executing tests, `uloop run-tests` saves unsaved loaded Scene changes and unsaved current Prefab Stage changes by default. If saving fails, it returns `Success: false`, keeps `TestCount` at `0`, lists the unsaved items in `Message`, and does not start the Unity Test Runner.
 
+Active pause points are automatically cleared (including Harmony unpatching) before test execution begins. Cleared IDs are reported in the response's `ClearedPausePointIds` field.
+
 `NoTestsFound` means zero tests matched — not a test failure. Check `NoTestsFoundExplanation` and `Message` for asmdef hints.
 
 ## Usage
@@ -70,6 +72,7 @@ Returns JSON with:
 - `FailedCount` (number): Failed tests
 - `SkippedCount` (number): Skipped tests
 - `XmlPath` (string): Path to NUnit XML result file. Empty string when no XML was saved (typically on `Success: true`); populated only when tests failed and the XML file exists on disk.
+- `ClearedPausePointIds` (string[], optional): IDs of pause points that were cleared before test execution. Omitted from JSON when no pause points were active.
 
 ### XML Result File
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/UnityCLILoop.FirstPartyTools.RunTests.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/UnityCLILoop.FirstPartyTools.RunTests.Editor.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
         "GUID:d427b32aad9cb44fc8e962437c9dbcd8",
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
+++ b/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.PausePoint.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.RunTests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor")]

--- a/Packages/src/Runtime/PausePoints/UloopPausePointClearAllResult.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointClearAllResult.cs
@@ -12,18 +12,22 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public UloopPausePointClearAllResult(
             int clearedCount,
             DateTime clearedAtUtc,
-            UloopPausePointEditorStateSnapshot editorState)
+            UloopPausePointEditorStateSnapshot editorState,
+            string[] clearedIds)
         {
             Debug.Assert(editorState != null, "editorState must not be null");
+            Debug.Assert(clearedIds != null, "clearedIds must not be null");
 
             ClearedCount = clearedCount;
             ClearedAtUtc = clearedAtUtc;
             EditorState = editorState;
+            ClearedIds = clearedIds;
         }
 
         public int ClearedCount { get; }
         public DateTime ClearedAtUtc { get; }
         public UloopPausePointEditorStateSnapshot EditorState { get; }
+        public string[] ClearedIds { get; }
     }
 }
 #endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -80,7 +80,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             OnClearedAll?.Invoke();
 
             DateTime now = NowUtc();
-            int clearedCount = 0;
+            List<string> clearedIds = new();
             foreach (UloopPausePointEntry entry in Entries.Values)
             {
                 if (entry.Status == UloopPausePointStatus.Cleared)
@@ -88,15 +88,15 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                     continue;
                 }
 
+                clearedIds.Add(entry.Id);
                 entry.MarkCleared();
-                clearedCount++;
             }
             ClearLatestHitSnapshot();
 
             UloopPausePointEditorStateSnapshot editorState = UloopPausePointEditorStateSnapshot.FromController(
                 _pauseController,
                 UloopPausePointEditorStateCapturedAt.ClearAll);
-            return new UloopPausePointClearAllResult(clearedCount, now, editorState);
+            return new UloopPausePointClearAllResult(clearedIds.Count, now, editorState, clearedIds.ToArray());
         }
 
         public static UloopPausePointSnapshot GetStatus(string id)


### PR DESCRIPTION
## Summary

- Clear all active pause points (including underlying code patches) after
  validation and filter creation pass, but before test execution begins.
  This structurally eliminates the mid-test pause point hang described in #1687.
- Cleared pause point IDs are reported in an optional `ClearedPausePointIds`
  response field (`NullValueHandling.Ignore` — additive, no protocol bump).
- The clear uses the same `UloopPausePointRegistry.ClearAll()` path as
  `clear-pause-point --all`, so Harmony unpatching is included without
  code duplication.
- The IPC server is single-flight (`UNITY_SERVER_BUSY` rejects concurrent
  commands), making mid-run re-arming impossible via CLI.

## Design decisions

- **Clear placement**: after validation + filter creation, before test
  execution. Rejected calls (bad test mode, missing framework, invalid
  filter) produce zero side effects on pause point state.
- **Constructor injection seam**: `Func<string[]>` for testable clearing
  without a real registry.
- **`UloopPausePointClearAllResult.ClearedIds`**: collects entry IDs so
  callers can report which markers were removed.

## Test plan

- [x] 14/14 RunTestsUseCaseTests green (5 new tests for pause point clearing)
- [x] Compile: 0 errors, 0 warnings
- [x] Live verification: arm pause point → run-tests → response contains
  `ClearedPausePointIds` → `pause-point-status` shows `Cleared`

Closes #1689

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

