### PR TITLE
fix: Confirm migration apply and list target files in the wizard

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -151,24 +151,116 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(loggedException, Is.SameAs(expectedException));
         }
 
-        [TestCase(
-            1,
-            "1 file needs V3 C# source structure migration.\n" +
-            "The Unity Console is showing errors because this file still uses the old custom tool API.\n\n" +
-            "Click Migrate to update it automatically. The errors should disappear after migration.")]
-        [TestCase(
-            3,
-            "3 files need V3 C# source structure migration.\n" +
-            "The Unity Console is showing errors because these files still use the old custom tool API.\n\n" +
-            "Click Migrate to update them automatically. The errors should disappear after migration.")]
-        public void GetMigrationStatusText_WhenTargetsExist_ReturnsFileCount(
-            int fileCount,
-            string expectedText)
+        [Test]
+        public void GetMigrationStatusText_WhenTargetsExist_IncludesRelativeFilePaths()
         {
-            // Verifies that the migration wizard summarizes detected V2 custom tool files.
-            string text = ThirdPartyToolMigrationWizardWindow.GetMigrationStatusText(fileCount);
+            // Verifies the migration status lists project-relative target paths after the summary.
+            string projectRoot = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "UnityCliLoopMigrationStatusRoot",
+                System.Guid.NewGuid().ToString("N"));
+            System.IO.Directory.CreateDirectory(projectRoot);
+            try
+            {
+                string[] filePaths =
+                {
+                    System.IO.Path.Combine(projectRoot, "Assets", "Vendor", "One.cs"),
+                    System.IO.Path.Combine(projectRoot, "Assets", "Vendor", "Two.cs")
+                };
 
-            Assert.That(text, Is.EqualTo(expectedText));
+                string text = ThirdPartyToolMigrationWizardWindow.GetMigrationStatusText(
+                    filePaths,
+                    projectRoot);
+
+                Assert.That(text, Does.StartWith(
+                    "2 files need V3 C# source structure migration.\n" +
+                    "The Unity Console is showing errors because these files still use the old custom tool API.\n\n" +
+                    "Click Migrate to update them automatically. The errors should disappear after migration.\n\n" +
+                    "Files:\n"));
+                Assert.That(text, Does.Contain("Assets/Vendor/One.cs"));
+                Assert.That(text, Does.Contain("Assets/Vendor/Two.cs"));
+                Assert.That(text, Does.Not.Contain("\\"));
+            }
+            finally
+            {
+                System.IO.Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void FormatMigrationTargetPathsForStatus_WhenPathsUseBackslashes_NormalizesToForwardSlashes()
+        {
+            // Verifies displayed migration paths always use forward slashes on every platform.
+            string normalized = ThirdPartyToolMigrationWizardStateRules.NormalizeDisplayPathSeparators(
+                "Assets\\Vendor\\Tool.cs");
+
+            Assert.That(normalized, Is.EqualTo("Assets/Vendor/Tool.cs"));
+        }
+
+        [Test]
+        public void FormatMigrationTargetPathsForStatus_WhenPathCountExceedsLimit_AppendsOverflowSummary()
+        {
+            // Verifies long target lists truncate with a +N more files suffix.
+            string projectRoot = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "UnityCliLoopMigrationOverflowRoot",
+                System.Guid.NewGuid().ToString("N"));
+            System.IO.Directory.CreateDirectory(projectRoot);
+            try
+            {
+                int totalCount = ThirdPartyToolMigrationWizardStateRules.MaxMigrationTargetPathsInStatus + 3;
+                string[] filePaths = new string[totalCount];
+                for (int index = 0; index < totalCount; index++)
+                {
+                    filePaths[index] = System.IO.Path.Combine(projectRoot, "Assets", $"File{index:D3}.cs");
+                }
+
+                string text = ThirdPartyToolMigrationWizardText.FormatMigrationTargetPathsForStatus(
+                    filePaths,
+                    projectRoot);
+
+                Assert.That(text, Does.Contain("Assets/File000.cs"));
+                Assert.That(
+                    text,
+                    Does.Contain(
+                        $"Assets/File{(ThirdPartyToolMigrationWizardStateRules.MaxMigrationTargetPathsInStatus - 1):D3}.cs"));
+                Assert.That(text, Does.Contain("+3 more files"));
+                Assert.That(text, Does.Not.Contain($"Assets/File{ThirdPartyToolMigrationWizardStateRules.MaxMigrationTargetPathsInStatus:D3}.cs"));
+            }
+            finally
+            {
+                System.IO.Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ConfirmMigrationApply_WhenDialogIsCanceled_ReturnsFalse()
+        {
+            // Verifies Cancel leaves migration unstarted by returning false from the confirm helper.
+            bool confirmed = ThirdPartyToolMigrationWizardWindow.ConfirmMigrationApply(
+                2,
+                (title, message, ok, cancel) =>
+                {
+                    Assert.That(title, Is.EqualTo(ThirdPartyToolMigrationWizardText.MigrationConfirmDialogTitle));
+                    Assert.That(message, Does.Contain("2 files will be rewritten in place."));
+                    Assert.That(message, Does.Contain("VCS recommended"));
+                    Assert.That(ok, Is.EqualTo(ThirdPartyToolMigrationWizardText.MigrationConfirmDialogOkText));
+                    Assert.That(cancel, Is.EqualTo(ThirdPartyToolMigrationWizardText.MigrationConfirmDialogCancelText));
+                    return false;
+                });
+
+            Assert.That(confirmed, Is.False);
+        }
+
+        [Test]
+        public void ConfirmMigrationApply_WhenDialogIsAccepted_ReturnsTrue()
+        {
+            // Verifies Migrate confirmation allows the apply path to continue.
+            bool confirmed = ThirdPartyToolMigrationWizardWindow.ConfirmMigrationApply(
+                1,
+                (_, _, _, _) => true);
+
+            Assert.That(confirmed, Is.True);
         }
 
         [Test]

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationWizardWindowTests.cs
@@ -188,7 +188,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void FormatMigrationTargetPathsForStatus_WhenPathsUseBackslashes_NormalizesToForwardSlashes()
+        public void NormalizeDisplayPathSeparators_WhenPathsUseBackslashes_NormalizesToForwardSlashes()
         {
             // Verifies displayed migration paths always use forward slashes on every platform.
             string normalized = ThirdPartyToolMigrationWizardStateRules.NormalizeDisplayPathSeparators(

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardStateRules.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardStateRules.cs
@@ -10,6 +10,39 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     internal static class ThirdPartyToolMigrationWizardStateRules
     {
         internal const int MigrationProgressUiUpdateIntervalMilliseconds = 100;
+        internal const int MaxMigrationTargetPathsInStatus = 50;
+
+        internal static int GetMigrationTargetPathsOverflowCount(int totalPathCount, int maxPaths)
+        {
+            Debug.Assert(totalPathCount >= 0, "totalPathCount must not be negative");
+            Debug.Assert(maxPaths > 0, "maxPaths must be positive");
+
+            if (totalPathCount <= maxPaths)
+            {
+                return 0;
+            }
+
+            return totalPathCount - maxPaths;
+        }
+
+        internal static string NormalizeDisplayPathSeparators(string path)
+        {
+            Debug.Assert(path != null, "path must not be null");
+
+            // Status text must stay Windows-safe: never leave backslashes in displayed relative paths.
+            return path.Replace('\\', '/');
+        }
+
+        internal static string ToProjectRelativeDisplayPath(string filePath, string projectRoot)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(filePath), "filePath must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            string relativePath = System.IO.Path.GetRelativePath(
+                System.IO.Path.GetFullPath(projectRoot),
+                System.IO.Path.GetFullPath(filePath));
+            return NormalizeDisplayPathSeparators(relativePath);
+        }
 
         internal static bool ShouldReportMigrationProgress(
             long lastReportTimestamp,

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardText.cs
@@ -29,6 +29,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             "- After editing, summarize changed files, remaining candidates, and any commands I should verify manually.";
         internal const string MigrationNotCheckedText = "C# source migration status has not been checked.";
         internal const string NoMigrationTargetsText = "No C# source structure migration is needed.";
+        internal const string MigrationConfirmDialogTitle = "Migrate C# Sources?";
+        internal const string MigrationConfirmDialogOkText = "Migrate";
+        internal const string MigrationConfirmDialogCancelText = "Cancel";
         private const string MigrationCheckingText = "Scanning C# source files for V3 custom tool API migration...";
         private const string MigrationApplyingText = "Migrating C# source files to V3 custom tool APIs...";
         private const string MigrationButtonReadyText = "Migrate";
@@ -39,11 +42,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private const string RemoveMigrationSkillButtonText = "Remove Migration Skill";
         private const string UpdatingMigrationSkillButtonText = "Updating...";
         private const string CopyMigrationSkillPromptButtonText = "Copy AI Prompt";
+        private const string MigrationTargetFilesHeading = "Files:";
 
-        internal static string GetMigrationStatusText(int fileCount)
+        internal static string GetMigrationStatusText(string[] filePaths, string projectRoot)
         {
-            Debug.Assert(fileCount >= 0, "fileCount must not be negative");
+            Debug.Assert(filePaths != null, "filePaths must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
 
+            int fileCount = filePaths.Length;
             string noun = fileCount == 1 ? "file" : "files";
             string verb = fileCount == 1 ? "needs" : "need";
             string subject = fileCount == 1 ? "this file still uses" : "these files still use";
@@ -52,7 +58,49 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return $"{fileCount} {noun} {verb} V3 C# source structure migration.\n" +
                 $"The Unity Console is showing errors because {subject} the old custom tool API.\n\n" +
                 $"Click Migrate to update {objectPronoun} automatically. " +
-                "The errors should disappear after migration.";
+                "The errors should disappear after migration.\n\n" +
+                FormatMigrationTargetPathsForStatus(filePaths, projectRoot);
+        }
+
+        internal static string GetMigrationConfirmDialogMessage(int fileCount)
+        {
+            Debug.Assert(fileCount >= 0, "fileCount must not be negative");
+
+            string noun = fileCount == 1 ? "file" : "files";
+            return $"{fileCount} {noun} will be rewritten in place.\n\n" +
+                "Commit or back up your project first (VCS recommended).";
+        }
+
+        internal static string FormatMigrationTargetPathsForStatus(string[] filePaths, string projectRoot)
+        {
+            Debug.Assert(filePaths != null, "filePaths must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
+            int maxPaths = ThirdPartyToolMigrationWizardStateRules.MaxMigrationTargetPathsInStatus;
+            int overflowCount = ThirdPartyToolMigrationWizardStateRules.GetMigrationTargetPathsOverflowCount(
+                filePaths.Length,
+                maxPaths);
+            int displayCount = filePaths.Length - overflowCount;
+            System.Text.StringBuilder builder = new();
+            builder.Append(MigrationTargetFilesHeading);
+            for (int index = 0; index < displayCount; index++)
+            {
+                builder.Append('\n');
+                builder.Append(
+                    ThirdPartyToolMigrationWizardStateRules.ToProjectRelativeDisplayPath(
+                        filePaths[index],
+                        projectRoot));
+            }
+
+            if (overflowCount > 0)
+            {
+                builder.Append('\n');
+                builder.Append('+');
+                builder.Append(overflowCount);
+                builder.Append(" more files");
+            }
+
+            return builder.ToString();
         }
 
         internal static string GetMigrationProgressText(

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardView.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardView.cs
@@ -133,10 +133,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _refreshButton.SetEnabled(true);
         }
 
-        internal void ShowMigrationTargetsState(int fileCount, bool isMigrating)
+        internal void ShowMigrationTargetsState(string[] filePaths, string projectRoot, bool isMigrating)
         {
+            Debug.Assert(filePaths != null, "filePaths must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(projectRoot), "projectRoot must not be null or empty");
+
             _migrationStatusTextField.SetValueWithoutNotify(
-                ThirdPartyToolMigrationWizardText.GetMigrationStatusText(fileCount));
+                ThirdPartyToolMigrationWizardText.GetMigrationStatusText(filePaths, projectRoot));
             ViewDataBinder.SetVisible(_migrationProgressBar, false);
             ViewDataBinder.SetVisible(_migrationButtonRow, true);
             _migrateButton.SetEnabled(!isMigrating);

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,6 +34,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private bool _isUpdatingMigrationSkill;
         private SkillsTarget _migrationSkillTarget = SkillsTarget.Claude;
         private SkillInstallState _migrationSkillInstallState = SkillInstallState.Missing;
+        private string[] _pendingMigrationFilePaths = Array.Empty<string>();
         private CancellationTokenSource _migrationOperationCts;
         private CancellationTokenSource _migrationSkillOperationCts;
         private SkillSetupUseCase _skillSetupUseCase;
@@ -184,9 +186,23 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 frameSize);
         }
 
-        internal static string GetMigrationStatusText(int fileCount)
+        internal static string GetMigrationStatusText(string[] filePaths, string projectRoot)
         {
-            return ThirdPartyToolMigrationWizardText.GetMigrationStatusText(fileCount);
+            return ThirdPartyToolMigrationWizardText.GetMigrationStatusText(filePaths, projectRoot);
+        }
+
+        internal static bool ConfirmMigrationApply(
+            int fileCount,
+            Func<string, string, string, string, bool> displayDialog)
+        {
+            Debug.Assert(displayDialog != null, "displayDialog must not be null");
+            Debug.Assert(fileCount >= 0, "fileCount must not be negative");
+
+            return displayDialog(
+                ThirdPartyToolMigrationWizardText.MigrationConfirmDialogTitle,
+                ThirdPartyToolMigrationWizardText.GetMigrationConfirmDialogMessage(fileCount),
+                ThirdPartyToolMigrationWizardText.MigrationConfirmDialogOkText,
+                ThirdPartyToolMigrationWizardText.MigrationConfirmDialogCancelText);
         }
 
         internal static string GetMigrationProgressText(
@@ -458,11 +474,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
-            ShowMigrationTargetsState(preview.FileCount);
+            ShowMigrationTargetsState(preview.FilePaths);
         }
 
         private async void HandleMigrateThirdPartyTools()
         {
+            if (!ConfirmMigrationApply(
+                _pendingMigrationFilePaths.Length,
+                (title, message, ok, cancel) => EditorUtility.DisplayDialog(title, message, ok, cancel)))
+            {
+                return;
+            }
+
             CancellationToken ct = BeginMigrationOperation();
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             ThirdPartyToolMigrationResult result = default;
@@ -555,9 +578,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ScheduleResizeToContent();
         }
 
-        private void ShowMigrationTargetsState(int fileCount)
+        private void ShowMigrationTargetsState(string[] filePaths)
         {
-            _view.ShowMigrationTargetsState(fileCount, _isMigrating);
+            Debug.Assert(filePaths != null, "filePaths must not be null");
+
+            _pendingMigrationFilePaths = filePaths;
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            _view.ShowMigrationTargetsState(filePaths, projectRoot, _isMigrating);
             ScheduleResizeToContent();
         }
 


### PR DESCRIPTION
## Summary
- Ask for confirmation before Migrate rewrites files in place, with VCS backup guidance
- Show project-relative target paths (forward-slash normalized) in the existing status TextField
- Truncate long lists at 50 paths with a `+N more files` suffix
- Cover path normalization, overflow truncation, and cancel confirmation with pure tests

## User Impact
Users see which files will change before migrating, and can cancel the irreversible in-place rewrite.

## Test plan
- [x] `uloop compile` — 0/0
- [x] `uloop run-tests --filter-type regex --filter-value ThirdPartyToolMigrationWizardWindowTests` — 55/55
- [x] Live: status shows `Files:` with forward-slash relative paths; Cancel confirmation returns false

### Live verification
```
statusContainsFilesHeading=True
statusContainsForwardSlashPath=True
statusHasBackslash=False
cancelBlocksApply=True
```
Screenshot: `.uloop/outputs/Screenshots/Unity CLI Loop Migration_20260712_104714_141.png`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

