### PR TITLE
fix: captured variables stay readable after re-enabling a pause point while paused

### DIFF
--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -84,7 +84,7 @@ uloop enable-watch --id "speed" --expression "UloopPausePoint.TryGetCapturedValu
 uloop get-watch-values --id "speed"
 ```
 
-`enable-watch` compiles the C# expression once, evaluates it immediately for a baseline, and then evaluates it once per changed `Time.frameCount` while Unity is both playing and paused. Multiple watches run in registration order. `enable-watch` rejects a duplicate id instead of overwriting; clear with `clear-watch --id <id>` before re-registering a changed expression. `clear-watch --id <id>` removes one watch; `clear-watch --all` removes all watches. `get-watch-values` without `--id` returns every registered watch.
+`enable-watch` compiles the C# expression once, evaluates it immediately for a baseline, and then evaluates it once per changed `Time.frameCount`, but only while Play Mode is running and the Editor is paused (each hit pause and each `Step`); nothing is recorded while the game runs unpaused. Multiple watches run in registration order. `enable-watch` rejects a duplicate id instead of overwriting; clear with `clear-watch --id <id>` before re-registering a changed expression. `clear-watch --id <id>` removes one watch; `clear-watch --all` removes all watches. `get-watch-values` without `--id` returns every registered watch.
 
 The expression may use `UloopPausePoint.TryGetCapturedValue("name")` to inspect the latest raw pause-point capture while paused. Each history entry includes the frame and either a stringified value or an explicit error type and message. A throwing expression is recorded as an error and does not stop the Editor update loop. `--max-history` accepts 1 through 100 and drops the oldest entries after the limit.
 

--- a/.agents/skills/uloop-pause-point/SKILL.md
+++ b/.agents/skills/uloop-pause-point/SKILL.md
@@ -73,7 +73,7 @@ While Unity is paused on a hit, `execute-dynamic-code` can read live captured re
 - `GetCapturedNames()` lists captured variable names from that snapshot.
 - `GetCapturedPausePointId()` returns the pause-point id for the held snapshot.
 
-The holder clears when Unity resumes (not when you `Step` while still paused), when the matching pause point is cleared, when a new hit replaces the snapshot, or when PlayMode exits. After resume, `TryGetCapturedValue` returns `Found=false`.
+The holder clears when Unity resumes (not when you `Step` while still paused), when the matching pause point is cleared, when a new hit replaces the snapshot, or when PlayMode exits. After resume, `TryGetCapturedValue` returns `Found=false`. Re-enabling the same pause point while still paused (for example to refresh its timeout during a step session) keeps the held references, because a re-enable does not resume Unity.
 
 ## Watch Expressions
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -84,7 +84,7 @@ uloop enable-watch --id "speed" --expression "UloopPausePoint.TryGetCapturedValu
 uloop get-watch-values --id "speed"
 ```
 
-`enable-watch` compiles the C# expression once, evaluates it immediately for a baseline, and then evaluates it once per changed `Time.frameCount` while Unity is both playing and paused. Multiple watches run in registration order. `enable-watch` rejects a duplicate id instead of overwriting; clear with `clear-watch --id <id>` before re-registering a changed expression. `clear-watch --id <id>` removes one watch; `clear-watch --all` removes all watches. `get-watch-values` without `--id` returns every registered watch.
+`enable-watch` compiles the C# expression once, evaluates it immediately for a baseline, and then evaluates it once per changed `Time.frameCount`, but only while Play Mode is running and the Editor is paused (each hit pause and each `Step`); nothing is recorded while the game runs unpaused. Multiple watches run in registration order. `enable-watch` rejects a duplicate id instead of overwriting; clear with `clear-watch --id <id>` before re-registering a changed expression. `clear-watch --id <id>` removes one watch; `clear-watch --all` removes all watches. `get-watch-values` without `--id` returns every registered watch.
 
 The expression may use `UloopPausePoint.TryGetCapturedValue("name")` to inspect the latest raw pause-point capture while paused. Each history entry includes the frame and either a stringified value or an explicit error type and message. A throwing expression is recorded as an error and does not stop the Editor update loop. `--max-history` accepts 1 through 100 and drops the oldest entries after the limit.
 

--- a/.claude/skills/uloop-pause-point/SKILL.md
+++ b/.claude/skills/uloop-pause-point/SKILL.md
@@ -73,7 +73,7 @@ While Unity is paused on a hit, `execute-dynamic-code` can read live captured re
 - `GetCapturedNames()` lists captured variable names from that snapshot.
 - `GetCapturedPausePointId()` returns the pause-point id for the held snapshot.
 
-The holder clears when Unity resumes (not when you `Step` while still paused), when the matching pause point is cleared, when a new hit replaces the snapshot, or when PlayMode exits. After resume, `TryGetCapturedValue` returns `Found=false`.
+The holder clears when Unity resumes (not when you `Step` while still paused), when the matching pause point is cleared, when a new hit replaces the snapshot, or when PlayMode exits. After resume, `TryGetCapturedValue` returns `Found=false`. Re-enabling the same pause point while still paused (for example to refresh its timeout during a step session) keeps the held references, because a re-enable does not resume Unity.
 
 ## Watch Expressions
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -598,6 +598,26 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void TryGetCapturedValue_WhenSamePausePointIsReenabledThenCleared_StillClearsRawCapture()
+        {
+            // Verifies Clear(id) after a same-id re-enable still drops the raw capture holder,
+            // even though the re-enable already reset the hit snapshot bookkeeping.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointCapturedVariableFrame frame = new(
+                new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 1) },
+                false);
+            UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, Array.Empty<UloopCapturedVariable>(), false);
+
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointRegistry.Clear("jump");
+
+            (bool found, object value) = UloopPausePoint.TryGetCapturedValue("speed");
+            Assert.That(found, Is.False);
+            Assert.That(value, Is.Null);
+            Assert.That(UloopPausePoint.GetCapturedPausePointId(), Is.Empty);
+        }
+
+        [Test]
         public void Hit_WhenPausePointIsEnabled_ReportsEmptyCapturedVariables()
         {
             // Verifies the plain marker path (no source pause point) reports an empty, non-null list.

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -579,6 +579,25 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void TryGetCapturedValue_WhenSamePausePointIsReenabledWhilePaused_KeepsLatestHitRawCapture()
+        {
+            // Verifies re-enabling the same id while still paused (e.g. to refresh its timeout
+            // during a step session) keeps the held raw capture instead of clearing it.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointCapturedVariableFrame frame = new(
+                new[] { new UloopPausePointCapturedVariableEntry("speed", UloopCapturedVariableScope.Local, 1) },
+                false);
+            UloopPausePointRegistry.HitWithCapturedFrame("jump", frame, Array.Empty<UloopCapturedVariable>(), false);
+
+            UloopPausePointRegistry.Enable("jump", 30);
+
+            (bool found, object value) = UloopPausePoint.TryGetCapturedValue("speed");
+            Assert.That(found, Is.True);
+            Assert.That(value, Is.EqualTo(1));
+            Assert.That(UloopPausePoint.GetCapturedPausePointId(), Is.EqualTo("jump"));
+        }
+
+        [Test]
         public void Hit_WhenPausePointIsEnabled_ReportsEmptyCapturedVariables()
         {
             // Verifies the plain marker path (no source pause point) reports an empty, non-null list.

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -84,7 +84,7 @@ uloop enable-watch --id "speed" --expression "UloopPausePoint.TryGetCapturedValu
 uloop get-watch-values --id "speed"
 ```
 
-`enable-watch` compiles the C# expression once, evaluates it immediately for a baseline, and then evaluates it once per changed `Time.frameCount` while Unity is both playing and paused. Multiple watches run in registration order. `enable-watch` rejects a duplicate id instead of overwriting; clear with `clear-watch --id <id>` before re-registering a changed expression. `clear-watch --id <id>` removes one watch; `clear-watch --all` removes all watches. `get-watch-values` without `--id` returns every registered watch.
+`enable-watch` compiles the C# expression once, evaluates it immediately for a baseline, and then evaluates it once per changed `Time.frameCount`, but only while Play Mode is running and the Editor is paused (each hit pause and each `Step`); nothing is recorded while the game runs unpaused. Multiple watches run in registration order. `enable-watch` rejects a duplicate id instead of overwriting; clear with `clear-watch --id <id>` before re-registering a changed expression. `clear-watch --id <id>` removes one watch; `clear-watch --all` removes all watches. `get-watch-values` without `--id` returns every registered watch.
 
 The expression may use `UloopPausePoint.TryGetCapturedValue("name")` to inspect the latest raw pause-point capture while paused. Each history entry includes the frame and either a stringified value or an explicit error type and message. A throwing expression is recorded as an error and does not stop the Editor update loop. `--max-history` accepts 1 through 100 and drops the oldest entries after the limit.
 

--- a/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
+++ b/Packages/src/Editor/CliOnlyTools~/PausePoint/Skill/SKILL.md
@@ -73,7 +73,7 @@ While Unity is paused on a hit, `execute-dynamic-code` can read live captured re
 - `GetCapturedNames()` lists captured variable names from that snapshot.
 - `GetCapturedPausePointId()` returns the pause-point id for the held snapshot.
 
-The holder clears when Unity resumes (not when you `Step` while still paused), when the matching pause point is cleared, when a new hit replaces the snapshot, or when PlayMode exits. After resume, `TryGetCapturedValue` returns `Found=false`.
+The holder clears when Unity resumes (not when you `Step` while still paused), when the matching pause point is cleared, when a new hit replaces the snapshot, or when PlayMode exits. After resume, `TryGetCapturedValue` returns `Found=false`. Re-enabling the same pause point while still paused (for example to refresh its timeout during a step session) keeps the held references, because a re-enable does not resume Unity.
 
 ## Watch Expressions
 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -53,7 +53,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             int generation = ++_nextGeneration;
             UloopPausePointEntry entry = new(id, timeoutSeconds, mode, maxHistory, now, generation);
             Entries[id] = entry;
-            ClearLatestHitSnapshotIfMatches(id);
+            // Why not clear the raw capture holder here: a re-enable does not resume Unity, so the
+            // paused-window constraint (see UloopPausePointRawCaptureHolder's class comment) is not
+            // violated by keeping the previous hit's live references across a same-id re-enable.
+            ForgetHitSnapshotForId(id);
             return entry.ToSnapshot(now, _pauseController);
         }
 
@@ -86,7 +89,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 _ => "Pause point cleared."
             };
             entry.MarkCleared(UloopPausePointClearedReason.ExplicitClear, message);
-            ClearLatestHitSnapshotIfMatches(id);
+            ClearHitSnapshotAndRawCaptureForId(id);
             return entry.ToSnapshot(now, _pauseController);
         }
 
@@ -244,21 +247,28 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             UloopPausePointRawCaptureHolder.Clear();
         }
 
-        private static void ClearLatestHitSnapshotIfMatches(string id)
+        // Drops the id's own hit-history entry and, if it currently owns the latest hit, that
+        // pointer too - but never touches the raw capture holder. Enable() uses this so a same-id
+        // re-enable while paused only resets the entry's generation bookkeeping.
+        private static void ForgetHitSnapshotForId(string id)
         {
             _hitSnapshots.RemoveAll(hitSnapshot => hitSnapshot.Id == id);
-            if (_latestHitSnapshot == null)
+            if (_latestHitSnapshot != null && _latestHitSnapshot.Id == id)
             {
-                return;
+                _latestHitSnapshot = null;
             }
+        }
 
-            if (_latestHitSnapshot.Id != id)
+        // Same as ForgetHitSnapshotForId, plus clears the raw capture holder when the id owned the
+        // latest hit. Clear(id) uses this because an explicit clear is documented to drop captures.
+        private static void ClearHitSnapshotAndRawCaptureForId(string id)
+        {
+            bool ownedLatestHit = _latestHitSnapshot != null && _latestHitSnapshot.Id == id;
+            ForgetHitSnapshotForId(id);
+            if (ownedLatestHit)
             {
-                return;
+                UloopPausePointRawCaptureHolder.Clear();
             }
-
-            _latestHitSnapshot = null;
-            UloopPausePointRawCaptureHolder.Clear();
         }
 
         public static void ConfigureForTests(IUloopPausePointPauseController pauseController, Func<DateTime> nowProvider)

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -259,13 +259,16 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
         }
 
-        // Same as ForgetHitSnapshotForId, plus clears the raw capture holder when the id owned the
-        // latest hit. Clear(id) uses this because an explicit clear is documented to drop captures.
+        // Same as ForgetHitSnapshotForId, plus clears the raw capture holder when the holder's
+        // captured snapshot belongs to the cleared id. Clear(id) uses this because an explicit
+        // clear is documented to drop captures. Ownership is checked against the holder itself
+        // (not _latestHitSnapshot) because Enable()'s ForgetHitSnapshotForId already nulls out
+        // _latestHitSnapshot on a same-id re-enable, which would otherwise make a later Clear(id)
+        // think it no longer owns a holder it actually still does.
         private static void ClearHitSnapshotAndRawCaptureForId(string id)
         {
-            bool ownedLatestHit = _latestHitSnapshot != null && _latestHitSnapshot.Id == id;
             ForgetHitSnapshotForId(id);
-            if (ownedLatestHit)
+            if (UloopPausePointRawCaptureHolder.GetCapturedPausePointId() == id)
             {
                 UloopPausePointRawCaptureHolder.Clear();
             }


### PR DESCRIPTION
## Summary
- Re-enabling a pause point while Unity stays paused (for example to refresh its timeout during a Step session) no longer breaks `UloopPausePoint.TryGetCapturedValue`; the captured variables of the current hit stay readable.
- Docs: clarified that watch expressions evaluate only while Play Mode is running AND the Editor is paused, so the wording can no longer be read as "also evaluates while the game runs unpaused."

## User Impact
- Before: after a hit, running `enable-pause-point` again on the same id (a natural move in a long `control-play-mode --action Step` session, because the enable-time timeout does not extend after hits) silently cleared the raw capture holder. `TryGetCapturedValue` returned `Found=false` and watch expressions built on it recorded `null` from that point on. This was reported from real usage as a suspected Step bug.
- After: the held captures survive a same-id re-enable, matching the documented lifetime (the holder clears on resume, explicit clear, a replacing hit, or PlayMode exit — a re-enable does not resume Unity, so the paused-window invariant still holds).

## Changes
- Split the registry helper shared by `Enable` and `Clear`: `Enable` now only resets the hit bookkeeping (`ForgetHitSnapshotForId`), while `Clear` keeps dropping the raw capture holder (`ClearHitSnapshotAndRawCaptureForId`). `ClearAll`, the simulate-* snapshot reset, and the resume/PlayMode-exit lifecycle are unchanged.
- Added a regression test: hit with a captured frame, re-enable the same id, assert the captured value is still retrievable.
- Pause-point skill doc (source + two generated copies, byte-identical): documented the re-enable behavior and reworded the watch-expression evaluation timing (docs-only second commit).

## Verification
- TDD: the new test failed (`found=false`) before the fix and passes after.
- `uloop compile`: 0 errors / 0 warnings.
- EditMode `PausePointTests`: 48/48 green, including existing clear/replace/resume regressions.
- E2E on a live Unity 6000.3.15f1 project: hit → `Found=true` → same-id re-enable → still `Found=true` → `Step` ×5 → still `Found=true`; resume still clears the holder.
- No IPC wire-format change; protocol version intentionally untouched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

