### PR TITLE
fix: Dispatcher release heading now carries the uloop prefix like the project runner

### DIFF
--- a/cli/release-automation/internal/automation/release_pr_body.go
+++ b/cli/release-automation/internal/automation/release_pr_body.go
@@ -87,7 +87,7 @@ func releasePRCheckComponentDisplayName(component string) (string, bool) {
 	case "unity-package":
 		return "Unity Package", true
 	case "dispatcher":
-		return "Dispatcher", true
+		return "uloop Dispatcher", true
 	case "uloop-project-runner":
 		return "uloop Project Runner", true
 	default:

--- a/cli/release-automation/internal/automation/release_pr_checks_test.go
+++ b/cli/release-automation/internal/automation/release_pr_checks_test.go
@@ -77,7 +77,7 @@ func TestReleasePRCheckComponentHeadingsAreClarified(t *testing.T) {
 		t.Fatal("expected component release headings to change")
 	}
 	assertReleasePRCheckLogContains(t, clarifiedBody, "## [Unity Package 3.0.0-beta.48](https://example.test/compare/v3.0.0-beta.47...v3.0.0-beta.48) (2026-07-01)")
-	assertReleasePRCheckLogContains(t, clarifiedBody, "## [Dispatcher 3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop Dispatcher 3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)")
 	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop Project Runner 3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)")
 }
 


### PR DESCRIPTION
## Summary
- Release PR headings for the two native binaries now share the same naming style.

## User Impact
- Before: the project runner section was headed `uloop Project Runner 3.0.0-beta.47` while the dispatcher section was headed just `Dispatcher 3.0.1-beta.13`.
- After: the dispatcher heading reads `uloop Dispatcher 3.0.1-beta.13`, matching the project runner style.

## Changes
- Update the dispatcher entry in the release PR body clarifier's display-name map from `Dispatcher` to `uloop Dispatcher`, and adjust the heading test expectation.

## Verification
- `go test ./internal/automation/` in `cli/release-automation` (expectation updated first and confirmed failing, then green)
- `scripts/check-go-cli.sh` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

