### PR TITLE
fix: quietly save dirty Scenes before CLI Play Mode start

### DIFF
--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -260,6 +260,60 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Message, Does.Contain("no saved compiler diagnostics"));
         }
 
+        [Test]
+        public async Task ExecuteAsync_WhenPlayStartSaveFails_DoesNotEnterPlayMode()
+        {
+            // Verifies dirty Scene/Prefab save failure blocks Edit→Play instead of prompting or hanging.
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: new[] { "Scene: Assets/Scenes/Sample.unity" },
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(1));
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.IsPlaying, Is.False);
+            Assert.That(response.Message, Does.Contain("could not be saved"));
+            Assert.That(response.Message, Does.Contain("Scene: Assets/Scenes/Sample.unity"));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenPlayStartLeavesUnsavedChanges_DoesNotEnterPlayMode()
+        {
+            // Verifies remaining dirty editor state after a quiet save still blocks Play start.
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: new[] { "Prefab Stage: Assets/Prefabs/Hud.prefab" });
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(1));
+            Assert.That(quietSaver.DetectCallCount, Is.EqualTo(1));
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.Message, Does.Contain("unsaved scene or prefab changes"));
+            Assert.That(response.Message, Does.Contain("Prefab Stage: Assets/Prefabs/Hud.prefab"));
+        }
+
         private sealed class StubCompilationFailureProvider : IControlPlayModeCompilationFailureProvider
         {
             private readonly ControlPlayModeCompileError[] _errors;
@@ -287,6 +341,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public bool HasScriptCompilationFailed()
             {
                 return _hasScriptCompilationFailed;
+            }
+        }
+
+        private sealed class StubEditorUnsavedChangesQuietSaver : IEditorUnsavedChangesQuietSaver
+        {
+            private readonly string[] _saveFailures;
+            private readonly string[] _remainingAfterSave;
+
+            public int SaveCallCount { get; private set; }
+            public int DetectCallCount { get; private set; }
+
+            public StubEditorUnsavedChangesQuietSaver(string[] saveFailures, string[] remainingAfterSave)
+            {
+                _saveFailures = saveFailures;
+                _remainingAfterSave = remainingAfterSave;
+            }
+
+            public string[] DetectUnsavedEditorChanges()
+            {
+                DetectCallCount++;
+                return _remainingAfterSave;
+            }
+
+            public string[] SaveUnsavedEditorChanges()
+            {
+                SaveCallCount++;
+                return _saveFailures;
             }
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesQuietSaver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesQuietSaver.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Quietly saves dirty loaded Scenes and the current Prefab Stage without prompting the user.
+    /// Shared by run-tests and control-play-mode so Play Mode start and test runs use the same path.
+    /// </summary>
+    public sealed class EditorUnsavedChangesQuietSaver : IEditorUnsavedChangesQuietSaver
+    {
+        public string[] DetectUnsavedEditorChanges()
+        {
+            List<string> unsavedEditorChanges = new();
+            AddDirtyLoadedScenes(unsavedEditorChanges);
+            AddDirtyPrefabStage(unsavedEditorChanges);
+            return unsavedEditorChanges.ToArray();
+        }
+
+        public string[] SaveUnsavedEditorChanges()
+        {
+            List<string> failedChanges = new();
+            SaveDirtyLoadedScenes(failedChanges);
+            SaveDirtyPrefabStage(failedChanges);
+            return failedChanges.ToArray();
+        }
+
+        private static void AddDirtyLoadedScenes(List<string> unsavedEditorChanges)
+        {
+            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
+
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
+                {
+                    continue;
+                }
+
+                unsavedEditorChanges.Add("Scene: " + GetSceneDisplayPath(scene));
+            }
+        }
+
+        private static void SaveDirtyLoadedScenes(List<string> failedChanges)
+        {
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(scene.path) || !EditorSceneManager.SaveScene(scene))
+                {
+                    failedChanges.Add("Scene: " + GetSceneDisplayPath(scene));
+                }
+            }
+        }
+
+        private static void AddDirtyPrefabStage(List<string> unsavedEditorChanges)
+        {
+            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
+
+            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
+            {
+                return;
+            }
+
+            unsavedEditorChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
+        }
+
+        private static void SaveDirtyPrefabStage(List<string> failedChanges)
+        {
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+
+            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
+            {
+                return;
+            }
+
+            if (!SavePrefabStage(prefabStage))
+            {
+                failedChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
+            }
+        }
+
+        private static bool SavePrefabStage(PrefabStage prefabStage)
+        {
+            Debug.Assert(prefabStage != null, "prefabStage must not be null");
+
+            if (string.IsNullOrEmpty(prefabStage.assetPath))
+            {
+                return false;
+            }
+
+            bool success;
+            PrefabUtility.SaveAsPrefabAsset(prefabStage.prefabContentsRoot, prefabStage.assetPath, out success);
+            if (success)
+            {
+                prefabStage.ClearDirtiness();
+            }
+
+            return success;
+        }
+
+        private static string GetSceneDisplayPath(Scene scene)
+        {
+            if (!string.IsNullOrEmpty(scene.path))
+            {
+                return scene.path;
+            }
+
+            if (!string.IsNullOrEmpty(scene.name))
+            {
+                return scene.name;
+            }
+
+            return "Untitled scene";
+        }
+
+        private static string GetPrefabStageDisplayPath(PrefabStage prefabStage)
+        {
+            Debug.Assert(prefabStage != null, "prefabStage must not be null");
+
+            if (!string.IsNullOrEmpty(prefabStage.assetPath))
+            {
+                return prefabStage.assetPath;
+            }
+
+            return GetSceneDisplayPath(prefabStage.scene);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesQuietSaver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesQuietSaver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 780f216b4d59344fe81ae313c7991353
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesQuietSaver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesQuietSaver.cs
@@ -1,0 +1,16 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Detects and quietly saves dirty Editor Scene / Prefab Stage state without user prompts.
+    /// </summary>
+    public interface IEditorUnsavedChangesQuietSaver
+    {
+        string[] DetectUnsavedEditorChanges();
+
+        /// <summary>
+        /// Saves dirty loaded Scenes and the current Prefab Stage.
+        /// Returns display paths that could not be saved; empty when every dirty item saved.
+        /// </summary>
+        string[] SaveUnsavedEditorChanges();
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesQuietSaver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesQuietSaver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c814c807e8042425899f1100d619e415
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
+using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -12,17 +13,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public const int DefaultTimeoutSeconds = 180;
 
+        private const string UnsavedEditorChangesSaveFailureMessage =
+            "Play mode could not start because unsaved scene or prefab changes could not be saved.";
+        private const string UnsavedEditorChangesRemainingFailureMessage =
+            "Play mode could not start while the editor has unsaved scene or prefab changes.";
+
         private readonly IControlPlayModeCompilationFailureProvider _compilationFailureProvider;
         private readonly IControlPlayModeCompilationFailureGate _compilationFailureGate;
+        private readonly IEditorUnsavedChangesQuietSaver _unsavedChangesQuietSaver;
 
         public ControlPlayModeUseCase(
             IControlPlayModeCompilationFailureProvider compilationFailureProvider = null,
-            IControlPlayModeCompilationFailureGate compilationFailureGate = null)
+            IControlPlayModeCompilationFailureGate compilationFailureGate = null,
+            IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver = null)
         {
             _compilationFailureProvider =
                 compilationFailureProvider ?? ControlPlayModeServices.CompilationFailureProvider;
             _compilationFailureGate =
                 compilationFailureGate ?? ControlPlayModeServices.CompilationFailureGate;
+            _unsavedChangesQuietSaver =
+                unsavedChangesQuietSaver ?? new EditorUnsavedChangesQuietSaver();
         }
 
         public Task<ControlPlayModeResponse> ExecuteAsync(ControlPlayModeSchema parameters, CancellationToken ct)
@@ -108,6 +118,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     true);
             }
 
+            // Why only when entering Play from Edit: SaveScene does not work while already playing,
+            // and resume-from-pause must not rewrite Scene assets.
+            if (!wasPlaying)
+            {
+                ControlPlayModeActionResult saveResult = SaveDirtyEditorChangesBeforePlayStart();
+                if (saveResult.HasResponse)
+                {
+                    return saveResult;
+                }
+            }
+
             if (wasPaused)
             {
                 EditorApplication.isPaused = false;
@@ -122,6 +143,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool changed = wasPaused || !wasPlaying;
             string message = wasPaused ? "Play mode resumed" : "Play mode started";
             return ControlPlayModeActionResult.FromState(message, changed, false);
+        }
+
+        private ControlPlayModeActionResult SaveDirtyEditorChangesBeforePlayStart()
+        {
+            string[] failedChanges = _unsavedChangesQuietSaver.SaveUnsavedEditorChanges();
+            Debug.Assert(failedChanges != null, "Unsaved editor change save must return an array");
+            if (failedChanges.Length > 0)
+            {
+                return ControlPlayModeActionResult.FromResponse(
+                    CreateSaveFailedResponse(UnsavedEditorChangesSaveFailureMessage, failedChanges),
+                    false);
+            }
+
+            string[] remainingChanges = _unsavedChangesQuietSaver.DetectUnsavedEditorChanges();
+            Debug.Assert(remainingChanges != null, "Unsaved editor change detection must return an array");
+            if (remainingChanges.Length > 0)
+            {
+                return ControlPlayModeActionResult.FromResponse(
+                    CreateSaveFailedResponse(UnsavedEditorChangesRemainingFailureMessage, remainingChanges),
+                    false);
+            }
+
+            return ControlPlayModeActionResult.FromState(string.Empty, false, false);
         }
 
         private static ControlPlayModeActionResult ExecutePlayModeStop(bool wasPaused, bool wasPlaying)
@@ -170,6 +214,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
 
             return response;
+        }
+
+        private static ControlPlayModeResponse CreateSaveFailedResponse(string messagePrefix, string[] failedChanges)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(messagePrefix), "messagePrefix must not be null or empty");
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+            Debug.Assert(failedChanges.Length > 0, "failedChanges must not be empty");
+
+            string message = messagePrefix + " Unsaved changes: " + string.Join(", ", failedChanges);
+            return CreateResponse(message, false, false);
         }
 
         private static ControlPlayModeResponse CreateCompileErrorBlockedResponse(

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor.asmdef
@@ -2,6 +2,7 @@
     "name": "UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
+        "GUID:d427b32aad9cb44fc8e962437c9dbcd8",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b"
     ],
     "includePlatforms": [

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
 using UnityEditor;
-using UnityEditor.SceneManagement;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -24,17 +21,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string UnsavedEditorChangesSaveFailureMessage =
             "Tests cannot save unsaved scene or prefab changes before running tests.";
 
+        private readonly IEditorUnsavedChangesQuietSaver _unsavedChangesQuietSaver;
+
+        public TestExecutionStateValidationService()
+            : this(new EditorUnsavedChangesQuietSaver())
+        {
+        }
+
+        public TestExecutionStateValidationService(IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver)
+        {
+            Debug.Assert(unsavedChangesQuietSaver != null, "unsavedChangesQuietSaver must not be null");
+            _unsavedChangesQuietSaver = unsavedChangesQuietSaver;
+        }
+
         protected virtual bool IsPlaying => EditorApplication.isPlaying;
         protected virtual bool IsPaused => EditorApplication.isPaused;
         protected virtual bool IsCompiling => EditorApplication.isCompiling;
         protected virtual bool IsUpdating => EditorApplication.isUpdating;
         protected virtual string[] DetectUnsavedEditorChanges()
         {
-            return DetectCurrentUnsavedEditorChanges();
+            return _unsavedChangesQuietSaver.DetectUnsavedEditorChanges();
         }
         protected virtual ValidationResult SaveUnsavedEditorChanges()
         {
-            return SaveCurrentUnsavedEditorChanges();
+            string[] failedChanges = _unsavedChangesQuietSaver.SaveUnsavedEditorChanges();
+            Debug.Assert(failedChanges != null, "Unsaved editor change save must return an array");
+            if (failedChanges.Length > 0)
+            {
+                return ValidationResult.Failure(CreateUnsavedEditorChangesSaveFailureMessage(failedChanges));
+            }
+
+            return ValidationResult.Success();
         }
 
         public virtual ValidationResult Validate(UnityCliLoopTestMode testMode, bool saveBeforeRun)
@@ -76,137 +93,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return ValidationResult.Success();
-        }
-
-        private static string[] DetectCurrentUnsavedEditorChanges()
-        {
-            List<string> unsavedEditorChanges = new();
-            AddDirtyLoadedScenes(unsavedEditorChanges);
-            AddDirtyPrefabStage(unsavedEditorChanges);
-            return unsavedEditorChanges.ToArray();
-        }
-
-        private static ValidationResult SaveCurrentUnsavedEditorChanges()
-        {
-            List<string> failedChanges = new();
-            SaveDirtyLoadedScenes(failedChanges);
-            SaveDirtyPrefabStage(failedChanges);
-            if (failedChanges.Count > 0)
-            {
-                return ValidationResult.Failure(CreateUnsavedEditorChangesSaveFailureMessage(failedChanges.ToArray()));
-            }
-
-            return ValidationResult.Success();
-        }
-
-        private static void AddDirtyLoadedScenes(List<string> unsavedEditorChanges)
-        {
-            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
-
-            for (int i = 0; i < SceneManager.sceneCount; i++)
-            {
-                Scene scene = SceneManager.GetSceneAt(i);
-                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
-                {
-                    continue;
-                }
-
-                unsavedEditorChanges.Add("Scene: " + GetSceneDisplayPath(scene));
-            }
-        }
-
-        private static void SaveDirtyLoadedScenes(List<string> failedChanges)
-        {
-            Debug.Assert(failedChanges != null, "failedChanges must not be null");
-
-            for (int i = 0; i < SceneManager.sceneCount; i++)
-            {
-                Scene scene = SceneManager.GetSceneAt(i);
-                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
-                {
-                    continue;
-                }
-
-                if (string.IsNullOrEmpty(scene.path) || !EditorSceneManager.SaveScene(scene))
-                {
-                    failedChanges.Add("Scene: " + GetSceneDisplayPath(scene));
-                }
-            }
-        }
-
-        private static void AddDirtyPrefabStage(List<string> unsavedEditorChanges)
-        {
-            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
-
-            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
-            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
-            {
-                return;
-            }
-
-            unsavedEditorChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
-        }
-
-        private static void SaveDirtyPrefabStage(List<string> failedChanges)
-        {
-            Debug.Assert(failedChanges != null, "failedChanges must not be null");
-
-            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
-            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
-            {
-                return;
-            }
-
-            if (!SavePrefabStage(prefabStage))
-            {
-                failedChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
-            }
-        }
-
-        private static bool SavePrefabStage(PrefabStage prefabStage)
-        {
-            Debug.Assert(prefabStage != null, "prefabStage must not be null");
-
-            if (string.IsNullOrEmpty(prefabStage.assetPath))
-            {
-                return false;
-            }
-
-            bool success;
-            PrefabUtility.SaveAsPrefabAsset(prefabStage.prefabContentsRoot, prefabStage.assetPath, out success);
-            if (success)
-            {
-                prefabStage.ClearDirtiness();
-            }
-
-            return success;
-        }
-
-        private static string GetSceneDisplayPath(Scene scene)
-        {
-            if (!string.IsNullOrEmpty(scene.path))
-            {
-                return scene.path;
-            }
-
-            if (!string.IsNullOrEmpty(scene.name))
-            {
-                return scene.name;
-            }
-
-            return "Untitled scene";
-        }
-
-        private static string GetPrefabStageDisplayPath(PrefabStage prefabStage)
-        {
-            Debug.Assert(prefabStage != null, "prefabStage must not be null");
-
-            if (!string.IsNullOrEmpty(prefabStage.assetPath))
-            {
-                return prefabStage.assetPath;
-            }
-
-            return GetSceneDisplayPath(prefabStage.scene);
         }
 
         private static string CreateUnsavedEditorChangesFailureMessage(string[] unsavedEditorChanges)


### PR DESCRIPTION
## Summary
- `control-play-mode --action Play` now quietly saves dirty loaded Scenes and the current Prefab Stage before Edit→Play, matching the run-tests save path
- Extracted shared `EditorUnsavedChangesQuietSaver` so both tools use the same quiet-save implementation

## User Impact
- **Before:** Starting Play Mode via CLI with unsaved Scene/Prefab changes could leave the Editor blocked on a save dialog or leave dirty state that later tools trip over
- **After:** CLI Play start auto-saves those dirty assets when possible, or fails with an explicit message listing what could not be saved
- Resume-from-pause does **not** save (SaveScene is ineffective while already playing)

## Changes
- Add `IEditorUnsavedChangesQuietSaver` / `EditorUnsavedChangesQuietSaver` under Common/EditorUtility
- `TestExecutionStateValidationService` delegates detect/save to the shared helper
- `ControlPlayModeUseCase` runs quiet save only on Edit→Play
- ControlPlayMode asmdef references EditorUtility
- Tests for save failure and remaining-dirty failure paths

## Verification
- [x] `uloop compile` — 0 errors / 0 warnings
- [x] `uloop run-tests` filter `ControlPlayModeUseCaseTests|TestExecutionStateValidationServiceTests` — 24 passed

## Test plan
- [ ] CI green on this PR (or local verify if umbrella PR CI is skipped)
- [ ] Manual: dirty a Scene, `uloop control-play-mode --action Play` → Scene saved, Play starts
- [ ] Manual: resume from pause → no unexpected Scene rewrite

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

