### PR TITLE
feat: Expose raw captured pause point variables while Unity is paused

### DIFF
--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -502,7 +502,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new("scores", UloopCapturedVariableScope.Local, "System.Collections.Generic.List`1[System.Int32]", "[10,20,30]", string.Empty, string.Empty, 0)
             };
 
-            UloopPausePointRegistry.HitWithCapturedVariables("jump", frame, capturedVariables, false);
+            UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, capturedVariables, false);
 
             (bool foundScores, object scoresValue) = UloopPausePoint.TryGetCapturedValue("scores");
             (bool foundNull, object nullValue) = UloopPausePoint.TryGetCapturedValue("empty");
@@ -526,7 +526,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointCapturedVariableFrame frame = new(
                 new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 5) },
                 false);
-            UloopPausePointRegistry.HitWithCapturedVariables(
+            UloopPausePointRegistry.HitWithCapturedFrame(
                 "jump", frame, Array.Empty<UloopCapturedVariable>(), false);
 
             UloopPausePointRegistry.Clear("jump");
@@ -550,12 +550,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 2) },
                 false);
 
-            UloopPausePointRegistry.HitWithCapturedVariables("jump", jumpFrame, Array.Empty<UloopCapturedVariable>(), false);
-            UloopPausePointRegistry.HitWithCapturedVariables("land", landFrame, Array.Empty<UloopCapturedVariable>(), false);
+            UloopPausePointRegistry.HitWithCapturedFrame("jump", jumpFrame, Array.Empty<UloopCapturedVariable>(), false);
+            UloopPausePointRegistry.HitWithCapturedFrame("land", landFrame, Array.Empty<UloopCapturedVariable>(), false);
 
             (bool found, object value) = UloopPausePoint.TryGetCapturedValue("speed");
             Assert.That(found, Is.True);
             Assert.That(value, Is.EqualTo(2));
+            Assert.That(UloopPausePoint.GetCapturedPausePointId(), Is.EqualTo("land"));
+        }
+
+        [Test]
+        public void TryGetCapturedValue_WhenUnrelatedPausePointIsCleared_KeepsLatestHitRawCapture()
+        {
+            // Verifies Clear(id) only drops raw refs when id matches the latest hit snapshot.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointRegistry.Enable("land", 30);
+            UloopPausePointCapturedVariableFrame landFrame = new(
+                new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 7) },
+                false);
+            UloopPausePointRegistry.HitWithCapturedFrame("land", landFrame, Array.Empty<UloopCapturedVariable>(), false);
+
+            UloopPausePointRegistry.Clear("jump");
+
+            (bool found, object value) = UloopPausePoint.TryGetCapturedValue("speed");
+            Assert.That(found, Is.True);
+            Assert.That(value, Is.EqualTo(7));
             Assert.That(UloopPausePoint.GetCapturedPausePointId(), Is.EqualTo("land"));
         }
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -485,6 +485,81 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void TryGetCapturedValue_WhenLatestHitStoredRawFrame_ReturnsLiveReferences()
+        {
+            // Verifies raw capture exposes live objects for the latest hit only.
+            UloopPausePointRegistry.Enable("jump", 30);
+            List<int> scores = new() { 10, 20, 30 };
+            UloopPausePointCapturedVariableFrame frame = new(
+                new[]
+                {
+                    new UloopPausePointCapturedVariableEntry("scores", UloopCapturedVariableScope.Local, scores),
+                    new UloopPausePointCapturedVariableEntry("empty", UloopCapturedVariableScope.Local, null)
+                },
+                false);
+            UloopCapturedVariable[] capturedVariables =
+            {
+                new("scores", UloopCapturedVariableScope.Local, "System.Collections.Generic.List`1[System.Int32]", "[10,20,30]", string.Empty, string.Empty, 0)
+            };
+
+            UloopPausePointRegistry.HitWithCapturedVariables("jump", frame, capturedVariables, false);
+
+            (bool foundScores, object scoresValue) = UloopPausePoint.TryGetCapturedValue("scores");
+            (bool foundNull, object nullValue) = UloopPausePoint.TryGetCapturedValue("empty");
+            (bool foundMissing, object missingValue) = UloopPausePoint.TryGetCapturedValue("missing");
+
+            Assert.That(foundScores, Is.True);
+            Assert.That(scoresValue, Is.SameAs(scores));
+            Assert.That(foundNull, Is.True);
+            Assert.That(nullValue, Is.Null);
+            Assert.That(foundMissing, Is.False);
+            Assert.That(missingValue, Is.Null);
+            Assert.That(UloopPausePoint.GetCapturedPausePointId(), Is.EqualTo("jump"));
+            Assert.That(UloopPausePoint.GetCapturedNames(), Is.EqualTo(new[] { "scores", "empty" }));
+        }
+
+        [Test]
+        public void TryGetCapturedValue_WhenRegistryClearsLatestHit_ReturnsNotFound()
+        {
+            // Verifies clear and reset paths drop raw references instead of leaving stale handles.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointCapturedVariableFrame frame = new(
+                new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 5) },
+                false);
+            UloopPausePointRegistry.HitWithCapturedVariables(
+                "jump", frame, Array.Empty<UloopCapturedVariable>(), false);
+
+            UloopPausePointRegistry.Clear("jump");
+
+            (bool found, object value) = UloopPausePoint.TryGetCapturedValue("speed");
+            Assert.That(found, Is.False);
+            Assert.That(value, Is.Null);
+            Assert.That(UloopPausePoint.GetCapturedPausePointId(), Is.Empty);
+        }
+
+        [Test]
+        public void TryGetCapturedValue_WhenNewHitReplacesPrevious_ExposesLatestSnapshotOnly()
+        {
+            // Verifies only the latest hit snapshot is held, matching _latestHitSnapshot semantics.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointRegistry.Enable("land", 30);
+            UloopPausePointCapturedVariableFrame jumpFrame = new(
+                new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 1) },
+                false);
+            UloopPausePointCapturedVariableFrame landFrame = new(
+                new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 2) },
+                false);
+
+            UloopPausePointRegistry.HitWithCapturedVariables("jump", jumpFrame, Array.Empty<UloopCapturedVariable>(), false);
+            UloopPausePointRegistry.HitWithCapturedVariables("land", landFrame, Array.Empty<UloopCapturedVariable>(), false);
+
+            (bool found, object value) = UloopPausePoint.TryGetCapturedValue("speed");
+            Assert.That(found, Is.True);
+            Assert.That(value, Is.EqualTo(2));
+            Assert.That(UloopPausePoint.GetCapturedPausePointId(), Is.EqualTo("land"));
+        }
+
+        [Test]
         public void Hit_WhenPausePointIsEnabled_ReportsEmptyCapturedVariables()
         {
             // Verifies the plain marker path (no source pause point) reports an empty, non-null list.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
@@ -25,12 +25,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(
-                instance, parameterNamesAndValues, localNamesAndValues);
+            (UloopPausePointCapturedVariableFrame frame, List<UloopCapturedVariable> variables, bool truncated) =
+                CaptureFrame(instance, parameterNamesAndValues, localNamesAndValues);
 
             if (MainThreadSwitcher.IsMainThread)
             {
-                UloopPausePointRegistry.HitWithCapturedVariables(id, variables, truncated);
+                UloopPausePointRegistry.HitWithCapturedVariables(id, frame, variables, truncated);
                 return;
             }
 
@@ -38,7 +38,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // touched from the main thread, so an off-thread hit is recorded on the next
             // main-thread tick instead of inline. HitCore re-checks IsEnabled at that point, so a
             // marker that already got disarmed by a faster hit safely no-ops there.
-            MainThreadSwitcher.AddContinuation(() => UloopPausePointRegistry.HitWithCapturedVariables(id, variables, truncated));
+            MainThreadSwitcher.AddContinuation(
+                () => UloopPausePointRegistry.HitWithCapturedVariables(id, frame, variables, truncated));
+        }
+
+        internal static (UloopPausePointCapturedVariableFrame Frame, List<UloopCapturedVariable> Variables, bool Truncated)
+            CaptureFrame(object instance, object[] parameterNamesAndValues, object[] localNamesAndValues)
+        {
+            UloopPausePointCapturedVariableFrame frame = SourcePausePointVariableCollector.Collect(
+                instance, parameterNamesAndValues, localNamesAndValues);
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(frame);
+            return (frame, variables, truncated);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointCapture.cs
@@ -30,7 +30,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (MainThreadSwitcher.IsMainThread)
             {
-                UloopPausePointRegistry.HitWithCapturedVariables(id, frame, variables, truncated);
+                UloopPausePointRegistry.HitWithCapturedFrame(id, frame, variables, truncated);
                 return;
             }
 
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // main-thread tick instead of inline. HitCore re-checks IsEnabled at that point, so a
             // marker that already got disarmed by a faster hit safely no-ops there.
             MainThreadSwitcher.AddContinuation(
-                () => UloopPausePointRegistry.HitWithCapturedVariables(id, frame, variables, truncated));
+                () => UloopPausePointRegistry.HitWithCapturedFrame(id, frame, variables, truncated));
         }
 
         internal static (UloopPausePointCapturedVariableFrame Frame, List<UloopCapturedVariable> Variables, bool Truncated)
@@ -47,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             UloopPausePointCapturedVariableFrame frame = SourcePausePointVariableCollector.Collect(
                 instance, parameterNamesAndValues, localNamesAndValues);
-            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.Format(frame);
+            (List<UloopCapturedVariable> variables, bool truncated) = SourcePausePointVariableFormatter.FormatFrame(frame);
             return (frame, variables, truncated);
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableCollector.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableCollector.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds the shared demangled capture frame consumed by the formatter and raw-ref holder.
+    /// </summary>
+    internal static class SourcePausePointVariableCollector
+    {
+        private static readonly Regex HoistedLocalFieldNamePattern = new(@"^<([^>]+)>5__\d+$", RegexOptions.Compiled);
+        private const string StateMachineOuterThisFieldName = "<>4__this";
+
+        public static UloopPausePointCapturedVariableFrame Collect(
+            object instance, object[] parameterNamesAndValues, object[] localNamesAndValues)
+        {
+            Debug.Assert(parameterNamesAndValues != null, "parameterNamesAndValues must not be null");
+            Debug.Assert(localNamesAndValues != null, "localNamesAndValues must not be null");
+            Debug.Assert(parameterNamesAndValues.Length % 2 == 0, "parameterNamesAndValues must contain name/value pairs");
+            Debug.Assert(localNamesAndValues.Length % 2 == 0, "localNamesAndValues must contain name/value pairs");
+
+            List<UloopPausePointCapturedVariableEntry> entries = new();
+            bool truncated = false;
+            HashSet<string> capturedNames = new();
+
+            bool countCapReached = AppendPairs(
+                entries, capturedNames, ref truncated, localNamesAndValues, UloopCapturedVariableScope.Local);
+            if (!countCapReached)
+            {
+                countCapReached = AppendPairs(
+                    entries, capturedNames, ref truncated, parameterNamesAndValues, UloopCapturedVariableScope.Parameter);
+            }
+
+            if (instance != null && !countCapReached)
+            {
+                CollectInstanceFieldVariables(instance, entries, capturedNames, ref truncated);
+            }
+
+            return new UloopPausePointCapturedVariableFrame(entries, truncated);
+        }
+
+        private static bool AppendPairs(
+            List<UloopPausePointCapturedVariableEntry> entries, HashSet<string> capturedNames, ref bool truncated,
+            object[] namesAndValues, string scope)
+        {
+            for (int i = 0; i < namesAndValues.Length; i += 2)
+            {
+                string name = (string)namesAndValues[i];
+                object value = namesAndValues[i + 1];
+                if (!TryAppendEntry(entries, capturedNames, ref truncated, name, scope, value))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void CollectInstanceFieldVariables(
+            object instance, List<UloopPausePointCapturedVariableEntry> entries, HashSet<string> capturedNames,
+            ref bool truncated)
+        {
+            (object outerThis, bool countCapReached) = CollectDirectFieldVariables(
+                instance, entries, capturedNames, ref truncated, followOuterThis: true);
+            if (countCapReached || outerThis == null)
+            {
+                return;
+            }
+
+            CollectDirectFieldVariables(outerThis, entries, capturedNames, ref truncated, followOuterThis: false);
+        }
+
+        private static (object OuterThis, bool CountCapReached) CollectDirectFieldVariables(
+            object source, List<UloopPausePointCapturedVariableEntry> entries, HashSet<string> capturedNames,
+            ref bool truncated, bool followOuterThis)
+        {
+            object outerThis = null;
+            bool isCompilerGeneratedStateMachine = Attribute.IsDefined(source.GetType(), typeof(CompilerGeneratedAttribute));
+            string plainFieldScope = isCompilerGeneratedStateMachine
+                ? UloopCapturedVariableScope.Parameter
+                : UloopCapturedVariableScope.InstanceField;
+
+            foreach (FieldInfo field in EnumerateInstanceFields(source.GetType()))
+            {
+                if (followOuterThis && field.Name == StateMachineOuterThisFieldName)
+                {
+                    outerThis = field.GetValue(source);
+                    continue;
+                }
+
+                Match hoistedLocalMatch = HoistedLocalFieldNamePattern.Match(field.Name);
+                if (hoistedLocalMatch.Success)
+                {
+                    if (!TryAppendEntry(
+                        entries, capturedNames, ref truncated, hoistedLocalMatch.Groups[1].Value,
+                        UloopCapturedVariableScope.Local, field.GetValue(source)))
+                    {
+                        return (outerThis, true);
+                    }
+
+                    continue;
+                }
+
+                if (field.Name.StartsWith("<", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!TryAppendEntry(entries, capturedNames, ref truncated, field.Name, plainFieldScope, field.GetValue(source)))
+                {
+                    return (outerThis, true);
+                }
+            }
+
+            return (outerThis, false);
+        }
+
+        private static IEnumerable<FieldInfo> EnumerateInstanceFields(Type type)
+        {
+            const BindingFlags flags =
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+            for (Type current = type;
+                 current != null && current != typeof(UnityEngine.Object) && current != typeof(object);
+                 current = current.BaseType)
+            {
+                foreach (FieldInfo field in current.GetFields(flags))
+                {
+                    yield return field;
+                }
+            }
+        }
+
+        private static bool TryAppendEntry(
+            List<UloopPausePointCapturedVariableEntry> entries, HashSet<string> capturedNames, ref bool truncated,
+            string name, string scope, object rawValue)
+        {
+            if (!capturedNames.Add(name))
+            {
+                return true;
+            }
+
+            if (entries.Count >= SourcePausePointConstants.MaxCapturedVariableCount)
+            {
+                truncated = true;
+                return false;
+            }
+
+            entries.Add(new UloopPausePointCapturedVariableEntry(name, scope, rawValue));
+            return true;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableCollector.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableCollector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de60b915f89f645178073973356c1502
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
@@ -24,10 +24,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             UloopPausePointCapturedVariableFrame frame = SourcePausePointVariableCollector.Collect(
                 instance, parameterNamesAndValues, localNamesAndValues);
-            return Format(frame);
+            return FormatFrame(frame);
         }
 
-        public static (List<UloopCapturedVariable> Variables, bool Truncated) Format(
+        public static (List<UloopCapturedVariable> Variables, bool Truncated) FormatFrame(
             UloopPausePointCapturedVariableFrame frame)
         {
             Debug.Assert(frame != null, "frame must not be null");

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
@@ -12,171 +12,34 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Turns the raw name/value pairs a pause point captured into the DTOs a CLI response can
-    /// serialize: demangling compiler-hoisted local/`this` fields, classifying UnityEngine.Object
-    /// references, and capping both value length and variable count.
+    /// Turns the shared capture frame into DTOs a CLI response can serialize.
     /// </summary>
     internal static class SourcePausePointVariableFormatter
     {
-        // Roslyn hoists a local that crosses an await/yield into a state machine field named
-        // "<name>5__N"; this demangles it back to the source-level local name.
-        private static readonly Regex HoistedLocalFieldNamePattern = new(@"^<([^>]+)>5__\d+$", RegexOptions.Compiled);
-        private const string StateMachineOuterThisFieldName = "<>4__this";
         private const string OffMainThreadValue = "(captured off main thread)";
         private const string DestroyedValue = "(destroyed)";
 
         public static (List<UloopCapturedVariable> Variables, bool Truncated) Format(
             object instance, object[] parameterNamesAndValues, object[] localNamesAndValues)
         {
-            Debug.Assert(parameterNamesAndValues != null, "parameterNamesAndValues must not be null");
-            Debug.Assert(localNamesAndValues != null, "localNamesAndValues must not be null");
-            Debug.Assert(parameterNamesAndValues.Length % 2 == 0, "parameterNamesAndValues must contain name/value pairs");
-            Debug.Assert(localNamesAndValues.Length % 2 == 0, "localNamesAndValues must contain name/value pairs");
+            UloopPausePointCapturedVariableFrame frame = SourcePausePointVariableCollector.Collect(
+                instance, parameterNamesAndValues, localNamesAndValues);
+            return Format(frame);
+        }
+
+        public static (List<UloopCapturedVariable> Variables, bool Truncated) Format(
+            UloopPausePointCapturedVariableFrame frame)
+        {
+            Debug.Assert(frame != null, "frame must not be null");
 
             List<UloopCapturedVariable> results = new();
-            // Reports whether ANY value was clipped or the count cap was hit; a single over-long
-            // value must not stop enumeration of the remaining locals/parameters/instance fields.
-            bool truncated = false;
-            // An async state machine's own fields include hoisted copies of the original method's
-            // parameters under their plain source name (only true locals get the "<name>5__N"
-            // treatment); tracking already-captured names keeps those from being double-reported
-            // once as Parameter (from the array below) and again as InstanceField (from the walk).
-            HashSet<string> capturedNames = new();
-
-            bool countCapReached = AppendPairs(
-                results, capturedNames, ref truncated, localNamesAndValues, UloopCapturedVariableScope.Local);
-            if (!countCapReached)
+            bool truncated = frame.Truncated;
+            foreach (UloopPausePointCapturedVariableEntry entry in frame.Entries)
             {
-                countCapReached = AppendPairs(
-                    results, capturedNames, ref truncated, parameterNamesAndValues, UloopCapturedVariableScope.Parameter);
-            }
-
-            if (instance != null && !countCapReached)
-            {
-                CollectInstanceFieldVariables(instance, results, capturedNames, ref truncated);
+                results.Add(FormatVariable(entry.Name, entry.Scope, entry.Value, ref truncated));
             }
 
             return (results, truncated);
-        }
-
-        // Returns true once the count cap is hit, so the caller can stop enumerating further
-        // arrays/fields; a per-value length truncation alone must not signal this.
-        private static bool AppendPairs(
-            List<UloopCapturedVariable> results, HashSet<string> capturedNames, ref bool truncated,
-            object[] namesAndValues, string scope)
-        {
-            for (int i = 0; i < namesAndValues.Length; i += 2)
-            {
-                string name = (string)namesAndValues[i];
-                object value = namesAndValues[i + 1];
-                if (!TryAppendVariable(results, capturedNames, ref truncated, name, scope, value))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        // Async/iterator state machines hoist the original `this` into a `<>4__this` field; this
-        // follows it exactly one level deep to also capture the real instance's fields, without
-        // recursing into any further state-machine hop.
-        private static void CollectInstanceFieldVariables(
-            object instance, List<UloopCapturedVariable> results, HashSet<string> capturedNames, ref bool truncated)
-        {
-            (object outerThis, bool countCapReached) = CollectDirectFieldVariables(
-                instance, results, capturedNames, ref truncated, followOuterThis: true);
-            if (countCapReached || outerThis == null)
-            {
-                return;
-            }
-
-            CollectDirectFieldVariables(outerThis, results, capturedNames, ref truncated, followOuterThis: false);
-        }
-
-        private static (object OuterThis, bool CountCapReached) CollectDirectFieldVariables(
-            object source, List<UloopCapturedVariable> results, HashSet<string> capturedNames, ref bool truncated,
-            bool followOuterThis)
-        {
-            object outerThis = null;
-            // A compiler-generated state machine hoists the original method's parameters as
-            // plain-named fields (only true locals get the "<name>5__N" treatment), so those
-            // fields are the method's Parameter scope, not this type's own InstanceField scope.
-            bool isCompilerGeneratedStateMachine = Attribute.IsDefined(source.GetType(), typeof(CompilerGeneratedAttribute));
-            string plainFieldScope = isCompilerGeneratedStateMachine
-                ? UloopCapturedVariableScope.Parameter
-                : UloopCapturedVariableScope.InstanceField;
-
-            foreach (FieldInfo field in EnumerateInstanceFields(source.GetType()))
-            {
-                if (followOuterThis && field.Name == StateMachineOuterThisFieldName)
-                {
-                    outerThis = field.GetValue(source);
-                    continue;
-                }
-
-                Match hoistedLocalMatch = HoistedLocalFieldNamePattern.Match(field.Name);
-                if (hoistedLocalMatch.Success)
-                {
-                    if (!TryAppendVariable(
-                        results, capturedNames, ref truncated, hoistedLocalMatch.Groups[1].Value,
-                        UloopCapturedVariableScope.Local, field.GetValue(source)))
-                    {
-                        return (outerThis, true);
-                    }
-
-                    continue;
-                }
-
-                if (field.Name.StartsWith("<", StringComparison.Ordinal))
-                {
-                    // Other compiler-generated plumbing (state machine "<>1__state", "<>t__builder",
-                    // auto-property backing fields, etc.) carries no source-level meaning to capture.
-                    continue;
-                }
-
-                if (!TryAppendVariable(results, capturedNames, ref truncated, field.Name, plainFieldScope, field.GetValue(source)))
-                {
-                    return (outerThis, true);
-                }
-            }
-
-            return (outerThis, false);
-        }
-
-        private static IEnumerable<FieldInfo> EnumerateInstanceFields(Type type)
-        {
-            const BindingFlags flags =
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
-
-            for (Type current = type;
-                 current != null && current != typeof(UnityEngine.Object) && current != typeof(object);
-                 current = current.BaseType)
-            {
-                foreach (FieldInfo field in current.GetFields(flags))
-                {
-                    yield return field;
-                }
-            }
-        }
-
-        private static bool TryAppendVariable(
-            List<UloopCapturedVariable> results, HashSet<string> capturedNames, ref bool truncated, string name,
-            string scope, object rawValue)
-        {
-            if (!capturedNames.Add(name))
-            {
-                return true;
-            }
-
-            if (results.Count >= SourcePausePointConstants.MaxCapturedVariableCount)
-            {
-                truncated = true;
-                return false;
-            }
-
-            results.Add(FormatVariable(name, scope, rawValue, ref truncated));
-            return true;
         }
 
         private static UloopCapturedVariable FormatVariable(string name, string scope, object rawValue, ref bool truncated)
@@ -211,14 +74,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (!MainThreadSwitcher.IsMainThread)
             {
-                // Transform/AssetDatabase/InstanceID access all require the main thread; degrade
-                // to a plain type-tagged placeholder rather than risk touching engine state here.
                 return new UloopCapturedVariable(name, scope, typeName, OffMainThreadValue, string.Empty, string.Empty, 0);
             }
 
             if (unityObjectCandidate == null)
             {
-                // Fake-null: the managed wrapper is a live reference, so GetInstanceID() is still safe.
                 return new UloopCapturedVariable(
                     name, scope, typeName, DestroyedValue,
                     UloopCapturedVariableUnityObjectKind.Destroyed, string.Empty, unityObjectCandidate.GetInstanceID());

--- a/Packages/src/Runtime/PausePoints/UloopPausePoint.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePoint.cs
@@ -22,6 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         /// <summary>
         /// Tries to read a raw captured variable from the latest pause-point hit while Unity is paused.
+        /// When multiple captured variables share the same name, the last one wins.
         /// </summary>
         public static (bool Found, object Value) TryGetCapturedValue(string name)
         {

--- a/Packages/src/Runtime/PausePoints/UloopPausePoint.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePoint.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace io.github.hatayama.UnityCliLoop.Runtime
@@ -15,6 +17,42 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
 #if UNITY_EDITOR
             UloopPausePointRegistry.Hit(id);
+#endif
+        }
+
+        /// <summary>
+        /// Tries to read a raw captured variable from the latest pause-point hit while Unity is paused.
+        /// </summary>
+        public static (bool Found, object Value) TryGetCapturedValue(string name)
+        {
+#if UNITY_EDITOR
+            return UloopPausePointRawCaptureHolder.TryGetCapturedValue(name);
+#else
+            return (false, null);
+#endif
+        }
+
+        /// <summary>
+        /// Returns captured variable names from the latest pause-point hit, or empty when none is held.
+        /// </summary>
+        public static IReadOnlyList<string> GetCapturedNames()
+        {
+#if UNITY_EDITOR
+            return UloopPausePointRawCaptureHolder.GetCapturedNames();
+#else
+            return Array.Empty<string>();
+#endif
+        }
+
+        /// <summary>
+        /// Returns the pause-point id for the latest raw capture snapshot, or empty when none is held.
+        /// </summary>
+        public static string GetCapturedPausePointId()
+        {
+#if UNITY_EDITOR
+            return UloopPausePointRawCaptureHolder.GetCapturedPausePointId();
+#else
+            return string.Empty;
 #endif
         }
     }

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableEntry.cs
@@ -1,0 +1,21 @@
+#if UNITY_EDITOR
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// One demangled captured variable before string formatting for CLI responses.
+    /// </summary>
+    internal sealed class UloopPausePointCapturedVariableEntry
+    {
+        public UloopPausePointCapturedVariableEntry(string name, string scope, object value)
+        {
+            Name = name;
+            Scope = scope;
+            Value = value;
+        }
+
+        public string Name { get; }
+        public string Scope { get; }
+        public object Value { get; }
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableEntry.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6bfe22de3d5d41d19f48e65e950f635
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableFrame.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableFrame.cs
@@ -1,0 +1,22 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// Shared demangled capture output consumed by both the string formatter and raw-ref holder.
+    /// </summary>
+    internal sealed class UloopPausePointCapturedVariableFrame
+    {
+        public UloopPausePointCapturedVariableFrame(
+            IReadOnlyList<UloopPausePointCapturedVariableEntry> entries, bool truncated)
+        {
+            Entries = entries;
+            Truncated = truncated;
+        }
+
+        public IReadOnlyList<UloopPausePointCapturedVariableEntry> Entries { get; }
+        public bool Truncated { get; }
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableFrame.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCapturedVariableFrame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c20cc7494cadf416e894f63f8b55da0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureHolder.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureHolder.cs
@@ -1,0 +1,81 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using System.Threading;
+
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// Retains raw captured variable references for the latest pause-point hit only.
+    /// Why: execute-dynamic-code can inspect live objects while Unity stays paused; references
+    /// must not outlive that paused window.
+    /// </summary>
+    internal static class UloopPausePointRawCaptureHolder
+    {
+        private static UloopPausePointRawCaptureSnapshot _latest;
+
+        internal static void Store(UloopPausePointCapturedVariableFrame frame, string pausePointId)
+        {
+            Dictionary<string, object> valuesByName = new();
+            foreach (UloopPausePointCapturedVariableEntry entry in frame.Entries)
+            {
+                valuesByName[entry.Name] = entry.Value;
+            }
+
+            UloopPausePointRawCaptureSnapshot snapshot = new(pausePointId, valuesByName);
+            Interlocked.Exchange(ref _latest, snapshot);
+        }
+
+        internal static void Clear()
+        {
+            Interlocked.Exchange(ref _latest, null);
+        }
+
+        internal static (bool Found, object Value) TryGetCapturedValue(string name)
+        {
+            UloopPausePointRawCaptureSnapshot snapshot = Volatile.Read(ref _latest);
+            if (snapshot == null)
+            {
+                return (false, null);
+            }
+
+            if (!snapshot.ValuesByName.TryGetValue(name, out object value))
+            {
+                return (false, null);
+            }
+
+            return (true, value);
+        }
+
+        internal static IReadOnlyList<string> GetCapturedNames()
+        {
+            UloopPausePointRawCaptureSnapshot snapshot = Volatile.Read(ref _latest);
+            if (snapshot == null)
+            {
+                return System.Array.Empty<string>();
+            }
+
+            return snapshot.Names;
+        }
+
+        internal static string GetCapturedPausePointId()
+        {
+            UloopPausePointRawCaptureSnapshot snapshot = Volatile.Read(ref _latest);
+            return snapshot?.PausePointId ?? string.Empty;
+        }
+
+        private sealed class UloopPausePointRawCaptureSnapshot
+        {
+            public UloopPausePointRawCaptureSnapshot(string pausePointId, Dictionary<string, object> valuesByName)
+            {
+                PausePointId = pausePointId;
+                ValuesByName = valuesByName;
+                Names = new List<string>(valuesByName.Keys);
+            }
+
+            public string PausePointId { get; }
+            public IReadOnlyDictionary<string, object> ValuesByName { get; }
+            public IReadOnlyList<string> Names { get; }
+        }
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureHolder.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c5e64f9c5619468e860b28361156a61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
@@ -1,0 +1,48 @@
+#if UNITY_EDITOR
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// Clears raw capture references when Unity leaves the paused-hit window.
+    /// </summary>
+    [InitializeOnLoad]
+    internal static class UloopPausePointRawCaptureLifecycle
+    {
+        static UloopPausePointRawCaptureLifecycle()
+        {
+            EditorApplication.pauseStateChanged += OnPauseStateChanged;
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPauseStateChanged(PauseState pauseState)
+        {
+            if (pauseState != PauseState.Unpaused)
+            {
+                return;
+            }
+
+            // Why: Step can transiently unpause then re-pause; delayCall re-checks the settled state.
+            EditorApplication.delayCall += ClearRawCaptureIfStillUnpaused;
+        }
+
+        private static void ClearRawCaptureIfStillUnpaused()
+        {
+            if (EditorApplication.isPaused)
+            {
+                return;
+            }
+
+            UloopPausePointRawCaptureHolder.Clear();
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange change)
+        {
+            if (change == PlayModeStateChange.ExitingPlayMode || change == PlayModeStateChange.EnteredEditMode)
+            {
+                UloopPausePointRawCaptureHolder.Clear();
+            }
+        }
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e91b0adefacc84e5d96264e965dbd602
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -72,7 +72,6 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             };
             entry.MarkCleared(UloopPausePointClearedReason.ExplicitClear, message);
             ClearLatestHitSnapshotIfMatches(id);
-            UloopPausePointRawCaptureHolder.Clear();
             return entry.ToSnapshot(now, _pauseController);
         }
 
@@ -132,7 +131,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             return HitCore(id, null, capturedVariables, capturedVariablesTruncated);
         }
 
-        public static UloopPausePointSnapshot HitWithCapturedVariables(
+        public static UloopPausePointSnapshot HitWithCapturedFrame(
             string id,
             UloopPausePointCapturedVariableFrame capturedFrame,
             IReadOnlyList<UloopCapturedVariable> capturedVariables,

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -72,6 +72,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             };
             entry.MarkCleared(UloopPausePointClearedReason.ExplicitClear, message);
             ClearLatestHitSnapshotIfMatches(id);
+            UloopPausePointRawCaptureHolder.Clear();
             return entry.ToSnapshot(now, _pauseController);
         }
 
@@ -95,6 +96,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 entry.MarkCleared(clearedReason);
             }
             ClearLatestHitSnapshot();
+            UloopPausePointRawCaptureHolder.Clear();
 
             UloopPausePointEditorStateSnapshot editorState = UloopPausePointEditorStateSnapshot.FromController(
                 _pauseController,
@@ -119,7 +121,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         public static UloopPausePointSnapshot Hit(string id)
         {
-            return HitCore(id, Array.Empty<UloopCapturedVariable>(), false);
+            return HitCore(id, null, Array.Empty<UloopCapturedVariable>(), false);
         }
 
         public static UloopPausePointSnapshot HitWithCapturedVariables(
@@ -127,7 +129,19 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
             Debug.Assert(capturedVariables != null, "capturedVariables must not be null");
 
-            return HitCore(id, capturedVariables, capturedVariablesTruncated);
+            return HitCore(id, null, capturedVariables, capturedVariablesTruncated);
+        }
+
+        public static UloopPausePointSnapshot HitWithCapturedVariables(
+            string id,
+            UloopPausePointCapturedVariableFrame capturedFrame,
+            IReadOnlyList<UloopCapturedVariable> capturedVariables,
+            bool capturedVariablesTruncated)
+        {
+            Debug.Assert(capturedFrame != null, "capturedFrame must not be null");
+            Debug.Assert(capturedVariables != null, "capturedVariables must not be null");
+
+            return HitCore(id, capturedFrame, capturedVariables, capturedVariablesTruncated);
         }
 
         // Returns after a single dictionary lookup when the id is not armed. Harmony-injected
@@ -143,7 +157,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
 
         private static UloopPausePointSnapshot HitCore(
-            string id, IReadOnlyList<UloopCapturedVariable> capturedVariables, bool capturedVariablesTruncated)
+            string id,
+            UloopPausePointCapturedVariableFrame capturedFrame,
+            IReadOnlyList<UloopCapturedVariable> capturedVariables,
+            bool capturedVariablesTruncated)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
@@ -183,6 +200,11 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _latestHitSnapshot = snapshot;
             _hitSnapshots.RemoveAll(hitSnapshot => hitSnapshot.Id == id);
             _hitSnapshots.Add(snapshot);
+            if (capturedFrame != null)
+            {
+                UloopPausePointRawCaptureHolder.Store(capturedFrame, id);
+            }
+
             return snapshot;
         }
 
@@ -200,6 +222,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
             _latestHitSnapshot = null;
             _hitSnapshots.Clear();
+            UloopPausePointRawCaptureHolder.Clear();
         }
 
         private static void ClearLatestHitSnapshotIfMatches(string id)
@@ -216,6 +239,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
 
             _latestHitSnapshot = null;
+            UloopPausePointRawCaptureHolder.Clear();
         }
 
         public static void ConfigureForTests(IUloopPausePointPauseController pauseController, Func<DateTime> nowProvider)
@@ -236,6 +260,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _hitSnapshots.Clear();
             _pauseController = new UnityEditorPausePointPauseController();
             _nowProvider = () => DateTime.UtcNow;
+            UloopPausePointRawCaptureHolder.Clear();
         }
 
         private static DateTime NowUtc()


### PR DESCRIPTION
Refs: 2026-07-12_uloop検証フィードバック改善 実装計画.md#PR 2-3 (B-2 案2)

## Summary
- Demangled capture frames are shared between the string formatter and a latest-hit-only raw holder.
- `UloopPausePoint.TryGetCapturedValue` returns `(bool Found, object Value)`; `GetCapturedNames()` and `GetCapturedPausePointId()` expose snapshot metadata.
- Resume clearing uses `pauseStateChanged` + `delayCall` re-check so PlayMode Step does not drop refs mid-inspection.

## User Impact
- While Unity is paused on a hit, execute-dynamic-code can read live collection/object references (not just string previews).
- After resume/clear/new hit/PlayMode exit, raw refs are dropped (`Found=false`).

## Design (Fable 5 conditional LGTM)
- Latest hit only (mirrors `_latestHitSnapshot`)
- Tuple `TryGetCapturedValue` avoids null ambiguity
- Intermediate `UloopPausePointCapturedVariableFrame` consumed by Collector + Formatter + Holder
- No CLI/DTO field additions

## Protocol
- No protocol version bump

## Verification
- `uloop compile` 0 errors / 0 warnings
- `PausePointTests` + `SourcePausePointVariableFormatterTests` 72 passed

### Real-device evidence

**Pause中に raw 参照を読める**
```
enable-pause-point --file Assets/Tests/Editor/CollectionPreviewPausePointFixture.cs --line 11
execute-dynamic-code → new CollectionPreviewPausePointFixture().BuildScores()
execute-dynamic-code:
  TryGetCapturedValue("scores") → Found=true, List contents "10,20,30"
  GetCapturedPausePointId() → Assets/Tests/Editor/CollectionPreviewPausePointFixture.cs:11
```

**resume 後は Found=false**
```
control-play-mode --action Play  (resume)
execute-dynamic-code → TryGetCapturedValue("scores").Found → false ("cleared-after-resume")
```

**Step 干渉検証 (PlayMode paused)**
```
control-play-mode Pause → hit fixture → TryGetCapturedValue → "held-before-step"
control-play-mode Step → TryGetCapturedValue → "held-after-step" (holder retained; isPaused stayed true)
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

