### PR TITLE
docs: guide agents through API Update / Script Updating Consent modals

### DIFF
--- a/.agents/skills/uloop-compile/SKILL.md
+++ b/.agents/skills/uloop-compile/SKILL.md
@@ -30,3 +30,7 @@ Returns JSON:
 - `ErrorCount`: number or null
 - `WarningCount`: number or null
 - `Message`: string
+
+## Troubleshooting
+
+If compile times out or Unity stops responding to uloop while the Editor looks idle, check whether Unity is showing **API Update Required** / **Script Updating Consent**. Ask the user to choose Go Ahead or No — never auto-dismiss that modal. Interactive Editors have no public uloop/Unity API to suppress it.

--- a/.claude/skills/uloop-compile/SKILL.md
+++ b/.claude/skills/uloop-compile/SKILL.md
@@ -30,3 +30,7 @@ Returns JSON:
 - `ErrorCount`: number or null
 - `WarningCount`: number or null
 - `Message`: string
+
+## Troubleshooting
+
+If compile times out or Unity stops responding to uloop while the Editor looks idle, check whether Unity is showing **API Update Required** / **Script Updating Consent**. Ask the user to choose Go Ahead or No — never auto-dismiss that modal. Interactive Editors have no public uloop/Unity API to suppress it.

--- a/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Compile/Skill/SKILL.md
@@ -30,3 +30,7 @@ Returns JSON:
 - `ErrorCount`: number or null
 - `WarningCount`: number or null
 - `Message`: string
+
+## Troubleshooting
+
+If compile times out or Unity stops responding to uloop while the Editor looks idle, check whether Unity is showing **API Update Required** / **Script Updating Consent**. Ask the user to choose Go Ahead or No — never auto-dismiss that modal. Interactive Editors have no public uloop/Unity API to suppress it.

--- a/cli/common/errors/error_editor_unresponsive.go
+++ b/cli/common/errors/error_editor_unresponsive.go
@@ -2,6 +2,11 @@ package clierrors
 
 import "github.com/hatayama/unity-cli-loop/common/unityipc"
 
+// ApiUpdateConsentModalNextAction is shared recovery guidance when the Editor main
+// thread may be blocked by Unity's API Update / Script Updating Consent modal
+// (group-5 PR 5-3: interactive Editors have no public suppress path).
+const ApiUpdateConsentModalNextAction = "The Editor may be showing an API Update / Script Updating Consent modal; check the Unity window and ask the user what to choose — never auto-dismiss it."
+
 func connectionAttemptCause(err *unityipc.ConnectionAttemptError) string {
 	if err == nil {
 		return ""
@@ -24,6 +29,7 @@ func unityEditorUnresponsiveError(err *unityipc.EditorUnresponsiveError, context
 		Command:     context.Command,
 		NextActions: []string{
 			"Check Unity for a modal dialog or long editor operation that is blocking the Editor main thread.",
+			ApiUpdateConsentModalNextAction,
 			"Run `uloop focus-window` if Unity is hidden behind another window.",
 			"Close the modal dialog or wait for the Editor operation to finish, then retry the command.",
 		},

--- a/cli/common/errors/error_editor_unresponsive.go
+++ b/cli/common/errors/error_editor_unresponsive.go
@@ -3,8 +3,8 @@ package clierrors
 import "github.com/hatayama/unity-cli-loop/common/unityipc"
 
 // ApiUpdateConsentModalNextAction is shared recovery guidance when the Editor main
-// thread may be blocked by Unity's API Update / Script Updating Consent modal
-// (group-5 PR 5-3: interactive Editors have no public suppress path).
+// thread may be blocked by Unity's API Update / Script Updating Consent modal.
+// Interactive Editors have no public suppress path.
 const ApiUpdateConsentModalNextAction = "The Editor may be showing an API Update / Script Updating Consent modal; check the Unity window and ask the user what to choose — never auto-dismiss it."
 
 func connectionAttemptCause(err *unityipc.ConnectionAttemptError) string {

--- a/cli/common/errors/error_envelope_test.go
+++ b/cli/common/errors/error_envelope_test.go
@@ -140,6 +140,9 @@ func TestClassifyEditorUnresponsiveError(t *testing.T) {
 	if !strings.Contains(joinedActions, "modal dialog") {
 		t.Fatalf("next actions should mention modal dialog: %#v", cliErr.NextActions)
 	}
+	if !strings.Contains(joinedActions, "API Update") || !strings.Contains(joinedActions, "never auto-dismiss") {
+		t.Fatalf("next actions should mention API Update consent guidance: %#v", cliErr.NextActions)
+	}
 	if !strings.Contains(joinedActions, "uloop focus-window") {
 		t.Fatalf("next actions should mention focus-window: %#v", cliErr.NextActions)
 	}

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "8b248a96bc8a1cbc8312c7f77da08d9ef8903680"
+  "sharedInputsHash": "033603e642ddb95410f139bc5b081ab6449c6145"
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "033603e642ddb95410f139bc5b081ab6449c6145"
+  "sharedInputsHash": "fbbc3c34d301331c513155ea2bab2a33a4b5de97"
 }

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -574,6 +574,7 @@ func TestCompileWaitTimeoutError(t *testing.T) {
 	expectedActions := []string{
 		"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is responsive before treating this as a freeze.",
 		"Unity-side compile continues after this timeout; retry `uloop compile` — the result remains retrievable for about 10 more minutes without `uloop launch -r`.",
+		clierrors.ApiUpdateConsentModalNextAction,
 		"Only if Unity does not respond to any command, restart it with `uloop launch -r`.",
 	}
 	if len(cliErr.NextActions) != len(expectedActions) {

--- a/cli/project-runner/internal/projectrunner/execution_errors.go
+++ b/cli/project-runner/internal/projectrunner/execution_errors.go
@@ -25,6 +25,7 @@ func compileWaitTimeoutError(projectRoot string) clierrors.CLIError {
 		NextActions: []string{
 			"Run a light command such as `uloop get-logs --max-count 1` to check whether Unity is responsive before treating this as a freeze.",
 			"Unity-side compile continues after this timeout; retry `uloop compile` — the result remains retrievable for about 10 more minutes without `uloop launch -r`.",
+			clierrors.ApiUpdateConsentModalNextAction,
 			"Only if Unity does not respond to any command, restart it with `uloop launch -r`.",
 		},
 	}

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "8c336555a69a3cf485147e5669ce8bb4d3fe2982"
+  "sharedInputsHash": "1a172ee39ad96eb18508f235e8606fe3b36f5ad3"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "1a172ee39ad96eb18508f235e8606fe3b36f5ad3"
+  "sharedInputsHash": "581697442cd42c4467c8a80ab3bce98f403890c6"
 }


### PR DESCRIPTION
## Summary
- Investigation close for PR 5-3: interactive Editors have **no public API / documented CLI flag** to suppress the API Update / Script Updating Consent modal
- B-lite: add one shared `NextActions` line on compile-wait timeout and Editor-unresponsive errors — check the Unity window and ask the user; **never auto-dismiss**
- Document the same guidance in the source `uloop-compile` skill (regenerated `.claude` / `.agents` copies)

## Investigation findings (include in review)

### Trigger
`uloop compile` → `CompileController` → `AssetDatabase.Refresh()` can surface Unity’s updater when obsolete / UnityUpgradable APIs are present (also possible on import / other Refresh paths).

### Public levers
| Lever | Interactive GUI (`uloop launch`) | batchmode |
|---|---|---|
| `-accept-apiupdate` | Documented for **batchmode only** | Runs updater without dialog |
| `-disable-assembly-updater` | AssemblyUpdater only; **ScriptUpdater still runs** | same |
| `-ignorecompilererrors` (already on launch) | Safe Mode only; unrelated | — |
| Public C# suppress API | **None** | — |

### CsReference reinforcement (6000.3, Fable-verified)
`UnityScriptUpdaterConsentAPI.AskFor` shows `DisplayDialogComplex("Script Updating Consent", ...)` after skip branches, including:
- `DoesCommandLineIndicateAPIUpdatingShouldBeDeclined()` → **NoConsent without dialog** (non-destructive)
- `DoesCommandLineIndicateAPIUpdatingShouldHappenWithoutConsent()` → consent without dialog

Both are **native/extern**; the triggering arg is undocumented. Auto-accept / reflection remain rejected. A future experiment (outside this PR) would only pursue the **decline** path if the modal actually bites — recorded in umbrella notes.

### Chosen product response
Agents must treat the modal as user-owned consent. CLI timeouts already return; guidance now names this modal explicitly.

## User Impact
- **Before:** compile timeout / main-thread stall guidance did not name API Update consent; agents could thrash or try to “fix” a modal
- **After:** NextActions and the compile skill tell agents to inspect Unity and ask the user; no auto-dismiss

## Verification
- [x] `scripts/check-go-cli.sh`
- [x] `uloop skills install --claude --agents` regenerated copies from package source
- [x] `scripts/stamp-release-inputs.sh` (common module change)
- [x] No protocol bump; no Refresh-skip optimization

## Test plan
- [ ] CI green
- [ ] Confirm compile-wait timeout JSON includes the new NextActions line

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

