### PR TITLE
fix: run-tests now times out hung Test Runner waits instead of holding the tool slot for 30 minutes

### DIFF
--- a/.agents/skills/uloop-run-tests/SKILL.md
+++ b/.agents/skills/uloop-run-tests/SKILL.md
@@ -30,6 +30,7 @@ uloop run-tests [options]
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
+| `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 
 ## Output
 

--- a/.claude/skills/uloop-run-tests/SKILL.md
+++ b/.claude/skills/uloop-run-tests/SKILL.md
@@ -30,6 +30,7 @@ uloop run-tests [options]
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
+| `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 
 ## Output
 

--- a/Assets/Tests/Editor/RunTestsUseCaseTests.cs
+++ b/Assets/Tests/Editor/RunTestsUseCaseTests.cs
@@ -49,6 +49,58 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public async Task ExecuteAsync_WithNonPositiveTimeoutSeconds_ShouldFailFastWithoutRunningTests()
+        {
+            // Verifies invalid TimeoutSeconds is rejected before validation or Test Runner work.
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait
+            );
+            RunTestsSchema parameters = new()
+            {
+                TimeoutSeconds = 0
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.ExecutionFailed));
+            Assert.That(response.Message, Does.Contain("greater than zero"));
+            Assert.That(executionService.WasCalled, Is.False);
+            Assert.That(validationService.WasCalled, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WithTimeoutSecondsAboveMax_ShouldFailFastWithoutRunningTests()
+        {
+            // Verifies TimeoutSeconds above MaxTimeoutSeconds fail before arming CancelAfter.
+            StubTestExecutionService executionService = new();
+            StubTestExecutionStateValidationService validationService = new(ValidationResult.Success());
+            RunTestsUseCase useCase = new(
+                new TestFilterCreationService(),
+                executionService,
+                validationService,
+                waitForTestRunnerCleanupAsync: NoCleanupWait
+            );
+            RunTestsSchema parameters = new()
+            {
+                TimeoutSeconds = RunTestsExecutionTimeout.MaxTimeoutSeconds + 1
+            };
+
+            RunTestsResponse response = await useCase.ExecuteAsync(parameters, CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.Status, Is.EqualTo(RunTestsExecutionStatus.ExecutionFailed));
+            Assert.That(response.Message, Does.Contain(RunTestsExecutionTimeout.MaxTimeoutSeconds.ToString()));
+            Assert.That(executionService.WasCalled, Is.False);
+            Assert.That(validationService.WasCalled, Is.False);
+        }
+
+        [Test]
         public async Task ExecuteAsync_WithUnknownTestMode_ShouldFailFastWithoutRunningTests()
         {
             // Verifies unknown enum values do not bypass the EditMode play-state guard.

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs
@@ -27,27 +27,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// Validates TimeoutSeconds before creating a CancelAfter source.
         /// </summary>
-        public static bool TryValidate(int timeoutSeconds, out string errorMessage)
+        public static (bool IsValid, string ErrorMessage) Validate(int timeoutSeconds)
         {
             if (timeoutSeconds <= 0)
             {
-                errorMessage =
+                return (
+                    false,
                     "TimeoutSeconds must be greater than zero. " +
-                    "Pass --timeout-seconds with a positive integer.";
-                return false;
+                    "Pass --timeout-seconds with a positive integer.");
             }
 
             if (timeoutSeconds > MaxTimeoutSeconds)
             {
-                errorMessage =
+                return (
+                    false,
                     $"TimeoutSeconds must be less than or equal to {MaxTimeoutSeconds} " +
                     $"(CLI absolute response limit is 30 minutes). " +
-                    $"Received: {timeoutSeconds}.";
-                return false;
+                    $"Received: {timeoutSeconds}.");
             }
 
-            errorMessage = null;
-            return true;
+            return (true, null);
         }
 
         /// <summary>
@@ -59,7 +58,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(
                 timeoutSeconds > 0 && timeoutSeconds <= MaxTimeoutSeconds,
-                "timeoutSeconds must be validated with TryValidate before CreateLinkedTimeoutSource");
+                "timeoutSeconds must be validated with Validate before CreateLinkedTimeoutSource");
 
             CancellationTokenSource linkedCancellationTokenSource =
                 CancellationTokenSource.CreateLinkedTokenSource(parentCancellationToken);
@@ -89,6 +88,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public static bool IsTimeoutCancellation(CancellationToken parentCancellationToken)
         {
+            // Why parent-only check is enough today: the linked source has exactly two cancel
+            // causes (CancelAfter and parent/disconnect). If another linked cancel source is
+            // added later, also require timeoutCancellationTokenSource.IsCancellationRequested.
             return !parentCancellationToken.IsCancellationRequested;
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Bounds run-tests execution with a linked CancelAfter timeout so a missing
+    /// RunFinished callback cannot hold the single-flight tool slot until the CLI
+    /// absolute response limit.
+    /// </summary>
+    internal static class RunTestsExecutionTimeout
+    {
+        /// <summary>
+        /// Default budget for hung Test Runner detection. Chosen to free the slot well
+        /// before the CLI 30-minute absolute response timeout while leaving headroom
+        /// for normal agent-driven suites (seconds to a few minutes).
+        /// </summary>
+        public const int DefaultTimeoutSeconds = 600;
+
+        /// <summary>
+        /// Upper bound kept below the CLI finalResponseTimeout (30 minutes) so the C#
+        /// CancelAfter always fires first when a caller asks for a long wait.
+        /// </summary>
+        public const int MaxTimeoutSeconds = 1500;
+
+        /// <summary>
+        /// Validates TimeoutSeconds before creating a CancelAfter source.
+        /// </summary>
+        public static bool TryValidate(int timeoutSeconds, out string errorMessage)
+        {
+            if (timeoutSeconds <= 0)
+            {
+                errorMessage =
+                    "TimeoutSeconds must be greater than zero. " +
+                    "Pass --timeout-seconds with a positive integer.";
+                return false;
+            }
+
+            if (timeoutSeconds > MaxTimeoutSeconds)
+            {
+                errorMessage =
+                    $"TimeoutSeconds must be less than or equal to {MaxTimeoutSeconds} " +
+                    $"(CLI absolute response limit is 30 minutes). " +
+                    $"Received: {timeoutSeconds}.";
+                return false;
+            }
+
+            errorMessage = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Creates a linked token source that cancels after timeoutSeconds.
+        /// </summary>
+        public static CancellationTokenSource CreateLinkedTimeoutSource(
+            CancellationToken parentCancellationToken,
+            int timeoutSeconds)
+        {
+            Debug.Assert(
+                timeoutSeconds > 0 && timeoutSeconds <= MaxTimeoutSeconds,
+                "timeoutSeconds must be validated with TryValidate before CreateLinkedTimeoutSource");
+
+            CancellationTokenSource linkedCancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(parentCancellationToken);
+            // Why CancelAfter here: frees the single-flight slot when RunFinished never fires.
+            // PR 1-1 only completes the await via cancellation; TestRunnerApi may keep running
+            // until PR 1-2 routes this same cancel path through an explicit stop + PlayMode restore.
+            linkedCancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+            return linkedCancellationTokenSource;
+        }
+
+        /// <summary>
+        /// Builds the agent-facing message for a CancelAfter timeout.
+        /// </summary>
+        public static string CreateTimeoutMessage(int timeoutSeconds)
+        {
+            Debug.Assert(timeoutSeconds > 0, "timeoutSeconds must be greater than zero");
+
+            return
+                $"run-tests timed out after {timeoutSeconds} seconds without a RunFinished callback. " +
+                "The Unity Test Runner may still be running in the background. " +
+                "Increase --timeout-seconds for long suites, or restart with `uloop launch -r` if Unity is stuck.";
+        }
+
+        /// <summary>
+        /// True when cancellation came from CancelAfter (or another linked child) rather
+        /// than the parent request/disconnect token.
+        /// </summary>
+        public static bool IsTimeoutCancellation(CancellationToken parentCancellationToken)
+        {
+            return !parentCancellationToken.IsCancellationRequested;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec4d1f084af74468c80eab93d0494817
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsSchema.cs
@@ -27,5 +27,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string FilterValue { get; set; } = "";
         public bool SaveBeforeRun { get; set; } = true;
 
+        /// <summary>
+        /// Maximum seconds to wait for Unity Test Runner RunFinished before canceling the await.
+        /// Kept below the CLI absolute response timeout so hung runs free the single-flight slot first.
+        /// </summary>
+        public int TimeoutSeconds { get; set; } = RunTestsExecutionTimeout.DefaultTimeoutSeconds;
     }
 } 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -73,6 +73,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return RunTestsResponse.CreateTestFrameworkUnavailable();
             }
 
+            if (!RunTestsExecutionTimeout.TryValidate(parameters.TimeoutSeconds, out string timeoutError))
+            {
+                return CreateFailureResponse(timeoutError);
+            }
+
             ValidationResult validation = _validationService.Validate(parameters.TestMode, parameters.SaveBeforeRun);
             if (!validation.IsValid)
             {
@@ -100,17 +105,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // pause source is a human manually pausing via the Editor UI, which is native
             // Unity behavior and out of scope.
             ct.ThrowIfCancellationRequested();
+            using CancellationTokenSource timeoutCancellationTokenSource =
+                RunTestsExecutionTimeout.CreateLinkedTimeoutSource(ct, parameters.TimeoutSeconds);
+            CancellationToken executionCt = timeoutCancellationTokenSource.Token;
             SerializableTestResult result;
-            if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)
+            try
             {
-                result = await _executionService.ExecutePlayModeTestAsync(filter, ct);
-            }
-            else
-            {
-                result = await _executionService.ExecuteEditModeTestAsync(filter, ct);
-            }
+                if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)
+                {
+                    result = await _executionService.ExecutePlayModeTestAsync(filter, executionCt);
+                }
+                else
+                {
+                    result = await _executionService.ExecuteEditModeTestAsync(filter, executionCt);
+                }
 
-            await _waitForTestRunnerCleanupAsync(ct);
+                await _waitForTestRunnerCleanupAsync(executionCt);
+            }
+            catch (OperationCanceledException) when (RunTestsExecutionTimeout.IsTimeoutCancellation(ct))
+            {
+                // Why return a tool failure instead of rethrowing: agents need an actionable
+                // timeout message (extend --timeout-seconds / launch -r). Parent/disconnect
+                // cancellation still propagates so the IPC session can tear down normally.
+                // Why not stop TestRunnerApi here yet: PR 1-2 will route this same cancel path
+                // through explicit runner stop + PlayMode restore; until then the runner may
+                // keep running in the background after the await is released.
+                return CreateFailureResponse(
+                    RunTestsExecutionTimeout.CreateTimeoutMessage(parameters.TimeoutSeconds));
+            }
 
             // 3. Response creation.
             RunTestsResponse response = new(

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -73,7 +73,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return RunTestsResponse.CreateTestFrameworkUnavailable();
             }
 
-            if (!RunTestsExecutionTimeout.TryValidate(parameters.TimeoutSeconds, out string timeoutError))
+            (bool isTimeoutValid, string timeoutError) = RunTestsExecutionTimeout.Validate(parameters.TimeoutSeconds);
+            if (!isTimeoutValid)
             {
                 return CreateFailureResponse(timeoutError);
             }
@@ -120,7 +121,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     result = await _executionService.ExecuteEditModeTestAsync(filter, executionCt);
                 }
 
-                await _waitForTestRunnerCleanupAsync(executionCt);
+                // Why parent ct (not executionCt): CancelAfter only guards the RunFinished wait.
+                // Using the linked token here would mis-report a successful run as timed out when
+                // the fixed cleanup delay straddles the deadline after RunFinished already arrived.
+                await _waitForTestRunnerCleanupAsync(ct);
             }
             catch (OperationCanceledException) when (RunTestsExecutionTimeout.IsTimeoutCancellation(ct))
             {

--- a/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/Skill/SKILL.md
@@ -30,6 +30,7 @@ uloop run-tests [options]
 | `--filter-type` | string | `all` | Filter type: `all`, `exact`, `regex`, `assembly` |
 | `--filter-value` | string | - | Filter value (test name, pattern, or assembly) |
 | `--fail-on-unsaved-changes` | flag | - | Fail before test execution if unsaved editor changes remain instead of auto-saving them |
+| `--timeout-seconds` | integer | `600` | Maximum seconds to wait for RunFinished before canceling the await (max `1500`). Increase for long suites; on timeout the Test Runner may still be running until stop handling lands |
 
 ## Output
 

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -99,6 +99,11 @@
             "type": "boolean",
             "description": "Save unsaved loaded Scene changes and current Prefab Stage changes before running tests",
             "default": true
+          },
+          "TimeoutSeconds": {
+            "type": "integer",
+            "description": "Maximum seconds to wait for Unity Test Runner RunFinished before canceling the await and freeing the tool slot",
+            "default": 600
           }
         }
       }

--- a/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeout.UnitTests.csproj
+++ b/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeout.UnitTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs" Link="Production/RunTestsExecutionTimeout.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeoutTests.cs
+++ b/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeoutTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.UnitTests
+{
+    /// <summary>
+    /// Pure unit coverage for run-tests CancelAfter timeout helpers.
+    /// </summary>
+    [TestFixture]
+    public class RunTestsExecutionTimeoutTests
+    {
+        [Test]
+        public void TryValidate_WhenTimeoutSecondsIsZero_ShouldReject()
+        {
+            // Verifies non-positive TimeoutSeconds fail before CancelAfter is armed.
+            bool isValid = RunTestsExecutionTimeout.TryValidate(0, out string errorMessage);
+
+            Assert.That(isValid, Is.False);
+            Assert.That(errorMessage, Does.Contain("greater than zero"));
+            Assert.That(errorMessage, Does.Contain("--timeout-seconds"));
+        }
+
+        [Test]
+        public void TryValidate_WhenTimeoutSecondsExceedsMax_ShouldReject()
+        {
+            // Verifies values above MaxTimeoutSeconds are rejected so C# CancelAfter stays ahead of the CLI 30-minute absolute limit.
+            int tooLarge = RunTestsExecutionTimeout.MaxTimeoutSeconds + 1;
+
+            bool isValid = RunTestsExecutionTimeout.TryValidate(tooLarge, out string errorMessage);
+
+            Assert.That(isValid, Is.False);
+            Assert.That(errorMessage, Does.Contain(RunTestsExecutionTimeout.MaxTimeoutSeconds.ToString()));
+            Assert.That(errorMessage, Does.Contain(tooLarge.ToString()));
+        }
+
+        [Test]
+        public void TryValidate_WhenTimeoutSecondsIsDefault_ShouldAccept()
+        {
+            // Verifies the agreed default (600s) is inside the allowed range.
+            bool isValid = RunTestsExecutionTimeout.TryValidate(
+                RunTestsExecutionTimeout.DefaultTimeoutSeconds,
+                out string errorMessage);
+
+            Assert.That(isValid, Is.True);
+            Assert.That(errorMessage, Is.Null);
+        }
+
+        [Test]
+        public void TryValidate_WhenTimeoutSecondsIsMax_ShouldAccept()
+        {
+            // Verifies the inclusive upper bound remains usable for long suites.
+            bool isValid = RunTestsExecutionTimeout.TryValidate(
+                RunTestsExecutionTimeout.MaxTimeoutSeconds,
+                out string errorMessage);
+
+            Assert.That(isValid, Is.True);
+            Assert.That(errorMessage, Is.Null);
+        }
+
+        [Test]
+        public void CreateTimeoutMessage_ShouldGuideCallerToExtendTimeoutAndWarnAboutBackgroundRunner()
+        {
+            // Verifies timeout copy tells agents how to extend the budget and that Test Runner may still be running.
+            string message = RunTestsExecutionTimeout.CreateTimeoutMessage(600);
+
+            Assert.That(message, Does.Contain("600"));
+            Assert.That(message, Does.Contain("--timeout-seconds"));
+            Assert.That(message, Does.Contain("background"));
+            Assert.That(message, Does.Contain("uloop launch -r"));
+        }
+
+        [Test]
+        public void IsTimeoutCancellation_WhenParentIsNotCanceled_ShouldReturnTrue()
+        {
+            // Verifies CancelAfter-driven cancellation is distinguished from parent/disconnect cancellation.
+            using CancellationTokenSource parent = new();
+
+            Assert.That(RunTestsExecutionTimeout.IsTimeoutCancellation(parent.Token), Is.True);
+        }
+
+        [Test]
+        public void IsTimeoutCancellation_WhenParentIsCanceled_ShouldReturnFalse()
+        {
+            // Verifies parent/disconnect cancellation is not reported as a run-tests timeout.
+            using CancellationTokenSource parent = new();
+            parent.Cancel();
+
+            Assert.That(RunTestsExecutionTimeout.IsTimeoutCancellation(parent.Token), Is.False);
+        }
+
+        [Test]
+        public async Task CreateLinkedTimeoutSource_WhenTimeoutElapses_ShouldCancelWithoutCancelingParent()
+        {
+            // Verifies CancelAfter fires on the linked source while leaving the parent token usable.
+            using CancellationTokenSource parent = new();
+            using CancellationTokenSource linked = RunTestsExecutionTimeout.CreateLinkedTimeoutSource(
+                parent.Token,
+                timeoutSeconds: 1);
+
+            TaskCompletionSource<bool> canceled =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using CancellationTokenRegistration registration = linked.Token.Register(() => canceled.TrySetResult(true));
+
+            bool observed = await canceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(observed, Is.True);
+            Assert.That(linked.IsCancellationRequested, Is.True);
+            Assert.That(parent.IsCancellationRequested, Is.False);
+            Assert.That(RunTestsExecutionTimeout.IsTimeoutCancellation(parent.Token), Is.True);
+        }
+
+        [Test]
+        public void CreateLinkedTimeoutSource_WhenParentCancels_ShouldCancelLinkedSource()
+        {
+            // Verifies parent cancellation still propagates through the linked timeout source.
+            using CancellationTokenSource parent = new();
+            using CancellationTokenSource linked = RunTestsExecutionTimeout.CreateLinkedTimeoutSource(
+                parent.Token,
+                timeoutSeconds: RunTestsExecutionTimeout.DefaultTimeoutSeconds);
+
+            parent.Cancel();
+
+            Assert.That(linked.IsCancellationRequested, Is.True);
+            Assert.That(RunTestsExecutionTimeout.IsTimeoutCancellation(parent.Token), Is.False);
+        }
+    }
+}

--- a/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeoutTests.cs
+++ b/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeoutTests.cs
@@ -13,10 +13,10 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
     public class RunTestsExecutionTimeoutTests
     {
         [Test]
-        public void TryValidate_WhenTimeoutSecondsIsZero_ShouldReject()
+        public void Validate_WhenTimeoutSecondsIsZero_ShouldReject()
         {
             // Verifies non-positive TimeoutSeconds fail before CancelAfter is armed.
-            bool isValid = RunTestsExecutionTimeout.TryValidate(0, out string errorMessage);
+            (bool isValid, string errorMessage) = RunTestsExecutionTimeout.Validate(0);
 
             Assert.That(isValid, Is.False);
             Assert.That(errorMessage, Does.Contain("greater than zero"));
@@ -24,12 +24,12 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
         }
 
         [Test]
-        public void TryValidate_WhenTimeoutSecondsExceedsMax_ShouldReject()
+        public void Validate_WhenTimeoutSecondsExceedsMax_ShouldReject()
         {
             // Verifies values above MaxTimeoutSeconds are rejected so C# CancelAfter stays ahead of the CLI 30-minute absolute limit.
             int tooLarge = RunTestsExecutionTimeout.MaxTimeoutSeconds + 1;
 
-            bool isValid = RunTestsExecutionTimeout.TryValidate(tooLarge, out string errorMessage);
+            (bool isValid, string errorMessage) = RunTestsExecutionTimeout.Validate(tooLarge);
 
             Assert.That(isValid, Is.False);
             Assert.That(errorMessage, Does.Contain(RunTestsExecutionTimeout.MaxTimeoutSeconds.ToString()));
@@ -37,24 +37,22 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
         }
 
         [Test]
-        public void TryValidate_WhenTimeoutSecondsIsDefault_ShouldAccept()
+        public void Validate_WhenTimeoutSecondsIsDefault_ShouldAccept()
         {
             // Verifies the agreed default (600s) is inside the allowed range.
-            bool isValid = RunTestsExecutionTimeout.TryValidate(
-                RunTestsExecutionTimeout.DefaultTimeoutSeconds,
-                out string errorMessage);
+            (bool isValid, string errorMessage) = RunTestsExecutionTimeout.Validate(
+                RunTestsExecutionTimeout.DefaultTimeoutSeconds);
 
             Assert.That(isValid, Is.True);
             Assert.That(errorMessage, Is.Null);
         }
 
         [Test]
-        public void TryValidate_WhenTimeoutSecondsIsMax_ShouldAccept()
+        public void Validate_WhenTimeoutSecondsIsMax_ShouldAccept()
         {
             // Verifies the inclusive upper bound remains usable for long suites.
-            bool isValid = RunTestsExecutionTimeout.TryValidate(
-                RunTestsExecutionTimeout.MaxTimeoutSeconds,
-                out string errorMessage);
+            (bool isValid, string errorMessage) = RunTestsExecutionTimeout.Validate(
+                RunTestsExecutionTimeout.MaxTimeoutSeconds);
 
             Assert.That(isValid, Is.True);
             Assert.That(errorMessage, Is.Null);


### PR DESCRIPTION
Refs: docs/spec hang survey section 2 / PR 1-1

## Summary
- `uloop run-tests` now cancels the await after a bounded timeout (default 600s, max 1500s) when Unity Test Runner never fires `RunFinished`
- Agents get an actionable failure message that explains how to raise `--timeout-seconds` and that the Test Runner may still be running until stop handling lands

## User Impact
- Before: a hung/frozen test run could keep the single-flight tool slot busy until the CLI absolute 30-minute response limit
- After: the command returns much sooner with guidance to extend `--timeout-seconds` or restart Unity

## Changes
- Add `TimeoutSeconds` to the run-tests C# schema and `default-tools.json` (additive; no protocolVersion bump)
- Link request cancellation with `CancelAfter` in the run-tests use case
- Document that PR 1-2 will replace the interim cancel-only path with explicit TestRunnerApi stop + PlayMode restore
- Pure C# unit tests for validation/CancelAfter; EditMode coverage only for fail-fast validation

## Verification
- `dotnet test tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeout.UnitTests.csproj`
- `dist/darwin-arm64/uloop compile --project-path <UNITY_PROJECT_ROOT>`
- `dist/darwin-arm64/uloop run-tests --test-mode EditMode --filter-type regex --filter-value "RunTestsUseCaseTests|DefaultToolsCatalogDriftTests"`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

