### PR TITLE
fix: fall back window screenshots to Device Simulator

### DIFF
--- a/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs
+++ b/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies window-name fallback from Game to Device Simulator for screenshot capture.
+    /// </summary>
+    public class ScreenshotWindowNameResolverTests
+    {
+        [Test]
+        public void ShouldFallbackToSimulator_WhenDefaultGameExactMisses_ReturnsTrue()
+        {
+            // Verifies the default Game exact lookup falls back when no window matched.
+            bool shouldFallback = ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.exact,
+                matchCount: 0);
+
+            Assert.That(shouldFallback, Is.True);
+        }
+
+        [Test]
+        public void ShouldFallbackToSimulator_WhenGameAlreadyMatched_ReturnsFalse()
+        {
+            // Verifies fallback is skipped when the Game window was found.
+            bool shouldFallback = ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.exact,
+                matchCount: 1);
+
+            Assert.That(shouldFallback, Is.False);
+        }
+
+        [Test]
+        public void ShouldFallbackToSimulator_WhenRequestedNameIsNotGame_ReturnsFalse()
+        {
+            // Verifies explicit non-Game names do not silently switch to Simulator.
+            bool shouldFallback = ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                "Inspector",
+                WindowMatchMode.exact,
+                matchCount: 0);
+
+            Assert.That(shouldFallback, Is.False);
+        }
+
+        [Test]
+        public void ShouldFallbackToSimulator_WhenMatchModeIsNotExact_ReturnsFalse()
+        {
+            // Verifies prefix/contains Game lookups do not trigger Simulator fallback.
+            bool shouldFallback = ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.contains,
+                matchCount: 0);
+
+            Assert.That(shouldFallback, Is.False);
+        }
+
+        [Test]
+        public void ResolveCaptureWindowName_WhenFallbackApplies_ReturnsSimulator()
+        {
+            // Verifies the resolved capture title becomes Simulator after a Game miss.
+            string resolved = ScreenshotWindowNameResolver.ResolveCaptureWindowName(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.exact,
+                primaryMatchCount: 0);
+
+            Assert.That(resolved, Is.EqualTo(UnityCliLoopConstants.SCREENSHOT_SIMULATOR_WINDOW_NAME));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs
+++ b/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs
@@ -69,5 +69,17 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(resolved, Is.EqualTo(UnityCliLoopConstants.SCREENSHOT_SIMULATOR_WINDOW_NAME));
         }
+
+        [Test]
+        public void ResolveCaptureWindowName_WhenFallbackDoesNotApply_ReturnsRequestedName()
+        {
+            // Verifies Resolve keeps the requested title when Game already matched.
+            string resolved = ScreenshotWindowNameResolver.ResolveCaptureWindowName(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.exact,
+                primaryMatchCount: 1);
+
+            Assert.That(resolved, Is.EqualTo(UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME));
+        }
     }
 }

--- a/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs.meta
+++ b/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a5f3a68bb5c448d591afcddae2e273a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -256,14 +256,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SynchronizationContext editorContext =
                 CapturedEditorSynchronizationContext.RequireCurrent("window screenshot use case");
             EditorWindow[] windows = EditorWindowCaptureUtility.FindWindowsByName(request.WindowName, request.MatchMode);
-            string captureWindowName = request.WindowName;
-            if (ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
-                    request.WindowName,
-                    request.MatchMode,
-                    windows.Length))
+            string captureWindowName = ScreenshotWindowNameResolver.ResolveCaptureWindowName(
+                request.WindowName,
+                request.MatchMode,
+                windows.Length);
+            bool usedSimulatorFallback = !string.Equals(
+                captureWindowName,
+                request.WindowName,
+                StringComparison.OrdinalIgnoreCase);
+            if (usedSimulatorFallback)
             {
                 // why: Device Simulator replaces the Game tab, so the default "Game" title miss should retry Simulator
-                captureWindowName = UnityCliLoopConstants.SCREENSHOT_SIMULATOR_WINDOW_NAME;
                 windows = EditorWindowCaptureUtility.FindWindowsByName(captureWindowName, request.MatchMode);
                 if (windows.Length > 0)
                 {
@@ -277,16 +280,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (windows.Length == 0)
             {
-                string notFoundMessage =
-                    $"Window '{request.WindowName}' not found (MatchMode: {request.MatchMode})";
-                if (ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
-                        request.WindowName,
-                        request.MatchMode,
-                        matchCount: 0))
-                {
-                    notFoundMessage +=
-                        $". Device Simulator may be active — pass --window-name {UnityCliLoopConstants.SCREENSHOT_SIMULATOR_WINDOW_NAME}";
-                }
+                string notFoundMessage = usedSimulatorFallback
+                    ? "Neither Game nor Simulator window found; open the Game view or Device Simulator and retry"
+                    : $"Window '{request.WindowName}' not found (MatchMode: {request.MatchMode})";
 
                 VibeLogger.LogError(
                     "screenshot_window_not_found",

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -256,18 +256,51 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SynchronizationContext editorContext =
                 CapturedEditorSynchronizationContext.RequireCurrent("window screenshot use case");
             EditorWindow[] windows = EditorWindowCaptureUtility.FindWindowsByName(request.WindowName, request.MatchMode);
+            string captureWindowName = request.WindowName;
+            if (ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                    request.WindowName,
+                    request.MatchMode,
+                    windows.Length))
+            {
+                // why: Device Simulator replaces the Game tab, so the default "Game" title miss should retry Simulator
+                captureWindowName = UnityCliLoopConstants.SCREENSHOT_SIMULATOR_WINDOW_NAME;
+                windows = EditorWindowCaptureUtility.FindWindowsByName(captureWindowName, request.MatchMode);
+                if (windows.Length > 0)
+                {
+                    VibeLogger.LogInfo(
+                        "screenshot_window_fallback_simulator",
+                        $"Window '{request.WindowName}' not found; capturing '{captureWindowName}' instead",
+                        correlationId: correlationId
+                    );
+                }
+            }
+
             if (windows.Length == 0)
             {
+                string notFoundMessage =
+                    $"Window '{request.WindowName}' not found (MatchMode: {request.MatchMode})";
+                if (ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                        request.WindowName,
+                        request.MatchMode,
+                        matchCount: 0))
+                {
+                    notFoundMessage +=
+                        $". Device Simulator may be active — pass --window-name {UnityCliLoopConstants.SCREENSHOT_SIMULATOR_WINDOW_NAME}";
+                }
+
                 VibeLogger.LogError(
                     "screenshot_window_not_found",
-                    $"Window '{request.WindowName}' not found (MatchMode: {request.MatchMode})",
+                    notFoundMessage,
                     correlationId: correlationId
                 );
-                return new ScreenshotResponse();
+                return new ScreenshotResponse
+                {
+                    Message = notFoundMessage,
+                };
             }
 
             string outputDirectory = EnsureOutputDirectoryExists(request.OutputDirectory);
-            string safeWindowName = SanitizeFileName(request.WindowName);
+            string safeWindowName = SanitizeFileName(captureWindowName);
             string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss_fff");
             List<ScreenshotInfo> screenshots = new();
 
@@ -336,7 +369,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             VibeLogger.LogInfo(
                 "screenshot_success",
                 $"Captured {screenshots.Count} window(s)",
-                new { WindowName = request.WindowName, ScreenshotCount = screenshots.Count },
+                new { WindowName = captureWindowName, RequestedWindowName = request.WindowName, ScreenshotCount = screenshots.Count },
                 correlationId: correlationId
             );
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotWindowNameResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotWindowNameResolver.cs
@@ -1,0 +1,51 @@
+using System;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves which Editor window title to capture for screenshot --capture-mode window.
+    /// </summary>
+    internal static class ScreenshotWindowNameResolver
+    {
+        /// <summary>
+        /// Decide whether to retry with the Device Simulator title after a Game window miss.
+        /// why: CLI default window name is Game, but Device Simulator replaces that tab so the title is Simulator.
+        /// </summary>
+        internal static bool ShouldFallbackToSimulator(
+            string requestedWindowName,
+            WindowMatchMode matchMode,
+            int matchCount)
+        {
+            if (matchCount > 0)
+            {
+                return false;
+            }
+
+            // why: only the default Game exact lookup means "capture the play view chrome"
+            if (matchMode != WindowMatchMode.exact)
+            {
+                return false;
+            }
+
+            return string.Equals(
+                requestedWindowName,
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static string ResolveCaptureWindowName(
+            string requestedWindowName,
+            WindowMatchMode matchMode,
+            int primaryMatchCount)
+        {
+            if (ShouldFallbackToSimulator(requestedWindowName, matchMode, primaryMatchCount))
+            {
+                return UnityCliLoopConstants.SCREENSHOT_SIMULATOR_WINDOW_NAME;
+            }
+
+            return requestedWindowName;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotWindowNameResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotWindowNameResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a11098664166e4ad6a3bf77ad41fb85b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/ToolContracts/ScreenshotSchema.cs
+++ b/Packages/src/Editor/ToolContracts/ScreenshotSchema.cs
@@ -5,7 +5,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     /// </summary>
     public class ScreenshotSchema : UnityCliLoopToolSchema
     {
-        public string WindowName { get; set; } = "Game";
+        public string WindowName { get; set; } = UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME;
         public float ResolutionScale { get; set; } = 1.0f;
         public WindowMatchMode MatchMode { get; set; } = WindowMatchMode.exact;
         public string OutputDirectory { get; set; } = "";

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -103,6 +103,8 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
             "simulate_mouse_x = image_x / resolutionScale; simulate_mouse_y = image_y / resolutionScale + imageToInputOffsetY";
         public const string SCREENSHOT_WINDOW_TO_INPUT_FORMULA_UNAVAILABLE =
             "unavailable: window screenshots include Unity Editor chrome; use capture-mode rendering for mouse input coordinates";
+        public const string SCREENSHOT_DEFAULT_WINDOW_NAME = "Game";
+        public const string SCREENSHOT_SIMULATOR_WINDOW_NAME = "Simulator";
 
         public const int CORRELATION_ID_LENGTH = 8;
         public const string GUID_FORMAT_NO_HYPHENS = "N";


### PR DESCRIPTION
Refs: MasaVault `2026-07-14_シミュレーターモードでのマウスシミュレート調査.md` PR-2 (To-Do 10–12)

## Summary
- When `--capture-mode window` uses the default window name `Game` and no matching tab exists, retry with `Simulator`.
- Choice: **implement fallback** (not guidance-only). The change is a small exact-match retry; error text still mentions `--window-name Simulator` if both miss.
- Window title constants live in `UnityCliLoopConstants`; schema default uses the same constant.

## User Impact
- With only Device Simulator open, `uloop screenshot --capture-mode window` (no `--window-name`) captures the Simulator chrome instead of returning 0 screenshots.

## Test plan
- [x] `dist/darwin-arm64/uloop compile` → 0/0
- [x] `ScreenshotWindowNameResolverTests` EditMode → passed
- [x] Game tab closed, Simulator open: default `--capture-mode window` returns `Simulator_*.png`
- [x] GHA: not applicable on this PR — base is umbrella `feature/simulator-view-support` (workflows only for `main` / `v3-beta`). Full GHA on the final umbrella → `v3-beta` PR.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

