### PR TITLE
fix: pause-point disconnect and expiry no longer leave Play Mode stuck paused

### DIFF
--- a/Assets/Tests/Editor/PausePointCaptureModeTests.cs
+++ b/Assets/Tests/Editor/PausePointCaptureModeTests.cs
@@ -180,6 +180,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 PauseCount++;
             }
+
+            public void Resume()
+            {
+                // Why zero: Unity's isPaused is a bool; Option B Resume must fully clear pause.
+                PauseCount = 0;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -329,14 +329,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void ResumeEditorPauseForClientDisconnect_WhenPaused_ShouldResume()
+        public void ResumeEditorPauseForClientDisconnect_WhenPaused_ShouldResumeOnMainThreadApply()
         {
-            // Verifies mid-request / bridge disconnect path resumes unconditionally (Option B).
+            // Verifies disconnect only arms a pending flag; main-thread apply resumes once (Option B).
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePoint.Pause("jump");
 
             UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
+            Assert.That(_pauseController.IsPaused, Is.True);
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(0));
 
+            UloopPausePointRegistry.ApplyPendingClientDisconnectResume();
+
+            Assert.That(_pauseController.IsPaused, Is.False);
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ApplyPendingClientDisconnectResume_WhenNotPaused_ShouldDiscardPendingFlag()
+        {
+            // Verifies a disconnect request while already running does not call Resume.
+            Assert.That(_pauseController.IsPaused, Is.False);
+
+            UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
+            UloopPausePointRegistry.ApplyPendingClientDisconnectResume();
+
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(0));
             Assert.That(_pauseController.IsPaused, Is.False);
         }
 
@@ -977,6 +995,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public bool IsPlaying { get; private set; } = true;
             public bool IsPaused { get; private set; }
             public int PauseCount { get; private set; }
+            public int ResumeCount { get; private set; }
 
             public void Pause()
             {
@@ -986,6 +1005,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             public void Resume()
             {
+                ResumeCount++;
                 IsPaused = false;
             }
         }

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -285,6 +285,59 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.Message, Is.EqualTo("Pause point was already hit (auto-disarmed); nothing to clear."));
+            Assert.That(_pauseController.IsPaused, Is.False);
+        }
+
+        [Test]
+        public void Clear_AfterHit_ShouldResumeEditorPause()
+        {
+            // Verifies Option B: Clear resumes even when the pause was left from a pause-point hit.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+            Assert.That(_pauseController.IsPaused, Is.True);
+
+            UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(_pauseController.IsPaused, Is.False);
+        }
+
+        [Test]
+        public void ClearAll_AfterHit_ShouldResumeEditorPause()
+        {
+            // Verifies ClearAll also resumes under Option B.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            UloopPausePointRegistry.ClearAll();
+
+            Assert.That(_pauseController.IsPaused, Is.False);
+        }
+
+        [Test]
+        public void ApplyCaptureWindowExpirations_WhenHitPastTimeout_ShouldExpireAndResume()
+        {
+            // Verifies abandoned SingleShot hits still expire at ExpiresAtUtc and resume without a Clear poll.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+            _nowUtc = _nowUtc.AddSeconds(31);
+
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
+
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus("jump");
+            Assert.That(status.Status, Is.EqualTo(UloopPausePointStatus.Expired));
+            Assert.That(_pauseController.IsPaused, Is.False);
+        }
+
+        [Test]
+        public void ResumeEditorPauseForClientDisconnect_WhenPaused_ShouldResume()
+        {
+            // Verifies mid-request / bridge disconnect path resumes unconditionally (Option B).
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
+
+            Assert.That(_pauseController.IsPaused, Is.False);
         }
 
         [Test]
@@ -929,6 +982,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 PauseCount++;
                 IsPaused = true;
+            }
+
+            public void Resume()
+            {
+                IsPaused = false;
             }
         }
     }

--- a/Assets/Tests/Editor/PausePointToolModeTests.cs
+++ b/Assets/Tests/Editor/PausePointToolModeTests.cs
@@ -142,6 +142,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 PauseCount++;
             }
+
+            public void Resume()
+            {
+                // Why zero: Unity's isPaused is a bool; Option B Resume must fully clear pause.
+                PauseCount = 0;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
@@ -262,6 +262,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 PauseCount++;
             }
+
+            public void Resume()
+            {
+                // Why zero: Unity's isPaused is a bool; Option B Resume must fully clear pause.
+                PauseCount = 0;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
@@ -477,6 +477,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 PauseCount++;
             }
+
+            public void Resume()
+            {
+                // Why zero: Unity's isPaused is a bool; Option B Resume must fully clear pause.
+                PauseCount = 0;
+            }
         }
     }
 }

--- a/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs
@@ -124,6 +124,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             {
                 IsPaused = true;
             }
+
+            public void Resume()
+            {
+                IsPaused = false;
+            }
         }
     }
 }

--- a/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
@@ -104,6 +104,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             {
                 IsPaused = true;
             }
+
+            public void Resume()
+            {
+                IsPaused = false;
+            }
         }
     }
 }

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -1025,6 +1025,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             {
                 IsPaused = true;
             }
+
+            public void Resume()
+            {
+                IsPaused = false;
+            }
         }
 
         private static BadgeVisual RequireBadgeVisual(string keyName)

--- a/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
@@ -412,6 +412,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             {
                 IsPaused = true;
             }
+
+            public void Resume()
+            {
+                IsPaused = false;
+            }
         }
 
         #endregion

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using io.github.hatayama.UnityCliLoop.Runtime;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
@@ -22,6 +23,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 if (!client.IsConnected)
                 {
+                    // Why: Option B resumes on mid-request CLI disconnect so an abandoned pause
+                    // does not leave frame-dependent tools stuck after the agent dies.
+                    UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
                     requestCancellationTokenSource.Cancel();
                     return;
                 }

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientSessionManager.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientSessionManager.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
@@ -86,6 +87,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 _clientStreams.TryRemove(clientKey, out _);
             }
+
+            // Why: bridge teardown must not leave Play Mode paused after clients are forced off.
+            UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
         }
 
         internal void StartClientHandler(BridgeClientConnection client, CancellationToken cancellationToken)

--- a/Packages/src/Runtime/PausePoints/IUloopPausePointPauseController.cs
+++ b/Packages/src/Runtime/PausePoints/IUloopPausePointPauseController.cs
@@ -9,6 +9,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         bool IsPlaying { get; }
         bool IsPaused { get; }
         void Pause();
+        void Resume();
     }
 }
 #endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -56,16 +56,23 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string StatusBeforeClear { get; private set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; private set; }
 
-        public void ExpireIfNeeded(DateTime nowUtc)
+        public bool ExpireIfNeeded(DateTime nowUtc)
         {
-            if (!IsEnabled)
+            if (Status == UloopPausePointStatus.Cleared || Status == UloopPausePointStatus.Expired)
             {
-                return;
+                return false;
             }
 
             if (nowUtc < ExpiresAtUtc)
             {
-                return;
+                return false;
+            }
+
+            // Why also Hit: SingleShot disarms on hit (IsEnabled=false) but the capture window
+            // still ends at ExpiresAtUtc; without this, an abandoned pause after hit never expires.
+            if (!IsEnabled && Status != UloopPausePointStatus.Hit)
+            {
+                return false;
             }
 
             IsEnabled = false;
@@ -73,6 +80,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             Message = HitCount == 0
                 ? "Pause point expired before it was hit."
                 : $"Pause point capture window expired after {HitCount} hit(s); capture history is preserved.";
+            return true;
         }
 
         public void MarkCleared(string clearedReason, string message = "Pause point cleared.")

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
@@ -13,6 +13,18 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
             EditorApplication.pauseStateChanged += OnPauseStateChanged;
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+            EditorApplication.update += OnEditorUpdate;
+        }
+
+        private static void OnEditorUpdate()
+        {
+            if (!EditorApplication.isPaused)
+            {
+                return;
+            }
+
+            // Why while paused only: abandoned Hit windows must expire without a CLI poll.
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
         }
 
         private static void OnPauseStateChanged(PauseState pauseState)

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
@@ -18,6 +18,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         private static void OnEditorUpdate()
         {
+            // Why before the isPaused gate: disconnect may request resume while already unpaused;
+            // the pending flag must still be consumed on the main thread.
+            UloopPausePointRegistry.ApplyPendingClientDisconnectResume();
+
             if (!EditorApplication.isPaused)
             {
                 return;

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -90,6 +90,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             };
             entry.MarkCleared(UloopPausePointClearedReason.ExplicitClear, message);
             ClearHitSnapshotAndRawCaptureForId(id);
+            // Why always Resume: Option B does not distinguish manual vs pause-point pause.
+            ResumeEditorPause();
             return entry.ToSnapshot(now, _pauseController);
         }
 
@@ -114,6 +116,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
             ClearLatestHitSnapshot();
             UloopPausePointRawCaptureHolder.Clear();
+            // Why always Resume: Option B does not distinguish manual vs pause-point pause.
+            ResumeEditorPause();
 
             UloopPausePointEditorStateSnapshot editorState = UloopPausePointEditorStateSnapshot.FromController(
                 _pauseController,
@@ -132,7 +136,11 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
 
             UloopPausePointEntry entry = Entries[id];
-            entry.ExpireIfNeeded(now);
+            if (entry.ExpireIfNeeded(now))
+            {
+                ResumeEditorPause();
+            }
+
             return entry.ToSnapshot(now, _pauseController);
         }
 
@@ -192,7 +200,12 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
 
             UloopPausePointEntry entry = Entries[id];
-            entry.ExpireIfNeeded(now);
+            if (entry.ExpireIfNeeded(now))
+            {
+                ResumeEditorPause();
+                return entry.ToSnapshot(now, _pauseController);
+            }
+
             if (!entry.IsEnabled)
             {
                 // Why: delayed main-thread hits can lose the race to Clear/ClearAll; surface that race.
@@ -245,6 +258,43 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _latestHitSnapshot = null;
             _hitSnapshots.Clear();
             UloopPausePointRawCaptureHolder.Clear();
+        }
+
+        /// <summary>
+        /// Expires capture windows that have elapsed and resumes the Editor when any expire.
+        /// Used while paused so expiry still runs without a CLI status poll.
+        /// </summary>
+        public static void ApplyCaptureWindowExpirations()
+        {
+            DateTime now = NowUtc();
+            bool anyExpired = false;
+            foreach (UloopPausePointEntry entry in Entries.Values)
+            {
+                if (entry.ExpireIfNeeded(now))
+                {
+                    anyExpired = true;
+                }
+            }
+
+            if (anyExpired)
+            {
+                ResumeEditorPause();
+            }
+        }
+
+        /// <summary>
+        /// Resumes Editor pause when a CLI client drops mid-request or the bridge disconnects all clients.
+        /// Why not on every short-lived command close: that would resume immediately after await-pause-point
+        /// returns a Hit and break the paused inspection workflow.
+        /// </summary>
+        public static void ResumeEditorPauseForClientDisconnect()
+        {
+            ResumeEditorPause();
+        }
+
+        private static void ResumeEditorPause()
+        {
+            _pauseController.Resume();
         }
 
         // Drops the id's own hit-history entry and, if it currently owns the latest hit, that

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -2,15 +2,16 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.Runtime
 {
     /// <summary>
     /// Stores enabled pause point state for the current Editor domain. All members except
-    /// IsArmed are main-thread-only by convention; IsArmed is the one entry point an
-    /// off-main-thread Harmony-injected Capture call may reach, so Entries is a
-    /// ConcurrentDictionary to make that cross-thread read safe.
+    /// IsArmed and ResumeEditorPauseForClientDisconnect are main-thread-only by convention;
+    /// IsArmed is the Harmony Capture entry point, and the disconnect resume path only sets a
+    /// pending flag so thread-pool callers never touch EditorApplication.isPaused.
     /// </summary>
     internal static class UloopPausePointRegistry
     {
@@ -23,6 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         private static Func<DateTime> _nowProvider = () => DateTime.UtcNow;
         private static int _nextGeneration;
         private static int _nextHitSequence;
+        // Why Interlocked: disconnect monitor / DisconnectAllClients run on the thread pool.
+        private static int _pendingClientDisconnectResume;
         private static UloopPausePointSnapshot _latestHitSnapshot;
         // One input can hit several markers in the same frame; tools need the full list,
         // not just the latest hit, to report every marker that interrupted them.
@@ -283,12 +286,34 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         }
 
         /// <summary>
-        /// Resumes Editor pause when a CLI client drops mid-request or the bridge disconnects all clients.
+        /// Requests Editor resume when a CLI client drops mid-request or the bridge disconnects all clients.
+        /// Why flag only: callers run on the thread pool where Unity Editor APIs are unsafe; the main-thread
+        /// Editor update pump applies the resume via ApplyPendingClientDisconnectResume.
         /// Why not on every short-lived command close: that would resume immediately after await-pause-point
         /// returns a Hit and break the paused inspection workflow.
         /// </summary>
         public static void ResumeEditorPauseForClientDisconnect()
         {
+            Interlocked.Exchange(ref _pendingClientDisconnectResume, 1);
+        }
+
+        /// <summary>
+        /// Consumes a pending client-disconnect resume on the Editor main thread.
+        /// </summary>
+        public static void ApplyPendingClientDisconnectResume()
+        {
+            if (Interlocked.Exchange(ref _pendingClientDisconnectResume, 0) == 0)
+            {
+                return;
+            }
+
+            // Why discard when already running: Option B still clears a stale request without
+            // calling Resume on an Editor that is not paused.
+            if (!_pauseController.IsPaused)
+            {
+                return;
+            }
+
             ResumeEditorPause();
         }
 
@@ -340,6 +365,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _nextHitSequence = 0;
             _latestHitSnapshot = null;
             _hitSnapshots.Clear();
+            Interlocked.Exchange(ref _pendingClientDisconnectResume, 0);
             _pauseController = new UnityEditorPausePointPauseController();
             _nowProvider = () => DateTime.UtcNow;
             UloopPausePointRawCaptureHolder.Clear();

--- a/Packages/src/Runtime/PausePoints/UnityEditorPausePointPauseController.cs
+++ b/Packages/src/Runtime/PausePoints/UnityEditorPausePointPauseController.cs
@@ -15,6 +15,13 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
             EditorApplication.isPaused = true;
         }
+
+        public void Resume()
+        {
+            // Why unconditional: Option B clears any Editor pause on disconnect/clear/expiry,
+            // including a manual pause that happens to be active.
+            EditorApplication.isPaused = false;
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Play Mode no longer stays paused forever after a pause-point hit when the agent disconnects, clears markers, or the capture window expires
- Frame-dependent tools (screenshot / simulate-*) can proceed again after those events instead of timing out on a leftover pause

## User Impact
- **Before:** A pause-point hit paused Unity without tying that pause to the CLI session. If the agent died or abandoned the session, Unity stayed paused and later tools failed with “PlayMode is paused”
- **After:** Clear / ClearAll, capture-window expiry, mid-request CLI disconnect, and bridge `DisconnectAllClients` all resume Play Mode
- **Trade-off (approved Option B):** those triggers also clear a **manual** Editor pause or `control-play-mode Pause` if one happens to be active—there is no ownership distinction

## Changes
- Add `Resume()` on `IUloopPausePointPauseController`
- Registry resumes on Clear / ClearAll / newly expired capture windows (including SingleShot hits past `ExpiresAtUtc`)
- While paused, Editor update applies capture-window expirations without requiring a CLI poll
- Mid-request client disconnect monitor and `DisconnectAllClients` call `ResumeEditorPauseForClientDisconnect`
- Short-lived per-command TCP closes do **not** resume (would break post-`await-pause-point` inspection)

## Out of scope
- Domain reload residual pause handling (reload normally resets `isPaused`)

## Verification
- [x] `uloop compile` — 0 errors / 0 warnings
- [x] `uloop run-tests` filter `PausePointTests` — 53 passed
- [x] `uloop run-tests` filter `PausePointCaptureModeTests|PausePointToolModeTests` — 12 passed

## Test plan
- [ ] CI green on this PR
- [ ] Manual: enable pause-point, hit, `clear-pause-point` → Play Mode resumes
- [ ] Manual: hit, wait past enable timeout with Editor paused → resumes without Clear
- [ ] Manual: while paused after hit, kill an in-flight long request mid-way → resumes
- [ ] Manual: after `await-pause-point` returns Hit, Unity stays paused until Clear/expiry (short command disconnect must not resume)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

