### PR TITLE
fix: stop Roslyn worker revive after server reset or reload shutdown

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -46,6 +46,114 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         /// <summary>
+        /// Verifies full Shutdown advances lifecycle generation so in-flight retries cannot restart the worker.
+        /// </summary>
+        [Test]
+        public void Shutdown_WhenCalled_ShouldAdvanceLifecycleGeneration()
+        {
+            SharedRoslynCompilerWorkerSession session = new();
+            string unusedWorkerDirectoryPath = Path.Combine(
+                Path.GetTempPath(),
+                $"SharedRoslynCompilerWorkerSessionTests_{Guid.NewGuid():N}");
+
+            int generationBefore = session.ExecuteWithStateLock(session.GetLifecycleGenerationLocked);
+            session.Shutdown(unusedWorkerDirectoryPath);
+            int generationAfter = session.ExecuteWithStateLock(session.GetLifecycleGenerationLocked);
+
+            Assert.That(generationBefore, Is.EqualTo(0));
+            Assert.That(generationAfter, Is.EqualTo(1));
+            Assert.That(
+                session.ExecuteWithStateLock(() => session.IsLifecycleGenerationCurrentLocked(generationBefore)),
+                Is.False);
+            Assert.That(
+                session.ExecuteWithStateLock(() => session.IsLifecycleGenerationCurrentLocked(generationAfter)),
+                Is.True);
+        }
+
+        /// <summary>
+        /// Verifies retry-path process kill keeps the lifecycle open so a replacement worker may start.
+        /// </summary>
+        [Test]
+        public void ShutdownProcessLocked_WhenCalledAlone_ShouldStillAllowWorkerRestart()
+        {
+            SharedRoslynCompilerWorkerSession session = new();
+            Process startedProcess = null;
+            int startCallCount = 0;
+            session.SwapProcessStarterForTests(_ =>
+            {
+                startCallCount++;
+                startedProcess = new Process();
+                return startedProcess;
+            });
+
+            try
+            {
+                int generationAtStart = session.ExecuteWithStateLock(session.GetLifecycleGenerationLocked);
+                session.ExecuteWithStateLock(session.ShutdownProcessLocked);
+
+                bool started = session.ExecuteWithStateLock(
+                    () =>
+                    {
+                        if (!session.IsLifecycleGenerationCurrentLocked(generationAtStart))
+                        {
+                            return false;
+                        }
+
+                        return session.StartProcessLocked(new ProcessStartInfo());
+                    });
+
+                Assert.That(started, Is.True);
+                Assert.That(startCallCount, Is.EqualTo(1));
+                Assert.That(
+                    session.ExecuteWithStateLock(session.GetLifecycleGenerationLocked),
+                    Is.EqualTo(generationAtStart));
+            }
+            finally
+            {
+                startedProcess?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Verifies a stale lifecycle generation refuses StartProcess after full Shutdown.
+        /// </summary>
+        [Test]
+        public void StartProcessLocked_WhenLifecycleGenerationIsStale_ShouldBeDetectableBeforeStart()
+        {
+            SharedRoslynCompilerWorkerSession session = new();
+            string unusedWorkerDirectoryPath = Path.Combine(
+                Path.GetTempPath(),
+                $"SharedRoslynCompilerWorkerSessionTests_{Guid.NewGuid():N}");
+            int startCallCount = 0;
+            session.SwapProcessStarterForTests(_ =>
+            {
+                startCallCount++;
+                return new Process();
+            });
+
+            int generationAtStart = session.ExecuteWithStateLock(session.GetLifecycleGenerationLocked);
+            session.Shutdown(unusedWorkerDirectoryPath);
+
+            bool wouldStart = session.ExecuteWithStateLock(
+                () => session.IsLifecycleGenerationCurrentLocked(generationAtStart));
+            Assert.That(wouldStart, Is.False);
+
+            bool started = session.ExecuteWithStateLock(
+                () =>
+                {
+                    if (!session.IsLifecycleGenerationCurrentLocked(generationAtStart))
+                    {
+                        return false;
+                    }
+
+                    return session.StartProcessLocked(new ProcessStartInfo());
+                });
+
+            Assert.That(started, Is.False);
+            Assert.That(startCallCount, Is.Zero);
+        }
+
+        /// <summary>
         /// Verifies replacing the cached worker releases the previously owned process handle.
         /// </summary>
         [Test]

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -59,6 +59,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return new WorkerAttemptResult(null, true, failureReason, failureContext);
             }
+
+            public static WorkerAttemptResult NonRetryableFailure(string failureReason, object failureContext)
+            {
+                return new WorkerAttemptResult(null, false, failureReason, failureContext);
+            }
         }
 
         /// <summary>
@@ -68,25 +73,41 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             public bool IsReady { get; }
 
+            public bool IsRetryable { get; }
+
             public string FailureReason { get; }
 
             public object FailureContext { get; }
 
-            private WorkerStartupResult(bool isReady, string failureReason, object failureContext)
+            private WorkerStartupResult(
+                bool isReady,
+                bool isRetryable,
+                string failureReason,
+                object failureContext)
             {
                 IsReady = isReady;
+                IsRetryable = isRetryable;
                 FailureReason = failureReason;
                 FailureContext = failureContext;
             }
 
             public static WorkerStartupResult Ready()
             {
-                return new WorkerStartupResult(true, null, null);
+                return new WorkerStartupResult(true, false, null, null);
             }
 
             public static WorkerStartupResult Failure(string failureReason, object failureContext)
             {
-                return new WorkerStartupResult(false, failureReason, failureContext);
+                return new WorkerStartupResult(false, true, failureReason, failureContext);
+            }
+
+            public static WorkerStartupResult ClosedLifecycleFailure()
+            {
+                return new WorkerStartupResult(
+                    false,
+                    false,
+                    "shared_worker_lifecycle_closed",
+                    new { reason = "lifecycle_generation_advanced" });
             }
         }
 
@@ -151,11 +172,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action markBuildFinished,
             Action incrementBuildCount)
         {
+            int lifecycleGenerationAtStart = ServiceValue.ExecuteWithStateLock(
+                ServiceValue.GetLifecycleGenerationLocked);
+
             for (int attempt = 1; attempt <= SharedCompilerWorkerMaxAttempts; attempt++)
             {
                 WorkerAttemptResult attemptResult = await TryCompileOnceAsync(
                     requestFilePath,
                     externalCompilerPaths,
+                    lifecycleGenerationAtStart,
                     ct,
                     markBuildStarted,
                     markBuildFinished,
@@ -185,14 +210,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private static async Task<WorkerAttemptResult> TryCompileOnceAsync(
             string requestFilePath,
             ExternalCompilerPaths externalCompilerPaths,
+            int lifecycleGenerationAtStart,
             CancellationToken ct,
             Action markBuildStarted,
             Action markBuildFinished,
             Action incrementBuildCount)
         {
-            WorkerStartupResult startupResult = EnsureWorkerReady(externalCompilerPaths);
+            WorkerStartupResult startupResult = EnsureWorkerReady(
+                externalCompilerPaths,
+                lifecycleGenerationAtStart);
             if (!startupResult.IsReady)
             {
+                if (!startupResult.IsRetryable)
+                {
+                    return WorkerAttemptResult.NonRetryableFailure(
+                        startupResult.FailureReason,
+                        startupResult.FailureContext);
+                }
+
                 return WorkerAttemptResult.RetryableFailure(
                     startupResult.FailureReason,
                     startupResult.FailureContext);
@@ -206,11 +241,27 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 incrementBuildCount).ConfigureAwait(false);
         }
 
-        private static WorkerStartupResult EnsureWorkerReady(ExternalCompilerPaths externalCompilerPaths)
+        private static WorkerStartupResult EnsureWorkerReady(
+            ExternalCompilerPaths externalCompilerPaths,
+            int lifecycleGenerationAtStart)
         {
-            if (ServiceValue.ExecuteWithStateLock(ServiceValue.HasLiveProcessLocked))
+            WorkerStartupResult earlyResult = ServiceValue.ExecuteWithStateLock(() =>
             {
-                return WorkerStartupResult.Ready();
+                if (!ServiceValue.IsLifecycleGenerationCurrentLocked(lifecycleGenerationAtStart))
+                {
+                    return WorkerStartupResult.ClosedLifecycleFailure();
+                }
+
+                if (ServiceValue.HasLiveProcessLocked())
+                {
+                    return WorkerStartupResult.Ready();
+                }
+
+                return null;
+            });
+            if (earlyResult != null)
+            {
+                return earlyResult;
             }
 
             WorkerPaths workerPaths = CreateWorkerPaths();
@@ -224,7 +275,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return workerAssemblyResult;
             }
 
-            return StartWorkerProcess(externalCompilerPaths, workerPaths);
+            return StartWorkerProcess(
+                externalCompilerPaths,
+                workerPaths,
+                lifecycleGenerationAtStart);
         }
 
         private static WorkerStartupResult EnsureWorkerAssemblyBuilt(
@@ -268,23 +322,31 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static WorkerStartupResult StartWorkerProcess(
             ExternalCompilerPaths externalCompilerPaths,
-            WorkerPaths workerPaths)
+            WorkerPaths workerPaths,
+            int lifecycleGenerationAtStart)
         {
             ProcessStartInfo startInfo = CreateWorkerStartInfo(externalCompilerPaths, workerPaths);
-            bool started = ServiceValue.ExecuteWithStateLock(
-                () => ServiceValue.StartProcessLocked(startInfo));
-            if (!started)
+            return ServiceValue.ExecuteWithStateLock(() =>
             {
-                return WorkerStartupResult.Failure(
-                    "worker_start_failed",
-                    new
-                    {
-                        dotnet_host_path = externalCompilerPaths.DotnetHostPath,
-                        worker_assembly_path = workerPaths.AssemblyPath
-                    });
-            }
+                if (!ServiceValue.IsLifecycleGenerationCurrentLocked(lifecycleGenerationAtStart))
+                {
+                    return WorkerStartupResult.ClosedLifecycleFailure();
+                }
 
-            return WorkerStartupResult.Ready();
+                bool started = ServiceValue.StartProcessLocked(startInfo);
+                if (!started)
+                {
+                    return WorkerStartupResult.Failure(
+                        "worker_start_failed",
+                        new
+                        {
+                            dotnet_host_path = externalCompilerPaths.DotnetHostPath,
+                            worker_assembly_path = workerPaths.AssemblyPath
+                        });
+                }
+
+                return WorkerStartupResult.Ready();
+            });
         }
 
         private static async Task<WorkerAttemptResult> InvokeWorkerOnceAsync(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
@@ -27,6 +27,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private string _workerDirectoryPath;
         private int _responseTimeoutMilliseconds =
             SharedRoslynCompilerWorkerLineReader.DefaultResponseTimeoutMilliseconds;
+        // Why a generation instead of a sticky bool: full Shutdown (reset/reload/quit) must
+        // invalidate in-flight retry loops, while a later compile after reset must still start a worker.
+        private int _lifecycleGeneration;
 
         /// <summary>
         /// Serializes worker request/response conversations without holding the state lock across awaits.
@@ -81,6 +84,18 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             AssertStateLockHeld();
             return _workerProcess != null && !_workerProcess.HasExited;
+        }
+
+        internal int GetLifecycleGenerationLocked()
+        {
+            AssertStateLockHeld();
+            return _lifecycleGeneration;
+        }
+
+        internal bool IsLifecycleGenerationCurrentLocked(int expectedLifecycleGeneration)
+        {
+            AssertStateLockHeld();
+            return _lifecycleGeneration == expectedLifecycleGeneration;
         }
 
         internal bool StartProcessLocked(ProcessStartInfo startInfo)
@@ -269,6 +284,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             _coordination.RunShutdownWithoutCompileGate(() =>
             {
+                // Why advance here (not in ShutdownProcessLocked): retry cleanup kills the process
+                // so the same compile conversation can start a replacement worker. Server reset /
+                // reload / quit must invalidate that restart path for in-flight retries only.
+                _lifecycleGeneration++;
                 ShutdownProcessLocked();
                 CleanupWorkerDirectoryLocked(fallbackWorkerDirectoryPath);
             });


### PR DESCRIPTION
## Summary
- After server reset / domain reload / Editor quit, an in-flight shared Roslyn compile retry no longer starts a replacement worker.
- Ordinary crash/retry cleanup still may restart the worker within the same compile conversation.

## User Impact
- **Before:** Shutdown could interleave with retry → `EnsureWorkerReady` briefly resurrected a worker (stdin EOF self-exits; no lasting leak, but wrong lifecycle).
- **After:** Full lifecycle Shutdown advances a generation latch; stale retries fail closed without starting a new process. The next compile after reset captures the new generation and works normally.

## Design
- Generation latch on `SharedRoslynCompilerWorkerSession` (not sticky bool + GetRuntimeFacade clear).
- `Shutdown()` advances generation under the state lock, then kills the process.
- `ShutdownProcessLocked` alone does **not** advance generation (legitimate retry).
- `TryCompileWithRetriesAsync` captures generation via lock; `EnsureWorkerReady` / `StartWorkerProcess` compare+start atomically under the same lock.
- Non-retryable failure reason: `shared_worker_lifecycle_closed`.

### Out of scope (umbrella notes)
- Mapping `shared_worker_lifecycle_closed` to PR 6-2 restarting NextActions if/when it becomes user-visible.

## Verification
- `uloop compile` → Success
- 3 EditMode tests: Shutdown advances gen; process-only shutdown still allows restart; stale gen refuses start → Passed

## Test plan
- [ ] Confirm process-only kill still allows `StartProcessLocked` for the captured generation
- [ ] Confirm full `Shutdown` advances generation and refuses stale starts
- [ ] Optional Editor: reset during compile should not leave a resurrected worker for that conversation


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

