### PR TITLE
fix: Preserve encoding and asmdef formatting during migration writes

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationAsmdefTextEditorTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationAsmdefTextEditorTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Text;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies surgical asmdef references edits preserve surrounding bytes.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationAsmdefTextEditorTests
+    {
+        [Test]
+        public void ReplaceReferencesArray_WhenSourceUsesCrlfAndFourSpaceIndent_PreservesBytesOutsideArray()
+        {
+            // Verifies CRLF/4-space asmdef text keeps every byte outside the references array.
+            string source =
+                "{\r\n" +
+                "    \"name\": \"MyCompany.Tools.Editor\",\r\n" +
+                "    \"references\": [\r\n" +
+                "        \"uLoopMCP.Editor\"\r\n" +
+                "    ],\r\n" +
+                "    \"includePlatforms\": [\r\n" +
+                "        \"Editor\"\r\n" +
+                "    ]\r\n" +
+                "}\r\n";
+            string expected =
+                "{\r\n" +
+                "    \"name\": \"MyCompany.Tools.Editor\",\r\n" +
+                "    \"references\": [\r\n" +
+                "        \"GUID:fc3fd32eddbee40e39c2d76dc184957b\"\r\n" +
+                "    ],\r\n" +
+                "    \"includePlatforms\": [\r\n" +
+                "        \"Editor\"\r\n" +
+                "    ]\r\n" +
+                "}\r\n";
+
+            ThirdPartyToolMigrationAsmdefTextEditor.AsmdefReferencesEditResult result =
+                ThirdPartyToolMigrationAsmdefTextEditor.ReplaceReferencesArray(
+                    source,
+                    new[] { "GUID:fc3fd32eddbee40e39c2d76dc184957b" });
+
+            Assert.That(result.Replaced, Is.True);
+            Assert.That(result.Content, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ReplaceReferencesArray_WhenSourceUsesTwoSpaceIndentAndLf_MatchesSourceStyle()
+        {
+            // Verifies 2-space LF asmdefs render migrated elements with matching indentation.
+            string source =
+                "{\n" +
+                "  \"name\": \"MyCompany.Tools.Editor\",\n" +
+                "  \"references\": [\n" +
+                "    \"Old\"\n" +
+                "  ]\n" +
+                "}\n";
+
+            ThirdPartyToolMigrationAsmdefTextEditor.AsmdefReferencesEditResult result =
+                ThirdPartyToolMigrationAsmdefTextEditor.ReplaceReferencesArray(
+                    source,
+                    new[] { "New1", "New2" });
+
+            Assert.That(result.Replaced, Is.True);
+            Assert.That(result.Content, Does.Contain("  \"references\": [\n    \"New1\",\n    \"New2\"\n  ]"));
+            Assert.That(result.Content, Does.Not.Contain("\r\n"));
+        }
+
+        [Test]
+        public void ReplaceReferencesArray_WhenArrayIsSingleLine_KeepsSingleLineFormat()
+        {
+            // Verifies a single-line references array stays single-line after replacement.
+            string source = "{\"name\":\"MyCompany.Tools.Editor\",\"references\": [\"Old\"]}";
+
+            ThirdPartyToolMigrationAsmdefTextEditor.AsmdefReferencesEditResult result =
+                ThirdPartyToolMigrationAsmdefTextEditor.ReplaceReferencesArray(
+                    source,
+                    new[] { "New1", "New2" });
+
+            Assert.That(result.Replaced, Is.True);
+            Assert.That(result.Content, Is.EqualTo(
+                "{\"name\":\"MyCompany.Tools.Editor\",\"references\": [\"New1\", \"New2\"]}"));
+        }
+
+        [Test]
+        public void ReplaceReferencesArray_WhenStringValueEqualsReferences_IgnoresDecoyValue()
+        {
+            // Verifies decoy string values and escaped text do not steal the references array match.
+            string source =
+                "{\n" +
+                "  \"name\": \"references\",\n" +
+                "  \"note\": \"\\\"references\\\":\",\n" +
+                "  \"references\": [\"Old\"]\n" +
+                "}\n";
+
+            ThirdPartyToolMigrationAsmdefTextEditor.AsmdefReferencesEditResult result =
+                ThirdPartyToolMigrationAsmdefTextEditor.ReplaceReferencesArray(
+                    source,
+                    new[] { "New" });
+
+            Assert.That(result.Replaced, Is.True);
+            Assert.That(result.Content, Does.Contain("\"name\": \"references\""));
+            Assert.That(result.Content, Does.Contain("\"note\": \"\\\"references\\\":\""));
+            Assert.That(result.Content, Does.Contain("\"references\": [\"New\"]"));
+        }
+
+        [Test]
+        public void ReplaceReferencesArray_WhenReferencesPropertyIsMissing_ReturnsNotReplaced()
+        {
+            // Verifies asmdefs without a references property report NotReplaced.
+            string source =
+                "{\n" +
+                "  \"name\": \"MyCompany.Tools.Editor\"\n" +
+                "}\n";
+
+            ThirdPartyToolMigrationAsmdefTextEditor.AsmdefReferencesEditResult result =
+                ThirdPartyToolMigrationAsmdefTextEditor.ReplaceReferencesArray(
+                    source,
+                    new[] { "New" });
+
+            Assert.That(result.Replaced, Is.False);
+            Assert.That(result.Content, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenReferencesPropertyIsMissing_FallsBackToReserialization()
+        {
+            // Verifies missing references still gains required entries through full re-serialization.
+            string source =
+                "{\n" +
+                "    \"name\": \"MyCompany.Tools.Editor\"\n" +
+                "}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: true,
+                    requiresToolContractsReference: false,
+                    requiresApplicationReference: false,
+                    requiresDomainReference: false,
+                    requiresFirstPartyScreenshotReference: false);
+
+            Assert.That(result.Changed, Is.True);
+            Assert.That(result.Content, Does.Contain("\"references\": ["));
+            Assert.That(result.Content, Does.Contain("GUID:fc3fd32eddbee40e39c2d76dc184957b"));
+        }
+
+        [Test]
+        public void MigrateAsmdefSource_WhenNothingChanges_ReturnsSourceUnchanged()
+        {
+            // Verifies the early-return path leaves the original asmdef text untouched.
+            string source =
+                "{\r\n" +
+                "    \"name\": \"MyCompany.Tools.Editor\",\r\n" +
+                "    \"references\": [\r\n" +
+                "        \"GUID:fc3fd32eddbee40e39c2d76dc184957b\"\r\n" +
+                "    ]\r\n" +
+                "}\r\n";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateAsmdefSource(
+                    source,
+                    hasLegacyCSharpSource: false,
+                    requiresToolContractsReference: false,
+                    requiresApplicationReference: false,
+                    requiresDomainReference: false,
+                    requiresFirstPartyScreenshotReference: false);
+
+            Assert.That(result.Changed, Is.False);
+            Assert.That(result.Content, Is.EqualTo(source));
+            Assert.That(Encoding.UTF8.GetBytes(result.Content), Is.EqualTo(Encoding.UTF8.GetBytes(source)));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationAsmdefTextEditorTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationAsmdefTextEditorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e62e3d40a673d4e338e77cde3e7e3aa6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationFileWriterTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationFileWriterTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 using NUnit.Framework;
@@ -170,6 +171,118 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 }
 
                 Assert.That(CountSidecarFiles(tempDirectory), Is.EqualTo(0));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [Test]
+        public void WriteBatch_WhenTargetHasUtf8Bom_PreservesBomBytes()
+        {
+            // Verifies a UTF-8 BOM target keeps EF BB BF after a batch write.
+            string tempDirectory = CreateTempDirectory();
+            try
+            {
+                string filePath = Path.Combine(tempDirectory, "BomFile.cs");
+                File.WriteAllText(filePath, "original", new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+                ThirdPartyToolMigrationFileWriter.WriteBatch(
+                    new List<MigrationFileChange>
+                    {
+                        new MigrationFileChange(filePath, "migrated")
+                    });
+
+                byte[] bytes = File.ReadAllBytes(filePath);
+                Assert.That(bytes[0], Is.EqualTo(0xEF));
+                Assert.That(bytes[1], Is.EqualTo(0xBB));
+                Assert.That(bytes[2], Is.EqualTo(0xBF));
+                Assert.That(Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3), Is.EqualTo("migrated"));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [Test]
+        public void WriteBatch_WhenTargetIsUtf16LittleEndian_PreservesEncoding()
+        {
+            // Verifies a UTF-16 LE BOM target is rewritten as UTF-16 LE with the new content.
+            string tempDirectory = CreateTempDirectory();
+            try
+            {
+                string filePath = Path.Combine(tempDirectory, "Utf16File.cs");
+                Encoding utf16 = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+                File.WriteAllText(filePath, "original", utf16);
+
+                ThirdPartyToolMigrationFileWriter.WriteBatch(
+                    new List<MigrationFileChange>
+                    {
+                        new MigrationFileChange(filePath, "migrated")
+                    });
+
+                byte[] bytes = File.ReadAllBytes(filePath);
+                Assert.That(bytes[0], Is.EqualTo(0xFF));
+                Assert.That(bytes[1], Is.EqualTo(0xFE));
+                Assert.That(utf16.GetString(bytes, 2, bytes.Length - 2), Is.EqualTo("migrated"));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [Test]
+        public void WriteBatch_WhenTargetHasNoBom_DoesNotAddBom()
+        {
+            // Verifies a BOM-less UTF-8 target does not gain EF BB BF after a batch write.
+            string tempDirectory = CreateTempDirectory();
+            try
+            {
+                string filePath = Path.Combine(tempDirectory, "NoBomFile.cs");
+                File.WriteAllText(filePath, "original", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+                ThirdPartyToolMigrationFileWriter.WriteBatch(
+                    new List<MigrationFileChange>
+                    {
+                        new MigrationFileChange(filePath, "migrated")
+                    });
+
+                byte[] bytes = File.ReadAllBytes(filePath);
+                Assert.That(bytes.Length, Is.GreaterThanOrEqualTo(1));
+                Assert.That(bytes[0], Is.Not.EqualTo(0xEF));
+                Assert.That(Encoding.UTF8.GetString(bytes), Is.EqualTo("migrated"));
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [Test]
+        public void WriteBatch_WhenContentUsesCrlf_PreservesCrlfBytes()
+        {
+            // Verifies CRLF content bytes survive the batch write without lone LF rewriting.
+            string tempDirectory = CreateTempDirectory();
+            try
+            {
+                string filePath = Path.Combine(tempDirectory, "CrlfFile.cs");
+                File.WriteAllText(filePath, "original\r\nline", new UTF8Encoding(false));
+                string migratedContent = "migrated\r\nline\r\n";
+
+                ThirdPartyToolMigrationFileWriter.WriteBatch(
+                    new List<MigrationFileChange>
+                    {
+                        new MigrationFileChange(filePath, migratedContent)
+                    });
+
+                byte[] bytes = File.ReadAllBytes(filePath);
+                string decoded = Encoding.UTF8.GetString(bytes);
+                Assert.That(decoded, Is.EqualTo(migratedContent));
+                Assert.That(decoded.Contains("\r\n"), Is.True);
+                Assert.That(decoded.Replace("\r\n", string.Empty).Contains("\n"), Is.False);
             }
             finally
             {

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefRules.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefRules.cs
@@ -51,12 +51,26 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     Array.Empty<RemovedLegacyPlayerLoopTimingSignature>());
             }
 
-            JArray migratedReferences = CreateReferencesArray(migrationResult.References);
-            asmdef["references"] = migratedReferences;
+            ThirdPartyToolMigrationAsmdefTextEditor.AsmdefReferencesEditResult editResult =
+                ThirdPartyToolMigrationAsmdefTextEditor.ReplaceReferencesArray(source, migrationResult.References);
+            // The surgical edit needs an existing "references" array to anchor on; when the asmdef has
+            // none, there is no original formatting to preserve, so full re-serialization is acceptable.
+            string migratedSource = editResult.Replaced
+                ? editResult.Content
+                : CreateReserializedAsmdefSource(asmdef, migrationResult.References);
             return new ThirdPartyToolMigrationContentResult(
-                asmdef.ToString(Formatting.Indented),
+                migratedSource,
                 migrationResult.ReplacementCount,
                 Array.Empty<RemovedLegacyPlayerLoopTimingSignature>());
+        }
+
+        private static string CreateReserializedAsmdefSource(JObject asmdef, string[] references)
+        {
+            Debug.Assert(asmdef != null, "asmdef must not be null");
+            Debug.Assert(references != null, "references must not be null");
+
+            asmdef["references"] = CreateReferencesArray(references);
+            return asmdef.ToString(Formatting.Indented);
         }
 
         private static string[] ReadReferenceValues(JArray references)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefTextEditor.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefTextEditor.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+
+using Newtonsoft.Json;
+
+namespace io.github.hatayama.UnityCliLoop.Infrastructure
+{
+    /// <summary>
+    /// Replaces only the top-level "references" array inside asmdef JSON text so every byte
+    /// outside that array (indentation, line endings, trailing newline, other properties)
+    /// is preserved exactly.
+    /// </summary>
+    internal static class ThirdPartyToolMigrationAsmdefTextEditor
+    {
+        internal static AsmdefReferencesEditResult ReplaceReferencesArray(
+            string source,
+            string[] references)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(references != null, "references must not be null");
+            Debug.Assert(references.Length > 0, "references must not be empty");
+
+            ReferencesArraySpan span = FindTopLevelReferencesArray(source);
+            if (!span.Found)
+            {
+                return AsmdefReferencesEditResult.NotReplaced;
+            }
+
+            string renderedArray = RenderReferencesArray(source, span, references);
+            string content = source.Substring(0, span.ArrayStartIndex) +
+                renderedArray +
+                source.Substring(span.ArrayEndIndexExclusive);
+            return AsmdefReferencesEditResult.ReplacedWith(content);
+        }
+
+        private static ReferencesArraySpan FindTopLevelReferencesArray(string source)
+        {
+            int depth = 0;
+            int index = 0;
+            while (index < source.Length)
+            {
+                char current = source[index];
+                if (current == '"')
+                {
+                    int stringStartIndex = index;
+                    index = SkipJsonString(source, index);
+                    if (depth != 1)
+                    {
+                        continue;
+                    }
+
+                    // A depth-1 string is a property name only when the next
+                    // non-whitespace character is a colon.
+                    int colonIndex = SkipWhitespace(source, index);
+                    if (colonIndex >= source.Length || source[colonIndex] != ':')
+                    {
+                        continue;
+                    }
+
+                    string propertyName = source.Substring(
+                        stringStartIndex + 1,
+                        index - stringStartIndex - 2);
+                    int valueStartIndex = SkipWhitespace(source, colonIndex + 1);
+                    if (!string.Equals(propertyName, "references", StringComparison.Ordinal) ||
+                        valueStartIndex >= source.Length ||
+                        source[valueStartIndex] != '[')
+                    {
+                        continue;
+                    }
+
+                    int arrayEndIndexExclusive = SkipJsonArray(source, valueStartIndex);
+                    return ReferencesArraySpan.FoundAt(
+                        stringStartIndex,
+                        valueStartIndex,
+                        arrayEndIndexExclusive);
+                }
+
+                if (current == '{' || current == '[')
+                {
+                    depth++;
+                }
+                else if (current == '}' || current == ']')
+                {
+                    depth--;
+                }
+
+                index++;
+            }
+
+            return ReferencesArraySpan.NotFound;
+        }
+
+        // Returns the index just after the closing quote.
+        private static int SkipJsonString(string source, int openQuoteIndex)
+        {
+            int index = openQuoteIndex + 1;
+            while (index < source.Length)
+            {
+                char current = source[index];
+                if (current == '\\')
+                {
+                    index += 2;
+                    continue;
+                }
+
+                if (current == '"')
+                {
+                    return index + 1;
+                }
+
+                index++;
+            }
+
+            return source.Length;
+        }
+
+        // Returns the index just after the matching closing bracket.
+        private static int SkipJsonArray(string source, int openBracketIndex)
+        {
+            int bracketDepth = 0;
+            int index = openBracketIndex;
+            while (index < source.Length)
+            {
+                char current = source[index];
+                if (current == '"')
+                {
+                    index = SkipJsonString(source, index);
+                    continue;
+                }
+
+                if (current == '[')
+                {
+                    bracketDepth++;
+                }
+                else if (current == ']')
+                {
+                    bracketDepth--;
+                    if (bracketDepth == 0)
+                    {
+                        return index + 1;
+                    }
+                }
+
+                index++;
+            }
+
+            return source.Length;
+        }
+
+        private static int SkipWhitespace(string source, int startIndex)
+        {
+            int index = startIndex;
+            while (index < source.Length && char.IsWhiteSpace(source[index]))
+            {
+                index++;
+            }
+
+            return index;
+        }
+
+        private static string RenderReferencesArray(
+            string source,
+            ReferencesArraySpan span,
+            string[] references)
+        {
+            string originalArrayText = source.Substring(
+                span.ArrayStartIndex,
+                span.ArrayEndIndexExclusive - span.ArrayStartIndex);
+            if (originalArrayText.IndexOf('\n') < 0)
+            {
+                return RenderSingleLineArray(references);
+            }
+
+            // The file's own newline flavor and the property line's indent decide the layout;
+            // Environment.NewLine would silently rewrite CRLF files on macOS and vice versa.
+            string newline = source.IndexOf("\r\n", StringComparison.Ordinal) >= 0 ? "\r\n" : "\n";
+            string propertyIndent = GetLineIndent(source, span.PropertyNameIndex);
+            string indentUnit = propertyIndent.Length > 0 ? propertyIndent : "    ";
+            string elementIndent = propertyIndent + indentUnit;
+            StringBuilder builder = new();
+            builder.Append('[');
+            for (int index = 0; index < references.Length; index++)
+            {
+                builder.Append(newline);
+                builder.Append(elementIndent);
+                builder.Append(JsonConvert.ToString(references[index]));
+                if (index < references.Length - 1)
+                {
+                    builder.Append(',');
+                }
+            }
+
+            builder.Append(newline);
+            builder.Append(propertyIndent);
+            builder.Append(']');
+            return builder.ToString();
+        }
+
+        private static string RenderSingleLineArray(string[] references)
+        {
+            StringBuilder builder = new();
+            builder.Append('[');
+            for (int index = 0; index < references.Length; index++)
+            {
+                builder.Append(JsonConvert.ToString(references[index]));
+                if (index < references.Length - 1)
+                {
+                    builder.Append(", ");
+                }
+            }
+
+            builder.Append(']');
+            return builder.ToString();
+        }
+
+        // Returns the leading whitespace of the property's line, or empty when the
+        // property does not start its own line.
+        private static string GetLineIndent(string source, int propertyNameIndex)
+        {
+            Debug.Assert(propertyNameIndex > 0, "propertyNameIndex must be inside the object");
+
+            int lineStartIndex = source.LastIndexOf('\n', propertyNameIndex - 1) + 1;
+            int index = lineStartIndex;
+            while (index < propertyNameIndex && (source[index] == ' ' || source[index] == '\t'))
+            {
+                index++;
+            }
+
+            if (index != propertyNameIndex)
+            {
+                return string.Empty;
+            }
+
+            return source.Substring(lineStartIndex, index - lineStartIndex);
+        }
+
+        internal readonly struct AsmdefReferencesEditResult
+        {
+            public static AsmdefReferencesEditResult NotReplaced => new(false, string.Empty);
+
+            public static AsmdefReferencesEditResult ReplacedWith(string content)
+            {
+                return new AsmdefReferencesEditResult(true, content);
+            }
+
+            private AsmdefReferencesEditResult(bool replaced, string content)
+            {
+                Replaced = replaced;
+                Content = content;
+            }
+
+            public bool Replaced { get; }
+            public string Content { get; }
+        }
+
+        private readonly struct ReferencesArraySpan
+        {
+            public static ReferencesArraySpan NotFound => new(false, 0, 0, 0);
+
+            public static ReferencesArraySpan FoundAt(
+                int propertyNameIndex,
+                int arrayStartIndex,
+                int arrayEndIndexExclusive)
+            {
+                return new ReferencesArraySpan(
+                    true,
+                    propertyNameIndex,
+                    arrayStartIndex,
+                    arrayEndIndexExclusive);
+            }
+
+            private ReferencesArraySpan(
+                bool found,
+                int propertyNameIndex,
+                int arrayStartIndex,
+                int arrayEndIndexExclusive)
+            {
+                Found = found;
+                PropertyNameIndex = propertyNameIndex;
+                ArrayStartIndex = arrayStartIndex;
+                ArrayEndIndexExclusive = arrayEndIndexExclusive;
+            }
+
+            public bool Found { get; }
+            public int PropertyNameIndex { get; }
+            public int ArrayStartIndex { get; }
+            public int ArrayEndIndexExclusive { get; }
+        }
+    }
+}

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefTextEditor.cs.meta
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationAsmdefTextEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0cca2e10f7002407c963bc4f3966b7e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
@@ -92,7 +93,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             string tempFilePath = CreateUniqueSidecarPath(change.FilePath, TempSidecarExtension);
             // Register before WriteAllText so a mid-write IOException can still clean up a partial .tmp.
             preparedWrites.Add(new PreparedWrite(change.FilePath, tempFilePath));
-            ThirdPartyToolMigrationFileAccess.WriteAllText(tempFilePath, change.Content);
+            // The plan carries decoded strings only, so the original file's BOM/encoding must be
+            // re-detected here and reapplied; otherwise every migrated file collapses to BOM-less UTF-8.
+            Encoding encoding = ThirdPartyToolMigrationFileAccess.Exists(change.FilePath)
+                ? ThirdPartyToolMigrationFileAccess.DetectEncodingFromBom(change.FilePath)
+                : new UTF8Encoding(false);
+            ThirdPartyToolMigrationFileAccess.WriteAllTextWithEncoding(tempFilePath, change.Content, encoding);
         }
 
         private static void CommitAll(List<PreparedWrite> preparedWrites)
@@ -271,6 +277,65 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             Debug.Assert(content != null, "content must not be null");
 
             File.WriteAllText(GetFileSystemPath(filePath), content);
+        }
+
+        internal static Encoding DetectEncodingFromBom(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+
+            byte[] bom = new byte[4];
+            int readCount = 0;
+            using (FileStream stream = File.OpenRead(GetFileSystemPath(filePath)))
+            {
+                // FileStream.Read may return fewer bytes than requested; read until EOF or 4 bytes.
+                while (readCount < bom.Length)
+                {
+                    int read = stream.Read(bom, readCount, bom.Length - readCount);
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    readCount += read;
+                }
+            }
+
+            // UTF-32 BOMs must be checked before UTF-16 because they share the same leading bytes.
+            if (readCount >= 4 && bom[0] == 0xFF && bom[1] == 0xFE && bom[2] == 0x00 && bom[3] == 0x00)
+            {
+                return new UTF32Encoding(bigEndian: false, byteOrderMark: true);
+            }
+
+            if (readCount >= 4 && bom[0] == 0x00 && bom[1] == 0x00 && bom[2] == 0xFE && bom[3] == 0xFF)
+            {
+                return new UTF32Encoding(bigEndian: true, byteOrderMark: true);
+            }
+
+            if (readCount >= 3 && bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF)
+            {
+                return new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+            }
+
+            if (readCount >= 2 && bom[0] == 0xFF && bom[1] == 0xFE)
+            {
+                return new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+            }
+
+            if (readCount >= 2 && bom[0] == 0xFE && bom[1] == 0xFF)
+            {
+                return new UnicodeEncoding(bigEndian: true, byteOrderMark: true);
+            }
+
+            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        }
+
+        internal static void WriteAllTextWithEncoding(string filePath, string content, Encoding encoding)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+            Debug.Assert(content != null, "content must not be null");
+            Debug.Assert(encoding != null, "encoding must not be null");
+
+            File.WriteAllText(GetFileSystemPath(filePath), content, encoding);
         }
 
         internal static IEnumerable<string> ReadLines(string filePath)

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationFileWriter.cs
@@ -271,14 +271,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             return File.ReadAllText(GetFileSystemPath(filePath));
         }
 
-        internal static void WriteAllText(string filePath, string content)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
-            Debug.Assert(content != null, "content must not be null");
-
-            File.WriteAllText(GetFileSystemPath(filePath), content);
-        }
-
         internal static Encoding DetectEncodingFromBom(string filePath)
         {
             Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");


### PR DESCRIPTION
## Summary
- Re-detect the original file BOM/encoding in `Prepare` and write migrated content with that encoding
- Add surgical asmdef `references` array editing so indentation, line endings, and surrounding properties stay byte-identical
- Fall back to full re-serialization only when the asmdef has no `references` property to anchor on
- Cover BOM/UTF-16/CRLF writer cases and asmdef surgical-edit edge cases with focused tests

## User Impact
Applying V2→V3 third-party tool migration no longer rewrites entire files just to change one reference, and keeps the original encoding/BOM of migrated sources.

## Test plan
- [x] `uloop compile` — 0 errors / 0 warnings
- [x] `uloop run-tests` filter `ThirdPartyToolMigrationFileWriterTests|ThirdPartyToolMigrationAsmdefTextEditorTests` — 16/16 passed
- [x] Live demo via `uloop execute-dynamic-code`: CRLF + 4-space asmdef with `uLoopMCP.Editor` → only references array changes; prefix/suffix outside array unchanged

### Live verification log
```
changed=True
prefixOutsideArrayUnchanged=True
suffixOutsideArrayUnchanged=True
hasCrlf=True
hasLoneLf=False
fourSpaceIndent=True
hasToolContractsGuid=True
legacyRemoved=True
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

