### PR TITLE
chore: remove unused CommandRunner sync Execute entry point

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -53,37 +53,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             );
         }
 
-        public ExecutionResult Execute(ExecutionContext context)
-        {
-            string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
-            if (!TryBeginExecution(out int undoGroup))
-            {
-                return CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_IN_PROGRESS);
-            }
-
-            try
-            {
-                using CancellationTokenSource combinedCts = CreateCombinedCancellationTokenSource(context);
-                return ExecuteInternal(context, combinedCts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                return CreateCancelledResult();
-            }
-            catch (Exception ex)
-            {
-                LogExecutionError(ex, correlationId);
-
-                return CreateErrorResult(
-                    ex.Message,
-                    new List<string> { $"Exception: {ex.Message}" });
-            }
-            finally
-            {
-                EndExecution(undoGroup);
-            }
-        }
-
         public void Cancel()
         {
             _cancellationTokenSource?.Cancel();


### PR DESCRIPTION
## Summary
- Removes the unused public sync `CommandRunner.Execute(ExecutionContext)` API.
- Raw-assembly sync fallback via `ExecuteInternal` / `TryFindExecuteMethod` is unchanged.

## User Impact
- No runtime behavior change. Production already uses `ExecuteAsync` only.

## Changes
- Deleted `CommandRunner.Execute` after DeadCodeScanner confirmed `PublicCandidate` (0 refs) and no release-please / contract / pin references.
- Kept `ExecuteInternal` because `ExecuteInternalAsync` still calls it when no `ExecuteAsync` entry point exists.
- Did not delete pre-existing dead `Cancel()` (not cascading from this removal).

## Verification
- [x] DeadCodeScanner (CommandRunner.Execute was PublicCandidate; post-delete absent)
- [x] `uloop compile` 0/0
- [x] EditMode `CommandRunnerCancellationTests|CompiledCommandEntryPointResolverTests` 5/5

## Refs
- Explicit cleanup requested after PR 3-1 design note
- Umbrella notes: `/tmp/claude-shared/group3-umbrella-notes.md` (marked deleted)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

