### PR TITLE
fix: run-tests cancel now exits Play Mode before re-enabling domain reload

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Injectable side effects for cancel-time Test Runner stop and PlayMode restore.
+    /// </summary>
+    internal sealed class RunTestsCancelStopRestoreHooks
+    {
+        /// <summary>
+        /// Attempts to cancel an in-flight Test Runner job. Returns false when unavailable.
+        /// </summary>
+        public Func<string, bool> TryCancelTestRun { get; set; }
+
+        /// <summary>
+        /// True when a Test Runner job is still active. Optional; null skips EditMode run polling.
+        /// </summary>
+        public Func<bool> IsRunActive { get; set; }
+
+        /// <summary>
+        /// True while the Editor is in Play Mode.
+        /// </summary>
+        public Func<bool> IsPlaying { get; set; }
+
+        /// <summary>
+        /// Requests Play Mode exit. Must be idempotent.
+        /// </summary>
+        public Action RequestExitPlayMode { get; set; }
+
+        /// <summary>
+        /// Wall-clock delay used for upper-bounded polling. Callers must pass CancellationToken.None.
+        /// </summary>
+        public Func<int, CancellationToken, Task> DelayAsync { get; set; }
+
+        /// <summary>
+        /// Warning logger for soft failures inside the no-throw stop path.
+        /// </summary>
+        public Action<string> LogWarning { get; set; }
+    }
+
+    /// <summary>
+    /// Outcome of cancel-time stop/restore. Used to extend agent-facing timeout messages.
+    /// </summary>
+    internal readonly struct RunTestsCancelStopRestoreResult
+    {
+        public RunTestsCancelStopRestoreResult(
+            bool testRunCancelAttempted,
+            bool testRunCancelSucceeded,
+            bool playModeExitRequested,
+            bool playModeExitConfirmed,
+            bool stopWaitTimedOut,
+            string degradationNote)
+        {
+            TestRunCancelAttempted = testRunCancelAttempted;
+            TestRunCancelSucceeded = testRunCancelSucceeded;
+            PlayModeExitRequested = playModeExitRequested;
+            PlayModeExitConfirmed = playModeExitConfirmed;
+            StopWaitTimedOut = stopWaitTimedOut;
+            DegradationNote = degradationNote ?? string.Empty;
+        }
+
+        public bool TestRunCancelAttempted { get; }
+        public bool TestRunCancelSucceeded { get; }
+        public bool PlayModeExitRequested { get; }
+        public bool PlayModeExitConfirmed { get; }
+        public bool StopWaitTimedOut { get; }
+        public string DegradationNote { get; }
+    }
+
+    /// <summary>
+    /// Stops Test Runner work and restores Editor Play Mode after run-tests cancellation.
+    /// </summary>
+    internal static class RunTestsCancelStopRestore
+    {
+        public const int DefaultStopWaitTimeoutMilliseconds = 10000;
+        public const int DefaultPollIntervalMilliseconds = 100;
+
+        /// <summary>
+        /// Performs stop/restore without observing the already-canceled execution token.
+        /// Why CancellationToken.None: executionCt is already canceled when this runs; waiting on
+        /// it would throw immediately and skip PlayMode restore / scope lifetime guarantees.
+        /// Why never throw: callers invoke this from cancel catch paths; throwing would hide the
+        /// original OperationCanceledException and leave DomainReloadDisableScope dispose timing undefined.
+        /// </summary>
+        public static async Task<RunTestsCancelStopRestoreResult> StopAndRestoreAsync(
+            bool isPlayMode,
+            string runGuid,
+            RunTestsCancelStopRestoreHooks hooks,
+            int stopWaitTimeoutMilliseconds = DefaultStopWaitTimeoutMilliseconds,
+            int pollIntervalMilliseconds = DefaultPollIntervalMilliseconds)
+        {
+            Debug.Assert(hooks != null, "hooks must not be null");
+            Debug.Assert(hooks.IsPlaying != null, "hooks.IsPlaying must not be null");
+            Debug.Assert(hooks.RequestExitPlayMode != null, "hooks.RequestExitPlayMode must not be null");
+            Debug.Assert(hooks.DelayAsync != null, "hooks.DelayAsync must not be null");
+            Debug.Assert(hooks.LogWarning != null, "hooks.LogWarning must not be null");
+            Debug.Assert(stopWaitTimeoutMilliseconds > 0, "stopWaitTimeoutMilliseconds must be positive");
+            Debug.Assert(pollIntervalMilliseconds > 0, "pollIntervalMilliseconds must be positive");
+
+            try
+            {
+                return await StopAndRestoreCoreAsync(
+                    isPlayMode,
+                    runGuid,
+                    hooks,
+                    stopWaitTimeoutMilliseconds,
+                    pollIntervalMilliseconds);
+            }
+            catch (Exception exception)
+            {
+                // Why catch-all: this method is an absolute no-throw boundary for cancel paths.
+                hooks.LogWarning(
+                    "run-tests stop/restore failed unexpectedly and was swallowed: " + exception);
+                return new RunTestsCancelStopRestoreResult(
+                    testRunCancelAttempted: false,
+                    testRunCancelSucceeded: false,
+                    playModeExitRequested: false,
+                    playModeExitConfirmed: false,
+                    stopWaitTimedOut: false,
+                    degradationNote:
+                        "Stop/restore failed unexpectedly; Editor state may still be dirty. " +
+                        "Restart with `uloop launch -r` if Unity remains stuck.");
+            }
+        }
+
+        private static async Task<RunTestsCancelStopRestoreResult> StopAndRestoreCoreAsync(
+            bool isPlayMode,
+            string runGuid,
+            RunTestsCancelStopRestoreHooks hooks,
+            int stopWaitTimeoutMilliseconds,
+            int pollIntervalMilliseconds)
+        {
+            bool testRunCancelAttempted = false;
+            bool testRunCancelSucceeded = false;
+            if (hooks.TryCancelTestRun != null && !string.IsNullOrEmpty(runGuid))
+            {
+                testRunCancelAttempted = true;
+                try
+                {
+                    testRunCancelSucceeded = hooks.TryCancelTestRun(runGuid);
+                }
+                catch (Exception exception)
+                {
+                    hooks.LogWarning(
+                        "TryCancelTestRun failed and was ignored (falling back to public stop path): " +
+                        exception);
+                    testRunCancelSucceeded = false;
+                }
+            }
+
+            bool playModeExitRequested = false;
+            bool playModeExitConfirmed = !isPlayMode || !hooks.IsPlaying();
+            bool stopWaitTimedOut = false;
+
+            if (isPlayMode && hooks.IsPlaying())
+            {
+                playModeExitRequested = true;
+                try
+                {
+                    hooks.RequestExitPlayMode();
+                }
+                catch (Exception exception)
+                {
+                    hooks.LogWarning("RequestExitPlayMode failed and was ignored: " + exception);
+                }
+
+                (bool confirmed, bool timedOut) = await WaitUntilAsync(
+                    () => !hooks.IsPlaying(),
+                    hooks.DelayAsync,
+                    stopWaitTimeoutMilliseconds,
+                    pollIntervalMilliseconds);
+                playModeExitConfirmed = confirmed;
+                stopWaitTimedOut = timedOut;
+            }
+            else if (!isPlayMode && hooks.IsRunActive != null && hooks.IsRunActive())
+            {
+                (bool confirmed, bool timedOut) = await WaitUntilAsync(
+                    () => !hooks.IsRunActive(),
+                    hooks.DelayAsync,
+                    stopWaitTimeoutMilliseconds,
+                    pollIntervalMilliseconds);
+                stopWaitTimedOut = timedOut;
+                if (!confirmed)
+                {
+                    // EditMode has no public job-cancel API under TF 1.3.9 without Option A.
+                }
+            }
+
+            string degradationNote = BuildDegradationNote(
+                isPlayMode,
+                testRunCancelAttempted,
+                testRunCancelSucceeded,
+                playModeExitRequested,
+                playModeExitConfirmed,
+                stopWaitTimedOut);
+
+            return new RunTestsCancelStopRestoreResult(
+                testRunCancelAttempted,
+                testRunCancelSucceeded,
+                playModeExitRequested,
+                playModeExitConfirmed,
+                stopWaitTimedOut,
+                degradationNote);
+        }
+
+        private static async Task<(bool Confirmed, bool TimedOut)> WaitUntilAsync(
+            Func<bool> isDone,
+            Func<int, CancellationToken, Task> delayAsync,
+            int timeoutMilliseconds,
+            int pollIntervalMilliseconds)
+        {
+            int elapsedMilliseconds = 0;
+            while (elapsedMilliseconds < timeoutMilliseconds)
+            {
+                if (isDone())
+                {
+                    return (true, false);
+                }
+
+                await delayAsync(pollIntervalMilliseconds, CancellationToken.None);
+                elapsedMilliseconds += pollIntervalMilliseconds;
+            }
+
+            return (isDone(), true);
+        }
+
+        private static string BuildDegradationNote(
+            bool isPlayMode,
+            bool testRunCancelAttempted,
+            bool testRunCancelSucceeded,
+            bool playModeExitRequested,
+            bool playModeExitConfirmed,
+            bool stopWaitTimedOut)
+        {
+            StringBuilder note = new();
+            if (!testRunCancelAttempted || !testRunCancelSucceeded)
+            {
+                note.Append(
+                    "Unity Test Framework 1.3.9 has no public API to cancel an in-flight test job");
+                if (!isPlayMode)
+                {
+                    note.Append("; an EditMode job may still be running until it finishes");
+                }
+                note.Append(". ");
+            }
+
+            if (playModeExitRequested && !playModeExitConfirmed)
+            {
+                note.Append("Play Mode exit was requested but not confirmed within the stop wait. ");
+            }
+            else if (playModeExitRequested && playModeExitConfirmed)
+            {
+                note.Append("Play Mode exit was requested and confirmed. ");
+            }
+
+            if (stopWaitTimedOut)
+            {
+                note.Append("Stop-wait polling reached its upper bound. ");
+            }
+
+            note.Append("Restart with `uloop launch -r` if Unity remains stuck.");
+            return note.ToString();
+        }
+    }
+
+    /// <summary>
+    /// OperationCanceledException that carries cancel-time stop/restore details for timeout messaging.
+    /// </summary>
+    internal sealed class RunTestsExecutionCanceledException : OperationCanceledException
+    {
+        public RunTestsExecutionCanceledException(
+            CancellationToken token,
+            RunTestsCancelStopRestoreResult stopResult)
+            : base("run-tests execution was canceled", token)
+        {
+            StopResult = stopResult;
+        }
+
+        public RunTestsCancelStopRestoreResult StopResult { get; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
@@ -237,7 +237,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool stopWaitTimedOut)
         {
             StringBuilder note = new();
-            if (!testRunCancelAttempted || !testRunCancelSucceeded)
+            // Why guard on PlayMode exit confirmed: once Play Mode has exited, the in-flight
+            // PlayMode job is effectively stopped; warning about missing CancelTestRun only
+            // confuses agents. Keep the warning for EditMode and for unconfirmed PlayMode exit.
+            if ((!testRunCancelAttempted || !testRunCancelSucceeded) &&
+                (!isPlayMode || !playModeExitConfirmed))
             {
                 note.Append(
                     "Unity Test Framework 1.3.9 has no public API to cancel an in-flight test job");

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 969616ef8ae9c4fefab838ab6daa5edf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs
@@ -63,8 +63,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationTokenSource linkedCancellationTokenSource =
                 CancellationTokenSource.CreateLinkedTokenSource(parentCancellationToken);
             // Why CancelAfter here: frees the single-flight slot when RunFinished never fires.
-            // PR 1-1 only completes the await via cancellation; TestRunnerApi may keep running
-            // until PR 1-2 routes this same cancel path through an explicit stop + PlayMode restore.
+            // Cancel paths then run StopAndRestore (PlayMode exit / optional job cancel) before
+            // DomainReloadDisableScope dispose so reload is not re-enabled mid-run.
             linkedCancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
             return linkedCancellationTokenSource;
         }
@@ -72,14 +72,22 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// <summary>
         /// Builds the agent-facing message for a CancelAfter timeout.
         /// </summary>
-        public static string CreateTimeoutMessage(int timeoutSeconds)
+        public static string CreateTimeoutMessage(
+            int timeoutSeconds,
+            string stopRestoreDegradationNote = null)
         {
             Debug.Assert(timeoutSeconds > 0, "timeoutSeconds must be greater than zero");
 
-            return
+            string message =
                 $"run-tests timed out after {timeoutSeconds} seconds without a RunFinished callback. " +
-                "The Unity Test Runner may still be running in the background. " +
                 "Increase --timeout-seconds for long suites, or restart with `uloop launch -r` if Unity is stuck.";
+            if (!string.IsNullOrEmpty(stopRestoreDegradationNote))
+            {
+                return message + " " + stopRestoreDegradationNote;
+            }
+
+            return message +
+                " The Unity Test Runner may still be running in the background.";
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -126,14 +126,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // the fixed cleanup delay straddles the deadline after RunFinished already arrived.
                 await _waitForTestRunnerCleanupAsync(ct);
             }
-            catch (OperationCanceledException) when (RunTestsExecutionTimeout.IsTimeoutCancellation(ct))
+            catch (RunTestsExecutionCanceledException canceledException)
+                when (RunTestsExecutionTimeout.IsTimeoutCancellation(ct))
             {
                 // Why return a tool failure instead of rethrowing: agents need an actionable
                 // timeout message (extend --timeout-seconds / launch -r). Parent/disconnect
                 // cancellation still propagates so the IPC session can tear down normally.
-                // Why not stop TestRunnerApi here yet: PR 1-2 will route this same cancel path
-                // through explicit runner stop + PlayMode restore; until then the runner may
-                // keep running in the background after the await is released.
+                return CreateFailureResponse(
+                    RunTestsExecutionTimeout.CreateTimeoutMessage(
+                        parameters.TimeoutSeconds,
+                        canceledException.StopResult.DegradationNote));
+            }
+            catch (OperationCanceledException) when (RunTestsExecutionTimeout.IsTimeoutCancellation(ct))
+            {
                 return CreateFailureResponse(
                     RunTestsExecutionTimeout.CreateTimeoutMessage(parameters.TimeoutSeconds));
             }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -45,19 +45,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why not `using`: Dispose must run only after cancel-time stop/restore finishes.
             // Disposing earlier re-enables domain reload while Test Runner / Play Mode may still be active.
             DomainReloadDisableScope scope = new DomainReloadDisableScope();
-            bool executionStarted = false;
             try
             {
-                executionStarted = true;
                 return await ExecuteTestWithEventNotification(TestMode.PlayMode, filter, ct);
             }
             catch (OperationCanceledException originalException)
             {
-                if (!executionStarted)
-                {
-                    throw;
-                }
-
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: true,
                     runGuid: null,
@@ -75,19 +68,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
-            bool executionStarted = false;
             try
             {
-                executionStarted = true;
                 return await ExecuteTestWithEventNotification(TestMode.EditMode, filter, ct);
             }
             catch (OperationCanceledException originalException)
             {
-                if (!executionStarted)
-                {
-                    throw;
-                }
-
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: false,
                     runGuid: null,

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -42,8 +42,32 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             ct.ThrowIfCancellationRequested();
             DomainReloadDisableScope.RecoverAbandonedScopeBeforeNewRun();
-            using DomainReloadDisableScope scope = new DomainReloadDisableScope();
-            return await ExecuteTestWithEventNotification(TestMode.PlayMode, filter, ct);
+            // Why not `using`: Dispose must run only after cancel-time stop/restore finishes.
+            // Disposing earlier re-enables domain reload while Test Runner / Play Mode may still be active.
+            DomainReloadDisableScope scope = new DomainReloadDisableScope();
+            bool executionStarted = false;
+            try
+            {
+                executionStarted = true;
+                return await ExecuteTestWithEventNotification(TestMode.PlayMode, filter, ct);
+            }
+            catch (OperationCanceledException originalException)
+            {
+                if (!executionStarted)
+                {
+                    throw;
+                }
+
+                RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
+                    isPlayMode: true,
+                    runGuid: null,
+                    RunTestsCancelStopRestoreUnityHooks.Resolve());
+                throw new RunTestsExecutionCanceledException(originalException.CancellationToken, stopResult);
+            }
+            finally
+            {
+                scope.Dispose();
+            }
         }
 
         public static async Task<SerializableTestResult> ExecuteEditModeTest(
@@ -51,7 +75,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
-            return await ExecuteTestWithEventNotification(TestMode.EditMode, filter, ct);
+            bool executionStarted = false;
+            try
+            {
+                executionStarted = true;
+                return await ExecuteTestWithEventNotification(TestMode.EditMode, filter, ct);
+            }
+            catch (OperationCanceledException originalException)
+            {
+                if (!executionStarted)
+                {
+                    throw;
+                }
+
+                RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
+                    isPlayMode: false,
+                    runGuid: null,
+                    RunTestsCancelStopRestoreUnityHooks.Resolve());
+                throw new RunTestsExecutionCanceledException(originalException.CancellationToken, stopResult);
+            }
         }
 
         private static async Task<SerializableTestResult> ExecuteTestWithEventNotification(
@@ -96,7 +138,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             catch (Exception exception)
             {
-                Debug.LogWarning($"Failed to save NUnit XML result file: {exception}");
+                Debug.LogWarning($"Failed to save failure XML result file: {exception}");
                 return null;
             }
         }
@@ -108,7 +150,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             testRunnerApi.RegisterCallbacks(callback);
 
             Filter unityFilter = CreateUnityFilter(testMode, filter);
-            testRunnerApi.Execute(new ExecutionSettings(unityFilter));
+            // runGuid is discarded until Option A stores it for CancelTestRun.
+            _ = testRunnerApi.Execute(new ExecutionSettings(unityFilter));
         }
 
         private static Filter CreateUnityFilter(TestMode testMode, TestExecutionFilter filter)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsCancelStopRestoreUnityHooks.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsCancelStopRestoreUnityHooks.cs
@@ -1,0 +1,51 @@
+#if ULOOP_HAS_TEST_FRAMEWORK
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Unity Editor hooks for cancel-time stop/restore. Option B baseline (public API only).
+    /// Option A (CancelTestRun reflection) can plug into TryCancelTestRun later with B fallback.
+    /// </summary>
+    internal static class RunTestsCancelStopRestoreUnityHooks
+    {
+        /// <summary>
+        /// Optional override for pure unit / EditMode stubbing. Null uses production hooks.
+        /// </summary>
+        internal static RunTestsCancelStopRestoreHooks OverrideHooksForTests { get; set; }
+
+        internal static RunTestsCancelStopRestoreHooks Resolve()
+        {
+            return OverrideHooksForTests ?? CreateDefault();
+        }
+
+        internal static RunTestsCancelStopRestoreHooks CreateDefault()
+        {
+            return new RunTestsCancelStopRestoreHooks
+            {
+                // Why null TryCancelTestRun until Option A is user-approved: TF 1.3.9 exposes
+                // CancelTestRun only as an internal API, and reflection requires explicit permission.
+                // When Option A lands, resolve CancelTestRun once, cache it, and fall back here on failure.
+                TryCancelTestRun = null,
+                IsRunActive = null,
+                IsPlaying = () => EditorApplication.isPlaying,
+                RequestExitPlayMode = () =>
+                {
+                    if (EditorApplication.isPlaying)
+                    {
+                        EditorApplication.isPlaying = false;
+                    }
+                },
+                DelayAsync = (milliseconds, ct) => TimerDelay.Wait(milliseconds, ct),
+                LogWarning = message => Debug.LogWarning(message)
+            };
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsCancelStopRestoreUnityHooks.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsCancelStopRestoreUnityHooks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f2ab0cbfd3b84cb1bb59bd7edb2a5b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/RunTestsExecutionTimeout.UnitTests/RunTestsCancelStopRestoreTests.cs
+++ b/tests/RunTestsExecutionTimeout.UnitTests/RunTestsCancelStopRestoreTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.UnitTests
+{
+    /// <summary>
+    /// Pure unit coverage for cancel-time Test Runner stop and PlayMode restore orchestration.
+    /// </summary>
+    [TestFixture]
+    public class RunTestsCancelStopRestoreTests
+    {
+        [Test]
+        public async Task StopAndRestoreAsync_WhenPlayModeIsActive_ShouldExitThenConfirmBeforeReturning()
+        {
+            // Verifies PlayMode cancel path requests exit and waits until not playing.
+            int playingChecks = 0;
+            bool exitRequested = false;
+            RecordingHooks hooks = new(
+                isPlaying: () =>
+                {
+                    playingChecks++;
+                    return !exitRequested;
+                },
+                requestExitPlayMode: () => exitRequested = true);
+
+            RunTestsCancelStopRestoreResult result = await RunTestsCancelStopRestore.StopAndRestoreAsync(
+                isPlayMode: true,
+                runGuid: null,
+                hooks.Create(),
+                stopWaitTimeoutMilliseconds: 1000,
+                pollIntervalMilliseconds: 1);
+
+            Assert.That(exitRequested, Is.True);
+            Assert.That(result.PlayModeExitRequested, Is.True);
+            Assert.That(result.PlayModeExitConfirmed, Is.True);
+            Assert.That(result.StopWaitTimedOut, Is.False);
+            Assert.That(playingChecks, Is.GreaterThan(0));
+            Assert.That(result.DegradationNote, Does.Contain("Play Mode exit was requested and confirmed"));
+        }
+
+        [Test]
+        public async Task StopAndRestoreAsync_WhenPlayModeExitNeverConfirms_ShouldTimeOutWithoutThrowing()
+        {
+            // Verifies the upper bound frees cancel handling when PlayMode exit never completes.
+            RecordingHooks hooks = new(
+                isPlaying: () => true,
+                requestExitPlayMode: () => { });
+
+            RunTestsCancelStopRestoreResult result = await RunTestsCancelStopRestore.StopAndRestoreAsync(
+                isPlayMode: true,
+                runGuid: null,
+                hooks.Create(),
+                stopWaitTimeoutMilliseconds: 5,
+                pollIntervalMilliseconds: 1);
+
+            Assert.That(result.PlayModeExitRequested, Is.True);
+            Assert.That(result.PlayModeExitConfirmed, Is.False);
+            Assert.That(result.StopWaitTimedOut, Is.True);
+            Assert.That(result.DegradationNote, Does.Contain("not confirmed"));
+        }
+
+        [Test]
+        public async Task StopAndRestoreAsync_WhenTryCancelThrows_ShouldFallBackToPlayModeExit()
+        {
+            // Verifies Option A style cancel failures degrade to the public PlayMode exit path.
+            bool exitRequested = false;
+            RecordingHooks hooks = new(
+                isPlaying: () => !exitRequested,
+                requestExitPlayMode: () => exitRequested = true,
+                tryCancelTestRun: _ => throw new InvalidOperationException("lookup failed"));
+
+            RunTestsCancelStopRestoreResult result = await RunTestsCancelStopRestore.StopAndRestoreAsync(
+                isPlayMode: true,
+                runGuid: "run-guid",
+                hooks.Create(),
+                stopWaitTimeoutMilliseconds: 1000,
+                pollIntervalMilliseconds: 1);
+
+            Assert.That(result.TestRunCancelAttempted, Is.True);
+            Assert.That(result.TestRunCancelSucceeded, Is.False);
+            Assert.That(exitRequested, Is.True);
+            Assert.That(result.PlayModeExitConfirmed, Is.True);
+            Assert.That(hooks.Warnings.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task StopAndRestoreAsync_WhenDelayThrows_ShouldReturnDegradedResultWithoutThrowing()
+        {
+            // Verifies the no-throw contract: unexpected hook failures become degradation notes.
+            RecordingHooks hooks = new(
+                isPlaying: () => true,
+                requestExitPlayMode: () => { },
+                delayAsync: (_, _) => throw new InvalidOperationException("delay failed"));
+
+            RunTestsCancelStopRestoreResult result = await RunTestsCancelStopRestore.StopAndRestoreAsync(
+                isPlayMode: true,
+                runGuid: null,
+                hooks.Create(),
+                stopWaitTimeoutMilliseconds: 1000,
+                pollIntervalMilliseconds: 1);
+
+            Assert.That(result.DegradationNote, Does.Contain("failed unexpectedly"));
+            Assert.That(hooks.Warnings.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task StopAndRestoreAsync_WhenEditModeAndCancelUnavailable_ShouldSkipPlayModeExit()
+        {
+            // Verifies EditMode Option B path does not touch PlayMode and documents job-stop limits.
+            bool exitRequested = false;
+            RecordingHooks hooks = new(
+                isPlaying: () => false,
+                requestExitPlayMode: () => exitRequested = true);
+
+            RunTestsCancelStopRestoreResult result = await RunTestsCancelStopRestore.StopAndRestoreAsync(
+                isPlayMode: false,
+                runGuid: null,
+                hooks.Create());
+
+            Assert.That(exitRequested, Is.False);
+            Assert.That(result.PlayModeExitRequested, Is.False);
+            Assert.That(result.DegradationNote, Does.Contain("no public API"));
+            Assert.That(result.DegradationNote, Does.Contain("EditMode"));
+        }
+
+        [Test]
+        public async Task StopAndRestoreAsync_ShouldNotObserveAlreadyCanceledTokensForInternalWaits()
+        {
+            // Verifies internal polling uses CancellationToken.None rather than a canceled execution token.
+            using CancellationTokenSource canceled = new();
+            canceled.Cancel();
+            CancellationToken observedToken = CancellationToken.None;
+            bool exitRequested = false;
+            RecordingHooks hooks = new(
+                isPlaying: () => !exitRequested,
+                requestExitPlayMode: () => exitRequested = true,
+                delayAsync: (milliseconds, ct) =>
+                {
+                    observedToken = ct;
+                    ct.ThrowIfCancellationRequested();
+                    return Task.CompletedTask;
+                });
+
+            await RunTestsCancelStopRestore.StopAndRestoreAsync(
+                isPlayMode: true,
+                runGuid: null,
+                hooks.Create(),
+                stopWaitTimeoutMilliseconds: 1000,
+                pollIntervalMilliseconds: 1);
+
+            Assert.That(observedToken.IsCancellationRequested, Is.False);
+            Assert.That(canceled.IsCancellationRequested, Is.True);
+        }
+
+        private sealed class RecordingHooks
+        {
+            private readonly Func<bool> _isPlaying;
+            private readonly Action _requestExitPlayMode;
+            private readonly Func<string, bool> _tryCancelTestRun;
+            private readonly Func<int, CancellationToken, Task> _delayAsync;
+
+            public RecordingHooks(
+                Func<bool> isPlaying,
+                Action requestExitPlayMode,
+                Func<string, bool> tryCancelTestRun = null,
+                Func<int, CancellationToken, Task> delayAsync = null)
+            {
+                _isPlaying = isPlaying;
+                _requestExitPlayMode = requestExitPlayMode;
+                _tryCancelTestRun = tryCancelTestRun;
+                _delayAsync = delayAsync ?? ((_, _) => Task.CompletedTask);
+            }
+
+            public System.Collections.Generic.List<string> Warnings { get; } = new();
+
+            public RunTestsCancelStopRestoreHooks Create()
+            {
+                return new RunTestsCancelStopRestoreHooks
+                {
+                    TryCancelTestRun = _tryCancelTestRun,
+                    IsRunActive = null,
+                    IsPlaying = _isPlaying,
+                    RequestExitPlayMode = _requestExitPlayMode,
+                    DelayAsync = _delayAsync,
+                    LogWarning = warning => Warnings.Add(warning)
+                };
+            }
+        }
+    }
+}

--- a/tests/RunTestsExecutionTimeout.UnitTests/RunTestsCancelStopRestoreTests.cs
+++ b/tests/RunTestsExecutionTimeout.UnitTests/RunTestsCancelStopRestoreTests.cs
@@ -39,6 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
             Assert.That(result.StopWaitTimedOut, Is.False);
             Assert.That(playingChecks, Is.GreaterThan(0));
             Assert.That(result.DegradationNote, Does.Contain("Play Mode exit was requested and confirmed"));
+            Assert.That(result.DegradationNote, Does.Not.Contain("no public API"));
         }
 
         [Test]

--- a/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeout.UnitTests.csproj
+++ b/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeout.UnitTests.csproj
@@ -15,5 +15,6 @@
 
   <ItemGroup>
     <Compile Include="../../Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs" Link="Production/RunTestsExecutionTimeout.cs" />
+    <Compile Include="../../Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs" Link="Production/RunTestsCancelStopRestore.cs" />
   </ItemGroup>
 </Project>

--- a/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeoutTests.cs
+++ b/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeoutTests.cs
@@ -71,6 +71,19 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
         }
 
         [Test]
+        public void CreateTimeoutMessage_WhenStopRestoreNoteProvided_ShouldAppendDegradationDetails()
+        {
+            // Verifies cancel-time stop/restore notes are appended for agent guidance.
+            string message = RunTestsExecutionTimeout.CreateTimeoutMessage(
+                600,
+                "Play Mode exit was requested and confirmed.");
+
+            Assert.That(message, Does.Contain("600"));
+            Assert.That(message, Does.Contain("Play Mode exit was requested and confirmed."));
+            Assert.That(message, Does.Not.Contain("may still be running in the background"));
+        }
+
+        [Test]
         public void IsTimeoutCancellation_WhenParentIsNotCanceled_ShouldReturnTrue()
         {
             // Verifies CancelAfter-driven cancellation is distinguished from parent/disconnect cancellation.


### PR DESCRIPTION
Refs: hang survey section 2 / PR 1-2 (Option B baseline; Option A pending user permission)

## Summary
- On run-tests cancel/timeout, request Play Mode exit and wait (upper-bounded) before disposing `DomainReloadDisableScope`
- Agents get stop/restore details in the timeout message

## User Impact
- Before: cancel freed the CLI await but could leave Play Mode / reload settings in a bad state
- After: cancel path restores Play Mode first, then re-enables domain reload

## Changes
- Add injectable `RunTestsCancelStopRestore` orchestrator (no-throw; internal waits use `CancellationToken.None` + 10s bound)
- Wire PlayMode/EditMode executers to run stop/restore before scope dispose
- Option B baseline: public `EditorApplication.isPlaying = false` only; `CancelTestRun` reflection not enabled yet (needs explicit user permission). If approved, Option A will plug into `TryCancelTestRun` with cached lookup and automatic B fallback

## Verification
- `dotnet test tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeout.UnitTests.csproj` (16 passed)
- `uloop compile` green
- `uloop run-tests --filter-type regex --filter-value "RunTestsUseCaseTests|PlayModeTestExecuterTests|DomainReloadDisableScopeTests"` (25 passed)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

