### PR TITLE
feat: add pause point capture modes and history

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -30,6 +30,25 @@ uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 5. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
 6. Clear the marker with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` or stop PlayMode before moving on. Use `uloop clear-pause-point --all` to clear every active marker at once, for example when resetting between E2E scenarios. Clearing also removes the underlying code patch, so the method runs untouched afterwards.
 
+## Capture Modes and History
+
+Choose the capture mode when enabling a pause point:
+
+- `single-shot` is the default. The first hit pauses Unity and disarms the marker.
+- `continuous` pauses Unity on every hit and remains armed. Each hit adds a frame to `CapturedVariableHistory`, while `CapturedVariables` remains the latest-hit compatibility view.
+- `trace` remains armed and records each hit without pausing Unity.
+
+`--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
+
+To inspect value changes one Editor Step at a time, enable a `continuous` pause point on a line inside `Update` or `FixedUpdate`, trigger the first hit, then run:
+
+```bash
+uloop control-play-mode --action Step
+uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"
+```
+
+Repeat the Step/status pair to inspect the history tail. A new frame is captured only when the patched line executes during that frame; event handlers such as `OnCollisionEnter` update only when the event occurs again. Use a longer `--timeout-seconds` for a Step session because the enable-time timeout does not extend after hits.
+
 ## Reading CapturedVariables
 
 Every hit response embeds `CapturedVariables`: the method's in-scope locals, its parameters, and the `this` instance fields, captured at the exact moment execution reached the patched line. Values are point-in-time strings, not live references, so they stay valid as evidence even after Unity resumes.

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -30,6 +30,25 @@ uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 5. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
 6. Clear the marker with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` or stop PlayMode before moving on. Use `uloop clear-pause-point --all` to clear every active marker at once, for example when resetting between E2E scenarios. Clearing also removes the underlying code patch, so the method runs untouched afterwards.
 
+## Capture Modes and History
+
+Choose the capture mode when enabling a pause point:
+
+- `single-shot` is the default. The first hit pauses Unity and disarms the marker.
+- `continuous` pauses Unity on every hit and remains armed. Each hit adds a frame to `CapturedVariableHistory`, while `CapturedVariables` remains the latest-hit compatibility view.
+- `trace` remains armed and records each hit without pausing Unity.
+
+`--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
+
+To inspect value changes one Editor Step at a time, enable a `continuous` pause point on a line inside `Update` or `FixedUpdate`, trigger the first hit, then run:
+
+```bash
+uloop control-play-mode --action Step
+uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"
+```
+
+Repeat the Step/status pair to inspect the history tail. A new frame is captured only when the patched line executes during that frame; event handlers such as `OnCollisionEnter` update only when the event occurs again. Use a longer `--timeout-seconds` for a Step session because the enable-time timeout does not extend after hits.
+
 ## Reading CapturedVariables
 
 Every hit response embeds `CapturedVariables`: the method's in-scope locals, its parameters, and the `this` instance fields, captured at the exact moment execution reached the patched line. Values are point-in-time strings, not live references, so they stay valid as evidence even after Unity resumes.

--- a/Assets/Tests/Editor/PausePointCaptureModeTests.cs
+++ b/Assets/Tests/Editor/PausePointCaptureModeTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Linq;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies pause point capture modes and bounded hit history behavior.
+    /// </summary>
+    [TestFixture]
+    public sealed class PausePointCaptureModeTests
+    {
+        private DateTime _nowUtc;
+        private FakePausePointPauseController _pauseController;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _nowUtc = new DateTime(2026, 6, 3, 0, 0, 0, DateTimeKind.Utc);
+            _pauseController = new FakePausePointPauseController();
+            UloopPausePointRegistry.ConfigureForTests(_pauseController, () => _nowUtc);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UloopPausePointRegistry.ResetForTests();
+        }
+
+        /// <summary>
+        /// Verifies continuous capture keeps the marker armed while exposing ordered history and the latest variables.
+        /// </summary>
+        [Test]
+        public void Continuous_WhenHitMultipleTimes_PreservesHistoryAndLatestVariables()
+        {
+            UloopCapturedVariable[] firstVariables = { CreateVariable("speed", "1") };
+            UloopCapturedVariable[] secondVariables = { CreateVariable("speed", "2") };
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Continuous, 20);
+
+            UloopPausePointRegistry.HitWithCapturedVariables("jump", firstVariables, false);
+            UloopPausePointRegistry.HitWithCapturedVariables("jump", secondVariables, false);
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+
+            Assert.That(snapshot.IsEnabled, Is.True);
+            Assert.That(snapshot.HitCount, Is.EqualTo(2));
+            Assert.That(snapshot.CapturedVariables.Single().Value, Is.EqualTo("2"));
+            Assert.That(snapshot.CapturedVariableHistory.Select(frame => frame.HitSequence), Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(snapshot.CapturedVariableHistory.Last().CapturedVariables.Single().Value, Is.EqualTo("2"));
+            Assert.That(_pauseController.PauseCount, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// Verifies trace capture records a hit without requesting an Editor pause.
+        /// </summary>
+        [Test]
+        public void Trace_WhenHit_DoesNotPauseAndKeepsMarkerArmed()
+        {
+            UloopPausePointRegistry.Enable("trace", 30, UloopPausePointCaptureMode.Trace, 20);
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Hit("trace");
+
+            Assert.That(snapshot.IsEnabled, Is.True);
+            Assert.That(snapshot.HitCount, Is.EqualTo(1));
+            Assert.That(snapshot.Mode, Is.EqualTo(UloopPausePointCaptureMode.Trace));
+            Assert.That(snapshot.CapturedVariableHistory, Has.Count.EqualTo(1));
+            Assert.That(_pauseController.PauseCount, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Verifies the bounded history drops the oldest frame and reports the dropped count.
+        /// </summary>
+        [Test]
+        public void History_WhenMaxHistoryIsExceeded_DropsOldestFrames()
+        {
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Trace, 2);
+
+            UloopPausePointRegistry.Hit("jump");
+            UloopPausePointRegistry.Hit("jump");
+            UloopPausePointRegistry.Hit("jump");
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+
+            Assert.That(snapshot.CapturedVariableHistory.Select(frame => frame.HitSequence), Is.EqualTo(new[] { 2, 3 }));
+            Assert.That(snapshot.HistoryDroppedCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Verifies the default single-shot mode retains current disarm behavior and records its hit.
+        /// </summary>
+        [Test]
+        public void SingleShot_WhenHit_DisarmsAndKeepsOneHistoryFrame()
+        {
+            UloopPausePointRegistry.Enable("jump", 30);
+
+            UloopPausePointRegistry.Hit("jump");
+            UloopPausePointRegistry.Hit("jump");
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+
+            Assert.That(snapshot.IsEnabled, Is.False);
+            Assert.That(snapshot.HitCount, Is.EqualTo(1));
+            Assert.That(snapshot.CapturedVariableHistory, Has.Count.EqualTo(1));
+            Assert.That(_pauseController.PauseCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Verifies clearing an armed continuous marker disarms it without erasing captured history.
+        /// </summary>
+        [Test]
+        public void Clear_WhenContinuousMarkerHasHits_DisarmsAndPreservesHistory()
+        {
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Continuous, 20);
+            UloopPausePointRegistry.Hit("jump");
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(snapshot.IsEnabled, Is.False);
+            Assert.That(snapshot.CapturedVariableHistory, Has.Count.EqualTo(1));
+            Assert.That(snapshot.ClearedReason, Is.EqualTo(UloopPausePointClearedReason.ExplicitClear));
+            Assert.That(snapshot.Message, Is.EqualTo("Pause point cleared after 1 hit(s); capture history is preserved."));
+        }
+
+        /// <summary>
+        /// Verifies expiry after a continuous hit reports a capture-window message and retains history.
+        /// </summary>
+        [Test]
+        public void Expire_WhenContinuousMarkerHasHits_DisarmsAndPreservesHistory()
+        {
+            UloopPausePointRegistry.Enable("jump", 1, UloopPausePointCaptureMode.Continuous, 20);
+            UloopPausePointRegistry.Hit("jump");
+            _nowUtc = _nowUtc.AddSeconds(2);
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+
+            Assert.That(snapshot.Status, Is.EqualTo(UloopPausePointStatus.Expired));
+            Assert.That(snapshot.CapturedVariableHistory, Has.Count.EqualTo(1));
+            Assert.That(snapshot.Message, Is.EqualTo("Pause point capture window expired after 1 hit(s); capture history is preserved."));
+        }
+
+        /// <summary>
+        /// Verifies re-enabling a marker starts a fresh generation with empty history.
+        /// </summary>
+        [Test]
+        public void Enable_WhenMarkerIsReenabled_ResetsHistory()
+        {
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Trace, 2);
+            UloopPausePointRegistry.Hit("jump");
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
+                "jump", 30, UloopPausePointCaptureMode.Trace, 2);
+
+            Assert.That(snapshot.HitCount, Is.EqualTo(0));
+            Assert.That(snapshot.CapturedVariableHistory, Is.Empty);
+            Assert.That(snapshot.HistoryDroppedCount, Is.EqualTo(0));
+        }
+
+        private static UloopCapturedVariable CreateVariable(string name, string value)
+        {
+            return new UloopCapturedVariable(
+                name,
+                UloopCapturedVariableScope.Local,
+                "System.String",
+                value,
+                string.Empty,
+                string.Empty,
+                0);
+        }
+
+        private sealed class FakePausePointPauseController : IUloopPausePointPauseController
+        {
+            public int PauseCount { get; private set; }
+            public bool IsPlaying => true;
+            public bool IsPaused => PauseCount > 0;
+
+            public void Pause()
+            {
+                PauseCount++;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointCaptureModeTests.cs.meta
+++ b/Assets/Tests/Editor/PausePointCaptureModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf4f284db0df5429a8d287aa1833ae45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/PausePointStatusResponseContractTests.cs
@@ -31,6 +31,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 IsHit = true,
                 HitCount = 1,
                 TimeoutSeconds = 30,
+                Mode = "continuous",
+                MaxHistory = 20,
+                CapturedVariableHistory = new List<PausePointStatusCapturedHistoryFrame>
+                {
+                    new()
+                    {
+                        HitSequence = 1,
+                        FrameCount = 42,
+                        HitAtUtc = "2026-06-03T00:00:01.0000000Z",
+                        CapturedVariables = new List<PausePointStatusCapturedVariable>(),
+                        Truncated = false
+                    }
+                },
+                HistoryDroppedCount = 0,
                 Expired = false,
                 EnabledAtUtc = "2026-06-03T00:00:00.0000000Z",
                 ElapsedSinceEnabledMilliseconds = 1200,

--- a/Assets/Tests/Editor/PausePointToolModeTests.cs
+++ b/Assets/Tests/Editor/PausePointToolModeTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies pause point tool mode parameters and response history mapping.
+    /// </summary>
+    [TestFixture]
+    public sealed class PausePointToolModeTests
+    {
+        private FakePausePointPauseController _pauseController;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _pauseController = new FakePausePointPauseController();
+            UloopPausePointRegistry.ConfigureForTests(_pauseController, () => DateTime.UtcNow);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UloopPausePointRegistry.ResetForTests();
+        }
+
+        /// <summary>
+        /// Verifies mode and max-history JSON parameters reach the enable response.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenModeAndMaxHistoryAreProvided_MapsParameters()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["timeoutSeconds"] = 30,
+                ["mode"] = UloopPausePointCaptureMode.Continuous,
+                ["maxHistory"] = 2
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Mode, Is.EqualTo(UloopPausePointCaptureMode.Continuous));
+            Assert.That(response.MaxHistory, Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// Verifies an unknown mode returns a user-facing validation failure with supported values.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenModeIsUnknown_ReturnsSupportedModeValidationFailure()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["mode"] = "unknown",
+                ["maxHistory"] = 20
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("Mode must be one of: single-shot, continuous, trace."));
+        }
+
+        /// <summary>
+        /// Verifies an out-of-range max-history value returns a user-facing validation failure.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenMaxHistoryIsOutOfRange_ReturnsValidationFailure()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["mode"] = UloopPausePointCaptureMode.SingleShot,
+                ["maxHistory"] = UloopPausePointRegistry.MaxHistoryLimit + 1
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("MaxHistory must be between 1 and 100."));
+        }
+
+        /// <summary>
+        /// Verifies a non-positive max-history value returns a validation failure.
+        /// </summary>
+        [Test]
+        public async Task Enable_WhenMaxHistoryIsZero_ReturnsValidationFailure()
+        {
+            EnablePausePointTool tool = new();
+            JObject parameters = new()
+            {
+                ["id"] = "jump",
+                ["mode"] = UloopPausePointCaptureMode.SingleShot,
+                ["maxHistory"] = 0
+            };
+
+            PausePointResponse response = (PausePointResponse)await tool.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Message, Is.EqualTo("MaxHistory must be between 1 and 100."));
+        }
+
+        /// <summary>
+        /// Verifies the CLI-only status bridge exposes mode and captured history fields.
+        /// </summary>
+        [Test]
+        public void StatusBridge_WhenContinuousMarkerHasHit_ReturnsHistoryFields()
+        {
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Continuous, 20);
+            UloopPausePointRegistry.Hit("jump");
+
+            PausePointStatusResponse response = PausePointStatusBridgeCommand.Execute(
+                new JObject { ["id"] = "jump" });
+
+            Assert.That(response.Mode, Is.EqualTo(UloopPausePointCaptureMode.Continuous));
+            Assert.That(response.MaxHistory, Is.EqualTo(20));
+            Assert.That(response.CapturedVariableHistory, Has.Count.EqualTo(1));
+            Assert.That(response.HistoryDroppedCount, Is.EqualTo(0));
+        }
+
+        private sealed class FakePausePointPauseController : IUloopPausePointPauseController
+        {
+            public int PauseCount { get; private set; }
+            public bool IsPlaying => true;
+            public bool IsPaused => PauseCount > 0;
+
+            public void Pause()
+            {
+                PauseCount++;
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/PausePointToolModeTests.cs.meta
+++ b/Assets/Tests/Editor/PausePointToolModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e934cb81e3d6542e788dd37faaa6026b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
@@ -75,6 +75,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(_pauseController.PauseCount, Is.EqualTo(1));
         }
 
+        /// <summary>
+        /// Verifies the source capture path records every hit for an armed continuous marker.
+        /// </summary>
+        [Test]
+        public void Capture_WhenContinuousPausePointIsEnabled_RecordsEveryFormattedHit()
+        {
+            UloopPausePointRegistry.Enable("jump", 30, UloopPausePointCaptureMode.Continuous, 20);
+
+            SourcePausePointCapture.Capture("jump", null, Array.Empty<object>(), new object[] { "speed", 1 });
+            SourcePausePointCapture.Capture("jump", null, Array.Empty<object>(), new object[] { "speed", 2 });
+
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");
+
+            Assert.That(snapshot.IsEnabled, Is.True);
+            Assert.That(snapshot.HitCount, Is.EqualTo(2));
+            Assert.That(snapshot.CapturedVariableHistory, Has.Count.EqualTo(2));
+            Assert.That(snapshot.CapturedVariables.Single(variable => variable.Name == "speed").Value, Is.EqualTo("2"));
+            Assert.That(_pauseController.PauseCount, Is.EqualTo(2));
+        }
+
         [UnityTest]
         public IEnumerator Capture_WhenCalledOffMainThread_RecordsHitOnNextMainThreadTick()
         {

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -30,6 +30,25 @@ uloop await-pause-point --id "Assets/Scripts/Enemy.cs:42" --timeout-seconds 30
 5. While Unity is still paused, capture any additional evidence with `uloop execute-dynamic-code`, `uloop get-hierarchy`, `uloop find-game-objects`, and one screenshot.
 6. Clear the marker with `uloop clear-pause-point --id "Assets/Scripts/Enemy.cs:42"` or stop PlayMode before moving on. Use `uloop clear-pause-point --all` to clear every active marker at once, for example when resetting between E2E scenarios. Clearing also removes the underlying code patch, so the method runs untouched afterwards.
 
+## Capture Modes and History
+
+Choose the capture mode when enabling a pause point:
+
+- `single-shot` is the default. The first hit pauses Unity and disarms the marker.
+- `continuous` pauses Unity on every hit and remains armed. Each hit adds a frame to `CapturedVariableHistory`, while `CapturedVariables` remains the latest-hit compatibility view.
+- `trace` remains armed and records each hit without pausing Unity.
+
+`--max-history` defaults to 20 and accepts values from 1 through 100. When the limit is exceeded, the oldest frames are dropped and `HistoryDroppedCount` reports how many were removed. `pause-point-status` returns the current `Mode`, `MaxHistory`, history frames, and dropped count.
+
+To inspect value changes one Editor Step at a time, enable a `continuous` pause point on a line inside `Update` or `FixedUpdate`, trigger the first hit, then run:
+
+```bash
+uloop control-play-mode --action Step
+uloop pause-point-status --id "Assets/Scripts/Enemy.cs:42"
+```
+
+Repeat the Step/status pair to inspect the history tail. A new frame is captured only when the patched line executes during that frame; event handlers such as `OnCollisionEnter` update only when the event occurs again. Use a longer `--timeout-seconds` for a Step session because the enable-time timeout does not extend after hits.
+
 ## Reading CapturedVariables
 
 Every hit response embeds `CapturedVariables`: the method's in-scope locals, its parameters, and the `this` instance fields, captured at the exact moment execution reached the patched line. Values are point-in-time strings, not live references, so they stay valid as evidence even after Unity resumes.

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -23,6 +25,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public int Line { get; set; }
 
         public int TimeoutSeconds { get; set; } = UloopPausePointRegistry.DefaultTimeoutSeconds;
+
+        public string Mode { get; set; } = UloopPausePointCaptureMode.SingleShot;
+
+        public int MaxHistory { get; set; } = UloopPausePointRegistry.DefaultMaxHistory;
     }
 
     /// <summary>
@@ -51,6 +57,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool IsHit { get; set; }
         public int HitCount { get; set; }
         public int TimeoutSeconds { get; set; }
+        public string Mode { get; set; } = string.Empty;
+        public int MaxHistory { get; set; }
+        public IReadOnlyList<PausePointCapturedHistoryFrame> CapturedVariableHistory { get; set; } =
+            Array.Empty<PausePointCapturedHistoryFrame>();
+        public int HistoryDroppedCount { get; set; }
         public bool Expired { get; set; }
         public string EnabledAtUtc { get; set; } = string.Empty;
         public long ElapsedSinceEnabledMilliseconds { get; set; }
@@ -84,6 +95,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 IsHit = snapshot.IsHit,
                 HitCount = snapshot.HitCount,
                 TimeoutSeconds = snapshot.TimeoutSeconds,
+                Mode = snapshot.Mode,
+                MaxHistory = snapshot.MaxHistory,
+                CapturedVariableHistory = snapshot.CapturedVariableHistory
+                    .Select(PausePointCapturedHistoryFrame.FromSnapshot)
+                    .ToList(),
+                HistoryDroppedCount = snapshot.HistoryDroppedCount,
                 Expired = snapshot.Expired,
                 EnabledAtUtc = snapshot.EnabledAtUtc,
                 ElapsedSinceEnabledMilliseconds = snapshot.ElapsedSinceEnabledMilliseconds,
@@ -117,6 +134,72 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Message = result.ClearedCount == 0
                     ? "No active pause points to clear."
                     : "Pause points cleared."
+            };
+        }
+    }
+
+    /// <summary>
+    /// One formatted capture frame included in the enable-pause-point response history.
+    /// </summary>
+    public class PausePointCapturedHistoryFrame
+    {
+        public int HitSequence { get; set; }
+        public int FrameCount { get; set; }
+        public string HitAtUtc { get; set; } = string.Empty;
+        public IReadOnlyList<PausePointCapturedVariable> CapturedVariables { get; set; } =
+            Array.Empty<PausePointCapturedVariable>();
+        public bool Truncated { get; set; }
+
+        internal static PausePointCapturedHistoryFrame FromSnapshot(
+            UloopPausePointCapturedHistoryFrame snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            return new PausePointCapturedHistoryFrame
+            {
+                HitSequence = snapshot.HitSequence,
+                FrameCount = snapshot.FrameCount,
+                HitAtUtc = snapshot.HitAtUtc,
+                CapturedVariables = snapshot.CapturedVariables
+                    .Select(PausePointCapturedVariable.FromSnapshot)
+                    .ToList(),
+                Truncated = snapshot.Truncated
+            };
+        }
+    }
+
+    /// <summary>
+    /// One formatted variable included in a pause point capture history frame.
+    /// </summary>
+    public class PausePointCapturedVariable
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Scope { get; set; } = string.Empty;
+        public string TypeName { get; set; } = string.Empty;
+        public string Value { get; set; } = string.Empty;
+        public string UnityObjectKind { get; set; } = string.Empty;
+        public string UnityObjectPath { get; set; } = string.Empty;
+        public int UnityObjectInstanceId { get; set; }
+
+        internal static PausePointCapturedVariable FromSnapshot(UloopCapturedVariable snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            return new PausePointCapturedVariable
+            {
+                Name = snapshot.Name,
+                Scope = snapshot.Scope,
+                TypeName = snapshot.TypeName,
+                Value = snapshot.Value,
+                UnityObjectKind = snapshot.UnityObjectKind,
+                UnityObjectPath = snapshot.UnityObjectPath,
+                UnityObjectInstanceId = snapshot.UnityObjectInstanceId
             };
         }
     }
@@ -187,6 +270,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public PausePointResponse Enable(EnablePausePointSchema parameters)
         {
+            string captureSettingsError = ValidateCaptureSettings(parameters);
+            if (captureSettingsError != null)
+            {
+                return CreateValidationFailure(captureSettingsError);
+            }
+
             string modeError = ValidateEnableMode(parameters);
             if (modeError != null)
             {
@@ -203,7 +292,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return EnableBySourceLocation(parameters);
             }
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(parameters.Id, parameters.TimeoutSeconds);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
+                parameters.Id,
+                parameters.TimeoutSeconds,
+                parameters.Mode,
+                parameters.MaxHistory);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.Warning = CreateEnableWarning();
             return response;
@@ -257,7 +350,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 };
             }
 
-            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(id, parameters.TimeoutSeconds);
+            UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Enable(
+                id,
+                parameters.TimeoutSeconds,
+                parameters.Mode,
+                parameters.MaxHistory);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.ResolvedLine = resolveResult.Resolution.ResolvedLine;
             response.ResolvedMethod = resolveResult.Resolution.MethodDisplayName;
@@ -308,6 +405,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (!hasId && hasFile != hasLine)
             {
                 return "File and Line must both be provided together.";
+            }
+
+            return null;
+        }
+
+        private static string ValidateCaptureSettings(EnablePausePointSchema parameters)
+        {
+            string[] supportedModes =
+            {
+                UloopPausePointCaptureMode.SingleShot,
+                UloopPausePointCaptureMode.Continuous,
+                UloopPausePointCaptureMode.Trace
+            };
+            if (!supportedModes.Contains(parameters.Mode))
+            {
+                return $"Mode must be one of: {string.Join(", ", supportedModes)}.";
+            }
+
+            if (parameters.MaxHistory <= 0 || parameters.MaxHistory > UloopPausePointRegistry.MaxHistoryLimit)
+            {
+                return $"MaxHistory must be between 1 and {UloopPausePointRegistry.MaxHistoryLimit}.";
             }
 
             return null;

--- a/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/PausePointStatusBridgeCommand.cs
@@ -56,6 +56,11 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
         public bool IsHit { get; set; }
         public int HitCount { get; set; }
         public int TimeoutSeconds { get; set; }
+        public string Mode { get; set; } = string.Empty;
+        public int MaxHistory { get; set; }
+        public IReadOnlyList<PausePointStatusCapturedHistoryFrame> CapturedVariableHistory { get; set; } =
+            Array.Empty<PausePointStatusCapturedHistoryFrame>();
+        public int HistoryDroppedCount { get; set; }
         public bool Expired { get; set; }
         public string EnabledAtUtc { get; set; } = string.Empty;
         public long ElapsedSinceEnabledMilliseconds { get; set; }
@@ -90,6 +95,12 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 IsHit = snapshot.IsHit,
                 HitCount = snapshot.HitCount,
                 TimeoutSeconds = snapshot.TimeoutSeconds,
+                Mode = snapshot.Mode,
+                MaxHistory = snapshot.MaxHistory,
+                CapturedVariableHistory = snapshot.CapturedVariableHistory
+                    .Select(PausePointStatusCapturedHistoryFrame.FromSnapshot)
+                    .ToList(),
+                HistoryDroppedCount = snapshot.HistoryDroppedCount,
                 Expired = snapshot.Expired,
                 EnabledAtUtc = snapshot.EnabledAtUtc,
                 ElapsedSinceEnabledMilliseconds = snapshot.ElapsedSinceEnabledMilliseconds,
@@ -109,6 +120,39 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 ClearedReason = snapshot.ClearedReason,
                 StatusBeforeClear = snapshot.StatusBeforeClear,
                 LateHitDiscardedAfterClear = snapshot.LateHitDiscardedAfterClear
+            };
+        }
+    }
+
+    /// <summary>
+    /// One formatted capture frame included in the CLI-only pause point status response history.
+    /// </summary>
+    public class PausePointStatusCapturedHistoryFrame
+    {
+        public int HitSequence { get; set; }
+        public int FrameCount { get; set; }
+        public string HitAtUtc { get; set; } = string.Empty;
+        public IReadOnlyList<PausePointStatusCapturedVariable> CapturedVariables { get; set; } =
+            Array.Empty<PausePointStatusCapturedVariable>();
+        public bool Truncated { get; set; }
+
+        internal static PausePointStatusCapturedHistoryFrame FromSnapshot(
+            UloopPausePointCapturedHistoryFrame snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            return new PausePointStatusCapturedHistoryFrame
+            {
+                HitSequence = snapshot.HitSequence,
+                FrameCount = snapshot.FrameCount,
+                HitAtUtc = snapshot.HitAtUtc,
+                CapturedVariables = snapshot.CapturedVariables
+                    .Select(PausePointStatusCapturedVariable.FromCapturedVariable)
+                    .ToList(),
+                Truncated = snapshot.Truncated
             };
         }
     }

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCaptureMode.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCaptureMode.cs
@@ -1,0 +1,14 @@
+#if UNITY_EDITOR
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// Defines how a pause point behaves after it captures a hit.
+    /// </summary>
+    internal static class UloopPausePointCaptureMode
+    {
+        public const string SingleShot = "single-shot";
+        public const string Continuous = "continuous";
+        public const string Trace = "trace";
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCaptureMode.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCaptureMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2057563b6f48b41ada9ba6d245b357b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCapturedHistoryFrame.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCapturedHistoryFrame.cs
@@ -1,0 +1,32 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.Runtime
+{
+    /// <summary>
+    /// Stores the formatted evidence captured by one pause point hit.
+    /// </summary>
+    internal sealed class UloopPausePointCapturedHistoryFrame
+    {
+        public UloopPausePointCapturedHistoryFrame(
+            int hitSequence,
+            int frameCount,
+            string hitAtUtc,
+            IReadOnlyList<UloopCapturedVariable> capturedVariables,
+            bool truncated)
+        {
+            HitSequence = hitSequence;
+            FrameCount = frameCount;
+            HitAtUtc = hitAtUtc;
+            CapturedVariables = capturedVariables;
+            Truncated = truncated;
+        }
+
+        public int HitSequence { get; }
+        public int FrameCount { get; }
+        public string HitAtUtc { get; }
+        public IReadOnlyList<UloopCapturedVariable> CapturedVariables { get; }
+        public bool Truncated { get; }
+    }
+}
+#endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointCapturedHistoryFrame.cs.meta
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointCapturedHistoryFrame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 709b465a62e244755a4c8ee3a2208b35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -10,10 +10,18 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
     /// </summary>
     internal sealed class UloopPausePointEntry
     {
-        public UloopPausePointEntry(string id, int timeoutSeconds, DateTime enabledAtUtc, int generation)
+        public UloopPausePointEntry(
+            string id,
+            int timeoutSeconds,
+            string mode,
+            int maxHistory,
+            DateTime enabledAtUtc,
+            int generation)
         {
             Id = id;
             TimeoutSeconds = timeoutSeconds;
+            Mode = mode;
+            MaxHistory = maxHistory;
             EnabledAtUtc = enabledAtUtc;
             ExpiresAtUtc = enabledAtUtc.AddSeconds(timeoutSeconds);
             Generation = generation;
@@ -21,10 +29,13 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             IsEnabled = true;
             Message = "Pause point enabled.";
             CapturedVariables = Array.Empty<UloopCapturedVariable>();
+            _capturedVariableHistory = new Queue<UloopPausePointCapturedHistoryFrame>(maxHistory);
         }
 
         public string Id { get; }
         public int TimeoutSeconds { get; }
+        public string Mode { get; }
+        public int MaxHistory { get; }
         public DateTime EnabledAtUtc { get; }
         public DateTime ExpiresAtUtc { get; }
         public int Generation { get; }
@@ -40,6 +51,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string Message { get; private set; }
         public IReadOnlyList<UloopCapturedVariable> CapturedVariables { get; private set; }
         public bool CapturedVariablesTruncated { get; private set; }
+        public int HistoryDroppedCount { get; private set; }
         public string ClearedReason { get; private set; } = string.Empty;
         public string StatusBeforeClear { get; private set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; private set; }
@@ -58,7 +70,9 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
             IsEnabled = false;
             Status = UloopPausePointStatus.Expired;
-            Message = "Pause point expired before it was hit.";
+            Message = HitCount == 0
+                ? "Pause point expired before it was hit."
+                : $"Pause point capture window expired after {HitCount} hit(s); capture history is preserved.";
         }
 
         public void MarkCleared(string clearedReason, string message = "Pause point cleared.")
@@ -78,6 +92,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 ClearedReason = UloopPausePointClearedReason.AfterExpired;
             }
             else if (Status == UloopPausePointStatus.Hit &&
+                !IsEnabled &&
                 clearedReason == UloopPausePointClearedReason.ExplicitClear)
             {
                 ClearedReason = UloopPausePointClearedReason.AlreadyHit;
@@ -99,17 +114,12 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             LateHitDiscardedAfterClear = true;
         }
 
-        public void RecordHit(DateTime nowUtc, bool isPlaying, bool isPaused, int hitSequence)
-        {
-            RecordHitWithCapturedVariables(
-                nowUtc, isPlaying, isPaused, hitSequence, Array.Empty<UloopCapturedVariable>(), false);
-        }
-
         public void RecordHitWithCapturedVariables(
             DateTime nowUtc,
             bool isPlaying,
             bool isPaused,
             int hitSequence,
+            int frameCount,
             IReadOnlyList<UloopCapturedVariable> capturedVariables,
             bool capturedVariablesTruncated)
         {
@@ -127,11 +137,27 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             LastHitSequence = hitSequence;
             IsPlayingAtHit = isPlaying;
             IsPausedAtHit = isPaused;
-            IsEnabled = false;
+            IsEnabled = Mode != UloopPausePointCaptureMode.SingleShot;
             Status = UloopPausePointStatus.Hit;
-            Message = "Pause point hit; Unity pause was requested.";
+            Message = Mode == UloopPausePointCaptureMode.Trace
+                ? "Pause point hit; recorded to history without pausing (trace mode)."
+                : "Pause point hit; Unity pause was requested.";
             CapturedVariables = capturedVariables;
             CapturedVariablesTruncated = capturedVariablesTruncated;
+
+            if (_capturedVariableHistory.Count == MaxHistory)
+            {
+                _capturedVariableHistory.Dequeue();
+                HistoryDroppedCount++;
+            }
+
+            _capturedVariableHistory.Enqueue(
+                new UloopPausePointCapturedHistoryFrame(
+                    hitSequence,
+                    frameCount,
+                    FormatUtc(nowUtc),
+                    capturedVariables,
+                    capturedVariablesTruncated));
         }
 
         public UloopPausePointSnapshot ToSnapshot(DateTime nowUtc, IUloopPausePointPauseController pauseController)
@@ -161,6 +187,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 isHit,
                 HitCount,
                 TimeoutSeconds,
+                Mode,
+                MaxHistory,
+                new List<UloopPausePointCapturedHistoryFrame>(_capturedVariableHistory),
+                HistoryDroppedCount,
                 expired,
                 FormatUtc(EnabledAtUtc),
                 elapsedMilliseconds,
@@ -201,6 +231,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             DateTime utcValue = value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();
             return utcValue.ToString("O");
         }
+
+        private readonly Queue<UloopPausePointCapturedHistoryFrame> _capturedVariableHistory;
     }
 }
 #endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -15,6 +15,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
     internal static class UloopPausePointRegistry
     {
         public const int DefaultTimeoutSeconds = 30;
+        public const int DefaultMaxHistory = 20;
+        public const int MaxHistoryLimit = 100;
 
         private static readonly ConcurrentDictionary<string, UloopPausePointEntry> Entries = new();
         private static IUloopPausePointPauseController _pauseController = new UnityEditorPausePointPauseController();
@@ -35,14 +37,21 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public static Action<string> OnCleared { get; set; }
         public static Action OnClearedAll { get; set; }
 
-        public static UloopPausePointSnapshot Enable(string id, int timeoutSeconds)
+        public static UloopPausePointSnapshot Enable(
+            string id,
+            int timeoutSeconds,
+            string mode = UloopPausePointCaptureMode.SingleShot,
+            int maxHistory = DefaultMaxHistory)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(id), "id must not be null or empty");
             Debug.Assert(timeoutSeconds > 0, "timeoutSeconds must be greater than zero");
+            Debug.Assert(IsSupportedMode(mode), "mode must be a supported pause point capture mode");
+            Debug.Assert(maxHistory > 0, "maxHistory must be greater than zero");
+            Debug.Assert(maxHistory <= MaxHistoryLimit, "maxHistory must not exceed the history limit");
 
             DateTime now = NowUtc();
             int generation = ++_nextGeneration;
-            UloopPausePointEntry entry = new(id, timeoutSeconds, now, generation);
+            UloopPausePointEntry entry = new(id, timeoutSeconds, mode, maxHistory, now, generation);
             Entries[id] = entry;
             ClearLatestHitSnapshotIfMatches(id);
             return entry.ToSnapshot(now, _pauseController);
@@ -63,10 +72,16 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             UloopPausePointEntry entry = Entries[id];
             // Resolve expiry first so a clear after the timeout reports "expired", not a normal clear.
             entry.ExpireIfNeeded(now);
-            string message = entry.Status switch
+            string message = !entry.IsEnabled && entry.Status == UloopPausePointStatus.Hit
+                ? "Pause point was already hit (auto-disarmed); nothing to clear."
+                : entry.Status switch
             {
-                UloopPausePointStatus.Hit => "Pause point was already hit (auto-disarmed); nothing to clear.",
-                UloopPausePointStatus.Expired => "Pause point had already expired before being hit; nothing to clear.",
+                UloopPausePointStatus.Hit =>
+                    $"Pause point cleared after {entry.HitCount} hit(s); capture history is preserved.",
+                UloopPausePointStatus.Expired when entry.HitCount > 0 =>
+                    "Pause point capture window had already expired; nothing to clear.",
+                UloopPausePointStatus.Expired =>
+                    "Pause point had already expired before being hit; nothing to clear.",
                 UloopPausePointStatus.Cleared => "Pause point was already cleared.",
                 _ => "Pause point cleared."
             };
@@ -190,11 +205,16 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 return entry.ToSnapshot(now, _pauseController);
             }
 
-            _pauseController.Pause();
+            if (entry.Mode != UloopPausePointCaptureMode.Trace)
+            {
+                _pauseController.Pause();
+            }
+
             int hitSequence = ++_nextHitSequence;
+            int frameCount = Time.frameCount;
             entry.RecordHitWithCapturedVariables(
                 now, _pauseController.IsPlaying, _pauseController.IsPaused, hitSequence,
-                capturedVariables, capturedVariablesTruncated);
+                frameCount, capturedVariables, capturedVariablesTruncated);
             UloopPausePointSnapshot snapshot = entry.ToSnapshot(now, _pauseController);
             _latestHitSnapshot = snapshot;
             _hitSnapshots.RemoveAll(hitSnapshot => hitSnapshot.Id == id);
@@ -266,6 +286,13 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
             DateTime now = _nowProvider();
             return now.Kind == DateTimeKind.Utc ? now : now.ToUniversalTime();
+        }
+
+        private static bool IsSupportedMode(string mode)
+        {
+            return mode == UloopPausePointCaptureMode.SingleShot ||
+                   mode == UloopPausePointCaptureMode.Continuous ||
+                   mode == UloopPausePointCaptureMode.Trace;
         }
     }
 }

--- a/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointSnapshot.cs
@@ -18,6 +18,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             bool isHit,
             int hitCount,
             int timeoutSeconds,
+            string mode,
+            int maxHistory,
+            IReadOnlyList<UloopPausePointCapturedHistoryFrame> capturedVariableHistory,
+            int historyDroppedCount,
             bool expired,
             string enabledAtUtc,
             long elapsedMilliseconds,
@@ -44,6 +48,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             IsHit = isHit;
             HitCount = hitCount;
             TimeoutSeconds = timeoutSeconds;
+            Mode = mode ?? UloopPausePointCaptureMode.SingleShot;
+            MaxHistory = maxHistory;
+            CapturedVariableHistory = capturedVariableHistory ?? Array.Empty<UloopPausePointCapturedHistoryFrame>();
+            HistoryDroppedCount = historyDroppedCount;
             Expired = expired;
             EnabledAtUtc = enabledAtUtc ?? string.Empty;
             ElapsedSinceEnabledMilliseconds = elapsedMilliseconds;
@@ -69,6 +77,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public bool IsHit { get; }
         public int HitCount { get; }
         public int TimeoutSeconds { get; }
+        public string Mode { get; }
+        public int MaxHistory { get; }
+        public IReadOnlyList<UloopPausePointCapturedHistoryFrame> CapturedVariableHistory { get; }
+        public int HistoryDroppedCount { get; }
         public bool Expired { get; }
         public string EnabledAtUtc { get; }
         public long ElapsedSinceEnabledMilliseconds { get; }
@@ -97,6 +109,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 false,
                 false,
                 0,
+                0,
+                UloopPausePointCaptureMode.SingleShot,
+                0,
+                Array.Empty<UloopPausePointCapturedHistoryFrame>(),
                 0,
                 false,
                 string.Empty,

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -360,6 +360,21 @@
             "type": "integer",
             "description": "Seconds before the enable request expires and stops pausing late hits",
             "default": 30
+          },
+          "Mode": {
+            "type": "string",
+            "description": "Capture mode: single-shot pauses once, continuous pauses on every hit, trace records hits without pausing",
+            "enum": [
+              "single-shot",
+              "continuous",
+              "trace"
+            ],
+            "default": "single-shot"
+          },
+          "MaxHistory": {
+            "type": "integer",
+            "description": "Maximum number of captured hit frames to retain (1-100)",
+            "default": 20
           }
         }
       }

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -1,0 +1,59 @@
+package projectrunner
+
+type pausePointStatusResponse struct {
+	Id                              string                           `json:"Id"`
+	Status                          string                           `json:"Status"`
+	IsEnabled                       bool                             `json:"IsEnabled"`
+	IsHit                           bool                             `json:"IsHit"`
+	HitCount                        int                              `json:"HitCount"`
+	TimeoutSeconds                  int                              `json:"TimeoutSeconds"`
+	Mode                            string                           `json:"Mode"`
+	MaxHistory                      int                              `json:"MaxHistory"`
+	CapturedVariableHistory         []pausePointCapturedHistoryFrame `json:"CapturedVariableHistory"`
+	HistoryDroppedCount             int                              `json:"HistoryDroppedCount"`
+	Expired                         bool                             `json:"Expired"`
+	EnabledAtUtc                    string                           `json:"EnabledAtUtc"`
+	ElapsedSinceEnabledMilliseconds int64                            `json:"ElapsedSinceEnabledMilliseconds"`
+	RemainingMilliseconds           int64                            `json:"RemainingMilliseconds"`
+	Generation                      int                              `json:"Generation"`
+	EditorState                     pausePointEditorState            `json:"EditorState"`
+	FirstHitAtUtc                   string                           `json:"FirstHitAtUtc"`
+	LastHitAtUtc                    string                           `json:"LastHitAtUtc"`
+	FirstHitSequence                int                              `json:"FirstHitSequence"`
+	LastHitSequence                 int                              `json:"LastHitSequence"`
+	Message                         string                           `json:"Message"`
+	RecommendedNextAction           string                           `json:"RecommendedNextAction"`
+	CapturedVariables               []pausePointCapturedVariable     `json:"CapturedVariables"`
+	CapturedVariablesTruncated      bool                             `json:"CapturedVariablesTruncated"`
+	ClearedReason                   string                           `json:"ClearedReason"`
+	StatusBeforeClear               string                           `json:"StatusBeforeClear"`
+	LateHitDiscardedAfterClear      bool                             `json:"LateHitDiscardedAfterClear"`
+}
+
+type pausePointEditorState struct {
+	IsPlaying  bool   `json:"IsPlaying"`
+	IsPaused   bool   `json:"IsPaused"`
+	CapturedAt string `json:"CapturedAt"`
+}
+
+// pausePointCapturedHistoryFrame mirrors the Unity-side history DTO field-for-field.
+type pausePointCapturedHistoryFrame struct {
+	HitSequence       int                          `json:"HitSequence"`
+	FrameCount        int                          `json:"FrameCount"`
+	HitAtUtc          string                       `json:"HitAtUtc"`
+	CapturedVariables []pausePointCapturedVariable `json:"CapturedVariables"`
+	Truncated         bool                         `json:"Truncated"`
+}
+
+// pausePointCapturedVariable mirrors the flat Unity-side
+// PausePointStatusCapturedVariable/UloopCapturedVariable DTO field-for-field: one variable
+// captured at a source pause point (a local, a parameter, or a `this` instance field).
+type pausePointCapturedVariable struct {
+	Name                  string `json:"Name"`
+	Scope                 string `json:"Scope"`
+	TypeName              string `json:"TypeName"`
+	Value                 string `json:"Value"`
+	UnityObjectKind       string `json:"UnityObjectKind"`
+	UnityObjectPath       string `json:"UnityObjectPath"`
+	UnityObjectInstanceId int    `json:"UnityObjectInstanceId"`
+}

--- a/cli/project-runner/internal/projectrunner/pause_point_wait.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait.go
@@ -45,51 +45,6 @@ type pausePointStatusOptions struct {
 	id string
 }
 
-type pausePointStatusResponse struct {
-	Id                              string                       `json:"Id"`
-	Status                          string                       `json:"Status"`
-	IsEnabled                       bool                         `json:"IsEnabled"`
-	IsHit                           bool                         `json:"IsHit"`
-	HitCount                        int                          `json:"HitCount"`
-	TimeoutSeconds                  int                          `json:"TimeoutSeconds"`
-	Expired                         bool                         `json:"Expired"`
-	EnabledAtUtc                    string                       `json:"EnabledAtUtc"`
-	ElapsedSinceEnabledMilliseconds int64                        `json:"ElapsedSinceEnabledMilliseconds"`
-	RemainingMilliseconds           int64                        `json:"RemainingMilliseconds"`
-	Generation                      int                          `json:"Generation"`
-	EditorState                     pausePointEditorState        `json:"EditorState"`
-	FirstHitAtUtc                   string                       `json:"FirstHitAtUtc"`
-	LastHitAtUtc                    string                       `json:"LastHitAtUtc"`
-	FirstHitSequence                int                          `json:"FirstHitSequence"`
-	LastHitSequence                 int                          `json:"LastHitSequence"`
-	Message                         string                       `json:"Message"`
-	RecommendedNextAction           string                       `json:"RecommendedNextAction"`
-	CapturedVariables               []pausePointCapturedVariable `json:"CapturedVariables"`
-	CapturedVariablesTruncated      bool                         `json:"CapturedVariablesTruncated"`
-	ClearedReason                   string                       `json:"ClearedReason"`
-	StatusBeforeClear               string                       `json:"StatusBeforeClear"`
-	LateHitDiscardedAfterClear      bool                         `json:"LateHitDiscardedAfterClear"`
-}
-
-type pausePointEditorState struct {
-	IsPlaying  bool   `json:"IsPlaying"`
-	IsPaused   bool   `json:"IsPaused"`
-	CapturedAt string `json:"CapturedAt"`
-}
-
-// pausePointCapturedVariable mirrors the flat Unity-side
-// PausePointStatusCapturedVariable/UloopCapturedVariable DTO field-for-field: one variable
-// captured at a source pause point (a local, a parameter, or a `this` instance field).
-type pausePointCapturedVariable struct {
-	Name                  string `json:"Name"`
-	Scope                 string `json:"Scope"`
-	TypeName              string `json:"TypeName"`
-	Value                 string `json:"Value"`
-	UnityObjectKind       string `json:"UnityObjectKind"`
-	UnityObjectPath       string `json:"UnityObjectPath"`
-	UnityObjectInstanceId int    `json:"UnityObjectInstanceId"`
-}
-
 type pausePointWaitState string
 
 const (

--- a/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_wait_test.go
@@ -30,11 +30,15 @@ func TestWaitForPausePointReturnsHitAfterEnabledStatus(t *testing.T) {
 	responses := []pausePointStatusResponse{
 		{Id: "jump", Status: pausePointStatusEnabled, IsEnabled: true},
 		{
-			Id:          "jump",
-			Status:      pausePointStatusHit,
-			IsHit:       true,
-			HitCount:    1,
-			EditorState: pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "PausePointHit"},
+			Id:                      "jump",
+			Status:                  pausePointStatusHit,
+			IsHit:                   true,
+			HitCount:                1,
+			Mode:                    "continuous",
+			MaxHistory:              20,
+			CapturedVariableHistory: []pausePointCapturedHistoryFrame{{HitSequence: 1, FrameCount: 42, HitAtUtc: "2026-06-03T00:00:01.0000000Z"}},
+			HistoryDroppedCount:     0,
+			EditorState:             pausePointEditorState{IsPlaying: true, IsPaused: true, CapturedAt: "PausePointHit"},
 		},
 	}
 	requestCount := 0
@@ -64,6 +68,9 @@ func TestWaitForPausePointReturnsHitAfterEnabledStatus(t *testing.T) {
 	}
 	if response.Status != pausePointStatusHit || response.HitCount != 1 {
 		t.Fatalf("response mismatch: %#v", response)
+	}
+	if response.Mode != "continuous" || response.MaxHistory != 20 || len(response.CapturedVariableHistory) != 1 {
+		t.Fatalf("capture history mismatch: %#v", response)
 	}
 	if requestCount != 2 {
 		t.Fatalf("request count mismatch: %d", requestCount)

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -5,6 +5,18 @@
   "IsHit": true,
   "HitCount": 1,
   "TimeoutSeconds": 30,
+  "Mode": "continuous",
+  "MaxHistory": 20,
+  "CapturedVariableHistory": [
+    {
+      "HitSequence": 1,
+      "FrameCount": 42,
+      "HitAtUtc": "2026-06-03T00:00:01.0000000Z",
+      "CapturedVariables": [],
+      "Truncated": false
+    }
+  ],
+  "HistoryDroppedCount": 0,
   "Expired": false,
   "EnabledAtUtc": "2026-06-03T00:00:00.0000000Z",
   "ElapsedSinceEnabledMilliseconds": 1200,


### PR DESCRIPTION
## Summary

This Phase 1 base branch adds continuous and trace capture modes plus bounded pause point hit history.

- Add single-shot, continuous, and trace capture modes while preserving single-shot as the default.
- Retain bounded captured-variable history with hit sequence, frame count, timestamp, truncation, and dropped-frame metadata.
- Expose mode/history through enable-pause-point and pause-point-status, including validation and shared C#/Go response contracts.
- Add await-pause-point contract coverage, CLI schema guidance, and the source pause-point skill documentation with regenerated copies.

## Validation

- Unity compile: 0 errors, 0 warnings.
- Targeted Unity tests: 58/58 passed.
- scripts/check-go-cli.sh: passed.
- Continuous E2E: an Update line in SimulateMouseDemoScene was hit, then three Editor Steps grew history from four consecutive frames.
- Trace E2E: playback continued without pause; 372 hits were recorded with a five-frame history and 367 dropped frames.
- Single-shot E2E: the first hit paused Unity, recorded one history frame, and auto-disarmed.
- The checkout has no dedicated jumping-ball scene, so the equivalent Update-path behavior was verified in SimulateMouseDemoScene using dist/darwin-arm64/uloop directly; no PATH-resolved uloop was used.
