### PR TITLE
feat: expose pause point modes and capture history in tools

### DIFF
--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
@@ -31,6 +31,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 IsHit = true,
                 HitCount = 1,
                 TimeoutSeconds = 30,
+                Mode = "continuous",
+                MaxHistory = 20,
+                CapturedVariableHistory = new List<PausePointStatusCapturedHistoryFrame>
+                {
+                    new()
+                    {
+                        HitSequence = 1,
+                        FrameCount = 42,
+                        HitAtUtc = "2026-06-03T00:00:01.0000000Z",
+                        CapturedVariables = new List<PausePointStatusCapturedVariable>(),
+                        Truncated = false
+                    }
+                },
+                HistoryDroppedCount = 0,
                 Expired = false,
                 EnabledAtUtc = "2026-06-03T00:00:00.0000000Z",
                 ElapsedSinceEnabledMilliseconds = 1200,

--- a/Assets/Tests/Editor/PausePointToolModeTests.cs
+++ b/Assets/Tests/Editor/PausePointToolModeTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies pause point tool mode parameters and response history mapping.
+    /// </summary>
+    [TestFixture]
+    public sealed class PausePointToolModeTests
+    {
+        private FakePausePointPauseController _pauseController;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _pauseController = new FakePausePointPauseController();
+            UloopPausePointRegistry.ConfigureForTests(_pauseController, () => DateTime.UtcNow);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UloopPausePointRegistry.ResetForTests();
+        }
+
+        /// <summary>
+        /// Verifies mode and max-history JSON parameters reach the enable response.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenModeAndMaxHistoryAreProvided_MapsParameters()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["timeoutSeconds"] = 30,
+                ["mode"] = UloopPausePointCaptureMode.Continuous,
+                ["maxHistory"] = 2
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Mode, Is.EqualTo(UloopPausePointCaptureMode.Continuous));
+            Assert.That(response.MaxHistory, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// Verifies an unknown mode returns a user-facing validation failure with supported values.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenModeIsUnknown_ReturnsSupportedModeValidationFailure()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["mode"] = "unknown",
+                ["maxHistory"] = 20
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("Mode must be one of: single-shot, continuous, trace."));
+        }
+
+        /// <summary>
+        /// Verifies an out-of-range max-history value returns a user-facing validation failure.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenMaxHistoryIsOutOfRange_ReturnsValidationFailure()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["mode"] = UloopPausePointCaptureMode.SingleShot,
+                ["maxHistory"] = UloopPausePointRegistry.MaxHistoryLimit + 1
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("MaxHistory must be between 1 and 100."));
+        }
+
+        /// <summary>
+        /// Verifies the CLI-only status bridge exposes mode and captured history fields.
+        /// </summary>
+        [Test]
+        public void StatusBridge_WhenContinuousMarkerHasHit_ReturnsHistoryFields()
+        {
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Continuous, 20);
+            UloopPausePointRegistry.Hit("jump");
+
+            PausePointStatusResponse response = PausePointStatusBridgeCommand.Execute(
+                new JObject { ["id"] = "jump" });
+
+            Assert.That(response.Mode, Is.EqualTo(UloopPausePointCaptureMode.Continuous));
+            Assert.That(response.MaxHistory, Is.EqualTo(20));
+            Assert.That(response.CapturedVariableHistory, Has.Count.EqualTo(1));
+            Assert.That(response.HistoryDroppedCount, Is.EqualTo(0));
+        }
+
+        private sealed class FakePausePointPauseController : IUloopPausePointPauseController
+        {
+            public int PauseCount { get; private set; }
+            public bool IsPlaying => true;
+            public bool IsPaused => PauseCount > 0;
+
+            public void Pause()
+            {
+                PauseCount++;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointToolModeTests.cs
+++ b/Assets/Tests/Editor/PausePointToolModeTests.cs
@@ -95,6 +95,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
+        /// Verifies a non-positive max-history value returns a validation failure.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenMaxHistoryIsZero_ReturnsValidationFailure()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["mode"] = UloopPausePointCaptureMode.SingleShot,
+                ["maxHistory"] = 0
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("MaxHistory must be between 1 and 100."));
+        }
+
+        /// <summary>
         /// Verifies the CLI-only status bridge exposes mode and captured history fields.
         /// </summary>
         [Test]

--- a/Assets/Tests/Editor/PausePointToolModeTests.cs.meta
+++ b/Assets/Tests/Editor/PausePointToolModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e934cb81e3d6542e788dd37faaa6026b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
@@ -75,6 +75,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(_pauseController.PauseCount, Is.EqualTo(1));
         }
 
+        /// <summary>
+        /// Verifies the source capture path records every hit for an armed continuous marker.
+        /// </summary>
+        [Test]
+        public void Capture_WhenContinuousPausePointIsEnabled_RecordsEveryFormattedHit()
+        {
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Continuous, 20);
+
+            SourcePausePointCapture.Capture("jump", null, Array.Empty<object>(), new object[] { "speed", 1 });
+            SourcePausePointCapture.Capture("jump", null, Array.Empty<object>(), new object[] { "speed", 2 });
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+
+            Assert.That(snapshot.IsEnabled, Is.True);
+            Assert.That(snapshot.HitCount, Is.EqualTo(2));
+            Assert.That(snapshot.CapturedVariableHistory, Has.Count.EqualTo(2));
+            Assert.That(snapshot.CapturedVariables.Single(variable => variable.Name == "speed").Value, Is.EqualTo("2"));
+            Assert.That(_pauseController.PauseCount, Is.EqualTo(2));
+        }
+
         [UnityTest]
         public IEnumerator Capture_WhenCalledOffMainThread_RecordsHitOnNextMainThreadTick()
         {

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -23,6 +25,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public int Line { get; set; }
 
         public int TimeoutSeconds { get; set; } = UloopPausePointRegistry.DefaultTimeoutSeconds;
+
+        public string Mode { get; set; } = UloopPausePointCaptureMode.SingleShot;
+
+        public int MaxHistory { get; set; } = UloopPausePointRegistry.DefaultMaxHistory;
     }
 
     /// <summary>
@@ -51,6 +57,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool IsHit { get; set; }
         public int HitCount { get; set; }
         public int TimeoutSeconds { get; set; }
+        public string Mode { get; set; } = string.Empty;
+        public int MaxHistory { get; set; }
+        public IReadOnlyList<PausePointCapturedHistoryFrame> CapturedVariableHistory { get; set; } =
+            Array.Empty<PausePointCapturedHistoryFrame>();
+        public int HistoryDroppedCount { get; set; }
         public bool Expired { get; set; }
         public string EnabledAtUtc { get; set; } = string.Empty;
         public long ElapsedSinceEnabledMilliseconds { get; set; }
@@ -84,6 +95,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 IsHit = snapshot.IsHit,
                 HitCount = snapshot.HitCount,
                 TimeoutSeconds = snapshot.TimeoutSeconds,
+                Mode = snapshot.Mode,
+                MaxHistory = snapshot.MaxHistory,
+                CapturedVariableHistory = snapshot.CapturedVariableHistory
+                    .Select(PausePointCapturedHistoryFrame.FromSnapshot)
+                    .ToList(),
+                HistoryDroppedCount = snapshot.HistoryDroppedCount,
                 Expired = snapshot.Expired,
                 EnabledAtUtc = snapshot.EnabledAtUtc,
                 ElapsedSinceEnabledMilliseconds = snapshot.ElapsedSinceEnabledMilliseconds,
@@ -117,6 +134,72 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Message = result.ClearedCount == 0
                     ? "No active pause points to clear."
                     : "Pause points cleared."
+            };
+        }
+    }
+
+    /// <summary>
+    /// One formatted capture frame included in the enable-pause-point response history.
+    /// </summary>
+    public class PausePointCapturedHistoryFrame
+    {
+        public int HitSequence { get; set; }
+        public int FrameCount { get; set; }
+        public string HitAtUtc { get; set; } = string.Empty;
+        public IReadOnlyList<PausePointCapturedVariable> CapturedVariables { get; set; } =
+            Array.Empty<PausePointCapturedVariable>();
+        public bool Truncated { get; set; }
+
+        internal static PausePointCapturedHistoryFrame FromSnapshot(
+            UloopPausePointCapturedHistoryFrame snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            return new PausePointCapturedHistoryFrame
+            {
+                HitSequence = snapshot.HitSequence,
+                FrameCount = snapshot.FrameCount,
+                HitAtUtc = snapshot.HitAtUtc,
+                CapturedVariables = snapshot.CapturedVariables
+                    .Select(PausePointCapturedVariable.FromSnapshot)
+                    .ToList(),
+                Truncated = snapshot.Truncated
+            };
+        }
+    }
+
+    /// <summary>
+    /// One formatted variable included in a pause point capture history frame.
+    /// </summary>
+    public class PausePointCapturedVariable
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Scope { get; set; } = string.Empty;
+        public string TypeName { get; set; } = string.Empty;
+        public string Value { get; set; } = string.Empty;
+        public string UnityObjectKind { get; set; } = string.Empty;
+        public string UnityObjectPath { get; set; } = string.Empty;
+        public int UnityObjectInstanceId { get; set; }
+
+        internal static PausePointCapturedVariable FromSnapshot(UloopCapturedVariable snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            return new PausePointCapturedVariable
+            {
+                Name = snapshot.Name,
+                Scope = snapshot.Scope,
+                TypeName = snapshot.TypeName,
+                Value = snapshot.Value,
+                UnityObjectKind = snapshot.UnityObjectKind,
+                UnityObjectPath = snapshot.UnityObjectPath,
+                UnityObjectInstanceId = snapshot.UnityObjectInstanceId
             };
         }
     }
@@ -187,6 +270,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public PausePointResponse Enable(EnablePausePointSchema parameters)
         {
+            string captureSettingsError = ValidateCaptureSettings(parameters);
+            if (captureSettingsError != null)
+            {
+                return CreateValidationFailure(captureSettingsError);
+            }
+
             string modeError = ValidateEnableMode(parameters);
             if (modeError != null)
             {
@@ -203,7 +292,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return EnableBySourceLocation(parameters);
             }
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(parameters.Id, parameters.TimeoutSeconds);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
+                parameters.Id,
+                parameters.TimeoutSeconds,
+                parameters.Mode,
+                parameters.MaxHistory);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.Warning = CreateEnableWarning();
             return response;
@@ -257,7 +350,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 };
             }
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(id, parameters.TimeoutSeconds);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
+                id,
+                parameters.TimeoutSeconds,
+                parameters.Mode,
+                parameters.MaxHistory);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.ResolvedLine = resolveResult.Resolution.ResolvedLine;
             response.ResolvedMethod = resolveResult.Resolution.MethodDisplayName;
@@ -308,6 +405,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!hasId && hasFile != hasLine)
             {
                 return "File and Line must both be provided together.";
+            }
+
+            return null;
+        }
+
+        private static string ValidateCaptureSettings(EnablePausePointSchema parameters)
+        {
+            string[] supportedModes =
+            {
+                UloopPausePointCaptureMode.SingleShot,
+                UloopPausePointCaptureMode.Continuous,
+                UloopPausePointCaptureMode.Trace
+            };
+            if (!supportedModes.Contains(parameters.Mode))
+            {
+                return $"Mode must be one of: {string.Join(", ", supportedModes)}.";
+            }
+
+            if (parameters.MaxHistory <= 0 || parameters.MaxHistory > UloopPausePointRegistry.MaxHistoryLimit)
+            {
+                return $"MaxHistory must be between 1 and {UloopPausePointRegistry.MaxHistoryLimit}.";
             }
 
             return null;

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -56,6 +56,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public bool IsHit { get; set; }
         public int HitCount { get; set; }
         public int TimeoutSeconds { get; set; }
+        public string Mode { get; set; } = string.Empty;
+        public int MaxHistory { get; set; }
+        public IReadOnlyList<PausePointStatusCapturedHistoryFrame> CapturedVariableHistory { get; set; } =
+            Array.Empty<PausePointStatusCapturedHistoryFrame>();
+        public int HistoryDroppedCount { get; set; }
         public bool Expired { get; set; }
         public string EnabledAtUtc { get; set; } = string.Empty;
         public long ElapsedSinceEnabledMilliseconds { get; set; }
@@ -90,6 +95,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 IsHit = snapshot.IsHit,
                 HitCount = snapshot.HitCount,
                 TimeoutSeconds = snapshot.TimeoutSeconds,
+                Mode = snapshot.Mode,
+                MaxHistory = snapshot.MaxHistory,
+                CapturedVariableHistory = snapshot.CapturedVariableHistory
+                    .Select(PausePointStatusCapturedHistoryFrame.FromSnapshot)
+                    .ToList(),
+                HistoryDroppedCount = snapshot.HistoryDroppedCount,
                 Expired = snapshot.Expired,
                 EnabledAtUtc = snapshot.EnabledAtUtc,
                 ElapsedSinceEnabledMilliseconds = snapshot.ElapsedSinceEnabledMilliseconds,
@@ -109,6 +120,39 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 ClearedReason = snapshot.ClearedReason,
                 StatusBeforeClear = snapshot.StatusBeforeClear,
                 LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear
+            };
+        }
+    }
+
+    /// <summary>
+    /// One formatted capture frame included in the CLI-only pause point status response history.
+    /// </summary>
+    public class PausePointStatusCapturedHistoryFrame
+    {
+        public int HitSequence { get; set; }
+        public int FrameCount { get; set; }
+        public string HitAtUtc { get; set; } = string.Empty;
+        public IReadOnlyList<PausePointStatusCapturedVariable> CapturedVariables { get; set; } =
+            Array.Empty<PausePointStatusCapturedVariable>();
+        public bool Truncated { get; set; }
+
+        internal static PausePointStatusCapturedHistoryFrame FromSnapshot(
+            UloopPausePointCapturedHistoryFrame snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            return new PausePointStatusCapturedHistoryFrame
+            {
+                HitSequence = snapshot.HitSequence,
+                FrameCount = snapshot.FrameCount,
+                HitAtUtc = snapshot.HitAtUtc,
+                CapturedVariables = snapshot.CapturedVariables
+                    .Select(PausePointStatusCapturedVariable.FromCapturedVariable)
+                    .ToList(),
+                Truncated = snapshot.Truncated
             };
         }
     }

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -1,0 +1,59 @@
+package projectrunner
+
+type pausePointStatusResponse struct {
+	Id                              string                           `json:"Id"`
+	Status                          string                           `json:"Status"`
+	IsEnabled                       bool                             `json:"IsEnabled"`
+	IsHit                           bool                             `json:"IsHit"`
+	HitCount                        int                              `json:"HitCount"`
+	TimeoutSeconds                  int                              `json:"TimeoutSeconds"`
+	Mode                            string                           `json:"Mode"`
+	MaxHistory                      int                              `json:"MaxHistory"`
+	CapturedVariableHistory         []pausePointCapturedHistoryFrame `json:"CapturedVariableHistory"`
+	HistoryDroppedCount             int                              `json:"HistoryDroppedCount"`
+	Expired                         bool                             `json:"Expired"`
+	EnabledAtUtc                    string                           `json:"EnabledAtUtc"`
+	ElapsedSinceEnabledMilliseconds int64                            `json:"ElapsedSinceEnabledMilliseconds"`
+	RemainingMilliseconds           int64                            `json:"RemainingMilliseconds"`
+	Generation                      int                              `json:"Generation"`
+	EditorState                     pausePointEditorState            `json:"EditorState"`
+	FirstHitAtUtc                   string                           `json:"FirstHitAtUtc"`
+	LastHitAtUtc                    string                           `json:"LastHitAtUtc"`
+	FirstHitSequence                int                              `json:"FirstHitSequence"`
+	LastHitSequence                 int                              `json:"LastHitSequence"`
+	Message                         string                           `json:"Message"`
+	RecommendedNextAction           string                           `json:"RecommendedNextAction"`
+	CapturedVariables               []pausePointCapturedVariable     `json:"CapturedVariables"`
+	CapturedVariablesTruncated      bool                             `json:"CapturedVariablesTruncated"`
+	ClearedReason                   string                           `json:"ClearedReason"`
+	StatusBeforeClear               string                           `json:"StatusBeforeClear"`
+	LateHitDiscardedAfterClear      bool                             `json:"LateHitDiscardedAfterClear"`
+}
+
+type pausePointEditorState struct {
+	IsPlaying  bool   `json:"IsPlaying"`
+	IsPaused   bool   `json:"IsPaused"`
+	CapturedAt string `json:"CapturedAt"`
+}
+
+// pausePointCapturedHistoryFrame mirrors the Unity-side history DTO field-for-field.
+type pausePointCapturedHistoryFrame struct {
+	HitSequence       int                          `json:"HitSequence"`
+	FrameCount        int                          `json:"FrameCount"`
+	HitAtUtc          string                       `json:"HitAtUtc"`
+	CapturedVariables []pausePointCapturedVariable `json:"CapturedVariables"`
+	Truncated         bool                         `json:"Truncated"`
+}
+
+// pausePointCapturedVariable mirrors the flat Unity-side
+// PausePointStatusCapturedVariable/UloopCapturedVariable DTO field-for-field: one variable
+// captured at a source pause point (a local, a parameter, or a `this` instance field).
+type pausePointCapturedVariable struct {
+	Name                  string `json:"Name"`
+	Scope                 string `json:"Scope"`
+	TypeName              string `json:"TypeName"`
+	Value                 string `json:"Value"`
+	UnityObjectKind       string `json:"UnityObjectKind"`
+	UnityObjectPath       string `json:"UnityObjectPath"`
+	UnityObjectInstanceId int    `json:"UnityObjectInstanceId"`
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -45,51 +45,6 @@ type pausePointStatusOptions struct {
 	id string
 }
 
-type pausePointStatusResponse struct {
-	Id                              string                       `json:"Id"`
-	Status                          string                       `json:"Status"`
-	IsEnabled                       bool                         `json:"IsEnabled"`
-	IsHit                           bool                         `json:"IsHit"`
-	HitCount                        int                          `json:"HitCount"`
-	TimeoutSeconds                  int                          `json:"TimeoutSeconds"`
-	Expired                         bool                         `json:"Expired"`
-	EnabledAtUtc                    string                       `json:"EnabledAtUtc"`
-	ElapsedSinceEnabledMilliseconds int64                        `json:"ElapsedSinceEnabledMilliseconds"`
-	RemainingMilliseconds           int64                        `json:"RemainingMilliseconds"`
-	Generation                      int                          `json:"Generation"`
-	EditorState                     pausePointEditorState        `json:"EditorState"`
-	FirstHitAtUtc                   string                       `json:"FirstHitAtUtc"`
-	LastHitAtUtc                    string                       `json:"LastHitAtUtc"`
-	FirstHitSequence                int                          `json:"FirstHitSequence"`
-	LastHitSequence                 int                          `json:"LastHitSequence"`
-	Message                         string                       `json:"Message"`
-	RecommendedNextAction           string                       `json:"RecommendedNextAction"`
-	CapturedVariables               []pausePointCapturedVariable `json:"CapturedVariables"`
-	CapturedVariablesTruncated      bool                         `json:"CapturedVariablesTruncated"`
-	ClearedReason                   string                       `json:"ClearedReason"`
-	StatusBeforeClear               string                       `json:"StatusBeforeClear"`
-	LateHitDiscardedAfterClear      bool                         `json:"LateHitDiscardedAfterClear"`
-}
-
-type pausePointEditorState struct {
-	IsPlaying  bool   `json:"IsPlaying"`
-	IsPaused   bool   `json:"IsPaused"`
-	CapturedAt string `json:"CapturedAt"`
-}
-
-// pausePointCapturedVariable mirrors the flat Unity-side
-// PausePointStatusCapturedVariable/UloopCapturedVariable DTO field-for-field: one variable
-// captured at a source pause point (a local, a parameter, or a `this` instance field).
-type pausePointCapturedVariable struct {
-	Name                  string `json:"Name"`
-	Scope                 string `json:"Scope"`
-	TypeName              string `json:"TypeName"`
-	Value                 string `json:"Value"`
-	UnityObjectKind       string `json:"UnityObjectKind"`
-	UnityObjectPath       string `json:"UnityObjectPath"`
-	UnityObjectInstanceId int    `json:"UnityObjectInstanceId"`
-}
-
 type pausePointWaitState string
 
 const (

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -5,6 +5,18 @@
   "IsHit": true,
   "HitCount": 1,
   "TimeoutSeconds": 30,
+  "Mode": "continuous",
+  "MaxHistory": 20,
+  "CapturedVariableHistory": [
+    {
+      "HitSequence": 1,
+      "FrameCount": 42,
+      "HitAtUtc": "2026-06-03T00:00:01.0000000Z",
+      "CapturedVariables": [],
+      "Truncated": false
+    }
+  ],
+  "HistoryDroppedCount": 0,
   "Expired": false,
   "EnabledAtUtc": "2026-06-03T00:00:00.0000000Z",
   "ElapsedSinceEnabledMilliseconds": 1200,


### PR DESCRIPTION
## Summary
- Enable-pause-point accepts capture mode and bounded history options.
- Pause point responses expose mode, history frames, and dropped-history counts.

## User Impact
- CLI users can select `single-shot`, `continuous`, or `trace` when enabling a pause point.
- Invalid modes and history limits return clear validation responses instead of assertion failures.
- Both normal tool responses and pause-point-status include the same captured history data.

## Changes
- Added `Mode` and `MaxHistory` schema fields with defaults and explicit external-input validation.
- Mapped runtime history into enable and CLI-only status response DTOs.
- Added status contract coverage, tool parameter mapping tests, and continuous source-capture coverage.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` (0 errors, 0 warnings)
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "(PausePointToolModeTests|PausePointStatusResponseContractTests|PausePointTests|SourcePausePointCaptureTests)"` (57 passed)
- `uloop sync` followed by `uloop enable-pause-point --mode continuous --max-history 2` showed the new flags and response fields; the marker was cleared afterward.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

