### PR TITLE
fix: pause-point disconnect no longer leaves Play Mode stuck; quiet-save before CLI Play

### DIFF
--- a/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
+++ b/Assets/Tests/Editor/ControlPlayModeUseCaseTests.cs
@@ -260,6 +260,60 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Message, Does.Contain("no saved compiler diagnostics"));
         }
 
+        [Test]
+        public async Task ExecuteAsync_WhenPlayStartSaveFails_DoesNotEnterPlayMode()
+        {
+            // Verifies dirty Scene/Prefab save failure blocks Edit→Play instead of prompting or hanging.
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: new[] { "Scene: Assets/Scenes/Sample.unity" },
+                remainingAfterSave: System.Array.Empty<string>());
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(1));
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.IsPlaying, Is.False);
+            Assert.That(response.Message, Does.Contain("could not be saved"));
+            Assert.That(response.Message, Does.Contain("Scene: Assets/Scenes/Sample.unity"));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenPlayStartLeavesUnsavedChanges_DoesNotEnterPlayMode()
+        {
+            // Verifies remaining dirty editor state after a quiet save still blocks Play start.
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            StubEditorUnsavedChangesQuietSaver quietSaver = new(
+                saveFailures: System.Array.Empty<string>(),
+                remainingAfterSave: new[] { "Prefab Stage: Assets/Prefabs/Hud.prefab" });
+            ControlPlayModeUseCase useCase = new ControlPlayModeUseCase(
+                new StubCompilationFailureProvider(System.Array.Empty<ControlPlayModeCompileError>()),
+                new StubCompilationFailureGate(false),
+                quietSaver);
+            ControlPlayModeSchema schema = new ControlPlayModeSchema
+            {
+                Action = PlayModeAction.Play,
+            };
+
+            ControlPlayModeResponse response = await useCase.ExecuteAsync(schema, CancellationToken.None);
+
+            Assert.That(quietSaver.SaveCallCount, Is.EqualTo(1));
+            Assert.That(quietSaver.DetectCallCount, Is.EqualTo(1));
+            Assert.That(EditorApplication.isPlaying, Is.False);
+            Assert.That(response.Changed, Is.False);
+            Assert.That(response.Message, Does.Contain("unsaved scene or prefab changes"));
+            Assert.That(response.Message, Does.Contain("Prefab Stage: Assets/Prefabs/Hud.prefab"));
+        }
+
         private sealed class StubCompilationFailureProvider : IControlPlayModeCompilationFailureProvider
         {
             private readonly ControlPlayModeCompileError[] _errors;
@@ -287,6 +341,33 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public bool HasScriptCompilationFailed()
             {
                 return _hasScriptCompilationFailed;
+            }
+        }
+
+        private sealed class StubEditorUnsavedChangesQuietSaver : IEditorUnsavedChangesQuietSaver
+        {
+            private readonly string[] _saveFailures;
+            private readonly string[] _remainingAfterSave;
+
+            public int SaveCallCount { get; private set; }
+            public int DetectCallCount { get; private set; }
+
+            public StubEditorUnsavedChangesQuietSaver(string[] saveFailures, string[] remainingAfterSave)
+            {
+                _saveFailures = saveFailures;
+                _remainingAfterSave = remainingAfterSave;
+            }
+
+            public string[] DetectUnsavedEditorChanges()
+            {
+                DetectCallCount++;
+                return _remainingAfterSave;
+            }
+
+            public string[] SaveUnsavedEditorChanges()
+            {
+                SaveCallCount++;
+                return _saveFailures;
             }
         }
     }

--- a/Assets/Tests/Editor/PausePointCaptureModeTests.cs
+++ b/Assets/Tests/Editor/PausePointCaptureModeTests.cs
@@ -180,6 +180,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 PauseCount++;
             }
+
+            public void Resume()
+            {
+                // Why zero: Unity's isPaused is a bool; Option B Resume must fully clear pause.
+                PauseCount = 0;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -285,6 +285,77 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.Clear("jump");
 
             Assert.That(snapshot.Message, Is.EqualTo("Pause point was already hit (auto-disarmed); nothing to clear."));
+            Assert.That(_pauseController.IsPaused, Is.False);
+        }
+
+        [Test]
+        public void Clear_AfterHit_ShouldResumeEditorPause()
+        {
+            // Verifies Option B: Clear resumes even when the pause was left from a pause-point hit.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+            Assert.That(_pauseController.IsPaused, Is.True);
+
+            UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(_pauseController.IsPaused, Is.False);
+        }
+
+        [Test]
+        public void ClearAll_AfterHit_ShouldResumeEditorPause()
+        {
+            // Verifies ClearAll also resumes under Option B.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            UloopPausePointRegistry.ClearAll();
+
+            Assert.That(_pauseController.IsPaused, Is.False);
+        }
+
+        [Test]
+        public void ApplyCaptureWindowExpirations_WhenHitPastTimeout_ShouldExpireAndResume()
+        {
+            // Verifies abandoned SingleShot hits still expire at ExpiresAtUtc and resume without a Clear poll.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+            _nowUtc = _nowUtc.AddSeconds(31);
+
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
+
+            UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus("jump");
+            Assert.That(status.Status, Is.EqualTo(UloopPausePointStatus.Expired));
+            Assert.That(_pauseController.IsPaused, Is.False);
+        }
+
+        [Test]
+        public void ResumeEditorPauseForClientDisconnect_WhenPaused_ShouldResumeOnMainThreadApply()
+        {
+            // Verifies disconnect only arms a pending flag; main-thread apply resumes once (Option B).
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
+            Assert.That(_pauseController.IsPaused, Is.True);
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(0));
+
+            UloopPausePointRegistry.ApplyPendingClientDisconnectResume();
+
+            Assert.That(_pauseController.IsPaused, Is.False);
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ApplyPendingClientDisconnectResume_WhenNotPaused_ShouldDiscardPendingFlag()
+        {
+            // Verifies a disconnect request while already running does not call Resume.
+            Assert.That(_pauseController.IsPaused, Is.False);
+
+            UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
+            UloopPausePointRegistry.ApplyPendingClientDisconnectResume();
+
+            Assert.That(_pauseController.ResumeCount, Is.EqualTo(0));
+            Assert.That(_pauseController.IsPaused, Is.False);
         }
 
         [Test]
@@ -924,11 +995,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public bool IsPlaying { get; private set; } = true;
             public bool IsPaused { get; private set; }
             public int PauseCount { get; private set; }
+            public int ResumeCount { get; private set; }
 
             public void Pause()
             {
                 PauseCount++;
                 IsPaused = true;
+            }
+
+            public void Resume()
+            {
+                ResumeCount++;
+                IsPaused = false;
             }
         }
     }

--- a/Assets/Tests/Editor/PausePointToolModeTests.cs
+++ b/Assets/Tests/Editor/PausePointToolModeTests.cs
@@ -142,6 +142,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 PauseCount++;
             }
+
+            public void Resume()
+            {
+                // Why zero: Unity's isPaused is a bool; Option B Resume must fully clear pause.
+                PauseCount = 0;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointCapture/SourcePausePointCaptureTests.cs
@@ -262,6 +262,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 PauseCount++;
             }
+
+            public void Resume()
+            {
+                // Why zero: Unity's isPaused is a bool; Option B Resume must fully clear pause.
+                PauseCount = 0;
+            }
         }
     }
 }

--- a/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointPatcher/SourcePausePointPatcherTests.cs
@@ -477,6 +477,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             {
                 PauseCount++;
             }
+
+            public void Resume()
+            {
+                // Why zero: Unity's isPaused is a bool; Option B Resume must fully clear pause.
+                PauseCount = 0;
+            }
         }
     }
 }

--- a/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/PlayMode/KeyboardInputSimulationResponseFactoryTests.cs
@@ -124,6 +124,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             {
                 IsPaused = true;
             }
+
+            public void Resume()
+            {
+                IsPaused = false;
+            }
         }
     }
 }

--- a/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
+++ b/Assets/Tests/PlayMode/MouseInputSimulationResponseFactoryTests.cs
@@ -104,6 +104,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             {
                 IsPaused = true;
             }
+
+            public void Resume()
+            {
+                IsPaused = false;
+            }
         }
     }
 }

--- a/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
+++ b/Assets/Tests/PlayMode/SimulateKeyboardTests.cs
@@ -1025,6 +1025,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             {
                 IsPaused = true;
             }
+
+            public void Resume()
+            {
+                IsPaused = false;
+            }
         }
 
         private static BadgeVisual RequireBadgeVisual(string keyName)

--- a/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
+++ b/Assets/Tests/PlayMode/SimulateMouseInputTests.cs
@@ -412,6 +412,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
             {
                 IsPaused = true;
             }
+
+            public void Resume()
+            {
+                IsPaused = false;
+            }
         }
 
         #endregion

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesQuietSaver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesQuietSaver.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Quietly saves dirty loaded Scenes and the current Prefab Stage without prompting the user.
+    /// Shared by run-tests and control-play-mode so Play Mode start and test runs use the same path.
+    /// </summary>
+    public sealed class EditorUnsavedChangesQuietSaver : IEditorUnsavedChangesQuietSaver
+    {
+        public string[] DetectUnsavedEditorChanges()
+        {
+            List<string> unsavedEditorChanges = new();
+            AddDirtyLoadedScenes(unsavedEditorChanges);
+            AddDirtyPrefabStage(unsavedEditorChanges);
+            return unsavedEditorChanges.ToArray();
+        }
+
+        public string[] SaveUnsavedEditorChanges()
+        {
+            List<string> failedChanges = new();
+            SaveDirtyLoadedScenes(failedChanges);
+            SaveDirtyPrefabStage(failedChanges);
+            return failedChanges.ToArray();
+        }
+
+        private static void AddDirtyLoadedScenes(List<string> unsavedEditorChanges)
+        {
+            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
+
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
+                {
+                    continue;
+                }
+
+                unsavedEditorChanges.Add("Scene: " + GetSceneDisplayPath(scene));
+            }
+        }
+
+        private static void SaveDirtyLoadedScenes(List<string> failedChanges)
+        {
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(scene.path) || !EditorSceneManager.SaveScene(scene))
+                {
+                    failedChanges.Add("Scene: " + GetSceneDisplayPath(scene));
+                }
+            }
+        }
+
+        private static void AddDirtyPrefabStage(List<string> unsavedEditorChanges)
+        {
+            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
+
+            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
+            {
+                return;
+            }
+
+            unsavedEditorChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
+        }
+
+        private static void SaveDirtyPrefabStage(List<string> failedChanges)
+        {
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+
+            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
+            {
+                return;
+            }
+
+            if (!SavePrefabStage(prefabStage))
+            {
+                failedChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
+            }
+        }
+
+        private static bool SavePrefabStage(PrefabStage prefabStage)
+        {
+            Debug.Assert(prefabStage != null, "prefabStage must not be null");
+
+            if (string.IsNullOrEmpty(prefabStage.assetPath))
+            {
+                return false;
+            }
+
+            bool success;
+            PrefabUtility.SaveAsPrefabAsset(prefabStage.prefabContentsRoot, prefabStage.assetPath, out success);
+            if (success)
+            {
+                prefabStage.ClearDirtiness();
+            }
+
+            return success;
+        }
+
+        private static string GetSceneDisplayPath(Scene scene)
+        {
+            if (!string.IsNullOrEmpty(scene.path))
+            {
+                return scene.path;
+            }
+
+            if (!string.IsNullOrEmpty(scene.name))
+            {
+                return scene.name;
+            }
+
+            return "Untitled scene";
+        }
+
+        private static string GetPrefabStageDisplayPath(PrefabStage prefabStage)
+        {
+            Debug.Assert(prefabStage != null, "prefabStage must not be null");
+
+            if (!string.IsNullOrEmpty(prefabStage.assetPath))
+            {
+                return prefabStage.assetPath;
+            }
+
+            return GetSceneDisplayPath(prefabStage.scene);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesQuietSaver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/EditorUnsavedChangesQuietSaver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 780f216b4d59344fe81ae313c7991353
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesQuietSaver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesQuietSaver.cs
@@ -1,0 +1,16 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Detects and quietly saves dirty Editor Scene / Prefab Stage state without user prompts.
+    /// </summary>
+    public interface IEditorUnsavedChangesQuietSaver
+    {
+        string[] DetectUnsavedEditorChanges();
+
+        /// <summary>
+        /// Saves dirty loaded Scenes and the current Prefab Stage.
+        /// Returns display paths that could not be saved; empty when every dirty item saved.
+        /// </summary>
+        string[] SaveUnsavedEditorChanges();
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesQuietSaver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/EditorUtility/IEditorUnsavedChangesQuietSaver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c814c807e8042425899f1100d619e415
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/ControlPlayModeUseCase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
+using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -12,17 +13,26 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public const int DefaultTimeoutSeconds = 180;
 
+        private const string UnsavedEditorChangesSaveFailureMessage =
+            "Play mode could not start because unsaved scene or prefab changes could not be saved.";
+        private const string UnsavedEditorChangesRemainingFailureMessage =
+            "Play mode could not start while the editor has unsaved scene or prefab changes.";
+
         private readonly IControlPlayModeCompilationFailureProvider _compilationFailureProvider;
         private readonly IControlPlayModeCompilationFailureGate _compilationFailureGate;
+        private readonly IEditorUnsavedChangesQuietSaver _unsavedChangesQuietSaver;
 
         public ControlPlayModeUseCase(
             IControlPlayModeCompilationFailureProvider compilationFailureProvider = null,
-            IControlPlayModeCompilationFailureGate compilationFailureGate = null)
+            IControlPlayModeCompilationFailureGate compilationFailureGate = null,
+            IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver = null)
         {
             _compilationFailureProvider =
                 compilationFailureProvider ?? ControlPlayModeServices.CompilationFailureProvider;
             _compilationFailureGate =
                 compilationFailureGate ?? ControlPlayModeServices.CompilationFailureGate;
+            _unsavedChangesQuietSaver =
+                unsavedChangesQuietSaver ?? new EditorUnsavedChangesQuietSaver();
         }
 
         public Task<ControlPlayModeResponse> ExecuteAsync(ControlPlayModeSchema parameters, CancellationToken ct)
@@ -108,6 +118,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     true);
             }
 
+            // Why only when entering Play from Edit: SaveScene does not work while already playing,
+            // and resume-from-pause must not rewrite Scene assets.
+            if (!wasPlaying)
+            {
+                ControlPlayModeActionResult saveResult = SaveDirtyEditorChangesBeforePlayStart();
+                if (saveResult.HasResponse)
+                {
+                    return saveResult;
+                }
+            }
+
             if (wasPaused)
             {
                 EditorApplication.isPaused = false;
@@ -122,6 +143,29 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool changed = wasPaused || !wasPlaying;
             string message = wasPaused ? "Play mode resumed" : "Play mode started";
             return ControlPlayModeActionResult.FromState(message, changed, false);
+        }
+
+        private ControlPlayModeActionResult SaveDirtyEditorChangesBeforePlayStart()
+        {
+            string[] failedChanges = _unsavedChangesQuietSaver.SaveUnsavedEditorChanges();
+            Debug.Assert(failedChanges != null, "Unsaved editor change save must return an array");
+            if (failedChanges.Length > 0)
+            {
+                return ControlPlayModeActionResult.FromResponse(
+                    CreateSaveFailedResponse(UnsavedEditorChangesSaveFailureMessage, failedChanges),
+                    false);
+            }
+
+            string[] remainingChanges = _unsavedChangesQuietSaver.DetectUnsavedEditorChanges();
+            Debug.Assert(remainingChanges != null, "Unsaved editor change detection must return an array");
+            if (remainingChanges.Length > 0)
+            {
+                return ControlPlayModeActionResult.FromResponse(
+                    CreateSaveFailedResponse(UnsavedEditorChangesRemainingFailureMessage, remainingChanges),
+                    false);
+            }
+
+            return ControlPlayModeActionResult.FromState(string.Empty, false, false);
         }
 
         private static ControlPlayModeActionResult ExecutePlayModeStop(bool wasPaused, bool wasPlaying)
@@ -170,6 +214,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
 
             return response;
+        }
+
+        private static ControlPlayModeResponse CreateSaveFailedResponse(string messagePrefix, string[] failedChanges)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(messagePrefix), "messagePrefix must not be null or empty");
+            Debug.Assert(failedChanges != null, "failedChanges must not be null");
+            Debug.Assert(failedChanges.Length > 0, "failedChanges must not be empty");
+
+            string message = messagePrefix + " Unsaved changes: " + string.Join(", ", failedChanges);
+            return CreateResponse(message, false, false);
         }
 
         private static ControlPlayModeResponse CreateCompileErrorBlockedResponse(

--- a/Packages/src/Editor/FirstPartyTools/ControlPlayMode/UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ControlPlayMode/UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor.asmdef
@@ -2,6 +2,7 @@
     "name": "UnityCLILoop.FirstPartyTools.ControlPlayMode.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
+        "GUID:d427b32aad9cb44fc8e962437c9dbcd8",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b"
     ],
     "includePlatforms": [

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestExecutionStateValidationService.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
 using UnityEditor;
-using UnityEditor.SceneManagement;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -24,17 +21,37 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const string UnsavedEditorChangesSaveFailureMessage =
             "Tests cannot save unsaved scene or prefab changes before running tests.";
 
+        private readonly IEditorUnsavedChangesQuietSaver _unsavedChangesQuietSaver;
+
+        public TestExecutionStateValidationService()
+            : this(new EditorUnsavedChangesQuietSaver())
+        {
+        }
+
+        public TestExecutionStateValidationService(IEditorUnsavedChangesQuietSaver unsavedChangesQuietSaver)
+        {
+            Debug.Assert(unsavedChangesQuietSaver != null, "unsavedChangesQuietSaver must not be null");
+            _unsavedChangesQuietSaver = unsavedChangesQuietSaver;
+        }
+
         protected virtual bool IsPlaying => EditorApplication.isPlaying;
         protected virtual bool IsPaused => EditorApplication.isPaused;
         protected virtual bool IsCompiling => EditorApplication.isCompiling;
         protected virtual bool IsUpdating => EditorApplication.isUpdating;
         protected virtual string[] DetectUnsavedEditorChanges()
         {
-            return DetectCurrentUnsavedEditorChanges();
+            return _unsavedChangesQuietSaver.DetectUnsavedEditorChanges();
         }
         protected virtual ValidationResult SaveUnsavedEditorChanges()
         {
-            return SaveCurrentUnsavedEditorChanges();
+            string[] failedChanges = _unsavedChangesQuietSaver.SaveUnsavedEditorChanges();
+            Debug.Assert(failedChanges != null, "Unsaved editor change save must return an array");
+            if (failedChanges.Length > 0)
+            {
+                return ValidationResult.Failure(CreateUnsavedEditorChangesSaveFailureMessage(failedChanges));
+            }
+
+            return ValidationResult.Success();
         }
 
         public virtual ValidationResult Validate(UnityCliLoopTestMode testMode, bool saveBeforeRun)
@@ -76,137 +93,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             return ValidationResult.Success();
-        }
-
-        private static string[] DetectCurrentUnsavedEditorChanges()
-        {
-            List<string> unsavedEditorChanges = new();
-            AddDirtyLoadedScenes(unsavedEditorChanges);
-            AddDirtyPrefabStage(unsavedEditorChanges);
-            return unsavedEditorChanges.ToArray();
-        }
-
-        private static ValidationResult SaveCurrentUnsavedEditorChanges()
-        {
-            List<string> failedChanges = new();
-            SaveDirtyLoadedScenes(failedChanges);
-            SaveDirtyPrefabStage(failedChanges);
-            if (failedChanges.Count > 0)
-            {
-                return ValidationResult.Failure(CreateUnsavedEditorChangesSaveFailureMessage(failedChanges.ToArray()));
-            }
-
-            return ValidationResult.Success();
-        }
-
-        private static void AddDirtyLoadedScenes(List<string> unsavedEditorChanges)
-        {
-            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
-
-            for (int i = 0; i < SceneManager.sceneCount; i++)
-            {
-                Scene scene = SceneManager.GetSceneAt(i);
-                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
-                {
-                    continue;
-                }
-
-                unsavedEditorChanges.Add("Scene: " + GetSceneDisplayPath(scene));
-            }
-        }
-
-        private static void SaveDirtyLoadedScenes(List<string> failedChanges)
-        {
-            Debug.Assert(failedChanges != null, "failedChanges must not be null");
-
-            for (int i = 0; i < SceneManager.sceneCount; i++)
-            {
-                Scene scene = SceneManager.GetSceneAt(i);
-                if (!scene.IsValid() || !scene.isLoaded || !scene.isDirty)
-                {
-                    continue;
-                }
-
-                if (string.IsNullOrEmpty(scene.path) || !EditorSceneManager.SaveScene(scene))
-                {
-                    failedChanges.Add("Scene: " + GetSceneDisplayPath(scene));
-                }
-            }
-        }
-
-        private static void AddDirtyPrefabStage(List<string> unsavedEditorChanges)
-        {
-            Debug.Assert(unsavedEditorChanges != null, "unsavedEditorChanges must not be null");
-
-            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
-            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
-            {
-                return;
-            }
-
-            unsavedEditorChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
-        }
-
-        private static void SaveDirtyPrefabStage(List<string> failedChanges)
-        {
-            Debug.Assert(failedChanges != null, "failedChanges must not be null");
-
-            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
-            if (prefabStage == null || !prefabStage.scene.IsValid() || !prefabStage.scene.isDirty)
-            {
-                return;
-            }
-
-            if (!SavePrefabStage(prefabStage))
-            {
-                failedChanges.Add("Prefab Stage: " + GetPrefabStageDisplayPath(prefabStage));
-            }
-        }
-
-        private static bool SavePrefabStage(PrefabStage prefabStage)
-        {
-            Debug.Assert(prefabStage != null, "prefabStage must not be null");
-
-            if (string.IsNullOrEmpty(prefabStage.assetPath))
-            {
-                return false;
-            }
-
-            bool success;
-            PrefabUtility.SaveAsPrefabAsset(prefabStage.prefabContentsRoot, prefabStage.assetPath, out success);
-            if (success)
-            {
-                prefabStage.ClearDirtiness();
-            }
-
-            return success;
-        }
-
-        private static string GetSceneDisplayPath(Scene scene)
-        {
-            if (!string.IsNullOrEmpty(scene.path))
-            {
-                return scene.path;
-            }
-
-            if (!string.IsNullOrEmpty(scene.name))
-            {
-                return scene.name;
-            }
-
-            return "Untitled scene";
-        }
-
-        private static string GetPrefabStageDisplayPath(PrefabStage prefabStage)
-        {
-            Debug.Assert(prefabStage != null, "prefabStage must not be null");
-
-            if (!string.IsNullOrEmpty(prefabStage.assetPath))
-            {
-                return prefabStage.assetPath;
-            }
-
-            return GetSceneDisplayPath(prefabStage.scene);
         }
 
         private static string CreateUnsavedEditorChangesFailureMessage(string[] unsavedEditorChanges)

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientDisconnectMonitor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using io.github.hatayama.UnityCliLoop.Runtime;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
 {
@@ -22,6 +23,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 if (!client.IsConnected)
                 {
+                    // Why: Option B resumes on mid-request CLI disconnect so an abandoned pause
+                    // does not leave frame-dependent tools stuck after the agent dies.
+                    UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
                     requestCancellationTokenSource.Cancel();
                     return;
                 }

--- a/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientSessionManager.cs
+++ b/Packages/src/Editor/Infrastructure/UnityCliLoopBridgeClientSessionManager.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Infrastructure
@@ -86,6 +87,9 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             {
                 _clientStreams.TryRemove(clientKey, out _);
             }
+
+            // Why: bridge teardown must not leave Play Mode paused after clients are forced off.
+            UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
         }
 
         internal void StartClientHandler(BridgeClientConnection client, CancellationToken cancellationToken)

--- a/Packages/src/Runtime/PausePoints/IUloopPausePointPauseController.cs
+++ b/Packages/src/Runtime/PausePoints/IUloopPausePointPauseController.cs
@@ -9,6 +9,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         bool IsPlaying { get; }
         bool IsPaused { get; }
         void Pause();
+        void Resume();
     }
 }
 #endif

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -56,16 +56,23 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string StatusBeforeClear { get; private set; } = string.Empty;
         public bool LateHitDiscardedAfterClear { get; private set; }
 
-        public void ExpireIfNeeded(DateTime nowUtc)
+        public bool ExpireIfNeeded(DateTime nowUtc)
         {
-            if (!IsEnabled)
+            if (Status == UloopPausePointStatus.Cleared || Status == UloopPausePointStatus.Expired)
             {
-                return;
+                return false;
             }
 
             if (nowUtc < ExpiresAtUtc)
             {
-                return;
+                return false;
+            }
+
+            // Why also Hit: SingleShot disarms on hit (IsEnabled=false) but the capture window
+            // still ends at ExpiresAtUtc; without this, an abandoned pause after hit never expires.
+            if (!IsEnabled && Status != UloopPausePointStatus.Hit)
+            {
+                return false;
             }
 
             IsEnabled = false;
@@ -73,6 +80,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             Message = HitCount == 0
                 ? "Pause point expired before it was hit."
                 : $"Pause point capture window expired after {HitCount} hit(s); capture history is preserved.";
+            return true;
         }
 
         public void MarkCleared(string clearedReason, string message = "Pause point cleared.")

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
@@ -13,6 +13,22 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
             EditorApplication.pauseStateChanged += OnPauseStateChanged;
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+            EditorApplication.update += OnEditorUpdate;
+        }
+
+        private static void OnEditorUpdate()
+        {
+            // Why before the isPaused gate: disconnect may request resume while already unpaused;
+            // the pending flag must still be consumed on the main thread.
+            UloopPausePointRegistry.ApplyPendingClientDisconnectResume();
+
+            if (!EditorApplication.isPaused)
+            {
+                return;
+            }
+
+            // Why while paused only: abandoned Hit windows must expire without a CLI poll.
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
         }
 
         private static void OnPauseStateChanged(PauseState pauseState)

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -2,15 +2,16 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using UnityEngine;
 
 namespace io.github.hatayama.UnityCliLoop.Runtime
 {
     /// <summary>
     /// Stores enabled pause point state for the current Editor domain. All members except
-    /// IsArmed are main-thread-only by convention; IsArmed is the one entry point an
-    /// off-main-thread Harmony-injected Capture call may reach, so Entries is a
-    /// ConcurrentDictionary to make that cross-thread read safe.
+    /// IsArmed and ResumeEditorPauseForClientDisconnect are main-thread-only by convention;
+    /// IsArmed is the Harmony Capture entry point, and the disconnect resume path only sets a
+    /// pending flag so thread-pool callers never touch EditorApplication.isPaused.
     /// </summary>
     internal static class UloopPausePointRegistry
     {
@@ -23,6 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         private static Func<DateTime> _nowProvider = () => DateTime.UtcNow;
         private static int _nextGeneration;
         private static int _nextHitSequence;
+        // Why Interlocked: disconnect monitor / DisconnectAllClients run on the thread pool.
+        private static int _pendingClientDisconnectResume;
         private static UloopPausePointSnapshot _latestHitSnapshot;
         // One input can hit several markers in the same frame; tools need the full list,
         // not just the latest hit, to report every marker that interrupted them.
@@ -90,6 +93,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             };
             entry.MarkCleared(UloopPausePointClearedReason.ExplicitClear, message);
             ClearHitSnapshotAndRawCaptureForId(id);
+            // Why always Resume: Option B does not distinguish manual vs pause-point pause.
+            ResumeEditorPause();
             return entry.ToSnapshot(now, _pauseController);
         }
 
@@ -114,6 +119,8 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
             ClearLatestHitSnapshot();
             UloopPausePointRawCaptureHolder.Clear();
+            // Why always Resume: Option B does not distinguish manual vs pause-point pause.
+            ResumeEditorPause();
 
             UloopPausePointEditorStateSnapshot editorState = UloopPausePointEditorStateSnapshot.FromController(
                 _pauseController,
@@ -132,7 +139,11 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
 
             UloopPausePointEntry entry = Entries[id];
-            entry.ExpireIfNeeded(now);
+            if (entry.ExpireIfNeeded(now))
+            {
+                ResumeEditorPause();
+            }
+
             return entry.ToSnapshot(now, _pauseController);
         }
 
@@ -192,7 +203,12 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
 
             UloopPausePointEntry entry = Entries[id];
-            entry.ExpireIfNeeded(now);
+            if (entry.ExpireIfNeeded(now))
+            {
+                ResumeEditorPause();
+                return entry.ToSnapshot(now, _pauseController);
+            }
+
             if (!entry.IsEnabled)
             {
                 // Why: delayed main-thread hits can lose the race to Clear/ClearAll; surface that race.
@@ -247,6 +263,65 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             UloopPausePointRawCaptureHolder.Clear();
         }
 
+        /// <summary>
+        /// Expires capture windows that have elapsed and resumes the Editor when any expire.
+        /// Used while paused so expiry still runs without a CLI status poll.
+        /// </summary>
+        public static void ApplyCaptureWindowExpirations()
+        {
+            DateTime now = NowUtc();
+            bool anyExpired = false;
+            foreach (UloopPausePointEntry entry in Entries.Values)
+            {
+                if (entry.ExpireIfNeeded(now))
+                {
+                    anyExpired = true;
+                }
+            }
+
+            if (anyExpired)
+            {
+                ResumeEditorPause();
+            }
+        }
+
+        /// <summary>
+        /// Requests Editor resume when a CLI client drops mid-request or the bridge disconnects all clients.
+        /// Why flag only: callers run on the thread pool where Unity Editor APIs are unsafe; the main-thread
+        /// Editor update pump applies the resume via ApplyPendingClientDisconnectResume.
+        /// Why not on every short-lived command close: that would resume immediately after await-pause-point
+        /// returns a Hit and break the paused inspection workflow.
+        /// </summary>
+        public static void ResumeEditorPauseForClientDisconnect()
+        {
+            Interlocked.Exchange(ref _pendingClientDisconnectResume, 1);
+        }
+
+        /// <summary>
+        /// Consumes a pending client-disconnect resume on the Editor main thread.
+        /// </summary>
+        public static void ApplyPendingClientDisconnectResume()
+        {
+            if (Interlocked.Exchange(ref _pendingClientDisconnectResume, 0) == 0)
+            {
+                return;
+            }
+
+            // Why discard when already running: Option B still clears a stale request without
+            // calling Resume on an Editor that is not paused.
+            if (!_pauseController.IsPaused)
+            {
+                return;
+            }
+
+            ResumeEditorPause();
+        }
+
+        private static void ResumeEditorPause()
+        {
+            _pauseController.Resume();
+        }
+
         // Drops the id's own hit-history entry and, if it currently owns the latest hit, that
         // pointer too - but never touches the raw capture holder. Enable() uses this so a same-id
         // re-enable while paused only resets the entry's generation bookkeeping.
@@ -290,6 +365,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _nextHitSequence = 0;
             _latestHitSnapshot = null;
             _hitSnapshots.Clear();
+            Interlocked.Exchange(ref _pendingClientDisconnectResume, 0);
             _pauseController = new UnityEditorPausePointPauseController();
             _nowProvider = () => DateTime.UtcNow;
             UloopPausePointRawCaptureHolder.Clear();

--- a/Packages/src/Runtime/PausePoints/UnityEditorPausePointPauseController.cs
+++ b/Packages/src/Runtime/PausePoints/UnityEditorPausePointPauseController.cs
@@ -15,6 +15,13 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         {
             EditorApplication.isPaused = true;
         }
+
+        public void Resume()
+        {
+            // Why unconditional: Option B clears any Editor pause on disconnect/clear/expiry,
+            // including a manual pause that happens to be active.
+            EditorApplication.isPaused = false;
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Pause-point hits no longer leave Play Mode stuck paused after CLI disconnect, Clear, or capture-window expiry
- CLI `control-play-mode Play` quietly saves dirty Scenes / Prefab Stage before Edit→Play (same path as run-tests)

## User Impact
- **Before:** An abandoned pause-point pause blocked screenshot / simulate-* with “PlayMode is paused”; dirty Scene dialogs could stall CLI Play start
- **After:** Clear / expiry / mid-request disconnect / `DisconnectAllClients` resume Play Mode; Edit→Play auto-saves dirty editor assets or fails with an explicit list
- **Trade-off (approved Option B):** pause-point auto-resume also clears a manual Editor pause if one happens to be active—no ownership distinction
- Resume-from-pause does **not** rewrite Scene assets (SaveScene is ineffective while already playing)

## Sub-PRs (already merged into this branch)
| PR | Change |
|----|--------|
| #1754 | Resume Play Mode when pause-point markers clear, expire, or CLI disconnects mid-request (pending flag + main-thread apply) |
| #1755 | Quietly save dirty Scenes before CLI Play Mode start via shared `EditorUnsavedChangesQuietSaver` |

## Out of scope
- Domain reload residual pause handling

## Test plan
- [ ] CI green on this PR (Compile Check should run because base is `v3-beta`)
- [ ] Manual: pause-point hit → Clear / wait past timeout / kill mid-request → Play Mode resumes
- [ ] Manual: after `await-pause-point` Hit, short commands do not resume until Clear/expiry
- [ ] Manual: dirty a Scene → `uloop control-play-mode --action Play` → Scene saved, Play starts
- [ ] Manual: resume from pause → no unexpected Scene rewrite

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

