### PR TITLE
fix: Guard contract type renames against local type shadowing

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationLocalTypeShadowingTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationLocalTypeShadowingTests.cs
@@ -1,0 +1,135 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies local type shadowing is not rewritten by contract/domain/toolinfo renames.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationLocalTypeShadowingTests
+    {
+        [Test]
+        public void MigrateCSharpSource_WhenProjectDefinesSecuritySettings_KeepsProjectTypeUsages()
+        {
+            // Verifies a project-owned SecuritySettings type is not rewritten to the V3 security setting type.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class SecuritySettings
+{
+    public bool Enabled { get; set; }
+}
+
+public sealed class SettingsFactory
+{
+    public SecuritySettings Create()
+    {
+        return new SecuritySettings();
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Content, Does.Contain("public sealed class SecuritySettings"));
+            Assert.That(result.Content, Does.Contain("public SecuritySettings Create()"));
+            Assert.That(result.Content, Does.Contain("return new SecuritySettings();"));
+            Assert.That(result.Content, Does.Not.Contain("UnityCliLoopSecuritySetting"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenProjectDefinesServiceResult_KeepsProjectTypeUsages()
+        {
+            // Verifies a project-owned ServiceResult type is not rewritten to the ToolContracts type.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class ServiceResult
+{
+    public bool Ok { get; set; }
+}
+
+public sealed class ResultFactory
+{
+    public ServiceResult Create()
+    {
+        return new ServiceResult();
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Content, Does.Contain("public sealed class ServiceResult"));
+            Assert.That(result.Content, Does.Contain("public ServiceResult Create()"));
+            Assert.That(result.Content, Does.Contain("return new ServiceResult();"));
+            Assert.That(
+                result.Content,
+                Does.Not.Contain("io.github.hatayama.UnityCliLoop.ToolContracts.ServiceResult"));
+        }
+
+        [Test]
+        public void MigrateCSharpSource_WhenProjectDefinesToolInfo_KeepsProjectTypeUsages()
+        {
+            // Verifies a project-owned ToolInfo type is not rewritten to the ToolContracts type.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class ToolInfo
+{
+    public string Name { get; set; }
+}
+
+public sealed class ToolInfoFactory
+{
+    public ToolInfo Create()
+    {
+        return new ToolInfo();
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSource(source);
+
+            Assert.That(result.Content, Does.Contain("public sealed class ToolInfo"));
+            Assert.That(result.Content, Does.Contain("public ToolInfo Create()"));
+            Assert.That(result.Content, Does.Contain("return new ToolInfo();"));
+            Assert.That(
+                result.Content,
+                Does.Not.Contain("io.github.hatayama.UnityCliLoop.ToolContracts.ToolInfo"));
+        }
+
+        [Test]
+        public void MigrateCSharpSourceForLegacyAssembly_WhenAssemblyDeclaresSecuritySettings_KeepsProjectTypeUsages()
+        {
+            // Verifies sibling-file ownership of SecuritySettings also blocks bare reference rewrites.
+            string source = @"using io.github.hatayama.uLoopMCP;
+
+public sealed class SettingsFactory
+{
+    public SecuritySettings Create()
+    {
+        return new SecuritySettings();
+    }
+}";
+
+            ThirdPartyToolMigrationContentResult result =
+                ThirdPartyToolMigrationRules.MigrateCSharpSourceForLegacyAssembly(
+                    source,
+                    hasLegacyAssemblySource: true,
+                    hasAssemblyScopedCurrentToolContractsUsing: false,
+                    hasAssemblyScopedCurrentApplicationUsing: false,
+                    hasAssemblyScopedCurrentDomainUsing: false,
+                    hasAssemblyScopedCurrentFirstPartyToolsUsing: false,
+                    legacyAssemblyAliases: System.Array.Empty<string>(),
+                    legacyAssemblyToolInfoAliases: System.Array.Empty<string>(),
+                    currentApplicationAssemblyAliases: System.Array.Empty<string>(),
+                    currentDomainAssemblyAliases: System.Array.Empty<string>(),
+                    currentFirstPartyToolsAssemblyAliases: System.Array.Empty<string>(),
+                    assemblyDeclaredTypeNames: new[] { "SecuritySettings" });
+
+            Assert.That(result.Content, Does.Contain("public SecuritySettings Create()"));
+            Assert.That(result.Content, Does.Contain("return new SecuritySettings();"));
+            Assert.That(result.Content, Does.Not.Contain("UnityCliLoopSecuritySetting"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationLocalTypeShadowingTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationLocalTypeShadowingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8b72c13a78b849ab9ab7388b1658646
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationCSharpRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationCSharpRules.cs
@@ -371,10 +371,12 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 _migratedContent = ReplaceLegacyDomainTypeNamesInCode(
                     _migratedContent,
                     _legacyNamespaceAliases,
+                    _assemblyDeclaredTypeNames,
                     ref _replacementCount);
                 _migratedContent = ReplaceLegacyContractTypeNamesInCode(
                     _migratedContent,
                     _legacyNamespaceAliases,
+                    _assemblyDeclaredTypeNames,
                     ref _replacementCount);
                 ApplyCSharpReplacementRules();
             }
@@ -396,6 +398,7 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 ApplyRegistrarReplacementRules();
                 _migratedContent = ReplaceLegacyToolInfoTypeReferencesInCode(
                     _migratedContent,
+                    _assemblyDeclaredTypeNames,
                     ref _replacementCount);
             }
 

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationTypeReplacementRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationTypeReplacementRules.cs
@@ -110,14 +110,19 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public static string ReplaceLegacyContractTypeNamesInCode(
             string source,
             string[] aliases,
+            string[] assemblyDeclaredTypeNames,
             ref int replacementCount)
         {
             Debug.Assert(source != null, "source must not be null");
             Debug.Assert(aliases != null, "aliases must not be null");
+            Debug.Assert(assemblyDeclaredTypeNames != null, "assemblyDeclaredTypeNames must not be null");
 
             string migratedContent = source;
             foreach (TypeReplacementRule rule in ToolContractTypeReplacementRules)
             {
+                bool hasProtectedTypeDeclaration = DeclaresLocalType(migratedContent, rule.LegacyName) ||
+                    assemblyDeclaredTypeNames.Contains(rule.LegacyName);
+
                 Regex fullyQualifiedRegex = new(
                     $@"(?:(?:global::)?{Regex.Escape(LegacyNamespace)}\.){Regex.Escape(rule.LegacyName)}\b",
                     RegexOptions.Compiled);
@@ -145,7 +150,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 migratedContent = ReplaceRegexInCode(
                     migratedContent,
                     unqualifiedRegex,
-                    match => ShouldMigrateLegacyTypeReference(migratedContent, rule.LegacyName, match.Index)
+                    match => !hasProtectedTypeDeclaration &&
+                        ShouldMigrateLegacyTypeReference(migratedContent, rule.LegacyName, match.Index)
                         ? rule.CurrentName
                         : match.Value,
                     ref replacementCount);
@@ -157,14 +163,19 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public static string ReplaceLegacyDomainTypeNamesInCode(
             string source,
             string[] aliases,
+            string[] assemblyDeclaredTypeNames,
             ref int replacementCount)
         {
             Debug.Assert(source != null, "source must not be null");
             Debug.Assert(aliases != null, "aliases must not be null");
+            Debug.Assert(assemblyDeclaredTypeNames != null, "assemblyDeclaredTypeNames must not be null");
 
             string migratedContent = source;
             foreach (TypeReplacementRule rule in DomainTypeReplacementRules)
             {
+                bool hasProtectedTypeDeclaration = DeclaresLocalType(migratedContent, rule.LegacyName) ||
+                    assemblyDeclaredTypeNames.Contains(rule.LegacyName);
+
                 Regex fullyQualifiedRegex = new(
                     $@"(?:(?:global::)?{Regex.Escape(LegacyNamespace)}\.){Regex.Escape(rule.LegacyName)}\b",
                     RegexOptions.Compiled);
@@ -192,7 +203,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 migratedContent = ReplaceRegexInCode(
                     migratedContent,
                     unqualifiedRegex,
-                    match => ShouldMigrateLegacyTypeReference(migratedContent, rule.LegacyName, match.Index)
+                    match => !hasProtectedTypeDeclaration &&
+                        ShouldMigrateLegacyTypeReference(migratedContent, rule.LegacyName, match.Index)
                         ? $"{CurrentNamespace}.{rule.CurrentName}"
                         : match.Value,
                     ref replacementCount);
@@ -477,14 +489,21 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 ref replacementCount);
         }
 
-        public static string ReplaceLegacyToolInfoTypeReferencesInCode(string source, ref int replacementCount)
+        public static string ReplaceLegacyToolInfoTypeReferencesInCode(
+            string source,
+            string[] assemblyDeclaredTypeNames,
+            ref int replacementCount)
         {
             Debug.Assert(source != null, "source must not be null");
+            Debug.Assert(assemblyDeclaredTypeNames != null, "assemblyDeclaredTypeNames must not be null");
 
+            bool hasProtectedTypeDeclaration = DeclaresLocalType(source, "ToolInfo") ||
+                assemblyDeclaredTypeNames.Contains("ToolInfo");
             return ReplaceRegexInCode(
                 source,
                 UnqualifiedToolInfoRegex,
-                match => ShouldMigrateLegacyToolInfoTypeReference(source, match.Index)
+                match => !hasProtectedTypeDeclaration &&
+                    ShouldMigrateLegacyToolInfoTypeReference(source, match.Index)
                     ? $"{CurrentNamespace}.ToolInfo"
                     : match.Value,
                 ref replacementCount);


### PR DESCRIPTION
## Summary
- Add the same `DeclaresLocalType` + `assemblyDeclaredTypeNames` guard used by Application renames to Contract, Domain, and ToolInfo unqualified rewrites
- Thread `assemblyDeclaredTypeNames` through those rename helpers from the C# migration context
- Cover SecuritySettings / ServiceResult / ToolInfo local shadowing with TDD regression tests (Red then Green)

## User Impact
Migrating third-party tools no longer renames usages of a project-defined `SecuritySettings`, `ServiceResult`, or `ToolInfo` type, which previously produced compile-breaking mismatches.

## Test plan
- [x] TDD Red: LocalTypeShadowingTests 0/4 before the fix
- [x] `uloop compile` — 0/0
- [x] LocalTypeShadowingTests 4/4
- [x] Related filter (`SecuritySettings|ServiceResult|ToolInfo|LocalTypeShadowing|MainThreadSwitcher_KeepsProject`) 22/22
- [x] Live demo: local `SecuritySettings` keeps class/usages and is not rewritten to `UnityCliLoopSecuritySetting`

### Live verification log
```
keepsClass=True
keepsReturnType=True
keepsConstructor=True
noV3Rename=True
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

