### PR TITLE
feat: Pause point wait command is now await-pause-point

### DIFF
--- a/.agents/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.agents/skills/uloop-execute-dynamic-code/SKILL.md
@@ -11,7 +11,7 @@ Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-c
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
-This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, enable a source pause point on that line instead (`uloop enable-pause-point --file <file> --line <line>`, see the `uloop-wait-for-pause-point` skill): the hit response's `CapturedVariables` already contains the locals, parameters, and instance fields at that line, with no code edit or recompile. Do not try to reconstruct those values with execute-dynamic-code.
+This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, enable a source pause point on that line instead (`uloop enable-pause-point --file <file> --line <line>`, see the `uloop-pause-point` skill): the hit response's `CapturedVariables` already contains the locals, parameters, and instance fields at that line, with no code edit or recompile. Do not try to reconstruct those values with execute-dynamic-code.
 
 ## Parameters
 

--- a/.agents/skills/uloop-get-logs/SKILL.md
+++ b/.agents/skills/uloop-get-logs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-get-logs
 toolName: get-logs
-description: "Read current Unity Console entries from a running Editor. Use during bug investigation after compile, tests, PlayMode, dynamic code, or immediately after `uloop-wait-for-pause-point`."
+description: "Read current Unity Console entries from a running Editor. Use during bug investigation after compile, tests, PlayMode, dynamic code, or immediately after `uloop-pause-point`."
 ---
 
 # uloop get-logs

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -4,7 +4,7 @@ toolName: await-pause-point
 description: "Pauses Unity playback at any source file:line without editing code or recompiling, and returns a snapshot of the locals, parameters, and instance fields at that exact frame. Use for bug investigation, PlayMode/E2E verification, checking variable values at a specific frame, or confirming that a code path executed."
 ---
 
-# uloop pause-point
+# uloop await-pause-point
 
 ## Quick Check Template
 

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -1,9 +1,10 @@
 ---
-name: uloop-wait-for-pause-point
+name: uloop-pause-point
+toolName: await-pause-point
 description: "Pauses Unity playback at any source file:line without editing code or recompiling, and returns a snapshot of the locals, parameters, and instance fields at that exact frame. Use for bug investigation, PlayMode/E2E verification, checking variable values at a specific frame, or confirming that a code path executed."
 ---
 
-# uloop wait-for-pause-point
+# uloop pause-point
 
 ## Quick Check Template
 
@@ -21,7 +22,7 @@ The response returns the derived marker `Id` (`Assets/Scripts/Enemy.cs:42`), the
 3. Wait for the hit, even if the trigger command already returned `InterruptedByPausePoint=true`:
 
 ```bash
-uloop wait-for-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
+uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 ```
 
 4. Read `CapturedVariables` in the hit response first: the locals, parameters, and `this` instance fields at the paused line are already there (see the next section). Adding a temporary `Debug.Log` just to see a local variable is no longer necessary.
@@ -55,7 +56,7 @@ Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or st
 
 ## Timeout Checks
 
-If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error carries the same hint and shell-neutral `Error.Details.RecommendedNextAction`: it means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first, so clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. Then inspect `Error.Details.Status`, `HitCount`, `Generation`, `EnabledAtUtc`, `EditorState`, `ElapsedSinceEnabledMilliseconds`, and `RemainingMilliseconds` to distinguish input not being consumed, stale evidence from an older marker generation, runtime conditions not being met, an id mismatch, or Unity already being paused. `ElapsedSinceEnabledMilliseconds` is measured from `enable-pause-point`, not from `wait-for-pause-point`.
+If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error carries the same hint and shell-neutral `Error.Details.RecommendedNextAction`: it means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first, so clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. Then inspect `Error.Details.Status`, `HitCount`, `Generation`, `EnabledAtUtc`, `EditorState`, `ElapsedSinceEnabledMilliseconds`, and `RemainingMilliseconds` to distinguish input not being consumed, stale evidence from an older marker generation, runtime conditions not being met, an id mismatch, or Unity already being paused. `ElapsedSinceEnabledMilliseconds` is measured from `enable-pause-point`, not from `await-pause-point`.
 
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 

--- a/.agents/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.agents/skills/uloop-simulate-keyboard/SKILL.md
@@ -45,7 +45,7 @@ If a successful `Press` or `KeyDown` leaves `Keyboard.current.<key>.isPressed` t
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the key is safe: when the pause lands mid-command, `simulate-keyboard` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the key when you want the settled result state rather than the input-handling moment.
+For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill. Pausing on the line that handles the key is safe: when the pause lands mid-command, `simulate-keyboard` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the key when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker. `PressEdgeObserved` is still reported on pause-point interruptions.
 

--- a/.agents/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-input/SKILL.md
@@ -50,7 +50,7 @@ uloop simulate-mouse-input --action <action> [options]
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the mouse input is safe: when the pause lands mid-command, `simulate-mouse-input` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the input when you want the settled result state rather than the input-handling moment.
+For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill. Pausing on the line that handles the mouse input is safe: when the pause lands mid-command, `simulate-mouse-input` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the input when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker.
 - Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.

--- a/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -70,7 +70,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 
 ## Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this UI input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the UI event is safe: when the pause lands mid-command, `simulate-mouse-ui` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the event when you want the settled result state rather than the input-handling moment.
+For standard frame proof when this UI input drives a state transition, follow the `uloop-pause-point` skill. Pausing on the line that handles the UI event is safe: when the pause lands mid-command, `simulate-mouse-ui` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the event when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and `Success: true` only means the command ended cleanly. Read `Message` first: it states whether the pointer event was already dispatched before the pause (only the overlay animation was interrupted) or the pause landed first (no pointer event was fired).
 - Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.

--- a/.claude/skills/uloop-execute-dynamic-code/SKILL.md
+++ b/.claude/skills/uloop-execute-dynamic-code/SKILL.md
@@ -11,7 +11,7 @@ Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-c
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
-This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, enable a source pause point on that line instead (`uloop enable-pause-point --file <file> --line <line>`, see the `uloop-wait-for-pause-point` skill): the hit response's `CapturedVariables` already contains the locals, parameters, and instance fields at that line, with no code edit or recompile. Do not try to reconstruct those values with execute-dynamic-code.
+This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, enable a source pause point on that line instead (`uloop enable-pause-point --file <file> --line <line>`, see the `uloop-pause-point` skill): the hit response's `CapturedVariables` already contains the locals, parameters, and instance fields at that line, with no code edit or recompile. Do not try to reconstruct those values with execute-dynamic-code.
 
 ## Parameters
 

--- a/.claude/skills/uloop-get-logs/SKILL.md
+++ b/.claude/skills/uloop-get-logs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-get-logs
 toolName: get-logs
-description: "Read current Unity Console entries from a running Editor. Use during bug investigation after compile, tests, PlayMode, dynamic code, or immediately after `uloop-wait-for-pause-point`."
+description: "Read current Unity Console entries from a running Editor. Use during bug investigation after compile, tests, PlayMode, dynamic code, or immediately after `uloop-pause-point`."
 ---
 
 # uloop get-logs

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -4,7 +4,7 @@ toolName: await-pause-point
 description: "Pauses Unity playback at any source file:line without editing code or recompiling, and returns a snapshot of the locals, parameters, and instance fields at that exact frame. Use for bug investigation, PlayMode/E2E verification, checking variable values at a specific frame, or confirming that a code path executed."
 ---
 
-# uloop pause-point
+# uloop await-pause-point
 
 ## Quick Check Template
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -1,9 +1,10 @@
 ---
-name: uloop-wait-for-pause-point
+name: uloop-pause-point
+toolName: await-pause-point
 description: "Pauses Unity playback at any source file:line without editing code or recompiling, and returns a snapshot of the locals, parameters, and instance fields at that exact frame. Use for bug investigation, PlayMode/E2E verification, checking variable values at a specific frame, or confirming that a code path executed."
 ---
 
-# uloop wait-for-pause-point
+# uloop pause-point
 
 ## Quick Check Template
 
@@ -21,7 +22,7 @@ The response returns the derived marker `Id` (`Assets/Scripts/Enemy.cs:42`), the
 3. Wait for the hit, even if the trigger command already returned `InterruptedByPausePoint=true`:
 
 ```bash
-uloop wait-for-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
+uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 ```
 
 4. Read `CapturedVariables` in the hit response first: the locals, parameters, and `this` instance fields at the paused line are already there (see the next section). Adding a temporary `Debug.Log` just to see a local variable is no longer necessary.
@@ -55,7 +56,7 @@ Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or st
 
 ## Timeout Checks
 
-If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error carries the same hint and shell-neutral `Error.Details.RecommendedNextAction`: it means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first, so clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. Then inspect `Error.Details.Status`, `HitCount`, `Generation`, `EnabledAtUtc`, `EditorState`, `ElapsedSinceEnabledMilliseconds`, and `RemainingMilliseconds` to distinguish input not being consumed, stale evidence from an older marker generation, runtime conditions not being met, an id mismatch, or Unity already being paused. `ElapsedSinceEnabledMilliseconds` is measured from `enable-pause-point`, not from `wait-for-pause-point`.
+If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error carries the same hint and shell-neutral `Error.Details.RecommendedNextAction`: it means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first, so clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. Then inspect `Error.Details.Status`, `HitCount`, `Generation`, `EnabledAtUtc`, `EditorState`, `ElapsedSinceEnabledMilliseconds`, and `RemainingMilliseconds` to distinguish input not being consumed, stale evidence from an older marker generation, runtime conditions not being met, an id mismatch, or Unity already being paused. `ElapsedSinceEnabledMilliseconds` is measured from `enable-pause-point`, not from `await-pause-point`.
 
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 

--- a/.claude/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.claude/skills/uloop-simulate-keyboard/SKILL.md
@@ -45,7 +45,7 @@ If a successful `Press` or `KeyDown` leaves `Keyboard.current.<key>.isPressed` t
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the key is safe: when the pause lands mid-command, `simulate-keyboard` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the key when you want the settled result state rather than the input-handling moment.
+For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill. Pausing on the line that handles the key is safe: when the pause lands mid-command, `simulate-keyboard` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the key when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker. `PressEdgeObserved` is still reported on pause-point interruptions.
 

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -50,7 +50,7 @@ uloop simulate-mouse-input --action <action> [options]
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the mouse input is safe: when the pause lands mid-command, `simulate-mouse-input` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the input when you want the settled result state rather than the input-handling moment.
+For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill. Pausing on the line that handles the mouse input is safe: when the pause lands mid-command, `simulate-mouse-input` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the input when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker.
 - Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.

--- a/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -70,7 +70,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 
 ## Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this UI input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the UI event is safe: when the pause lands mid-command, `simulate-mouse-ui` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the event when you want the settled result state rather than the input-handling moment.
+For standard frame proof when this UI input drives a state transition, follow the `uloop-pause-point` skill. Pausing on the line that handles the UI event is safe: when the pause lands mid-command, `simulate-mouse-ui` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the event when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and `Success: true` only means the command ended cleanly. Read `Message` first: it states whether the pointer event was already dispatched before the pause (only the overlay animation was interrupted) or the pause landed first (no pointer event was fired).
 - Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -654,7 +654,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void PausePointStatusBridgeCommand_Clear_CallsPatcherUnpatchSoTheIdCanBeFreshlyRePatched()
         {
-            // Verifies the CLI bridge's Clear (the path Go's wait-for-pause-point timeout
+            // Verifies the CLI bridge's Clear (the path Go's await-pause-point timeout
             // auto-clear and clear-pause-point-status hit) also calls
             // SourcePausePointPatcher.Unpatch, using the same stale-Mvid gate signal as the tool
             // tests above to prove the ledger entry was actually removed.

--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -164,7 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             IReadOnlyDictionary<string, string> descriptions = SkillInstallLayout.GetToolDescriptionsByToolName(_projectRoot);
 
             Assert.That(descriptions["compile"], Is.EqualTo("Compile the Unity project and report errors/warnings. Use after C# edits."));
-            Assert.That(descriptions[UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT], Does.StartWith("Pauses Unity playback"));
+            Assert.That(descriptions[UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT], Does.StartWith("Pauses Unity playback"));
         }
 
         // Tests that duplicate skill names use the earlier source root across each precedence boundary.

--- a/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
@@ -36,7 +36,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string[] toolNames = allTools.Select(tool => tool.Name).ToArray();
 
             Assert.That(isAvailable, Is.True);
-            Assert.That(toolNames, Does.Contain(UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT));
+            Assert.That(toolNames, Does.Contain(UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT));
             Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT));
             Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT));
             Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS));
@@ -45,7 +45,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void IsToolEnabled_WhenWaitForPausePointDisabled_DisablesPausePointAuxiliaryTools()
         {
-            // Verifies pause point auxiliary tools follow the wait-for-pause-point setting.
+            // Verifies pause point auxiliary tools follow the await-pause-point setting.
             IToolSettingsPort toolSettingsPort = new InMemoryToolSettingsPort();
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
@@ -57,9 +57,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 toolRegistrarService,
                 new StaticToolSkillDescriptionProvider(new Dictionary<string, string>()));
 
-            useCase.SetToolEnabled(UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT, false);
+            useCase.SetToolEnabled(UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT, false);
 
-            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT), Is.False);
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT), Is.False);
             Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT), Is.False);
             Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT), Is.False);
             Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS), Is.False);
@@ -77,7 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 UnityCliLoopToolDiscovery.DiscoverTools);
             Dictionary<string, string> descriptions = new()
             {
-                [UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT] = "Pause point description"
+                [UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT] = "Pause point description"
             };
             ToolSettingsUseCase useCase = new(
                 toolSettingsPort,
@@ -87,7 +87,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             bool isAvailable = useCase.TryGetToolCatalog(out ToolSettingsUseCase.ToolCatalogItem[] allTools);
             ToolSettingsUseCase.ToolCatalogItem waitTool = allTools
-                .Single(tool => tool.Name == UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT);
+                .Single(tool => tool.Name == UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT);
 
             Assert.That(isAvailable, Is.True);
             Assert.That(waitTool.SkillDescription, Is.EqualTo("Pause point description"));

--- a/Packages/src/Editor/Application/UseCases/ToolSettingsUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ToolSettingsUseCase.cs
@@ -17,7 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
     {
         private static readonly string[] NativeToolNames =
         {
-            UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT
+            UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT
         };
 
         private readonly IToolSettingsPort _toolSettingsPort;

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -4,7 +4,7 @@ toolName: await-pause-point
 description: "Pauses Unity playback at any source file:line without editing code or recompiling, and returns a snapshot of the locals, parameters, and instance fields at that exact frame. Use for bug investigation, PlayMode/E2E verification, checking variable values at a specific frame, or confirming that a code path executed."
 ---
 
-# uloop pause-point
+# uloop await-pause-point
 
 ## Quick Check Template
 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -1,9 +1,10 @@
 ---
-name: uloop-wait-for-pause-point
+name: uloop-pause-point
+toolName: await-pause-point
 description: "Pauses Unity playback at any source file:line without editing code or recompiling, and returns a snapshot of the locals, parameters, and instance fields at that exact frame. Use for bug investigation, PlayMode/E2E verification, checking variable values at a specific frame, or confirming that a code path executed."
 ---
 
-# uloop wait-for-pause-point
+# uloop pause-point
 
 ## Quick Check Template
 
@@ -21,7 +22,7 @@ The response returns the derived marker `Id` (`Assets/Scripts/Enemy.cs:42`), the
 3. Wait for the hit, even if the trigger command already returned `InterruptedByPausePoint=true`:
 
 ```bash
-uloop wait-for-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
+uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 ```
 
 4. Read `CapturedVariables` in the hit response first: the locals, parameters, and `this` instance fields at the paused line are already there (see the next section). Adding a temporary `Debug.Log` just to see a local variable is no longer necessary.
@@ -55,7 +56,7 @@ Use `Generation`, `EnabledAtUtc`, and the hit sequence fields from the hit or st
 
 ## Timeout Checks
 
-If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error carries the same hint and shell-neutral `Error.Details.RecommendedNextAction`: it means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first, so clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. Then inspect `Error.Details.Status`, `HitCount`, `Generation`, `EnabledAtUtc`, `EditorState`, `ElapsedSinceEnabledMilliseconds`, and `RemainingMilliseconds` to distinguish input not being consumed, stale evidence from an older marker generation, runtime conditions not being met, an id mismatch, or Unity already being paused. `ElapsedSinceEnabledMilliseconds` is measured from `enable-pause-point`, not from `wait-for-pause-point`.
+If this command times out, the patched line was not reached while the command waited. Read `Error.Details.Hint` first: it names the most likely cause when PlayMode is not running, Unity is already paused, or the marker was enabled but never hit. A `PAUSE_POINT_EXPIRED` error carries the same hint and shell-neutral `Error.Details.RecommendedNextAction`: it means the marker's own `enable-pause-point --timeout-seconds` window (measured from enable, not from wait) ran out first, so clear and re-enable the pause point using the returned `Id` and `TimeoutSeconds`. Then inspect `Error.Details.Status`, `HitCount`, `Generation`, `EnabledAtUtc`, `EditorState`, `ElapsedSinceEnabledMilliseconds`, and `RemainingMilliseconds` to distinguish input not being consumed, stale evidence from an older marker generation, runtime conditions not being met, an id mismatch, or Unity already being paused. `ElapsedSinceEnabledMilliseconds` is measured from `enable-pause-point`, not from `await-pause-point`.
 
 Use `uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"` only when you need to confirm the marker is armed or inspect the current hit state.
 

--- a/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs
+++ b/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs
@@ -38,7 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
 
             if (PausePointAuxiliaryToolNames.Contains(toolName))
             {
-                return UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT;
+                return UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT;
             }
 
             return toolName;

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Skill/SKILL.md
@@ -11,7 +11,7 @@ Run focused C# snippets in the active Unity Editor with `uloop execute-dynamic-c
 
 For basic selected GameObject discovery or property inspection, use `find-game-objects --search-mode Selected` before this tool. Use this tool after the built-in inspection tools are not enough or when you need to modify Unity state.
 
-This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, enable a source pause point on that line instead (`uloop enable-pause-point --file <file> --line <line>`, see the `uloop-wait-for-pause-point` skill): the hit response's `CapturedVariables` already contains the locals, parameters, and instance fields at that line, with no code edit or recompile. Do not try to reconstruct those values with execute-dynamic-code.
+This tool can inspect reachable Unity state, such as GameObjects, components, public properties, static values, and method results. It cannot directly read local variables or intermediate calculations inside an already-running method. When those values matter, enable a source pause point on that line instead (`uloop enable-pause-point --file <file> --line <line>`, see the `uloop-pause-point` skill): the hit response's `CapturedVariables` already contains the locals, parameters, and instance fields at that line, with no code edit or recompile. Do not try to reconstruct those values with execute-dynamic-code.
 
 ## Parameters
 

--- a/Packages/src/Editor/FirstPartyTools/GetLogs/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/GetLogs/Skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uloop-get-logs
 toolName: get-logs
-description: "Read current Unity Console entries from a running Editor. Use during bug investigation after compile, tests, PlayMode, dynamic code, or immediately after `uloop-wait-for-pause-point`."
+description: "Read current Unity Console entries from a running Editor. Use during bug investigation after compile, tests, PlayMode, dynamic code, or immediately after `uloop-pause-point`."
 ---
 
 # uloop get-logs

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
@@ -45,7 +45,7 @@ If a successful `Press` or `KeyDown` leaves `Keyboard.current.<key>.isPressed` t
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the key is safe: when the pause lands mid-command, `simulate-keyboard` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the key when you want the settled result state rather than the input-handling moment.
+For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill. Pausing on the line that handles the key is safe: when the pause lands mid-command, `simulate-keyboard` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the key when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker. `PressEdgeObserved` is still reported on pause-point interruptions.
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
@@ -50,7 +50,7 @@ uloop simulate-mouse-input --action <action> [options]
 
 ### Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the mouse input is safe: when the pause lands mid-command, `simulate-mouse-input` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the input when you want the settled result state rather than the input-handling moment.
+For standard frame proof when this input drives a state transition, follow the `uloop-pause-point` skill. Pausing on the line that handles the mouse input is safe: when the pause lands mid-command, `simulate-mouse-input` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the input when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and input bookkeeping was released. `PausePointId` and `PausePointHitCount` identify the marker.
 - Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
@@ -70,7 +70,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 
 ## Pause Point Inspection (Standard for E2E)
 
-For standard frame proof when this UI input drives a state transition, follow the `uloop-wait-for-pause-point` skill. Pausing on the line that handles the UI event is safe: when the pause lands mid-command, `simulate-mouse-ui` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the event when you want the settled result state rather than the input-handling moment.
+For standard frame proof when this UI input drives a state transition, follow the `uloop-pause-point` skill. Pausing on the line that handles the UI event is safe: when the pause lands mid-command, `simulate-mouse-ui` returns promptly with `InterruptedByPausePoint: true` instead of running to completion. Prefer a line after the app consumed the event when you want the settled result state rather than the input-handling moment.
 
 - If `InterruptedByPausePoint: true`, Unity is paused and `Success: true` only means the command ended cleanly. Read `Message` first: it states whether the pointer event was already dispatched before the pause (only the overlay animation was interrupted) or the pause landed first (no pointer event was fired).
 - Clear pause points (`uloop clear-pause-point --all`) before final validation when they were enabled only for inspection.

--- a/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
+++ b/Packages/src/Editor/Infrastructure/SkillSetup/SkillTargetInstaller.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     {
         private static readonly string[] DeprecatedSkillNames =
         {
+            "uloop-wait-for-pause-point",
             "uloop-capture-window",
             "uloop-get-provider-details",
             "uloop-unity-search",

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -70,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string COMMAND_NAME_GET_TOOL_DETAILS = "get-tool-details";
         public const string COMMAND_NAME_GET_VERSION = "get-version";
         public const string COMMAND_NAME_GET_COMPILE_STATUS = "get-compile-status";
-        public const string COMMAND_NAME_WAIT_FOR_PAUSE_POINT = "wait-for-pause-point";
+        public const string COMMAND_NAME_AWAIT_PAUSE_POINT = "await-pause-point";
         public const string COMMAND_NAME_PAUSE_POINT_STATUS = "pause-point-status";
         public const string COMMAND_NAME_GET_PAUSE_POINT_STATUS = "get-pause-point-status";
         public const string COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS = "clear-pause-point-status";

--- a/cli/common/clicore/command_errors_test.go
+++ b/cli/common/clicore/command_errors_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestAvailableCommandNamesIncludesBuiltIns(t *testing.T) {
 	// Verifies unknown-command suggestions include built-in CLI commands before cached tools.
 	names := availableCommandNames(ToolsCache{})
-	expectedBuiltIns := []string{"launch", "list", "sync", "focus-window", "wait-for-pause-point", "pause-point-status", "skills", "completion", "install", "update", "uninstall"}
+	expectedBuiltIns := []string{"launch", "list", "sync", "focus-window", "await-pause-point", "pause-point-status", "skills", "completion", "install", "update", "uninstall"}
 	for index, expected := range expectedBuiltIns {
 		if names[index] != expected {
 			t.Fatalf("built-in command mismatch: %#v", names)

--- a/cli/common/clicore/command_registry.go
+++ b/cli/common/clicore/command_registry.go
@@ -8,7 +8,7 @@ const (
 	SkillsCommandName               = "skills"
 	CompileCommandName              = "compile"
 	ExecuteDynamicCodeCommandName   = "execute-dynamic-code"
-	PausePointWaitCommandName       = "wait-for-pause-point"
+	PausePointAwaitCommandName      = "await-pause-point"
 	PausePointStatusUserCommandName = "pause-point-status"
 	RunTestsCommandName             = "run-tests"
 	CompletionCommand               = "completion"
@@ -37,7 +37,7 @@ var NativeCommands = []NativeCommandEntry{
 	{Name: "list", Description: "Show Unity tools currently exposed by the Editor", Owner: RunnerOwned},
 	{Name: "sync", Description: "Refresh .uloop/tools.json from the running Editor", Owner: RunnerOwned},
 	{Name: "focus-window", Description: "Bring the Unity Editor window to the foreground", Owner: RunnerOwned},
-	{Name: PausePointWaitCommandName, Description: "Wait until a named UloopPausePoint.Pause marker pauses Unity", Owner: RunnerOwned},
+	{Name: PausePointAwaitCommandName, Description: "Wait until a named UloopPausePoint.Pause marker pauses Unity", Owner: RunnerOwned},
 	{Name: PausePointStatusUserCommandName, Description: "Show the state of a named UloopPausePoint.Pause marker", Owner: RunnerOwned},
 	{Name: SkillsCommandName, Description: "List, install, or uninstall agent skills", Owner: DispatcherOwned},
 	{Name: CompletionCommand, Description: "Print or install shell completion", Owner: DispatcherOwned},

--- a/cli/common/clicore/command_registry_test.go
+++ b/cli/common/clicore/command_registry_test.go
@@ -14,7 +14,7 @@ func TestNativeCommandEntriesDeclareOwners(t *testing.T) {
 		"list":                          RunnerOwned,
 		"sync":                          RunnerOwned,
 		"focus-window":                  RunnerOwned,
-		PausePointWaitCommandName:       RunnerOwned,
+		PausePointAwaitCommandName:      RunnerOwned,
 		PausePointStatusUserCommandName: RunnerOwned,
 	}
 	if len(NativeCommands) != len(expectedOwners) {
@@ -65,7 +65,7 @@ func TestIsRunnerOwnedCommandName(t *testing.T) {
 		"list",
 		"sync",
 		"focus-window",
-		PausePointWaitCommandName,
+		PausePointAwaitCommandName,
 		PausePointStatusUserCommandName,
 	} {
 		if !IsRunnerOwnedCommandName(command) {

--- a/cli/dispatcher/internal/dispatcher/command_help.go
+++ b/cli/dispatcher/internal/dispatcher/command_help.go
@@ -114,7 +114,7 @@ func nativeCommandDescription(command string) (string, bool) {
 
 func nativeCommandUsesProject(command string) bool {
 	switch command {
-	case clicore.LaunchCommandName, "list", "sync", "focus-window", clicore.SkillsCommandName, clicore.PausePointWaitCommandName, clicore.PausePointStatusUserCommandName:
+	case clicore.LaunchCommandName, "list", "sync", "focus-window", clicore.SkillsCommandName, clicore.PausePointAwaitCommandName, clicore.PausePointStatusUserCommandName:
 		return true
 	default:
 		return false

--- a/cli/dispatcher/internal/dispatcher/completion_options.go
+++ b/cli/dispatcher/internal/dispatcher/completion_options.go
@@ -18,7 +18,7 @@ var nativeCommandOptions = map[string][]string{
 	},
 	clicore.InstallCommandName: {"--" + installDirFlagName},
 	clicore.UpdateCommandName:  {"--" + updateToVersionFlagName},
-	clicore.PausePointWaitCommandName: {
+	clicore.PausePointAwaitCommandName: {
 		"--" + clicore.PausePointIDFlagName,
 		"--" + clicore.PausePointTimeoutFlagName,
 		"--" + clicore.PausePointLogsMaxCountFlagName,

--- a/cli/dispatcher/internal/dispatcher/help_test.go
+++ b/cli/dispatcher/internal/dispatcher/help_test.go
@@ -398,7 +398,7 @@ func TestRunDispatcherPausePointWaitHelpShowsDescriptionAndOptions(t *testing.T)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	code := RunDispatcher(context.Background(), []string{clicore.PausePointWaitCommandName, "--help"}, &stdout, &stderr)
+	code := RunDispatcher(context.Background(), []string{clicore.PausePointAwaitCommandName, "--help"}, &stdout, &stderr)
 
 	if code != 0 {
 		t.Fatalf("pause-point-wait help failed: code=%d stderr=%s", code, stderr.String())
@@ -406,7 +406,7 @@ func TestRunDispatcherPausePointWaitHelpShowsDescriptionAndOptions(t *testing.T)
 	output := stdout.String()
 	for _, expected := range []string{
 		"Usage:",
-		"uloop " + clicore.PausePointWaitCommandName + " [options]",
+		"uloop " + clicore.PausePointAwaitCommandName + " [options]",
 		"Wait until a named UloopPausePoint.Pause marker pauses Unity",
 		"Options:",
 		"--" + clicore.PausePointIDFlagName,

--- a/cli/dispatcher/internal/dispatcher/skills.go
+++ b/cli/dispatcher/internal/dispatcher/skills.go
@@ -66,6 +66,7 @@ func buildDefaultSkillTargetIDs() []string {
 }
 
 var deprecatedSkillNames = []string{
+	"uloop-wait-for-pause-point",
 	"uloop-capture-window",
 	"uloop-get-provider-details",
 	"uloop-unity-search",

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d2f7e8475cdf15e5334b349420182ca28dba8b22"
+  "sharedInputsHash": "8de73a7e2135cc3af0b4bc6cc32cd884a20338ec"
 }

--- a/cli/project-runner/internal/projectrunner/native_tool_settings.go
+++ b/cli/project-runner/internal/projectrunner/native_tool_settings.go
@@ -7,7 +7,7 @@ import (
 
 func isSettingsManagedNativeToolCommand(command string) bool {
 	switch command {
-	case clicore.PausePointWaitCommandName, clicore.PausePointStatusUserCommandName:
+	case clicore.PausePointAwaitCommandName, clicore.PausePointStatusUserCommandName:
 		return true
 	default:
 		return false

--- a/cli/project-runner/internal/projectrunner/pause_point_errors.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_errors.go
@@ -114,7 +114,7 @@ func pausePointStateError(
 		Retryable:   retryable,
 		SafeToRetry: retryable,
 		ProjectRoot: projectRoot,
-		Command:     clicore.PausePointWaitCommandName,
+		Command:     clicore.PausePointAwaitCommandName,
 		NextActions: []string{
 			"Run `uloop enable-pause-point --id <marker-id>` before waiting.",
 			"Confirm the code path calls `UloopPausePoint.Pause(\"<marker-id>\")` with the same id.",

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -133,7 +133,7 @@ func runWaitForPausePointCommand(
 	if err != nil {
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
 			ProjectRoot: connection.ProjectRoot,
-			Command:     clicore.PausePointWaitCommandName,
+			Command:     clicore.PausePointAwaitCommandName,
 		})
 		return 1
 	}
@@ -188,13 +188,13 @@ func runWaitForPausePoint(
 	stderr io.Writer,
 ) int {
 	startedAt := time.Now()
-	spinner := clicore.NewToolSpinner(stderr, clicore.PausePointWaitCommandName)
+	spinner := clicore.NewToolSpinner(stderr, clicore.PausePointAwaitCommandName)
 	response, state, err := waitForPausePoint(ctx, connection, options)
 	spinner.Stop()
 	if err != nil {
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{
 			ProjectRoot: connection.ProjectRoot,
-			Command:     clicore.PausePointWaitCommandName,
+			Command:     clicore.PausePointAwaitCommandName,
 		})
 		return 1
 	}
@@ -216,12 +216,12 @@ func runWaitForPausePoint(
 		if marshalErr != nil {
 			clierrors.WriteClassifiedError(stderr, marshalErr, clierrors.ErrorContext{
 				ProjectRoot: connection.ProjectRoot,
-				Command:     clicore.PausePointWaitCommandName,
+				Command:     clicore.PausePointAwaitCommandName,
 			})
 			return 1
 		}
 		clicore.WriteJSON(stdout, result)
-		writeDebugTiming(stderr, clicore.PausePointWaitCommandName, time.Since(startedAt), unityipc.UnitySendOutcome{})
+		writeDebugTiming(stderr, clicore.PausePointAwaitCommandName, time.Since(startedAt), unityipc.UnitySendOutcome{})
 		return 0
 	}
 
@@ -275,10 +275,10 @@ func parseWaitForPausePointOptions(args []string) (waitForPausePointOptions, err
 			options.matchingLogsMaxCount = maxCount
 		default:
 			return waitForPausePointOptions{}, &clierrors.ArgumentError{
-				Message:     "Unknown option for wait-for-pause-point: --" + name,
+				Message:     "Unknown option for await-pause-point: --" + name,
 				Option:      "--" + name,
-				Command:     clicore.PausePointWaitCommandName,
-				NextActions: []string{"Run `uloop wait-for-pause-point --help` to inspect supported options."},
+				Command:     clicore.PausePointAwaitCommandName,
+				NextActions: []string{"Run `uloop await-pause-point --help` to inspect supported options."},
 			}
 		}
 
@@ -292,7 +292,7 @@ func parseWaitForPausePointOptions(args []string) (waitForPausePointOptions, err
 			Message:      "Missing required option: --id",
 			Option:       "--" + clicore.PausePointIDFlagName,
 			ExpectedType: "value",
-			Command:      clicore.PausePointWaitCommandName,
+			Command:      clicore.PausePointAwaitCommandName,
 			NextActions:  []string{"Pass `--id <marker-id>` matching UloopPausePoint.Pause(\"<marker-id>\")."},
 		}
 	}

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
-// Verifies wait-for-pause-point polls until Unity reports the marker hit.
+// Verifies await-pause-point polls until Unity reports the marker hit.
 func TestWaitForPausePointReturnsHitAfterEnabledStatus(t *testing.T) {
 	originalQuery := queryPausePointStatus
 	originalPoll := pausePointStatusPoll
@@ -70,7 +70,7 @@ func TestWaitForPausePointReturnsHitAfterEnabledStatus(t *testing.T) {
 	}
 }
 
-// Verifies wait-for-pause-point clears the enabled marker after its own timeout.
+// Verifies await-pause-point clears the enabled marker after its own timeout.
 func TestRunWaitForPausePointClearsEnabledMarkerAfterTimeout(t *testing.T) {
 	originalQuery := queryPausePointStatus
 	originalClear := clearPausePointStatus
@@ -215,7 +215,7 @@ func TestPausePointExpiredErrorDerivesExpiredFromStatus(t *testing.T) {
 	}
 }
 
-// Verifies wait-for-pause-point does one final status probe before treating timeout as missed.
+// Verifies await-pause-point does one final status probe before treating timeout as missed.
 func TestRunWaitForPausePointReturnsFinalHitAtTimeoutBoundary(t *testing.T) {
 	originalQuery := queryPausePointStatus
 	originalClear := clearPausePointStatus
@@ -283,7 +283,7 @@ func TestRunWaitForPausePointReturnsFinalHitAtTimeoutBoundary(t *testing.T) {
 	}
 }
 
-// Verifies wait-for-pause-point rejects calls before the marker is enabled.
+// Verifies await-pause-point rejects calls before the marker is enabled.
 func TestWaitForPausePointReturnsNotEnabledStateImmediately(t *testing.T) {
 	originalQuery := queryPausePointStatus
 	defer func() {
@@ -829,14 +829,14 @@ func TestPausePointExpiredErrorReportsNoRemainingTime(t *testing.T) {
 // Verifies disabled native pause-point commands are rejected before Unity dispatch.
 func TestRunProjectLocalWaitForPausePointRespectsToolSettings(t *testing.T) {
 	projectRoot := createLaunchTestProject(t)
-	writeToolSettings(t, projectRoot, `{"disabledTools":["wait-for-pause-point"]}`)
+	writeToolSettings(t, projectRoot, `{"disabledTools":["await-pause-point"]}`)
 	t.Chdir(filepath.Dir(projectRoot))
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	code := RunProjectLocal(
 		context.Background(),
-		[]string{"--project-path", projectRoot, clicore.PausePointWaitCommandName, "--id", "jump"},
+		[]string{"--project-path", projectRoot, clicore.PausePointAwaitCommandName, "--id", "jump"},
 		&stdout,
 		&stderr)
 
@@ -847,12 +847,12 @@ func TestRunProjectLocalWaitForPausePointRespectsToolSettings(t *testing.T) {
 	if envelope.Error.ErrorCode != clierrors.ErrorCodeToolDisabled {
 		t.Fatalf("error code mismatch: %#v", envelope.Error)
 	}
-	if envelope.Error.Command != clicore.PausePointWaitCommandName {
+	if envelope.Error.Command != clicore.PausePointAwaitCommandName {
 		t.Fatalf("command mismatch: %#v", envelope.Error)
 	}
 }
 
-// Verifies wait-for-pause-point requires a marker id.
+// Verifies await-pause-point requires a marker id.
 func TestParseWaitForPausePointOptionsRequiresID(t *testing.T) {
 	_, err := parseWaitForPausePointOptions([]string{"--timeout-seconds", "1"})
 

--- a/cli/project-runner/internal/projectrunner/runner_commands.go
+++ b/cli/project-runner/internal/projectrunner/runner_commands.go
@@ -32,7 +32,7 @@ func runResolvedProjectCommand(
 		return runSync(ctx, connection, stdout, stderr)
 	case "focus-window":
 		return clicore.RunFocusWindow(ctx, connection.ProjectRoot, stdout, stderr)
-	case clicore.PausePointWaitCommandName:
+	case clicore.PausePointAwaitCommandName:
 		return runWaitForPausePointCommand(ctx, connection, commandArgs, stdout, stderr)
 	case clicore.PausePointStatusUserCommandName:
 		return runPausePointStatusCommand(ctx, connection, commandArgs, stdout, stderr)

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "beb7eb4a81fe05748dd1c11442357fbc06188c5d"
+  "sharedInputsHash": "9c44c24427c361475087a09bc9f0ed4271828ba3"
 }

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -15,7 +15,7 @@ conflicts, keep the identifier and document the mismatch here instead.
 The following public identifiers are kept by policy even though their names do not fully
 match the current glossary:
 
-- `UnityCliLoopConstants.COMMAND_NAME_WAIT_FOR_PAUSE_POINT` and
+- `UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT` and
   `UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS` are used as tool catalog names,
   not internal bridge commands.
 - The skill target types `SkillsTarget`, `SkillSetupTargetInfo`,
@@ -103,7 +103,7 @@ editor state access; they are the only layer that sequences multi-step tool work
 ### Pause point
 
 A registry entry (`UloopPausePointRegistry`) that freezes PlayMode when a specific code path
-is reached, then reports execution state through `wait-for-pause-point`/`pause-point-status`.
+is reached, then reports execution state through `await-pause-point`/`pause-point-status`.
 A pause point is enabled either by a hand-written `UloopPausePoint.Pause(id)` marker call, or
 as a source pause point resolved from a `--file`/`--line` location with no source edit.
 


### PR DESCRIPTION
## Summary
- Renames the native CLI command from `wait-for-pause-point` to `await-pause-point` with no backward-compatible alias.
- Renames the agent skill to `uloop-pause-point` with explicit `toolName: await-pause-point` so Tool Settings and skill sync stay aligned.

## User Impact
- Agents and users should call `uloop await-pause-point` instead of the removed `wait-for-pause-point` command.
- `skills install` removes stale `uloop-wait-for-pause-point` directories and installs `uloop-pause-point`.
- `enable-pause-point`, `clear-pause-point`, and `pause-point-status` are unchanged.

## Changes
- Go: `PausePointAwaitCommandName`, runner/dispatcher wiring, deprecated skill cleanup list.
- C#: `COMMAND_NAME_AWAIT_PAUSE_POINT`, Tool Settings linkage, deprecated skill cleanup list.
- Skill sources and regenerated `.claude`/`.agents` copies.
- Glossary update; shared release-input stamps refreshed.

## Verification
- `scripts/check-go-cli.sh`
- `dist/darwin-arm64/uloop compile --project-path <repo>`
- `uloop run-tests` (EditMode regex: PausePointTests|ToolSettingsUseCaseTests|SkillInstallLayoutTests) — 60 passed
- `uloop skills install --claude --agents` — deprecated removed: 1 per target
- `uloop wait-for-pause-point` → UNKNOWN_COMMAND
- `uloop await-pause-point --help` succeeds

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

