### PR TITLE
feat: add watch expression registry core

### DIFF
--- a/Assets/Tests/Editor/WatchExpressionCompilerTests.cs
+++ b/Assets/Tests/Editor/WatchExpressionCompilerTests.cs
@@ -16,6 +16,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     [TestFixture]
     public sealed class WatchExpressionCompilerTests
     {
+        private const int MaxCompilationWaitTicks = 600;
+
         /// <summary>
         /// Verifies a valid expression reaches the compile-only path and produces an evaluator.
         /// </summary>
@@ -25,9 +27,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WatchExpressionCompiler compiler = new(new DynamicCodeCompiler());
             Task<WatchCompilationResult> compilationTask = compiler.CompileAsync("1 + 2", CancellationToken.None);
 
-            while (!compilationTask.IsCompleted)
+            int waitTicks = 0;
+            while (!compilationTask.IsCompleted && waitTicks < MaxCompilationWaitTicks)
             {
+                waitTicks++;
                 yield return null;
+            }
+
+            if (!compilationTask.IsCompleted)
+            {
+                Assert.Fail($"Watch expression compilation did not complete within {MaxCompilationWaitTicks} editor ticks.");
+                yield break;
             }
 
             Assert.That(compilationTask.IsCompletedSuccessfully, Is.True);

--- a/Assets/Tests/Editor/WatchExpressionCompilerTests.cs
+++ b/Assets/Tests/Editor/WatchExpressionCompilerTests.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using UnityEngine.TestTools;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies watch expressions compile through the shared dynamic-code compiler without executing user code.
+    /// </summary>
+    [TestFixture]
+    public sealed class WatchExpressionCompilerTests
+    {
+        /// <summary>
+        /// Verifies a valid expression reaches the compile-only path and produces an evaluator.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator CompileAsync_ValidExpressionReturnsCompiledEvaluator()
+        {
+            WatchExpressionCompiler compiler = new(new DynamicCodeCompiler());
+            Task<WatchCompilationResult> compilationTask = compiler.CompileAsync("1 + 2", CancellationToken.None);
+
+            while (!compilationTask.IsCompleted)
+            {
+                yield return null;
+            }
+
+            Assert.That(compilationTask.IsCompletedSuccessfully, Is.True);
+            Assert.That(compilationTask.Result.Success, Is.True);
+            Assert.That(compilationTask.Result.Evaluator, Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Verifies an empty expression is rejected before invoking the compiler.
+        /// </summary>
+        [Test]
+        public void CompileAsync_EmptyExpressionReturnsFailure()
+        {
+            WatchExpressionCompiler compiler = new(new DynamicCodeCompiler());
+
+            Task<WatchCompilationResult> compilationTask = compiler.CompileAsync("", CancellationToken.None);
+
+            Assert.That(compilationTask.IsCompletedSuccessfully, Is.True);
+            Assert.That(compilationTask.Result.Success, Is.False);
+            Assert.That(compilationTask.Result.ErrorMessage, Does.Contain("must not be empty"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/WatchExpressionCompilerTests.cs.meta
+++ b/Assets/Tests/Editor/WatchExpressionCompilerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34b102bf4e1b0405f86c5b52defe1971
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/WatchExpressionEvaluationTests.cs
+++ b/Assets/Tests/Editor/WatchExpressionEvaluationTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies user-code evaluation failures become explicit watch history results.
+    /// </summary>
+    [TestFixture]
+    public sealed class WatchExpressionEvaluationTests
+    {
+        /// <summary>
+        /// Verifies an exception from the generated evaluator is returned as a typed failure result.
+        /// </summary>
+        [Test]
+        public void Evaluate_WhenUserCodeThrows_ReturnsFailureResult()
+        {
+            MethodInfo method = typeof(ThrowingWatchExpression).GetMethod(nameof(ThrowingWatchExpression.Evaluate));
+            CompiledWatchExpressionEvaluator evaluator = new(
+                new ThrowingWatchExpression(),
+                method);
+
+            WatchEvaluationResult result = evaluator.Evaluate();
+
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorTypeName, Is.EqualTo(typeof(InvalidOperationException).FullName));
+            Assert.That(result.ErrorMessage, Is.EqualTo("watch failed"));
+        }
+
+        private sealed class ThrowingWatchExpression
+        {
+            public object Evaluate()
+            {
+                throw new InvalidOperationException("watch failed");
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/WatchExpressionEvaluationTests.cs.meta
+++ b/Assets/Tests/Editor/WatchExpressionEvaluationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c03d6a9e9430142e29b209d58774aa40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/WatchExpressionRegistryTests.cs
+++ b/Assets/Tests/Editor/WatchExpressionRegistryTests.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies watch expression registration, ordered frame evaluation, bounded history, and re-entry protection.
+    /// </summary>
+    [TestFixture]
+    public sealed class WatchExpressionRegistryTests
+    {
+        [Test]
+        public void Register_AddsImmediateBaselineToHistory()
+        {
+            FakeWatchEditorStateProvider stateProvider = new(10, true, true);
+            WatchExpressionRegistry registry = new(stateProvider);
+
+            WatchRegistrationResult result = registry.Register(
+                "speed",
+                "speed",
+                new SequenceWatchExpressionEvaluator(3),
+                20);
+
+            Assert.That(result.Success, Is.True);
+            WatchExpressionHistoryEntry entry = registry.GetHistory("speed").Single();
+            Assert.That(entry.FrameCount, Is.EqualTo(10));
+            Assert.That(entry.Result.Value, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void EvaluateIfFrameChanged_EvaluatesInRegistrationOrderAndSkipsSameFrame()
+        {
+            FakeWatchEditorStateProvider stateProvider = new(10, true, true);
+            List<string> evaluationOrder = new();
+            WatchExpressionRegistry registry = new(stateProvider);
+            registry.Register("first", "first", new RecordingWatchExpressionEvaluator("first", evaluationOrder), 20);
+            registry.Register("second", "second", new RecordingWatchExpressionEvaluator("second", evaluationOrder), 20);
+            evaluationOrder.Clear();
+
+            stateProvider.FrameCount = 11;
+            bool evaluated = registry.EvaluateIfFrameChanged();
+            bool evaluatedAgain = registry.EvaluateIfFrameChanged();
+
+            Assert.That(evaluated, Is.True);
+            Assert.That(evaluatedAgain, Is.False);
+            Assert.That(evaluationOrder, Is.EqualTo(new[] { "first", "second" }));
+            Assert.That(registry.GetHistory("first"), Has.Count.EqualTo(2));
+            Assert.That(registry.GetHistory("second"), Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public void EvaluateIfFrameChanged_WhenNotPaused_DoesNotEvaluate()
+        {
+            FakeWatchEditorStateProvider stateProvider = new(10, true, false);
+            SequenceWatchExpressionEvaluator evaluator = new(1, 2);
+            WatchExpressionRegistry registry = new(stateProvider);
+            registry.Register("speed", "speed", evaluator, 20);
+
+            stateProvider.IsPaused = true;
+            stateProvider.FrameCount = 11;
+            registry.EvaluateIfFrameChanged();
+
+            Assert.That(registry.GetHistory("speed"), Has.Count.EqualTo(2));
+            Assert.That(evaluator.EvaluationCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void History_WhenLimitIsExceeded_DropsOldestEntry()
+        {
+            FakeWatchEditorStateProvider stateProvider = new(10, true, true);
+            WatchExpressionRegistry registry = new(stateProvider);
+            registry.Register("speed", "speed", new SequenceWatchExpressionEvaluator(0, 1, 2), 2);
+
+            stateProvider.FrameCount = 11;
+            registry.EvaluateIfFrameChanged();
+            stateProvider.FrameCount = 12;
+            registry.EvaluateIfFrameChanged();
+
+            IReadOnlyList<WatchExpressionHistoryEntry> history = registry.GetHistory("speed");
+            Assert.That(history.Select(entry => entry.FrameCount), Is.EqualTo(new[] { 11, 12 }));
+            Assert.That(registry.GetHistoryDroppedCount("speed"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void EvaluateIfFrameChanged_WhenEvaluatorReentersRegistry_DoesNotEvaluateNestedFrame()
+        {
+            FakeWatchEditorStateProvider stateProvider = new(10, true, true);
+            WatchExpressionRegistry registry = new(stateProvider);
+            ReenteringWatchExpressionEvaluator evaluator = new(() => registry.EvaluateIfFrameChanged());
+            registry.Register("speed", "speed", evaluator, 20);
+
+            stateProvider.FrameCount = 11;
+            bool evaluated = registry.EvaluateIfFrameChanged();
+
+            Assert.That(evaluated, Is.True);
+            Assert.That(evaluator.EvaluationCount, Is.EqualTo(2));
+            Assert.That(registry.GetHistory("speed"), Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public void ClearAll_RemovesAllRegisteredExpressions()
+        {
+            FakeWatchEditorStateProvider stateProvider = new(10, true, true);
+            WatchExpressionRegistry registry = new(stateProvider);
+            registry.Register("first", "first", new SequenceWatchExpressionEvaluator(1), 20);
+            registry.Register("second", "second", new SequenceWatchExpressionEvaluator(2), 20);
+
+            int clearedCount = registry.ClearAll();
+
+            Assert.That(clearedCount, Is.EqualTo(2));
+            Assert.That(registry.GetEntries(), Is.Empty);
+        }
+
+        private sealed class FakeWatchEditorStateProvider : IWatchEditorStateProvider
+        {
+            public FakeWatchEditorStateProvider(int frameCount, bool isPlaying, bool isPaused)
+            {
+                FrameCount = frameCount;
+                IsPlaying = isPlaying;
+                IsPaused = isPaused;
+            }
+
+            public int FrameCount { get; set; }
+            public bool IsPlaying { get; set; }
+            public bool IsPaused { get; set; }
+            public System.DateTime UtcNow => new(2026, 6, 3, 0, 0, 0, System.DateTimeKind.Utc);
+        }
+
+        private sealed class SequenceWatchExpressionEvaluator : IWatchExpressionEvaluator
+        {
+            private readonly Queue<object> _values;
+            private object _lastValue;
+
+            public SequenceWatchExpressionEvaluator(params object[] values)
+            {
+                _values = new Queue<object>(values);
+                _lastValue = values.Length > 0 ? values[values.Length - 1] : null;
+            }
+
+            public int EvaluationCount { get; private set; }
+
+            public WatchEvaluationResult Evaluate()
+            {
+                EvaluationCount++;
+                if (_values.Count > 0)
+                {
+                    _lastValue = _values.Dequeue();
+                }
+
+                return WatchEvaluationResult.SuccessResult(_lastValue);
+            }
+        }
+
+        private sealed class RecordingWatchExpressionEvaluator : IWatchExpressionEvaluator
+        {
+            private readonly string _name;
+            private readonly List<string> _evaluationOrder;
+
+            public RecordingWatchExpressionEvaluator(string name, List<string> evaluationOrder)
+            {
+                _name = name;
+                _evaluationOrder = evaluationOrder;
+            }
+
+            public WatchEvaluationResult Evaluate()
+            {
+                _evaluationOrder.Add(_name);
+                return WatchEvaluationResult.SuccessResult(_name);
+            }
+        }
+
+        private sealed class ReenteringWatchExpressionEvaluator : IWatchExpressionEvaluator
+        {
+            private readonly System.Action _reenter;
+            private bool _hasReentered;
+
+            public ReenteringWatchExpressionEvaluator(System.Action reenter)
+            {
+                _reenter = reenter;
+            }
+
+            public int EvaluationCount { get; private set; }
+
+            public WatchEvaluationResult Evaluate()
+            {
+                EvaluationCount++;
+                if (!_hasReentered)
+                {
+                    _hasReentered = true;
+                    _reenter();
+                }
+
+                return WatchEvaluationResult.SuccessResult(EvaluationCount);
+            }
+        }
+    }
+}

--- a/Assets/Tests/Editor/WatchExpressionRegistryTests.cs
+++ b/Assets/Tests/Editor/WatchExpressionRegistryTests.cs
@@ -199,7 +199,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private sealed class SequenceWatchExpressionEvaluator : IWatchExpressionEvaluator
         {
-        private readonly Queue<object> _values;
+            private readonly Queue<object> _values;
             private object _lastValue;
 
             public SequenceWatchExpressionEvaluator(params object[] values)

--- a/Assets/Tests/Editor/WatchExpressionRegistryTests.cs
+++ b/Assets/Tests/Editor/WatchExpressionRegistryTests.cs
@@ -13,6 +13,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     [TestFixture]
     public sealed class WatchExpressionRegistryTests
     {
+        /// <summary>
+        /// Verifies registration evaluates an immediate baseline frame.
+        /// </summary>
         [Test]
         public void Register_AddsImmediateBaselineToHistory()
         {
@@ -31,6 +34,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(entry.Result.Value, Is.EqualTo(3));
         }
 
+        /// <summary>
+        /// Verifies changed frames evaluate watches in registration order only once per frame.
+        /// </summary>
         [Test]
         public void EvaluateIfFrameChanged_EvaluatesInRegistrationOrderAndSkipsSameFrame()
         {
@@ -52,6 +58,27 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(registry.GetHistory("second"), Has.Count.EqualTo(2));
         }
 
+        /// <summary>
+        /// Verifies registering a watch after a frame advances does not skip existing watches on that frame.
+        /// </summary>
+        [Test]
+        public void Register_AfterFrameAdvance_DoesNotSkipExistingWatchEvaluation()
+        {
+            FakeWatchEditorStateProvider stateProvider = new(10, true, true);
+            WatchExpressionRegistry registry = new(stateProvider);
+            registry.Register("first", "first", new SequenceWatchExpressionEvaluator(1, 2), 20);
+
+            stateProvider.FrameCount = 11;
+            registry.Register("second", "second", new SequenceWatchExpressionEvaluator(3), 20);
+            registry.EvaluateIfFrameChanged();
+
+            Assert.That(registry.GetHistory("first"), Has.Count.EqualTo(2));
+            Assert.That(registry.GetHistory("second"), Has.Count.EqualTo(1));
+        }
+
+        /// <summary>
+        /// Verifies a frame change while not paused does not evaluate watches before a paused evaluation.
+        /// </summary>
         [Test]
         public void EvaluateIfFrameChanged_WhenNotPaused_DoesNotEvaluate()
         {
@@ -60,14 +87,24 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             WatchExpressionRegistry registry = new(stateProvider);
             registry.Register("speed", "speed", evaluator, 20);
 
-            stateProvider.IsPaused = true;
             stateProvider.FrameCount = 11;
-            registry.EvaluateIfFrameChanged();
+            bool evaluatedWhileNotPaused = registry.EvaluateIfFrameChanged();
 
+            Assert.That(evaluatedWhileNotPaused, Is.False);
+            Assert.That(registry.GetHistory("speed"), Has.Count.EqualTo(1));
+            Assert.That(evaluator.EvaluationCount, Is.EqualTo(1));
+
+            stateProvider.IsPaused = true;
+            bool evaluatedAfterPause = registry.EvaluateIfFrameChanged();
+
+            Assert.That(evaluatedAfterPause, Is.True);
             Assert.That(registry.GetHistory("speed"), Has.Count.EqualTo(2));
             Assert.That(evaluator.EvaluationCount, Is.EqualTo(2));
         }
 
+        /// <summary>
+        /// Verifies each watch keeps only its configured history tail and dropped count.
+        /// </summary>
         [Test]
         public void History_WhenLimitIsExceeded_DropsOldestEntry()
         {
@@ -85,6 +122,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(registry.GetHistoryDroppedCount("speed"), Is.EqualTo(1));
         }
 
+        /// <summary>
+        /// Verifies evaluator re-entry does not start a nested registry evaluation.
+        /// </summary>
         [Test]
         public void EvaluateIfFrameChanged_WhenEvaluatorReentersRegistry_DoesNotEvaluateNestedFrame()
         {
@@ -101,6 +141,9 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(registry.GetHistory("speed"), Has.Count.EqualTo(2));
         }
 
+        /// <summary>
+        /// Verifies clearing all watches removes every registered expression.
+        /// </summary>
         [Test]
         public void ClearAll_RemovesAllRegisteredExpressions()
         {
@@ -113,6 +156,30 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(clearedCount, Is.EqualTo(2));
             Assert.That(registry.GetEntries(), Is.Empty);
+        }
+
+        /// <summary>
+        /// Verifies clearing one watch leaves the other watch evaluating on later frames.
+        /// </summary>
+        [Test]
+        public void Clear_RemovesOnlySelectedExpression()
+        {
+            FakeWatchEditorStateProvider stateProvider = new(10, true, true);
+            SequenceWatchExpressionEvaluator firstEvaluator = new(1, 2);
+            SequenceWatchExpressionEvaluator secondEvaluator = new(3, 4);
+            WatchExpressionRegistry registry = new(stateProvider);
+            registry.Register("first", "first", firstEvaluator, 20);
+            registry.Register("second", "second", secondEvaluator, 20);
+
+            bool cleared = registry.Clear("first");
+            stateProvider.FrameCount = 11;
+            bool evaluated = registry.EvaluateIfFrameChanged();
+
+            Assert.That(cleared, Is.True);
+            Assert.That(evaluated, Is.True);
+            Assert.That(registry.GetHistory("first"), Is.Empty);
+            Assert.That(registry.GetHistory("second"), Has.Count.EqualTo(2));
+            Assert.That(secondEvaluator.EvaluationCount, Is.EqualTo(2));
         }
 
         private sealed class FakeWatchEditorStateProvider : IWatchEditorStateProvider
@@ -132,7 +199,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private sealed class SequenceWatchExpressionEvaluator : IWatchExpressionEvaluator
         {
-            private readonly Queue<object> _values;
+        private readonly Queue<object> _values;
             private object _lastValue;
 
             public SequenceWatchExpressionEvaluator(params object[] values)

--- a/Assets/Tests/Editor/WatchExpressionRegistryTests.cs.meta
+++ b/Assets/Tests/Editor/WatchExpressionRegistryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03a8a4ba5c86747bd843d06da897b4f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("UnityCliLoop.Tests.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/AssemblyInfo.cs
+++ b/Packages/src/Editor/FirstPartyTools/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnityCliLoop.Tests.Editor")]

--- a/Packages/src/Editor/FirstPartyTools/AssemblyInfo.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 677d4e62a27ed41d38b8c594190b855c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 176c4bcdaf3fb4a1b848edc027655003
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/CompiledWatchExpressionEvaluator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/CompiledWatchExpressionEvaluator.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Reflection;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Invokes a compiled watch expression and converts user-code failures into history data.
+    /// </summary>
+    internal sealed class CompiledWatchExpressionEvaluator : IWatchExpressionEvaluator
+    {
+        private readonly object _instance;
+        private readonly MethodInfo _evaluateMethod;
+
+        public CompiledWatchExpressionEvaluator(object instance, MethodInfo evaluateMethod)
+        {
+            _instance = instance;
+            _evaluateMethod = evaluateMethod;
+        }
+
+        public WatchEvaluationResult Evaluate()
+        {
+            // Why: only the generated user-code Invoke may throw during normal watch evaluation;
+            // converting that exception keeps the Editor update loop alive and preserves the error in history.
+            try
+            {
+                object value = _evaluateMethod.Invoke(_instance, null);
+                return WatchEvaluationResult.SuccessResult(value);
+            }
+            catch (Exception exception)
+            {
+                Exception userException = exception is TargetInvocationException
+                    && exception.InnerException != null
+                    ? exception.InnerException
+                    : exception;
+                return WatchEvaluationResult.FailureResult(
+                    userException.GetType().FullName ?? userException.GetType().Name,
+                    userException.Message);
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/CompiledWatchExpressionEvaluator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/CompiledWatchExpressionEvaluator.cs
@@ -8,33 +8,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal sealed class CompiledWatchExpressionEvaluator : IWatchExpressionEvaluator
     {
-        private readonly object _instance;
-        private readonly MethodInfo _evaluateMethod;
+        private readonly Func<object> _evaluate;
 
         public CompiledWatchExpressionEvaluator(object instance, MethodInfo evaluateMethod)
         {
-            _instance = instance;
-            _evaluateMethod = evaluateMethod;
+            _evaluate = (Func<object>)evaluateMethod.CreateDelegate(typeof(Func<object>), instance);
         }
 
         public WatchEvaluationResult Evaluate()
         {
-            // Why: only the generated user-code Invoke may throw during normal watch evaluation;
+            // Why: only the generated user-code delegate invocation may throw during normal watch evaluation;
             // converting that exception keeps the Editor update loop alive and preserves the error in history.
             try
             {
-                object value = _evaluateMethod.Invoke(_instance, null);
+                object value = _evaluate();
                 return WatchEvaluationResult.SuccessResult(value);
             }
             catch (Exception exception)
             {
-                Exception userException = exception is TargetInvocationException
-                    && exception.InnerException != null
-                    ? exception.InnerException
-                    : exception;
                 return WatchEvaluationResult.FailureResult(
-                    userException.GetType().FullName ?? userException.GetType().Name,
-                    userException.Message);
+                    exception.GetType().FullName ?? exception.GetType().Name,
+                    exception.Message);
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/Watch/CompiledWatchExpressionEvaluator.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/CompiledWatchExpressionEvaluator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 557de45ec69184c3d9064a487830da48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/IWatchEditorStateProvider.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/IWatchEditorStateProvider.cs
@@ -1,0 +1,13 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Supplies the Editor state required to detect a completed Play Mode Step.
+    /// </summary>
+    public interface IWatchEditorStateProvider
+    {
+        bool IsPlaying { get; }
+        bool IsPaused { get; }
+        int FrameCount { get; }
+        System.DateTime UtcNow { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/IWatchEditorStateProvider.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/IWatchEditorStateProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 118b4ce3ffb6e43d3b510568ec91e54e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/IWatchExpressionEvaluator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/IWatchExpressionEvaluator.cs
@@ -1,0 +1,10 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Evaluates one already-compiled watch expression at the current Editor state.
+    /// </summary>
+    public interface IWatchExpressionEvaluator
+    {
+        WatchEvaluationResult Evaluate();
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/IWatchExpressionEvaluator.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/IWatchExpressionEvaluator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef26be2705c3946d2a12747de1150c3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/UnityWatchEditorStateProvider.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/UnityWatchEditorStateProvider.cs
@@ -1,0 +1,17 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reads the Unity Editor state used by the watch step monitor.
+    /// </summary>
+    public sealed class UnityWatchEditorStateProvider : IWatchEditorStateProvider
+    {
+        public bool IsPlaying => EditorApplication.isPlaying;
+        public bool IsPaused => EditorApplication.isPaused;
+        public int FrameCount => Time.frameCount;
+        public DateTime UtcNow => DateTime.UtcNow;
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/UnityWatchEditorStateProvider.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/UnityWatchEditorStateProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bdd0b6325165b4de1a87ff6dfdb6404a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchCompilationResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchCompilationResult.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reports compilation success or diagnostics for one watch expression.
+    /// </summary>
+    public sealed class WatchCompilationResult
+    {
+        private WatchCompilationResult(
+            bool success,
+            IWatchExpressionEvaluator evaluator,
+            string errorMessage,
+            IReadOnlyList<CompilationError> compilationErrors)
+        {
+            Success = success;
+            Evaluator = evaluator;
+            ErrorMessage = errorMessage;
+            CompilationErrors = compilationErrors;
+        }
+
+        public bool Success { get; }
+        public IWatchExpressionEvaluator Evaluator { get; }
+        public string ErrorMessage { get; }
+        public IReadOnlyList<CompilationError> CompilationErrors { get; }
+
+        public static WatchCompilationResult SuccessResult(IWatchExpressionEvaluator evaluator)
+        {
+            return new WatchCompilationResult(true, evaluator, string.Empty, new List<CompilationError>());
+        }
+
+        public static WatchCompilationResult FailureResult(
+            string errorMessage,
+            IReadOnlyList<CompilationError> compilationErrors)
+        {
+            return new WatchCompilationResult(false, null, errorMessage, compilationErrors);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchCompilationResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchCompilationResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a80a15c5934d4badaa39fbfb15725d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchEvaluationResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchEvaluationResult.cs
@@ -1,0 +1,31 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Carries either a watch expression value or the user-code error that produced it.
+    /// </summary>
+    public sealed class WatchEvaluationResult
+    {
+        private WatchEvaluationResult(bool success, object value, string errorTypeName, string errorMessage)
+        {
+            Success = success;
+            Value = value;
+            ErrorTypeName = errorTypeName;
+            ErrorMessage = errorMessage;
+        }
+
+        public bool Success { get; }
+        public object Value { get; }
+        public string ErrorTypeName { get; }
+        public string ErrorMessage { get; }
+
+        public static WatchEvaluationResult SuccessResult(object value)
+        {
+            return new WatchEvaluationResult(true, value, string.Empty, string.Empty);
+        }
+
+        public static WatchEvaluationResult FailureResult(string errorTypeName, string errorMessage)
+        {
+            return new WatchEvaluationResult(false, null, errorTypeName, errorMessage);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchEvaluationResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchEvaluationResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15618384665094e95814d6145ddfa137
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionCompiler.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Wraps one user expression in a compiled evaluator using the execute-dynamic-code compiler.
+    /// </summary>
+    public sealed class WatchExpressionCompiler
+    {
+        private const string WatchNamespace = "io.github.hatayama.UnityCliLoop.DynamicWatch";
+        private const string WatchClassName = "WatchExpressionEntryPoint";
+        private const string EvaluateMethodName = "Evaluate";
+
+        private readonly IDynamicCompilationService _compilationService;
+
+        public WatchExpressionCompiler(IDynamicCompilationService compilationService)
+        {
+            _compilationService = compilationService ?? throw new ArgumentNullException(nameof(compilationService));
+        }
+
+        public async Task<WatchCompilationResult> CompileAsync(string expression, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(expression))
+            {
+                return WatchCompilationResult.FailureResult(
+                    "Watch expression must not be empty.",
+                    new List<CompilationError>());
+            }
+
+            CompilationResult compilationResult = await _compilationService.CompileAsync(
+                new CompilationRequest
+                {
+                    Code = BuildSource(expression),
+                    ClassName = WatchClassName,
+                    Namespace = WatchNamespace
+                },
+                ct).ConfigureAwait(false);
+
+            if (!compilationResult.Success)
+            {
+                return WatchCompilationResult.FailureResult(
+                    "Watch expression compilation failed.",
+                    compilationResult.Errors);
+            }
+
+            Type evaluatorType = compilationResult.CompiledAssembly.GetType(
+                $"{WatchNamespace}.{WatchClassName}",
+                false);
+            if (evaluatorType == null)
+            {
+                return WatchCompilationResult.FailureResult(
+                    "Compiled watch expression evaluator type was not found.",
+                    new List<CompilationError>());
+            }
+
+            MethodInfo evaluateMethod = evaluatorType.GetMethod(
+                EvaluateMethodName,
+                BindingFlags.Public | BindingFlags.Instance,
+                null,
+                Type.EmptyTypes,
+                null);
+            if (evaluateMethod == null)
+            {
+                return WatchCompilationResult.FailureResult(
+                    "Compiled watch expression evaluator method was not found.",
+                    new List<CompilationError>());
+            }
+
+            object evaluatorInstance = Activator.CreateInstance(evaluatorType);
+            IWatchExpressionEvaluator evaluator = new CompiledWatchExpressionEvaluator(
+                evaluatorInstance,
+                evaluateMethod);
+            return WatchCompilationResult.SuccessResult(evaluator);
+        }
+
+        internal static string BuildSource(string expression)
+        {
+            return $"using System;\n"
+                + "using io.github.hatayama.UnityCliLoop.Runtime;\n"
+                + $"namespace {WatchNamespace}\n"
+                + "{\n"
+                + $"    public sealed class {WatchClassName}\n"
+                + "    {\n"
+                + "        public object Evaluate()\n"
+                + "        {\n"
+                + $"            return (object)({expression});\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionCompiler.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionCompiler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fced3cdc0c2dc4e8c92c38028e858cb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionEntry.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionEntry.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Owns one registered watch expression and its bounded evaluation history.
+    /// </summary>
+    public sealed class WatchExpressionEntry
+    {
+        private readonly Queue<WatchExpressionHistoryEntry> _history = new();
+
+        internal WatchExpressionEntry(
+            string id,
+            string expression,
+            IWatchExpressionEvaluator evaluator,
+            int maxHistory)
+        {
+            Id = id;
+            Expression = expression;
+            Evaluator = evaluator;
+            MaxHistory = maxHistory;
+        }
+
+        public string Id { get; }
+        public string Expression { get; }
+        public int MaxHistory { get; }
+        public int HistoryDroppedCount { get; private set; }
+        internal IWatchExpressionEvaluator Evaluator { get; }
+
+        internal void Append(int frameCount, DateTime evaluatedAtUtc, WatchEvaluationResult result)
+        {
+            if (_history.Count == MaxHistory)
+            {
+                _history.Dequeue();
+                HistoryDroppedCount++;
+            }
+
+            _history.Enqueue(new WatchExpressionHistoryEntry(frameCount, evaluatedAtUtc, result));
+        }
+
+        internal IReadOnlyList<WatchExpressionHistoryEntry> CreateHistorySnapshot()
+        {
+            return new List<WatchExpressionHistoryEntry>(_history);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionEntry.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionEntry.cs
@@ -26,7 +26,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string Expression { get; }
         public int MaxHistory { get; }
         public int HistoryDroppedCount { get; private set; }
+        internal int LastEvaluatedFrameCount { get; private set; } = int.MinValue;
         internal IWatchExpressionEvaluator Evaluator { get; }
+
+        internal void MarkEvaluated(int frameCount)
+        {
+            LastEvaluatedFrameCount = frameCount;
+        }
 
         internal void Append(int frameCount, DateTime evaluatedAtUtc, WatchEvaluationResult result)
         {

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionEntry.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5ef57c494a6247148bcb73b75a925ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionHistoryEntry.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionHistoryEntry.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Represents one frame-indexed watch evaluation retained by the registry.
+    /// </summary>
+    public sealed class WatchExpressionHistoryEntry
+    {
+        public WatchExpressionHistoryEntry(int frameCount, DateTime evaluatedAtUtc, WatchEvaluationResult result)
+        {
+            FrameCount = frameCount;
+            EvaluatedAtUtc = evaluatedAtUtc;
+            Result = result;
+        }
+
+        public int FrameCount { get; }
+        public DateTime EvaluatedAtUtc { get; }
+        public WatchEvaluationResult Result { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionHistoryEntry.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionHistoryEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db2897cbb0c78499ea44ef8f0bb0e539
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionRegistry.cs
@@ -15,7 +15,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly IWatchEditorStateProvider _stateProvider;
         private readonly Dictionary<string, WatchExpressionEntry> _entriesById = new(StringComparer.Ordinal);
         private readonly List<WatchExpressionEntry> _entries = new();
-        private int _lastEvaluatedFrameCount = int.MinValue;
         private bool _isEvaluating;
 
         public WatchExpressionRegistry(IWatchEditorStateProvider stateProvider)
@@ -48,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _entriesById.Add(id, entry);
             _entries.Add(entry);
             int baselineFrameCount = _stateProvider.FrameCount;
-            _lastEvaluatedFrameCount = baselineFrameCount;
+            entry.MarkEvaluated(baselineFrameCount);
             _isEvaluating = true;
             try
             {
@@ -88,18 +87,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             int frameCount = _stateProvider.FrameCount;
-            if (_isEvaluating || frameCount == _lastEvaluatedFrameCount)
+            if (_isEvaluating)
             {
                 return false;
             }
 
-            _lastEvaluatedFrameCount = frameCount;
             _isEvaluating = true;
+            bool evaluatedAny = false;
             try
             {
                 foreach (WatchExpressionEntry entry in _entries)
                 {
+                    if (entry.LastEvaluatedFrameCount == frameCount)
+                    {
+                        continue;
+                    }
+
+                    entry.MarkEvaluated(frameCount);
                     EvaluateEntry(entry, frameCount);
+                    evaluatedAny = true;
                 }
             }
             finally
@@ -107,7 +113,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _isEvaluating = false;
             }
 
-            return true;
+            return evaluatedAny;
         }
 
         public IReadOnlyList<WatchExpressionEntry> GetEntries()

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionRegistry.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionRegistry.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Manages ordered in-memory watch expressions and evaluates them once per paused frame.
+    /// </summary>
+    public sealed class WatchExpressionRegistry
+    {
+        public const int DefaultMaxHistory = 20;
+        public const int MaxHistoryLimit = 100;
+
+        private readonly IWatchEditorStateProvider _stateProvider;
+        private readonly Dictionary<string, WatchExpressionEntry> _entriesById = new(StringComparer.Ordinal);
+        private readonly List<WatchExpressionEntry> _entries = new();
+        private int _lastEvaluatedFrameCount = int.MinValue;
+        private bool _isEvaluating;
+
+        public WatchExpressionRegistry(IWatchEditorStateProvider stateProvider)
+        {
+            _stateProvider = stateProvider ?? throw new ArgumentNullException(nameof(stateProvider));
+        }
+
+        public WatchRegistrationResult Register(
+            string id,
+            string expression,
+            IWatchExpressionEvaluator evaluator,
+            int maxHistory)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(id), "id must not be null or empty");
+            Debug.Assert(!string.IsNullOrWhiteSpace(expression), "expression must not be null or empty");
+            Debug.Assert(evaluator != null, "evaluator must not be null");
+
+            if (_entriesById.ContainsKey(id))
+            {
+                return WatchRegistrationResult.FailureResult($"Watch expression '{id}' is already registered.");
+            }
+
+            if (maxHistory <= 0 || maxHistory > MaxHistoryLimit)
+            {
+                return WatchRegistrationResult.FailureResult(
+                    $"maxHistory must be between 1 and {MaxHistoryLimit}.");
+            }
+
+            WatchExpressionEntry entry = new(id, expression, evaluator, maxHistory);
+            _entriesById.Add(id, entry);
+            _entries.Add(entry);
+            int baselineFrameCount = _stateProvider.FrameCount;
+            _lastEvaluatedFrameCount = baselineFrameCount;
+            _isEvaluating = true;
+            try
+            {
+                EvaluateEntry(entry, baselineFrameCount);
+            }
+            finally
+            {
+                _isEvaluating = false;
+            }
+            return WatchRegistrationResult.SuccessResult();
+        }
+
+        public bool Clear(string id)
+        {
+            if (!_entriesById.Remove(id, out WatchExpressionEntry entry))
+            {
+                return false;
+            }
+
+            _entries.Remove(entry);
+            return true;
+        }
+
+        public int ClearAll()
+        {
+            int clearedCount = _entries.Count;
+            _entriesById.Clear();
+            _entries.Clear();
+            return clearedCount;
+        }
+
+        public bool EvaluateIfFrameChanged()
+        {
+            if (!_stateProvider.IsPlaying || !_stateProvider.IsPaused)
+            {
+                return false;
+            }
+
+            int frameCount = _stateProvider.FrameCount;
+            if (_isEvaluating || frameCount == _lastEvaluatedFrameCount)
+            {
+                return false;
+            }
+
+            _lastEvaluatedFrameCount = frameCount;
+            _isEvaluating = true;
+            try
+            {
+                foreach (WatchExpressionEntry entry in _entries)
+                {
+                    EvaluateEntry(entry, frameCount);
+                }
+            }
+            finally
+            {
+                _isEvaluating = false;
+            }
+
+            return true;
+        }
+
+        public IReadOnlyList<WatchExpressionEntry> GetEntries()
+        {
+            return new List<WatchExpressionEntry>(_entries);
+        }
+
+        public IReadOnlyList<WatchExpressionHistoryEntry> GetHistory(string id)
+        {
+            if (!_entriesById.TryGetValue(id, out WatchExpressionEntry entry))
+            {
+                return Array.Empty<WatchExpressionHistoryEntry>();
+            }
+
+            return entry.CreateHistorySnapshot();
+        }
+
+        public int GetHistoryDroppedCount(string id)
+        {
+            return _entriesById.TryGetValue(id, out WatchExpressionEntry entry)
+                ? entry.HistoryDroppedCount
+                : 0;
+        }
+
+        private void EvaluateEntry(WatchExpressionEntry entry, int frameCount)
+        {
+            WatchEvaluationResult result = entry.Evaluator.Evaluate();
+            entry.Append(frameCount, _stateProvider.UtcNow, result);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionRegistry.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 988618605f260437ab4bc3d39caf2d47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionStepMonitor.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionStepMonitor.cs
@@ -1,0 +1,45 @@
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Bridges Unity Editor update ticks to the watch registry's frame-change evaluator.
+    /// </summary>
+    public sealed class WatchExpressionStepMonitor
+    {
+        private readonly WatchExpressionRegistry _registry;
+        private bool _isStarted;
+
+        public WatchExpressionStepMonitor(WatchExpressionRegistry registry)
+        {
+            _registry = registry;
+        }
+
+        public void Start()
+        {
+            if (_isStarted)
+            {
+                return;
+            }
+
+            EditorApplication.update += OnEditorUpdate;
+            _isStarted = true;
+        }
+
+        public void Stop()
+        {
+            if (!_isStarted)
+            {
+                return;
+            }
+
+            EditorApplication.update -= OnEditorUpdate;
+            _isStarted = false;
+        }
+
+        private void OnEditorUpdate()
+        {
+            _registry.EvaluateIfFrameChanged();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionStepMonitor.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchExpressionStepMonitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34f559671c8004bdaa658e0ef8f86947
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchRegistrationResult.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchRegistrationResult.cs
@@ -1,0 +1,27 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reports whether a watch expression was accepted by the in-memory registry.
+    /// </summary>
+    public sealed class WatchRegistrationResult
+    {
+        private WatchRegistrationResult(bool success, string errorMessage)
+        {
+            Success = success;
+            ErrorMessage = errorMessage;
+        }
+
+        public bool Success { get; }
+        public string ErrorMessage { get; }
+
+        public static WatchRegistrationResult SuccessResult()
+        {
+            return new WatchRegistrationResult(true, string.Empty);
+        }
+
+        public static WatchRegistrationResult FailureResult(string errorMessage)
+        {
+            return new WatchRegistrationResult(false, errorMessage);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchRegistrationResult.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchRegistrationResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f50fed9662d3c4619804a02240e70aee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary\n\n- add an in-memory WatchExpressionRegistry with ordered registration, immediate baseline evaluation, bounded history, and clear operations\n- detect paused Play Mode frame changes through an EditorApplication.update monitor with same-frame suppression and re-entry protection\n- reuse the execute-dynamic-code compiler to wrap expressions and convert only generated evaluator invocation failures into typed Result DTOs\n\n## Validation\n\n- Unity compile: 0 errors, 0 warnings\n- targeted EditMode tests: 9/9 passed\n- compile-only watch expression test covers the shared dynamic compiler without executing user code\n- evaluation failure test confirms exception type and message are retained as an explicit failure result

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

