### PR TITLE
fix: Keep PlayMode advancing while Unity is unfocused during CLI Play

### DIFF
--- a/Assets/Tests/Editor/CliPlayModeRunInBackgroundControllerTests.cs
+++ b/Assets/Tests/Editor/CliPlayModeRunInBackgroundControllerTests.cs
@@ -40,27 +40,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void OnPlayModeExiting_WhenActive_RestoresOriginalAndClears()
+        public void PeekOriginalIfActive_WhenActive_ReturnsOriginalWithoutClearing()
         {
-            // Verifies PlayMode exit (CLI Stop or manual Stop) restores the saved original value.
+            // Verifies early exit restore can re-apply the original without dropping ownership yet.
             InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
             CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
             controller.OnCliPlayStarting(currentRunInBackground: false);
 
-            bool? restored = controller.OnPlayModeExiting();
+            bool? peeked = controller.PeekOriginalIfActive();
+
+            Assert.That(peeked, Is.False);
+            Assert.That(store.IsActive, Is.True);
+            Assert.That(store.OriginalRunInBackground, Is.False);
+        }
+
+        [Test]
+        public void CommitRestoreAfterPlayModeExit_WhenActive_RestoresOriginalAndClears()
+        {
+            // Verifies stable EditMode exit (CLI Stop or manual Stop) restores and clears ownership.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+            controller.OnCliPlayStarting(currentRunInBackground: false);
+
+            bool? restored = controller.CommitRestoreAfterPlayModeExit();
 
             Assert.That(restored, Is.False);
             Assert.That(store.IsActive, Is.False);
         }
 
         [Test]
-        public void OnPlayModeExiting_WhenInactive_ReturnsNull()
+        public void CommitRestoreAfterPlayModeExit_WhenInactive_ReturnsNull()
         {
             // Verifies manual Play sessions that never went through CLI Play leave runInBackground alone.
             InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
             CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
 
-            bool? restored = controller.OnPlayModeExiting();
+            bool? restored = controller.CommitRestoreAfterPlayModeExit();
 
             Assert.That(restored, Is.Null);
             Assert.That(store.IsActive, Is.False);
@@ -84,7 +99,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void OnEditorStartup_WhenActiveButNotPlaying_RestoresOriginalAndClears()
         {
-            // Verifies an orphaned active flag after Play already ended is cleaned up on startup.
+            // Verifies domain reload after Play exit still restores when ownership was not committed yet.
             InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
             store.Activate(originalRunInBackground: false);
             CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
@@ -108,17 +123,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void OnPlayModeExiting_WhenOriginalWasTrue_RestoresTrue()
+        public void CommitRestoreAfterPlayModeExit_WhenOriginalWasTrue_RestoresTrue()
         {
             // Verifies projects that already had runInBackground enabled stay enabled after CLI Play ends.
             InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
             CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
             controller.OnCliPlayStarting(currentRunInBackground: true);
 
-            bool? restored = controller.OnPlayModeExiting();
+            bool? restored = controller.CommitRestoreAfterPlayModeExit();
 
             Assert.That(restored, Is.True);
             Assert.That(store.IsActive, Is.False);
+        }
+
+        [Test]
+        public void ExitSequence_PeekThenCommit_SurvivesTransitionOverwriteModel()
+        {
+            // Verifies early peek restore + later commit matches the ExitingPlayMode → EnteredEditMode path.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+            controller.OnCliPlayStarting(currentRunInBackground: false);
+
+            bool? peeked = controller.PeekOriginalIfActive();
+            bool? committed = controller.CommitRestoreAfterPlayModeExit();
+
+            Assert.That(peeked, Is.False);
+            Assert.That(committed, Is.False);
+            Assert.That(store.IsActive, Is.False);
+            Assert.That(controller.PeekOriginalIfActive(), Is.Null);
+            Assert.That(controller.CommitRestoreAfterPlayModeExit(), Is.Null);
         }
 
         private sealed class InMemoryCliPlayModeRunInBackgroundStore : ICliPlayModeRunInBackgroundStore

--- a/Assets/Tests/Editor/CliPlayModeRunInBackgroundControllerTests.cs
+++ b/Assets/Tests/Editor/CliPlayModeRunInBackgroundControllerTests.cs
@@ -1,0 +1,143 @@
+#nullable enable
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Pure unit tests for CLI PlayMode runInBackground override state transitions.
+    /// </summary>
+    public sealed class CliPlayModeRunInBackgroundControllerTests
+    {
+        [Test]
+        public void OnCliPlayStarting_WhenInactive_SavesOriginalAndRequestsTrue()
+        {
+            // Verifies CLI Play start records the pre-Play value and forces runInBackground on.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+
+            bool desired = controller.OnCliPlayStarting(currentRunInBackground: false);
+
+            Assert.That(desired, Is.True);
+            Assert.That(store.IsActive, Is.True);
+            Assert.That(store.OriginalRunInBackground, Is.False);
+        }
+
+        [Test]
+        public void OnCliPlayStarting_WhenAlreadyActive_DoesNotOverwriteOriginal()
+        {
+            // Verifies a second CLI Play while the override is active keeps the first original value.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+            controller.OnCliPlayStarting(currentRunInBackground: false);
+
+            bool desired = controller.OnCliPlayStarting(currentRunInBackground: true);
+
+            Assert.That(desired, Is.True);
+            Assert.That(store.IsActive, Is.True);
+            Assert.That(store.OriginalRunInBackground, Is.False);
+        }
+
+        [Test]
+        public void OnPlayModeExiting_WhenActive_RestoresOriginalAndClears()
+        {
+            // Verifies PlayMode exit (CLI Stop or manual Stop) restores the saved original value.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+            controller.OnCliPlayStarting(currentRunInBackground: false);
+
+            bool? restored = controller.OnPlayModeExiting();
+
+            Assert.That(restored, Is.False);
+            Assert.That(store.IsActive, Is.False);
+        }
+
+        [Test]
+        public void OnPlayModeExiting_WhenInactive_ReturnsNull()
+        {
+            // Verifies manual Play sessions that never went through CLI Play leave runInBackground alone.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+
+            bool? restored = controller.OnPlayModeExiting();
+
+            Assert.That(restored, Is.Null);
+            Assert.That(store.IsActive, Is.False);
+        }
+
+        [Test]
+        public void OnEditorStartup_WhenActiveAndStillPlaying_ReappliesTrue()
+        {
+            // Verifies domain reload during CLI Play re-applies runInBackground without clearing the original.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+            controller.OnCliPlayStarting(currentRunInBackground: false);
+
+            bool? desired = controller.OnEditorStartup(isPlaying: true);
+
+            Assert.That(desired, Is.True);
+            Assert.That(store.IsActive, Is.True);
+            Assert.That(store.OriginalRunInBackground, Is.False);
+        }
+
+        [Test]
+        public void OnEditorStartup_WhenActiveButNotPlaying_RestoresOriginalAndClears()
+        {
+            // Verifies an orphaned active flag after Play already ended is cleaned up on startup.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            store.Activate(originalRunInBackground: false);
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+
+            bool? desired = controller.OnEditorStartup(isPlaying: false);
+
+            Assert.That(desired, Is.False);
+            Assert.That(store.IsActive, Is.False);
+        }
+
+        [Test]
+        public void OnEditorStartup_WhenInactive_ReturnsNull()
+        {
+            // Verifies startup is a no-op when CLI never enabled a PlayMode override.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+
+            bool? desired = controller.OnEditorStartup(isPlaying: true);
+
+            Assert.That(desired, Is.Null);
+        }
+
+        [Test]
+        public void OnPlayModeExiting_WhenOriginalWasTrue_RestoresTrue()
+        {
+            // Verifies projects that already had runInBackground enabled stay enabled after CLI Play ends.
+            InMemoryCliPlayModeRunInBackgroundStore store = new InMemoryCliPlayModeRunInBackgroundStore();
+            CliPlayModeRunInBackgroundController controller = new CliPlayModeRunInBackgroundController(store);
+            controller.OnCliPlayStarting(currentRunInBackground: true);
+
+            bool? restored = controller.OnPlayModeExiting();
+
+            Assert.That(restored, Is.True);
+            Assert.That(store.IsActive, Is.False);
+        }
+
+        private sealed class InMemoryCliPlayModeRunInBackgroundStore : ICliPlayModeRunInBackgroundStore
+        {
+            public bool IsActive { get; private set; }
+
+            public bool OriginalRunInBackground { get; private set; }
+
+            public void Activate(bool originalRunInBackground)
+            {
+                OriginalRunInBackground = originalRunInBackground;
+                IsActive = true;
+            }
+
+            public void Clear()
+            {
+                IsActive = false;
+                OriginalRunInBackground = false;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/CliPlayModeRunInBackgroundControllerTests.cs.meta
+++ b/Assets/Tests/Editor/CliPlayModeRunInBackgroundControllerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 385bd0005d7bc4684b6a3fc00c554972
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundController.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundController.cs
@@ -47,10 +47,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Restores the original runInBackground value when PlayMode ends (CLI Stop or manual).
+        /// Returns the original value to re-apply while exiting PlayMode without clearing ownership.
+        /// Why: Unity may domain-reload or overwrite Application.runInBackground during the exit
+        /// transition; SessionState must stay active until EditMode is stable.
+        /// </summary>
+        public bool? PeekOriginalIfActive()
+        {
+            if (!_store.IsActive)
+            {
+                return null;
+            }
+
+            return _store.OriginalRunInBackground;
+        }
+
+        /// <summary>
+        /// Restores the original runInBackground value when EditMode is stable after Play ends.
         /// Returns null when this controller did not own an override.
         /// </summary>
-        public bool? OnPlayModeExiting()
+        public bool? CommitRestoreAfterPlayModeExit()
         {
             if (!_store.IsActive)
             {

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundController.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundController.cs
@@ -1,0 +1,88 @@
+#nullable enable
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Stores whether a CLI-started PlayMode session owns a temporary Application.runInBackground override.
+    /// </summary>
+    internal interface ICliPlayModeRunInBackgroundStore
+    {
+        bool IsActive { get; }
+
+        bool OriginalRunInBackground { get; }
+
+        void Activate(bool originalRunInBackground);
+
+        void Clear();
+    }
+
+    /// <summary>
+    /// Pure state machine for keeping runInBackground true during CLI-initiated PlayMode.
+    /// Why: Editor throttles the player loop when unfocused unless runInBackground is true, which
+    /// breaks time-dependent E2E between CLI commands. Manual Play must not be affected.
+    /// </summary>
+    internal sealed class CliPlayModeRunInBackgroundController
+    {
+        private readonly ICliPlayModeRunInBackgroundStore _store;
+
+        public CliPlayModeRunInBackgroundController(ICliPlayModeRunInBackgroundStore store)
+        {
+            Debug.Assert(store != null, "store must not be null");
+            _store = store!;
+        }
+
+        /// <summary>
+        /// Records the pre-Play value and requests runInBackground=true for a CLI Play start.
+        /// Returns the value that Application.runInBackground should be set to.
+        /// </summary>
+        public bool OnCliPlayStarting(bool currentRunInBackground)
+        {
+            if (!_store.IsActive)
+            {
+                _store.Activate(currentRunInBackground);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Restores the original runInBackground value when PlayMode ends (CLI Stop or manual).
+        /// Returns null when this controller did not own an override.
+        /// </summary>
+        public bool? OnPlayModeExiting()
+        {
+            if (!_store.IsActive)
+            {
+                return null;
+            }
+
+            bool originalRunInBackground = _store.OriginalRunInBackground;
+            _store.Clear();
+            return originalRunInBackground;
+        }
+
+        /// <summary>
+        /// Recovers override state after domain reload.
+        /// Why: SessionState survives domain reload but Application.runInBackground may not stay true,
+        /// and an orphaned active flag after Play has already ended must not stick forever.
+        /// Returns the value to apply, or null when no write is needed.
+        /// </summary>
+        public bool? OnEditorStartup(bool isPlaying)
+        {
+            if (!_store.IsActive)
+            {
+                return null;
+            }
+
+            if (isPlaying)
+            {
+                return true;
+            }
+
+            bool originalRunInBackground = _store.OriginalRunInBackground;
+            _store.Clear();
+            return originalRunInBackground;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundController.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d308430e33774a3fb1ba01b3f96a910
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundService.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundService.cs
@@ -56,13 +56,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private void OnPlayModeStateChanged(PlayModeStateChange state)
         {
-            // Why: ExitingPlayMode covers both CLI Stop and the Editor toolbar Stop button.
-            if (state != PlayModeStateChange.ExitingPlayMode)
+            // Why: ExitingPlayMode covers CLI Stop and the toolbar Stop button, but Unity may
+            // overwrite runInBackground during the transition or domain-reload afterward.
+            // Peek+apply early, then commit clear on EnteredEditMode (or OnEditorStartup if reload).
+            if (state == PlayModeStateChange.ExitingPlayMode)
+            {
+                bool? originalRunInBackground = _controller.PeekOriginalIfActive();
+                if (originalRunInBackground.HasValue)
+                {
+                    Application.runInBackground = originalRunInBackground.Value;
+                }
+
+                return;
+            }
+
+            if (state != PlayModeStateChange.EnteredEditMode)
             {
                 return;
             }
 
-            bool? restoredRunInBackground = _controller.OnPlayModeExiting();
+            bool? restoredRunInBackground = _controller.CommitRestoreAfterPlayModeExit();
             if (restoredRunInBackground.HasValue)
             {
                 Application.runInBackground = restoredRunInBackground.Value;

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundService.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundService.cs
@@ -1,0 +1,72 @@
+#nullable enable
+using UnityEditor;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Applies CLI PlayMode runInBackground overrides through Unity Application/Editor hooks.
+    /// </summary>
+    internal sealed class CliPlayModeRunInBackgroundService
+    {
+        private readonly CliPlayModeRunInBackgroundController _controller;
+        private bool _isPlayModeCallbackRegistered;
+
+        public CliPlayModeRunInBackgroundService(CliPlayModeRunInBackgroundController controller)
+        {
+            System.Diagnostics.Debug.Assert(controller != null, "controller must not be null");
+            _controller = controller!;
+        }
+
+        /// <summary>
+        /// Subscribes to PlayMode exit and re-applies or cleans up state after domain reload.
+        /// </summary>
+        public void InitializeForEditorStartup()
+        {
+            RegisterPlayModeCallback();
+
+            bool? desiredRunInBackground = _controller.OnEditorStartup(EditorApplication.isPlaying);
+            if (desiredRunInBackground.HasValue)
+            {
+                Application.runInBackground = desiredRunInBackground.Value;
+            }
+        }
+
+        /// <summary>
+        /// Enables runInBackground for a CLI-started PlayMode transition from EditMode.
+        /// </summary>
+        public void EnableForCliPlayStart()
+        {
+            bool desiredRunInBackground = _controller.OnCliPlayStarting(Application.runInBackground);
+            Application.runInBackground = desiredRunInBackground;
+        }
+
+        private void RegisterPlayModeCallback()
+        {
+            if (_isPlayModeCallbackRegistered)
+            {
+                return;
+            }
+
+            // Why: domain reload re-runs startup; unsubscribe first to avoid duplicate handlers.
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+            _isPlayModeCallbackRegistered = true;
+        }
+
+        private void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            // Why: ExitingPlayMode covers both CLI Stop and the Editor toolbar Stop button.
+            if (state != PlayModeStateChange.ExitingPlayMode)
+            {
+                return;
+            }
+
+            bool? restoredRunInBackground = _controller.OnPlayModeExiting();
+            if (restoredRunInBackground.HasValue)
+            {
+                Application.runInBackground = restoredRunInBackground.Value;
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundService.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80c6f9bc20de44cc082845a7a8e74271
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundSessionStore.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundSessionStore.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Persists CLI PlayMode runInBackground override state in SessionState so domain reload cannot lose it.
+    /// </summary>
+    internal sealed class CliPlayModeRunInBackgroundSessionStore : ICliPlayModeRunInBackgroundStore
+    {
+        // Why: domain reload clears static fields; SessionState is the Editor-local store that survives it.
+        private const string ActiveKey =
+            "io.github.hatayama.uloopmcp.cliPlayModeRunInBackground.active";
+        private const string OriginalKey =
+            "io.github.hatayama.uloopmcp.cliPlayModeRunInBackground.original";
+
+        public bool IsActive => SessionState.GetBool(ActiveKey, false);
+
+        public bool OriginalRunInBackground => SessionState.GetBool(OriginalKey, false);
+
+        public void Activate(bool originalRunInBackground)
+        {
+            SessionState.SetBool(OriginalKey, originalRunInBackground);
+            SessionState.SetBool(ActiveKey, true);
+        }
+
+        public void Clear()
+        {
+            SessionState.SetBool(ActiveKey, false);
+            SessionState.SetBool(OriginalKey, false);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundSessionStore.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/CliPlayModeRunInBackgroundSessionStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24dcfade385f04eadbc0d55d23ef80d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeServices.cs
@@ -8,9 +8,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         internal ControlPlayModeCompilationFailureService CompilationFailureService { get; } = new();
         internal ControlPlayModeCompilationFailureGate CompilationFailureGate { get; } = new();
 
+        internal CliPlayModeRunInBackgroundService RunInBackgroundService { get; } =
+            new CliPlayModeRunInBackgroundService(
+                new CliPlayModeRunInBackgroundController(new CliPlayModeRunInBackgroundSessionStore()));
+
         internal void InitializeForEditorStartup()
         {
             CompilationFailureService.InitializeForEditorStartup();
+            RunInBackgroundService.InitializeForEditorStartup();
         }
     }
 
@@ -26,6 +31,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static IControlPlayModeCompilationFailureGate CompilationFailureGate =>
             RegistryValue.CompilationFailureGate;
+
+        internal static CliPlayModeRunInBackgroundService RunInBackgroundService =>
+            RegistryValue.RunInBackgroundService;
 
         internal static void InitializeForEditorStartup()
         {

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -114,6 +114,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             if (!EditorApplication.isPlaying)
             {
+                // Why: only CLI-started Play owns the override; manual Editor Play must keep project defaults.
+                ControlPlayModeServices.RunInBackgroundService.EnableForCliPlayStart();
                 EditorApplication.isPlaying = true;
             }
 


### PR DESCRIPTION
Refs: 2026-07-12_uloop検証フィードバック改善 実装計画.md#PR 1-1 (B-4)

## Summary
- CLI-started PlayMode now keeps `Application.runInBackground` true for the whole session, so time-dependent E2E waits and Game View captures keep advancing even when Unity is unfocused.
- The original value is restored when Play ends (CLI Stop or manual toolbar Stop). Manual Play is unchanged.

## User Impact
- **Before:** Between CLI commands, an unfocused Editor could throttle the player loop, making fall waits / flight checks / rendering screenshots flaky.
- **After:** Once Play is started via `control-play-mode --action Play`, PlayMode keeps advancing until Stop, then the project's original `runInBackground` setting is restored.

## Changes
- Add a pure state machine (`CliPlayModeRunInBackgroundController`) with SessionState-backed store so domain reload cannot lose the original value.
- Wire enable into CLI Play start only (`!wasPlaying` path in `ControlPlayModeUseCase`).
- Restore path: peek+apply on `ExitingPlayMode`, commit clear on `EnteredEditMode`; editor startup re-applies true while still playing or restores orphaned ownership after exit domain reload.
- Existing `InputSimulationRunInBackgroundScope` is kept for simulate commands during manual Play.
- Protocol version: **not bumped** (no wire-format change).

## Known behavior
- If CLI Play enables the override and PlayMode entry then fails before a stable session, ownership may remain until the next editor startup / EditMode transition, which runs orphan cleanup via `OnEditorStartup(isPlaying: false)`.

## Verification
- `dist/darwin-arm64/uloop compile` → 0 errors / 0 warnings
- EditMode tests `CliPlayModeRunInBackground` → 10 passed
- Real Editor check:
  - prep `Application.runInBackground=false`
  - CLI Play → during `true`, `Time.time` advanced (1.57 → 3.64) across commands
  - CLI Stop → after `App=false`, `PlayerSettings.runInBackground=false`, SessionState inactive