### PR TITLE
fix: Stop migration masking from treating directive apostrophes as chars

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationCodeTextMaskBuilderTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationCodeTextMaskBuilderTests.cs
@@ -1,0 +1,78 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies migration code masking ignores preprocessor text and bounds char literals.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationCodeTextMaskBuilderTests
+    {
+        [Test]
+        public void CreateCodeCharacters_WhenRegionNameContainsApostrophe_KeepsFollowingCodeUnmasked()
+        {
+            // Verifies a #region title apostrophe does not mask the rest of the file as a char literal.
+            string source = "#region Bob's helpers\npublic class Tool {}\n";
+
+            bool[] codeCharacters = ThirdPartyToolMigrationCodeTextMaskBuilder.CreateCodeCharacters(source);
+
+            int codeStartIndex = source.IndexOf("public class Tool");
+            Assert.That(codeStartIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(AreAllCodeCharacters(codeCharacters, codeStartIndex, "public class Tool".Length), Is.True);
+        }
+
+        [Test]
+        public void CreateCodeCharacters_WhenWarningContainsApostrophe_KeepsFollowingCodeUnmasked()
+        {
+            // Verifies a #warning apostrophe does not mask the following source as a char literal.
+            string source = "#warning Don't call this API\npublic class Tool {}\n";
+
+            bool[] codeCharacters = ThirdPartyToolMigrationCodeTextMaskBuilder.CreateCodeCharacters(source);
+
+            int codeStartIndex = source.IndexOf("public class Tool");
+            Assert.That(codeStartIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(AreAllCodeCharacters(codeCharacters, codeStartIndex, "public class Tool".Length), Is.True);
+        }
+
+        [Test]
+        public void CreateCodeCharacters_WhenValidCharLiteral_MasksOnlyTheLiteral()
+        {
+            // Verifies a real char literal stays masked while the following statement remains code.
+            string source = "char c = 'a';\nint x = 1;\n";
+
+            bool[] codeCharacters = ThirdPartyToolMigrationCodeTextMaskBuilder.CreateCodeCharacters(source);
+
+            int literalIndex = source.IndexOf("'a'");
+            Assert.That(codeCharacters[literalIndex], Is.False);
+            Assert.That(codeCharacters[literalIndex + 1], Is.False);
+            Assert.That(codeCharacters[literalIndex + 2], Is.False);
+            Assert.That(codeCharacters[source.IndexOf("int x")], Is.True);
+        }
+
+        [Test]
+        public void CreateCodeCharacters_WhenApostropheDoesNotCloseSoon_TreatsItAsCode()
+        {
+            // Verifies a long unmatched apostrophe is not treated as an open-ended char literal.
+            string source = "var name = Bob's helpers;\nint x = 1;\n";
+
+            bool[] codeCharacters = ThirdPartyToolMigrationCodeTextMaskBuilder.CreateCodeCharacters(source);
+
+            Assert.That(codeCharacters[source.IndexOf("int x")], Is.True);
+            Assert.That(AreAllCodeCharacters(codeCharacters, source.IndexOf("helpers"), "helpers".Length), Is.True);
+        }
+
+        private static bool AreAllCodeCharacters(bool[] codeCharacters, int startIndex, int length)
+        {
+            for (int index = startIndex; index < startIndex + length; index++)
+            {
+                if (!codeCharacters[index])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationCodeTextMaskBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationCodeTextMaskBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca68b733dc7204b64827610344755ef4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationCodeTextMaskBuilder.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationCodeTextMaskBuilder.cs
@@ -62,6 +62,16 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             int index = 0;
             while (index < source.Length)
             {
+                if (IsPreprocessorDirectiveAt(source, index))
+                {
+                    // Preprocessor text is not C# code; skipping the whole directive line prevents
+                    // apostrophes in titles like #region Bob's helpers from opening a char literal.
+                    int directiveEndIndex = FindLineCommentEndIndex(source, index);
+                    MarkRangeAsIgnored(codeCharacters, index, directiveEndIndex);
+                    index = directiveEndIndex;
+                    continue;
+                }
+
                 if (IsInterpolatedRawStringStart(source, index))
                 {
                     index = MarkInterpolatedRawStringAsIgnored(codeCharacters, source, index);
@@ -244,7 +254,10 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public static int FindCharLiteralEndIndex(string source, int quoteIndex)
         {
             int index = quoteIndex + 1;
-            while (index < source.Length)
+            // Longest valid C# char literal content is \Uxxxxxxxx (10 chars). An unmatched apostrophe
+            // beyond that bound is ordinary code, not an open-ended char literal that masks the file.
+            int maxClosingQuoteIndex = quoteIndex + 1 + MaxCharLiteralContentLength;
+            while (index <= maxClosingQuoteIndex && index < source.Length)
             {
                 if (source[index] == '\\')
                 {
@@ -260,7 +273,32 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 index++;
             }
 
-            return source.Length;
+            return quoteIndex;
+        }
+
+        public static bool IsPreprocessorDirectiveAt(string source, int index)
+        {
+            Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(index >= 0, "index must not be negative");
+
+            if (index >= source.Length || source[index] != '#')
+            {
+                return false;
+            }
+
+            int lineStartIndex = index;
+            while (lineStartIndex > 0 && source[lineStartIndex - 1] != '\n')
+            {
+                lineStartIndex--;
+            }
+
+            int cursor = lineStartIndex;
+            while (cursor < index && (source[cursor] == ' ' || source[cursor] == '\t'))
+            {
+                cursor++;
+            }
+
+            return cursor == index;
         }
 
         public static void MarkRangeAsIgnored(bool[] codeCharacters, int startIndex, int endIndex)

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleCatalog.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationRuleCatalog.cs
@@ -56,6 +56,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public const string CurrentConstantsTypeName = "UnityCliLoopConstants";
         public const string CurrentEditorFrameWaitTimeoutMemberName = "EDITOR_FRAME_WAIT_TIMEOUT_MS";
         public const int MinimumRawStringDelimiterQuoteCount = 3;
+        // Longest valid C# char literal content is \Uxxxxxxxx; beyond that an apostrophe is ordinary code.
+        public const int MaxCharLiteralContentLength = 10;
         public static readonly string[] ExcludedDirectoryNames =
         {
             ".git",


### PR DESCRIPTION
## Summary
- Skip preprocessor directive lines in the migration code mask builder so `#region` / `#warning` titles are not scanned for char literals
- Bound char-literal detection to valid C# lengths so unmatched apostrophes no longer mask the rest of the file
- Add focused regression tests written first (TDD): Red on current behavior, then Green after the fix

## User Impact
V2→V3 third-party tool migration no longer silently skips real code after preprocessor titles that contain apostrophes (for example `#region Bob's helpers`).

## Test plan
- [x] TDD Red: new mask tests failed 3/4 before the fix
- [x] `uloop compile` — 0/0
- [x] `uloop run-tests --filter-type regex --filter-value ThirdPartyToolMigrationCodeTextMaskBuilderTests` — 4/4
- [x] Live demo via `uloop execute-dynamic-code`: region/warning following code unmasked; valid `'a'` still masked

### Live verification log
```
regionFollowingCodeUnmasked=True
warningFollowingCodeUnmasked=True
charLiteralMasked=True
afterLiteralUnmasked=True
isPreprocessorAtHash=True
charLiteralEndForValid=12
charLiteralEndForApostropheInRegion=11
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

