### PR TITLE
feat: document pause point capture workflows

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -30,6 +30,25 @@ uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 5. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
 6. Clear the marker with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` or stop PlayMode before moving on. Use `uloop clear-pause-point --all` to clear every active marker at once, for example when resetting between E2E scenarios. Clearing also removes the underlying code patch, so the method runs untouched afterwards.
 
+## Capture Modes and History
+
+Choose the capture mode when enabling a pause point:
+
+- `single-shot` is the default. The first hit pauses Unity and disarms the marker.
+- `continuous` pauses Unity on every hit and remains armed. Each hit adds a frame to `CapturedVariableHistory`, while `CapturedVariables` remains the latest-hit compatibility view.
+- `trace` remains armed and records each hit without pausing Unity.
+
+`--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
+
+To inspect value changes one Editor Step at a time, enable a `continuous` pause point on a line inside `Update` or `FixedUpdate`, trigger the first hit, then run:
+
+```bash
+uloop control-play-mode --action Step
+uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"
+```
+
+Repeat the Step/status pair to inspect the history tail. A new frame is captured only when the patched line executes during that frame; event handlers such as `OnCollisionEnter` update only when the event occurs again. Use a longer `--timeout-seconds` for a Step session because the enable-time timeout does not extend after hits.
+
 ## Reading CapturedVariables
 
 Every hit response embeds `CapturedVariables`: the method's in-scope locals, its parameters, and the `this` instance fields, captured at the exact moment execution reached the patched line. Values are point-in-time strings, not live references, so they stay valid as evidence even after Unity resumes.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -30,6 +30,25 @@ uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 5. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
 6. Clear the marker with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` or stop PlayMode before moving on. Use `uloop clear-pause-point --all` to clear every active marker at once, for example when resetting between E2E scenarios. Clearing also removes the underlying code patch, so the method runs untouched afterwards.
 
+## Capture Modes and History
+
+Choose the capture mode when enabling a pause point:
+
+- `single-shot` is the default. The first hit pauses Unity and disarms the marker.
+- `continuous` pauses Unity on every hit and remains armed. Each hit adds a frame to `CapturedVariableHistory`, while `CapturedVariables` remains the latest-hit compatibility view.
+- `trace` remains armed and records each hit without pausing Unity.
+
+`--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
+
+To inspect value changes one Editor Step at a time, enable a `continuous` pause point on a line inside `Update` or `FixedUpdate`, trigger the first hit, then run:
+
+```bash
+uloop control-play-mode --action Step
+uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"
+```
+
+Repeat the Step/status pair to inspect the history tail. A new frame is captured only when the patched line executes during that frame; event handlers such as `OnCollisionEnter` update only when the event occurs again. Use a longer `--timeout-seconds` for a Step session because the enable-time timeout does not extend after hits.
+
 ## Reading CapturedVariables
 
 Every hit response embeds `CapturedVariables`: the method's in-scope locals, its parameters, and the `this` instance fields, captured at the exact moment execution reached the patched line. Values are point-in-time strings, not live references, so they stay valid as evidence even after Unity resumes.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -30,6 +30,25 @@ uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 5. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
 6. Clear the marker with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` or stop PlayMode before moving on. Use `uloop clear-pause-point --all` to clear every active marker at once, for example when resetting between E2E scenarios. Clearing also removes the underlying code patch, so the method runs untouched afterwards.
 
+## Capture Modes and History
+
+Choose the capture mode when enabling a pause point:
+
+- `single-shot` is the default. The first hit pauses Unity and disarms the marker.
+- `continuous` pauses Unity on every hit and remains armed. Each hit adds a frame to `CapturedVariableHistory`, while `CapturedVariables` remains the latest-hit compatibility view.
+- `trace` remains armed and records each hit without pausing Unity.
+
+`--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
+
+To inspect value changes one Editor Step at a time, enable a `continuous` pause point on a line inside `Update` or `FixedUpdate`, trigger the first hit, then run:
+
+```bash
+uloop control-play-mode --action Step
+uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"
+```
+
+Repeat the Step/status pair to inspect the history tail. A new frame is captured only when the patched line executes during that frame; event handlers such as `OnCollisionEnter` update only when the event occurs again. Use a longer `--timeout-seconds` for a Step session because the enable-time timeout does not extend after hits.
+
 ## Reading CapturedVariables
 
 Every hit response embeds `CapturedVariables`: the method's in-scope locals, its parameters, and the `this` instance fields, captured at the exact moment execution reached the patched line. Values are point-in-time strings, not live references, so they stay valid as evidence even after Unity resumes.

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -373,7 +373,7 @@
           },
           "MaxHistory": {
             "type": "integer",
-            "description": "Maximum number of captured hit frames to retain",
+            "description": "Maximum number of captured hit frames to retain (1-100)",
             "default": 20
           }
         }

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -364,6 +364,11 @@
           "Mode": {
             "type": "string",
             "description": "Capture mode: single-shot pauses once, continuous pauses on every hit, trace records hits without pausing",
+            "enum": [
+              "single-shot",
+              "continuous",
+              "trace"
+            ],
             "default": "single-shot"
           },
           "MaxHistory": {

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -360,6 +360,16 @@
             "type": "integer",
             "description": "Seconds before the enable request expires and stops pausing late hits",
             "default": 30
+          },
+          "Mode": {
+            "type": "string",
+            "description": "Capture mode: single-shot pauses once, continuous pauses on every hit, trace records hits without pausing",
+            "default": "single-shot"
+          },
+          "MaxHistory": {
+            "type": "integer",
+            "description": "Maximum number of captured hit frames to retain",
+            "default": 20
           }
         }
       }

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -30,11 +30,15 @@ func TestWaitForPausePointReturnsHitAfterEnabledStatus(t *testing.T) {
 	responses := []pausePointStatusResponse{
 		{Id: "jump", Status: pausePointStatusEnabled, IsEnabled: true},
 		{
-			Id:          "jump",
-			Status:      pausePointStatusHit,
-			IsHit:       true,
-			HitCount:    1,
-			EditorState: pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "PausePointHit"},
+			Id:                      "jump",
+			Status:                  pausePointStatusHit,
+			IsHit:                   true,
+			HitCount:                1,
+			Mode:                    "continuous",
+			MaxHistory:              20,
+			CapturedVariableHistory: []pausePointCapturedHistoryFrame{{HitSequence: 1, FrameCount: 42, HitAtUtc: "2026-06-03T00:00:01.0000000Z"}},
+			HistoryDroppedCount:     0,
+			EditorState:             pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "PausePointHit"},
 		},
 	}
 	requestCount := 0
@@ -64,6 +68,9 @@ func TestWaitForPausePointReturnsHitAfterEnabledStatus(t *testing.T) {
 	}
 	if response.Status != pausePointStatusHit || response.HitCount != 1 {
 		t.Fatalf("response mismatch: %#v", response)
+	}
+	if response.Mode != "continuous" || response.MaxHistory != 20 || len(response.CapturedVariableHistory) != 1 {
+		t.Fatalf("capture history mismatch: %#v", response)
 	}
 	if requestCount != 2 {
 		t.Fatalf("request count mismatch: %d", requestCount)


### PR DESCRIPTION
## Summary\n- add the await-pause-point continuous-hit contract test and expose capture mode/history options in the embedded tool schema\n- document capture modes, bounded history, stepping, timeout behavior, and generated skill copies from the source skill\n- verify continuous, trace, and single-shot workflows with the repository development CLI\n\n## Validation\n- scripts/check-go-cli.sh\n- git diff --check\n- Unity compile and targeted tests were green on the base implementation\n- E2E used the Update path in SimulateMouseDemoScene because this checkout has no dedicated jumping-ball scene: continuous Step preserved four hits, trace recorded 372 hits without pausing and dropped 367 old frames, and single-shot auto-disarmed after one hit

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

