### PR TITLE
fix: keep Unity responsive while building the shared Roslyn worker DLL

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UnityEditor.Compilation;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 
@@ -151,6 +152,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
 
             Assert.That(started, Is.False);
             Assert.That(startCallCount, Is.Zero);
+        }
+
+        /// <summary>
+        /// Verifies the async offload path returns the test-hook build result without requiring a real csc.
+        /// </summary>
+        [Test]
+        public async Task CompileWorkerAssemblyAsync_WhenTestHookIsInstalled_ShouldReturnHookResult()
+        {
+            SharedRoslynCompilerWorkerSession session = new();
+            CompilerMessage[] expectedMessages =
+            {
+                new CompilerMessage
+                {
+                    type = CompilerMessageType.Error,
+                    message = "hooked"
+                }
+            };
+            session.SwapWorkerAssemblyCompilerForTests(
+                (paths, sourcePath, assemblyPath, responsePath) => expectedMessages);
+
+            SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult result =
+                await session.CompileWorkerAssemblyAsync(
+                    externalCompilerPaths: null,
+                    workerSourcePath: "unused.cs",
+                    workerAssemblyPath: "unused.dll",
+                    workerCompileResponseFilePath: "unused.rsp");
+
+            Assert.That(result.StartedSuccessfully, Is.True);
+            Assert.That(result.Messages, Is.SameAs(expectedMessages));
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerAssemblyBuilder.cs
@@ -133,6 +133,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return WorkerAssemblyBuildResult.Started(compilerMessages);
         }
 
+        /// <summary>
+        /// Runs <see cref="CompileWorkerAssembly"/> on the thread pool.
+        /// Why: the sync WaitForExit(timeout) path can otherwise block the Unity main thread when
+        /// EnsureWorkerReady runs before the first await of an idle compile-gate acquire.
+        /// </summary>
+        internal static Task<WorkerAssemblyBuildResult> CompileWorkerAssemblyOffMainThreadAsync(
+            ExternalCompilerPaths externalCompilerPaths,
+            string workerSourcePath,
+            string workerAssemblyPath,
+            string workerCompileResponseFilePath)
+        {
+            return Task.Run(
+                () => CompileWorkerAssembly(
+                    externalCompilerPaths,
+                    workerSourcePath,
+                    workerAssemblyPath,
+                    workerCompileResponseFilePath));
+        }
+
         internal static bool WaitForCompilerStreamDrain(
             Task<string> stdoutTask,
             Task<string> stderrTask,

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -216,9 +216,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Action markBuildFinished,
             Action incrementBuildCount)
         {
-            WorkerStartupResult startupResult = EnsureWorkerReady(
+            WorkerStartupResult startupResult = await EnsureWorkerReadyAsync(
                 externalCompilerPaths,
-                lifecycleGenerationAtStart);
+                lifecycleGenerationAtStart).ConfigureAwait(false);
             if (!startupResult.IsReady)
             {
                 if (!startupResult.IsRetryable)
@@ -241,7 +241,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 incrementBuildCount).ConfigureAwait(false);
         }
 
-        private static WorkerStartupResult EnsureWorkerReady(
+        private static async Task<WorkerStartupResult> EnsureWorkerReadyAsync(
             ExternalCompilerPaths externalCompilerPaths,
             int lifecycleGenerationAtStart)
         {
@@ -267,9 +267,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             WorkerPaths workerPaths = CreateWorkerPaths();
             SynchronizeWorkerSource(workerPaths);
 
-            WorkerStartupResult workerAssemblyResult = EnsureWorkerAssemblyBuilt(
+            WorkerStartupResult workerAssemblyResult = await EnsureWorkerAssemblyBuiltAsync(
                 externalCompilerPaths,
-                workerPaths);
+                workerPaths).ConfigureAwait(false);
             if (!workerAssemblyResult.IsReady)
             {
                 return workerAssemblyResult;
@@ -281,7 +281,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 lifecycleGenerationAtStart);
         }
 
-        private static WorkerStartupResult EnsureWorkerAssemblyBuilt(
+        private static async Task<WorkerStartupResult> EnsureWorkerAssemblyBuiltAsync(
             ExternalCompilerPaths externalCompilerPaths,
             WorkerPaths workerPaths)
         {
@@ -292,12 +292,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Why outside state lock: worker DLL compile can take seconds; shutdown must still kill
             // an already-running shared worker without waiting on this build.
+            // Why Task.Run (via CompileWorkerAssemblyAsync): WaitForExit(timeout) is synchronous and
+            // this path can still run on the Unity main thread before the first await when the
+            // compile gate is acquired without yielding.
             SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult buildResult =
-                ServiceValue.CompileWorkerAssembly(
+                await ServiceValue.CompileWorkerAssemblyAsync(
                     externalCompilerPaths,
                     workerPaths.SourcePath,
                     workerPaths.AssemblyPath,
-                    workerPaths.CompileResponseFilePath);
+                    workerPaths.CompileResponseFilePath).ConfigureAwait(false);
             if (!buildResult.StartedSuccessfully)
             {
                 return WorkerStartupResult.Failure(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerSession.cs
@@ -152,6 +152,35 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 workerCompileResponseFilePath);
         }
 
+        /// <summary>
+        /// Builds the worker assembly without blocking the caller thread on WaitForExit.
+        /// Test hooks stay synchronous so EditMode fixtures do not need thread-pool coordination.
+        /// </summary>
+        internal Task<SharedRoslynCompilerWorkerAssemblyBuilder.WorkerAssemblyBuildResult>
+            CompileWorkerAssemblyAsync(
+                ExternalCompilerPaths externalCompilerPaths,
+                string workerSourcePath,
+                string workerAssemblyPath,
+                string workerCompileResponseFilePath)
+        {
+            if (_compileWorkerAssemblyForTests != null)
+            {
+                return Task.FromResult(CompileWorkerAssembly(
+                    externalCompilerPaths,
+                    workerSourcePath,
+                    workerAssemblyPath,
+                    workerCompileResponseFilePath));
+            }
+
+            // Why not take the state lock here: build stays outside the process lock so shutdown
+            // can still kill a live worker while this Task.Run is in flight.
+            return SharedRoslynCompilerWorkerAssemblyBuilder.CompileWorkerAssemblyOffMainThreadAsync(
+                externalCompilerPaths,
+                workerSourcePath,
+                workerAssemblyPath,
+                workerCompileResponseFilePath);
+        }
+
         internal void ShutdownProcessLocked()
         {
             AssertStateLockHeld();


### PR DESCRIPTION
## Summary
- The rare first-time shared Roslyn worker DLL build no longer blocks the Unity main thread with synchronous `WaitForExit`.
- Existing timeout (30s) + Kill + stream drain behavior is unchanged.

## User Impact
- **Before:** When the compile gate was free, `EnsureWorkerReady` → `EnsureWorkerAssemblyBuilt` could run on the calling thread before the first await, so a missing worker DLL could freeze the Editor for up to the build timeout.
- **After:** That build runs on the thread pool via `Task.Run`; the Editor stays responsive. Timeout/kill remain as the safety net.

## Design (plan A)
- Offload boundary: entire `CompileWorkerAssembly` (including drain) via `CompileWorkerAssemblyOffMainThreadAsync`.
- No Unity APIs inside the build path (Process + File IO only).
- Build remains outside the session state lock.
- Rejected plan B: `WaitForExitAsync` is not available on Unity’s .NET Standard 2.1 profile; rewriting Exited+TCS would add moving parts without benefit.

### Call-site threading (condition 3)
- `TryCompileAsync` → `RunSerializedCompileAsync` → `TryCompileWithRetriesAsync` / `TryCompileOnceAsync`.
- When the async compile gate is acquired without yielding, work before the first `await` of `EnsureWorkerReadyAsync` (generation check, path sync) can still run on the caller thread — including the Unity main thread.
- The long `WaitForExit(timeout)` body is the part that must leave that thread; that is what `Task.Run` covers.

## Verification
- `uloop compile` → Success
- `CompileWorkerAssemblyAsync_WhenTestHookIsInstalled_ShouldReturnHookResult` → Passed

## Test plan
- [ ] Confirm test-hook async path still returns hooked messages
- [ ] Optional: delete worker DLL under temp RoslynWorker-* and run execute-dynamic-code; Editor should stay responsive during rebuild


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

