### PR TITLE
fix: shared Roslyn worker ReadLine no longer blocks Editor shutdown

### DIFF
--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -65,7 +65,9 @@ jobs:
 
       - name: Run concurrency unit tests
         if: steps.changes.outputs.csharp == 'true'
-        run: dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
+        run: |
+          dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
+          dotnet test tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj --configuration Release
 
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -27,7 +27,9 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Run concurrency unit tests
-        run: dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
+        run: |
+          dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
+          dotnet test tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj --configuration Release
 
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
@@ -71,13 +71,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     defineSymbols,
                     allowUnsafeCode);
 
-                CompilerMessage[] workerMessages = SharedRoslynCompilerWorkerHost.TryCompile(
+                CompilerMessage[] workerMessages = await SharedRoslynCompilerWorkerHost.TryCompileAsync(
                     workerRequestFilePath,
                     externalCompilerPaths,
                     ct,
                     markBuildStarted,
                     markBuildFinished,
-                    incrementBuildCount);
+                    incrementBuildCount).ConfigureAwait(false);
                 if (workerMessages != null)
                 {
                     return new DynamicCompilationBackendResult(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -295,6 +295,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action incrementBuildCount)
         {
             StreamReader reader = null;
+            // Why not send here: stdin WriteLine/Flush can throw IOException if the worker dies
+            // after HasLiveProcessLocked; keep send inside the retryable try below.
             bool prepared = ServiceValue.ExecuteWithStateLock(() =>
             {
                 if (!ServiceValue.HasLiveProcessLocked())
@@ -302,7 +304,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return false;
                 }
 
-                SendCompileRequestLocked(requestFilePath);
                 reader = ServiceValue.GetOutputReaderLocked();
                 return true;
             });
@@ -320,6 +321,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
+                ServiceValue.ExecuteWithStateLock(() => SendCompileRequestLocked(requestFilePath));
                 return await ReadWorkerResponseAsync(requestFilePath, reader, ct).ConfigureAwait(false);
             }
             catch (IOException ex)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using UnityEditor;
 using UnityEditor.Compilation;
 
@@ -123,7 +124,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             EditorApplication.quitting += ShutdownForQuit;
         }
 
-        public static CompilerMessage[] TryCompile(
+        public static Task<CompilerMessage[]> TryCompileAsync(
             string requestFilePath,
             ExternalCompilerPaths externalCompilerPaths,
             CancellationToken ct,
@@ -131,17 +132,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action markBuildFinished,
             Action incrementBuildCount)
         {
-            return ServiceValue.ExecuteLocked(
-                () => TryCompileWithRetries(
+            return ServiceValue.RunSerializedCompileAsync(
+                operationCt => TryCompileWithRetriesAsync(
                     requestFilePath,
                     externalCompilerPaths,
-                    ct,
+                    operationCt,
                     markBuildStarted,
                     markBuildFinished,
-                    incrementBuildCount));
+                    incrementBuildCount),
+                ct);
         }
 
-        private static CompilerMessage[] TryCompileWithRetries(
+        private static async Task<CompilerMessage[]> TryCompileWithRetriesAsync(
             string requestFilePath,
             ExternalCompilerPaths externalCompilerPaths,
             CancellationToken ct,
@@ -151,20 +153,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             for (int attempt = 1; attempt <= SharedCompilerWorkerMaxAttempts; attempt++)
             {
-                WorkerAttemptResult attemptResult = TryCompileOnce(
+                WorkerAttemptResult attemptResult = await TryCompileOnceAsync(
                     requestFilePath,
                     externalCompilerPaths,
                     ct,
                     markBuildStarted,
                     markBuildFinished,
-                    incrementBuildCount);
+                    incrementBuildCount).ConfigureAwait(false);
 
                 if (attemptResult.Succeeded)
                 {
                     return attemptResult.Messages;
                 }
 
-                ServiceValue.ShutdownProcessLocked();
+                ServiceValue.ExecuteWithStateLock(ServiceValue.ShutdownProcessLocked);
 
                 if (attemptResult.ShouldRetry && attempt < SharedCompilerWorkerMaxAttempts)
                 {
@@ -180,7 +182,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return null;
         }
 
-        private static WorkerAttemptResult TryCompileOnce(
+        private static async Task<WorkerAttemptResult> TryCompileOnceAsync(
             string requestFilePath,
             ExternalCompilerPaths externalCompilerPaths,
             CancellationToken ct,
@@ -196,17 +198,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     startupResult.FailureContext);
             }
 
-            return InvokeWorkerOnce(
+            return await InvokeWorkerOnceAsync(
                 requestFilePath,
                 ct,
                 markBuildStarted,
                 markBuildFinished,
-                incrementBuildCount);
+                incrementBuildCount).ConfigureAwait(false);
         }
 
         private static WorkerStartupResult EnsureWorkerReady(ExternalCompilerPaths externalCompilerPaths)
         {
-            if (ServiceValue.HasLiveProcessLocked())
+            if (ServiceValue.ExecuteWithStateLock(ServiceValue.HasLiveProcessLocked))
             {
                 return WorkerStartupResult.Ready();
             }
@@ -234,8 +236,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return WorkerStartupResult.Ready();
             }
 
+            // Why outside state lock: worker DLL compile can take seconds; shutdown must still kill
+            // an already-running shared worker without waiting on this build.
             SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult buildResult =
-                ServiceValue.CompileWorkerAssemblyLocked(
+                ServiceValue.CompileWorkerAssembly(
                     externalCompilerPaths,
                     workerPaths.SourcePath,
                     workerPaths.AssemblyPath,
@@ -267,7 +271,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             WorkerPaths workerPaths)
         {
             ProcessStartInfo startInfo = CreateWorkerStartInfo(externalCompilerPaths, workerPaths);
-            if (!ServiceValue.StartProcessLocked(startInfo))
+            bool started = ServiceValue.ExecuteWithStateLock(
+                () => ServiceValue.StartProcessLocked(startInfo));
+            if (!started)
             {
                 return WorkerStartupResult.Failure(
                     "worker_start_failed",
@@ -281,14 +287,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return WorkerStartupResult.Ready();
         }
 
-        private static WorkerAttemptResult InvokeWorkerOnce(
+        private static async Task<WorkerAttemptResult> InvokeWorkerOnceAsync(
             string requestFilePath,
             CancellationToken ct,
             Action markBuildStarted,
             Action markBuildFinished,
             Action incrementBuildCount)
         {
-            if (!ServiceValue.HasLiveProcessLocked())
+            StreamReader reader = null;
+            bool prepared = ServiceValue.ExecuteWithStateLock(() =>
+            {
+                if (!ServiceValue.HasLiveProcessLocked())
+                {
+                    return false;
+                }
+
+                SendCompileRequestLocked(requestFilePath);
+                reader = ServiceValue.GetOutputReaderLocked();
+                return true;
+            });
+
+            if (!prepared)
             {
                 return WorkerAttemptResult.RetryableFailure(
                     "worker_process_missing",
@@ -301,8 +320,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                SendCompileRequest(requestFilePath);
-                return ReadWorkerResponse(requestFilePath, ct);
+                return await ReadWorkerResponseAsync(requestFilePath, reader, ct).ConfigureAwait(false);
             }
             catch (IOException ex)
             {
@@ -314,7 +332,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             catch (OperationCanceledException)
             {
-                ServiceValue.ShutdownProcessLocked();
+                ServiceValue.ExecuteWithStateLock(ServiceValue.ShutdownProcessLocked);
                 throw;
             }
             finally
@@ -323,22 +341,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static void SendCompileRequest(string requestFilePath)
+        private static void SendCompileRequestLocked(string requestFilePath)
         {
             string absoluteRequestFilePath = Path.GetFullPath(requestFilePath);
             ServiceValue.SendCompileRequestLocked(absoluteRequestFilePath);
         }
 
-        private static WorkerAttemptResult ReadWorkerResponse(
+        private static async Task<WorkerAttemptResult> ReadWorkerResponseAsync(
             string requestFilePath,
+            StreamReader reader,
             CancellationToken ct)
         {
-            StreamReader reader = ServiceValue.GetOutputReaderLocked();
-            string responseHeader = SharedRoslynCompilerWorkerProtocol.ReadProtocolLine(
+            int timeoutMilliseconds = ServiceValue.ResponseTimeoutMilliseconds;
+            string responseHeader = await SharedRoslynCompilerWorkerProtocol.ReadProtocolLineAsync(
                 reader,
-                ct);
+                ct,
+                timeoutMilliseconds).ConfigureAwait(false);
             if (string.IsNullOrEmpty(responseHeader))
             {
+                // Why kill immediately: abandoned ReadLine tasks unblock only after the pipe closes.
+                ServiceValue.ExecuteWithStateLock(ServiceValue.ShutdownProcessLocked);
                 return WorkerAttemptResult.RetryableFailure(
                     "worker_empty_header",
                     new { request_file_path = requestFilePath });
@@ -346,21 +368,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (!SharedRoslynCompilerWorkerProtocol.TryParseResponseHeader(responseHeader, out int exitCode))
             {
+                ServiceValue.ExecuteWithStateLock(ServiceValue.ShutdownProcessLocked);
                 return WorkerAttemptResult.RetryableFailure(
                     SharedRoslynCompilerWorkerProtocol.GetResponseHeaderFailureReason(responseHeader),
                     new { header = responseHeader });
             }
 
-            List<string> outputLines = SharedRoslynCompilerWorkerProtocol.ReadDiagnosticLines(reader, ct);
+            List<string> outputLines = await SharedRoslynCompilerWorkerProtocol.ReadDiagnosticLinesAsync(
+                reader,
+                ct,
+                timeoutMilliseconds).ConfigureAwait(false);
             if (outputLines == null)
             {
+                ServiceValue.ExecuteWithStateLock(ServiceValue.ShutdownProcessLocked);
                 return WorkerAttemptResult.RetryableFailure(
                     "worker_missing_end_marker",
                     new { request_file_path = requestFilePath });
             }
 
             string combinedOutput = string.Join("\n", outputLines);
-            CompilerMessage[] compilerMessages = ExternalCompilerMessageParser.Parse(combinedOutput, string.Empty, exitCode);
+            CompilerMessage[] compilerMessages = ExternalCompilerMessageParser.Parse(
+                combinedOutput,
+                string.Empty,
+                exitCode);
             return WorkerAttemptResult.Successful(compilerMessages);
         }
 
@@ -368,7 +398,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             string workerDirectoryPath = GetWorkerDirectoryPath();
             Directory.CreateDirectory(workerDirectoryPath);
-            ServiceValue.RecordWorkerDirectoryLocked(workerDirectoryPath);
+            ServiceValue.ExecuteWithStateLock(
+                () => ServiceValue.RecordWorkerDirectoryLocked(workerDirectoryPath));
             return new WorkerPaths(
                 workerDirectoryPath,
                 Path.Combine(workerDirectoryPath, RoslynWorkerSourceFileName),
@@ -403,7 +434,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ExternalCompilerPaths externalCompilerPaths,
             WorkerPaths workerPaths)
         {
-            ProcessStartInfo startInfo = new()            {
+            ProcessStartInfo startInfo = new()
+            {
                 FileName = externalCompilerPaths.DotnetHostPath,
                 Arguments = "exec"
                     + " --runtimeconfig " + SharedRoslynCompilerWorkerAssemblyBuilder.QuoteCommandLineArgument(externalCompilerPaths.CompilerRuntimeConfigPath)
@@ -479,6 +511,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return ServiceValue.SwapWorkerAssemblyCompilerForTests(compiler);
         }
 
+        internal static void SetResponseTimeoutMillisecondsForTests(int timeoutMilliseconds)
+        {
+            ServiceValue.SetResponseTimeoutMillisecondsForTests(timeoutMilliseconds);
+        }
+
         private static void Shutdown()
         {
             ServiceValue.Shutdown(GetWorkerDirectoryPath());
@@ -506,6 +543,5 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 details = failureContext
             };
         }
-
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerLineReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerLineReader.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Async line reader for the shared Roslyn worker stdout protocol.
+    /// Kept free of UnityEngine so pure unit tests can cover timeout and abandonment.
+    /// </summary>
+    internal static class SharedRoslynCompilerWorkerLineReader
+    {
+        public const int DefaultResponseTimeoutMilliseconds = 30000;
+
+        /// <summary>
+        /// Reads one line with an upper bound. On timeout or cancel, the in-flight ReadLine task is
+        /// observed but not awaited; callers must close the stream/process so ReadLine can finish.
+        /// </summary>
+        public static async Task<string> ReadLineAsync(
+            TextReader reader,
+            CancellationToken ct,
+            int timeoutMilliseconds = DefaultResponseTimeoutMilliseconds)
+        {
+            Debug.Assert(reader != null, "reader must not be null");
+            Debug.Assert(timeoutMilliseconds > 0, "timeoutMilliseconds must be positive");
+            ct.ThrowIfCancellationRequested();
+
+            // Why Task.Run: StreamReader.ReadLine has no cancel token; isolation lets timeout return
+            // while the blocking read continues until the caller closes the pipe/process.
+            Task<string> readTask = Task.Run(() => reader.ReadLine(), CancellationToken.None);
+            using CancellationTokenSource timeoutCancellationTokenSource =
+                CancellationTokenSource.CreateLinkedTokenSource(ct);
+            Task delayTask = Task.Delay(timeoutMilliseconds, timeoutCancellationTokenSource.Token);
+            // Why observe delay faults: WhenAny leaves a canceled/faulted delay unobserved otherwise.
+            _ = delayTask.ContinueWith(
+                static observedTask => _ = observedTask.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            Task completedTask = await Task.WhenAny(readTask, delayTask).ConfigureAwait(false);
+            if (ReferenceEquals(completedTask, readTask))
+            {
+                timeoutCancellationTokenSource.Cancel();
+                return await readTask.ConfigureAwait(false);
+            }
+
+            ObserveAbandonedRead(readTask);
+            ct.ThrowIfCancellationRequested();
+            return null;
+        }
+
+        public static async Task<List<string>> ReadDiagnosticLinesAsync(
+            TextReader reader,
+            string endMarker,
+            CancellationToken ct,
+            int timeoutMilliseconds = DefaultResponseTimeoutMilliseconds)
+        {
+            Debug.Assert(reader != null, "reader must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(endMarker), "endMarker must not be empty");
+
+            List<string> outputLines = new();
+            while (true)
+            {
+                string outputLine = await ReadLineAsync(reader, ct, timeoutMilliseconds)
+                    .ConfigureAwait(false);
+                if (outputLine == null)
+                {
+                    return null;
+                }
+
+                if (outputLine == endMarker)
+                {
+                    return outputLines;
+                }
+
+                outputLines.Add(outputLine);
+            }
+        }
+
+        private static void ObserveAbandonedRead(Task<string> readTask)
+        {
+            _ = readTask.ContinueWith(
+                static observedTask => _ = observedTask.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerLineReader.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerLineReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2a7c4b18d9f4e6a0b3c5d7e9f1a2b4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerProtocol.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerProtocol.cs
@@ -25,7 +25,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string SharedCompilerWorkerEndMarkerToken = "{{SHARED_COMPILER_WORKER_END_MARKER}}";
         private const string SharedCompilerWorkerQuitCommandToken = "{{SHARED_COMPILER_WORKER_QUIT_COMMAND}}";
         private const string CompileRequestPathPrefixToken = "{{COMPILE_REQUEST_PATH_PREFIX}}";
-        private const int SharedCompilerWorkerResponseTimeoutMilliseconds = 30000;
 
         internal static string CreateCompileRequestCommand(string requestFilePath)
         {
@@ -59,40 +58,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return "worker_invalid_exit_code";
         }
 
-        internal static List<string> ReadDiagnosticLines(StreamReader reader, CancellationToken ct)
+        internal static Task<List<string>> ReadDiagnosticLinesAsync(
+            TextReader reader,
+            CancellationToken ct,
+            int timeoutMilliseconds = SharedRoslynCompilerWorkerLineReader.DefaultResponseTimeoutMilliseconds)
         {
-            List<string> outputLines = new();
-            while (true)
-            {
-                string outputLine = ReadProtocolLine(reader, ct);
-                if (outputLine == null)
-                {
-                    return null;
-                }
-
-                if (outputLine == SharedCompilerWorkerEndMarker)
-                {
-                    return outputLines;
-                }
-
-                outputLines.Add(outputLine);
-            }
+            return SharedRoslynCompilerWorkerLineReader.ReadDiagnosticLinesAsync(
+                reader,
+                SharedCompilerWorkerEndMarker,
+                ct,
+                timeoutMilliseconds);
         }
 
-        internal static string ReadProtocolLine(StreamReader reader, CancellationToken ct)
+        internal static Task<string> ReadProtocolLineAsync(
+            TextReader reader,
+            CancellationToken ct,
+            int timeoutMilliseconds = SharedRoslynCompilerWorkerLineReader.DefaultResponseTimeoutMilliseconds)
         {
-            Debug.Assert(reader != null, "reader must not be null");
-
-            Task<string> readTask = Task.Run(() => reader.ReadLine());
-            Task timeoutTask = Task.Delay(SharedCompilerWorkerResponseTimeoutMilliseconds, ct);
-            Task completedTask = Task.WhenAny(readTask, timeoutTask).GetAwaiter().GetResult();
-            if (!ReferenceEquals(completedTask, readTask))
-            {
-                ct.ThrowIfCancellationRequested();
-                return null;
-            }
-
-            return readTask.GetAwaiter().GetResult();
+            return SharedRoslynCompilerWorkerLineReader.ReadLineAsync(reader, ct, timeoutMilliseconds);
         }
 
         internal static string CreateProgramSource()

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using UnityEditor.Compilation;
 using Debug = UnityEngine.Debug;
 
@@ -12,36 +13,79 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
     /// Owns the shared Roslyn compiler worker process, temporary directory, and synchronized lifecycle.
+    /// Compile conversations are serialized with an async gate; process state uses a short sync lock
+    /// so shutdown can kill the worker without waiting for an in-flight read.
     /// </summary>
     internal sealed class SharedRoslynCompilerWorkerSession
     {
-        private readonly object _syncRoot = new();
+        private readonly SharedRoslynCompilerWorkerSessionCoordination _coordination = new();
         private Func<ProcessStartInfo, Process> _startProcess = ProcessStartHelper.TryStart;
         private Action<Process, string> _sendCompileRequest = SendCompileRequestCore;
         private Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]>
             _compileWorkerAssemblyForTests;
         private Process _workerProcess;
         private string _workerDirectoryPath;
+        private int _responseTimeoutMilliseconds =
+            SharedRoslynCompilerWorkerLineReader.DefaultResponseTimeoutMilliseconds;
 
+        /// <summary>
+        /// Serializes worker request/response conversations without holding the state lock across awaits.
+        /// </summary>
+        internal Task<T> RunSerializedCompileAsync<T>(
+            Func<CancellationToken, Task<T>> operation,
+            CancellationToken ct)
+        {
+            return _coordination.RunSerializedCompileAsync(operation, ct);
+        }
+
+        /// <summary>
+        /// Runs a short critical section over process/directory state.
+        /// </summary>
+        internal T ExecuteWithStateLock<T>(Func<T> operation)
+        {
+            return _coordination.ExecuteWithStateLock(operation);
+        }
+
+        internal void ExecuteWithStateLock(Action operation)
+        {
+            _coordination.ExecuteWithStateLock(operation);
+        }
+
+        /// <summary>
+        /// Legacy sync entry used by EditMode tests that only touch process start/dispose.
+        /// </summary>
         internal T ExecuteLocked<T>(Func<T> operation)
         {
-            Debug.Assert(operation != null, "operation must not be null");
+            return ExecuteWithStateLock(operation);
+        }
 
-            lock (_syncRoot)
+        internal int ResponseTimeoutMilliseconds
+        {
+            get
             {
-                return operation();
+                return _coordination.ExecuteWithStateLock(() => _responseTimeoutMilliseconds);
             }
+        }
+
+        internal void SetResponseTimeoutMillisecondsForTests(int timeoutMilliseconds)
+        {
+            Debug.Assert(timeoutMilliseconds > 0, "timeoutMilliseconds must be positive");
+
+            _coordination.ExecuteWithStateLock(() =>
+            {
+                _responseTimeoutMilliseconds = timeoutMilliseconds;
+            });
         }
 
         internal bool HasLiveProcessLocked()
         {
-            AssertLockHeld();
+            AssertStateLockHeld();
             return _workerProcess != null && !_workerProcess.HasExited;
         }
 
         internal bool StartProcessLocked(ProcessStartInfo startInfo)
         {
-            AssertLockHeld();
+            AssertStateLockHeld();
             // EnsureWorkerReady reaches this method only after the same lock observed no live process,
             // so replacement releases the stale handle without retrying graceful shutdown.
             Process previousProcess = _workerProcess;
@@ -54,29 +98,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal void SendCompileRequestLocked(string requestFilePath)
         {
-            AssertLockHeld();
+            AssertStateLockHeld();
             _sendCompileRequest(_workerProcess, requestFilePath);
         }
 
         internal StreamReader GetOutputReaderLocked()
         {
-            AssertLockHeld();
+            AssertStateLockHeld();
             return _workerProcess.StandardOutput;
         }
 
         internal void RecordWorkerDirectoryLocked(string workerDirectoryPath)
         {
-            AssertLockHeld();
+            AssertStateLockHeld();
             _workerDirectoryPath = workerDirectoryPath;
         }
 
-        internal SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult CompileWorkerAssemblyLocked(
+        internal SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult CompileWorkerAssembly(
             ExternalCompilerPaths externalCompilerPaths,
             string workerSourcePath,
             string workerAssemblyPath,
             string workerCompileResponseFilePath)
         {
-            AssertLockHeld();
             if (_compileWorkerAssemblyForTests != null)
             {
                 return SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult.Started(
@@ -96,7 +139,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal void ShutdownProcessLocked()
         {
-            AssertLockHeld();
+            AssertStateLockHeld();
             Process workerProcess = _workerProcess;
             _workerProcess = null;
             if (workerProcess == null)
@@ -218,13 +261,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
+        /// <summary>
+        /// Shuts down the worker without waiting for the compile gate.
+        /// In-flight readers fail fast when the process pipes close.
+        /// </summary>
         internal void Shutdown(string fallbackWorkerDirectoryPath)
         {
-            lock (_syncRoot)
+            _coordination.RunShutdownWithoutCompileGate(() =>
             {
                 ShutdownProcessLocked();
                 CleanupWorkerDirectoryLocked(fallbackWorkerDirectoryPath);
-            }
+            });
         }
 
         internal Func<ProcessStartInfo, Process> SwapProcessStarterForTests(
@@ -265,7 +312,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private void CleanupWorkerDirectoryLocked(string fallbackWorkerDirectoryPath)
         {
-            AssertLockHeld();
+            AssertStateLockHeld();
             string workerDirectoryPath = _workerDirectoryPath ?? fallbackWorkerDirectoryPath;
             if (!Directory.Exists(workerDirectoryPath))
             {
@@ -323,9 +370,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 aiTodo: "Investigate repeated worker shutdown communication failures if shared compilation stops recovering cleanly.");
         }
 
-        private void AssertLockHeld()
+        private void AssertStateLockHeld()
         {
-            Debug.Assert(Monitor.IsEntered(_syncRoot), "Shared worker session lock must be held");
+            _coordination.AssertStateLockHeld();
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSessionCoordination.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSessionCoordination.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Separates async compile conversation serialization from short process-state locking
+    /// so shutdown can kill the worker without waiting on an in-flight ReadLine.
+    /// Kept free of UnityEngine so pure unit tests can cover the shutdown interrupt path.
+    /// </summary>
+    internal sealed class SharedRoslynCompilerWorkerSessionCoordination
+    {
+        private readonly object _syncRoot = new();
+        private readonly SemaphoreSlim _compileGate = new(1, 1);
+
+        /// <summary>
+        /// Serializes worker request/response conversations without holding the state lock across awaits.
+        /// </summary>
+        public async Task<T> RunSerializedCompileAsync<T>(
+            Func<CancellationToken, Task<T>> operation,
+            CancellationToken ct)
+        {
+            Debug.Assert(operation != null, "operation must not be null");
+
+            await _compileGate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                return await operation(ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                _compileGate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Runs a short critical section over process/directory state.
+        /// Why not hold this across ReadLine: shutdown must be able to kill the worker while a read waits.
+        /// </summary>
+        public T ExecuteWithStateLock<T>(Func<T> operation)
+        {
+            Debug.Assert(operation != null, "operation must not be null");
+
+            lock (_syncRoot)
+            {
+                return operation();
+            }
+        }
+
+        public void ExecuteWithStateLock(Action operation)
+        {
+            Debug.Assert(operation != null, "operation must not be null");
+
+            lock (_syncRoot)
+            {
+                operation();
+            }
+        }
+
+        /// <summary>
+        /// Runs shutdown under the state lock without acquiring the compile gate.
+        /// </summary>
+        public void RunShutdownWithoutCompileGate(Action shutdownUnderStateLock)
+        {
+            Debug.Assert(shutdownUnderStateLock != null, "shutdownUnderStateLock must not be null");
+
+            lock (_syncRoot)
+            {
+                shutdownUnderStateLock();
+            }
+        }
+
+        public void AssertStateLockHeld()
+        {
+            Debug.Assert(Monitor.IsEntered(_syncRoot), "Shared worker session state lock must be held");
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSessionCoordination.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSessionCoordination.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8f3c1d0e4b64f2a9c7e5d1b0a6f8e2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj
+++ b/tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerLineReader.cs" Link="Production/SharedRoslynCompilerWorkerLineReader.cs" />
+    <Compile Include="../../Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSessionCoordination.cs" Link="Production/SharedRoslynCompilerWorkerSessionCoordination.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorkerLineReaderTests.cs
+++ b/tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorkerLineReaderTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.UnitTests
+{
+    /// <summary>
+    /// Pure unit coverage for async Roslyn worker line reading and compile-gate shutdown.
+    /// </summary>
+    [TestFixture]
+    public class SharedRoslynCompilerWorkerLineReaderTests
+    {
+        [Test]
+        public async Task ReadLineAsync_WhenLineAvailable_ShouldReturnLine()
+        {
+            // Verifies a normal protocol line is returned without hitting the timeout path.
+            using StringReader reader = new("hello\n");
+
+            string line = await SharedRoslynCompilerWorkerLineReader.ReadLineAsync(
+                reader,
+                CancellationToken.None,
+                timeoutMilliseconds: 1000);
+
+            Assert.That(line, Is.EqualTo("hello"));
+        }
+
+        [Test]
+        public async Task ReadLineAsync_WhenNoLineWithinTimeout_ShouldReturnNull()
+        {
+            // Verifies timeout returns null while the abandoned ReadLine is only observed.
+            using AnonymousPipeServerStream server = new(PipeDirection.Out);
+            using AnonymousPipeClientStream client = new(
+                PipeDirection.In,
+                server.ClientSafePipeHandle);
+            using StreamReader reader = new(client);
+
+            string line = await SharedRoslynCompilerWorkerLineReader.ReadLineAsync(
+                reader,
+                CancellationToken.None,
+                timeoutMilliseconds: 40);
+
+            Assert.That(line, Is.Null);
+            server.Dispose();
+        }
+
+        [Test]
+        public void ReadLineAsync_WhenCanceled_ShouldThrowOperationCanceledException()
+        {
+            // Verifies cooperative cancel surfaces as OperationCanceledException before ReadLine starts.
+            using CancellationTokenSource cancellationTokenSource = new();
+            cancellationTokenSource.Cancel();
+            using StringReader reader = new(string.Empty);
+
+            Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await SharedRoslynCompilerWorkerLineReader.ReadLineAsync(
+                    reader,
+                    cancellationTokenSource.Token,
+                    timeoutMilliseconds: 1000));
+        }
+
+        [Test]
+        public async Task ReadLineAsync_WhenCanceledDuringWait_ShouldThrowAndAllowPipeClose()
+        {
+            // Verifies mid-wait cancel returns without holding the caller on the abandoned ReadLine.
+            using AnonymousPipeServerStream server = new(PipeDirection.Out);
+            using AnonymousPipeClientStream client = new(
+                PipeDirection.In,
+                server.ClientSafePipeHandle);
+            using StreamReader reader = new(client);
+            using CancellationTokenSource cancellationTokenSource = new();
+            Task<string> readTask = SharedRoslynCompilerWorkerLineReader.ReadLineAsync(
+                reader,
+                cancellationTokenSource.Token,
+                timeoutMilliseconds: 5000);
+
+            await Task.Delay(20);
+            cancellationTokenSource.Cancel();
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await readTask);
+            server.Dispose();
+        }
+
+        [Test]
+        public async Task ReadDiagnosticLinesAsync_WhenEndMarkerArrives_ShouldReturnCollectedLines()
+        {
+            // Verifies diagnostic aggregation stops at the protocol end marker.
+            using StringReader reader = new("diag-a\ndiag-b\n__ULOOP_END__\n");
+
+            List<string> lines = await SharedRoslynCompilerWorkerLineReader.ReadDiagnosticLinesAsync(
+                reader,
+                "__ULOOP_END__",
+                CancellationToken.None,
+                timeoutMilliseconds: 1000);
+
+            Assert.That(lines, Is.EqualTo(new[] { "diag-a", "diag-b" }));
+        }
+    }
+
+    [TestFixture]
+    public class SharedRoslynCompilerWorkerSessionCoordinationTests
+    {
+        [Test]
+        public async Task RunShutdownWithoutCompileGate_WhileCompileGateHeld_ShouldCompleteWithoutWaitingForGate()
+        {
+            // Verifies shutdown bypasses the async compile gate so a stuck read cannot block it.
+            SharedRoslynCompilerWorkerSessionCoordination coordination = new();
+            TaskCompletionSource<bool> gateEntered =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> allowCompileToFinish =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            int shutdownStateLockEntries = 0;
+
+            Task<bool> compileTask = coordination.RunSerializedCompileAsync(
+                async _ =>
+                {
+                    gateEntered.TrySetResult(true);
+                    await allowCompileToFinish.Task;
+                    return true;
+                },
+                CancellationToken.None);
+
+            await gateEntered.Task;
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            coordination.RunShutdownWithoutCompileGate(() =>
+            {
+                coordination.AssertStateLockHeld();
+                shutdownStateLockEntries++;
+            });
+            stopwatch.Stop();
+
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(500));
+            Assert.That(shutdownStateLockEntries, Is.EqualTo(1));
+
+            allowCompileToFinish.TrySetResult(true);
+            bool compileResult = await compileTask;
+            Assert.That(compileResult, Is.True);
+        }
+
+        [Test]
+        public async Task RunSerializedCompileAsync_AfterShutdown_ShouldStillRunSerializedBody()
+        {
+            // Verifies a later compile conversation is not stuck after shutdown cleared process state.
+            SharedRoslynCompilerWorkerSessionCoordination coordination = new();
+            bool processCleared = false;
+
+            coordination.RunShutdownWithoutCompileGate(() =>
+            {
+                processCleared = true;
+            });
+
+            bool ran = await coordination.RunSerializedCompileAsync(
+                _ => Task.FromResult(true),
+                CancellationToken.None);
+
+            Assert.That(processCleared, Is.True);
+            Assert.That(ran, Is.True);
+            Assert.That(
+                coordination.ExecuteWithStateLock(() => processCleared),
+                Is.True);
+        }
+
+        [Test]
+        public async Task RunSerializedCompileAsync_ShouldSerializeConversations()
+        {
+            // Verifies write→read conversations stay single-flight under the async gate.
+            SharedRoslynCompilerWorkerSessionCoordination coordination = new();
+            int concurrent = 0;
+            int maxConcurrent = 0;
+            object concurrentLock = new();
+
+            Task<int> first = coordination.RunSerializedCompileAsync(
+                async _ =>
+                {
+                    lock (concurrentLock)
+                    {
+                        concurrent++;
+                        maxConcurrent = Math.Max(maxConcurrent, concurrent);
+                    }
+
+                    await Task.Delay(40);
+                    lock (concurrentLock)
+                    {
+                        concurrent--;
+                    }
+
+                    return 1;
+                },
+                CancellationToken.None);
+
+            Task<int> second = coordination.RunSerializedCompileAsync(
+                async _ =>
+                {
+                    lock (concurrentLock)
+                    {
+                        concurrent++;
+                        maxConcurrent = Math.Max(maxConcurrent, concurrent);
+                    }
+
+                    await Task.Delay(10);
+                    lock (concurrentLock)
+                    {
+                        concurrent--;
+                    }
+
+                    return 2;
+                },
+                CancellationToken.None);
+
+            int[] results = await Task.WhenAll(first, second);
+            Assert.That(results, Is.EquivalentTo(new[] { 1, 2 }));
+            Assert.That(maxConcurrent, Is.EqualTo(1));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Domain reload / Editor quit can interrupt a stuck shared Roslyn worker read without waiting up to 30s on the sync lock
- Dynamic-code compile conversations stay single-flight (write→read), while timeout paths kill the worker and observe abandoned reads

## User Impact
- **Before:** A blocked worker `ReadLine` held the session lock, so shutdown (reload/quit) could stall the Editor for the full response timeout
- **After:** Shutdown kills the worker under a short state lock and does not wait on the compile gate; in-flight readers fail fast when pipes close

## Lock boundary (before / after)

```text
BEFORE
┌─────────────────────────────────────────────────────────┐
│ ExecuteLocked(_syncRoot)                                │
│   write request                                         │
│   ReadLine()  ← blocks up to 30s WHILE HOLDING LOCK     │
│   read diagnostics                                      │
└─────────────────────────────────────────────────────────┘
ShutdownProcessLocked ALSO requires _syncRoot
→ shutdown waits behind the stuck ReadLine

AFTER
┌─ SemaphoreSlim compile gate (async, serializes conversations)
│    short _syncRoot: write + take StreamReader
│    await ReadLineAsync  ← OUTSIDE _syncRoot
│    short _syncRoot only if kill/retry needed
└─────────────────────────────────────────────────────────
Shutdown: lock(_syncRoot) only → kill/close pipes
          does NOT WaitAsync on the compile gate
→ stuck read unblocks via pipe close; abandoned Task observed
```

## Changes
- Extract Unity-free `SharedRoslynCompilerWorkerLineReader` (timeout/cancel + observe abandoned `ReadLine`)
- Extract `SharedRoslynCompilerWorkerSessionCoordination` (async compile gate + short state lock + shutdown bypass)
- `TryCompile` → `TryCompileAsync`; host kills worker on empty/invalid/timeout responses
- Pure unit tests for line reader + “shutdown while compile gate held”
- Wire tests into EditMode / compile-check CI workflows

## Out of scope (umbrella note)
- `SharedRoslynCompilerWorkerAssemblyBuilder` still uses sync `WaitForExit` for worker DLL builds; call sites can run on the Unity main thread during compile/prewarm

## Verification
- [x] `dotnet test tests/SharedRoslynCompilerWorker.UnitTests/...` (8 passed)
- [x] Unity Bee compiled `ExecuteDynamicCode.Editor` with no CS errors for these files
- [ ] Local `uloop compile` hung after domain reload in this environment (IPC warmup hit disposed `DynamicCodeExecutionScheduler`); CI compile check is the authoritative follow-up

## Test plan
- [ ] CI: SharedRoslynCompilerWorker unit tests green
- [ ] CI / local: EditMode `SharedRoslynCompilerWorkerHostTests` still pass
- [ ] Manual: trigger domain reload during a slow dynamic-code compile; Editor should not stick on worker ReadLine


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

