### PR TITLE
fix: Release note headings now match the collapsible summary labels

### DIFF
--- a/cli/release-automation/internal/automation/release_pr_body.go
+++ b/cli/release-automation/internal/automation/release_pr_body.go
@@ -69,17 +69,16 @@ func clarifyReleasePRCheckComponentHeadingBlock(block string) (string, bool) {
 
 	component := matches[1]
 	version := matches[2]
-	changed := false
-
-	if summarySlug, found := releasePRCheckComponentSummarySlug(component); found {
-		clarifiedSummary := "<details><summary>" + summarySlug + ": " + version + "</summary>"
-		block = strings.Replace(block, matches[0], clarifiedSummary, 1)
-		changed = true
+	displaySlug, found := releasePRCheckComponentDisplaySlug(component)
+	if !found {
+		return block, false
 	}
 
-	displayName, found := releasePRCheckComponentDisplayName(component)
-	if !found {
-		return block, changed
+	changed := false
+	if displaySlug != component {
+		clarifiedSummary := "<details><summary>" + displaySlug + ": " + version + "</summary>"
+		block = strings.Replace(block, matches[0], clarifiedSummary, 1)
+		changed = true
 	}
 
 	heading := "## [" + version + "]("
@@ -87,30 +86,22 @@ func clarifyReleasePRCheckComponentHeadingBlock(block string) (string, bool) {
 		return block, changed
 	}
 
-	clarifiedHeading := "## [" + displayName + " " + version + "]("
+	clarifiedHeading := "## [" + displaySlug + ": " + version + "]("
 	return strings.Replace(block, heading, clarifiedHeading, 1), true
 }
 
-// releasePRCheckComponentSummarySlug renames component summary labels whose
-// release-please component id lacks the uloop prefix. The release tag keeps
-// the bare component id, so consumers that resolve tags from summaries must
-// also accept the renamed slug (see release_tag_from_body in
+// releasePRCheckComponentDisplaySlug labels both the collapsible summary and
+// the changelog heading of a component block with the same slug. The
+// dispatcher slug gains the uloop prefix for display, while its release tag
+// keeps the bare component id, so consumers that resolve tags from summaries
+// must also accept the renamed slug (see release_tag_from_body in
 // scripts/sync-published-release-pr-labels.sh).
-func releasePRCheckComponentSummarySlug(component string) (string, bool) {
-	if component == "dispatcher" {
-		return "uloop-dispatcher", true
-	}
-	return "", false
-}
-
-func releasePRCheckComponentDisplayName(component string) (string, bool) {
+func releasePRCheckComponentDisplaySlug(component string) (string, bool) {
 	switch component {
-	case "unity-package":
-		return "Unity Package", true
+	case "unity-package", "uloop-project-runner":
+		return component, true
 	case "dispatcher", "uloop-dispatcher":
-		return "uloop Dispatcher", true
-	case "uloop-project-runner":
-		return "uloop Project Runner", true
+		return "uloop-dispatcher", true
 	default:
 		return "", false
 	}

--- a/cli/release-automation/internal/automation/release_pr_checks_test.go
+++ b/cli/release-automation/internal/automation/release_pr_checks_test.go
@@ -76,9 +76,9 @@ func TestReleasePRCheckComponentHeadingsAreClarified(t *testing.T) {
 	if !changed {
 		t.Fatal("expected component release headings to change")
 	}
-	assertReleasePRCheckLogContains(t, clarifiedBody, "## [Unity Package 3.0.0-beta.48](https://example.test/compare/v3.0.0-beta.47...v3.0.0-beta.48) (2026-07-01)")
-	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop Dispatcher 3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)")
-	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop Project Runner 3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "## [unity-package: 3.0.0-beta.48](https://example.test/compare/v3.0.0-beta.47...v3.0.0-beta.48) (2026-07-01)")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop-dispatcher: 3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)")
+	assertReleasePRCheckLogContains(t, clarifiedBody, "## [uloop-project-runner: 3.0.0-beta.45](https://example.test/compare/uloop-project-runner-v3.0.0-beta.44...uloop-project-runner-v3.0.0-beta.45) (2026-07-01)")
 	assertReleasePRCheckLogContains(t, clarifiedBody, "<details><summary>uloop-dispatcher: 3.0.1-beta.13</summary>")
 	assertReleasePRCheckLogContains(t, clarifiedBody, "<details><summary>unity-package: 3.0.0-beta.48</summary>")
 	assertReleasePRCheckLogContains(t, clarifiedBody, "<details><summary>uloop-project-runner: 3.0.0-beta.45</summary>")
@@ -87,7 +87,7 @@ func TestReleasePRCheckComponentHeadingsAreClarified(t *testing.T) {
 // Verifies an already clarified dispatcher block stays unchanged on a second clarification pass.
 func TestReleasePRCheckClarifiedDispatcherBlockIsStable(t *testing.T) {
 	body := "<details><summary>uloop-dispatcher: 3.0.1-beta.13</summary>\n\n" +
-		"## [uloop Dispatcher 3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)\n" +
+		"## [uloop-dispatcher: 3.0.1-beta.13](https://example.test/compare/dispatcher-v3.0.1-beta.12...dispatcher-v3.0.1-beta.13) (2026-07-11)\n" +
 		"</details>\n"
 
 	clarifiedBody, changed := clarifyReleasePRCheckComponentLabels(body)


### PR DESCRIPTION
## Summary
- Inside each collapsible release section, the top changelog heading now uses the exact same label as the summary row.

## User Impact
- Before: the summary row and the heading inside it named the same component in two styles, e.g. `uloop-project-runner: 3.0.0-beta.47` wrapping `uloop Project Runner 3.0.0-beta.47` (and likewise for `unity-package` / `uloop-dispatcher`).
- After: all three components read identically in both places, e.g. `uloop-project-runner: 3.0.0-beta.47` wrapping `## uloop-project-runner: 3.0.0-beta.47`.

## Changes
- The release PR body clarifier now stamps one display slug on both the summary and the heading, replacing the separate human-readable display-name map.
- No change to release-please component ids, tags, or the label-sync tag resolution (summary slugs are unchanged from #1696).

## Verification
- `go test ./internal/automation/` in `cli/release-automation` (updated expectations fail without the fix)
- `sh scripts/test-sync-published-release-pr-labels.sh` passes unchanged
- `scripts/check-go-cli.sh` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

