### PR TITLE
fix: run-tests timeout can cancel in-flight Test Runner jobs

### DIFF
--- a/Assets/Tests/Editor/TestRunnerApiCancelMethodLookupEditModeTests.cs
+++ b/Assets/Tests/Editor/TestRunnerApiCancelMethodLookupEditModeTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+
+using NUnit.Framework;
+using UnityEditor.TestTools.TestRunner.Api;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// EditMode coverage that the cancel-method lookup resolves against the real TestRunnerApi type.
+    /// </summary>
+    public sealed class TestRunnerApiCancelMethodLookupEditModeTests
+    {
+        [Test]
+        public void Resolve_AgainstRealTestRunnerApi_ShouldFindCancelTestRunAndParameterlessIsRunActive()
+        {
+            // Verifies TF 1.3.9's real TestRunnerApi exposes CancelTestRun(string) and IsRunActive()
+            // to Public|NonPublic lookup so Option A wiring does not silently fall back in this repo.
+            (MethodInfo cancelTestRun, MethodInfo isRunActive, string log) =
+                TestRunnerApiCancelMethodLookup.Resolve(typeof(TestRunnerApi));
+
+            Assert.That(cancelTestRun, Is.Not.Null, "CancelTestRun(string) must resolve on TestRunnerApi");
+            Assert.That(isRunActive, Is.Not.Null, "parameterless IsRunActive() must resolve on TestRunnerApi");
+            Assert.That(log, Is.Null);
+            Assert.That(cancelTestRun.IsStatic, Is.True);
+            Assert.That(isRunActive.IsStatic, Is.True);
+        }
+    }
+}

--- a/Assets/Tests/Editor/TestRunnerApiCancelMethodLookupEditModeTests.cs.meta
+++ b/Assets/Tests/Editor/TestRunnerApiCancelMethodLookupEditModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0e5a3f26f9d4b4a8c7e1d0b3a2f4e69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -45,15 +45,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // Why not `using`: Dispose must run only after cancel-time stop/restore finishes.
             // Disposing earlier re-enables domain reload while Test Runner / Play Mode may still be active.
             DomainReloadDisableScope scope = new DomainReloadDisableScope();
+            string runGuid = null;
             try
             {
-                return await ExecuteTestWithEventNotification(TestMode.PlayMode, filter, ct);
+                return await ExecuteTestWithEventNotification(
+                    TestMode.PlayMode,
+                    filter,
+                    ct,
+                    startedRunGuid => runGuid = startedRunGuid);
             }
             catch (OperationCanceledException originalException)
             {
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: true,
-                    runGuid: null,
+                    runGuid: runGuid,
                     RunTestsCancelStopRestoreUnityHooks.Resolve());
                 throw new RunTestsExecutionCanceledException(originalException.CancellationToken, stopResult);
             }
@@ -68,15 +73,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
+            string runGuid = null;
             try
             {
-                return await ExecuteTestWithEventNotification(TestMode.EditMode, filter, ct);
+                return await ExecuteTestWithEventNotification(
+                    TestMode.EditMode,
+                    filter,
+                    ct,
+                    startedRunGuid => runGuid = startedRunGuid);
             }
             catch (OperationCanceledException originalException)
             {
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: false,
-                    runGuid: null,
+                    runGuid: runGuid,
                     RunTestsCancelStopRestoreUnityHooks.Resolve());
                 throw new RunTestsExecutionCanceledException(originalException.CancellationToken, stopResult);
             }
@@ -85,7 +95,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static async Task<SerializableTestResult> ExecuteTestWithEventNotification(
             TestMode testMode,
             TestExecutionFilter filter,
-            CancellationToken ct)
+            CancellationToken ct,
+            Action<string> onRunStarted)
         {
             ct.ThrowIfCancellationRequested();
             TaskCompletionSource<SerializableTestResult> taskCompletionSource =
@@ -106,7 +117,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 taskCompletionSource.TrySetResult(result);
             };
 
-            StartTestExecution(testMode, filter, callback);
+            string runGuid = StartTestExecution(testMode, filter, callback);
+            onRunStarted?.Invoke(runGuid);
             // Without this registration the await below never completes on cancellation,
             // keeping the TestRunnerApi callback subscription alive forever.
             using CancellationTokenRegistration cancellationRegistration =
@@ -129,15 +141,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static void StartTestExecution(TestMode testMode, TestExecutionFilter filter, UnifiedTestCallback callback)
+        private static string StartTestExecution(TestMode testMode, TestExecutionFilter filter, UnifiedTestCallback callback)
         {
             TestRunnerApi testRunnerApi = ScriptableObject.CreateInstance<TestRunnerApi>();
             callback.SetTestRunnerApi(testRunnerApi);
             testRunnerApi.RegisterCallbacks(callback);
 
             Filter unityFilter = CreateUnityFilter(testMode, filter);
-            // runGuid is discarded until Option A stores it for CancelTestRun.
-            _ = testRunnerApi.Execute(new ExecutionSettings(unityFilter));
+            return testRunnerApi.Execute(new ExecutionSettings(unityFilter));
         }
 
         private static Filter CreateUnityFilter(TestMode testMode, TestExecutionFilter filter)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsCancelStopRestoreUnityHooks.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/RunTestsCancelStopRestoreUnityHooks.cs
@@ -10,8 +10,7 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
-    /// Unity Editor hooks for cancel-time stop/restore. Option B baseline (public API only).
-    /// Option A (CancelTestRun reflection) can plug into TryCancelTestRun later with B fallback.
+    /// Unity Editor hooks for cancel-time stop/restore, including Option A CancelTestRun reflection.
     /// </summary>
     internal static class RunTestsCancelStopRestoreUnityHooks
     {
@@ -27,13 +26,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static RunTestsCancelStopRestoreHooks CreateDefault()
         {
+            TestRunnerApiCancelBridge.EnsureResolved();
+
             return new RunTestsCancelStopRestoreHooks
             {
-                // Why null TryCancelTestRun until Option A is user-approved: TF 1.3.9 exposes
-                // CancelTestRun only as an internal API, and reflection requires explicit permission.
-                // When Option A lands, resolve CancelTestRun once, cache it, and fall back here on failure.
-                TryCancelTestRun = null,
-                IsRunActive = null,
+                // Why null when lookup fails: Option A is a superset of Option B. Cached miss
+                // keeps cancel on Play Mode exit + bounded wait without retrying reflection.
+                TryCancelTestRun = TestRunnerApiCancelBridge.HasCancelTestRun
+                    ? TestRunnerApiCancelBridge.TryCancelTestRun
+                    : null,
+                IsRunActive = TestRunnerApiCancelBridge.HasIsRunActive
+                    ? TestRunnerApiCancelBridge.TryIsRunActive
+                    : null,
                 IsPlaying = () => EditorApplication.isPlaying,
                 RequestExitPlayMode = () =>
                 {

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
@@ -1,0 +1,130 @@
+#if ULOOP_HAS_TEST_FRAMEWORK
+using System;
+using System.Reflection;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves TestRunnerApi cancel helpers once via reflection and caches the result.
+    /// Supports TF 1.3.9 (internal CancelTestRun) and TF 1.4+ (public CancelTestRun).
+    /// </summary>
+    internal static class TestRunnerApiCancelBridge
+    {
+        private static readonly object ResolveLock = new object();
+        private static bool _resolved;
+        private static MethodInfo _cancelTestRunMethod;
+        private static MethodInfo _isRunActiveMethod;
+        private static string _resolveLog;
+
+        /// <summary>
+        /// Resets cached lookup state for unit tests.
+        /// </summary>
+        internal static void ResetResolvedStateForTests()
+        {
+            lock (ResolveLock)
+            {
+                _resolved = false;
+                _cancelTestRunMethod = null;
+                _isRunActiveMethod = null;
+                _resolveLog = null;
+            }
+        }
+
+        /// <summary>
+        /// True when CancelTestRun(string) was resolved.
+        /// </summary>
+        internal static bool HasCancelTestRun
+        {
+            get
+            {
+                EnsureResolved();
+                return _cancelTestRunMethod != null;
+            }
+        }
+
+        /// <summary>
+        /// True when parameterless IsRunActive() was resolved.
+        /// </summary>
+        internal static bool HasIsRunActive
+        {
+            get
+            {
+                EnsureResolved();
+                return _isRunActiveMethod != null;
+            }
+        }
+
+        internal static string ResolveLogForTests
+        {
+            get
+            {
+                EnsureResolved();
+                return _resolveLog;
+            }
+        }
+
+        /// <summary>
+        /// Invokes CancelTestRun(guid) when available. Returns false when unavailable or invoke fails.
+        /// </summary>
+        internal static bool TryCancelTestRun(string runGuid)
+        {
+            EnsureResolved();
+            if (_cancelTestRunMethod == null || string.IsNullOrEmpty(runGuid))
+            {
+                return false;
+            }
+
+            object result = _cancelTestRunMethod.Invoke(null, new object[] { runGuid });
+            return result is bool canceled && canceled;
+        }
+
+        /// <summary>
+        /// Invokes parameterless IsRunActive() when available. Returns false when unavailable.
+        /// </summary>
+        internal static bool TryIsRunActive()
+        {
+            EnsureResolved();
+            if (_isRunActiveMethod == null)
+            {
+                return false;
+            }
+
+            object result = _isRunActiveMethod.Invoke(null, Array.Empty<object>());
+            return result is bool isActive && isActive;
+        }
+
+        /// <summary>
+        /// Resolves methods once. Failures are cached so later calls stay on the Option B path.
+        /// </summary>
+        internal static void EnsureResolved()
+        {
+            if (_resolved)
+            {
+                return;
+            }
+
+            lock (ResolveLock)
+            {
+                if (_resolved)
+                {
+                    return;
+                }
+
+                (MethodInfo cancel, MethodInfo isRunActive, string log) =
+                    TestRunnerApiCancelMethodLookup.Resolve(typeof(TestRunnerApi));
+                _cancelTestRunMethod = cancel;
+                _isRunActiveMethod = isRunActive;
+                _resolveLog = log;
+                _resolved = true;
+
+                if (!string.IsNullOrEmpty(log))
+                {
+                    Debug.LogWarning(log);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs
@@ -13,7 +13,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     internal static class TestRunnerApiCancelBridge
     {
         private static readonly object ResolveLock = new object();
-        private static bool _resolved;
+        // Why volatile: double-checked locking outside the lock must observe a completed resolve.
+        private static volatile bool _resolved;
         private static MethodInfo _cancelTestRunMethod;
         private static MethodInfo _isRunActiveMethod;
         private static string _resolveLog;

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/TestRunnerApiCancelBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9d4f2e15e8c4f3b0a7d6c9e2f1b3a58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestRunnerApiCancelMethodLookup.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestRunnerApiCancelMethodLookup.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Pure reflection lookup for TestRunnerApi cancel helpers. Separated so unit tests can
+    /// exercise TF version differences without Unity assemblies.
+    /// </summary>
+    internal static class TestRunnerApiCancelMethodLookup
+    {
+        /// <summary>
+        /// Resolves CancelTestRun(string) and parameterless IsRunActive() on the given type.
+        /// </summary>
+        public static (MethodInfo CancelTestRun, MethodInfo IsRunActive, string Log) Resolve(Type testRunnerApiType)
+        {
+            Debug.Assert(testRunnerApiType != null, "testRunnerApiType must not be null");
+
+            // Why Public|NonPublic: TF 1.3.9 keeps CancelTestRun internal; TF 1.4+ (Unity 6000)
+            // publishes the same CancelTestRun(string) signature.
+            const BindingFlags flags =
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+            MethodInfo cancelTestRun = testRunnerApiType.GetMethod(
+                "CancelTestRun",
+                flags,
+                binder: null,
+                types: new[] { typeof(string) },
+                modifiers: null);
+
+            // Why parameterless only: TF 2.0 changes IsRunActive to IsRunActive(string guid).
+            // Missing parameterless method is expected there; fall back to Option B polling.
+            MethodInfo isRunActive = testRunnerApiType.GetMethod(
+                "IsRunActive",
+                flags,
+                binder: null,
+                types: Type.EmptyTypes,
+                modifiers: null);
+
+            string log = null;
+            if (cancelTestRun == null)
+            {
+                log =
+                    "TestRunnerApi.CancelTestRun(string) was not found; " +
+                    "run-tests cancel will use the public Play Mode exit fallback.";
+            }
+            else if (isRunActive == null)
+            {
+                log =
+                    "TestRunnerApi.IsRunActive() was not found; " +
+                    "EditMode cancel will skip active-run polling and rely on CancelTestRun / Play Mode exit.";
+            }
+
+            return (cancelTestRun, isRunActive, log);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestRunnerApiCancelMethodLookup.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestRunnerApiCancelMethodLookup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8c3e1f04d7b4e2a9f6c5b8d1e0a2f47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeout.UnitTests.csproj
+++ b/tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeout.UnitTests.csproj
@@ -16,5 +16,6 @@
   <ItemGroup>
     <Compile Include="../../Packages/src/Editor/FirstPartyTools/RunTests/RunTestsExecutionTimeout.cs" Link="Production/RunTestsExecutionTimeout.cs" />
     <Compile Include="../../Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs" Link="Production/RunTestsCancelStopRestore.cs" />
+    <Compile Include="../../Packages/src/Editor/FirstPartyTools/RunTests/TestRunnerApiCancelMethodLookup.cs" Link="Production/TestRunnerApiCancelMethodLookup.cs" />
   </ItemGroup>
 </Project>

--- a/tests/RunTestsExecutionTimeout.UnitTests/TestRunnerApiCancelMethodLookupTests.cs
+++ b/tests/RunTestsExecutionTimeout.UnitTests/TestRunnerApiCancelMethodLookupTests.cs
@@ -1,0 +1,110 @@
+using System.Reflection;
+using NUnit.Framework;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.UnitTests
+{
+    /// <summary>
+    /// Pure unit coverage for TestRunnerApi cancel method reflection lookup.
+    /// </summary>
+    [TestFixture]
+    public class TestRunnerApiCancelMethodLookupTests
+    {
+        [Test]
+        public void Resolve_WhenInternalCancelAndParameterlessIsRunActiveExist_ShouldFindBoth()
+        {
+            // Verifies TF 1.3.9-shaped APIs (internal CancelTestRun + parameterless IsRunActive) resolve.
+            (MethodInfo cancel, MethodInfo isRunActive, string log) =
+                TestRunnerApiCancelMethodLookup.Resolve(typeof(Tf139ShapedApi));
+
+            Assert.That(cancel, Is.Not.Null);
+            Assert.That(isRunActive, Is.Not.Null);
+            Assert.That(log, Is.Null);
+            Assert.That((bool)cancel.Invoke(null, new object[] { "guid" }), Is.True);
+            Assert.That((bool)isRunActive.Invoke(null, null), Is.True);
+        }
+
+        [Test]
+        public void Resolve_WhenCancelIsPublic_ShouldStillFindCancelTestRun()
+        {
+            // Verifies TF 1.4+/Unity 6000 public CancelTestRun(string) is found with Public|NonPublic flags.
+            (MethodInfo cancel, MethodInfo isRunActive, string log) =
+                TestRunnerApiCancelMethodLookup.Resolve(typeof(Tf14PublicCancelApi));
+
+            Assert.That(cancel, Is.Not.Null);
+            Assert.That(isRunActive, Is.Not.Null);
+            Assert.That(log, Is.Null);
+        }
+
+        [Test]
+        public void Resolve_WhenOnlyGuidIsRunActiveExists_ShouldOmitIsRunActiveAndLog()
+        {
+            // Verifies TF 2.0 IsRunActive(string) is treated as unavailable parameterless lookup.
+            (MethodInfo cancel, MethodInfo isRunActive, string log) =
+                TestRunnerApiCancelMethodLookup.Resolve(typeof(Tf20GuidIsRunActiveApi));
+
+            Assert.That(cancel, Is.Not.Null);
+            Assert.That(isRunActive, Is.Null);
+            Assert.That(log, Does.Contain("IsRunActive()"));
+        }
+
+        [Test]
+        public void Resolve_WhenCancelMissing_ShouldReturnNullCancelAndFallbackLog()
+        {
+            // Verifies missing CancelTestRun falls back to Option B with a clear log.
+            (MethodInfo cancel, MethodInfo isRunActive, string log) =
+                TestRunnerApiCancelMethodLookup.Resolve(typeof(NoCancelApi));
+
+            Assert.That(cancel, Is.Null);
+            Assert.That(isRunActive, Is.Not.Null);
+            Assert.That(log, Does.Contain("CancelTestRun(string)"));
+        }
+
+        private static class Tf139ShapedApi
+        {
+            internal static bool CancelTestRun(string guid)
+            {
+                return guid == "guid";
+            }
+
+            internal static bool IsRunActive()
+            {
+                return true;
+            }
+        }
+
+        private static class Tf14PublicCancelApi
+        {
+            public static bool CancelTestRun(string guid)
+            {
+                return !string.IsNullOrEmpty(guid);
+            }
+
+            public static bool IsRunActive()
+            {
+                return false;
+            }
+        }
+
+        private static class Tf20GuidIsRunActiveApi
+        {
+            public static bool CancelTestRun(string guid)
+            {
+                return !string.IsNullOrEmpty(guid);
+            }
+
+            public static bool IsRunActive(string guid)
+            {
+                return !string.IsNullOrEmpty(guid);
+            }
+        }
+
+        private static class NoCancelApi
+        {
+            public static bool IsRunActive()
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- After a run-tests timeout or cancel, Unity can now request Test Runner to stop the in-flight job (EditMode included), not only exit Play Mode.
- On Test Framework versions where cancel helpers are unavailable or changed, behavior automatically falls back to the existing bounded Play Mode exit path.

## User Impact
- **Before:** Cancel/timeout relied on Play Mode exit only; EditMode jobs and some PlayMode cases could keep running until they finished on their own.
- **After:** When Unity Test Framework exposes `CancelTestRun`, uloop uses it with the run id from `Execute`. If `IsRunActive()` is missing (e.g. TF 2.0 guid overload), cancel still proceeds via the public Play Mode exit + capped wait without retrying reflection.

## Changes
- Keep and pass the `Execute` run GUID into cancel stop/restore.
- Resolve `CancelTestRun(string)` with `Public | NonPublic` once; cache success and failure.
- Resolve parameterless `IsRunActive()` only; miss → Option B fallback.
- Pure unit tests for TF 1.3.9 / 1.4 / 2.0 shaped lookup.

## Verification
- [x] `dotnet test tests/RunTestsExecutionTimeout.UnitTests/RunTestsExecutionTimeout.UnitTests.csproj`
- [x] `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` (0 errors / 0 warnings)
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

