### PR TITLE
fix: hold Auto Refresh when Editor starts unfocused (external scene dialog/crash)

### DIFF
--- a/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs
+++ b/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs
@@ -193,6 +193,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void FocusReturnService_WhenHoldSucceeds_EmitsHoldArmedVibeLog()
+        {
+            // Verifies successful Disallow arms held and emits the observability vibe event once.
+            bool autoRefreshHeld = false;
+            List<string> vibeOperations = new List<string>();
+            ExternalAssetFocusReturnService service = new ExternalAssetFocusReturnService(
+                () => autoRefreshHeld,
+                isHeld => autoRefreshHeld = isHeld,
+                () => false,
+                () => { },
+                () => { },
+                () => { },
+                logWarning: null,
+                logVibeInfo: (operation, message, context) => vibeOperations.Add(operation),
+                logVibeWarning: null);
+
+            service.HoldAutoRefreshIfNeeded();
+            service.HoldAutoRefreshIfNeeded();
+
+            Assert.That(autoRefreshHeld, Is.True);
+            Assert.That(vibeOperations, Is.EqualTo(new[] { "external_scene_hold_armed" }));
+        }
+
+        [Test]
+        public void FocusReturnService_WhenDisallowThrows_EmitsHoldFailedVibeLog()
+        {
+            // Verifies Disallow failures leave SessionState unheld and emit hold_failed vibe warning.
+            bool autoRefreshHeld = false;
+            List<string> vibeOperations = new List<string>();
+            ExternalAssetFocusReturnService service = new ExternalAssetFocusReturnService(
+                () => autoRefreshHeld,
+                isHeld => autoRefreshHeld = isHeld,
+                () => false,
+                () => throw new InvalidOperationException("kCodeReload"),
+                () => { },
+                () => { },
+                logWarning: _ => { },
+                logVibeInfo: null,
+                logVibeWarning: (operation, message, context) => vibeOperations.Add(operation));
+
+            service.HoldAutoRefreshIfNeeded();
+
+            Assert.That(autoRefreshHeld, Is.False);
+            Assert.That(vibeOperations, Is.EqualTo(new[] { "external_scene_hold_failed" }));
+        }
+
+        [Test]
         public void FocusReturnService_WhenFocusIsLost_HoldsAutoRefreshOnce()
         {
             // Verifies focus loss suspends Unity Auto Refresh only once per unfocused interval.

--- a/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs
+++ b/Assets/Tests/Editor/ExternalSceneChangeResolverTests.cs
@@ -216,6 +216,125 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void FocusReturnService_WhenHoldIfCurrentlyUnfocusedTwice_HoldsAutoRefreshOnce()
+        {
+            // Verifies Initialize-style unfocused Hold is idempotent (disallow once).
+            bool autoRefreshHeld = false;
+            int disallowCallCount = 0;
+            ExternalAssetFocusReturnService service = CreateFocusReturnService(
+                () => autoRefreshHeld,
+                isHeld => autoRefreshHeld = isHeld,
+                () => false,
+                () => disallowCallCount++,
+                () => { },
+                () => { });
+
+            service.HoldIfCurrentlyUnfocused();
+            service.HoldIfCurrentlyUnfocused();
+
+            Assert.That(autoRefreshHeld, Is.True);
+            Assert.That(disallowCallCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void FocusReturnService_WhenDisallowThrows_DoesNotSetHeldFlag()
+        {
+            // Verifies kCodeReload Disallow failures leave SessionState unheld for later reconcile.
+            bool autoRefreshHeld = false;
+            List<string> warnings = new List<string>();
+            ExternalAssetFocusReturnService service = CreateFocusReturnService(
+                () => autoRefreshHeld,
+                isHeld => autoRefreshHeld = isHeld,
+                () => false,
+                () => throw new InvalidOperationException("kCodeReload"),
+                () => { },
+                () => { },
+                warning => warnings.Add(warning));
+
+            service.HoldAutoRefreshIfNeeded();
+
+            Assert.That(autoRefreshHeld, Is.False);
+            Assert.That(warnings.Count, Is.EqualTo(1));
+            Assert.That(warnings[0], Does.Contain("DisallowAutoRefresh"));
+            Assert.That(warnings[0], Does.Contain("InvalidOperationException"));
+        }
+
+        [Test]
+        public void FocusReturnService_WhenDisallowStopsFailing_ReconcileHoldsAutoRefresh()
+        {
+            // Verifies update reconcile arms Hold after transient Disallow failures without delayCall chains.
+            bool autoRefreshHeld = false;
+            bool disallowShouldThrow = true;
+            int disallowCallCount = 0;
+            ExternalAssetFocusReturnService service = CreateFocusReturnService(
+                () => autoRefreshHeld,
+                isHeld => autoRefreshHeld = isHeld,
+                () => false,
+                () =>
+                {
+                    disallowCallCount++;
+                    if (disallowShouldThrow)
+                    {
+                        throw new InvalidOperationException("kCodeReload");
+                    }
+                },
+                () => { },
+                () => { },
+                _ => { });
+
+            service.ReconcileAutoRefreshHoldWithFocus();
+            Assert.That(autoRefreshHeld, Is.False);
+
+            disallowShouldThrow = false;
+            service.ReconcileAutoRefreshHoldWithFocus();
+
+            Assert.That(autoRefreshHeld, Is.True);
+            Assert.That(disallowCallCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void FocusReturnService_WhenFocusedAndHeld_ReconcileReleasesAfterPreflight()
+        {
+            // Verifies focused reconcile resolves external changes then releases a surviving Hold.
+            bool autoRefreshHeld = true;
+            List<string> events = new List<string>();
+            ExternalAssetFocusReturnService service = CreateFocusReturnService(
+                () => autoRefreshHeld,
+                isHeld => autoRefreshHeld = isHeld,
+                () => true,
+                () => events.Add("disallow"),
+                () => events.Add("allow"),
+                () => events.Add("preflight"));
+
+            service.ReconcileAutoRefreshHoldWithFocus();
+
+            Assert.That(autoRefreshHeld, Is.False);
+            Assert.That(events, Is.EqualTo(new[] { "preflight", "allow" }));
+        }
+
+        [Test]
+        public void FocusReturnService_WhenAllowThrows_KeepsHeldFlag()
+        {
+            // Verifies failed Allow leaves SessionState held so reconcile can retry without counter desync.
+            bool autoRefreshHeld = true;
+            List<string> warnings = new List<string>();
+            ExternalAssetFocusReturnService service = CreateFocusReturnService(
+                () => autoRefreshHeld,
+                isHeld => autoRefreshHeld = isHeld,
+                () => true,
+                () => { },
+                () => throw new InvalidOperationException("kCodeReload"),
+                () => { },
+                warning => warnings.Add(warning));
+
+            service.HandleFocusChanged(true);
+
+            Assert.That(autoRefreshHeld, Is.True);
+            Assert.That(warnings.Count, Is.EqualTo(1));
+            Assert.That(warnings[0], Does.Contain("AllowAutoRefresh"));
+        }
+
+        [Test]
         public void FocusReturnService_WhenFocusReturns_RunsPreflightBeforeReleasingAutoRefresh()
         {
             // Verifies focus return resolves editor state before Unity Auto Refresh resumes.
@@ -404,7 +523,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Func<bool> isEditorFocused,
             Action disallowAutoRefresh,
             Action allowAutoRefresh,
-            Action resolveFocusReturnChanges)
+            Action resolveFocusReturnChanges,
+            Action<string> logWarning = null)
         {
             return new ExternalAssetFocusReturnService(
                 getAutoRefreshHeld,
@@ -412,7 +532,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 isEditorFocused,
                 disallowAutoRefresh,
                 allowAutoRefresh,
-                resolveFocusReturnChanges);
+                resolveFocusReturnChanges,
+                logWarning);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalAssetFocusReturnService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalAssetFocusReturnService.cs
@@ -5,6 +5,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
     /// Coordinates Auto Refresh suspension while Unity is unfocused.
+    /// Why not rely on focusChanged alone: background launch never fires focus-lost, so
+    /// DisallowAutoRefresh must also be armed from Initialize and periodic reconcile.
     /// </summary>
     internal sealed class ExternalAssetFocusReturnService
     {
@@ -14,6 +16,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly Action _disallowAutoRefresh;
         private readonly Action _allowAutoRefresh;
         private readonly Action _resolveFocusReturnChanges;
+        private readonly Action<string> _logWarning;
 
         internal ExternalAssetFocusReturnService(
             Func<bool> getAutoRefreshHeld,
@@ -21,7 +24,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Func<bool> isEditorFocused,
             Action disallowAutoRefresh,
             Action allowAutoRefresh,
-            Action resolveFocusReturnChanges)
+            Action resolveFocusReturnChanges,
+            Action<string> logWarning = null)
         {
             Debug.Assert(getAutoRefreshHeld != null, "getAutoRefreshHeld must not be null");
             Debug.Assert(setAutoRefreshHeld != null, "setAutoRefreshHeld must not be null");
@@ -37,6 +41,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _allowAutoRefresh = allowAutoRefresh ?? throw new ArgumentNullException(nameof(allowAutoRefresh));
             _resolveFocusReturnChanges =
                 resolveFocusReturnChanges ?? throw new ArgumentNullException(nameof(resolveFocusReturnChanges));
+            _logWarning = logWarning ?? (message => Debug.LogWarning(message));
         }
 
         internal bool RestoreAutoRefreshIfHeld()
@@ -53,6 +58,40 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             HandleFocusChanged(true);
             return true;
+        }
+
+        /// <summary>
+        /// Arms DisallowAutoRefresh when the Editor starts unfocused (no focus-lost event yet).
+        /// </summary>
+        internal void HoldIfCurrentlyUnfocused()
+        {
+            if (_isEditorFocused())
+            {
+                return;
+            }
+
+            HoldAutoRefreshIfNeeded();
+        }
+
+        /// <summary>
+        /// Aligns held flag with focus without depending on focusChanged delivery.
+        /// Idempotent: only calls Disallow/Allow when state must change.
+        /// Why not delayCall retry chains: kCodeReload failures stay unheld and this reconcile retries later.
+        /// </summary>
+        internal void ReconcileAutoRefreshHoldWithFocus()
+        {
+            if (!_isEditorFocused())
+            {
+                HoldAutoRefreshIfNeeded();
+                return;
+            }
+
+            if (!_getAutoRefreshHeld())
+            {
+                return;
+            }
+
+            HandleFocusChanged(true);
         }
 
         internal void HandleFocusChanged(bool isFocused)
@@ -73,14 +112,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private void HoldAutoRefreshIfNeeded()
+        internal void HoldAutoRefreshIfNeeded()
         {
             if (_getAutoRefreshHeld())
             {
                 return;
             }
 
-            _disallowAutoRefresh();
+            if (!TryDisallowAutoRefresh())
+            {
+                return;
+            }
+
+            // Why only after success: setting SessionState on failure desyncs the Unity counter (§10).
             _setAutoRefreshHeld(true);
         }
 
@@ -91,8 +135,45 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            _allowAutoRefresh();
+            if (!TryAllowAutoRefresh())
+            {
+                return;
+            }
+
             _setAutoRefreshHeld(false);
+        }
+
+        private bool TryDisallowAutoRefresh()
+        {
+            // Why try-catch (hatayama-approved, Disallow/Allow boundary only): Unity throws during kCodeReload.
+            try
+            {
+                _disallowAutoRefresh();
+                return true;
+            }
+            catch (Exception exception)
+            {
+                _logWarning(
+                    "Unity CLI Loop could not DisallowAutoRefresh (often during domain reload). " +
+                    "Will retry via focus reconcile. " + exception.GetType().Name + ": " + exception.Message);
+                return false;
+            }
+        }
+
+        private bool TryAllowAutoRefresh()
+        {
+            try
+            {
+                _allowAutoRefresh();
+                return true;
+            }
+            catch (Exception exception)
+            {
+                _logWarning(
+                    "Unity CLI Loop could not AllowAutoRefresh (often during domain reload). " +
+                    "Will retry via focus reconcile. " + exception.GetType().Name + ": " + exception.Message);
+                return false;
+            }
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalAssetFocusReturnService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalAssetFocusReturnService.cs
@@ -17,6 +17,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private readonly Action _allowAutoRefresh;
         private readonly Action _resolveFocusReturnChanges;
         private readonly Action<string> _logWarning;
+        private readonly Action<string, string, object> _logVibeInfo;
+        private readonly Action<string, string, object> _logVibeWarning;
 
         internal ExternalAssetFocusReturnService(
             Func<bool> getAutoRefreshHeld,
@@ -25,7 +27,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action disallowAutoRefresh,
             Action allowAutoRefresh,
             Action resolveFocusReturnChanges,
-            Action<string> logWarning = null)
+            Action<string> logWarning = null,
+            Action<string, string, object> logVibeInfo = null,
+            Action<string, string, object> logVibeWarning = null)
         {
             Debug.Assert(getAutoRefreshHeld != null, "getAutoRefreshHeld must not be null");
             Debug.Assert(setAutoRefreshHeld != null, "setAutoRefreshHeld must not be null");
@@ -42,6 +46,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             _resolveFocusReturnChanges =
                 resolveFocusReturnChanges ?? throw new ArgumentNullException(nameof(resolveFocusReturnChanges));
             _logWarning = logWarning ?? (message => Debug.LogWarning(message));
+            // Why inject: pure C# unit tests stay free of VibeLogger; production wires VibeLogger.
+            _logVibeInfo = logVibeInfo ?? ((operation, message, context) => { });
+            _logVibeWarning = logVibeWarning ?? ((operation, message, context) => { });
         }
 
         internal bool RestoreAutoRefreshIfHeld()
@@ -82,7 +89,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (!_isEditorFocused())
             {
-                HoldAutoRefreshIfNeeded();
+                if (HoldAutoRefreshIfNeeded())
+                {
+                    // Why only on actual repair: reconcile ticks every 0.5s; spam would drown the gate timeline.
+                    _logVibeInfo(
+                        "external_scene_reconcile_repair",
+                        "Reconcile armed Auto Refresh hold while Editor is unfocused",
+                        new { held = true, isFocused = false });
+                }
+
                 return;
             }
 
@@ -92,6 +107,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             HandleFocusChanged(true);
+            _logVibeInfo(
+                "external_scene_reconcile_repair",
+                "Reconcile released Auto Refresh hold while Editor is focused",
+                new { held = _getAutoRefreshHeld(), isFocused = true });
         }
 
         internal void HandleFocusChanged(bool isFocused)
@@ -112,20 +131,28 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        internal void HoldAutoRefreshIfNeeded()
+        /// <summary>
+        /// Attempts to arm DisallowAutoRefresh. Returns true only when this call newly armed the hold.
+        /// </summary>
+        internal bool HoldAutoRefreshIfNeeded()
         {
             if (_getAutoRefreshHeld())
             {
-                return;
+                return false;
             }
 
             if (!TryDisallowAutoRefresh())
             {
-                return;
+                return false;
             }
 
             // Why only after success: setting SessionState on failure desyncs the Unity counter (§10).
             _setAutoRefreshHeld(true);
+            _logVibeInfo(
+                "external_scene_hold_armed",
+                "Auto Refresh hold armed",
+                new { held = true, isFocused = _isEditorFocused() });
+            return true;
         }
 
         private void ReleaseAutoRefreshIfHeld()
@@ -141,6 +168,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             _setAutoRefreshHeld(false);
+            _logVibeInfo(
+                "external_scene_hold_released",
+                "Auto Refresh hold released",
+                new { held = false, isFocused = _isEditorFocused() });
         }
 
         private bool TryDisallowAutoRefresh()
@@ -156,6 +187,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _logWarning(
                     "Unity CLI Loop could not DisallowAutoRefresh (often during domain reload). " +
                     "Will retry via focus reconcile. " + exception.GetType().Name + ": " + exception.Message);
+                _logVibeWarning(
+                    "external_scene_hold_failed",
+                    "DisallowAutoRefresh failed",
+                    new
+                    {
+                        exceptionType = exception.GetType().FullName,
+                        exceptionMessage = exception.Message,
+                        held = _getAutoRefreshHeld(),
+                        isFocused = _isEditorFocused()
+                    });
                 return false;
             }
         }
@@ -172,6 +213,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _logWarning(
                     "Unity CLI Loop could not AllowAutoRefresh (often during domain reload). " +
                     "Will retry via focus reconcile. " + exception.GetType().Name + ": " + exception.Message);
+                _logVibeWarning(
+                    "external_scene_release_failed",
+                    "AllowAutoRefresh failed",
+                    new
+                    {
+                        exceptionType = exception.GetType().FullName,
+                        exceptionMessage = exception.Message,
+                        held = _getAutoRefreshHeld(),
+                        isFocused = _isEditorFocused()
+                    });
                 return false;
             }
         }

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
@@ -32,7 +32,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 () => EditorApplication.isFocused,
                 AssetDatabase.DisallowAutoRefresh,
                 AssetDatabase.AllowAutoRefresh,
-                ResolveForFocusReturn);
+                ResolveForFocusReturn,
+                logWarning: null,
+                logVibeInfo: (operation, message, context) =>
+                {
+                    VibeLogger.LogInfo(operation, message, context, includeStackTrace: false);
+                },
+                logVibeWarning: (operation, message, context) =>
+                {
+                    VibeLogger.LogWarning(operation, message, context);
+                });
         // Why throttle: reconcile must not call Disallow/Allow every frame when already aligned.
         private const double AutoRefreshReconcileIntervalSeconds = 0.5d;
         private static bool _initialized;
@@ -107,6 +116,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static void HandleFocusChanged(bool isFocused)
         {
+            VibeLogger.LogInfo(
+                "external_scene_focus_changed",
+                "Editor focus changed",
+                new { isFocused, held = IsAutoRefreshHeld() },
+                includeStackTrace: false);
             FocusReturnService.HandleFocusChanged(isFocused);
         }
 
@@ -156,6 +170,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             // Focus return treats Unity's in-memory editor state as authoritative because source-control
             // operations can replace files while Unity is unfocused and would otherwise trigger reload dialogs.
+            (string AssetPath, bool IsDirty)[] openScenesBefore = GetOpenSceneStates();
+            object[] fingerprintDiffsBefore = BuildFingerprintDiffContexts(openScenesBefore);
+            VibeLogger.LogInfo(
+                "external_scene_resolve_focus_return",
+                "ResolveForFocusReturn started",
+                new
+                {
+                    phase = "start",
+                    scenes = openScenesBefore,
+                    fingerprintDiffs = fingerprintDiffsBefore,
+                    held = IsAutoRefreshHeld()
+                },
+                includeStackTrace: false);
+
             string[] dirtySceneSaveFailures = SaveDirtyOpenScenesBeforeReload();
             LogFocusReturnFailures("save dirty Scene files", dirtySceneSaveFailures);
 
@@ -175,10 +203,70 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 Debug.LogWarning(
                     "Unity CLI Loop skipped Prefab Stage external-change reload because the current Prefab Stage is still dirty or could not be saved.");
+                VibeLogger.LogInfo(
+                    "external_scene_resolve_focus_return",
+                    "ResolveForFocusReturn finished early (Prefab Stage still dirty or unsaved)",
+                    new
+                    {
+                        phase = "end",
+                        skippedPrefabReload = true,
+                        dirtySceneSaveFailures,
+                        missingSceneSaveFailures,
+                        dirtyPrefabSaveFailures,
+                        missingPrefabSaveFailures,
+                        held = IsAutoRefreshHeld()
+                    },
+                    includeStackTrace: false);
                 return;
             }
 
             ResolveCurrentPrefabStageExternalChangeForFocusReturn();
+
+            (string AssetPath, bool IsDirty)[] openScenesAfter = GetOpenSceneStates();
+            VibeLogger.LogInfo(
+                "external_scene_resolve_focus_return",
+                "ResolveForFocusReturn finished",
+                new
+                {
+                    phase = "end",
+                    scenes = openScenesAfter,
+                    fingerprintDiffs = BuildFingerprintDiffContexts(openScenesAfter),
+                    dirtySceneSaveFailures,
+                    missingSceneSaveFailures,
+                    held = IsAutoRefreshHeld()
+                },
+                includeStackTrace: false);
+        }
+
+        private static object[] BuildFingerprintDiffContexts((string AssetPath, bool IsDirty)[] scenes)
+        {
+            Debug.Assert(scenes != null, "scenes must not be null");
+
+            List<object> diffs = new List<object>(scenes.Length);
+            for (int i = 0; i < scenes.Length; i++)
+            {
+                string assetPath = scenes[i].AssetPath;
+                (bool Exists, DateTime LastWriteTimeUtc, long Length) current =
+                    ReadAssetFileFingerprint(assetPath);
+                bool hasSnapshot = SceneSnapshots.TryGetValue(
+                    assetPath,
+                    out (bool Exists, DateTime LastWriteTimeUtc, long Length) snapshot);
+                bool changed = !hasSnapshot ||
+                               !ExternalAssetFileStateComparer.HasSameFileState(snapshot, current);
+                diffs.Add(new
+                {
+                    assetPath,
+                    isDirty = scenes[i].IsDirty,
+                    changed,
+                    hasSnapshot,
+                    snapshotExists = hasSnapshot && snapshot.Exists,
+                    currentExists = current.Exists,
+                    snapshotLength = hasSnapshot ? snapshot.Length : 0L,
+                    currentLength = current.Length
+                });
+            }
+
+            return diffs.ToArray();
         }
 
         private static void RecordOpenSceneSnapshots()

--- a/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/ExternalSceneChangeTracker.cs
@@ -33,7 +33,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 AssetDatabase.DisallowAutoRefresh,
                 AssetDatabase.AllowAutoRefresh,
                 ResolveForFocusReturn);
+        // Why throttle: reconcile must not call Disallow/Allow every frame when already aligned.
+        private const double AutoRefreshReconcileIntervalSeconds = 0.5d;
         private static bool _initialized;
+        private static double _nextAutoRefreshReconcileTime;
 
         public static void Initialize()
         {
@@ -65,11 +68,30 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             PrefabStage.prefabSaved += HandlePrefabSaved;
             EditorApplication.focusChanged -= HandleFocusChanged;
             EditorApplication.focusChanged += HandleFocusChanged;
+            EditorApplication.update -= ReconcileAutoRefreshHoldOnUpdate;
+            EditorApplication.update += ReconcileAutoRefreshHoldOnUpdate;
+            // Why record before Hold: fingerprints must exist for focus-return resolve after startup Hold.
             if (!restoredHeldAutoRefresh && !IsAutoRefreshHeld())
             {
                 RecordOpenSceneSnapshots();
                 RecordCurrentPrefabStageSnapshot();
             }
+
+            // Why immediate Hold: background launch never fires focusChanged(false), so Auto Refresh
+            // would stay enabled until the first focus and show a native external-change dialog.
+            FocusReturnService.HoldIfCurrentlyUnfocused();
+        }
+
+        private static void ReconcileAutoRefreshHoldOnUpdate()
+        {
+            double now = EditorApplication.timeSinceStartup;
+            if (now < _nextAutoRefreshReconcileTime)
+            {
+                return;
+            }
+
+            _nextAutoRefreshReconcileTime = now + AutoRefreshReconcileIntervalSeconds;
+            FocusReturnService.ReconcileAutoRefreshHoldWithFocus();
         }
 
         public static (bool CanProceed, string Message, string[] ScenePaths) ResolveForCompile(


### PR DESCRIPTION
## Summary
- Background / never-focused Editor startup now arms `DisallowAutoRefresh` immediately (not only on `focusChanged(false)`)
- Throttled update reconcile keeps focus ↔ held flag aligned; kCodeReload failures log and retry via reconcile (no delayCall retry chains)
- SessionState held flag is set/cleared only after Disallow/Allow **succeed**

## User Impact
- **Before:** `uloop launch` in the background never fired focus-lost, so Auto Refresh stayed enabled. External Scene edits (e.g. git discard) then hit Unity’s native `EditorSceneManager::HandleOpenScenesChangeOnDisk` path → reload/ignore dialog, and in at least one local run a **native SIGSEGV** that killed the whole Editor
- **After:** unfocused startup holds Auto Refresh; focus return uses the existing quiet resolve path instead of the native dialog/crash path
- **Out of scope (approved):** discard while Unity stays focused (②) — mitigated only by reconcile + compile-time `ResolveForCompile`

## Real-world crash evidence (pre-fix)
`~/Library/Logs/Unity/Editor-prev.log` (~22:27 session), after loading `RaycastAnnotationPerspectiveDemoScene`:

```text
Native Crash Reporting
Got a segv while executing native code.
...
EditorSceneManager::HandleOpenScenesChangeOnDisk
EditorSceneManager::OnApplicationTick
...
EditorSceneManager::ReloadScene
```

This is the native external-scene-change path this PR bypasses by holding Auto Refresh until uloop can resolve quietly.

## Design choices (from approved answers)
- **Retry strategy:** no delayCall chains — catch logs + leave unheld; **update reconcile** retries
- **try-catch:** Disallow/Allow boundary only (hatayama-approved); always logs; never swallows
- **Idempotent Hold** covered by pure C# tests

## Verification
- [x] `uloop compile` — 0 errors / 0 warnings
- [x] `uloop run-tests` filter `ExternalSceneChangeResolverTests` — 23 passed (incl. vibe hold log tests)
- [x] Manual clean gate: quit → CLI launch unfocused → held probe `focused=False;held=True` → discard → first focus → **no dialog / no crash**
  - Evidence: `/tmp/claude-shared/pr-5-2-clean-gate-result.md` (+ vibe timeline + Editor-prev.log Loaded scene before Refresh)
  - **Post-fix held probe** = ODE snippet reading `EditorApplication.isFocused` + SessionState `...AutoRefreshHeld`; proves hold armed before discard/focus (not dialog absence alone)
- [x] Manual: focused discard (②) still may dialog — expected out of scope (approved)
- [x] ULOOP_DEBUG VibeLogger events on hold/focus/resolve/reconcile-repair (observability for gate correlation)

## Test plan
- [ ] CI green on this PR
- [x] Clean gate on patched build (see Verification)
- [x] Domain reload: held re-armed after unfocused compile path (vibe `hold_armed` at launch; no permanent Disallow desync observed)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


