### PR TITLE
fix: Dispatcher release summary now carries the uloop prefix

### DIFF
--- a/cli/release-automation/internal/automation/release_pr_body.go
+++ b/cli/release-automation/internal/automation/release_pr_body.go
@@ -67,26 +67,47 @@ func clarifyReleasePRCheckComponentHeadingBlock(block string) (string, bool) {
 		return block, false
 	}
 
-	displayName, found := releasePRCheckComponentDisplayName(matches[1])
-	if !found {
-		return block, false
+	component := matches[1]
+	version := matches[2]
+	changed := false
+
+	if summarySlug, found := releasePRCheckComponentSummarySlug(component); found {
+		clarifiedSummary := "<details><summary>" + summarySlug + ": " + version + "</summary>"
+		block = strings.Replace(block, matches[0], clarifiedSummary, 1)
+		changed = true
 	}
 
-	version := matches[2]
+	displayName, found := releasePRCheckComponentDisplayName(component)
+	if !found {
+		return block, changed
+	}
+
 	heading := "## [" + version + "]("
 	if !strings.Contains(block, heading) {
-		return block, false
+		return block, changed
 	}
 
 	clarifiedHeading := "## [" + displayName + " " + version + "]("
 	return strings.Replace(block, heading, clarifiedHeading, 1), true
 }
 
+// releasePRCheckComponentSummarySlug renames component summary labels whose
+// release-please component id lacks the uloop prefix. The release tag keeps
+// the bare component id, so consumers that resolve tags from summaries must
+// also accept the renamed slug (see release_tag_from_body in
+// scripts/sync-published-release-pr-labels.sh).
+func releasePRCheckComponentSummarySlug(component string) (string, bool) {
+	if component == "dispatcher" {
+		return "uloop-dispatcher", true
+	}
+	return "", false
+}
+
 func releasePRCheckComponentDisplayName(component string) (string, bool) {
 	switch component {
 	case "unity-package":
 		return "Unity Package", true
-	case "dispatcher":
+	case "dispatcher", "uloop-dispatcher":
 		return "uloop Dispatcher", true
 	case "uloop-project-runner":
 		return "uloop Project Runner", true

--- a/cli/release-automation/internal/automation/release_pr_checks_test.go
+++ b/cli/release-automation/internal/automation/release_pr_checks_test.go
@@ -79,6 +79,25 @@ func TestReleasePRCheckComponentHeadingsAreClarified(t *testing.T) {
 	assertReleasePRCheckLogContains(t, clarifiedBody, "## [Unity Package 3.0.0-beta.48](https://example.test/compare/v3.0.0-beta.47...v3.0.0-beta.48) (2026-07-01)")
 	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop Dispatcher 3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)")
 	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop Project Runner 3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "<details><summary>uloop-dispatcher: 3.0.1-beta.13</summary>")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "<details><summary>unity-package: 3.0.0-beta.48</summary>")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "<details><summary>uloop-project-runner: 3.0.0-beta.45</summary>")
+}
+
+// Verifies an already clarified dispatcher block stays unchanged on a second clarification pass.
+func TestReleasePRCheckClarifiedDispatcherBlockIsStable(t *testing.T) {
+	body := "<details><summary>uloop-dispatcher: 3.0.1-beta.13</summary>\n\n" +
+		"## [uloop Dispatcher 3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)\n" +
+		"</details>\n"
+
+	clarifiedBody, changed := clarifyReleasePRCheckComponentLabels(body)
+
+	if changed {
+		t.Fatal("expected clarified dispatcher block to stay unchanged")
+	}
+	if clarifiedBody != body {
+		t.Fatalf("expected body to stay unchanged, got:\n%s", clarifiedBody)
+	}
 }
 
 // Verifies that missing release PRs skip without dispatching checks.

--- a/scripts/sync-published-release-pr-labels.sh
+++ b/scripts/sync-published-release-pr-labels.sh
@@ -24,7 +24,7 @@ release_tag_from_body() {
         "v" + $version
       elif $component == "uloop-project-runner" then
         "uloop-project-runner-v" + $version
-      elif $component == "dispatcher" then
+      elif $component == "dispatcher" or $component == "uloop-dispatcher" then
         "dispatcher-v" + $version
       else
         ""

--- a/scripts/test-sync-published-release-pr-labels.sh
+++ b/scripts/test-sync-published-release-pr-labels.sh
@@ -175,6 +175,17 @@ test_marks_dispatcher_component_summary_release_pr_from_body() {
   assert_contains "$TMP_DIR/dispatcher-component-summary/output.txt" "Marked release PR #1470 as tagged for dispatcher-v3.0.1-beta.12."
 }
 
+# Verifies uloop-prefixed dispatcher summaries written by the release PR clarifier still resolve the dispatcher release tag.
+test_marks_uloop_dispatcher_component_summary_release_pr_from_body() {
+  run_case uloop-dispatcher-component-summary \
+    '[{"number":1696,"title":"chore: release v3-beta","body":"<details><summary>uloop-dispatcher: 3.0.1-beta.13</summary></details>","mergeCommit":{"oid":"abc123"}}]' \
+    '{"dispatcher-v3.0.1-beta.13":{"isDraft":false,"targetCommitish":"abc123"}}'
+
+  assert_file_equals "$TMP_DIR/uloop-dispatcher-component-summary/status.txt" "0"
+  assert_contains "$TMP_DIR/uloop-dispatcher-component-summary/gh.log" "release view dispatcher-v3.0.1-beta.13 --repo hatayama/unity-cli-loop --json isDraft,targetCommitish"
+  assert_contains "$TMP_DIR/uloop-dispatcher-component-summary/output.txt" "Marked release PR #1696 as tagged for dispatcher-v3.0.1-beta.13."
+}
+
 # Verifies component summaries take precedence over legacy numeric release titles.
 test_marks_project_runner_component_summary_release_pr_before_numeric_title() {
   run_case project-runner-component-before-title \
@@ -234,6 +245,7 @@ test_marks_stale_pending_release_pr
 test_marks_branch_title_release_pr_from_body
 test_marks_component_summary_release_pr_from_body
 test_marks_dispatcher_component_summary_release_pr_from_body
+test_marks_uloop_dispatcher_component_summary_release_pr_from_body
 test_marks_project_runner_component_summary_release_pr_from_body
 test_marks_project_runner_component_summary_release_pr_before_numeric_title
 test_keeps_draft_release_pending


### PR DESCRIPTION
## Summary
- The collapsible release sections now name the dispatcher consistently with the project runner.

## User Impact
- Before: release PR collapsible rows read `unity-package: ...`, `dispatcher: ...`, `uloop-project-runner: ...` — the dispatcher was the only native binary without the uloop prefix (visible in #1693).
- After: the dispatcher row reads `uloop-dispatcher: <version>`, matching the project runner naming.

## Changes
- The release PR body clarifier renames the dispatcher summary to `uloop-dispatcher: <version>` (display only; the release-please component id and the `dispatcher-v*` tag format stay untouched).
- `scripts/sync-published-release-pr-labels.sh` resolves release tags from these summaries, so it now also accepts the `uloop-dispatcher` slug and maps it to the `dispatcher-v` tag.
- Heading clarification keeps working on a renamed summary, and a second clarification pass leaves the block unchanged (covered by a new stability test).

## Verification
- `go test ./internal/automation/` in `cli/release-automation` (new assertions fail without the fix)
- `sh scripts/test-sync-published-release-pr-labels.sh` (new uloop-dispatcher tag-resolution case fails without the fix)
- `scripts/check-go-cli.sh` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

