### PR TITLE
fix: Report why pause points were cleared instead of only Cleared

### DIFF
--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
@@ -61,7 +61,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                         UnityObjectInstanceId = -1234
                     }
                 },
-                CapturedVariablesTruncated = true
+                CapturedVariablesTruncated = true,
+                ClearedReason = "",
+                StatusBeforeClear = "",
+                LateHitDiscardedAfterClear = false
             };
             string json = JsonConvert.SerializeObject(
                 response,

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -140,6 +140,21 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Clear_WhenAlreadyClearedByRunTests_PreservesOriginalReason()
+        {
+            // Verifies a later explicit clear does not erase run-tests auto-clear evidence.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointRegistry.ClearAll(UloopPausePointClearedReason.RunTestsAutoClear);
+
+            UloopPausePointRegistry.Clear("jump");
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+
+            Assert.That(snapshot.Status, Is.EqualTo(UloopPausePointStatus.Cleared));
+            Assert.That(snapshot.ClearedReason, Is.EqualTo(UloopPausePointClearedReason.RunTestsAutoClear));
+            Assert.That(snapshot.StatusBeforeClear, Is.EqualTo(UloopPausePointStatus.Enabled));
+        }
+
+        [Test]
         public void ClearAll_WhenEnabled_SetsRunTestsAutoClearReason()
         {
             // Verifies run-tests-style ClearAll is visible on status after wiping an enabled marker.

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
@@ -135,6 +137,51 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.Enable("jump", 30);
 
             Assert.That(UloopPausePointRegistry.GetHitSnapshots(), Is.Empty);
+        }
+
+        [Test]
+        public void ClearAll_WhenEnabled_SetsRunTestsAutoClearReason()
+        {
+            // Verifies run-tests-style ClearAll is visible on status after wiping an enabled marker.
+            UloopPausePointRegistry.Enable("jump", 30);
+
+            UloopPausePointRegistry.ClearAll(UloopPausePointClearedReason.RunTestsAutoClear);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+
+            Assert.That(snapshot.Status, Is.EqualTo(UloopPausePointStatus.Cleared));
+            Assert.That(snapshot.ClearedReason, Is.EqualTo(UloopPausePointClearedReason.RunTestsAutoClear));
+            Assert.That(snapshot.StatusBeforeClear, Is.EqualTo(UloopPausePointStatus.Enabled));
+        }
+
+        [Test]
+        public void ClearAll_WhenExpired_ReportsAfterExpiredReason()
+        {
+            // Verifies ClearAll after timeout keeps AfterExpired instead of erasing the timeout clue.
+            UloopPausePointRegistry.Enable("jump", 1);
+            _nowUtc = _nowUtc.AddSeconds(2);
+
+            UloopPausePointRegistry.ClearAll(UloopPausePointClearedReason.ClearAll);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+
+            Assert.That(snapshot.Status, Is.EqualTo(UloopPausePointStatus.Cleared));
+            Assert.That(snapshot.ClearedReason, Is.EqualTo(UloopPausePointClearedReason.AfterExpired));
+            Assert.That(snapshot.StatusBeforeClear, Is.EqualTo(UloopPausePointStatus.Expired));
+        }
+
+        [Test]
+        public void Hit_WhenAlreadyCleared_LogsLateHitAndSetsDiscardFlag()
+        {
+            // Verifies a delayed hit after Clear is observable instead of a silent no-op.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointRegistry.Clear("jump");
+
+            LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex("hit after it was cleared"));
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Hit("jump");
+
+            Assert.That(snapshot.Status, Is.EqualTo(UloopPausePointStatus.Cleared));
+            Assert.That(snapshot.LateHitDiscardedAfterClear, Is.True);
+            Assert.That(snapshot.ClearedReason, Is.EqualTo(UloopPausePointClearedReason.ExplicitClear));
+            Assert.That(_pauseController.PauseCount, Is.EqualTo(0));
         }
 
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -65,6 +65,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string Message { get; set; } = string.Empty;
         public string RecommendedNextAction { get; set; } = string.Empty;
         public string Warning { get; set; } = string.Empty;
+        public string ClearedReason { get; set; } = string.Empty;
+        public string StatusBeforeClear { get; set; } = string.Empty;
+        public bool LateHitDiscardedAfterClear { get; set; }
 
         internal static PausePointResponse FromSnapshot(UloopPausePointSnapshot snapshot)
         {
@@ -92,7 +95,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 FirstHitSequence = snapshot.FirstHitSequence,
                 LastHitSequence = snapshot.LastHitSequence,
                 Message = snapshot.Message,
-                RecommendedNextAction = snapshot.RecommendedNextAction
+                RecommendedNextAction = snapshot.RecommendedNextAction,
+                ClearedReason = snapshot.ClearedReason,
+                StatusBeforeClear = snapshot.StatusBeforeClear,
+                LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -164,7 +164,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static string[] ClearActivePausePointsDefault()
         {
-            UloopPausePointClearAllResult result = UloopPausePointRegistry.ClearAll();
+            UloopPausePointClearAllResult result = UloopPausePointRegistry.ClearAll(UloopPausePointClearedReason.RunTestsAutoClear);
             if (result.ClearedCount == 0)
             {
                 return null;

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -71,6 +71,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public IReadOnlyList<PausePointStatusCapturedVariable> CapturedVariables { get; set; } =
             Array.Empty<PausePointStatusCapturedVariable>();
         public bool CapturedVariablesTruncated { get; set; }
+        public string ClearedReason { get; set; } = string.Empty;
+        public string StatusBeforeClear { get; set; } = string.Empty;
+        public bool LateHitDiscardedAfterClear { get; set; }
 
         internal static PausePointStatusResponse FromSnapshot(UloopPausePointSnapshot snapshot)
         {
@@ -102,7 +105,10 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 CapturedVariables = snapshot.CapturedVariables
                     .Select(PausePointStatusCapturedVariable.FromCapturedVariable)
                     .ToList(),
-                CapturedVariablesTruncated = snapshot.CapturedVariablesTruncated
+                CapturedVariablesTruncated = snapshot.CapturedVariablesTruncated,
+                ClearedReason = snapshot.ClearedReason,
+                StatusBeforeClear = snapshot.StatusBeforeClear,
+                LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear
             };
         }
     }

--- a/Packages/src/Runtime/PausePoints/UloopPausePointClearedReason.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointClearedReason.cs
@@ -11,7 +11,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public const string ClearAll = "ClearAll";
         public const string RunTestsAutoClear = "RunTestsAutoClear";
         public const string AfterExpired = "AfterExpired";
-        public const string AlreadyCleared = "AlreadyCleared";
         public const string AlreadyHit = "AlreadyHit";
     }
 }

--- a/Packages/src/Runtime/PausePoints/UloopPausePointClearedReason.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointClearedReason.cs
@@ -1,0 +1,18 @@
+#if UNITY_EDITOR
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// Machine-readable reasons a pause point transitioned to Cleared.
+    /// Why: Cleared alone hid whether run-tests, explicit clear, or an expired marker was wiped.
+    /// </summary>
+    internal static class UloopPausePointClearedReason
+    {
+        public const string ExplicitClear = "ExplicitClear";
+        public const string ClearAll = "ClearAll";
+        public const string RunTestsAutoClear = "RunTestsAutoClear";
+        public const string AfterExpired = "AfterExpired";
+        public const string AlreadyCleared = "AlreadyCleared";
+        public const string AlreadyHit = "AlreadyHit";
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointClearedReason.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointClearedReason.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a78733ac41b8341d593561758fb06481
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -63,15 +63,19 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         public void MarkCleared(string clearedReason, string message = "Pause point cleared.")
         {
+            // Why: a second clear must not erase the first reason (e.g. RunTestsAutoClear).
+            if (Status == UloopPausePointStatus.Cleared)
+            {
+                IsEnabled = false;
+                Message = message;
+                return;
+            }
+
             // Why: keep the pre-clear status so agents can still see Expired/Hit after Cleared overwrites Status.
             StatusBeforeClear = Status;
             if (Status == UloopPausePointStatus.Expired)
             {
                 ClearedReason = UloopPausePointClearedReason.AfterExpired;
-            }
-            else if (Status == UloopPausePointStatus.Cleared)
-            {
-                ClearedReason = UloopPausePointClearedReason.AlreadyCleared;
             }
             else if (Status == UloopPausePointStatus.Hit &&
                 clearedReason == UloopPausePointClearedReason.ExplicitClear)

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -40,6 +40,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string Message { get; private set; }
         public IReadOnlyList<UloopCapturedVariable> CapturedVariables { get; private set; }
         public bool CapturedVariablesTruncated { get; private set; }
+        public string ClearedReason { get; private set; } = string.Empty;
+        public string StatusBeforeClear { get; private set; } = string.Empty;
+        public bool LateHitDiscardedAfterClear { get; private set; }
 
         public void ExpireIfNeeded(DateTime nowUtc)
         {
@@ -58,11 +61,38 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             Message = "Pause point expired before it was hit.";
         }
 
-        public void MarkCleared(string message = "Pause point cleared.")
+        public void MarkCleared(string clearedReason, string message = "Pause point cleared.")
         {
+            // Why: keep the pre-clear status so agents can still see Expired/Hit after Cleared overwrites Status.
+            StatusBeforeClear = Status;
+            if (Status == UloopPausePointStatus.Expired)
+            {
+                ClearedReason = UloopPausePointClearedReason.AfterExpired;
+            }
+            else if (Status == UloopPausePointStatus.Cleared)
+            {
+                ClearedReason = UloopPausePointClearedReason.AlreadyCleared;
+            }
+            else if (Status == UloopPausePointStatus.Hit &&
+                clearedReason == UloopPausePointClearedReason.ExplicitClear)
+            {
+                ClearedReason = UloopPausePointClearedReason.AlreadyHit;
+            }
+            else
+            {
+                ClearedReason = string.IsNullOrEmpty(clearedReason)
+                    ? UloopPausePointClearedReason.ExplicitClear
+                    : clearedReason;
+            }
+
             IsEnabled = false;
             Status = UloopPausePointStatus.Cleared;
             Message = message;
+        }
+
+        public void MarkLateHitDiscardedAfterClear()
+        {
+            LateHitDiscardedAfterClear = true;
         }
 
         public void RecordHit(DateTime nowUtc, bool isPlaying, bool isPaused, int hitSequence)
@@ -140,7 +170,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 Message,
                 recommendedNextAction,
                 CapturedVariables,
-                CapturedVariablesTruncated);
+                CapturedVariablesTruncated,
+                ClearedReason,
+                StatusBeforeClear,
+                LateHitDiscardedAfterClear);
         }
 
         private long CalculateRemainingMilliseconds(DateTime nowUtc)

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -70,12 +70,13 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 UloopPausePointStatus.Cleared => "Pause point was already cleared.",
                 _ => "Pause point cleared."
             };
-            entry.MarkCleared(message);
+            entry.MarkCleared(UloopPausePointClearedReason.ExplicitClear, message);
             ClearLatestHitSnapshotIfMatches(id);
             return entry.ToSnapshot(now, _pauseController);
         }
 
-        public static UloopPausePointClearAllResult ClearAll()
+        public static UloopPausePointClearAllResult ClearAll(
+            string clearedReason = UloopPausePointClearedReason.ClearAll)
         {
             OnClearedAll?.Invoke();
 
@@ -88,8 +89,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                     continue;
                 }
 
+                // Resolve expiry first so ClearAll after timeout keeps AfterExpired visibility.
+                entry.ExpireIfNeeded(now);
                 clearedIds.Add(entry.Id);
-                entry.MarkCleared();
+                entry.MarkCleared(clearedReason);
             }
             ClearLatestHitSnapshot();
 
@@ -158,6 +161,16 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             entry.ExpireIfNeeded(now);
             if (!entry.IsEnabled)
             {
+                // Why: delayed main-thread hits can lose the race to Clear/ClearAll; surface that race.
+                if (entry.Status == UloopPausePointStatus.Cleared)
+                {
+                    entry.MarkLateHitDiscardedAfterClear();
+                    Debug.LogWarning(
+                        $"Pause point '{id}' was hit after it was cleared " +
+                        $"(ClearedReason={entry.ClearedReason}, StatusBeforeClear={entry.StatusBeforeClear}). " +
+                        "The late hit was discarded.");
+                }
+
                 return entry.ToSnapshot(now, _pauseController);
             }
 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
@@ -31,7 +31,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             string message,
             string recommendedNextAction,
             IReadOnlyList<UloopCapturedVariable> capturedVariables,
-            bool capturedVariablesTruncated)
+            bool capturedVariablesTruncated,
+            string clearedReason,
+            string statusBeforeClear,
+            bool lateHitDiscardedAfterClear)
         {
             Debug.Assert(editorState != null, "editorState must not be null");
 
@@ -55,6 +58,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             RecommendedNextAction = recommendedNextAction ?? string.Empty;
             CapturedVariables = capturedVariables ?? Array.Empty<UloopCapturedVariable>();
             CapturedVariablesTruncated = capturedVariablesTruncated;
+            ClearedReason = clearedReason ?? string.Empty;
+            StatusBeforeClear = statusBeforeClear ?? string.Empty;
+            LateHitDiscardedAfterClear = lateHitDiscardedAfterClear;
         }
 
         public string Id { get; }
@@ -77,6 +83,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string RecommendedNextAction { get; }
         public IReadOnlyList<UloopCapturedVariable> CapturedVariables { get; }
         public bool CapturedVariablesTruncated { get; }
+        public string ClearedReason { get; }
+        public string StatusBeforeClear { get; }
+        public bool LateHitDiscardedAfterClear { get; }
 
         public static UloopPausePointSnapshot NotEnabled(string id, IUloopPausePointPauseController pauseController)
         {
@@ -104,6 +113,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 "Pause point is not enabled.",
                 string.Empty,
                 Array.Empty<UloopCapturedVariable>(),
+                false,
+                string.Empty,
+                string.Empty,
                 false);
         }
     }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -66,6 +66,9 @@ type pausePointStatusResponse struct {
 	RecommendedNextAction           string                       `json:"RecommendedNextAction"`
 	CapturedVariables               []pausePointCapturedVariable `json:"CapturedVariables"`
 	CapturedVariablesTruncated      bool                         `json:"CapturedVariablesTruncated"`
+	ClearedReason                   string                       `json:"ClearedReason"`
+	StatusBeforeClear               string                       `json:"StatusBeforeClear"`
+	LateHitDiscardedAfterClear      bool                         `json:"LateHitDiscardedAfterClear"`
 }
 
 type pausePointEditorState struct {

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -32,5 +32,8 @@
       "UnityObjectInstanceId": -1234
     }
   ],
-  "CapturedVariablesTruncated": true
+  "CapturedVariablesTruncated": true,
+  "ClearedReason": "",
+  "StatusBeforeClear": "",
+  "LateHitDiscardedAfterClear": false
 }


### PR DESCRIPTION
Refs: 2026-07-12_uloop検証フィードバック改善 実装計画.md#PR 2-1 (A-1)

## Summary
- Cleared pause points now report `ClearedReason` and `StatusBeforeClear` (additive).
- `run-tests` auto ClearAll uses `RunTestsAutoClear`; clearing after expiry uses `AfterExpired`.
- Delayed hits after clear log a warning and set `LateHitDiscardedAfterClear`.

## User Impact
- Agents can tell whether a marker was wiped by run-tests, expired, or explicitly cleared.
- Late hits that lose the race to Clear are no longer silent no-ops.

## Changes
- Runtime entry/snapshot/registry + RunTests wiring
- Tool/status bridge DTOs + shared contract JSON + Go DTO
- EditMode tests for RunTestsAutoClear / AfterExpired / late-hit discard

## Protocol
- No protocol version bump (additive response fields only)

## Verification
- `uloop compile` 0/0
- EditMode PausePointTests + contract: 43 passed
- Go `TestPausePointStatusResponseMatchesSharedContract` ok

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

