### PR TITLE
feat: Preview captured collections as JSON in pause point status

### DIFF
--- a/Assets/Tests/Editor/CollectionPreviewPausePointFixture.cs
+++ b/Assets/Tests/Editor/CollectionPreviewPausePointFixture.cs
@@ -1,0 +1,14 @@
+// Fixture for collection JSON preview smoke verification. Line numbers are referenced by manual E2E checks.
+namespace io.github.hatayama.UnityCliLoop.Tests.PausePointToolsFixtures
+{
+    using System.Collections.Generic;
+
+    public sealed class CollectionPreviewPausePointFixture
+    {
+        public List<int> BuildScores()
+        {
+            List<int> scores = new() { 10, 20, 30 };
+            return scores;
+        }
+    }
+}

--- a/Assets/Tests/Editor/CollectionPreviewPausePointFixture.cs.meta
+++ b/Assets/Tests/Editor/CollectionPreviewPausePointFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e36b3cb441daf4ca288096a49697d943
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
@@ -433,6 +433,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(truncated, Is.True);
         }
 
+        [Test]
+        public void Format_WithDeferredLinqQuery_FallsBackToToStringInsteadOfJson()
+        {
+            // Verifies deferred IEnumerable/LINQ is not executed for JSON preview.
+            IEnumerable<int> query = Enumerable.Range(1, 3).Select(static value => value);
+            object[] locals = { "query", query };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(variables.Single().Value, Is.EqualTo(query.ToString()));
+            Assert.That(variables.Single().Value, Does.Not.StartWith("["));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WhenMaterializedCollectionEnumerationThrows_FallsBackToToString()
+        {
+            // Verifies enumeration exceptions during preview do not escape into user game code.
+            LogAssert.Expect(LogType.Exception, "InvalidOperationException: enum boom");
+            ThrowingOnEnumerateCollection collection = new();
+            object[] locals = { "broken", collection };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(variables.Single().Value, Is.EqualTo(collection.ToString()));
+            Assert.That(truncated, Is.False);
+        }
+
         [UnityTest]
         public IEnumerator Format_WhenCalledOffMainThread_DegradesUnityObjectValueWithoutEngineApiAccess()
         {
@@ -503,6 +533,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 await Task.Yield();
                 OuterField += localValue;
                 return localValue;
+            }
+        }
+
+        private sealed class ThrowingOnEnumerateCollection : ICollection
+        {
+            public int Count => 3;
+            public bool IsSynchronized => false;
+            public object SyncRoot => this;
+
+            public void CopyTo(Array array, int index)
+            {
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                throw new InvalidOperationException("enum boom");
             }
         }
     }

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointVariableFormatterTests.cs
@@ -327,6 +327,112 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(variable.Value, Is.EqualTo("(destroyed)"));
         }
 
+        [Test]
+        public void Format_WithListOfIntegers_SerializesCollectionAsJsonArray()
+        {
+            // Verifies List<T> values preview as JSON instead of the default type-name ToString.
+            object[] locals = { "scores", new List<int> { 1, 2, 3 } };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(variables.Single().Value, Is.EqualTo("[1,2,3]"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithStringDictionary_SerializesCollectionAsJsonObject()
+        {
+            // Verifies dictionary values preview as JSON objects with string keys.
+            object[] locals =
+            {
+                "labels",
+                new Dictionary<string, string> { { "hp", "100" }, { "mp", "50" } }
+            };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(variables.Single().Value, Is.EqualTo("{\"hp\":\"100\",\"mp\":\"50\"}"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WhenCollectionElementCountExceedsPreviewCap_TruncatesElementsAndSetsFlag()
+        {
+            // Verifies only the first preview-cap elements are serialized and truncation is reported.
+            List<int> values = Enumerable.Range(0, SourcePausePointConstants.MaxCollectionPreviewElementCount + 5).ToList();
+            object[] locals = { "scores", values };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            string value = variables.Single().Value;
+            Assert.That(value, Does.StartWith("["));
+            Assert.That(value, Does.EndWith("]"));
+            Assert.That(value.Split(',').Length, Is.EqualTo(SourcePausePointConstants.MaxCollectionPreviewElementCount));
+            Assert.That(truncated, Is.True);
+        }
+
+        [Test]
+        public void Format_WithCompositeCollectionElements_FallsBackElementsToToString()
+        {
+            // Verifies composite element types stringify instead of expanding nested object graphs.
+            object[] locals = { "items", new List<InstanceFieldFixture> { new() { PublicField = 7 } } };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(variables.Single().Value, Does.Contain(nameof(InstanceFieldFixture)));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithCircularCollectionReference_DoesNotThrow()
+        {
+            // Verifies cyclic graphs degrade safely instead of crashing collection preview.
+            List<object> outer = new();
+            List<object> inner = new();
+            outer.Add(inner);
+            inner.Add(outer);
+            object[] locals = { "graph", outer };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(variables.Single().Value, Does.Contain("(circular)"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WithStringValue_KeepsPlainStringPreview()
+        {
+            // Verifies string is excluded from IEnumerable JSON preview and keeps the raw value.
+            object[] locals = { "label", "ready" };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(variables.Single().Value, Is.EqualTo("ready"));
+            Assert.That(truncated, Is.False);
+        }
+
+        [Test]
+        public void Format_WhenCollectionPreviewExceedsMaxLength_TruncatesValueAndSetsTruncatedFlag()
+        {
+            // Verifies expanded collection JSON uses the larger preview cap before clipping.
+            List<string> values = Enumerable.Range(0, SourcePausePointConstants.MaxCollectionPreviewElementCount)
+                .Select(_ => new string('x', 120))
+                .ToList();
+            object[] locals = { "chunks", values };
+
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
+                null, Array.Empty<object>(), locals);
+
+            Assert.That(variables.Single().Value.Length, Is.EqualTo(SourcePausePointConstants.MaxCollectionPreviewValueLength));
+            Assert.That(truncated, Is.True);
+        }
+
         [UnityTest]
         public IEnumerator Format_WhenCalledOffMainThread_DegradesUnityObjectValueWithoutEngineApiAccess()
         {

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
@@ -13,12 +13,11 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Builds a shallow JSON preview for captured IEnumerable values so pause-point status can show
-    /// collection contents instead of the default type-name ToString.
+    /// Builds a shallow JSON preview for captured materialized collections so pause-point status can
+    /// show collection contents instead of the default type-name ToString.
     /// </summary>
     internal static class SourcePausePointCollectionPreviewSerializer
     {
-        private const int MaxCollectionDepth = 2;
         private const string OffMainThreadValue = "(captured off main thread)";
         private const string DestroyedValue = "(destroyed)";
 
@@ -42,15 +41,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return false;
             }
 
-            if (rawValue is not IEnumerable enumerable)
+            // Why: deferred IEnumerable/LINQ must not execute user code during preview; only
+            // materialized ICollection/IDictionary snapshots are safe to walk.
+            if (rawValue is not ICollection && rawValue is not IDictionary)
             {
                 return false;
             }
 
-            HashSet<object> visited = new(ReferenceEqualityComparer.Instance);
-            JToken token = BuildToken(enumerable, MaxCollectionDepth, visited, ref truncated);
-            preview = token.ToString(Formatting.None);
-            return true;
+            try
+            {
+                HashSet<object> visited = new(ReferenceEqualityComparer.Instance);
+                JToken token = BuildToken(
+                    rawValue, SourcePausePointConstants.MaxCollectionPreviewDepth, visited, ref truncated);
+                preview = token.ToString(Formatting.None);
+                return true;
+            }
+            catch (Exception exception)
+            {
+                Debug.LogException(exception);
+                return false;
+            }
         }
 
         private static void HandleSerializationError(object sender, ErrorEventArgs args)
@@ -99,7 +109,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return BuildDictionaryToken(dictionary, remainingDepth, visited, ref truncated);
                 }
 
-                return BuildArrayToken(enumerable, remainingDepth, visited, ref truncated);
+                if (value is ICollection)
+                {
+                    return BuildArrayToken(enumerable, remainingDepth, visited, ref truncated);
+                }
+
+                return new JValue(SafeToString(value));
             }
 
             return new JValue(SafeToString(value));
@@ -138,12 +153,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     break;
                 }
 
-                string key = entry.Key == null ? "null" : entry.Key.ToString();
+                string key = FormatDictionaryKey(entry.Key);
                 jsonObject[key] = BuildToken(entry.Value, remainingDepth - 1, visited, ref truncated);
                 elementCount++;
             }
 
             return jsonObject;
+        }
+
+        private static string FormatDictionaryKey(object key)
+        {
+            if (key == null)
+            {
+                return "null";
+            }
+
+            if (key is UnityEngine.Object unityObject)
+            {
+                return FormatUnityObjectElement(unityObject);
+            }
+
+            return SafeToString(key);
         }
 
         private static bool IsJsonPrimitive(object value)
@@ -174,6 +204,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return unityObject.name;
         }
 
+        // Sanctioned try-catch in the capture path: user ToString() overrides are untrusted code
+        // we must not let crash a pause-point hit.
         private static string SafeToString(object value)
         {
             try

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds a shallow JSON preview for captured IEnumerable values so pause-point status can show
+    /// collection contents instead of the default type-name ToString.
+    /// </summary>
+    internal static class SourcePausePointCollectionPreviewSerializer
+    {
+        private const int MaxCollectionDepth = 2;
+        private const string OffMainThreadValue = "(captured off main thread)";
+        private const string DestroyedValue = "(destroyed)";
+
+        private static readonly JsonSerializer PrimitiveSerializer = JsonSerializer.Create(
+            new JsonSerializerSettings
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                Error = HandleSerializationError
+            });
+
+        public static bool TrySerialize(object rawValue, ref bool truncated, out string preview)
+        {
+            preview = string.Empty;
+            if (rawValue == null)
+            {
+                return false;
+            }
+
+            if (rawValue is string || rawValue is byte[])
+            {
+                return false;
+            }
+
+            if (rawValue is not IEnumerable enumerable)
+            {
+                return false;
+            }
+
+            HashSet<object> visited = new(ReferenceEqualityComparer.Instance);
+            JToken token = BuildToken(enumerable, MaxCollectionDepth, visited, ref truncated);
+            preview = token.ToString(Formatting.None);
+            return true;
+        }
+
+        private static void HandleSerializationError(object sender, ErrorEventArgs args)
+        {
+            Debug.LogException(args.ErrorContext.Error);
+            args.ErrorContext.Handled = true;
+        }
+
+        private static JToken BuildToken(
+            object value, int remainingDepth, HashSet<object> visited, ref bool truncated)
+        {
+            if (value == null)
+            {
+                return JValue.CreateNull();
+            }
+
+            if (value is UnityEngine.Object unityObject)
+            {
+                return new JValue(FormatUnityObjectElement(unityObject));
+            }
+
+            if (value is string stringValue)
+            {
+                return JValue.FromObject(stringValue, PrimitiveSerializer);
+            }
+
+            if (IsJsonPrimitive(value))
+            {
+                return JToken.FromObject(value, PrimitiveSerializer);
+            }
+
+            if (value is IEnumerable enumerable)
+            {
+                if (!visited.Add(value))
+                {
+                    return new JValue("(circular)");
+                }
+
+                if (remainingDepth <= 0)
+                {
+                    return new JValue(SafeToString(value));
+                }
+
+                if (value is IDictionary dictionary)
+                {
+                    return BuildDictionaryToken(dictionary, remainingDepth, visited, ref truncated);
+                }
+
+                return BuildArrayToken(enumerable, remainingDepth, visited, ref truncated);
+            }
+
+            return new JValue(SafeToString(value));
+        }
+
+        private static JArray BuildArrayToken(
+            IEnumerable enumerable, int remainingDepth, HashSet<object> visited, ref bool truncated)
+        {
+            JArray array = new();
+            int elementCount = 0;
+            foreach (object element in enumerable)
+            {
+                if (elementCount >= SourcePausePointConstants.MaxCollectionPreviewElementCount)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                array.Add(BuildToken(element, remainingDepth - 1, visited, ref truncated));
+                elementCount++;
+            }
+
+            return array;
+        }
+
+        private static JObject BuildDictionaryToken(
+            IDictionary dictionary, int remainingDepth, HashSet<object> visited, ref bool truncated)
+        {
+            JObject jsonObject = new();
+            int elementCount = 0;
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                if (elementCount >= SourcePausePointConstants.MaxCollectionPreviewElementCount)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                string key = entry.Key == null ? "null" : entry.Key.ToString();
+                jsonObject[key] = BuildToken(entry.Value, remainingDepth - 1, visited, ref truncated);
+                elementCount++;
+            }
+
+            return jsonObject;
+        }
+
+        private static bool IsJsonPrimitive(object value)
+        {
+            return value is bool
+                or byte or sbyte
+                or short or ushort
+                or int or uint
+                or long or ulong
+                or float or double
+                or decimal
+                or char
+                or Enum;
+        }
+
+        private static string FormatUnityObjectElement(UnityEngine.Object unityObject)
+        {
+            if (!MainThreadSwitcher.IsMainThread)
+            {
+                return OffMainThreadValue;
+            }
+
+            if (unityObject == null)
+            {
+                return DestroyedValue;
+            }
+
+            return unityObject.name;
+        }
+
+        private static string SafeToString(object value)
+        {
+            try
+            {
+                return value.ToString();
+            }
+            catch (Exception exception)
+            {
+                Debug.LogException(exception);
+                return $"(toString threw {exception.GetType().Name})";
+            }
+        }
+
+        private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+        {
+            public static ReferenceEqualityComparer Instance { get; } = new();
+
+            public new bool Equals(object x, object y)
+            {
+                return ReferenceEquals(x, y);
+            }
+
+            public int GetHashCode(object obj)
+            {
+                return RuntimeHelpersGetHashCode(obj);
+            }
+
+            // Why: object.GetHashCode is overridden by many collection types; reference identity is required.
+            private static int RuntimeHelpersGetHashCode(object obj)
+            {
+                return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCollectionPreviewSerializer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f4c2d1a9b7e4f6c8d3e5a1b2c4d6e8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -14,6 +14,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // pause-point evidence to stay skimmable, mirroring the truncation-by-cap pattern MatchingLogs uses.
         public const int MaxCapturedVariableCount = 50;
         public const int MaxCapturedVariableValueLength = 256;
+        public const int MaxCollectionPreviewElementCount = 10;
+        public const int MaxCollectionPreviewValueLength = 1024;
 
         public const string HarmonyId = "io.github.hatayama.uloop.source-pause-point";
         public const string BurstCompileAttributeFullName = "Unity.Burst.BurstCompileAttribute";

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointConstants.cs
@@ -16,6 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public const int MaxCapturedVariableValueLength = 256;
         public const int MaxCollectionPreviewElementCount = 10;
         public const int MaxCollectionPreviewValueLength = 1024;
+        public const int MaxCollectionPreviewDepth = 2;
 
         public const string HarmonyId = "io.github.hatayama.uloop.source-pause-point";
         public const string BurstCompileAttributeFullName = "Unity.Burst.BurstCompileAttribute";

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
@@ -242,8 +242,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return value.Substring(0, maxLength);
         }
 
-        // The single sanctioned try-catch in this codebase's capture path: user ToString()
-        // overrides are untrusted code we must not let crash a pause-point hit.
+        // Sanctioned try-catch sites in the capture path: user ToString() overrides (below) and
+        // materialized-collection enumeration in SourcePausePointCollectionPreviewSerializer.
+        // Both must not let untrusted user code crash a pause-point hit.
         private static string SafeToString(object value)
         {
             try

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
@@ -192,7 +192,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return FormatUnityObjectVariable(name, scope, typeName, unityObjectCandidate);
             }
 
-            string value = ApplyValueLengthCap(SafeToString(rawValue), ref truncated);
+            if (SourcePausePointCollectionPreviewSerializer.TrySerialize(rawValue, ref truncated, out string collectionPreview))
+            {
+                string cappedPreview = ApplyValueLengthCap(
+                    collectionPreview,
+                    SourcePausePointConstants.MaxCollectionPreviewValueLength,
+                    ref truncated);
+                return new UloopCapturedVariable(name, scope, typeName, cappedPreview, string.Empty, string.Empty, 0);
+            }
+
+            string value = ApplyValueLengthCap(
+                SafeToString(rawValue), SourcePausePointConstants.MaxCapturedVariableValueLength, ref truncated);
             return new UloopCapturedVariable(name, scope, typeName, value, string.Empty, string.Empty, 0);
         }
 
@@ -221,15 +231,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 classification.Kind, classification.Path, classification.InstanceId);
         }
 
-        private static string ApplyValueLengthCap(string value, ref bool truncated)
+        private static string ApplyValueLengthCap(string value, int maxLength, ref bool truncated)
         {
-            if (value.Length <= SourcePausePointConstants.MaxCapturedVariableValueLength)
+            if (value.Length <= maxLength)
             {
                 return value;
             }
 
             truncated = true;
-            return value.Substring(0, SourcePausePointConstants.MaxCapturedVariableValueLength);
+            return value.Substring(0, maxLength);
         }
 
         // The single sanctioned try-catch in this codebase's capture path: user ToString()

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/UnityCLILoop.FirstPartyTools.PausePoint.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/UnityCLILoop.FirstPartyTools.PausePoint.Editor.asmdef
@@ -13,7 +13,8 @@
     "overrideReferences": true,
     "precompiledReferences": [
         "UnityCliLoop.0Harmony.dll",
-        "Mono.Cecil.dll"
+        "Mono.Cecil.dll",
+        "Newtonsoft.Json.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [],


### PR DESCRIPTION
Refs: 2026-07-12_uloop検証フィードバック改善 実装計画.md#PR 2-2 (B-2 案1)

## Summary
- IEnumerable captured variables (excluding `string`) now preview as shallow JSON in `Value`.
- `UnityEngine.Object` values keep the existing dedicated classification path.
- Collection previews use custom depth-2 expansion, reference-cycle guards, element/count caps, and a 1024-char preview limit surfaced via `CapturedVariablesTruncated`.
- Expansion is limited to materialized `ICollection` / `IDictionary` values; deferred LINQ/iterators fall back to `ToString`.

## User Impact
- Agents can read `List<T>` / dictionary contents directly from `CapturedVariables` without execute-dynamic-code.
- Composite element types still stringify safely; Unity types in collections never go through Newtonsoft property walking.

## Changes
- `SourcePausePointCollectionPreviewSerializer` with manual depth control + `ReferenceLoopHandling.Ignore` primitive serializer error handler
- `SourcePausePointConstants`: `MaxCollectionPreviewElementCount=10`, `MaxCollectionPreviewValueLength=1024`, `MaxCollectionPreviewDepth=2`
- Newtonsoft.Json reference added to PausePoint Editor asmdef
- 9 new formatter tests + `CollectionPreviewPausePointFixture` for smoke verification

## Known limitations
- `HashSet<T>`, `IReadOnlyCollection<T>`, and similar types do not implement non-generic `ICollection`, so they are not JSON-expanded and remain `ToString` previews (intentional safe-side restriction).

## Protocol
- No protocol version bump (Value string embedding only; DTO fields unchanged)

## Verification
- `uloop compile` 0 errors / 0 warnings
- `SourcePausePointVariableFormatterTests` 26 passed

### Real-device evidence (pause point hit)
```
enable-pause-point --file Assets/Tests/Editor/CollectionPreviewPausePointFixture.cs --line 11
execute-dynamic-code → fixture.BuildScores()
pause-point-status CapturedVariables:
  Name: scores
  TypeName: System.Collections.Generic.List`1[[System.Int32, ...]]
  Value: "[10,20,30]"
  CapturedVariablesTruncated: false
```