### PR TITLE
fix: Release PRs are generated again after asset requirements grow

### DIFF
--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -299,10 +299,29 @@ create_package_release() {
   esac
 }
 
+# Required asset lists grow over time, and a published release only ships the
+# assets its own generation required. Reading the list from HEAD would demand
+# assets an older release (for example the pinned dispatcher floor) never had,
+# deadlocking the sync forever. A release without a local tag is being cut from
+# HEAD right now, so HEAD's list is correct for it.
+release_asset_requirements() {
+  verify_script_path=$1
+  release_tag=$2
+  tag_script_file="$TMP_DIR/$release_tag-$(basename "$verify_script_path")"
+
+  if git show "refs/tags/$release_tag:$verify_script_path" > "$tag_script_file" 2>/dev/null; then
+    sh "$tag_script_file" --list
+    return
+  fi
+
+  "$ROOT_DIR/$verify_script_path" --list
+}
+
 release_has_all_cli_assets() {
   release_data=$1
+  release_tag=$2
 
-  asset_names=$("${ROOT_DIR}/scripts/verify-native-cli-release-assets.sh" --list) || return 1
+  asset_names=$(release_asset_requirements "scripts/verify-native-cli-release-assets.sh" "$release_tag") || return 1
   for asset_name in $asset_names; do
     asset_count=$(printf '%s\n' "$release_data" | jq --arg name "$asset_name" '[.assets[]? | select(.name == $name and .size > 0)] | length' | strip_carriage_returns)
     if [ "$asset_count" -eq 0 ]; then
@@ -313,8 +332,9 @@ release_has_all_cli_assets() {
 
 release_has_all_dispatcher_assets() {
   release_data=$1
+  release_tag=$2
 
-  asset_names=$("${ROOT_DIR}/scripts/verify-dispatcher-release-assets.sh" --list) || return 1
+  asset_names=$(release_asset_requirements "scripts/verify-dispatcher-release-assets.sh" "$release_tag") || return 1
   for asset_name in $asset_names; do
     asset_count=$(printf '%s\n' "$release_data" | jq --arg name "$asset_name" '[.assets[]? | select(.name == $name and .size > 0)] | length' | strip_carriage_returns)
     if [ "$asset_count" -eq 0 ]; then
@@ -338,7 +358,7 @@ cli_release_is_ready() {
         return 1
       fi
 
-      release_has_all_cli_assets "$release_data"
+      release_has_all_cli_assets "$release_data" "$release_tag"
       ;;
     1)
       return 1
@@ -364,7 +384,7 @@ dispatcher_release_is_ready() {
         return 1
       fi
 
-      release_has_all_dispatcher_assets "$release_data"
+      release_has_all_dispatcher_assets "$release_data" "$release_tag"
       ;;
     1)
       return 1

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -42,6 +42,9 @@ dispatcher_asset_json() {
     complete)
       printf '[{"name":"install.sh","size":1},{"name":"install.sh.sha256","size":1},{"name":"install.ps1","size":1},{"name":"install.ps1.sha256","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-windows-amd64.zip","size":1},{"name":"uloop-dispatcher-windows-amd64.zip.sha256","size":1}]'
       ;;
+    legacy)
+      printf '[{"name":"install.sh","size":1},{"name":"install.ps1","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz","size":1},{"name":"uloop-dispatcher-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-dispatcher-windows-amd64.zip","size":1},{"name":"uloop-dispatcher-windows-amd64.zip.sha256","size":1}]'
+      ;;
     missing)
       printf '[]'
       ;;
@@ -564,6 +567,85 @@ test_waits_when_dispatcher_asset_list_fails() {
   assert_contains "$work_dir/github-output.txt" "ready=false"
 }
 
+# Verifies dispatcher floor readiness checks assets against the floor release's own tag generation, not HEAD's grown list.
+test_dispatcher_release_ready_uses_tag_generation_asset_list() {
+  work_dir=$(create_release_repo dispatcher-tag-generation-assets)
+
+  (
+    cd "$work_dir"
+    cat > scripts/verify-dispatcher-release-assets.sh <<'EOF_VERIFY_DISPATCHER_LEGACY'
+#!/bin/sh
+set -eu
+
+if [ "${1:-}" = "--list" ]; then
+  printf '%s\n' \
+    install.sh \
+    install.ps1 \
+    uloop-dispatcher-darwin-amd64.tar.gz \
+    uloop-dispatcher-darwin-amd64.tar.gz.sha256 \
+    uloop-dispatcher-darwin-arm64.tar.gz \
+    uloop-dispatcher-darwin-arm64.tar.gz.sha256 \
+    uloop-dispatcher-windows-amd64.zip \
+    uloop-dispatcher-windows-amd64.zip.sha256
+  exit 0
+fi
+
+exit 1
+EOF_VERIFY_DISPATCHER_LEGACY
+    git add scripts/verify-dispatcher-release-assets.sh
+    git commit -q -m "fix: dispatcher floor generation asset requirements"
+    git tag dispatcher-v3.0.0
+
+    write_release_files 3.0.0-beta.6
+    git add .
+    git commit -q -m "fix: require installer checksums"
+  )
+
+  run_sync "$work_dir" "" false "" published complete 0 0 "" published legacy
+
+  assert_not_contains "$work_dir/output.txt" "Dispatcher release dispatcher-v3.0.0 is not published with complete assets"
+  assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
+  assert_contains "$work_dir/github-output.txt" "ready=true"
+  assert_not_contains "$work_dir/github-output.txt" "ready=false"
+}
+
+# Verifies Project runner readiness checks assets against the runner release's own tag generation, not HEAD's grown list.
+test_cli_release_ready_uses_tag_generation_asset_list() {
+  work_dir=$(create_release_repo cli-tag-generation-assets)
+
+  (
+    cd "$work_dir"
+    cat > scripts/verify-native-cli-release-assets.sh <<'EOF_VERIFY_GROWN'
+#!/bin/sh
+set -eu
+
+if [ "${1:-}" = "--list" ]; then
+  printf '%s\n' \
+    uloop-project-runner-darwin-amd64.tar.gz \
+    uloop-project-runner-darwin-amd64.tar.gz.sha256 \
+    uloop-project-runner-darwin-arm64.tar.gz \
+    uloop-project-runner-darwin-arm64.tar.gz.sha256 \
+    uloop-project-runner-windows-amd64.zip \
+    uloop-project-runner-windows-amd64.zip.sha256 \
+    uloop-project-runner-linux-amd64.tar.gz \
+    uloop-project-runner-linux-amd64.tar.gz.sha256
+  exit 0
+fi
+
+exit 1
+EOF_VERIFY_GROWN
+    git add scripts/verify-native-cli-release-assets.sh
+    git commit -q -m "fix: require linux runner assets"
+  )
+
+  run_sync "$work_dir" "" false ""
+
+  assert_not_contains "$work_dir/output.txt" "Project runner release uloop-project-runner-v3.0.0-beta.6 is not published with complete assets"
+  assert_contains "$work_dir/gh.log" "release create v3.0.0-beta.6 --repo hatayama/unity-cli-loop --title v3.0.0-beta.6 --notes-file"
+  assert_contains "$work_dir/github-output.txt" "ready=true"
+  assert_not_contains "$work_dir/github-output.txt" "ready=false"
+}
+
 # Verifies the release sync waits for a concurrently publishing Project runner release before creating package releases.
 test_retries_until_cli_assets_are_ready() {
   work_dir=$(create_release_repo retries-until-cli-ready)
@@ -637,6 +719,8 @@ test_waits_for_cli_release_before_creating_root_release
 test_waits_for_cli_assets_before_creating_root_release
 test_waits_for_dispatcher_assets_before_creating_root_release
 test_waits_when_dispatcher_asset_list_fails
+test_dispatcher_release_ready_uses_tag_generation_asset_list
+test_cli_release_ready_uses_tag_generation_asset_list
 test_retries_until_cli_assets_are_ready
 test_key_rename_commit_is_not_treated_as_release_commit
 test_changelog_move_commit_is_not_treated_as_release_commit


### PR DESCRIPTION
## Summary
- The v3-beta release pipeline silently stopped generating release PRs on 2026-07-04; this restores it.

## User Impact
- Before: every push to v3-beta ran the release workflow, but the package release sync waited 10 minutes for installer checksum assets that `dispatcher-v3.0.1-beta.6` (the pinned dispatcher floor, published 2026-06-29) never shipped, reported `ready=false`, and release-please was skipped without any failure signal. No release PR could ever appear, so a week of fixes accumulated unreleased.
- After: the sync accepts already-published releases that are complete by the standards of their own generation, so release PRs are generated again. Future growth of the required asset list can no longer deadlock releases against older pinned releases.

## Changes
- `scripts/sync-release-please-package-releases.sh`: readiness checks now read the required asset list from the checked release's own tag (`git show refs/tags/<tag>:scripts/verify-*.sh`), falling back to HEAD's list only when the tag does not exist yet (a release about to be cut from HEAD). Applied to both the dispatcher floor gate and the project runner gate, which share the same retroactive-application bug.
- `scripts/test-sync-release-please-package-releases.sh`: two regression tests reproducing the deadlock (dispatcher floor with a legacy asset set, project runner release predating a grown requirement list).

## Verification
- `sh scripts/test-sync-release-please-package-releases.sh` (all 16 tests pass; the two new tests fail on the previous implementation)
- Desk-checked against production data: `dispatcher-v3.0.1-beta.6` and `uloop-project-runner-v3.0.0-beta.46` both satisfy their own tag-generation asset lists, so the sync will report `ready=true` after merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

