### PR TITLE
fix: Hold simulated key presses until gameplay can observe them

### DIFF
--- a/Assets/Tests/Editor/PressHoldUntilEdgeLogicTests.cs
+++ b/Assets/Tests/Editor/PressHoldUntilEdgeLogicTests.cs
@@ -1,0 +1,113 @@
+#nullable enable
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Pure unit tests for Press hold-until-edge wait decisions.
+    /// </summary>
+    public sealed class PressHoldUntilEdgeLogicTests
+    {
+        [Test]
+        public void IsBaseWaitSatisfied_WhenFramesAndDurationMet_ReturnsTrue()
+        {
+            // Verifies the normal Press wait can finish once min frames and duration both pass.
+            bool satisfied = PressHoldUntilEdgeLogic.IsBaseWaitSatisfied(
+                observedFrames: 2,
+                minimumObservationFrames: 2,
+                elapsedSeconds: 0f,
+                durationSeconds: 0f);
+
+            Assert.That(satisfied, Is.True);
+        }
+
+        [Test]
+        public void IsBaseWaitSatisfied_WhenFramesShort_ReturnsFalse()
+        {
+            // Verifies duration alone is not enough before the minimum observation frames elapse.
+            bool satisfied = PressHoldUntilEdgeLogic.IsBaseWaitSatisfied(
+                observedFrames: 1,
+                minimumObservationFrames: 2,
+                elapsedSeconds: 1f,
+                durationSeconds: 0f);
+
+            Assert.That(satisfied, Is.False);
+        }
+
+        [Test]
+        public void ShouldExtendHoldForEdge_WhenEdgeAlreadyObserved_ReturnsFalse()
+        {
+            // Verifies release proceeds immediately once the gameplay press edge was seen.
+            bool shouldExtend = PressHoldUntilEdgeLogic.ShouldExtendHoldForEdge(
+                pressEdgeObserved: true,
+                baseWaitSatisfied: true,
+                elapsedMilliseconds: 10,
+                timeoutMilliseconds: 5000);
+
+            Assert.That(shouldExtend, Is.False);
+        }
+
+        [Test]
+        public void ShouldExtendHoldForEdge_WhenEdgeMissingAndUnderTimeout_ReturnsTrue()
+        {
+            // Verifies release is delayed until the edge is observed (within the existing timeout budget).
+            bool shouldExtend = PressHoldUntilEdgeLogic.ShouldExtendHoldForEdge(
+                pressEdgeObserved: false,
+                baseWaitSatisfied: true,
+                elapsedMilliseconds: 100,
+                timeoutMilliseconds: 5000);
+
+            Assert.That(shouldExtend, Is.True);
+        }
+
+        [Test]
+        public void ShouldExtendHoldForEdge_WhenTimeoutExceeded_ReturnsFalse()
+        {
+            // Verifies the hold does not block forever when the edge never becomes visible.
+            bool shouldExtend = PressHoldUntilEdgeLogic.ShouldExtendHoldForEdge(
+                pressEdgeObserved: false,
+                baseWaitSatisfied: true,
+                elapsedMilliseconds: 5000,
+                timeoutMilliseconds: 5000);
+
+            Assert.That(shouldExtend, Is.False);
+        }
+
+        [Test]
+        public void ShouldExtendHoldForEdge_WhenBaseWaitNotSatisfied_ReturnsFalse()
+        {
+            // Verifies edge extension only starts after duration + min frames already completed.
+            bool shouldExtend = PressHoldUntilEdgeLogic.ShouldExtendHoldForEdge(
+                pressEdgeObserved: false,
+                baseWaitSatisfied: false,
+                elapsedMilliseconds: 0,
+                timeoutMilliseconds: 5000);
+
+            Assert.That(shouldExtend, Is.False);
+        }
+
+        [Test]
+        public void CountExtendedFrames_WhenBeyondBase_ReturnsDelta()
+        {
+            // Verifies response can report how many frames release was delayed for edge observation.
+            int extended = PressHoldUntilEdgeLogic.CountExtendedFrames(
+                observedFrames: 5,
+                baseSatisfiedFrameCount: 2);
+
+            Assert.That(extended, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void CountExtendedFrames_WhenNotBeyondBase_ReturnsZero()
+        {
+            // Verifies no extension is reported when release happened at the normal wait end.
+            int extended = PressHoldUntilEdgeLogic.CountExtendedFrames(
+                observedFrames: 2,
+                baseSatisfiedFrameCount: 2);
+
+            Assert.That(extended, Is.EqualTo(0));
+        }
+    }
+}

--- a/Assets/Tests/Editor/PressHoldUntilEdgeLogicTests.cs.meta
+++ b/Assets/Tests/Editor/PressHoldUntilEdgeLogicTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9096cc25d829c425b867a72b28f83b2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateHelper.cs
@@ -185,6 +185,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public static async Task<InputSimulationWaitOutcome> WaitForPressLifetime(float duration, CancellationToken ct)
         {
+            PressLifetimeWaitResult result = await WaitForPressLifetime(
+                duration,
+                isPressEdgeObserved: null,
+                ct).ConfigureAwait(false);
+            return result.Outcome;
+        }
+
+        /// <summary>
+        /// Waits for duration + min frames, then optionally holds release until a press edge is observed.
+        /// Why: when wasPressedThisFrame never becomes true in the normal window, delaying release
+        /// gives gameplay more frames without reinjecting down/up (which would double-fire actions).
+        /// </summary>
+        public static async Task<PressLifetimeWaitResult> WaitForPressLifetime(
+            float duration,
+            Func<bool>? isPressEdgeObserved,
+            CancellationToken ct)
+        {
             await SwitchToMainThreadIfNeeded(ct);
 
             int minimumObservationFrames = GetMinimumObservationFrameCount();
@@ -192,14 +209,43 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             float startTime = Time.realtimeSinceStartup;
             float elapsed = 0f;
             int observedFrames = 0;
+            int baseSatisfiedFrameCount = -1;
             int timeoutMilliseconds = GetPressLifetimeTimeoutMilliseconds(duration);
             System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
-            while (observedFrames < minimumObservationFrames || elapsed < duration)
+            while (true)
             {
+                bool baseWaitSatisfied = PressHoldUntilEdgeLogic.IsBaseWaitSatisfied(
+                    observedFrames,
+                    minimumObservationFrames,
+                    elapsed,
+                    duration);
+                if (baseWaitSatisfied && baseSatisfiedFrameCount < 0)
+                {
+                    baseSatisfiedFrameCount = observedFrames;
+                }
+
+                bool pressEdgeObserved = isPressEdgeObserved != null && isPressEdgeObserved();
+                bool shouldExtendForEdge = isPressEdgeObserved != null &&
+                    PressHoldUntilEdgeLogic.ShouldExtendHoldForEdge(
+                        pressEdgeObserved,
+                        baseWaitSatisfied,
+                        stopwatch.ElapsedMilliseconds,
+                        timeoutMilliseconds);
+
+                if (baseWaitSatisfied && !shouldExtendForEdge)
+                {
+                    int extendedFrames = baseSatisfiedFrameCount < 0
+                        ? 0
+                        : PressHoldUntilEdgeLogic.CountExtendedFrames(observedFrames, baseSatisfiedFrameCount);
+                    return new PressLifetimeWaitResult(
+                        InputSimulationWaitOutcome.Completed,
+                        extendedFrames);
+                }
+
                 if (IsPaused())
                 {
-                    return InputSimulationWaitOutcome.Paused;
+                    return new PressLifetimeWaitResult(InputSimulationWaitOutcome.Paused, 0);
                 }
 
                 InputSimulationWaitOutcome frameOutcome = await WaitOneRuntimeFrameOrTimeout(
@@ -208,21 +254,48 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ct).ConfigureAwait(false);
                 if (frameOutcome == InputSimulationWaitOutcome.TimedOut)
                 {
-                    return InputSimulationWaitOutcome.TimedOut;
+                    // Why: timeout during edge-extension still completes Press successfully with
+                    // PressEdgeObserved=false — same contract as before, not a hard failure.
+                    if (baseWaitSatisfied)
+                    {
+                        int extendedFrames = baseSatisfiedFrameCount < 0
+                            ? 0
+                            : PressHoldUntilEdgeLogic.CountExtendedFrames(observedFrames, baseSatisfiedFrameCount);
+                        return new PressLifetimeWaitResult(
+                            InputSimulationWaitOutcome.Completed,
+                            extendedFrames);
+                    }
+
+                    return new PressLifetimeWaitResult(InputSimulationWaitOutcome.TimedOut, 0);
                 }
 
                 await SwitchToMainThreadIfNeeded(ct);
                 if (IsPaused())
                 {
-                    return InputSimulationWaitOutcome.Paused;
+                    return new PressLifetimeWaitResult(InputSimulationWaitOutcome.Paused, 0);
                 }
 
                 observedFrames = Time.frameCount - startFrameCount;
                 elapsed = Time.realtimeSinceStartup - startTime;
             }
-
-            return InputSimulationWaitOutcome.Completed;
         }
+
+        /// <summary>
+        /// Outcome of a Press duration wait, including how many frames release was delayed for edge observation.
+        /// </summary>
+        internal readonly struct PressLifetimeWaitResult
+        {
+            public PressLifetimeWaitResult(InputSimulationWaitOutcome outcome, int extendedObservationFrames)
+            {
+                Outcome = outcome;
+                ExtendedObservationFrames = extendedObservationFrames;
+            }
+
+            public InputSimulationWaitOutcome Outcome { get; }
+
+            public int ExtendedObservationFrames { get; }
+        }
+
 
         public static void RunExplicitUpdate(InputUpdateType targetUpdateType)
         {

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressHoldUntilEdgeLogic.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressHoldUntilEdgeLogic.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Pure wait-loop decisions for Press holds that may extend until wasPressedThisFrame is observed.
+    /// Why: releasing as soon as duration/min frames elapse can drop the down state before gameplay
+    /// polls it; extending release is safe because down/up counts stay the same (no reinjection).
+    /// </summary>
+    internal static class PressHoldUntilEdgeLogic
+    {
+        /// <summary>
+        /// Returns whether the duration + minimum observation frame requirements are already satisfied.
+        /// </summary>
+        public static bool IsBaseWaitSatisfied(
+            int observedFrames,
+            int minimumObservationFrames,
+            float elapsedSeconds,
+            float durationSeconds)
+        {
+            return observedFrames >= minimumObservationFrames && elapsedSeconds >= durationSeconds;
+        }
+
+        /// <summary>
+        /// Returns whether the hold should continue after the base wait, waiting for a press edge.
+        /// </summary>
+        public static bool ShouldExtendHoldForEdge(
+            bool pressEdgeObserved,
+            bool baseWaitSatisfied,
+            long elapsedMilliseconds,
+            int timeoutMilliseconds)
+        {
+            if (pressEdgeObserved)
+            {
+                return false;
+            }
+
+            if (!baseWaitSatisfied)
+            {
+                return false;
+            }
+
+            return elapsedMilliseconds < timeoutMilliseconds;
+        }
+
+        /// <summary>
+        /// Returns how many observation frames were spent only after the base wait completed.
+        /// </summary>
+        public static int CountExtendedFrames(int observedFrames, int baseSatisfiedFrameCount)
+        {
+            if (observedFrames <= baseSatisfiedFrameCount)
+            {
+                return 0;
+            }
+
+            return observedFrames - baseSatisfiedFrameCount;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressHoldUntilEdgeLogic.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/PressHoldUntilEdgeLogic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84df81205d7fe4e64b5915317177cc72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardInputActionExecutor.cs
@@ -45,6 +45,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             KeyboardKeyState.RegisterTransientKey(key);
             bool pressWasApplied = false;
             bool pressEdgeObserved = false;
+            int pressHoldExtendedFrames = 0;
             InputSimulationWaitOutcome waitOutcome = InputSimulationWaitOutcome.Completed;
 
             // The edge must be probed inside gameplay input updates: editor-tick polling can
@@ -62,8 +63,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (waitOutcome == InputSimulationWaitOutcome.Completed)
                 {
                     pressWasApplied = true;
-                    waitOutcome = await InputSystemUpdateHelper.WaitForPressLifetime(duration, ct)
-                        .ConfigureAwait(false);
+                    InputSystemUpdateHelper.PressLifetimeWaitResult pressWaitResult =
+                        await InputSystemUpdateHelper.WaitForPressLifetime(
+                            duration,
+                            () => pressEdgeObserved,
+                            ct).ConfigureAwait(false);
+                    waitOutcome = pressWaitResult.Outcome;
+                    pressHoldExtendedFrames = pressWaitResult.ExtendedObservationFrames;
                 }
             }
             finally
@@ -123,16 +129,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             string durationText = duration > 0f ? $" for {InputSimulationDurationFormatter.FormatSeconds(duration)}s" : "";
-            string edgeText = pressEdgeObserved
-                ? ""
-                : " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it, so retry or verify with a focused log)";
+            string edgeText;
+            if (pressEdgeObserved && pressHoldExtendedFrames > 0)
+            {
+                edgeText =
+                    $" (release delayed {pressHoldExtendedFrames} frame(s) until wasPressedThisFrame was observed)";
+            }
+            else if (pressEdgeObserved)
+            {
+                edgeText = "";
+            }
+            else
+            {
+                edgeText =
+                    " (press edge was not observed via wasPressedThisFrame; gameplay polling may have missed it, so retry or verify with a focused log)";
+            }
+
             return new SimulateKeyboardResponse
             {
                 Success = true,
                 Message = $"Pressed '{keyName}'{durationText}{edgeText}",
                 Action = UnityCliLoopKeyboardAction.Press.ToString(),
                 KeyName = keyName,
-                PressEdgeObserved = pressEdgeObserved
+                PressEdgeObserved = pressEdgeObserved,
+                PressHoldExtendedFrames = pressHoldExtendedFrames > 0 ? pressHoldExtendedFrames : null
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
@@ -21,6 +21,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public List<UnityCliLoopPausePointHit>? PausePointHits { get; set; }
         public bool? PressEdgeObserved { get; set; }
 
+        /// <summary>
+        /// Extra observation frames spent holding the key after the normal duration window
+        /// while waiting for wasPressedThisFrame. Null when release was not delayed.
+        /// </summary>
+        public int? PressHoldExtendedFrames { get; set; }
+
         public SimulateKeyboardResponse()
         {
         }


### PR DESCRIPTION
Refs: 2026-07-12_uloop検証フィードバック改善 実装計画.md#PR 1-2 (B-3)

## Summary
- `simulate-keyboard --action Press` now keeps the key down past the normal duration window when `wasPressedThisFrame` has not yet been observed, up to the existing press timeout.
- No automatic down→up reinjection (avoids double-firing jumps). `KeyDown` is unchanged.

## Hypothesis check (PR description record)
- PlayMode Input settings observed via execute-dynamic-code:
  - `editorInputBehaviorInPlayMode=PointersAndKeyboardsRespectGameViewFocus`
  - `backgroundBehavior=ResetAndDisableNonBackgroundDevices`
  - `Keyboard.canRunInBackground=false`
- These are the preconditions for SoftReset on Game View focus loss. Live SoftReset/Disabled device-change events were not captured in-process without an OS unfocus; hold-until-edge remains useful regardless. **PR 1-3 remains conditional** on observing SoftReset events under real unfocus.

## User Impact
- **Before:** Short presses could report `PressEdgeObserved=false` and miss gameplay when the down state disappeared before the next observed frame.
- **After:** Release is delayed (bounded) until the edge is observed; response may include `PressHoldExtendedFrames` and a message about the delay.

## Changes
- `PressHoldUntilEdgeLogic` pure decisions + EditMode tests
- `WaitForPressLifetime` overload with edge callback + `PressLifetimeWaitResult`
- `SimulateKeyboardResponse.PressHoldExtendedFrames` (additive)
- Protocol version: **not bumped**

## Verification
- `uloop compile` → 0 errors / 0 warnings
- EditMode `PressHoldUntilEdgeLogic` → 8 passed
- Smoke: CLI Play + `simulate-keyboard Press Space --duration 0` → `PressEdgeObserved=true`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

