### PR TITLE
fix: Make migration wizard auto-scan and async handlers reliable

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -16,21 +16,78 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public sealed class ThirdPartyToolMigrationWizardWindowTests
     {
-        [TestCase(false, true, false)]
-        [TestCase(true, false, false)]
-        [TestCase(true, true, true)]
-        public void ShouldStartInitialRefresh_ReturnsExpectedValue(
-            bool shouldRefreshAfterCreateGui,
-            bool shouldAutoScanThirdPartyToolMigration,
-            bool expected)
+        [Test]
+        public void ConsumeShouldStartInitialRefresh_WhenPreparedForAutoScan_ReturnsTrueWithoutSessionFlag()
         {
-            // Verifies that automatic scanning requires both auto-open intent and the session scan flag.
-            bool shouldStartInitialRefresh =
-                ThirdPartyToolMigrationWizardWindow.ShouldStartInitialRefresh(
-                    shouldRefreshAfterCreateGui,
-                    shouldAutoScanThirdPartyToolMigration);
+            // Verifies auto-open windows start scanning from the serialized refresh flag alone.
+            ThirdPartyToolMigrationWizardWindow window =
+                ScriptableObject.CreateInstance<ThirdPartyToolMigrationWizardWindow>();
+            try
+            {
+                ThirdPartyToolMigrationWizardWindow.PrepareForOpen(
+                    window,
+                    "Unity CLI Loop Migration",
+                    new Rect(12f, 34f, 360f, 220f),
+                    shouldRefreshAfterCreateGui: true);
 
-            Assert.That(shouldStartInitialRefresh, Is.EqualTo(expected));
+                bool shouldStartInitialRefresh = window.ConsumeShouldStartInitialRefresh();
+
+                Assert.That(shouldStartInitialRefresh, Is.True);
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+
+        [Test]
+        public void ConsumeShouldStartInitialRefresh_WhenConsumedTwice_ReturnsFalseOnSecondCall()
+        {
+            // Verifies the initial-refresh flag is one-shot so CreateGUI cannot double-scan.
+            ThirdPartyToolMigrationWizardWindow window =
+                ScriptableObject.CreateInstance<ThirdPartyToolMigrationWizardWindow>();
+            try
+            {
+                ThirdPartyToolMigrationWizardWindow.PrepareForOpen(
+                    window,
+                    "Unity CLI Loop Migration",
+                    new Rect(12f, 34f, 360f, 220f),
+                    shouldRefreshAfterCreateGui: true);
+
+                bool first = window.ConsumeShouldStartInitialRefresh();
+                bool second = window.ConsumeShouldStartInitialRefresh();
+
+                Assert.That(first, Is.True);
+                Assert.That(second, Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+
+        [Test]
+        public void ConsumeShouldStartInitialRefresh_WhenManualOpen_ReturnsFalse()
+        {
+            // Verifies manually opened windows wait for an explicit Check instead of auto-scanning.
+            ThirdPartyToolMigrationWizardWindow window =
+                ScriptableObject.CreateInstance<ThirdPartyToolMigrationWizardWindow>();
+            try
+            {
+                ThirdPartyToolMigrationWizardWindow.PrepareForOpen(
+                    window,
+                    "Unity CLI Loop Migration",
+                    new Rect(12f, 34f, 360f, 220f),
+                    shouldRefreshAfterCreateGui: false);
+
+                bool shouldStartInitialRefresh = window.ConsumeShouldStartInitialRefresh();
+
+                Assert.That(shouldStartInitialRefresh, Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
         }
 
         [TestCase(false, false, false)]

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardStateRules.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardStateRules.cs
@@ -11,13 +11,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     {
         internal const int MigrationProgressUiUpdateIntervalMilliseconds = 100;
 
-        internal static bool ShouldStartInitialRefresh(
-            bool shouldRefreshAfterCreateGui,
-            bool shouldAutoScanThirdPartyToolMigration)
-        {
-            return shouldRefreshAfterCreateGui && shouldAutoScanThirdPartyToolMigration;
-        }
-
         internal static bool ShouldReportMigrationProgress(
             long lastReportTimestamp,
             long currentTimestamp,

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -34,6 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private SkillsTarget _migrationSkillTarget = SkillsTarget.Claude;
         private SkillInstallState _migrationSkillInstallState = SkillInstallState.Missing;
         private CancellationTokenSource _migrationOperationCts;
+        private CancellationTokenSource _migrationSkillOperationCts;
         private SkillSetupUseCase _skillSetupUseCase;
         private ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
         private ThirdPartyToolMigrationWizardView _view;
@@ -146,15 +147,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             Debug.Assert(ex != null, "ex must not be null");
 
             Debug.LogException(ex);
-        }
-
-        internal static bool ShouldStartInitialRefresh(
-            bool shouldRefreshAfterCreateGui,
-            bool shouldAutoScanThirdPartyToolMigration)
-        {
-            return ThirdPartyToolMigrationWizardStateRules.ShouldStartInitialRefresh(
-                shouldRefreshAfterCreateGui,
-                shouldAutoScanThirdPartyToolMigration);
         }
 
         internal static bool ShouldOpenWindowAfterAutoScan(
@@ -396,6 +388,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             _resizer?.Pause();
             CancelMigrationOperation();
+            CancelMigrationSkillOperation();
         }
 
         private void ShowInitialState(bool shouldStartInitialRefresh)
@@ -427,22 +420,38 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             System.IProgress<ThirdPartyToolMigrationProgress> progress = CreateProgressReporter(ct);
-            ThirdPartyToolMigrationPreview preview =
-                await Task.Run(async () =>
-                    await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct));
-            if (ct.IsCancellationRequested)
+            ThirdPartyToolMigrationPreview preview;
+            try
             {
+                preview = await Task.Run(async () =>
+                    await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct));
+                await MainThreadSwitcher.SwitchToMainThread();
+            }
+            catch (System.OperationCanceledException)
+            {
+                // Cancellation comes from window close or a superseding operation; that owner drives the UI.
+                return;
+            }
+            catch (System.Exception ex)
+            {
+                // Without this async-void boundary the exception hits the sync context, the window
+                // stays on "Scanning..." forever, and the operation CTS leaks.
+                Debug.LogException(ex);
+                if (IsMigrationOperationActive(ct))
+                {
+                    CompleteMigrationOperation(ct);
+                    ShowNotCheckedState();
+                }
+
                 return;
             }
 
-            await MainThreadSwitcher.SwitchToMainThread();
             if (ct.IsCancellationRequested)
             {
                 return;
             }
 
             CompleteMigrationOperation(ct);
-
             if (!preview.HasTargets)
             {
                 ShowNoMigrationTargetsState();
@@ -491,6 +500,19 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 }
 
                 isMigrationCompletionPending = false;
+            }
+            catch (System.OperationCanceledException)
+            {
+                // The finally block already skips the interrupted-refresh when the token is canceled.
+                return;
+            }
+            catch (System.Exception ex)
+            {
+                // PR1 makes a mid-batch apply failure a designed path (rollback, then throw). Log it and
+                // return; the finally block sees the still-pending completion and rescans, so the UI
+                // reflects the rolled-back files.
+                Debug.LogException(ex);
+                return;
             }
             finally
             {
@@ -579,6 +601,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private async void HandleToggleMigrationSkill()
         {
+            CancellationToken ct = BeginMigrationSkillOperation();
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             SkillSetupTargetInfo target = CreateMigrationSkillTargetInfo(_migrationSkillTarget);
             SkillInstallState currentInstallState =
@@ -600,21 +623,41 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                         projectRoot,
                         targets,
                         GroupMigrationSkillUnderUnityCliLoop,
-                        CancellationToken.None);
-                    return;
+                        ct);
                 }
-
-                await _skillSetupUseCase.InstallV3MigrationSkillFilesAsync(
-                    projectRoot,
-                    targets,
-                    GroupMigrationSkillUnderUnityCliLoop,
-                    CancellationToken.None);
+                else
+                {
+                    await _skillSetupUseCase.InstallV3MigrationSkillFilesAsync(
+                        projectRoot,
+                        targets,
+                        GroupMigrationSkillUnderUnityCliLoop,
+                        ct);
+                }
+            }
+            catch (System.OperationCanceledException)
+            {
+                // The window is closing or a newer toggle superseded this one; do not touch its UI.
+                return;
+            }
+            catch (System.Exception ex)
+            {
+                // Fall through so the tail refresh shows the real on-disk install state after a failure.
+                Debug.LogException(ex);
             }
             finally
             {
                 _isUpdatingMigrationSkill = false;
-                RefreshMigrationSkillState();
             }
+
+            // The use case may complete off the main thread; UI Toolkit access below requires it.
+            await MainThreadSwitcher.SwitchToMainThread();
+            if (!IsMigrationSkillOperationActive(ct))
+            {
+                return;
+            }
+
+            CompleteMigrationSkillOperation(ct);
+            RefreshMigrationSkillState();
         }
 
         private static SkillSetupTargetInfo CreateMigrationSkillTargetInfo(SkillsTarget target)
@@ -657,7 +700,27 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _migrationOperationCts = null;
         }
 
-        private bool ConsumeShouldStartInitialRefresh()
+        private CancellationToken BeginMigrationSkillOperation()
+        {
+            CancelMigrationSkillOperation();
+            CancellationTokenSource cts = new CancellationTokenSource();
+            _migrationSkillOperationCts = cts;
+            return cts.Token;
+        }
+
+        private void CancelMigrationSkillOperation()
+        {
+            if (_migrationSkillOperationCts == null)
+            {
+                return;
+            }
+
+            _migrationSkillOperationCts.Cancel();
+            _migrationSkillOperationCts.Dispose();
+            _migrationSkillOperationCts = null;
+        }
+
+        internal bool ConsumeShouldStartInitialRefresh()
         {
             if (!_shouldRefreshAfterCreateGui)
             {
@@ -665,9 +728,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             _shouldRefreshAfterCreateGui = false;
-            bool shouldAutoScanThirdPartyToolMigration =
-                GetSessionFlagsRepository().ConsumeShouldAutoScanThirdPartyToolMigration();
-            return ShouldStartInitialRefresh(true, shouldAutoScanThirdPartyToolMigration);
+            return true;
         }
 
         private void TryStartInitialRefresh()
@@ -696,6 +757,22 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private bool IsMigrationOperationActive(CancellationToken ct)
         {
             return _migrationOperationCts != null && _migrationOperationCts.Token.Equals(ct);
+        }
+
+        private void CompleteMigrationSkillOperation(CancellationToken ct)
+        {
+            if (!IsMigrationSkillOperationActive(ct))
+            {
+                return;
+            }
+
+            _migrationSkillOperationCts.Dispose();
+            _migrationSkillOperationCts = null;
+        }
+
+        private bool IsMigrationSkillOperationActive(CancellationToken ct)
+        {
+            return _migrationSkillOperationCts != null && _migrationSkillOperationCts.Token.Equals(ct);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Drive initial wizard refresh from `_shouldRefreshAfterCreateGui` alone so auto-opened windows still scan after the session flag is consumed
- Add async-void catch boundaries for `RefreshUI` and migrate/skill handlers so failures cannot leave Scanning forever or leak CTS
- Give migration-skill install/remove its own window-scoped CTS with close/supersede guards
- Replace the dead `ShouldStartInitialRefresh` AND rule with focused `ConsumeShouldStartInitialRefresh` regression tests

## User Impact
Opening Custom Tool Migration from auto-scan reliably starts scanning, and failed or canceled async wizard operations no longer leave the window stuck or throw after close.

## Test plan
- [x] `uloop compile` — 0/0
- [x] `uloop run-tests --filter-type regex --filter-value ThirdPartyToolMigrationWizardWindowTests` — 52/52
- [x] C1 live: session flag consumed, `ShowWindowInternal(true)` → window opens and scans (screenshot shows Scanning then Nothing to migrate)
- [x] Skill toggle: install creates `.claude/skills/v3-cli-invocation-migration`, remove deletes it
- [x] Close during scan: `errorCount=0`

### Live verification
- Screenshots: `.uloop/outputs/Screenshots/Unity CLI Loop Migration_20260712_103911_182.png` (Scanning), `..._103953_353.png` (scan complete)
- Skill path after install: `.claude/skills/v3-cli-invocation-migration` present; after remove: absent
- Close-during-scan console errors: 0

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

