### PR TITLE
fix: Align execute-dynamic-code diagnostic context with user snippet lines

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticColumnMapperTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticColumnMapperTests.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    [TestFixture]
+    public sealed class DynamicCodeDiagnosticColumnMapperTests
+    {
+        [Test]
+        public void MapWrappedColumnToUserColumn_SubtractsWrapperIndentAndClampsToOne()
+        {
+            // Verifies wrapped physical columns are rebased to user-snippet columns.
+            Assert.That(DynamicCodeDiagnosticColumnMapper.MapWrappedColumnToUserColumn(20), Is.EqualTo(8));
+            Assert.That(DynamicCodeDiagnosticColumnMapper.MapWrappedColumnToUserColumn(5), Is.EqualTo(1));
+            Assert.That(DynamicCodeDiagnosticColumnMapper.MapWrappedColumnToUserColumn(0), Is.EqualTo(0));
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticColumnMapperTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticColumnMapperTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f57214938bfeb4c76acbd60106b41e7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticContextBuilderTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticContextBuilderTests.cs
@@ -1,0 +1,49 @@
+using System;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    [TestFixture]
+    public sealed class DynamicCodeDiagnosticContextBuilderTests
+    {
+        [Test]
+        public void BuildContext_WhenUserLineFiveHasSyntaxError_ShowsUserSnippetNotWrapperBoilerplate()
+        {
+            // Verifies #line-mapped user line 5 renders against the user snippet instead of wrapper usings.
+            string[] userSnippetLines =
+            {
+                "int a=1;",
+                "int b=2;",
+                "int c=3;",
+                "int d=4;",
+                "int e= ;",
+                "return a;"
+            };
+
+            string context = DynamicCodeDiagnosticContextBuilder.BuildContext(userSnippetLines, 5, 8);
+
+            Assert.That(context, Does.Contain("L5:int e= ;"));
+            Assert.That(context, Does.Not.Contain("using System.Collections.Generic"));
+        }
+
+        [Test]
+        public void TryExtract_WhenWrappedSourceContainsLineDirectives_ReturnsIndentedUserSnippet()
+        {
+            // Verifies wrapped sources expose only the user region between #line markers.
+            string wrappedSource = WrapperTemplate.Build(
+                Array.Empty<string>(),
+                Array.Empty<string>(),
+                "TestNs",
+                "TestClass",
+                "int a=1;\nint e= ;\nreturn a;");
+
+            bool extracted = WrappedDynamicCodeUserSnippetExtractor.TryExtract(wrappedSource, out string userSnippet);
+
+            Assert.That(extracted, Is.True);
+            Assert.That(userSnippet, Does.Contain("int e= ;"));
+            Assert.That(userSnippet, Does.Not.Contain("using UnityEditor;"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticContextBuilderTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticContextBuilderTests.cs
@@ -1,4 +1,3 @@
-using System;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -26,6 +25,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
 
             Assert.That(context, Does.Contain("L5:int e= ;"));
             Assert.That(context, Does.Not.Contain("using System.Collections.Generic"));
+            Assert.That(context, Does.Not.Contain("L7:"));
+        }
+
+        [Test]
+        public void BuildContext_WhenUserColumnProvided_PlacesCaretUnderErrorCharacter()
+        {
+            // Verifies the caret line uses the same 1-based column basis as the rendered user line.
+            string[] userSnippetLines = { "int e= ;" };
+            string context = DynamicCodeDiagnosticContextBuilder.BuildContext(userSnippetLines, 1, 8);
+            string[] contextLines = context.Split('\n');
+
+            Assert.That(contextLines[1].IndexOf('^'), Is.EqualTo("L1:".Length + 7));
         }
 
         [Test]
@@ -33,8 +44,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         {
             // Verifies wrapped sources expose only the user region between #line markers.
             string wrappedSource = WrapperTemplate.Build(
-                Array.Empty<string>(),
-                Array.Empty<string>(),
+                System.Array.Empty<string>(),
+                System.Array.Empty<string>(),
                 "TestNs",
                 "TestClass",
                 "int a=1;\nint e= ;\nreturn a;");
@@ -44,6 +55,16 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(extracted, Is.True);
             Assert.That(userSnippet, Does.Contain("int e= ;"));
             Assert.That(userSnippet, Does.Not.Contain("using UnityEditor;"));
+        }
+
+        [Test]
+        public void Split_WhenOriginalSnippetHasTrailingNewline_DropsTrailingEmptyLine()
+        {
+            // Verifies trailing newline does not create an extra empty context line.
+            string[] lines = DynamicCodeUserSnippetLines.Split("int a=1;\nreturn a;\n");
+
+            Assert.That(lines, Has.Length.EqualTo(2));
+            Assert.That(lines[0], Is.EqualTo("int a=1;"));
         }
     }
 }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticContextBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeDiagnosticContextBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f66a60822655c4ae9945c33d36779c15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
@@ -88,6 +88,42 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Verifies wrapped UpdatedCode diagnostics render context from the user snippet region.
+        /// </summary>
+        [Test]
+        public void ConvertExecutionResultToResponse_WhenWrappedSourceFails_UsesUserSnippetContext()
+        {
+            DynamicCodeExecutionResponseFactory factory = new();
+            string wrappedSource = WrapperTemplate.Build(
+                Array.Empty<string>(),
+                Array.Empty<string>(),
+                "TestNs",
+                "TestClass",
+                "int a=1;\nint b=2;\nint c=3;\nint d=4;\nint e= ;\nreturn a;");
+            ExecutionResult result = new()
+            {
+                Success = false,
+                ErrorMessage = "Compilation error occurred",
+                UpdatedCode = wrappedSource,
+                CompilationErrors = new List<CompilationError>
+                {
+                    new CompilationError
+                    {
+                        ErrorCode = "CS1525",
+                        Message = "Invalid expression term ';'",
+                        Line = 5,
+                        Column = 8
+                    }
+                }
+            };
+
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+
+            Assert.That(response.Diagnostics[0].Context, Does.Contain("L5:int e= ;"));
+            Assert.That(response.Diagnostics[0].Context, Does.Not.Contain("using System.Collections.Generic"));
+        }
+
+        /// <summary>
         /// Verifies known compilation failures preserve friendly explanations, examples, and solutions.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/DynamicCodeExecutionResponseFactoryTests.cs
@@ -94,12 +94,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         public void ConvertExecutionResultToResponse_WhenWrappedSourceFails_UsesUserSnippetContext()
         {
             DynamicCodeExecutionResponseFactory factory = new();
+            string userCode = "int a=1;\nint b=2;\nint c=3;\nint d=4;\nint e= ;\nreturn a;";
             string wrappedSource = WrapperTemplate.Build(
                 Array.Empty<string>(),
                 Array.Empty<string>(),
                 "TestNs",
                 "TestClass",
-                "int a=1;\nint b=2;\nint c=3;\nint d=4;\nint e= ;\nreturn a;");
+                userCode);
             ExecutionResult result = new()
             {
                 Success = false,
@@ -112,15 +113,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                         ErrorCode = "CS1525",
                         Message = "Invalid expression term ';'",
                         Line = 5,
-                        Column = 8
+                        Column = 20
                     }
                 }
             };
 
-            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result);
+            ExecuteDynamicCodeResponse response = factory.ConvertExecutionResultToResponse(result, userCode);
 
+            Assert.That(response.Diagnostics[0].Column, Is.EqualTo(8));
+            Assert.That(response.Diagnostics[0].PointerColumn, Is.EqualTo(8));
             Assert.That(response.Diagnostics[0].Context, Does.Contain("L5:int e= ;"));
+            Assert.That(response.Diagnostics[0].Context, Does.Contain("int b=2;"));
+            Assert.That(response.Diagnostics[0].Context, Does.Not.Contain("__uloop_literal"));
             Assert.That(response.Diagnostics[0].Context, Does.Not.Contain("using System.Collections.Generic"));
+            Assert.That(response.Diagnostics[0].Context, Does.Not.Contain("L7:"));
+            string[] contextLines = response.Diagnostics[0].Context
+                .Split(new[] { '\n' }, System.StringSplitOptions.RemoveEmptyEntries);
+            int caretLineIndex = System.Array.FindIndex(contextLines, line => line.Contains('^'));
+            Assert.That(caretLineIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(contextLines[caretLineIndex].IndexOf('^'), Is.EqualTo("L5:".Length + 7));
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -188,6 +188,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 bool useOriginalUserContext = hasUserSnippetRegion
                     && DynamicCodeDiagnosticContextBuilder.IsUserSnippetLineInRange(originalUserLines, error.Line);
                 string[] contextLines = useOriginalUserContext ? originalUserLines : fallbackLines;
+                // why: compiler column is measured on hoisted wrapped source while Context shows original
+                // user text; literals hoisted on the same line before the error site can shift column a few
+                // positions even after indent subtraction.
                 int contextColumn = useOriginalUserContext
                     ? DynamicCodeDiagnosticColumnMapper.MapWrappedColumnToUserColumn(error.Column)
                     : error.Column;

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -171,14 +170,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Dictionary<string, List<string>> ambiguousCandidates = null)
         {
             List<CompilationErrorDto> list = new();
-            string[] lines = string.IsNullOrEmpty(updatedCode)
+            string[] userSnippetLines = ResolveUserSnippetLines(updatedCode);
+            string[] fallbackLines = string.IsNullOrEmpty(updatedCode)
                 ? Array.Empty<string>()
                 : updatedCode.Split(new[] { '\n' }, StringSplitOptions.None);
 
             foreach (CompilationError error in errors)
             {
                 (string hint, List<string> suggestions) = GetHintAndSuggestions(error, ambiguousCandidates);
-                string context = ExtractContext(lines, error.Line, error.Column);
+                bool hasUserSnippetRegion = WrappedDynamicCodeUserSnippetExtractor.TryExtract(updatedCode, out _);
+                bool useUserSnippetContext = DynamicCodeDiagnosticContextBuilder.IsUserSnippetLineInRange(
+                    userSnippetLines,
+                    error.Line);
+                string[] contextLines = useUserSnippetContext ? userSnippetLines : fallbackLines;
+                string context = ExtractContext(contextLines, error.Line, error.Column);
+                if (hasUserSnippetRegion && !useUserSnippetContext && error.Line > 0)
+                {
+                    hint = AppendWrapperOriginHint(hint);
+                }
+
                 list.Add(new CompilationErrorDto
                 {
                     Line = error.Line,
@@ -202,6 +212,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 })
                 .Select(group => group.First())
                 .ToList();
+        }
+
+        private static string[] ResolveUserSnippetLines(string updatedCode)
+        {
+            if (!WrappedDynamicCodeUserSnippetExtractor.TryExtract(updatedCode, out string userSnippet))
+            {
+                return Array.Empty<string>();
+            }
+
+            return WrappedDynamicCodeUserSnippetExtractor.SplitNormalizedLines(userSnippet);
+        }
+
+        private static string AppendWrapperOriginHint(string hint)
+        {
+            const string wrapperOriginHint =
+                "This diagnostic line does not map to the user snippet; it likely refers to generated wrapper code.";
+            if (string.IsNullOrEmpty(hint))
+            {
+                return wrapperOriginHint;
+            }
+
+            if (hint.Contains(wrapperOriginHint, StringComparison.Ordinal))
+            {
+                return hint;
+            }
+
+            return hint + " " + wrapperOriginHint;
         }
 
         private static (string hint, List<string> suggestions) GetHintAndSuggestions(
@@ -270,30 +307,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int lineNumber1Based,
             int column1Based)
         {
-            if (lines == null || lines.Length == 0 || lineNumber1Based <= 0 || lineNumber1Based > lines.Length)
-            {
-                return string.Empty;
-            }
-
-            int start = Math.Max(1, lineNumber1Based - 3);
-            int end = Math.Min(lines.Length, lineNumber1Based + 3);
-            StringBuilder sb = new();
-            for (int i = start; i <= end; i++)
-            {
-                string line = lines[i - 1].TrimEnd('\r');
-                string linePrefix = $"L{i}:";
-                sb.AppendLine(linePrefix + line);
-                if (i == lineNumber1Based)
-                {
-                    int caretPos = Math.Max(1, column1Based);
-                    sb.AppendLine(
-                        new string(' ', linePrefix.Length)
-                        + new string(' ', Math.Max(0, caretPos - 1))
-                        + "^");
-                }
-            }
-
-            return sb.ToString();
+            return DynamicCodeDiagnosticContextBuilder.BuildContext(lines, lineNumber1Based, column1Based);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -40,7 +40,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
         }
 
-        internal ExecuteDynamicCodeResponse ConvertExecutionResultToResponse(ExecutionResult result)
+        internal ExecuteDynamicCodeResponse ConvertExecutionResultToResponse(
+            ExecutionResult result,
+            string originalUserSnippet = null)
         {
             ExecuteDynamicCodeResponse response = new()            {
                 Success = result.Success,
@@ -53,7 +55,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (!result.Success)
             {
-                ApplyFailureResponseDetails(response, result);
+                ApplyFailureResponseDetails(response, result, originalUserSnippet);
             }
 
             if (result.Exception != null)
@@ -71,19 +73,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private void ApplyFailureResponseDetails(
             ExecuteDynamicCodeResponse response,
-            ExecutionResult result)
+            ExecutionResult result,
+            string originalUserSnippet)
         {
             DynamicCodeFriendlyError friendlyError = _friendlyErrorConverter.Convert(result);
             response.ErrorMessage = friendlyError.FriendlyMessage;
             response.Logs = result.Logs != null ? new List<string>(result.Logs) : new List<string>();
             AddFriendlyFailureDetails(response.Logs, friendlyError);
-            ApplyCompilationDiagnostics(response, result);
+            ApplyCompilationDiagnostics(response, result, originalUserSnippet);
             response.UpdatedCode = result.UpdatedCode ?? response.UpdatedCode;
         }
 
         private static void ApplyCompilationDiagnostics(
             ExecuteDynamicCodeResponse response,
-            ExecutionResult result)
+            ExecutionResult result,
+            string originalUserSnippet)
         {
             if (result.CompilationErrors?.Any() != true)
             {
@@ -93,6 +97,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             response.Diagnostics = BuildDiagnostics(
                 result.CompilationErrors,
                 result.UpdatedCode,
+                originalUserSnippet,
                 result.AmbiguousTypeCandidates);
             response.CompilationErrors = response.Diagnostics;
             response.DiagnosticsSummary = CreateDiagnosticsSummary(response.Diagnostics);
@@ -167,24 +172,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static List<CompilationErrorDto> BuildDiagnostics(
             List<CompilationError> errors,
             string updatedCode,
+            string originalUserSnippet,
             Dictionary<string, List<string>> ambiguousCandidates = null)
         {
             List<CompilationErrorDto> list = new();
-            string[] userSnippetLines = ResolveUserSnippetLines(updatedCode);
+            bool hasUserSnippetRegion = WrappedDynamicCodeUserSnippetExtractor.TryExtract(updatedCode, out _);
+            string[] originalUserLines = DynamicCodeUserSnippetLines.Split(originalUserSnippet);
             string[] fallbackLines = string.IsNullOrEmpty(updatedCode)
-                ? Array.Empty<string>()
+                ? System.Array.Empty<string>()
                 : updatedCode.Split(new[] { '\n' }, StringSplitOptions.None);
 
             foreach (CompilationError error in errors)
             {
                 (string hint, List<string> suggestions) = GetHintAndSuggestions(error, ambiguousCandidates);
-                bool hasUserSnippetRegion = WrappedDynamicCodeUserSnippetExtractor.TryExtract(updatedCode, out _);
-                bool useUserSnippetContext = DynamicCodeDiagnosticContextBuilder.IsUserSnippetLineInRange(
-                    userSnippetLines,
-                    error.Line);
-                string[] contextLines = useUserSnippetContext ? userSnippetLines : fallbackLines;
-                string context = ExtractContext(contextLines, error.Line, error.Column);
-                if (hasUserSnippetRegion && !useUserSnippetContext && error.Line > 0)
+                bool useOriginalUserContext = hasUserSnippetRegion
+                    && DynamicCodeDiagnosticContextBuilder.IsUserSnippetLineInRange(originalUserLines, error.Line);
+                string[] contextLines = useOriginalUserContext ? originalUserLines : fallbackLines;
+                int contextColumn = useOriginalUserContext
+                    ? DynamicCodeDiagnosticColumnMapper.MapWrappedColumnToUserColumn(error.Column)
+                    : error.Column;
+                int reportedColumn = useOriginalUserContext ? contextColumn : error.Column;
+                string context = ExtractContext(contextLines, error.Line, contextColumn);
+                if (hasUserSnippetRegion && !useOriginalUserContext && error.Line > 0)
                 {
                     hint = AppendWrapperOriginHint(hint);
                 }
@@ -192,13 +201,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 list.Add(new CompilationErrorDto
                 {
                     Line = error.Line,
-                    Column = error.Column,
+                    Column = reportedColumn,
                     Message = error.Message,
                     ErrorCode = error.ErrorCode,
                     Hint = hint,
                     Suggestions = suggestions,
                     Context = context,
-                    PointerColumn = error.Column
+                    PointerColumn = reportedColumn
                 });
             }
 
@@ -212,16 +221,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 })
                 .Select(group => group.First())
                 .ToList();
-        }
-
-        private static string[] ResolveUserSnippetLines(string updatedCode)
-        {
-            if (!WrappedDynamicCodeUserSnippetExtractor.TryExtract(updatedCode, out string userSnippet))
-            {
-                return Array.Empty<string>();
-            }
-
-            return WrappedDynamicCodeUserSnippetExtractor.SplitNormalizedLines(userSnippet);
         }
 
         private static string AppendWrapperOriginHint(string hint)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeDiagnosticColumnMapper.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeDiagnosticColumnMapper.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Maps wrapped-source compiler columns to user-snippet columns.
+    /// </summary>
+    internal static class DynamicCodeDiagnosticColumnMapper
+    {
+        internal static int MapWrappedColumnToUserColumn(int wrappedColumn1Based)
+        {
+            Debug.Assert(wrappedColumn1Based >= 0, "wrappedColumn1Based must not be negative");
+
+            if (wrappedColumn1Based <= 0)
+            {
+                return wrappedColumn1Based;
+            }
+
+            int userColumn = wrappedColumn1Based - WrapperTemplate.UserBodyIndentSpaces;
+            if (userColumn < 1)
+            {
+                return 1;
+            }
+
+            return userColumn;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeDiagnosticColumnMapper.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeDiagnosticColumnMapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d51798d2dce7a4e1da2f7301ee0d39ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeDiagnosticContextBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeDiagnosticContextBuilder.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Builds user-snippet diagnostic context from #line-mapped compiler locations.
+    /// </summary>
+    internal static class DynamicCodeDiagnosticContextBuilder
+    {
+        internal static string BuildContext(
+            string[] userSnippetLines,
+            int userLineNumber1Based,
+            int column1Based)
+        {
+            if (userSnippetLines == null
+                || userSnippetLines.Length == 0
+                || userLineNumber1Based <= 0
+                || userLineNumber1Based > userSnippetLines.Length)
+            {
+                return string.Empty;
+            }
+
+            int start = Math.Max(1, userLineNumber1Based - 3);
+            int end = Math.Min(userSnippetLines.Length, userLineNumber1Based + 3);
+            StringBuilder builder = new();
+            for (int lineIndex = start; lineIndex <= end; lineIndex++)
+            {
+                string line = userSnippetLines[lineIndex - 1];
+                string linePrefix = $"L{lineIndex}:";
+                builder.AppendLine(linePrefix + line);
+                if (lineIndex == userLineNumber1Based)
+                {
+                    int caretPos = Math.Max(1, column1Based);
+                    builder.AppendLine(
+                        new string(' ', linePrefix.Length)
+                        + new string(' ', Math.Max(0, caretPos - 1))
+                        + "^");
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        internal static bool IsUserSnippetLineInRange(string[] userSnippetLines, int userLineNumber1Based)
+        {
+            Debug.Assert(userSnippetLines != null, "userSnippetLines must not be null");
+            return userLineNumber1Based > 0 && userLineNumber1Based <= userSnippetLines.Length;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeDiagnosticContextBuilder.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeDiagnosticContextBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cd1229b5caab4c1985b0b720a2f01ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeUserSnippetLines.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeUserSnippetLines.cs
@@ -1,0 +1,57 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Splits user-authored execute-dynamic-code snippets into diagnostic context lines.
+    /// </summary>
+    internal static class DynamicCodeUserSnippetLines
+    {
+        internal static string[] Split(string userSnippet)
+        {
+            if (string.IsNullOrEmpty(userSnippet))
+            {
+                return System.Array.Empty<string>();
+            }
+
+            string[] rawLines = userSnippet.Split('\n');
+            string[] lines = new string[rawLines.Length];
+            for (int index = 0; index < rawLines.Length; index++)
+            {
+                lines[index] = rawLines[index].TrimEnd('\r');
+            }
+
+            return TrimTrailingEmptyLines(lines);
+        }
+
+        internal static string[] TrimTrailingEmptyLines(string[] lines)
+        {
+            if (lines == null || lines.Length == 0)
+            {
+                return System.Array.Empty<string>();
+            }
+
+            int lastNonEmptyIndex = lines.Length - 1;
+            while (lastNonEmptyIndex >= 0 && lines[lastNonEmptyIndex].Length == 0)
+            {
+                lastNonEmptyIndex--;
+            }
+
+            if (lastNonEmptyIndex < 0)
+            {
+                return System.Array.Empty<string>();
+            }
+
+            if (lastNonEmptyIndex == lines.Length - 1)
+            {
+                return lines;
+            }
+
+            string[] trimmedLines = new string[lastNonEmptyIndex + 1];
+            for (int index = 0; index <= lastNonEmptyIndex; index++)
+            {
+                trimmedLines[index] = lines[index];
+            }
+
+            return trimmedLines;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeUserSnippetLines.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeUserSnippetLines.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae576e690b9ea4dac93dda5012854038
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/PreUsingResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/PreUsingResolver.cs
@@ -339,37 +339,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return qualifiedChainParts != null && qualifiedChainParts.Count >= 2;
         }
 
-        // WrapperTemplate marks user code with #line directives;
-        // scanning only this region avoids false positives from boilerplate identifiers
         private static string ExtractUserCodeSection(string wrappedSource)
         {
-            string startMarker = WrapperTemplate.UserCodeStartMarker;
-            string endMarker = WrapperTemplate.UserCodeEndMarker;
-
-            int startIdx = wrappedSource.IndexOf(startMarker, System.StringComparison.Ordinal);
-            // Wrapped source from WrapperTemplate should always contain the marker
-            Debug.Assert(startIdx >= 0, "UserCodeStartMarker not found in wrappedSource");
-            if (startIdx < 0)
+            if (WrappedDynamicCodeUserSnippetExtractor.TryExtract(wrappedSource, out string userSnippet))
             {
-                return wrappedSource;
+                return userSnippet;
             }
 
-            int codeStart = wrappedSource.IndexOf('\n', startIdx);
-            Debug.Assert(codeStart >= 0, "newline after UserCodeStartMarker not found");
-            if (codeStart < 0)
-            {
-                return wrappedSource;
-            }
-            codeStart++;
-
-            int endIdx = wrappedSource.IndexOf(endMarker, codeStart, System.StringComparison.Ordinal);
-            Debug.Assert(endIdx >= 0, "UserCodeEndMarker not found in wrappedSource");
-            if (endIdx < 0)
-            {
-                return wrappedSource.Substring(codeStart);
-            }
-
-            return wrappedSource.Substring(codeStart, endIdx - codeStart);
+            return wrappedSource;
         }
 
         private static int SkipToEndOfLine(string s, int pos)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrappedDynamicCodeUserSnippetExtractor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrappedDynamicCodeUserSnippetExtractor.cs
@@ -55,7 +55,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 normalizedLines[index] = rawLines[index].TrimStart().TrimEnd('\r');
             }
 
-            return normalizedLines;
+            return DynamicCodeUserSnippetLines.TrimTrailingEmptyLines(normalizedLines);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrappedDynamicCodeUserSnippetExtractor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrappedDynamicCodeUserSnippetExtractor.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Extracts the user-authored snippet region from wrapped execute-dynamic-code sources.
+    /// </summary>
+    internal static class WrappedDynamicCodeUserSnippetExtractor
+    {
+        internal static bool TryExtract(string wrappedSource, out string userSnippet)
+        {
+            userSnippet = string.Empty;
+            if (string.IsNullOrEmpty(wrappedSource))
+            {
+                return false;
+            }
+
+            int startIndex = wrappedSource.IndexOf(WrapperTemplate.UserCodeStartMarker, System.StringComparison.Ordinal);
+            if (startIndex < 0)
+            {
+                return false;
+            }
+
+            int codeStart = wrappedSource.IndexOf('\n', startIndex);
+            if (codeStart < 0)
+            {
+                return false;
+            }
+            codeStart++;
+
+            int endIndex = wrappedSource.IndexOf(WrapperTemplate.UserCodeEndMarker, codeStart, System.StringComparison.Ordinal);
+            if (endIndex < 0)
+            {
+                userSnippet = wrappedSource.Substring(codeStart);
+                return true;
+            }
+
+            userSnippet = wrappedSource.Substring(codeStart, endIndex - codeStart);
+            return true;
+        }
+
+        internal static string[] SplitNormalizedLines(string userSnippet)
+        {
+            Debug.Assert(userSnippet != null, "userSnippet must not be null");
+
+            if (userSnippet.Length == 0)
+            {
+                return System.Array.Empty<string>();
+            }
+
+            string[] rawLines = userSnippet.Split('\n');
+            string[] normalizedLines = new string[rawLines.Length];
+            for (int index = 0; index < rawLines.Length; index++)
+            {
+                normalizedLines[index] = rawLines[index].TrimStart().TrimEnd('\r');
+            }
+
+            return normalizedLines;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrappedDynamicCodeUserSnippetExtractor.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrappedDynamicCodeUserSnippetExtractor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 017d4bb6a591a42e581747c5cb34488d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrapperTemplate.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrapperTemplate.cs
@@ -13,6 +13,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         internal const string UserCodeStartMarker = "#line 1 \"user-snippet.cs\"";
         internal const string UserCodeEndMarker = "#line default";
+        internal const int UserBodyIndentSpaces = 12;
 
         private static readonly DefaultUsingAlias[] DefaultUsingAliases =
         {
@@ -71,7 +72,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             foreach (string line in body.Split('\n'))
             {
-                sb.AppendLine($"            {line.TrimEnd('\r')}");
+                sb.AppendLine($"{new string(' ', UserBodyIndentSpaces)}{line.TrimEnd('\r')}");
             }
 
             sb.AppendLine(UserCodeEndMarker);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -75,7 +75,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return cancelledResponse;
                 }
 
-                ExecuteDynamicCodeResponse response = _responseFactory.ConvertExecutionResultToResponse(finalResult);
+                ExecuteDynamicCodeResponse response =
+                    _responseFactory.ConvertExecutionResultToResponse(finalResult, originalCode);
                 response.EmitTimingsInJsonResponse = parameters.IncludeTimings;
                 // Why: domain-reload timeouts can complete while Unity's synchronization context is stalled.
                 bool domainReloadWaitRequired =


### PR DESCRIPTION
## Summary

Fix execute-dynamic-code compilation diagnostics so `Line`, `Column`, `PointerColumn`, and `Context` all use the same user-snippet basis (A-2).

**Semantic change**: `Column` and `PointerColumn` are now user-snippet-relative when the wrapped source contains `#line` markers (previously only `Line` was remapped; columns stayed wrapper-physical).

## Pre-implementation verification

### Repro (real machine, before fix)

Command:
```bash
uloop execute-dynamic-code --code $'int a=1;\nint b=2;\nint c=3;\nint d=4;\nint e= ;\nreturn a;'
```

| Field | Before fix | Expected |
|-------|------------|----------|
| `Line` | 5 | User line 5 (`int e= ;`) |
| `Context` L5 | `using System.Collections.Generic` | User line 5 |

Additional case (`UndefinedSymbolOnLine3` on user line 3): `Line=3` was correct, but `Context` L3 showed `using System;`.

**Conclusion**: `#line` already maps `Line` to user snippet lines; `Context` incorrectly indexed into full wrapped `UpdatedCode`.

Auto-injected `using` count does not change `Line` (still user-relative). Literal hoisting rewrites user lines in wrapped output but `#line` mapping keeps `Line` on user ordinal.

### Convention checklist

- No overloads added
- No new try-catch
- Additive behavior only (diagnostic `Context`/`Hint` accuracy); no protocol bump
- Pure C# mapper + extractor with TDD tests; test what-comments; English commits/PR

## Implementation

- `WrapperTemplate.UserBodyIndentSpaces` (12): public constant for wrapper user-line indent
- `DynamicCodeDiagnosticColumnMapper`: subtract indent from wrapped column, clamp ≥1
- `DynamicCodeUserSnippetLines`: split original `parameters.Code`, trim trailing empty lines
- `DynamicCodeExecutionResponseFactory`: pass original user snippet for Context; map columns to user basis; `TryExtract` once outside diagnostic loop
- `ExecuteDynamicCodeUseCase`: pass `parameters.Code` to response factory

**Known limitation**: when literals are hoisted on the same line before the error column, caret may drift a few columns because compiler column is measured on hoisted wrapped source while Context shows original text. Documented in code comment.

## Verification

- `dist/darwin-arm64/uloop compile` — 0 errors / 0 warnings
- `DynamicCodeDiagnosticContextBuilderTests` + `DynamicCodeDiagnosticColumnMapperTests` + `DynamicCodeExecutionResponseFactoryTests` — 11 passed
- Post-fix real repro (raw JSON, `Diagnostics[0]`):

```json
{
  "Message": "CS1525: Invalid expression term ';'",
  "Line": 5,
  "Column": 8,
  "ErrorCode": "CS1525",
  "Hint": "",
  "Suggestions": [],
  "Context": "L2:int b=2;\nL3:int c=3;\nL4:int d=4;\nL5:int e= ;\n          ^\nL6:return a;\n",
  "PointerColumn": 8
}
```

Caret `^` is at column 8 (under `;` in `int e= ;`). Context shows original user lines (no `__uloop_literal_N`). No trailing `L7:` empty line.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

