### PR TITLE
fix: execute-dynamic-code returns retryable guidance when runtime is disposed mid-reset

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
@@ -731,6 +731,56 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(response.Logs, Contains.Item("Solutions:"));
         }
 
+        [Test]
+        public async Task ExecuteAsync_WhenRuntimeThrowsObjectDisposedException_ReturnsRetryableRestartingError()
+        {
+            // Verifies disposed-runtime ODE during execute maps to Success=false with restarting guidance.
+            MarkForegroundWarmupCompleted();
+            ObjectDisposedDynamicCodeExecutionRuntime runtime = new(
+                throwOnExecuteCount: 1,
+                successAfterThrow: false);
+            ExecuteDynamicCodeUseCase useCase = new(runtime);
+            ExecuteDynamicCodeResponse response = await useCase.ExecuteAsync(
+                new ExecuteDynamicCodeSchema
+                {
+                    Code = "return 1;",
+                    CompileOnly = false
+                },
+                CancellationToken.None);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(
+                response.ErrorMessage,
+                Is.EqualTo(UnityCliLoopConstants.ERROR_MESSAGE_DYNAMIC_CODE_RUNTIME_RESTARTING));
+            Assert.That(response.NextActions, Is.EqualTo(UnityCliLoopConstants.DYNAMIC_CODE_RUNTIME_RESTARTING_NEXT_ACTIONS));
+            Assert.That(response.NextActions[0], Does.Contain("Retry").IgnoreCase);
+            Assert.That(response.NextActions[1], Does.Contain("launch -r"));
+            Assert.That(response.NextActions[1], Does.Contain("not needed"));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenWarmupThrowsObjectDisposedException_ContinuesAsSilentNoOp()
+        {
+            // Verifies Warm-path ODE is incomplete warm (no CLI error), while Execute still succeeds afterward.
+            ObjectDisposedDynamicCodeExecutionRuntime runtime = new(
+                throwOnExecuteCount: 1,
+                successAfterThrow: true);
+            ExecuteDynamicCodeUseCase useCase = new(runtime);
+            ExecuteDynamicCodeResponse response = await useCase.ExecuteAsync(
+                new ExecuteDynamicCodeSchema
+                {
+                    Code = "return \"ok\";",
+                    CompileOnly = false
+                },
+                CancellationToken.None);
+
+            Assert.That(response.Success, Is.True);
+            Assert.That(response.Result, Is.EqualTo("ok"));
+            Assert.That(response.ErrorMessage, Is.Null.Or.Empty);
+            Assert.That(response.NextActions, Is.Null);
+            Assert.That(runtime.ExecuteCount, Is.GreaterThanOrEqualTo(2));
+        }
+
         /// <summary>
         /// Test support type used by editor and play mode fixtures.
         /// </summary>
@@ -774,6 +824,53 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                     YieldToForegroundRequests = request.YieldToForegroundRequests
                 });
                 return Task.FromResult<(bool, ExecutionResult)>((true, _results.Dequeue()));
+            }
+        }
+
+        /// <summary>
+        /// Throws ObjectDisposedException on the Nth ExecuteAsync, optionally returning success afterward.
+        /// </summary>
+        private sealed class ObjectDisposedDynamicCodeExecutionRuntime : IDynamicCodeExecutionRuntime
+        {
+            private readonly int _throwOnExecuteCount;
+            private readonly bool _successAfterThrow;
+
+            public ObjectDisposedDynamicCodeExecutionRuntime(int throwOnExecuteCount, bool successAfterThrow)
+            {
+                _throwOnExecuteCount = throwOnExecuteCount;
+                _successAfterThrow = successAfterThrow;
+            }
+
+            public int ExecuteCount { get; private set; }
+
+            public Task<ExecutionResult> ExecuteAsync(
+                DynamicCodeExecutionRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                ExecuteCount++;
+                if (ExecuteCount == _throwOnExecuteCount)
+                {
+                    // ObjectName matches the production scheduler dispose path without requiring type visibility.
+                    throw new ObjectDisposedException("DynamicCodeExecutionScheduler");
+                }
+
+                if (!_successAfterThrow)
+                {
+                    throw new InvalidOperationException("Unexpected ExecuteAsync after ObjectDisposedException");
+                }
+
+                return Task.FromResult(new ExecutionResult
+                {
+                    Success = true,
+                    Result = "ok"
+                });
+            }
+
+            public Task<(bool Entered, ExecutionResult Result)> TryExecuteIfIdleAsync(
+                DynamicCodeExecutionRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                throw new InvalidOperationException("TryExecuteIfIdleAsync is not used by these tests");
             }
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeExecutionResponseFactory.cs
@@ -28,6 +28,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     StringComparison.Ordinal);
         }
 
+        internal static bool IsRuntimeRestartingResult(ExecutionResult executionResult)
+        {
+            return executionResult != null
+                && !executionResult.Success
+                && string.Equals(
+                    executionResult.ErrorMessage,
+                    UnityCliLoopConstants.ERROR_MESSAGE_DYNAMIC_CODE_RUNTIME_RESTARTING,
+                    StringComparison.Ordinal);
+        }
+
         internal static ExecuteDynamicCodeResponse CreateCancelledResponse()
         {
             return new ExecuteDynamicCodeResponse
@@ -37,6 +47,35 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Logs = new List<string> { "Execution cancelled" },
                 CompilationErrors = new List<CompilationErrorDto>(),
                 ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED
+            };
+        }
+
+        internal static ExecuteDynamicCodeResponse CreateRuntimeRestartingResponse()
+        {
+            return new ExecuteDynamicCodeResponse
+            {
+                Success = false,
+                Result = string.Empty,
+                Logs = new List<string>
+                {
+                    UnityCliLoopConstants.ERROR_MESSAGE_DYNAMIC_CODE_RUNTIME_RESTARTING
+                },
+                CompilationErrors = new List<CompilationErrorDto>(),
+                ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_DYNAMIC_CODE_RUNTIME_RESTARTING,
+                NextActions = UnityCliLoopConstants.DYNAMIC_CODE_RUNTIME_RESTARTING_NEXT_ACTIONS
+            };
+        }
+
+        internal static ExecutionResult CreateRuntimeRestartingExecutionResult()
+        {
+            return new ExecutionResult
+            {
+                Success = false,
+                ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_DYNAMIC_CODE_RUNTIME_RESTARTING,
+                Logs = new List<string>
+                {
+                    UnityCliLoopConstants.ERROR_MESSAGE_DYNAMIC_CODE_RUNTIME_RESTARTING
+                }
             };
         }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
@@ -58,6 +58,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool DomainReloadWaitRequired { get; set; } = false;
 
         /// <summary>
+        /// Optional recovery steps when execution cannot complete automatically.
+        /// </summary>
+        public string[] NextActions { get; set; }
+
+        /// <summary>
         /// Lightweight internal timings for benchmark comparison.
         /// </summary>
         [JsonProperty("Timings")]
@@ -92,6 +97,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool ShouldSerializeDomainReloadWaitRequired()
         {
             return DomainReloadWaitRequired;
+        }
+
+        public bool ShouldSerializeNextActions()
+        {
+            return NextActions != null && NextActions.Length > 0;
         }
     }
     

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -75,6 +75,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return cancelledResponse;
                 }
 
+                if (DynamicCodeExecutionResponseFactory.IsRuntimeRestartingResult(finalResult))
+                {
+                    ExecuteDynamicCodeResponse restartingResponse =
+                        DynamicCodeExecutionResponseFactory.CreateRuntimeRestartingResponse();
+                    restartingResponse.EmitTimingsInJsonResponse = parameters.IncludeTimings;
+                    return restartingResponse;
+                }
+
                 ExecuteDynamicCodeResponse response =
                     _responseFactory.ConvertExecutionResultToResponse(finalResult, originalCode);
                 response.EmitTimingsInJsonResponse = parameters.IncludeTimings;
@@ -143,15 +151,34 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             if (!request.YieldToForegroundRequests)
             {
-                return await _runtime.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
+                // Why catch here: reset/reload disposes the scheduler mid-flight; map to an explicit
+                // retryable response instead of leaking ObjectDisposedException across the tool boundary.
+                // Why not retry inside UseCase: re-fetching a facade races domain reload.
+                try
+                {
+                    return await _runtime.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
+                }
+                catch (ObjectDisposedException)
+                {
+                    LogDynamicCodeRuntimeRestarting("execute");
+                    return DynamicCodeExecutionResponseFactory.CreateRuntimeRestartingExecutionResult();
+                }
             }
 
-            (bool entered, ExecutionResult result) = await _runtime.TryExecuteIfIdleAsync(
-                request,
-                cancellationToken).ConfigureAwait(false);
-            if (entered)
+            try
             {
-                return result;
+                (bool entered, ExecutionResult result) = await _runtime.TryExecuteIfIdleAsync(
+                    request,
+                    cancellationToken).ConfigureAwait(false);
+                if (entered)
+                {
+                    return result;
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                LogDynamicCodeRuntimeRestarting("try_execute_if_idle");
+                return DynamicCodeExecutionResponseFactory.CreateRuntimeRestartingExecutionResult();
             }
 
             return new ExecutionResult
@@ -178,7 +205,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             bool completed = false;
             try
             {
-                completed = await ExecuteForegroundWarmupSequenceAsync(cancellationToken).ConfigureAwait(false);
+                // Why catch here: warmup is best-effort; a disposed runtime during reset must not
+                // surface as a CLI error — treat as incomplete warm (same as entered=false).
+                try
+                {
+                    completed = await ExecuteForegroundWarmupSequenceAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (ObjectDisposedException)
+                {
+                    LogDynamicCodeRuntimeRestarting("warm");
+                    completed = false;
+                }
+
                 if (completed)
                 {
                     DynamicCodeForegroundWarmupState.MarkCompleted();
@@ -191,6 +229,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     DynamicCodeForegroundWarmupState.ResetAfterIncompleteAttempt();
                 }
             }
+        }
+
+        private static void LogDynamicCodeRuntimeRestarting(string path)
+        {
+            VibeLogger.LogWarning(
+                "dynamic_code_runtime_restarting",
+                "Dynamic-code runtime was disposed during reset or domain reload",
+                new { path },
+                humanNote: "ObjectDisposedException from the execution runtime was mapped at the UseCase boundary",
+                aiTodo: "Retry the same execute-dynamic-code shortly; do not treat this as a permanent failure");
         }
 
         private async Task<bool> ExecuteForegroundWarmupSequenceAsync(CancellationToken ct)

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -111,10 +111,22 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public const string ERROR_MESSAGE_ASSEMBLY_DEFINITION_IMPORT_ERROR = "Assembly Definition or Assembly Reference import error detected. Unity may not start compilation until asmdef or asmref errors are removed.";
         public const string ERROR_MESSAGE_EXECUTION_IN_PROGRESS = "Another execution is already in progress";
         public const string ERROR_MESSAGE_EXECUTION_CANCELLED = "Execution was cancelled or timed out";
+        public const string ERROR_MESSAGE_DYNAMIC_CODE_RUNTIME_RESTARTING =
+            "Dynamic-code runtime was disposed during a server reset or domain reload; retry the same command shortly.";
         public const string ERROR_MESSAGE_NO_COMPILED_ASSEMBLY = "No compiled assembly provided";
         public const string ERROR_MESSAGE_NO_EXECUTE_METHOD = "No Execute method found in compiled assembly";
         public const string ERROR_MESSAGE_FAILED_TO_CREATE_INSTANCE = "Failed to create instance of target type";
         public const string ERROR_MESSAGE_UNSUPPORTED_SIGNATURE = "Execute method signature not supported";
+
+        /// <summary>
+        /// Recovery steps when execute-dynamic-code hits a disposed runtime during reset/reload.
+        /// Why this tone: matches compile-wait guidance — retry recovers the result; launch -r is not first-line.
+        /// </summary>
+        public static readonly string[] DYNAMIC_CODE_RUNTIME_RESTARTING_NEXT_ACTIONS =
+        {
+            "Retry the same `uloop execute-dynamic-code` shortly — the bridge is restarting after reset or domain reload.",
+            "Unity is still running; `uloop launch -r` is not needed for this error.",
+        };
 
         public const int COMPILE_START_TIMEOUT_MS = 5000;
         public const int COMPILE_START_POLL_INTERVAL_MS = 100;


### PR DESCRIPTION
## Summary
- After a server reset or domain reload, `execute-dynamic-code` that hits a disposed runtime now returns `Success=false` with clear retry guidance instead of a raw `ObjectDisposedException`.
- Foreground warmup treats the same dispose as a quiet incomplete warm so CLI callers are not failed by best-effort warmup.

## User Impact
- **Before:** Warm could succeed, then Reset disposed the scheduler; the next Execute could surface a raw ODE / opaque failure while the bridge was simply restarting.
- **After:** Execute maps that case to a retryable “server restarting” style response (same tone as compile-wait NextActions: retry shortly; `uloop launch -r` is not first-line). Warm remains silent on ODE.

## Design (agreed plan A)
- Reset means “server restart in progress” → return an explicit tool error so Go’s existing retry/reconnect guidance can apply. Do **not** re-acquire a facade and retry inside the UseCase (reload race).
- Do **not** add a new RPC error type (protocol / CLI classification change) for this PR.
- Scheduler stays pure C# and may keep throwing ODE; mapping is at the UseCase boundary only.

### try-catch exception (documented)
- `catch (ObjectDisposedException)` is used under the allowed pattern “catch at a boundary and return an explicit error value.”
- Catch scope is minimal: only the runtime `ExecuteAsync` / `TryExecuteIfIdleAsync` awaits (and the Warm sequence’s runtime work). Not the whole UseCase method.
- On catch, emit one vibe log: `dynamic_code_runtime_restarting`.

### Warm asymmetry (fixed by tests)
- Warm ODE → silent no-op / incomplete warm (`entered=false` style).
- Execute ODE → `Success=false` + restarting `ErrorMessage` + `NextActions`.

## Repro context from PR 6-1
Confirmed pattern: **Warm succeeds → Reset → Execute hits disposed facade/scheduler** and throws ODE. This PR maps that Execute-path ODE so agents see a recoverable restart signal.

## Changes
- Constants for error message + NextActions in `UnityCliLoopConstants`.
- `ExecuteDynamicCodeResponse.NextActions` + factory helpers for the restarting response.
- UseCase boundary mapping for Execute / TryExecuteIfIdle / Warm.
- Two EditMode UseCase tests with an `IDynamicCodeExecutionRuntime` double (Execute → retryable; Warm → no-op then success).

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>` → Success
- `uloop run-tests` (regex) for the two new UseCase tests → Passed (2/2)

## Test plan
- [ ] Confirm Execute-path ODE returns `ERROR_MESSAGE_DYNAMIC_CODE_RUNTIME_RESTARTING` and NextActions mentioning retry / launch -r not needed
- [ ] Confirm Warm-path ODE does not fail the subsequent user Execute
- [ ] After umbrella merge, optional Editor gate: warm → reset → execute should be retryable guidance, not raw ODE


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

