### PR TITLE
fix: dynamic-code shutdown no longer waits forever on stuck user code

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionFacade.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionFacade.cs
@@ -20,7 +20,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public DynamicCodeExecutionFacade(IDynamicCodeExecutorPool executorPool)
         {
             _executorPool = executorPool ?? throw new ArgumentNullException(nameof(executorPool));
-            _executionScheduler = new DynamicCodeExecutionScheduler(_executorPool.Dispose);
+            DynamicCodeExecutionSchedulerHooks hooks = new()
+            {
+                // Why inject: scheduler stays pure C# for unit tests; Unity logging belongs at the facade edge.
+                LogWarning = message => Debug.LogWarning(message)
+            };
+            _executionScheduler = new DynamicCodeExecutionScheduler(_executorPool.Dispose, hooks);
         }
 
         public async Task<ExecutionResult> ExecuteAsync(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionScheduler.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionScheduler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,11 +12,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         private const int BusyHandoffWindowMilliseconds = 50;
         private const int CancelledPrewarmHandoffWindowMilliseconds = 500;
+        private const int DefaultShutdownTimeoutMilliseconds = 5000;
 
         private readonly Action _disposeResources;
         private readonly DynamicCodeExecutionSchedulerHooks _hooks;
         private readonly int _busyHandoffWindowMilliseconds;
         private readonly int _cancelledPrewarmHandoffWindowMilliseconds;
+        private readonly int _shutdownTimeoutMilliseconds;
         private readonly SemaphoreSlim _executionSemaphore = new(1, 1);
         private readonly CancellationTokenSource _lifetimeCancellationTokenSource = new();
         private readonly TaskCompletionSource<bool> _shutdownCompletionSource =
@@ -32,12 +35,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action disposeResources,
             DynamicCodeExecutionSchedulerHooks hooks = null,
             int busyHandoffWindowMilliseconds = BusyHandoffWindowMilliseconds,
-            int cancelledPrewarmHandoffWindowMilliseconds = CancelledPrewarmHandoffWindowMilliseconds)
+            int cancelledPrewarmHandoffWindowMilliseconds = CancelledPrewarmHandoffWindowMilliseconds,
+            int shutdownTimeoutMilliseconds = DefaultShutdownTimeoutMilliseconds)
         {
+            Debug.Assert(busyHandoffWindowMilliseconds > 0, "busyHandoffWindowMilliseconds must be positive");
+            Debug.Assert(
+                cancelledPrewarmHandoffWindowMilliseconds > 0,
+                "cancelledPrewarmHandoffWindowMilliseconds must be positive");
+            Debug.Assert(shutdownTimeoutMilliseconds > 0, "shutdownTimeoutMilliseconds must be positive");
+
             _disposeResources = disposeResources ?? throw new ArgumentNullException(nameof(disposeResources));
             _hooks = hooks ?? new DynamicCodeExecutionSchedulerHooks();
             _busyHandoffWindowMilliseconds = busyHandoffWindowMilliseconds;
             _cancelledPrewarmHandoffWindowMilliseconds = cancelledPrewarmHandoffWindowMilliseconds;
+            _shutdownTimeoutMilliseconds = shutdownTimeoutMilliseconds;
         }
 
         public void ThrowIfDisposed()
@@ -168,10 +179,43 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        public Task ShutdownAsync()
+        /// <summary>
+        /// Cancels in-flight work and waits for resource dispose up to the shutdown timeout.
+        /// Why timeout then TrySetResult: waiters must unblock even when user code ignores
+        /// cancellation; pool dispose stays deferred to the running action's finally.
+        /// </summary>
+        public async Task ShutdownAsync()
         {
             Dispose();
-            return _shutdownCompletionSource.Task;
+            if (_shutdownCompletionSource.Task.IsCompleted)
+            {
+                return;
+            }
+
+            using CancellationTokenSource timeoutCancellationTokenSource = new();
+            Task delayTask = Task.Delay(
+                _shutdownTimeoutMilliseconds,
+                timeoutCancellationTokenSource.Token);
+            // Why observe via ContinueWith: canceling Delay leaves a canceled task; observing it
+            // avoids unobserved-task noise without a try/catch around await.
+            _ = delayTask.ContinueWith(
+                _ => { },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            Task completedTask = await Task.WhenAny(_shutdownCompletionSource.Task, delayTask);
+            if (completedTask == _shutdownCompletionSource.Task)
+            {
+                timeoutCancellationTokenSource.Cancel();
+                return;
+            }
+
+            _hooks.InvokeLogWarning(
+                "Dynamic code scheduler shutdown drain timed out after " +
+                _shutdownTimeoutMilliseconds +
+                "ms; executor pool dispose is deferred until the running action reaches its finally.");
+            _shutdownCompletionSource.TrySetResult(true);
         }
 
         private async Task<(bool Entered, T Result)> TryRunWithoutForegroundYieldAsync<T>(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionSchedulerHooks.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionSchedulerHooks.cs
@@ -14,6 +14,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public Func<Task> AfterBusySemaphoreProbeFailedAsync { get; set; }
 
+        /// <summary>
+        /// Optional warning sink. Why not Debug.LogWarning here: the scheduler is pure C# and
+        /// must stay Unity-free for the dedicated unit-test project.
+        /// </summary>
+        public Action<string> LogWarning { get; set; }
+
         public async Task InvokeAfterBackgroundExecutionStatePublishedAsync()
         {
             if (AfterBackgroundExecutionStatePublishedAsync == null)
@@ -32,6 +38,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             await AfterBusySemaphoreProbeFailedAsync();
+        }
+
+        public void InvokeLogWarning(string message)
+        {
+            LogWarning?.Invoke(message);
         }
     }
 }

--- a/tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionSchedulerTests.cs
+++ b/tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionSchedulerTests.cs
@@ -214,15 +214,110 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
             }
         }
 
+        [Test]
+        public async Task ShutdownAsync_WhenIdle_ShouldDisposeResourcesAndComplete()
+        {
+            // Verifies idle shutdown completes immediately and disposes resources once.
+            int disposeCalls = 0;
+            DynamicCodeExecutionScheduler scheduler = CreateScheduler(
+                disposeResources: () => disposeCalls++);
+
+            await scheduler.ShutdownAsync();
+
+            Assert.That(disposeCalls, Is.EqualTo(1));
+            Assert.That(scheduler.ShutdownAsync().IsCompletedSuccessfully, Is.True);
+        }
+
+        [Test]
+        public async Task ShutdownAsync_WhenRunningActionObservesCancellation_ShouldDisposeBeforeTimeout()
+        {
+            // Verifies cooperative cancellation lets shutdown finish without hitting the timeout path.
+            int disposeCalls = 0;
+            System.Collections.Generic.List<string> warnings = new();
+            DynamicCodeExecutionSchedulerHooks hooks = new()
+            {
+                LogWarning = message => warnings.Add(message)
+            };
+            DynamicCodeExecutionScheduler scheduler = CreateScheduler(
+                hooks,
+                () => disposeCalls++,
+                shutdownTimeoutMilliseconds: 1000);
+
+            TaskCompletionSource<bool> executionStarted =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            Task<string> executionTask = scheduler.RunForegroundAsync(
+                async cancellationToken =>
+                {
+                    executionStarted.TrySetResult(true);
+                    await WaitForCancellationAsync(cancellationToken);
+                    return "canceled";
+                },
+                () => "busy",
+                CancellationToken.None);
+
+            await executionStarted.Task;
+            await scheduler.ShutdownAsync();
+
+            Assert.That(async () => await executionTask, Throws.InstanceOf<OperationCanceledException>());
+            Assert.That(disposeCalls, Is.EqualTo(1));
+            Assert.That(warnings, Is.Empty);
+        }
+
+        [Test]
+        public async Task ShutdownAsync_WhenRunningActionIgnoresCancellation_ShouldCompleteAfterTimeoutAndDeferDispose()
+        {
+            // Verifies timeout unblocks shutdown while pool dispose waits for the late finally.
+            int disposeCalls = 0;
+            System.Collections.Generic.List<string> warnings = new();
+            DynamicCodeExecutionSchedulerHooks hooks = new()
+            {
+                LogWarning = message => warnings.Add(message)
+            };
+            DynamicCodeExecutionScheduler scheduler = CreateScheduler(
+                hooks,
+                () => disposeCalls++,
+                shutdownTimeoutMilliseconds: 40);
+
+            TaskCompletionSource<bool> executionStarted =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> allowExecutionToComplete =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            Task<string> executionTask = scheduler.RunForegroundAsync(
+                async _ =>
+                {
+                    executionStarted.TrySetResult(true);
+                    await allowExecutionToComplete.Task;
+                    return "late";
+                },
+                () => "busy",
+                CancellationToken.None);
+
+            await executionStarted.Task;
+            await scheduler.ShutdownAsync();
+
+            Assert.That(disposeCalls, Is.EqualTo(0));
+            Assert.That(warnings, Has.Count.EqualTo(1));
+            Assert.That(warnings[0], Does.Contain("timed out after 40ms"));
+            Assert.That(warnings[0], Does.Contain("deferred until the running action reaches its finally"));
+
+            allowExecutionToComplete.TrySetResult(true);
+            string result = await executionTask;
+
+            Assert.That(result, Is.EqualTo("late"));
+            Assert.That(disposeCalls, Is.EqualTo(1));
+        }
+
         private static DynamicCodeExecutionScheduler CreateScheduler(
             DynamicCodeExecutionSchedulerHooks hooks = null,
-            Action disposeResources = null)
+            Action disposeResources = null,
+            int shutdownTimeoutMilliseconds = 1000)
         {
             return new DynamicCodeExecutionScheduler(
                 disposeResources ?? (() => { }),
                 hooks,
                 busyHandoffWindowMilliseconds: 20,
-                cancelledPrewarmHandoffWindowMilliseconds: 40);
+                cancelledPrewarmHandoffWindowMilliseconds: 40,
+                shutdownTimeoutMilliseconds: shutdownTimeoutMilliseconds);
         }
 
         private static async Task WaitForCancellationAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- `ShutdownAsync` now waits at most 5s (ctor-overridable) for in-flight work to finish disposing resources.
- If user code ignores cancellation past that bound, waiters unblock with a warning and pool dispose stays deferred to the late finally.

## User Impact
- **Before:** Server/runtime shutdown could hang indefinitely while `execute-dynamic-code` user code ignored cancellation.
- **After:** Shutdown drain always completes within the timeout. Domain-reload still does not wait for drain (unchanged).

## Changes
- Option A: timeout → `TrySetResult(true)` + warning; no force-dispose under a running action.
- `LogWarning` injected via `DynamicCodeExecutionSchedulerHooks`; facade wires `Debug.LogWarning` (scheduler stays pure C#).
- Cancelable `Task.Delay` so early completion does not leave a timeout timer running.
- Pure unit tests for idle, cooperative cancel, and ignore-cancel + late finally idempotency (no EditMode E2E).

## Refs
- Spec §3 PR 3-2
- Design: `/tmp/claude-shared/pr-3-2-design.md`
- Answers: `/tmp/claude-shared/pr-3-2-review-answers.md`

## Verification
- [x] `dotnet test tests/DynamicCodeExecutionScheduler.UnitTests` (9/9)
- [x] `uloop compile` 0/0
- [x] EditMode domain-reload drain test still passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

