### PR TITLE
fix: Tool Settings pause-point toggle now gates every pause point command

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: uloop-pause-point
-toolName: await-pause-point
 description: "Pauses Unity playback at any source file:line without editing code or recompiling, and returns a snapshot of the locals, parameters, and instance fields at that exact frame. Use for bug investigation, PlayMode/E2E verification, checking variable values at a specific frame, or confirming that a code path executed."
 ---
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: uloop-pause-point
-toolName: await-pause-point
 description: "Pauses Unity playback at any source file:line without editing code or recompiling, and returns a snapshot of the locals, parameters, and instance fields at that exact frame. Use for bug investigation, PlayMode/E2E verification, checking variable values at a specific frame, or confirming that a code path executed."
 ---
 

--- a/Assets/Tests/Editor/SkillInstallLayoutTests.cs
+++ b/Assets/Tests/Editor/SkillInstallLayoutTests.cs
@@ -164,7 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             IReadOnlyDictionary<string, string> descriptions = SkillInstallLayout.GetToolDescriptionsByToolName(_projectRoot);
 
             Assert.That(descriptions["compile"], Is.EqualTo("Compile the Unity project and report errors/warnings. Use after C# edits."));
-            Assert.That(descriptions[UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT], Does.StartWith("Pauses Unity playback"));
+            Assert.That(descriptions[UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT], Does.StartWith("Pauses Unity playback"));
         }
 
         // Tests that duplicate skill names use the earlier source root across each precedence boundary.

--- a/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
@@ -17,9 +17,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     public class ToolSettingsUseCaseTests
     {
         [Test]
-        public void TryGetToolCatalog_WhenRegistryAvailable_ShowsOnlyWaitForPausePointCommand()
+        public void TryGetToolCatalog_WhenRegistryAvailable_ShowsOnlyPausePointSettingsTool()
         {
-            // Verifies Tool Settings exposes only the parent pause point command.
+            // Verifies Tool Settings exposes only the pause-point family toggle.
             IToolSettingsPort toolSettingsPort = new InMemoryToolSettingsPort();
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
@@ -36,16 +36,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string[] toolNames = allTools.Select(tool => tool.Name).ToArray();
 
             Assert.That(isAvailable, Is.True);
-            Assert.That(toolNames, Does.Contain(UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT));
+            Assert.That(toolNames, Does.Contain(UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT));
+            Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT));
             Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT));
             Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT));
             Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS));
         }
 
         [Test]
-        public void IsToolEnabled_WhenWaitForPausePointDisabled_DisablesPausePointAuxiliaryTools()
+        public void IsToolEnabled_WhenPausePointDisabled_DisablesPausePointAuxiliaryTools()
         {
-            // Verifies pause point auxiliary tools follow the await-pause-point setting.
+            // Verifies pause point auxiliary tools follow the pause-point settings toggle.
+            IToolSettingsPort toolSettingsPort = new InMemoryToolSettingsPort();
+            UnityCliLoopToolRegistrarService toolRegistrarService = new(
+                new EmptyInternalToolNameProvider(),
+                toolSettingsPort,
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
+                UnityCliLoopToolDiscovery.DiscoverTools);
+            ToolSettingsUseCase useCase = new(
+                toolSettingsPort,
+                toolRegistrarService,
+                new StaticToolSkillDescriptionProvider(new Dictionary<string, string>()));
+
+            useCase.SetToolEnabled(UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT, false);
+
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT), Is.False);
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT), Is.False);
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT), Is.False);
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT), Is.False);
+            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS), Is.False);
+        }
+
+        [Test]
+        public void IsToolEnabled_WhenAwaitPausePointDisabled_DisablesPausePointAuxiliaryTools()
+        {
+            // Verifies disabling via the await-pause-point command name still maps to the pause-point toggle.
             IToolSettingsPort toolSettingsPort = new InMemoryToolSettingsPort();
             UnityCliLoopToolRegistrarService toolRegistrarService = new(
                 new EmptyInternalToolNameProvider(),
@@ -60,9 +85,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             useCase.SetToolEnabled(UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT, false);
 
             Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT), Is.False);
-            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT), Is.False);
-            Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT), Is.False);
             Assert.That(useCase.IsToolEnabled(UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS), Is.False);
+        }
+
+        [Test]
+        public void ToolSettingsToolLinkPolicy_WhenAwaitPausePointRequested_IsNotUserFacingAndMapsToPausePoint()
+        {
+            // Verifies await-pause-point is auxiliary and resolves to the pause-point settings key.
+            Assert.That(
+                ToolSettingsToolLinkPolicy.IsUserFacingToolSettingsTool(
+                    UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT),
+                Is.False);
+            Assert.That(
+                ToolSettingsToolLinkPolicy.GetSettingsToolName(
+                    UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT),
+                Is.EqualTo(UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT));
         }
 
         [Test]
@@ -77,7 +114,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 UnityCliLoopToolDiscovery.DiscoverTools);
             Dictionary<string, string> descriptions = new()
             {
-                [UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT] = "Pause point description"
+                [UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT] = "Pause point description"
             };
             ToolSettingsUseCase useCase = new(
                 toolSettingsPort,
@@ -86,11 +123,28 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             useCase.WarmupRegistry();
 
             bool isAvailable = useCase.TryGetToolCatalog(out ToolSettingsUseCase.ToolCatalogItem[] allTools);
-            ToolSettingsUseCase.ToolCatalogItem waitTool = allTools
-                .Single(tool => tool.Name == UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT);
+            ToolSettingsUseCase.ToolCatalogItem pausePointTool = allTools
+                .Single(tool => tool.Name == UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT);
 
             Assert.That(isAvailable, Is.True);
-            Assert.That(waitTool.SkillDescription, Is.EqualTo("Pause point description"));
+            Assert.That(pausePointTool.SkillDescription, Is.EqualTo("Pause point description"));
+        }
+
+        [Test]
+        public void IsSkillDisabledByToolSettings_WhenPausePointDisabled_ReturnsTrueForPausePointSkill()
+        {
+            // Verifies disabledTools pause-point key matches the pause-point skill tool name.
+            SkillInstallLayout.SkillSourceInfo skill = new(
+                "uloop-pause-point",
+                UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT,
+                new Dictionary<string, byte[]>());
+            string[] disabledTools = { UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT };
+
+            bool isDisabled = SkillDisabledToolFilter.IsSkillDisabledByToolSettings(
+                skill,
+                disabledTools);
+
+            Assert.That(isDisabled, Is.True);
         }
 
         private sealed class StaticToolSkillDescriptionProvider : IToolSkillDescriptionProvider

--- a/Packages/src/Editor/Application/UseCases/ToolSettingsUseCase.cs
+++ b/Packages/src/Editor/Application/UseCases/ToolSettingsUseCase.cs
@@ -17,7 +17,7 @@ namespace io.github.hatayama.UnityCliLoop.Application
     {
         private static readonly string[] NativeToolNames =
         {
-            UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT
+            UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT
         };
 
         private readonly IToolSettingsPort _toolSettingsPort;

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: uloop-pause-point
-toolName: await-pause-point
 description: "Pauses Unity playback at any source file:line without editing code or recompiling, and returns a snapshot of the locals, parameters, and instance fields at that exact frame. Use for bug investigation, PlayMode/E2E verification, checking variable values at a specific frame, or confirming that a code path executed."
 ---
 

--- a/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs
+++ b/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs
@@ -12,6 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     {
         private static readonly HashSet<string> PausePointAuxiliaryToolNames = new(System.StringComparer.Ordinal)
         {
+            UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT,
             UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT,
             UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT,
             UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS
@@ -38,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
 
             if (PausePointAuxiliaryToolNames.Contains(toolName))
             {
-                return UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT;
+                return UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT;
             }
 
             return toolName;

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -71,6 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string COMMAND_NAME_GET_VERSION = "get-version";
         public const string COMMAND_NAME_GET_COMPILE_STATUS = "get-compile-status";
         public const string COMMAND_NAME_AWAIT_PAUSE_POINT = "await-pause-point";
+        public const string SETTINGS_TOOL_NAME_PAUSE_POINT = "pause-point";
         public const string COMMAND_NAME_PAUSE_POINT_STATUS = "pause-point-status";
         public const string COMMAND_NAME_GET_PAUSE_POINT_STATUS = "get-pause-point-status";
         public const string COMMAND_NAME_CLEAR_PAUSE_POINT_STATUS = "clear-pause-point-status";

--- a/cli/project-runner/internal/projectrunner/native_tool_settings.go
+++ b/cli/project-runner/internal/projectrunner/native_tool_settings.go
@@ -1,16 +1,19 @@
 package projectrunner
 
 import (
-	"github.com/hatayama/unity-cli-loop/common/clicore"
 	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
 )
 
-func isSettingsManagedNativeToolCommand(command string) bool {
+const pausePointSettingsToolName = "pause-point"
+
+func settingsToolNameForNativeCommand(command string) (string, bool) {
 	switch command {
 	case clicore.PausePointAwaitCommandName, clicore.PausePointStatusUserCommandName:
-		return true
+		return pausePointSettingsToolName, true
 	default:
-		return false
+		return "", false
 	}
 }
 

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -829,7 +829,7 @@ func TestPausePointExpiredErrorReportsNoRemainingTime(t *testing.T) {
 // Verifies disabled native pause-point commands are rejected before Unity dispatch.
 func TestRunProjectLocalWaitForPausePointRespectsToolSettings(t *testing.T) {
 	projectRoot := createLaunchTestProject(t)
-	writeToolSettings(t, projectRoot, `{"disabledTools":["await-pause-point"]}`)
+	writeToolSettings(t, projectRoot, `{"disabledTools":["pause-point"]}`)
 	t.Chdir(filepath.Dir(projectRoot))
 
 	var stdout bytes.Buffer
@@ -848,6 +848,32 @@ func TestRunProjectLocalWaitForPausePointRespectsToolSettings(t *testing.T) {
 		t.Fatalf("error code mismatch: %#v", envelope.Error)
 	}
 	if envelope.Error.Command != clicore.PausePointAwaitCommandName {
+		t.Fatalf("command mismatch: %#v", envelope.Error)
+	}
+}
+
+// Verifies disabled pause-point-status is rejected before Unity dispatch.
+func TestRunProjectLocalPausePointStatusRespectsToolSettings(t *testing.T) {
+	projectRoot := createLaunchTestProject(t)
+	writeToolSettings(t, projectRoot, `{"disabledTools":["pause-point"]}`)
+	t.Chdir(filepath.Dir(projectRoot))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunProjectLocal(
+		context.Background(),
+		[]string{"--project-path", projectRoot, clicore.PausePointStatusUserCommandName, "--id", "jump"},
+		&stdout,
+		&stderr)
+
+	if code != 1 {
+		t.Fatalf("expected disabled command failure, got %d with stdout %s", code, stdout.String())
+	}
+	envelope := parsePausePointErrorEnvelope(t, stderr.Bytes())
+	if envelope.Error.ErrorCode != clierrors.ErrorCodeToolDisabled {
+		t.Fatalf("error code mismatch: %#v", envelope.Error)
+	}
+	if envelope.Error.Command != clicore.PausePointStatusUserCommandName {
 		t.Fatalf("command mismatch: %#v", envelope.Error)
 	}
 }

--- a/cli/project-runner/internal/projectrunner/runner_commands.go
+++ b/cli/project-runner/internal/projectrunner/runner_commands.go
@@ -20,8 +20,8 @@ func runResolvedProjectCommand(
 	stdout io.Writer,
 	stderr io.Writer,
 ) int {
-	if isSettingsManagedNativeToolCommand(command) &&
-		clicore.IsToolDisabledByToolSettings(command, clicore.LoadDisabledTools(connection.ProjectRoot)) {
+	if settingsToolName, isSettingsManaged := settingsToolNameForNativeCommand(command); isSettingsManaged &&
+		clicore.IsToolDisabledByToolSettings(settingsToolName, clicore.LoadDisabledTools(connection.ProjectRoot)) {
 		clierrors.WriteErrorEnvelope(stderr, nativeToolDisabledError(connection.ProjectRoot, command))
 		return 1
 	}


### PR DESCRIPTION
## Summary

Refs: pause-point rename plan (wave 2) — Tool Settings logical tool name

- Rename the Tool Settings toggle and `disabledTools` storage key from `await-pause-point` to `pause-point`, matching the pause point family it controls.
- Route `await-pause-point` and `pause-point-status` through the shared settings key on the Go runner so disabled toggles reject both commands (fixes a pre-existing gap where `pause-point-status` bypassed the gate).
- Drop the explicit `toolName: await-pause-point` skill override so `uloop-pause-point` naturally derives `pause-point` for skill sync and Show Details.

## Test plan

- [x] `scripts/check-go-cli.sh`
- [x] `uloop compile` — zero errors/warnings
- [x] EditMode: `ToolSettingsUseCaseTests`, `SkillInstallLayoutTests`
- [x] CLI: `pause-point` in `disabledTools` rejects both `await-pause-point` and `pause-point-status` with `TOOL_DISABLED`
- [ ] Unity Tool Settings UI shows `pause-point` with skill description (manual)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

