### PR TITLE
fix: Harden migration scans against symlink cycles and ignored folders

### DIFF
--- a/Assets/Tests/Editor/ThirdPartyToolMigrationProjectFileInventoryTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationProjectFileInventoryTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies migration project file inventory symlink/junction cycle guards.
+    /// </summary>
+    public sealed class ThirdPartyToolMigrationProjectFileInventoryTests
+    {
+        [Test]
+        public void Create_WhenAssetsContainsSelfReferentialSymbolicLink_CompletesWithoutLooping()
+        {
+            // Verifies a real directory symlink cycle is skipped and the inventory walk completes.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Ignore("Directory symlink creation requires elevated privileges on Windows.");
+            }
+
+            string projectRoot = CreateProjectRoot();
+            try
+            {
+                string assetsDirectory = Path.Combine(projectRoot, "Assets");
+                string vendorDirectory = Path.Combine(assetsDirectory, "VendorTools");
+                string cycleLinkDirectory = Path.Combine(vendorDirectory, "Cycle");
+                Directory.CreateDirectory(vendorDirectory);
+                string includedPath = Path.Combine(vendorDirectory, "IncludedTool.cs");
+                File.WriteAllText(includedPath, "public sealed class IncludedTool {}");
+                CreateDirectorySymbolicLink(cycleLinkDirectory, vendorDirectory);
+
+                ProjectFileInventory inventory = ProjectFileInventory.Create(projectRoot);
+
+                Assert.That(inventory.CSharpFilePaths, Does.Contain(includedPath));
+                Assert.That(
+                    inventory.CSharpFilePaths,
+                    Has.None.Matches<string>(path => path.IndexOf("Cycle", StringComparison.Ordinal) >= 0));
+            }
+            finally
+            {
+                Directory.Delete(projectRoot, recursive: true);
+            }
+        }
+
+        private static string CreateProjectRoot()
+        {
+            string projectRoot = Path.Combine(
+                Path.GetTempPath(),
+                "UnityCliLoopMigrationInventoryTests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "Assets"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "ProjectSettings"));
+            return projectRoot;
+        }
+
+        private static void CreateDirectorySymbolicLink(string linkPath, string targetPath)
+        {
+            int result = Symlink(targetPath, linkPath);
+            Assert.That(result, Is.EqualTo(0), $"symlink failed for {linkPath} -> {targetPath}");
+        }
+
+        [DllImport("libc", EntryPoint = "symlink", SetLastError = true)]
+        private static extern int Symlink(string targetPath, string linkPath);
+    }
+}

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationProjectFileInventoryTests.cs.meta
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationProjectFileInventoryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25c7741ecc6534e7aa0beb64ecbabcc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
+++ b/Assets/Tests/Editor/ThirdPartyToolMigrationRulesTests.cs
@@ -4522,5 +4522,26 @@ public sealed class OtherTool
             Assert.That(names.Contains("Temp"), Is.True);
             Assert.That(names.Contains(".git"), Is.True);
         }
+
+        [Test]
+        public void IsExcludedDirectoryName_WhenDirectoryEndsWithTilde_ReturnsTrue()
+        {
+            // Verifies Unity trailing-~ folders such as Samples~ are excluded from migration scans.
+            Assert.That(ThirdPartyToolMigrationRules.IsExcludedDirectoryName("Samples~"), Is.True);
+        }
+
+        [Test]
+        public void IsExcludedDirectoryName_WhenDirectoryStartsWithDot_ReturnsTrue()
+        {
+            // Verifies hidden/dot folders are excluded even when not listed by exact name.
+            Assert.That(ThirdPartyToolMigrationRules.IsExcludedDirectoryName(".hidden"), Is.True);
+        }
+
+        [Test]
+        public void IsExcludedDirectoryName_WhenDirectoryIsOrdinaryAssetFolder_ReturnsFalse()
+        {
+            // Verifies normal Assets subfolders remain eligible for migration scanning.
+            Assert.That(ThirdPartyToolMigrationRules.IsExcludedDirectoryName("VendorTools"), Is.False);
+        }
     }
 }

--- a/Packages/src/Editor/Domain/ThirdPartyToolMigrationSourceDetectionRules.cs
+++ b/Packages/src/Editor/Domain/ThirdPartyToolMigrationSourceDetectionRules.cs
@@ -270,6 +270,13 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         {
             Debug.Assert(!string.IsNullOrEmpty(directoryName), "directoryName must not be null or empty");
 
+            // Unity ignores trailing-~ folders (Samples~) and hidden/dot folders; keep them out of scans.
+            if (directoryName.StartsWith(".", StringComparison.Ordinal) ||
+                directoryName.EndsWith("~", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
             return ExcludedDirectoryNames.Any(
                 excludedDirectoryName => string.Equals(
                     excludedDirectoryName,

--- a/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationProjectFileInventory.cs
+++ b/Packages/src/Editor/Infrastructure/ThirdPartyToolMigration/ThirdPartyToolMigrationProjectFileInventory.cs
@@ -227,8 +227,30 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 return true;
             }
 
+            // why not follow symlinks/junctions: cycle prevention takes priority over scanning
+            // through linked package trees that some developers keep under Assets.
+            if (!Directory.Exists(directoryPath))
+            {
+                // Dangling reparse points report Exists=false; skip before reading Attributes.
+                return true;
+            }
+
+            if (IsReparsePointDirectory(directoryPath))
+            {
+                return true;
+            }
+
             string directoryName = Path.GetFileName(directoryPath);
             return ThirdPartyToolMigrationRules.IsExcludedDirectoryName(directoryName);
+        }
+
+        private static bool IsReparsePointDirectory(string directoryPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(directoryPath), "directoryPath must not be null or empty");
+            Debug.Assert(Directory.Exists(directoryPath), "directoryPath must exist before reading attributes");
+
+            DirectoryInfo directoryInfo = new DirectoryInfo(directoryPath);
+            return (directoryInfo.Attributes & FileAttributes.ReparsePoint) != 0;
         }
 
         private static bool IsProjectRootPackagesDirectory(string projectRoot, string directoryPath)


### PR DESCRIPTION
## Summary
- Skip symlink/junction directories during migration inventory and preflight walks (cycle prevention first)
- Guard attribute reads with `Directory.Exists` so dangling reparse points are skipped without try/catch
- Exclude Unity trailing-~ folders and hidden/dot folders from directory-name rules
- Leave the existing exact-name exclusion list unchanged (including `.git`)

## User Impact
Migration scans no longer risk hanging on directory symlink cycles, and they ignore folders Unity itself does not import.

## Test plan
- [x] `uloop compile` — 0/0
- [x] Pure-name tests + real macOS symlink cycle inventory test — 5/5
- [x] Live: `IsExcludedDirectoryName` for Samples~ / .hidden / VendorTools / .git list

### Live verification
```
samplesTilde=True;dotHidden=True;vendor=False;gitListed=True
```
Symlink cycle coverage: EditMode `Create_WhenAssetsContainsSelfReferentialSymbolicLink_CompletesWithoutLooping` passed in Unity.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

