### PR TITLE
fix: Expand temporary V3 migration skill removed-command guidance

### DIFF
--- a/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/SKILL.md
+++ b/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/SKILL.md
@@ -5,6 +5,8 @@ description: Migrate only uloop V2 CLI option syntax in agent skills, Markdown, 
 
 # V3 CLI Invocation Migration
 
+Agent-facing CLI migration candidates live in this skill. Installed-skill cleanup names stay in `SkillTargetInstaller` / `skills.go` `deprecatedSkillNames`.
+
 Use this skill to update V2-era `uloop` CLI option syntax to V3
 syntax in agent-facing docs and automation.
 
@@ -37,8 +39,9 @@ Prefer `rg` for searches when available. If `rg` is unavailable, use the best av
 - For third-party tools, check the tool's current schema or documentation
   before deciding whether `false` means removal, a `--no-*` flag, or a
   renamed option.
-- For first-party tools, use the reference table. `compile` and `run-tests`
-  have special renamed negative flags.
+- For first-party tools, use the reference table. `compile`, `run-tests`,
+  `get-hierarchy`, `record-input`, and `replay-input` have special renamed
+  negative flags.
 - A valid edit is limited to replacing, adding, or removing a `uloop` option
   token and the boolean value attached to that option in the same invocation.
 - Preserve surrounding Markdown, shell, and PowerShell formatting. Do not
@@ -63,6 +66,8 @@ Prefer `rg` for searches when available. If `rg` is unavailable, use the best av
 - `uloop` command lines and examples.
 - Boolean-looking CLI options: `--* true`, `--*=true`, `--* false`, `--*=false`.
 - First-party renamed options from the reference, including bare flags.
-- Removed commands: `get-project-info` and `get-version`. Report these as
-  out-of-scope command migration candidates unless the user explicitly asked
-  to migrate removed commands.
+- Removed or renamed commands: `get-project-info`, `get-version`,
+  `unity-search`, `execute-menu-item`, `get-menu-items`,
+  `get-unity-search-providers`, `get-provider-details`, and `capture-window`
+  (renamed to `screenshot`). Report these as out-of-scope command migration
+  candidates unless the user explicitly asked to migrate removed commands.

--- a/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
+++ b/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
@@ -1,5 +1,7 @@
 # First-Party V2 to V3 CLI Migration
 
+Agent-facing CLI migration candidates live here. Installed-skill cleanup names stay in `SkillTargetInstaller` / `skills.go` `deprecatedSkillNames`.
+
 Use this reference as the canonical option migration map. Search results are
 only candidates. Edit a match only after the surrounding context proves it is
 a V2 `uloop` invocation.
@@ -21,8 +23,10 @@ Prefer `rg` when available, but any repository search tool is acceptable.
 - Search `uloop` first and inspect command examples, shell scripts, PowerShell scripts, and agent skills.
 - Search boolean-looking CLI syntax: `--` plus nearby `true` or `false`, including `--flag true`, `--flag=false`, and inline Markdown command examples.
 - Search renamed first-party option names: `wait-for-domain-reload`, `reload-external-scene-changes`, `force-recompile`, `save-before-run`, `show-overlay`, `include-components`, `include-inactive`, and `compile-only`.
-- Search removed first-party commands only to report them as out-of-scope
-  command migration candidates: `get-project-info` and `get-version`.
+- Search removed or renamed first-party commands only to report them as
+  out-of-scope command migration candidates: `get-project-info`, `get-version`,
+  `unity-search`, `execute-menu-item`, `get-menu-items`,
+  `get-unity-search-providers`, `get-provider-details`, and `capture-window`.
 - Skip generated installed skill copies under `.agents`, `.claude`, `.codex`, `.cursor`, `.gemini`, `.windsurf`, `.agent`, or equivalent target folders unless the user explicitly asks to migrate installed copies.
 
 ## Boolean Argument Rules
@@ -33,6 +37,7 @@ Prefer `rg` when available, but any repository search tool is acceptable.
 | `--flag=false` | remove the option when the V3 default is already false |
 | `--flag true` | remove the option when the V3 default is already true |
 | `--flag false` | use the V3 negative option when the V3 default is true |
+| `--flag=false` | use the V3 negative option when the V3 default is true |
 
 For third-party tools, inspect the current tool schema or docs before choosing the replacement. Do not infer third-party negative flags from first-party conventions.
 
@@ -65,3 +70,9 @@ For third-party tools, inspect the current tool schema or docs before choosing t
 | --- | --- |
 | `uloop get-project-info` | Report only unless the user explicitly asks for removed command migration. Do not guess from the command name alone. |
 | `uloop get-version` | Report only unless the user explicitly asks for removed command migration. Do not guess from the command name alone. |
+| `uloop unity-search` | Report only unless the user explicitly asks for removed command migration. Do not guess from the command name alone. |
+| `uloop execute-menu-item` | Report only unless the user explicitly asks for removed command migration. Do not guess from the command name alone. |
+| `uloop get-menu-items` | Report only unless the user explicitly asks for removed command migration. Do not guess from the command name alone. |
+| `uloop get-unity-search-providers` | Report only unless the user explicitly asks for removed command migration. Do not guess from the command name alone. |
+| `uloop get-provider-details` | Report only unless the user explicitly asks for removed command migration. Do not guess from the command name alone. |
+| `uloop capture-window` | Renamed to `uloop screenshot`. Report only unless the user explicitly asks for removed command migration. Do not guess from the command name alone. |

--- a/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
+++ b/Packages/src/TemporarySkills~/v3-cli-invocation-migration/Skill/references/first-party-v2-to-v3.md
@@ -34,8 +34,11 @@ Prefer `rg` when available, but any repository search tool is acceptable.
 | V2 form | V3 form |
 | --- | --- |
 | `--flag true` | `--flag` when the V3 option is a positive default-false boolean |
+| `--flag=true` | `--flag` when the V3 option is a positive default-false boolean |
 | `--flag=false` | remove the option when the V3 default is already false |
+| `--flag false` | remove the option when the V3 default is already false |
 | `--flag true` | remove the option when the V3 default is already true |
+| `--flag=true` | remove the option when the V3 default is already true |
 | `--flag false` | use the V3 negative option when the V3 default is true |
 | `--flag=false` | use the V3 negative option when the V3 default is true |
 


### PR DESCRIPTION
## Summary
- Expand removed/renamed first-party command search guidance to eight V2 commands, including `capture-window` → `screenshot`
- Align SKILL.md special negative-flag wording with the reference table (`get-hierarchy`, `record-input`, `replay-input`)
- Document default-true `--flag=false` equals-form migration in the boolean rules table
- Keep agent-facing docs separate from Go/C# installed-skill cleanup lists

## User Impact
Agents using the temporary V3 CLI migration skill report the complete set of removed V2 commands and apply first-party boolean flag rules more accurately.

## Test plan
- [x] Source Markdown updated under `Packages/src/TemporarySkills~/`
- [x] Live: `uloop skills install-v3-migration --claude` installs updated content
- [x] Live: installed skill/reference contain all 8 commands, negative-flag wording, `--flag=false` default-true row, screenshot rename note, and no `wait-for-pause-point`

### Live verification
```
ok:get-project-info
ok:get-version
ok:unity-search
ok:execute-menu-item
ok:get-menu-items
ok:get-unity-search-providers
ok:get-provider-details
ok:capture-window
ok:no-wait-for-pause-point
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

