### PR TITLE
fix: Make third-party migration writes an all-or-nothing batch

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileWriterTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileWriterTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+using static io.github.hatayama.UnityCliLoop.Infrastructure.ThirdPartyToolMigrationFileServiceConstants;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies batch migration writes commit atomically or roll back.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationFileWriterTests
+    {
+        [Test]
+        public void WriteBatch_WhenAllTargetsAreWritable_CommitsEveryFileAndLeavesNoSidecars()
+        {
+            // Verifies a mixed existing/new batch commits all targets and leaves no sidecar files.
+            string tempDirectory = CreateTempDirectory();
+            try
+            {
+                string existingFile1 = Path.Combine(tempDirectory, "ExistingOne.cs");
+                string existingFile2 = Path.Combine(tempDirectory, "ExistingTwo.cs");
+                string newFile = Path.Combine(tempDirectory, "NewFile.cs");
+                File.WriteAllText(existingFile1, "original-one");
+                File.WriteAllText(existingFile2, "original-two");
+
+                List<MigrationFileChange> changes = new()
+                {
+                    new MigrationFileChange(existingFile1, "migrated-one"),
+                    new MigrationFileChange(existingFile2, "migrated-two"),
+                    new MigrationFileChange(newFile, "migrated-new")
+                };
+
+                ThirdPartyToolMigrationFileWriter.WriteBatch(changes);
+
+                Assert.That(File.ReadAllText(existingFile1), Is.EqualTo("migrated-one"));
+                Assert.That(File.ReadAllText(existingFile2), Is.EqualTo("migrated-two"));
+                Assert.That(File.ReadAllText(newFile), Is.EqualTo("migrated-new"));
+                Assert.That(CountSidecarFiles(tempDirectory), Is.EqualTo(0));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [Test]
+        public void WriteBatch_WhenPrepareFails_LeavesAllTargetFilesUntouched()
+        {
+            // Verifies a prepare failure leaves every target untouched and removes temp sidecars.
+            string tempDirectory = CreateTempDirectory();
+            try
+            {
+                string existingFile = Path.Combine(tempDirectory, "Existing.cs");
+                File.WriteAllText(existingFile, "original");
+                string missingDirectoryFile = Path.Combine(
+                    tempDirectory,
+                    "missing-directory",
+                    "Missing.cs");
+
+                List<MigrationFileChange> changes = new()
+                {
+                    new MigrationFileChange(existingFile, "migrated"),
+                    new MigrationFileChange(missingDirectoryFile, "never-written")
+                };
+
+                Assert.Throws<DirectoryNotFoundException>(
+                    () => ThirdPartyToolMigrationFileWriter.WriteBatch(changes));
+
+                Assert.That(File.ReadAllText(existingFile), Is.EqualTo("original"));
+                Assert.That(CountSidecarFiles(tempDirectory), Is.EqualTo(0));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [Test]
+        public void WriteBatch_WhenCommitFails_RestoresCommittedFilesFromBackups()
+        {
+            // Verifies a mid-batch commit failure restores already committed files from backups.
+            string tempDirectory = CreateTempDirectory();
+            try
+            {
+                string file1 = Path.Combine(tempDirectory, "FileOne.cs");
+                string file2 = Path.Combine(tempDirectory, "FileTwo.cs");
+                string file3 = Path.Combine(tempDirectory, "FileThree.cs");
+                File.WriteAllText(file1, "original-one");
+                File.WriteAllText(file3, "original-three");
+                Directory.CreateDirectory(file2);
+
+                List<MigrationFileChange> changes = new()
+                {
+                    new MigrationFileChange(file1, "migrated-one"),
+                    new MigrationFileChange(file2, "migrated-two"),
+                    new MigrationFileChange(file3, "migrated-three")
+                };
+
+                Assert.Throws<IOException>(
+                    () => ThirdPartyToolMigrationFileWriter.WriteBatch(changes));
+
+                Assert.That(File.ReadAllText(file1), Is.EqualTo("original-one"));
+                Assert.That(File.ReadAllText(file3), Is.EqualTo("original-three"));
+                Assert.That(CountSidecarFiles(tempDirectory), Is.EqualTo(0));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [Test]
+        public void WriteBatch_WhenCommitFails_DeletesNewlyCreatedFiles()
+        {
+            // Verifies rollback removes newly created targets that had no backup sidecar.
+            string tempDirectory = CreateTempDirectory();
+            try
+            {
+                string newFile = Path.Combine(tempDirectory, "NewFile.cs");
+                string failingTarget = Path.Combine(tempDirectory, "FailingTarget.cs");
+                Directory.CreateDirectory(failingTarget);
+
+                List<MigrationFileChange> changes = new()
+                {
+                    new MigrationFileChange(newFile, "migrated-new"),
+                    new MigrationFileChange(failingTarget, "never-committed")
+                };
+
+                Assert.Throws<IOException>(
+                    () => ThirdPartyToolMigrationFileWriter.WriteBatch(changes));
+
+                Assert.That(File.Exists(newFile), Is.False);
+                Assert.That(CountSidecarFiles(tempDirectory), Is.EqualTo(0));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task WriteBatchAsync_WhenBatchExceedsYieldSize_CommitsEveryFile()
+        {
+            // Verifies the async prepare yield path still commits every file in a large batch.
+            string tempDirectory = CreateTempDirectory();
+            try
+            {
+                List<MigrationFileChange> changes = new();
+                for (int index = 0; index < PreviewYieldBatchSize + 8; index++)
+                {
+                    string filePath = Path.Combine(tempDirectory, $"File{index:D2}.cs");
+                    File.WriteAllText(filePath, $"original-{index}");
+                    changes.Add(new MigrationFileChange(filePath, $"migrated-{index}"));
+                }
+
+                await ThirdPartyToolMigrationFileWriter.WriteBatchAsync(changes);
+
+                for (int index = 0; index < changes.Count; index++)
+                {
+                    Assert.That(
+                        File.ReadAllText(changes[index].FilePath),
+                        Is.EqualTo($"migrated-{index}"));
+                }
+
+                Assert.That(CountSidecarFiles(tempDirectory), Is.EqualTo(0));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        private static string CreateTempDirectory()
+        {
+            string tempDirectory = Path.Combine(
+                Path.GetTempPath(),
+                "UnityCliLoopMigrationWriterTests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDirectory);
+            return tempDirectory;
+        }
+
+        private static int CountSidecarFiles(string directory)
+        {
+            return Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+                .Count(filePath =>
+                    filePath.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase) ||
+                    filePath.EndsWith(".bak", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileWriterTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileWriterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e2826ae14e624b0d81d3bf76a647d5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileService.cs
@@ -92,10 +92,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string normalizedProjectRoot = NormalizeProjectRoot(projectRoot);
             MigrationPlan plan = GetCurrentMigrationPlan(normalizedProjectRoot);
             InvalidatePreviewCache();
-            foreach (MigrationFileChange change in plan.Changes)
-            {
-                ThirdPartyToolMigrationFileWriter.Write(change.FilePath, change.Content);
-            }
+            ThirdPartyToolMigrationFileWriter.WriteBatch(plan.Changes);
 
             return new ThirdPartyToolMigrationResult(
                 plan.ChangedFilePaths.Count,
@@ -120,15 +117,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             InvalidatePreviewCache();
-            for (int index = 0; index < plan.Changes.Count; index++)
-            {
-                MigrationFileChange change = plan.Changes[index];
-                ThirdPartyToolMigrationFileWriter.Write(change.FilePath, change.Content);
-                if ((index + 1) % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
-                {
-                    await Task.Yield();
-                }
-            }
+            await ThirdPartyToolMigrationFileWriter.WriteBatchAsync(plan.Changes);
 
             return new ThirdPartyToolMigrationResult(
                 plan.ChangedFilePaths.Count,

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
@@ -42,7 +42,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 foreach (MigrationFileChange change in changes)
                 {
-                    preparedWrites.Add(Prepare(change));
+                    Prepare(preparedWrites, change);
                 }
 
                 prepared = true;
@@ -68,7 +68,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 for (int index = 0; index < changes.Count; index++)
                 {
-                    preparedWrites.Add(Prepare(changes[index]));
+                    Prepare(preparedWrites, changes[index]);
                     if ((index + 1) % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
                     {
                         await Task.Yield();
@@ -87,11 +87,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
         }
 
-        private static PreparedWrite Prepare(MigrationFileChange change)
+        private static void Prepare(List<PreparedWrite> preparedWrites, MigrationFileChange change)
         {
             string tempFilePath = CreateUniqueSidecarPath(change.FilePath, TempSidecarExtension);
+            // Register before WriteAllText so a mid-write IOException can still clean up a partial .tmp.
+            preparedWrites.Add(new PreparedWrite(change.FilePath, tempFilePath));
             ThirdPartyToolMigrationFileAccess.WriteAllText(tempFilePath, change.Content);
-            return new PreparedWrite(change.FilePath, tempFilePath);
         }
 
         private static void CommitAll(List<PreparedWrite> preparedWrites)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
@@ -2,30 +2,212 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
     /// <summary>
-    /// Writes migrated files atomically through temporary sidecar files.
+    /// Writes a migration plan as one batch transaction: every temp sidecar is written first,
+    /// then all targets are committed via rename/replace while their backups are kept, and a
+    /// mid-batch commit failure rolls the already committed files back from those backups.
     /// </summary>
     internal static class ThirdPartyToolMigrationFileWriter
     {
-        internal static void Write(string filePath, string content)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
-            Debug.Assert(content != null, "content must not be null");
+        private const string TempSidecarExtension = ".tmp";
+        private const string BackupSidecarExtension = ".bak";
 
-            string tempFilePath = CreateUniqueSidecarPath(filePath, ".tmp");
-            ThirdPartyToolMigrationFileAccess.WriteAllText(tempFilePath, content);
-            if (!ThirdPartyToolMigrationFileAccess.Exists(filePath))
+        internal static void WriteBatch(IReadOnlyList<MigrationFileChange> changes)
+        {
+            Debug.Assert(changes != null, "changes must not be null");
+
+            List<PreparedWrite> preparedWrites = PrepareAll(changes);
+            CommitAll(preparedWrites);
+        }
+
+        internal static async Task WriteBatchAsync(IReadOnlyList<MigrationFileChange> changes)
+        {
+            Debug.Assert(changes != null, "changes must not be null");
+
+            List<PreparedWrite> preparedWrites = await PrepareAllAsync(changes);
+            // Commit is rename-only and fast; it must run without yields so no editor callback
+            // (asset refresh, domain reload) can observe a half-committed batch.
+            CommitAll(preparedWrites);
+        }
+
+        private static List<PreparedWrite> PrepareAll(IReadOnlyList<MigrationFileChange> changes)
+        {
+            List<PreparedWrite> preparedWrites = new(changes.Count);
+            bool prepared = false;
+            try
             {
-                ThirdPartyToolMigrationFileAccess.Move(tempFilePath, filePath);
-                return;
+                foreach (MigrationFileChange change in changes)
+                {
+                    preparedWrites.Add(Prepare(change));
+                }
+
+                prepared = true;
+                return preparedWrites;
+            }
+            finally
+            {
+                if (!prepared)
+                {
+                    // A prepare failure has not touched any target file yet; deleting the temp
+                    // sidecars returns the project to its exact pre-apply state.
+                    DeleteTempSidecars(preparedWrites, 0);
+                }
+            }
+        }
+
+        private static async Task<List<PreparedWrite>> PrepareAllAsync(
+            IReadOnlyList<MigrationFileChange> changes)
+        {
+            List<PreparedWrite> preparedWrites = new(changes.Count);
+            bool prepared = false;
+            try
+            {
+                for (int index = 0; index < changes.Count; index++)
+                {
+                    preparedWrites.Add(Prepare(changes[index]));
+                    if ((index + 1) % ThirdPartyToolMigrationFileServiceConstants.PreviewYieldBatchSize == 0)
+                    {
+                        await Task.Yield();
+                    }
+                }
+
+                prepared = true;
+                return preparedWrites;
+            }
+            finally
+            {
+                if (!prepared)
+                {
+                    DeleteTempSidecars(preparedWrites, 0);
+                }
+            }
+        }
+
+        private static PreparedWrite Prepare(MigrationFileChange change)
+        {
+            string tempFilePath = CreateUniqueSidecarPath(change.FilePath, TempSidecarExtension);
+            ThirdPartyToolMigrationFileAccess.WriteAllText(tempFilePath, change.Content);
+            return new PreparedWrite(change.FilePath, tempFilePath);
+        }
+
+        private static void CommitAll(List<PreparedWrite> preparedWrites)
+        {
+            List<CommittedWrite> committedWrites = new(preparedWrites.Count);
+            bool committed = false;
+            try
+            {
+                foreach (PreparedWrite preparedWrite in preparedWrites)
+                {
+                    committedWrites.Add(Commit(preparedWrite));
+                }
+
+                committed = true;
+            }
+            finally
+            {
+                if (committed)
+                {
+                    DeleteBackupSidecars(committedWrites);
+                }
+                else
+                {
+                    // The commit exception is propagating right now; rollback and cleanup must be
+                    // best-effort so they never replace that original exception.
+                    RollbackCommitted(committedWrites);
+                    DeleteTempSidecars(preparedWrites, committedWrites.Count);
+                }
+            }
+        }
+
+        private static CommittedWrite Commit(PreparedWrite preparedWrite)
+        {
+            if (!ThirdPartyToolMigrationFileAccess.Exists(preparedWrite.TargetFilePath))
+            {
+                ThirdPartyToolMigrationFileAccess.Move(
+                    preparedWrite.TempFilePath,
+                    preparedWrite.TargetFilePath);
+                return new CommittedWrite(preparedWrite.TargetFilePath, null);
             }
 
-            string backupFilePath = CreateUniqueSidecarPath(filePath, ".bak");
-            ThirdPartyToolMigrationFileAccess.Replace(tempFilePath, filePath, backupFilePath);
-            ThirdPartyToolMigrationFileAccess.Delete(backupFilePath);
+            string backupFilePath = CreateUniqueSidecarPath(
+                preparedWrite.TargetFilePath,
+                BackupSidecarExtension);
+            ThirdPartyToolMigrationFileAccess.Replace(
+                preparedWrite.TempFilePath,
+                preparedWrite.TargetFilePath,
+                backupFilePath);
+            return new CommittedWrite(preparedWrite.TargetFilePath, backupFilePath);
+        }
+
+        private static void RollbackCommitted(List<CommittedWrite> committedWrites)
+        {
+            for (int index = committedWrites.Count - 1; index >= 0; index--)
+            {
+                CommittedWrite committedWrite = committedWrites[index];
+                try
+                {
+                    ThirdPartyToolMigrationFileAccess.Delete(committedWrite.TargetFilePath);
+                    if (committedWrite.BackupFilePath != null)
+                    {
+                        ThirdPartyToolMigrationFileAccess.Move(
+                            committedWrite.BackupFilePath,
+                            committedWrite.TargetFilePath);
+                    }
+                }
+                catch (Exception restoreException)
+                {
+                    // Keep restoring the remaining files; a file that cannot be restored keeps
+                    // its .bak on disk so the user can recover it manually.
+                    UnityEngine.Debug.LogError(
+                        $"[uloop] Migration rollback failed for '{committedWrite.TargetFilePath}': " +
+                        $"{restoreException.Message}" +
+                        (committedWrite.BackupFilePath == null
+                            ? string.Empty
+                            : $" Backup kept at '{committedWrite.BackupFilePath}'."));
+                }
+            }
+        }
+
+        private static void DeleteTempSidecars(List<PreparedWrite> preparedWrites, int firstIndex)
+        {
+            for (int index = firstIndex; index < preparedWrites.Count; index++)
+            {
+                TryDeleteSidecar(preparedWrites[index].TempFilePath);
+            }
+        }
+
+        private static void DeleteBackupSidecars(List<CommittedWrite> committedWrites)
+        {
+            foreach (CommittedWrite committedWrite in committedWrites)
+            {
+                if (committedWrite.BackupFilePath != null)
+                {
+                    TryDeleteSidecar(committedWrite.BackupFilePath);
+                }
+            }
+        }
+
+        private static void TryDeleteSidecar(string sidecarFilePath)
+        {
+            try
+            {
+                if (ThirdPartyToolMigrationFileAccess.Exists(sidecarFilePath))
+                {
+                    ThirdPartyToolMigrationFileAccess.Delete(sidecarFilePath);
+                }
+            }
+            catch (Exception deleteException)
+            {
+                // Sidecar cleanup must never fail the migration itself; a stray sidecar is
+                // visible in the project window and harmless to compilation.
+                UnityEngine.Debug.LogError(
+                    $"[uloop] Failed to delete migration sidecar '{sidecarFilePath}': " +
+                    $"{deleteException.Message}");
+            }
         }
 
         internal static string CreateUniqueSidecarPath(string filePath, string extension)
@@ -42,6 +224,31 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             }
 
             return sidecarPath;
+        }
+
+        private readonly struct PreparedWrite
+        {
+            public PreparedWrite(string targetFilePath, string tempFilePath)
+            {
+                TargetFilePath = targetFilePath;
+                TempFilePath = tempFilePath;
+            }
+
+            public string TargetFilePath { get; }
+            public string TempFilePath { get; }
+        }
+
+        private readonly struct CommittedWrite
+        {
+            public CommittedWrite(string targetFilePath, string backupFilePath)
+            {
+                TargetFilePath = targetFilePath;
+                BackupFilePath = backupFilePath;
+            }
+
+            public string TargetFilePath { get; }
+            // Null when the target file did not exist before the commit (plain move, no backup).
+            public string BackupFilePath { get; }
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace per-file `Write` with `WriteBatch` / `WriteBatchAsync` so migration apply is one prepare → commit transaction
- Keep `.bak` sidecars until the full commit succeeds; on mid-batch failure, restore already committed targets and leave no half-migrated project
- Move the async yield cadence into prepare; commit stays rename-only with no yields
- Add focused writer tests for happy path, prepare failure, commit rollback of existing and newly created files, and async yield-sized batches

## User Impact
Applying a V2→V3 third-party tool migration no longer leaves the project half-rewritten when a file write fails mid-batch; already written files are restored from backups.

## Test plan
- [x] `uloop compile` — 0 errors / 0 warnings
- [x] `uloop run-tests --filter-type regex --filter-value ThirdPartyToolMigrationFileWriterTests` — 5/5 passed
- [x] Live demo via `uloop execute-dynamic-code` + reflection: inject commit failure with a directory target → `IOException`, file1 restored to original, file3 untouched, sidecarCount=0

### Live verification log
```
tempDirectory=.../UnityCliLoopMigrationWriterLiveDemo/...
exception=IOException: The file '.../FileTwo.cs' already exists.
file1After=original-one
file3After=original-three
file1Restored=True
file3Untouched=True
sidecarCount=0
```