### PR TITLE
fix: dynamic-code wrapper no longer drops cancellation on a sync Execute path

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/WrapperTemplateTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/WrapperTemplateTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// String-level coverage for WrapperTemplate entry-point generation (no compile-and-run).
+    /// </summary>
+    [TestFixture]
+    public class WrapperTemplateTests
+    {
+        [Test]
+        public void Build_ShouldGenerateExecuteAsyncWithCancellationTokenAndOmitSyncExecute()
+        {
+            // Verifies wrapped snippets expose only ExecuteAsync with ct, not a sync Execute that
+            // would discard the runtime token via ExecuteAsync(parameters, default).
+            string wrappedSource = WrapperTemplate.Build(
+                new List<string>(),
+                System.Array.Empty<string>(),
+                "TestNs",
+                "TestClass",
+                "return 1;");
+
+            Assert.That(wrappedSource, Does.Contain("public async System.Threading.Tasks.Task<object> ExecuteAsync("));
+            Assert.That(wrappedSource, Does.Contain("System.Threading.CancellationToken ct = default)"));
+            Assert.That(wrappedSource, Does.Not.Contain("public object Execute("));
+            Assert.That(wrappedSource, Does.Not.Contain("ExecuteAsync(parameters, default)"));
+            Assert.That(wrappedSource, Does.Not.Contain("GetAwaiter().GetResult()"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/WrapperTemplateTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/WrapperTemplateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1f6b4a37a0e4c5b9e8d2c1a0f3b5e7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrapperTemplate.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/WrapperTemplate.cs
@@ -78,12 +78,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             sb.AppendLine(UserCodeEndMarker);
             sb.AppendLine("#line hidden");
             sb.AppendLine("        }");
-            sb.AppendLine();
-            sb.AppendLine("        public object Execute(");
-            sb.AppendLine("            System.Collections.Generic.Dictionary<string, object> parameters = null)");
-            sb.AppendLine("        {");
-            sb.AppendLine("            return ExecuteAsync(parameters, default).GetAwaiter().GetResult();");
-            sb.AppendLine("        }");
+            // Why no sync Execute(): the runtime always prefers ExecuteAsync and passes the real
+            // combined CancellationToken. A sync wrapper that called ExecuteAsync(..., default)
+            // discarded that token and added an unused sync-over-async landmine.
             sb.AppendLine("    }");
             sb.AppendLine("}");
 


### PR DESCRIPTION
## Summary
- Wrapped `execute-dynamic-code` snippets no longer generate an unused sync `Execute()` that called `ExecuteAsync(..., default)` and discarded the runtime cancellation token.
- Generation stays async-only; the live path already invokes `ExecuteAsync` with the combined token.

## User Impact
- **Before:** Generated wrappers included a sync entry point that would ignore cancellation if ever used.
- **After:** Only `ExecuteAsync(..., ct)` is generated. Cooperative cancellation on the real runtime path is unchanged and no longer shadowed by a dead sync landmine.

## Changes
- Delete sync `Execute()` from `WrapperTemplate` (design option A; runtime never called it).
- String-level EditMode test asserts no `public object Execute(` / `ExecuteAsync(parameters, default)` / `GetAwaiter().GetResult()` in generated source (no compile-and-run E2E).
- Docs/SKILL.md: no mentions of generated sync `Execute()` found.
- Out of scope: pre-existing dead `CommandRunner.Execute(ExecutionContext)` — recorded for umbrella notes, not deleted here.

## Refs
- Spec: MasaVault `2026-07-13_uloopハング可能性の全数調査結果.md` §3 PR 3-1
- Design: `/tmp/claude-shared/pr-3-1-design.md`

## Verification
- [x] `uloop compile` (0/0)
- [x] EditMode `WrapperTemplateTests.Build_ShouldGenerateExecuteAsyncWithCancellationTokenAndOmitSyncExecute`
- [ ] Fable final review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

