### PR TITLE
fix: align compile wait timeout with result TTL (10m / 20m)

### DIFF
--- a/Assets/Tests/Editor/UnityCliLoopEditorSessionStateRepositoryTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopEditorSessionStateRepositoryTests.cs
@@ -331,17 +331,36 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void ClearExpiredCompileResult_WhenResultIsStale_ClearsSessionValue()
+        public void ClearExpiredCompileResult_WhenResultIsJustUnderLifetime_KeepsSessionValue()
         {
-            // Verifies stale compile results do not survive indefinitely across commands.
-            DateTime now = new DateTime(2026, 5, 30, 0, 32, 1, DateTimeKind.Utc);
+            // Verifies compile results stay retrievable until the 20-minute TTL elapses.
+            DateTime completedAt = new DateTime(2026, 5, 30, 0, 0, 0, DateTimeKind.Utc);
+            DateTime nowJustUnderLifetime = completedAt.AddMinutes(20).AddSeconds(-1);
             _compileResultSessionRepository.StoreCompileResult(
                 "compile_test_request",
                 forceRecompile: false,
                 resultJson: "{\"Success\":true}",
-                completedAtUtc: new DateTime(2026, 5, 30, 0, 0, 0, DateTimeKind.Utc));
+                completedAtUtc: completedAt);
 
-            bool cleared = _compileSessionLifecycleService.ClearExpiredCompileResult(now);
+            bool cleared = _compileSessionLifecycleService.ClearExpiredCompileResult(nowJustUnderLifetime);
+
+            Assert.That(cleared, Is.False);
+            Assert.That(_compileResultSessionRepository.GetStoredCompileResult().HasResult, Is.True);
+        }
+
+        [Test]
+        public void ClearExpiredCompileResult_WhenResultIsJustOverLifetime_ClearsSessionValue()
+        {
+            // Verifies compile results expire immediately after the 20-minute TTL.
+            DateTime completedAt = new DateTime(2026, 5, 30, 0, 0, 0, DateTimeKind.Utc);
+            DateTime nowJustOverLifetime = completedAt.AddMinutes(20).AddSeconds(1);
+            _compileResultSessionRepository.StoreCompileResult(
+                "compile_test_request",
+                forceRecompile: false,
+                resultJson: "{\"Success\":true}",
+                completedAtUtc: completedAt);
+
+            bool cleared = _compileSessionLifecycleService.ClearExpiredCompileResult(nowJustOverLifetime);
 
             Assert.That(cleared, Is.True);
             Assert.That(_compileResultSessionRepository.GetStoredCompileResult().HasResult, Is.False);

--- a/Packages/src/Editor/Domain/UnityCliLoopCompileSessionLifecycleService.cs
+++ b/Packages/src/Editor/Domain/UnityCliLoopCompileSessionLifecycleService.cs
@@ -8,7 +8,10 @@ namespace io.github.hatayama.UnityCliLoop.Domain
     /// </summary>
     public sealed class UnityCliLoopCompileSessionLifecycleService
     {
-        private static readonly TimeSpan CompileResultLifetime = TimeSpan.FromMinutes(32);
+        // Why 20m: Go compileWaitTimeout is 10m; TTL must stay longer (wait ≤ TTL) so a
+        // timed-out client can still retrieve the result by retrying uloop compile for
+        // about 10 more minutes. Why not keep 32m: shrink session-state leak window.
+        private static readonly TimeSpan CompileResultLifetime = TimeSpan.FromMinutes(20);
         private readonly ISessionFlagsRepository _sessionFlagsRepository;
         private readonly ICompileResultSessionRepository _compileResultSessionRepository;
         private readonly IPendingCompileSessionRepository _pendingCompileSessionRepository;

--- a/cli/project-runner/internal/projectrunner/compile_wait.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait.go
@@ -18,11 +18,14 @@ import (
 )
 
 const (
-	compileStatusCommandName  = "get-compile-status"
-	compileRequestIDParam     = "RequestId"
-	compileWaitParam          = clicore.DomainReloadWaitParam
-	compileForceParam         = "ForceRecompile"
-	compileWaitTimeout        = clicore.ToolReadinessTimeout
+	compileStatusCommandName = "get-compile-status"
+	compileRequestIDParam    = "RequestId"
+	compileWaitParam         = clicore.DomainReloadWaitParam
+	compileForceParam        = "ForceRecompile"
+	// Why separate from ToolReadinessTimeout (180s): launch readiness stays short.
+	// Why 10m: worst-case blind block beats headroom. Why ≤ C# CompileResultLifetime (20m):
+	// timed-out clients can still retrieve results by retrying uloop compile ~10m more.
+	compileWaitTimeout        = 10 * time.Minute
 	compileWaitPollInterval   = clicore.ToolReadinessPoll
 	compileStatusProbeTimeout = clicore.ToolReadinessProbeTimeout
 	compileResponseTimeout    = 2 * time.Second

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -567,13 +567,13 @@ func TestCompileWaitTimeoutError(t *testing.T) {
 	if cliErr.ProjectRoot != "/tmp/MyProject" {
 		t.Fatalf("project root mismatch: %#v", cliErr)
 	}
-	expectedMessage := "Compile status wait timed out after 180000ms. This does not mean the Unity Editor is frozen; the compile may simply still be running."
+	expectedMessage := "Compile status wait timed out after 600000ms. This does not mean the Unity Editor is frozen; the compile may simply still be running."
 	if cliErr.Message != expectedMessage {
 		t.Fatalf("message mismatch: %#v", cliErr.Message)
 	}
 	expectedActions := []string{
 		"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is responsive before treating this as a freeze.",
-		"If Unity responds, retry `uloop compile`; the previous compile likely finished in the meantime.",
+		"Unity-side compile continues after this timeout; retry `uloop compile` — the result remains retrievable for about 10 more minutes without `uloop launch -r`.",
 		"Only if Unity does not respond to any command, restart it with `uloop launch -r`.",
 	}
 	if len(cliErr.NextActions) != len(expectedActions) {

--- a/cli/project-runner/internal/projectrunner/execution_errors.go
+++ b/cli/project-runner/internal/projectrunner/execution_errors.go
@@ -19,11 +19,12 @@ func compileWaitTimeoutError(projectRoot string) clierrors.CLIError {
 		SafeToRetry: true,
 		ProjectRoot: projectRoot,
 		Command:     clicore.CompileCommandName,
-		// Agents have terminated whole sessions after misreading this timeout as a
-		// frozen Editor, so the guidance must walk them through a responsiveness check.
+		// Why: agents historically treated this timeout as a frozen Editor and ran
+		// launch -r. The real recovery path is retrying compile while C# still holds
+		// the result (CompileResultLifetime 20m = wait 10m + ~10m retrievable window).
 		NextActions: []string{
 			"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is responsive before treating this as a freeze.",
-			"If Unity responds, retry `uloop compile`; the previous compile likely finished in the meantime.",
+			"Unity-side compile continues after this timeout; retry `uloop compile` — the result remains retrievable for about 10 more minutes without `uloop launch -r`.",
 			"Only if Unity does not respond to any command, restart it with `uloop launch -r`.",
 		},
 	}


### PR DESCRIPTION
## Summary
- Separate `compileWaitTimeout` from launch `ToolReadinessTimeout` (180s stays untouched): compile wait is now **10 minutes**
- Lower C# `CompileResultLifetime` from 32m to **20 minutes** (`wait ≤ TTL`) so a timed-out client can still retrieve the result
- Rewrite compile-wait `NextActions` so agents retry `uloop compile` (~10 more minutes of retrievable window) instead of jumping to `launch -r`

## User Impact
- **Before:** CLI gave up at 180s while Unity kept compile results for 32m; agents often treated the timeout as a freeze and restarted the Editor
- **After:** CLI waits up to 10m; timeout guidance tells agents Unity-side compile continues and `uloop compile` retry can still pick up the result for about 10 more minutes without restart

## Design
Approved Option C: `/tmp/claude-shared/pr-5-1-design-answers.md`

## Verification
- [x] `scripts/check-go-cli.sh`
- [x] `uloop compile` — 0 errors / 0 warnings
- [x] `uloop run-tests` filter `UnityCliLoopEditorSessionStateRepositoryTests` — 20 passed (incl. TTL boundary just-under / just-over 20m)
- [x] No protocol bump / no shared-inputs stamp (project-runner-only Go change)

## Test plan
- [ ] CI green on this PR
- [ ] Optional: long compile >3m still completes under the new 10m wait

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

