### PR TITLE
fix: package compiles again on Unity 6000.4 and newer

### DIFF
--- a/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
+++ b/Packages/src/Editor/Utils/RaycastGridAnnotator.cs
@@ -373,7 +373,12 @@ namespace io.github.hatayama.uLoopMCP
             Debug.Assert(collider != null, "Collider is required for raycast clustering.");
 
             // A placement area can use several colliders on one object; one annotation should describe the clickable object.
+#if UNITY_6000_4_OR_NEWER
+            // GetInstanceID is obsolete-as-error on Unity 6000.4+; the lower 32 bits of EntityId equal the legacy instance id.
+            return (int)EntityId.ToULong(collider!.gameObject.GetEntityId());
+#else
             return collider!.gameObject.GetInstanceID();
+#endif
         }
 
         private static RaycastClusterSample CreateClusterSample(


### PR DESCRIPTION
## Summary
- Installing the package on Unity 6000.4+ no longer fails with a CS0619 compile error.

## User Impact
- Before: on Unity 6000.4+ (e.g. 6000.5.3f1), the package failed to compile with `error CS0619: 'Object.GetInstanceID()' is obsolete` at `RaycastGridAnnotator.cs:376`, so git-URL installs from main were broken.
- After: the package compiles cleanly on Unity 6000.4+ while keeping identical behavior on older Unity versions.

## Changes
- Apply the same `UNITY_6000_4_OR_NEWER` guard used by the #1118 fix to the one call site it missed. On 6000.4+ the cluster key is derived from the lower 32 bits of `EntityId`, which equal the legacy instance id (this is exactly how Unity's own `GetInstanceID()` compatibility shim is implemented), so clustering semantics are unchanged.

## Verification
- Red: batch-compiled a scratch project referencing this package on Unity 6000.5.0f1 **without** the fix → reproduced the exact CS0619 at `RaycastGridAnnotator.cs:376`.
- Green: same batch compile **with** the fix on Unity 6000.5.0f1 → 0 errors.
- Boundary/legacy: batch compile on Unity 6000.4.3f1 and 2022.3.62f3 → 0 errors on both.

Fixes #1732

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated `RaycastGridAnnotator` for Unity 6000.4+ compatibility by deriving cluster keys from the lower 32 bits of `EntityId`. Older Unity versions continue using `GetInstanceID()`.

## Verification

- Unity 6000.5.0f1: compilation errors resolved
- Unity 6000.4.3f1: zero errors
- Unity 2022.3.62f3: zero errors

Fixes `#1732`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->