### PR TITLE
feat: Add busy-stall focus rescue and richer server_busy / compile guidance

### DIFF
--- a/Assets/Tests/Editor/CompileResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/CompileResponseFactoryTests.cs
@@ -215,6 +215,65 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void CreateResponse_WhenExternalSceneCannotBeReloaded_AddsNextActions()
+        {
+            // Verifies reload-failure messages from ExternalSceneChangeResolver also surface reload guidance.
+            CompilerMessage error = new CompilerMessage
+            {
+                type = CompilerMessageType.Error,
+                message =
+                    "Compilation cannot reload externally changed Scene files before compile. " +
+                    "Scenes that could not be reloaded: Assets/Scenes/SampleScene.unity.",
+                file = "Assets/Scenes/SampleScene.unity",
+                line = 0
+            };
+            CompileResult result = new CompileResult(
+                success: false,
+                errorCount: 1,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: new[] { error },
+                errors: new[] { error },
+                warnings: Array.Empty<CompilerMessage>(),
+                message: error.message);
+
+            CompileResponse response =
+                CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+
+            Assert.That(response.NextActions, Is.Not.Null);
+            Assert.That(response.NextActions, Has.Length.EqualTo(2));
+        }
+
+        [Test]
+        public void CreateResponse_WhenExternalSceneStopMessageUsesDifferentWording_DoesNotAddNextActions()
+        {
+            // Verifies the stopped variant ("changed externally") does not match the NextActions substring gate.
+            CompilerMessage error = new CompilerMessage
+            {
+                type = CompilerMessageType.Error,
+                message =
+                    "Compilation stopped because open Scene files changed externally. " +
+                    "External Scene changes: Assets/Scenes/SampleScene.unity.",
+                file = "Assets/Scenes/SampleScene.unity",
+                line = 0
+            };
+            CompileResult result = new CompileResult(
+                success: false,
+                errorCount: 1,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: new[] { error },
+                errors: new[] { error },
+                warnings: Array.Empty<CompilerMessage>(),
+                message: error.message);
+
+            CompileResponse response =
+                CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+
+            Assert.That(response.NextActions, Is.Null);
+        }
+
+        [Test]
         public void CreateResponse_WhenUnityTestFrameworkSymbolIsMissing_AddsTestAsmdefHint()
         {
             // Verifies compile failures from unmarked test asmdefs include the TestAssemblies fix.

--- a/Assets/Tests/Editor/CompileResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/CompileResponseFactoryTests.cs
@@ -185,6 +185,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void CreateResponse_WhenExternalSceneCannotBeResolved_AddsNextActions()
+        {
+            // Verifies unresolved external Scene changes include execute-dynamic-code reload guidance.
+            CompilerMessage error = new CompilerMessage
+            {
+                type = CompilerMessageType.Error,
+                message = "Compilation cannot resolve externally changed Scene files before compile.",
+                file = "Assets/Scenes/SampleScene.unity",
+                line = 0
+            };
+            CompileResult result = new CompileResult(
+                success: false,
+                errorCount: 1,
+                warningCount: 0,
+                completedAt: DateTime.Now,
+                messages: new[] { error },
+                errors: new[] { error },
+                warnings: Array.Empty<CompilerMessage>(),
+                message: error.message);
+
+            CompileResponse response =
+                CompileResponseFactory.CreateResponse(result, forceRecompile: false);
+
+            Assert.That(response.NextActions, Is.Not.Null);
+            Assert.That(response.NextActions, Has.Length.EqualTo(2));
+            Assert.That(response.NextActions[0], Does.Contain("execute-dynamic-code"));
+            Assert.That(response.NextActions[0], Does.Contain("EditorSceneManager.OpenScene"));
+        }
+
+        [Test]
         public void CreateResponse_WhenUnityTestFrameworkSymbolIsMissing_AddsTestAsmdefHint()
         {
             // Verifies compile failures from unmarked test asmdefs include the TestAssemblies fix.

--- a/Assets/Tests/Editor/CompileResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/CompileResponseFactoryTests.cs
@@ -212,6 +212,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.NextActions, Has.Length.EqualTo(2));
             Assert.That(response.NextActions[0], Does.Contain("execute-dynamic-code"));
             Assert.That(response.NextActions[0], Does.Contain("EditorSceneManager.OpenScene"));
+            Assert.That(response.NextActions[0], Does.Contain("OpenSceneMode.Single discards unsaved"));
+            Assert.That(response.NextActions[1], Does.Contain("unsaved in-editor changes"));
+            Assert.That(response.NextActions[1], Does.Not.Contain("stop-on-external-scene-changes"));
         }
 
         [Test]

--- a/Assets/Tests/Editor/ToolExecutionEditorReadyPolicyTests.cs
+++ b/Assets/Tests/Editor/ToolExecutionEditorReadyPolicyTests.cs
@@ -48,6 +48,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Evaluate_WhenDynamicCodeRunsDuringCompilationAndUpdate_ShouldReportBothEditorFlags()
+        {
+            // Verifies busy decisions copy live compile and import flags instead of inferring mutual exclusion.
+            ToolExecutionEditorState editorState = new ToolExecutionEditorState(
+                isCompiling: true,
+                isUpdating: true,
+                isPlaying: false,
+                isPaused: false);
+
+            ToolExecutionEditorReadyDecision decision = ToolExecutionEditorReadyPolicy.Evaluate(
+                UnityCliLoopConstants.TOOL_NAME_EXECUTE_DYNAMIC_CODE,
+                editorState);
+
+            Assert.That(decision.IsReady, Is.False);
+            Assert.That(decision.IsCompiling, Is.True);
+            Assert.That(decision.IsUpdating, Is.True);
+        }
+
+        [Test]
         public void Evaluate_WhenReadOnlyToolRunsDuringBusyEditorState_ShouldReturnReadyDecision()
         {
             // Tests that read-only tools bypass state guards that only protect mutating commands.

--- a/Packages/src/Editor/Application/UnityCliLoopEditorStateGuard.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopEditorStateGuard.cs
@@ -29,7 +29,9 @@ namespace io.github.hatayama.UnityCliLoop.Application
                 decision.RunningOperationName,
                 decision.RequestedToolName,
                 decision.IsPlaying,
-                decision.IsPaused);
+                decision.IsPaused,
+                decision.IsCompiling,
+                decision.IsUpdating);
         }
     }
 }

--- a/Packages/src/Editor/Application/UnityCliLoopToolBusyException.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolBusyException.cs
@@ -11,13 +11,17 @@ namespace io.github.hatayama.UnityCliLoop.Application
             string runningToolName,
             string requestedToolName,
             bool? isPlaying = null,
-            bool? isPaused = null)
+            bool? isPaused = null,
+            bool? isCompiling = null,
+            bool? isUpdating = null)
             : base(CreateMessage(runningToolName, requestedToolName))
         {
             RunningToolName = runningToolName;
             RequestedToolName = requestedToolName;
             IsPlaying = isPlaying;
             IsPaused = isPaused;
+            IsCompiling = isCompiling;
+            IsUpdating = isUpdating;
         }
 
         public string RunningToolName { get; }
@@ -27,6 +31,10 @@ namespace io.github.hatayama.UnityCliLoop.Application
         public bool? IsPlaying { get; }
 
         public bool? IsPaused { get; }
+
+        public bool? IsCompiling { get; }
+
+        public bool? IsUpdating { get; }
 
         private static string CreateMessage(string runningToolName, string requestedToolName)
         {

--- a/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
+++ b/Packages/src/Editor/Application/UnityCliLoopToolExecutionService.cs
@@ -76,7 +76,9 @@ namespace io.github.hatayama.UnityCliLoop.Application
                     runningToolName,
                     requestedToolName,
                     editorRuntimeStatePort.IsPlaying,
-                    editorRuntimeStatePort.IsPaused);
+                    editorRuntimeStatePort.IsPaused,
+                    editorRuntimeStatePort.IsCompiling,
+                    editorRuntimeStatePort.IsUpdating);
             }
 
             (bool HasValue, bool IsPlaying, bool IsPaused) playState =

--- a/Packages/src/Editor/Domain/ToolExecutionEditorReadyPolicy.cs
+++ b/Packages/src/Editor/Domain/ToolExecutionEditorReadyPolicy.cs
@@ -37,7 +37,9 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                     UnityCompileOperationName,
                     toolName,
                     editorState.IsPlaying,
-                    editorState.IsPaused);
+                    editorState.IsPaused,
+                    true,
+                    false);
             }
 
             if ((condition & GuardCondition.NotUpdating) != 0 && editorState.IsUpdating)
@@ -46,7 +48,9 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                     UnityAssetDatabaseUpdateOperationName,
                     toolName,
                     editorState.IsPlaying,
-                    editorState.IsPaused);
+                    editorState.IsPaused,
+                    false,
+                    true);
             }
 
             return ToolExecutionEditorReadyDecision.Ready(toolName);
@@ -98,13 +102,17 @@ namespace io.github.hatayama.UnityCliLoop.Domain
         public readonly string RequestedToolName;
         public readonly bool IsPlaying;
         public readonly bool IsPaused;
+        public readonly bool IsCompiling;
+        public readonly bool IsUpdating;
 
         private ToolExecutionEditorReadyDecision(
             bool isReady,
             string runningOperationName,
             string requestedToolName,
             bool isPlaying,
-            bool isPaused)
+            bool isPaused,
+            bool isCompiling,
+            bool isUpdating)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(requestedToolName), "requestedToolName must not be null or whitespace");
             Debug.Assert(isReady || !string.IsNullOrWhiteSpace(runningOperationName), "runningOperationName must not be null or whitespace for busy decisions");
@@ -114,6 +122,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             RequestedToolName = requestedToolName;
             IsPlaying = isPlaying;
             IsPaused = isPaused;
+            IsCompiling = isCompiling;
+            IsUpdating = isUpdating;
         }
 
         public static ToolExecutionEditorReadyDecision Ready(string requestedToolName)
@@ -123,6 +133,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                 string.Empty,
                 requestedToolName,
                 false,
+                false,
+                false,
                 false);
         }
 
@@ -130,14 +142,18 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             string runningOperationName,
             string requestedToolName,
             bool isPlaying,
-            bool isPaused)
+            bool isPaused,
+            bool isCompiling,
+            bool isUpdating)
         {
             return new ToolExecutionEditorReadyDecision(
                 false,
                 runningOperationName,
                 requestedToolName,
                 isPlaying,
-                isPaused);
+                isPaused,
+                isCompiling,
+                isUpdating);
         }
     }
 }

--- a/Packages/src/Editor/Domain/ToolExecutionEditorReadyPolicy.cs
+++ b/Packages/src/Editor/Domain/ToolExecutionEditorReadyPolicy.cs
@@ -38,8 +38,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                     toolName,
                     editorState.IsPlaying,
                     editorState.IsPaused,
-                    true,
-                    false);
+                    editorState.IsCompiling,
+                    editorState.IsUpdating);
             }
 
             if ((condition & GuardCondition.NotUpdating) != 0 && editorState.IsUpdating)
@@ -49,8 +49,8 @@ namespace io.github.hatayama.UnityCliLoop.Domain
                     toolName,
                     editorState.IsPlaying,
                     editorState.IsPaused,
-                    false,
-                    true);
+                    editorState.IsCompiling,
+                    editorState.IsUpdating);
             }
 
             return ToolExecutionEditorReadyDecision.Ready(toolName);

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResponse.cs
@@ -68,6 +68,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string Message { get; set; }
 
         /// <summary>
+        /// Optional recovery steps when compile cannot proceed automatically.
+        /// </summary>
+        public string[] NextActions { get; set; }
+
+        /// <summary>
         /// Unity project root path (from UnityEngine.Application.dataPath).
         /// Set only when WaitForDomainReload=true so the CLI can report which project produced the result.
         /// </summary>

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
@@ -20,8 +20,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             "Reload each changed Scene with execute-dynamic-code, for example: " +
             "`uloop execute-dynamic-code --code 'using UnityEditor.SceneManagement; using UnityEngine.SceneManagement; " +
             "EditorSceneManager.OpenScene(\"<SCENE_ASSET_PATH>\", OpenSceneMode.Single);'` " +
-            "using the Scene path from Errors[].File.",
-            "Alternatively rerun compile without `--stop-on-external-scene-changes` to let uloop reload externally changed Scenes automatically."
+            "using the Scene path from Errors[].File. OpenSceneMode.Single discards unsaved in-editor Scene changes.",
+            "If the Scene has unsaved in-editor changes that conflict with the external change, decide first: " +
+            "save the Scene to keep editor changes, or reload it to take the external content."
         };
 
         internal static CompileResponse CreateResponse(

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
@@ -15,6 +15,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string MissingTestFrameworkReferenceHint =
             "Possible test asmdef issue: Unity test framework symbols are missing. Make sure com.unity.test-framework is installed and add optionalUnityReferences: [\"TestAssemblies\"] or enable testAssemblies on the test asmdef.";
 
+        private static readonly string[] ExternalSceneChangeNextActions =
+        {
+            "Reload each changed Scene with execute-dynamic-code, for example: " +
+            "`uloop execute-dynamic-code --code 'using UnityEditor.SceneManagement; using UnityEngine.SceneManagement; " +
+            "EditorSceneManager.OpenScene(\"<SCENE_ASSET_PATH>\", OpenSceneMode.Single);'` " +
+            "using the Scene path from Errors[].File.",
+            "Alternatively rerun compile without `--stop-on-external-scene-changes` to let uloop reload externally changed Scenes automatically."
+        };
+
         internal static CompileResponse CreateResponse(
             CompileResult result,
             bool forceRecompile)
@@ -37,13 +46,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     message: result.Message ?? "Compilation status is unknown. Use get-logs to inspect the compiler output.");
             }
 
-            return new CompileResponse(
+            CompileResponse response = new CompileResponse(
                 success: result.Success,
                 errorCount: result.Errors?.Length ?? 0,
                 warningCount: result.Warnings?.Length ?? 0,
                 errors: ToIssues(result.Errors),
                 warnings: ToIssues(result.Warnings),
                 message: AddMissingTestFrameworkReferenceHint(result.Message, result.Errors));
+            response.NextActions = CreateExternalSceneChangeNextActions(result.Message);
+            return response;
+        }
+
+        private static string[] CreateExternalSceneChangeNextActions(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return null;
+            }
+
+            if (!message.Contains("externally changed Scene files", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            return ExternalSceneChangeNextActions;
         }
 
         private static CompileResponse CreateForceCompileResult(CompileResult result)

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseFactory.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseFactory.cs
@@ -79,7 +79,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                     busyEx.IsPlaying,
                     busyEx.IsPaused,
                     exceptionResponse.Explanation ?? ex.Message,
-                    EditorMainThreadLivenessTracker.SecondsSinceLastMainThreadTick());
+                    EditorMainThreadLivenessTracker.SecondsSinceLastMainThreadTick(),
+                    busyEx.IsCompiling,
+                    busyEx.IsUpdating);
             }
             else
             {

--- a/Packages/src/Editor/Infrastructure/Api/ServerBusyErrorData.cs
+++ b/Packages/src/Editor/Infrastructure/Api/ServerBusyErrorData.cs
@@ -19,6 +19,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool? isPaused { get; }
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public bool? isCompiling { get; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public bool? isUpdating { get; }
+
         // Lets a client distinguish "main thread still ticking, tool genuinely running long" from
         // a frozen/deadlocked Editor while BUSY, without needing native stack sampling.
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -30,13 +36,17 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             bool? isPlaying,
             bool? isPaused,
             string message,
-            double? secondsSinceLastMainThreadTick = null)
+            double? secondsSinceLastMainThreadTick = null,
+            bool? isCompiling = null,
+            bool? isUpdating = null)
             : base(message)
         {
             this.runningToolName = runningToolName;
             this.requestedToolName = requestedToolName;
             this.isPlaying = isPlaying;
             this.isPaused = isPaused;
+            this.isCompiling = isCompiling;
+            this.isUpdating = isUpdating;
             this.secondsSinceLastMainThreadTick = secondsSinceLastMainThreadTick;
         }
     }

--- a/cli/common/errors/busy_editor_state.go
+++ b/cli/common/errors/busy_editor_state.go
@@ -1,0 +1,66 @@
+package clierrors
+
+const unityServerBusyResponsivenessStallThresholdSeconds = 5.0
+
+func unityServerBusyNextActions(data map[string]any) []string {
+	actions := []string{
+		"Wait for the running Unity command to complete.",
+		"Retry the command after Unity reports it is no longer busy.",
+	}
+
+	if rpcBoolData(data, "isCompiling") {
+		actions = append(
+			[]string{"Unity is compiling scripts; wait for compilation to finish before retrying."},
+			actions...)
+	} else if rpcBoolData(data, "isUpdating") {
+		actions = append(
+			[]string{"Unity is importing assets; wait for the asset database update to finish before retrying."},
+			actions...)
+	}
+
+	if stallSeconds, ok := rpcFloatData(data, "secondsSinceLastMainThreadTick"); ok &&
+		stallSeconds >= unityServerBusyResponsivenessStallThresholdSeconds {
+		actions = append(
+			actions,
+			"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is still responsive before treating this as a freeze.")
+	}
+
+	return actions
+}
+
+func unityServerBusyEditorActivitySummary(data map[string]any) map[string]any {
+	if data == nil {
+		return nil
+	}
+
+	summary := map[string]any{}
+	copyOptionalBoolField(summary, data, "isCompiling")
+	copyOptionalBoolField(summary, data, "isUpdating")
+	copyOptionalBoolField(summary, data, "isPlaying")
+	copyOptionalBoolField(summary, data, "isPaused")
+	if stallSeconds, ok := rpcFloatData(data, "secondsSinceLastMainThreadTick"); ok {
+		summary["secondsSinceLastMainThreadTick"] = stallSeconds
+	}
+	if len(summary) == 0 {
+		return nil
+	}
+	return summary
+}
+
+func rpcBoolData(data map[string]any, key string) bool {
+	value, ok := data[key].(bool)
+	return ok && value
+}
+
+func rpcFloatData(data map[string]any, key string) (float64, bool) {
+	value, ok := data[key].(float64)
+	return value, ok
+}
+
+func copyOptionalBoolField(destination map[string]any, source map[string]any, key string) {
+	value, ok := source[key].(bool)
+	if !ok || !value {
+		return
+	}
+	destination[key] = value
+}

--- a/cli/common/errors/busy_editor_state_test.go
+++ b/cli/common/errors/busy_editor_state_test.go
@@ -1,0 +1,57 @@
+package clierrors
+
+import "testing"
+
+// Verifies compiling busy payloads surface script-compile guidance in NextActions.
+func TestUnityServerBusyNextActions_WhenCompiling_IncludesCompileGuidance(t *testing.T) {
+	data := map[string]any{
+		"isCompiling": true,
+	}
+
+	actions := unityServerBusyNextActions(data)
+	if len(actions) < 3 {
+		t.Fatalf("expected compile-specific guidance, got %#v", actions)
+	}
+	if actions[0] != "Unity is compiling scripts; wait for compilation to finish before retrying." {
+		t.Fatalf("first action mismatch: %#v", actions)
+	}
+}
+
+// Verifies stalled main-thread ticks add a lightweight responsiveness check action.
+func TestUnityServerBusyNextActions_WhenMainThreadStalled_IncludesResponsivenessCheck(t *testing.T) {
+	data := map[string]any{
+		"secondsSinceLastMainThreadTick": 12.0,
+	}
+
+	actions := unityServerBusyNextActions(data)
+	found := false
+	for _, action := range actions {
+		if action == "Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is still responsive before treating this as a freeze." {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("responsiveness action missing: %#v", actions)
+	}
+}
+
+// Verifies editor activity summaries copy only populated busy-state fields.
+func TestUnityServerBusyEditorActivitySummary_CopiesKnownFields(t *testing.T) {
+	data := map[string]any{
+		"isCompiling":                    true,
+		"isUpdating":                     false,
+		"secondsSinceLastMainThreadTick": 1.5,
+	}
+
+	summary := unityServerBusyEditorActivitySummary(data)
+	if summary["isCompiling"] != true {
+		t.Fatalf("isCompiling mismatch: %#v", summary)
+	}
+	if _, ok := summary["isUpdating"]; ok {
+		t.Fatalf("false bool fields should be omitted: %#v", summary)
+	}
+	if summary["secondsSinceLastMainThreadTick"] != 1.5 {
+		t.Fatalf("stall seconds mismatch: %#v", summary)
+	}
+}

--- a/cli/common/errors/error_envelope.go
+++ b/cli/common/errors/error_envelope.go
@@ -140,6 +140,10 @@ func unityServerBusyError(
 	data map[string]any,
 	context ErrorContext,
 ) CLIError {
+	if editorActivity := unityServerBusyEditorActivitySummary(data); editorActivity != nil {
+		details["EditorActivity"] = editorActivity
+	}
+
 	return CLIError{
 		ErrorCode:   errorCodeUnityServerBusy,
 		Phase:       ErrorPhaseDispatch,
@@ -148,11 +152,8 @@ func unityServerBusyError(
 		SafeToRetry: true,
 		ProjectRoot: context.ProjectRoot,
 		Command:     context.Command,
-		NextActions: []string{
-			"Wait for the running Unity command to complete.",
-			"Retry the command after Unity reports it is no longer busy.",
-		},
-		Details: details,
+		NextActions: unityServerBusyNextActions(data),
+		Details:     details,
 	}
 }
 

--- a/cli/common/errors/error_envelope_test.go
+++ b/cli/common/errors/error_envelope_test.go
@@ -267,6 +267,28 @@ func TestClassifyServerBusyRPCError(t *testing.T) {
 	}
 }
 
+func TestClassifyServerBusyRPCError_WhenCompiling_IncludesEditorActivityAndGuidance(t *testing.T) {
+	// Verifies compiling busy payloads add editor activity details and compile-specific guidance.
+	err := &unityipc.RPCError{
+		Code:    -32603,
+		Message: "Unity is busy running 'unity-compile'.",
+		Data: json.RawMessage(
+			`{"type":"server_busy","runningToolName":"unity-compile","requestedToolName":"get-logs","isCompiling":true}`),
+	}
+
+	cliErr := ClassifyError(err, ErrorContext{ProjectRoot: "/tmp/MyProject", Command: "get-logs"})
+	editorActivity, ok := cliErr.Details["EditorActivity"].(map[string]any)
+	if !ok {
+		t.Fatalf("editor activity missing: %#v", cliErr.Details)
+	}
+	if editorActivity["isCompiling"] != true {
+		t.Fatalf("isCompiling mismatch: %#v", editorActivity)
+	}
+	if cliErr.NextActions[0] != "Unity is compiling scripts; wait for compilation to finish before retrying." {
+		t.Fatalf("next actions mismatch: %#v", cliErr.NextActions)
+	}
+}
+
 func TestWriteClassifiedServerBusyRPCErrorWritesErrorEnvelope(t *testing.T) {
 	// Verifies server_busy output uses the same machine-readable error envelope as other failures.
 	err := &unityipc.RPCError{

--- a/cli/dispatcher/internal/dispatcher/error_envelope_test.go
+++ b/cli/dispatcher/internal/dispatcher/error_envelope_test.go
@@ -1,6 +1,7 @@
 package dispatcher
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
 
 	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
 func TestClassifyLaunchStartupTimeoutError(t *testing.T) {
@@ -76,6 +78,30 @@ func TestClassifyInstallUnsupportedOS(t *testing.T) {
 	}
 	expectedAction := "Run `uloop install` on macOS or Windows."
 	if len(cliErr.NextActions) == 0 || cliErr.NextActions[0] != expectedAction {
+		t.Fatalf("next actions mismatch: %#v", cliErr.NextActions)
+	}
+}
+
+func TestClassifyServerBusyRPCError_WhenCompiling_IncludesEditorActivity(t *testing.T) {
+	// Verifies dispatcher-side busy classification surfaces compile-specific editor activity guidance.
+	cliErr := clierrors.ClassifyError(
+		&unityipc.RPCError{
+			Code:    -32603,
+			Message: "Unity is busy running 'unity-compile'.",
+			Data: json.RawMessage(
+				`{"type":"server_busy","runningToolName":"unity-compile","requestedToolName":"get-logs","isCompiling":true}`),
+		},
+		clierrors.ErrorContext{ProjectRoot: "/tmp/MyProject", Command: "get-logs"},
+	)
+
+	editorActivity, ok := cliErr.Details["EditorActivity"].(map[string]any)
+	if !ok {
+		t.Fatalf("editor activity missing: %#v", cliErr.Details)
+	}
+	if editorActivity["isCompiling"] != true {
+		t.Fatalf("isCompiling mismatch: %#v", editorActivity)
+	}
+	if cliErr.NextActions[0] != "Unity is compiling scripts; wait for compilation to finish before retrying." {
 		t.Fatalf("next actions mismatch: %#v", cliErr.NextActions)
 	}
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "8de73a7e2135cc3af0b4bc6cc32cd884a20338ec"
+  "sharedInputsHash": "dff7284c186f1c36decc25ab36242de2860feeac"
 }

--- a/cli/project-runner/internal/projectrunner/connection_retry.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry.go
@@ -20,7 +20,7 @@ const (
 	focusRestoreTimeout                 = 2 * time.Second
 	serverConnectionRetryDefaultTimeout = 10 * time.Second
 	serverConnectionRetryDefaultPoll    = 1 * time.Second
-	defaultBusyFocusStallThreshold      = 30 * time.Second
+	defaultBusyFocusStallThreshold      = 5 * time.Second
 )
 
 type connectionRetryDeps struct {

--- a/cli/project-runner/internal/projectrunner/connection_retry.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry.go
@@ -20,6 +20,7 @@ const (
 	focusRestoreTimeout                 = 2 * time.Second
 	serverConnectionRetryDefaultTimeout = 10 * time.Second
 	serverConnectionRetryDefaultPoll    = 1 * time.Second
+	defaultBusyFocusStallThreshold      = 30 * time.Second
 )
 
 type connectionRetryDeps struct {
@@ -27,6 +28,7 @@ type connectionRetryDeps struct {
 	focusUnityProcess       func(context.Context, int) (unityprocess.RestoreFocusFunc, error)
 	retryTimeout            time.Duration
 	retryPoll               time.Duration
+	busyFocusStallThreshold time.Duration
 }
 
 func defaultConnectionRetryDeps() connectionRetryDeps {
@@ -46,6 +48,7 @@ const (
 	focusReasonMainThreadStall               connectionRetryFocusReason = "main_thread_stall"
 	focusReasonHeartbeatSilenceTimeout       connectionRetryFocusReason = "heartbeat_silence_timeout"
 	focusReasonFinalResponseTimeout          connectionRetryFocusReason = "final_response_timeout"
+	focusReasonBusyStall                     connectionRetryFocusReason = "busy_stall"
 )
 
 // Why: domain reload on large projects can keep the IPC endpoint down well past the
@@ -58,6 +61,13 @@ const serverConnectionRetryUnityAliveFactor = 6
 
 func unityAliveRetryWindow(deps connectionRetryDeps) time.Duration {
 	return deps.retryTimeout * serverConnectionRetryUnityAliveFactor
+}
+
+func busyFocusStallThresholdFor(deps connectionRetryDeps) time.Duration {
+	if deps.busyFocusStallThreshold > 0 {
+		return deps.busyFocusStallThreshold
+	}
+	return defaultBusyFocusStallThreshold
 }
 
 type connectionRetryFocusController struct {
@@ -187,6 +197,7 @@ func sendWithTransientConnectionRetryWithDeps(
 
 	var lastOutcome unityipc.UnitySendOutcome
 	var lastErr error
+	busySequenceStartedAt := time.Time{}
 	focusController := newConnectionRetryFocusController(connection, method, deps)
 	defer func() {
 		restoreContext, cancel := context.WithTimeout(context.Background(), focusRestoreTimeout)
@@ -209,6 +220,11 @@ func sendWithTransientConnectionRetryWithDeps(
 		if isUnityServerBusyRPCError(err) {
 			// Busy means the request was never executed, so a bounded retry is safe and
 			// usually absorbs back-to-back tool calls without bothering the caller.
+			if busySequenceStartedAt.IsZero() {
+				busySequenceStartedAt = time.Now()
+			} else if time.Since(busySequenceStartedAt) >= busyFocusStallThresholdFor(deps) {
+				focusController.tryFocus(ctx, focusReasonBusyStall, err)
+			}
 			lastOutcome = outcome
 			lastErr = err
 			if finished, finalOutcome, finalErr := finishBusyRetry(

--- a/cli/project-runner/internal/projectrunner/connection_retry_test.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_test.go
@@ -713,6 +713,83 @@ func TestSendWithTransientConnectionRetryReturnsBusyAfterRetryWindow(t *testing.
 	}
 }
 
+// Verifies persistent busy retries focus Unity once after the busy stall threshold and restore focus on exit.
+func TestSendWithTransientConnectionRetryFocusesOnceAfterPersistentBusy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TCP endpoint injection is only used by this non-Windows client test")
+	}
+
+	deps := defaultConnectionRetryDeps()
+	deps.retryTimeout = 500 * time.Millisecond
+	deps.retryPoll = 5 * time.Millisecond
+	deps.busyFocusStallThreshold = 30 * time.Millisecond
+	focusCallCount := 0
+	restoreCallCount := 0
+	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
+		return &clicore.UnityProcess{Pid: 123}, nil
+	}
+	deps.focusUnityProcess = func(context.Context, int) (clicore.RestoreFocusFunc, error) {
+		focusCallCount++
+		return func(context.Context) error {
+			restoreCallCount++
+			return nil
+		}, nil
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	busy := `{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Unity is busy running 'compile'.","data":{"type":"server_busy","runningToolName":"compile","requestedToolName":"get-logs","message":"busy"}}}`
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func() {
+				defer func() {
+					_ = conn.Close()
+				}()
+				if _, readErr := unityipc.Read(bufio.NewReader(conn)); readErr != nil {
+					return
+				}
+				_ = unityipc.Write(conn, []byte(busy))
+			}()
+		}
+	}()
+
+	connection := unityipc.Connection{
+		Endpoint: unityipc.Endpoint{
+			Network: "tcp",
+			Address: listener.Addr().String(),
+		},
+		ProjectRoot: t.TempDir(),
+	}
+
+	_, err = sendWithTransientConnectionRetryWithDeps(
+		context.Background(),
+		connection,
+		"get-logs",
+		map[string]any{},
+		nil,
+		0,
+		deps)
+	if err == nil {
+		t.Fatal("expected busy error after retry window")
+	}
+	if focusCallCount != 1 {
+		t.Fatalf("expected one busy-stall focus attempt, got %d", focusCallCount)
+	}
+	if restoreCallCount != 1 {
+		t.Fatalf("expected focus restore after busy retry exit, got %d", restoreCallCount)
+	}
+}
+
 // Verifies that undispatched dial failures keep retrying past the base window while a
 // running Unity process is confirmed, so a domain reload longer than the base window
 // (e.g. on large projects) does not fail the command spuriously.

--- a/cli/project-runner/internal/projectrunner/connection_retry_test.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_test.go
@@ -713,7 +713,9 @@ func TestSendWithTransientConnectionRetryReturnsBusyAfterRetryWindow(t *testing.
 	}
 }
 
-// Verifies persistent busy retries focus Unity once after the busy stall threshold and restore focus on exit.
+// TDD repro for B-7a: before busy_stall focus rescue, persistent server_busy never called
+// focusUnityProcess (focusCallCount stayed 0). This assertion was Red on pre-fix
+// connection_retry.go and turns Green after the busy stall threshold hook.
 func TestSendWithTransientConnectionRetryFocusesOnceAfterPersistentBusy(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("TCP endpoint injection is only used by this non-Windows client test")

--- a/cli/project-runner/internal/projectrunner/connection_retry_test.go
+++ b/cli/project-runner/internal/projectrunner/connection_retry_test.go
@@ -20,6 +20,19 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
+// Verifies the default busy-stall focus threshold fires before the bounded busy retry window ends.
+func TestDefaultBusyFocusStallThresholdFitsWithinBusyRetryWindow(t *testing.T) {
+	deps := defaultConnectionRetryDeps()
+	threshold := busyFocusStallThresholdFor(deps)
+	if threshold >= deps.retryTimeout {
+		t.Fatalf(
+			"busy focus stall threshold must stay below the busy retry window: threshold=%s window=%s",
+			threshold,
+			deps.retryTimeout,
+		)
+	}
+}
+
 // Verifies transient IPC connection failures focus Unity once and restore focus before reporting server-not-responding.
 func TestSendWithTransientConnectionRetryReportsUnityServerNotResponding(t *testing.T) {
 	deps := defaultConnectionRetryDeps()

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "9c44c24427c361475087a09bc9f0ed4271828ba3"
+  "sharedInputsHash": "be6d79a7389bbf54e3c5020913f91955c15ec3f4"
 }


### PR DESCRIPTION
## Summary

- **B-7a**: When `server_busy` retries persist for 5s within the 10s busy retry window, focus Unity once via `connectionRetryFocusController` (`busy_stall`) and restore focus on exit.
- **B-7b**: Enrich `UNITY_SERVER_BUSY` CLI errors with `EditorActivity` (compile/import/play state when true) and contextual `NextActions`.
- **B-8**: When compile fails on externally changed Scene files (resolve/reload/save failure messages), add `NextActions` with an `execute-dynamic-code` `EditorSceneManager.OpenScene` example and unsaved-change guidance.

## Pre-implementation verification (new protocol)

### B-7a — busy path focus rescue repro (TDD Red → Green)

- **Root cause (pre-fix)**: busy retry loop never called `focusController.tryFocus`; terminal focus path also skips `server_busy`.
- **TDD repro**: `TestSendWithTransientConnectionRetryFocusesOnceAfterPersistentBusy` was Red on pre-fix code (`focusCallCount` stayed 0).
- **Production tuning**: `finishBusyRetry` bounds busy retries to `serverConnectionRetryDefaultTimeout` (10s), so the stall threshold must stay below that window. Default is **5s** (focus at 5s, ~5s retry remaining). `TestDefaultBusyFocusStallThresholdFitsWithinBusyRetryWindow` guards this ratio.

### B-7b — discriminable Unity states on `server_busy`

| Field | Source | Included? |
|-------|--------|-----------|
| `isCompiling` | `EditorApplication.isCompiling` via `EditorRuntimeStateService` | Yes |
| `isUpdating` | `EditorApplication.isUpdating` | Yes |
| `isPlaying` / `isPaused` | existing play state | Yes |
| `secondsSinceLastMainThreadTick` | `EditorMainThreadLivenessTracker` | Yes (existing) |
| `isDomainReloadInProgress` | only on compile-status bridge, not `server_busy` path | **Not added** |

### B-8 — external Scene error wording (source-backed)

`ExternalSceneChangeResolver.cs` messages containing `"externally changed Scene files"`:
- `CreateUnresolvedMessage` (line 124)
- `CreateReloadFailureMessage` (line 132)
- `CreateDirtySaveBeforeReloadFailureMessage` (line 140)

These occur after auto save/reload attempts fail (default path without `--stop-on-external-scene-changes`). `CreateStoppedMessage` (line 116) uses different wording and does not match the NextActions gate.

NextActions[1] advises on unsaved in-editor conflicts (not a misleading `--stop-on-external-scene-changes` rerun hint).

## Fable review fixes (bc20a6d8)

1. **B-7a threshold**: `defaultBusyFocusStallThreshold` 30s → **5s**; constant regression test added.
2. **B-8 NextActions[1]**: removed incorrect auto-reload flag advice; added unsaved-change decision guidance; OpenScene example notes `Single` discards unsaved editor changes.
3. **Editor readiness policy**: pass `editorState.IsCompiling` / `IsUpdating` through without mutual-exclusion literals.

## Verification

- `scripts/check-go-cli.sh` pass (includes `TestDefaultBusyFocusStallThresholdFitsWithinBusyRetryWindow` + busy-stall focus test)
- `dist/darwin-arm64/uloop compile` — 0 errors / 0 warnings
- `CompileResponseFactoryTests` + `ToolExecutionEditorReadyPolicyTests` — 13 passed

## Release triggers

- `cli/common` touched with project-runner + dispatcher companions; `scripts/stamp-release-inputs.sh` run in prior commit.
- No IPC protocol version bump.