### PR TITLE
feat: List valid tool enum values and suggest keyboard key names

### DIFF
--- a/.agents/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.agents/skills/uloop-simulate-keyboard/SKILL.md
@@ -28,7 +28,7 @@ uloop simulate-keyboard --action <action> --key <key> [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--action` | enum | `Press` | `Press`, `KeyDown`, `KeyUp` |
-| `--key` | string | (required) | Key name matching Input System Key enum (e.g. `W`, `Space`, `LeftShift`, `A`, `Enter`). Case-insensitive. |
+| `--key` | string | (required) | Key name matching Input System Key enum (e.g. `W`, `Space`, `LeftShift`, `A`, `Enter`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`. |
 | `--duration` | number | `0` | Hold duration in seconds for Press action (0 = one-shot tap). Ignored by KeyDown/KeyUp. |
 
 ### Actions

--- a/.claude/skills/uloop-simulate-keyboard/SKILL.md
+++ b/.claude/skills/uloop-simulate-keyboard/SKILL.md
@@ -28,7 +28,7 @@ uloop simulate-keyboard --action <action> --key <key> [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--action` | enum | `Press` | `Press`, `KeyDown`, `KeyUp` |
-| `--key` | string | (required) | Key name matching Input System Key enum (e.g. `W`, `Space`, `LeftShift`, `A`, `Enter`). Case-insensitive. |
+| `--key` | string | (required) | Key name matching Input System Key enum (e.g. `W`, `Space`, `LeftShift`, `A`, `Enter`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`. |
 | `--duration` | number | `0` | Hold duration in seconds for Press action (0 = one-shot tap). Ignored by KeyDown/KeyUp. |
 
 ### Actions

--- a/Assets/Tests/Editor/CaseInsensitiveStringEnumConverterTests.cs
+++ b/Assets/Tests/Editor/CaseInsensitiveStringEnumConverterTests.cs
@@ -9,7 +9,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     [TestFixture]
     public class CaseInsensitiveStringEnumConverterTests
     {
-        // Verifies control-play-mode accepts lowercase enum tokens from the CLI.
+        // Locks lowercase enum strings that already worked before the converter was added.
         [Test]
         public void Deserialize_PlayModeAction_AcceptsLowercaseAction()
         {
@@ -35,6 +35,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(exception.Message, Does.Contain("Stop"));
             Assert.That(exception.Message, Does.Contain("Pause"));
             Assert.That(exception.Message, Does.Contain("Step"));
+        }
+
+        // Verifies integer enum tokens are rejected with an explicit string-only message.
+        [Test]
+        public void Deserialize_PlayModeAction_IntegerToken_RejectedWithExplicitMessage()
+        {
+            JObject token = JObject.Parse("{\"action\":1}");
+
+            JsonSerializationException exception = Assert.Throws<JsonSerializationException>(() =>
+                token.ToObject<ControlPlayModeSchema>(UnityCliLoopToolParameterSerializer.CamelCaseSerializer));
+
+            Assert.That(exception.Message, Does.Contain("Enum parameter values must be JSON strings"));
+            Assert.That(exception.Message, Does.Contain("Integer"));
+            Assert.That(exception.Message, Does.Contain("PlayModeAction"));
         }
     }
 }

--- a/Assets/Tests/Editor/CaseInsensitiveStringEnumConverterTests.cs
+++ b/Assets/Tests/Editor/CaseInsensitiveStringEnumConverterTests.cs
@@ -1,0 +1,40 @@
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    [TestFixture]
+    public class CaseInsensitiveStringEnumConverterTests
+    {
+        // Verifies control-play-mode accepts lowercase enum tokens from the CLI.
+        [Test]
+        public void Deserialize_PlayModeAction_AcceptsLowercaseAction()
+        {
+            JObject token = JObject.Parse("{\"action\":\"play\"}");
+
+            ControlPlayModeSchema schema = token.ToObject<ControlPlayModeSchema>(
+                UnityCliLoopToolParameterSerializer.CamelCaseSerializer);
+
+            Assert.That(schema.Action, Is.EqualTo(PlayModeAction.Play));
+        }
+
+        // Verifies invalid enum values surface the allowed action names in the error.
+        [Test]
+        public void Deserialize_PlayModeAction_InvalidValue_ListsValidValues()
+        {
+            JObject token = JObject.Parse("{\"action\":\"jump\"}");
+
+            JsonSerializationException exception = Assert.Throws<JsonSerializationException>(() =>
+                token.ToObject<ControlPlayModeSchema>(UnityCliLoopToolParameterSerializer.CamelCaseSerializer));
+
+            Assert.That(exception.Message, Does.Contain("Valid values:"));
+            Assert.That(exception.Message, Does.Contain("Play"));
+            Assert.That(exception.Message, Does.Contain("Stop"));
+            Assert.That(exception.Message, Does.Contain("Pause"));
+            Assert.That(exception.Message, Does.Contain("Step"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/CaseInsensitiveStringEnumConverterTests.cs.meta
+++ b/Assets/Tests/Editor/CaseInsensitiveStringEnumConverterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed26577fb4ae643a89c5e3c8e8b455ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/KeyboardKeyNameSuggesterTests.cs
+++ b/Assets/Tests/Editor/KeyboardKeyNameSuggesterTests.cs
@@ -1,0 +1,32 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+using System.Collections.Generic;
+using System.Linq;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using NUnit.Framework;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    [TestFixture]
+    public class KeyboardKeyNameSuggesterTests
+    {
+        // Verifies bare digit keys suggest both Digit and Numpad enum names.
+        [Test]
+        public void Suggest_ForBareDigit_IncludesDigitAndNumpadNames()
+        {
+            IReadOnlyList<string> suggestions = KeyboardKeyNameSuggester.Suggest("3");
+
+            Assert.That(suggestions, Does.Contain("Digit3"));
+            Assert.That(suggestions, Does.Contain("Numpad3"));
+        }
+
+        // Verifies partial key names still return close enum matches.
+        [Test]
+        public void Suggest_ForPartialName_ReturnsPrefixMatches()
+        {
+            IReadOnlyList<string> suggestions = KeyboardKeyNameSuggester.Suggest("LeftSh");
+
+            Assert.That(suggestions.Any(name => name == "LeftShift"), Is.True);
+        }
+    }
+}
+#endif

--- a/Assets/Tests/Editor/KeyboardKeyNameSuggesterTests.cs.meta
+++ b/Assets/Tests/Editor/KeyboardKeyNameSuggesterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e787247d922846cb97905834c470a4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardKeyNameSuggester.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardKeyNameSuggester.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+#if ULOOP_HAS_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Suggests Input System Key enum names for unknown simulate-keyboard key inputs.
+    /// </summary>
+    internal static class KeyboardKeyNameSuggester
+    {
+        private const int MaxSuggestions = 6;
+
+        public static IReadOnlyList<string> Suggest(string invalidKeyName)
+        {
+            if (string.IsNullOrWhiteSpace(invalidKeyName))
+            {
+                return Array.Empty<string>();
+            }
+
+#if !ULOOP_HAS_INPUT_SYSTEM
+            return Array.Empty<string>();
+#else
+            string trimmed = invalidKeyName.Trim();
+            List<string> suggestions = new();
+
+            if (trimmed.Length == 1 && char.IsDigit(trimmed[0]))
+            {
+                string digit = trimmed;
+                AddUnique(suggestions, $"Digit{digit}");
+                AddUnique(suggestions, $"Numpad{digit}");
+            }
+
+            string[] allNames = Enum.GetNames(typeof(Key));
+            StringComparison comparison = StringComparison.OrdinalIgnoreCase;
+            for (int index = 0; index < allNames.Length; index++)
+            {
+                string name = allNames[index];
+                if (name.StartsWith(trimmed, comparison) ||
+                    name.Contains(trimmed, comparison))
+                {
+                    AddUnique(suggestions, name);
+                    if (suggestions.Count >= MaxSuggestions)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return suggestions;
+#endif
+        }
+
+#if ULOOP_HAS_INPUT_SYSTEM
+        private static void AddUnique(List<string> suggestions, string candidate)
+        {
+            for (int index = 0; index < suggestions.Count; index++)
+            {
+                if (string.Equals(suggestions[index], candidate, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+            }
+
+            suggestions.Add(candidate);
+        }
+#endif
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardKeyNameSuggester.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardKeyNameSuggester.cs
@@ -38,8 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             for (int index = 0; index < allNames.Length; index++)
             {
                 string name = allNames[index];
-                if (name.StartsWith(trimmed, comparison) ||
-                    name.Contains(trimmed, comparison))
+                if (name.Contains(trimmed, comparison))
                 {
                     AddUnique(suggestions, name);
                     if (suggestions.Count >= MaxSuggestions)

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardKeyNameSuggester.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/KeyboardKeyNameSuggester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9064de4241e224b38bdc0e3cbadc15f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 #if ULOOP_HAS_INPUT_SYSTEM
@@ -70,10 +71,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string normalizedKey = NormalizeKeyName(parameters.Key);
             if (!Enum.TryParse<Key>(normalizedKey, ignoreCase: true, out Key key) || key == Key.None)
             {
+                IReadOnlyList<string> suggestions = KeyboardKeyNameSuggester.Suggest(parameters.Key);
+                string suggestionText = suggestions.Count == 0
+                    ? string.Empty
+                    : $" Did you mean: {string.Join(", ", suggestions)}?";
                 return new SimulateKeyboardResponse
                 {
                     Success = false,
-                    Message = $"Invalid key name: \"{parameters.Key}\". Use Input System Key enum names (e.g. \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\").",
+                    Message =
+                        $"Invalid key name: \"{parameters.Key}\". Use Input System Key enum names (e.g. \"W\", \"Space\", \"LeftShift\", \"A\", \"Enter\").{suggestionText}",
                     Action = parameters.Action.ToString()
                 };
             }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/Skill/SKILL.md
@@ -28,7 +28,7 @@ uloop simulate-keyboard --action <action> --key <key> [options]
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `--action` | enum | `Press` | `Press`, `KeyDown`, `KeyUp` |
-| `--key` | string | (required) | Key name matching Input System Key enum (e.g. `W`, `Space`, `LeftShift`, `A`, `Enter`). Case-insensitive. |
+| `--key` | string | (required) | Key name matching Input System Key enum (e.g. `W`, `Space`, `LeftShift`, `A`, `Enter`). Case-insensitive. Digit keys use `Digit0`-`Digit9` or `Numpad0`-`Numpad9`, not bare `0`-`9`. |
 | `--duration` | number | `0` | Hold duration in seconds for Press action (0 = one-shot tap). Ignored by KeyDown/KeyUp. |
 
 ### Actions

--- a/Packages/src/Editor/ToolContracts/CaseInsensitiveStringEnumConverter.cs
+++ b/Packages/src/Editor/ToolContracts/CaseInsensitiveStringEnumConverter.cs
@@ -1,0 +1,66 @@
+using System;
+using Newtonsoft.Json;
+
+namespace io.github.hatayama.UnityCliLoop.ToolContracts
+{
+    /// <summary>
+    /// Deserializes string tokens into enum values using case-insensitive name matching.
+    /// </summary>
+    internal sealed class CaseInsensitiveStringEnumConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            Type enumType = Nullable.GetUnderlyingType(objectType) ?? objectType;
+            return enumType.IsEnum;
+        }
+
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object existingValue,
+            JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                Type underlyingType = Nullable.GetUnderlyingType(objectType);
+                if (underlyingType != null)
+                {
+                    return null;
+                }
+
+                throw new JsonSerializationException(
+                    $"Cannot convert null value to {objectType.Name}.");
+            }
+
+            if (reader.TokenType != JsonToken.String)
+            {
+                throw new JsonSerializationException(
+                    $"Unexpected token {reader.TokenType} when parsing enum.");
+            }
+
+            string rawValue = reader.Value?.ToString() ?? string.Empty;
+            Type enumType = Nullable.GetUnderlyingType(objectType) ?? objectType;
+            if (Enum.TryParse(enumType, rawValue, ignoreCase: true, out object parsed))
+            {
+                return parsed;
+            }
+
+            string[] validValues = Enum.GetNames(enumType);
+            string pathSuffix = string.IsNullOrEmpty(reader.Path) ? string.Empty : $" Path '{reader.Path}'.";
+            throw new JsonSerializationException(
+                $"Error converting value \"{rawValue}\" to type '{enumType.Name}'.{pathSuffix} " +
+                $"Valid values: {string.Join(", ", validValues)}.");
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.WriteValue(value.ToString());
+        }
+    }
+}

--- a/Packages/src/Editor/ToolContracts/CaseInsensitiveStringEnumConverter.cs
+++ b/Packages/src/Editor/ToolContracts/CaseInsensitiveStringEnumConverter.cs
@@ -4,7 +4,10 @@ using Newtonsoft.Json;
 namespace io.github.hatayama.UnityCliLoop.ToolContracts
 {
     /// <summary>
-    /// Deserializes string tokens into enum values using case-insensitive name matching.
+    /// Parses tool enum parameters from JSON string tokens and lists valid enum names on failure.
+    /// Case-insensitive string matching already worked with the default Newtonsoft enum reader;
+    /// this converter exists so invalid values return an explicit Valid values list.
+    /// Integer tokens are rejected because the CLI only sends string enum values.
     /// </summary>
     internal sealed class CaseInsensitiveStringEnumConverter : JsonConverter
     {
@@ -32,14 +35,16 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
                     $"Cannot convert null value to {objectType.Name}.");
             }
 
+            Type enumType = Nullable.GetUnderlyingType(objectType) ?? objectType;
+
             if (reader.TokenType != JsonToken.String)
             {
                 throw new JsonSerializationException(
-                    $"Unexpected token {reader.TokenType} when parsing enum.");
+                    $"Enum parameter values must be JSON strings. Received {reader.TokenType} token " +
+                    $"'{reader.Value}' for type '{enumType.Name}'.");
             }
 
             string rawValue = reader.Value?.ToString() ?? string.Empty;
-            Type enumType = Nullable.GetUnderlyingType(objectType) ?? objectType;
             if (Enum.TryParse(enumType, rawValue, ignoreCase: true, out object parsed))
             {
                 return parsed;

--- a/Packages/src/Editor/ToolContracts/CaseInsensitiveStringEnumConverter.cs.meta
+++ b/Packages/src/Editor/ToolContracts/CaseInsensitiveStringEnumConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa84b16583af749adb82d8a60f3c4f58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopTool.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopTool.cs
@@ -15,7 +15,8 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         // Both JsonSerializer and the resolver are thread-safe once configured.
         internal static readonly JsonSerializer CamelCaseSerializer = JsonSerializer.Create(new JsonSerializerSettings
         {
-            ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver()
+            ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver(),
+            Converters = { new CaseInsensitiveStringEnumConverter() }
         });
     }
 


### PR DESCRIPTION
Refs: 2026-07-12_uloop検証フィードバック改善 実装計画.md#PR 3-1 (B-5 + B-6)

## Summary
- Invalid tool enum strings now return a `Valid values:` list during Unity-side schema deserialization (B-5).
- Lowercase enum strings such as `play` already deserialized correctly with the default Newtonsoft reader; this PR locks that behavior with a regression test rather than introducing new acceptance.
- Unknown `simulate-keyboard --key` values suggest close Input System Key names, including `Digit3` / `Numpad3` for bare `3` (B-6).
- Simulate-keyboard skill documents digit key naming (`Digit0-9` / `Numpad0-9`).

## Parsing locations (recorded)
- **Go (`cli/project-runner/internal/projectrunner/tool_params.go`)**: passes string option values through unchanged; no enum validation.
- **Unity (`Packages/src/Editor/ToolContracts/UnityCliLoopTool.cs`)**: Newtonsoft deserializes schema DTOs. Measured baseline: a serializer with only `CamelCasePropertyNamesContractResolver` already accepts `{"action":"play"}` as `PlayModeAction.Play`, so B-5 field errors were not caused by enum case sensitivity.
- **Unity converter (`CaseInsensitiveStringEnumConverter`)**: adds `Valid values:` on invalid string enums; rejects integer enum tokens with an explicit string-only error (intentional narrowing — the CLI only sends strings).
- **Unity (`Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs`)**: resolves `--key` via `Enum.TryParse<Key>` and emits suggestions through `KeyboardKeyNameSuggester`.

## User Impact
- Mis-typed tool enum values get actionable `Valid values:` hints.
- Mis-typed keyboard keys get `Did you mean:` suggestions instead of a generic invalid-key message.

## Protocol
- No protocol version bump.
- Intentional narrowing: integer JSON tokens for enum parameters are no longer accepted on the Unity side. The CLI has always sent string enum values, and protocol generation matching prevents mixed-generation clients from relying on integer wire forms.

## Verification
- `uloop compile` 0 errors / 0 warnings
- EditMode: `CaseInsensitiveStringEnumConverterTests` (3) + `KeyboardKeyNameSuggesterTests` (1 when Input System present) passed via regex filter
- `uloop skills install --claude --agents` regenerated simulate-keyboard skill copies