### PR TITLE
fix: abandoned DomainReloadDisableScope state no longer blocks the next PlayMode test run

### DIFF
--- a/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
+++ b/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
@@ -118,6 +118,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.True);
             DomainReloadDisableScope.RecoverAbandonedScopeBeforeNewRun();
 
+            Assert.That(DomainReloadDisableScope.GetActiveScopeCountForTests(), Is.EqualTo(0));
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+
             DomainReloadDisableScope nextScope = new DomainReloadDisableScope();
             DomainReloadDisableScopeRecoveryData markerData = DomainReloadDisableScopeRecovery.ReadMarkerDataForTests();
 
@@ -125,6 +130,58 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(markerData.originalOptions, Is.EqualTo((int)EnterPlayModeOptions.None));
 
             nextScope.Dispose();
+
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+            System.GC.KeepAlive(abandonedScope);
+        }
+
+        [Test]
+        public void RecoverAbandonedScopeBeforeNewRun_WhenCountIsPositiveWithoutMarker_ShouldClearPhantomCount()
+        {
+            // Verifies inconsistent abandoned counts cannot block the next run from saving a fresh marker.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+            DomainReloadDisableScope abandonedScope = new DomainReloadDisableScope();
+            DomainReloadDisableScopeRecovery.ClearPendingRestoreForTests();
+            Assert.That(DomainReloadDisableScope.GetActiveScopeCountForTests(), Is.EqualTo(1));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+
+            DomainReloadDisableScope.RecoverAbandonedScopeBeforeNewRun();
+
+            Assert.That(DomainReloadDisableScope.GetActiveScopeCountForTests(), Is.EqualTo(0));
+
+            DomainReloadDisableScope nextScope = new DomainReloadDisableScope();
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.True);
+            nextScope.Dispose();
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+            System.GC.KeepAlive(abandonedScope);
+        }
+
+        [Test]
+        public void Dispose_AfterRecoverAbandonedScope_ShouldBeIdempotent()
+        {
+            // Verifies disposing a live instance after Recover no longer asserts or double-restores.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+            DomainReloadDisableScope abandonedScope = new DomainReloadDisableScope();
+            DomainReloadDisableScope.RecoverAbandonedScopeBeforeNewRun();
+
+            Assert.DoesNotThrow(() => abandonedScope.Dispose());
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+            Assert.That(DomainReloadDisableScope.GetActiveScopeCountForTests(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void RecoverAbandonedScopeBeforeNewRun_WhenCountIsZeroWithPendingMarker_ShouldRestoreSettings()
+        {
+            // Verifies domain-reload-like state (count reset, marker retained) is cleared before a new run.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+            DomainReloadDisableScope abandonedScope = new DomainReloadDisableScope();
+            DomainReloadDisableScope.ResetActiveScopeCountForTests();
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.True);
+
+            DomainReloadDisableScope.RecoverAbandonedScopeBeforeNewRun();
 
             Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
             Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));

--- a/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
+++ b/Assets/Tests/Editor/DomainReloadDisableScopeTests.cs
@@ -173,6 +173,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void Dispose_OfAbandonedInstance_AfterNewScopeStarted_ShouldLeaveNewScopeIntact()
+        {
+            // Verifies a delayed Dispose from an abandoned scope cannot restore settings under a newer scope.
+            SetEnterPlayModeSettings(false, EnterPlayModeOptions.None);
+            DomainReloadDisableScope abandonedScope = new DomainReloadDisableScope();
+            int generationBeforeRecover = DomainReloadDisableScope.GetGenerationForTests();
+            DomainReloadDisableScope.RecoverAbandonedScopeBeforeNewRun();
+            Assert.That(DomainReloadDisableScope.GetGenerationForTests(), Is.EqualTo(generationBeforeRecover + 1));
+
+            DomainReloadDisableScope nextScope = new DomainReloadDisableScope();
+            Assert.That(DomainReloadDisableScope.GetActiveScopeCountForTests(), Is.EqualTo(1));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.True);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
+
+            abandonedScope.Dispose();
+
+            Assert.That(DomainReloadDisableScope.GetActiveScopeCountForTests(), Is.EqualTo(1));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.True);
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.True);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.DisableDomainReload));
+
+            nextScope.Dispose();
+            Assert.That(DomainReloadDisableScope.GetActiveScopeCountForTests(), Is.EqualTo(0));
+            Assert.That(DomainReloadDisableScopeRecovery.HasPendingRestoreForTests(), Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptionsEnabled, Is.False);
+            Assert.That(EditorSettings.enterPlayModeOptions, Is.EqualTo(EnterPlayModeOptions.None));
+        }
+
+        [Test]
         public void RecoverAbandonedScopeBeforeNewRun_WhenCountIsZeroWithPendingMarker_ShouldRestoreSettings()
         {
             // Verifies domain-reload-like state (count reset, marker retained) is cleared before a new run.

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/DomainReloadDisableScope.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/DomainReloadDisableScope.cs
@@ -9,6 +9,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class DomainReloadDisableScope : IDisposable
     {
         private static int _activeScopeCount;
+        private static int _generation;
+
+        private readonly int _createdGeneration;
         private bool _disposed;
         
         public DomainReloadDisableScope()
@@ -20,6 +23,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             _activeScopeCount++;
+            // Why capture generation: RecoverAbandoned may invalidate this instance while a newer
+            // scope owns the static count; Dispose must ignore stale instances.
+            _createdGeneration = _generation;
             
             EditorSettings.enterPlayModeOptionsEnabled = true;
             EditorSettings.enterPlayModeOptions = EnterPlayModeOptions.DisableDomainReload;
@@ -34,8 +40,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             _disposed = true;
 
-            // Why tolerate zero: RecoverAbandonedScopeBeforeNewRun may have already cleared the
-            // static count and restored settings while this instance was still alive.
+            if (_createdGeneration != _generation)
+            {
+                // Why return: RecoverAbandoned already invalidated this instance. Decrementing
+                // would steal the count from a newer active scope (e.g. delayed cancel finally).
+                return;
+            }
+
+            System.Diagnostics.Debug.Assert(
+                _activeScopeCount > 0,
+                "active scope count must be positive for the current generation before dispose");
             if (_activeScopeCount == 0)
             {
                 return;
@@ -65,18 +79,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Why clear count even without a marker: a non-zero count would skip SaveCurrentSettings
             // on the next constructor and nest on a phantom scope, delaying restore indefinitely.
+            // Why bump generation: live instances from the abandoned run must not Dispose into the
+            // next run's count if their await completes late.
             _activeScopeCount = 0;
+            _generation++;
             DomainReloadDisableScopeRecovery.RestoreIfPending();
         }
 
         internal static void ResetActiveScopeCountForTests()
         {
             _activeScopeCount = 0;
+            _generation = 0;
         }
 
         internal static int GetActiveScopeCountForTests()
         {
             return _activeScopeCount;
+        }
+
+        internal static int GetGenerationForTests()
+        {
+            return _generation;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/DomainReloadDisableScope.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/DomainReloadDisableScope.cs
@@ -33,7 +33,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             _disposed = true;
-            System.Diagnostics.Debug.Assert(_activeScopeCount > 0, "active scope count must be positive before dispose");
+
+            // Why tolerate zero: RecoverAbandonedScopeBeforeNewRun may have already cleared the
+            // static count and restored settings while this instance was still alive.
+            if (_activeScopeCount == 0)
+            {
+                return;
+            }
+
             _activeScopeCount--;
 
             if (_activeScopeCount == 0)
@@ -43,26 +50,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Resets stale scope state before a new PlayMode test run starts.
+        /// Clears abandoned static scope state and restores pending Enter Play Mode settings
+        /// before a new PlayMode test run starts.
         /// </summary>
         internal static void RecoverAbandonedScopeBeforeNewRun()
         {
+            // Why always restore when a marker exists (even if count is already 0): domain reload
+            // resets the static count while leaving the recovery marker on disk.
             if (_activeScopeCount == 0)
             {
+                DomainReloadDisableScopeRecovery.RestoreIfPending();
                 return;
             }
 
-            if (!DomainReloadDisableScopeRecovery.HasPendingRestore())
-            {
-                return;
-            }
-
+            // Why clear count even without a marker: a non-zero count would skip SaveCurrentSettings
+            // on the next constructor and nest on a phantom scope, delaying restore indefinitely.
             _activeScopeCount = 0;
+            DomainReloadDisableScopeRecovery.RestoreIfPending();
         }
 
         internal static void ResetActiveScopeCountForTests()
         {
             _activeScopeCount = 0;
+        }
+
+        internal static int GetActiveScopeCountForTests()
+        {
+            return _activeScopeCount;
         }
     }
 }


### PR DESCRIPTION
Refs: hang survey section 2 / PR 1-3  
Design: `/tmp/claude-shared/pr-1-3-design.md`

## Summary
- Abandoned or reload-leftover `DomainReloadDisableScope` state is cleared before the next PlayMode test run
- Disposing a live scope after recovery no longer asserts or double-restores

## User Impact
- Before: inconsistent abandoned scope counts could leave domain reload disabled longer than intended or block clean recovery
- After: the next run restores pending settings and starts from a clean scope count

## Changes
- `RecoverAbandonedScopeBeforeNewRun` always restores pending markers and clears non-zero counts (with or without a marker)
- `Dispose` tolerates count already zeroed by Recover
- EditMode tests for phantom-count, reload-like marker retention, and post-Recover Dispose

## Verification
- `uloop compile` green
- `uloop run-tests --filter-type regex --filter-value DomainReloadDisableScopeTests` (10 passed)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

