### PR TITLE
fix: Dispatcher heading in release notes now shows its component name

### DIFF
--- a/cli/release-automation/internal/automation/release_pr_body.go
+++ b/cli/release-automation/internal/automation/release_pr_body.go
@@ -86,6 +86,8 @@ func releasePRCheckComponentDisplayName(component string) (string, bool) {
 	switch component {
 	case "unity-package":
 		return "Unity Package", true
+	case "dispatcher":
+		return "Dispatcher", true
 	case "uloop-project-runner":
 		return "uloop Project Runner", true
 	default:

--- a/cli/release-automation/internal/automation/release_pr_checks_test.go
+++ b/cli/release-automation/internal/automation/release_pr_checks_test.go
@@ -64,6 +64,9 @@ func TestReleasePRCheckComponentHeadingsAreClarified(t *testing.T) {
 	body := "<details><summary>unity-package: 3.0.0-beta.48</summary>\n\n" +
 		"## [3.0.0-beta.48](https://example.test/compare/v3.0.0-beta.47...v3.0.0-beta.48) (2026-07-01)\n" +
 		"</details>\n" +
+		"<details><summary>dispatcher: 3.0.1-beta.13</summary>\n\n" +
+		"## [3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)\n" +
+		"</details>\n" +
 		"<details><summary>uloop-project-runner: 3.0.0-beta.45</summary>\n\n" +
 		"## [3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)\n" +
 		"</details>\n"
@@ -74,6 +77,7 @@ func TestReleasePRCheckComponentHeadingsAreClarified(t *testing.T) {
 		t.Fatal("expected component release headings to change")
 	}
 	assertReleasePRCheckLogContains(t, clarifiedBody, "## [Unity Package 3.0.0-beta.48](https://example.test/compare/v3.0.0-beta.47...v3.0.0-beta.48) (2026-07-01)")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "## [Dispatcher 3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)")
 	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop Project Runner 3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)")
 }
 


### PR DESCRIPTION
## Summary
- The dispatcher section of release PR bodies now gets a labeled changelog heading like the other components.

## User Impact
- Before: in release PRs, the Unity package and project runner sections showed headings like `Unity Package 3.0.0-beta.49` / `uloop Project Runner 3.0.0-beta.47`, but the dispatcher section showed only a bare `3.0.1-beta.13` with no component name (visible in #1693).
- After: the dispatcher heading reads `Dispatcher 3.0.1-beta.13`, consistent with the other components.

## Changes
- Add the missing `dispatcher` entry to the release PR body clarifier's component display-name map.
- Extend the heading-clarification test with a dispatcher section.

## Verification
- `go test ./internal/automation/` in `cli/release-automation` (the new assertion fails without the fix)
- `scripts/check-go-cli.sh` passes (fmt, vet, lint, tests, builds)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

