### PR TITLE
docs: add Device Simulator guidance to mouse/screenshot skills

### DIFF
--- a/.agents/skills/uloop-raycast/SKILL.md
+++ b/.agents/skills/uloop-raycast/SKILL.md
@@ -33,6 +33,8 @@ unity_x = input_x
 unity_y = gameViewHeight - input_y
 ```
 
+- Device Simulator play view is supported. Prefer coordinates from `uloop screenshot --capture-mode rendering` (or its annotated `SimX`/`SimY`).
+
 ## Examples
 
 ```bash

--- a/.agents/skills/uloop-screenshot/SKILL.md
+++ b/.agents/skills/uloop-screenshot/SKILL.md
@@ -18,7 +18,7 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. |
+| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. When the Game tab is Device Simulator and the title is `Simulator`, default `Game` falls back to `Simulator`. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) |
 | `--match-mode` | enum | `exact` | Window name matching mode: `exact`, `prefix`, or `contains`. Ignored when `--capture-mode rendering`. |
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
@@ -36,7 +36,13 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 ## Window Name
 
-The window name is the text displayed in the window's title bar (tab). Common names: Game, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+The window name is the text displayed in the window's title bar (tab). Common names: Game, Simulator, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+
+## Device Simulator
+
+- Prefer `--capture-mode rendering` for the annotate → click flow. It works with both the normal Game view and Device Simulator, and coordinates match `simulate-mouse-ui` / `simulate-mouse-input` / `raycast`.
+- `--capture-mode window` captures Editor chrome (toolbar/borders). With Device Simulator as the play view, default `--window-name Game` falls back to `Simulator` when no Game tab exists; you can also pass `--window-name Simulator`.
+- Simulator Fit to Screen / Scale / Safe Area overlays are chrome-only and do not change rendering-mode input coordinates. After device rotation, re-run annotate (or re-read `Screen` size) before clicking.
 
 ## Output
 

--- a/.agents/skills/uloop-screenshot/references/annotated-elements.md
+++ b/.agents/skills/uloop-screenshot/references/annotated-elements.md
@@ -2,6 +2,8 @@
 
 Read this when using `uloop screenshot --capture-mode rendering --annotate-elements true` or `--annotate-raycast-grid true` output to find coordinates for `simulate-mouse-ui`, `simulate-mouse-input`, or `raycast`.
 
+Device Simulator is supported for this flow: prefer `--capture-mode rendering` (not `window`) so coordinates match the simulated device resolution.
+
 ## AnnotatedElements Fields
 
 `AnnotatedElements` is empty unless `--annotate-elements true` is used, or unless `--annotate-raycast-grid true` adds clustered 3D collider candidates (with or without `--raycast-layer-mask`). UI entries are sorted by z-order, frontmost first. Each item contains:

--- a/.agents/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-input/SKILL.md
@@ -106,6 +106,7 @@ unity_y = gameViewHeight - input_y
 ```
 
 - `Mouse.current.position` uses bottom-left Unity coordinates, so the value read inside Unity may show the converted Y.
+- Device Simulator play view is supported. Prefer rendering-mode screenshots for coordinates; they match the simulated device resolution, not Simulator chrome scale.
 
 ## Prerequisites
 

--- a/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -67,6 +67,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 - Dragging on empty space (no draggable UI element) returns `Success = false`
 - `--bypass-raycast` still uses coordinates for pointer event positions, but chooses the clicked, long-pressed, or dragged GameObject by `--target-path`
 - If `--target-path` or `--drop-target-path` matches multiple active GameObjects, the command fails instead of choosing an arbitrary duplicate
+- Device Simulator play view is supported. Prefer `uloop screenshot --capture-mode rendering --annotate-elements` for coordinates; they use the simulated device resolution (`Handles.GetMainGameViewSize()` / `Screen`), not the Simulator chrome scale.
 
 ## Pause Point Inspection (Standard for E2E)
 

--- a/.claude/skills/uloop-raycast/SKILL.md
+++ b/.claude/skills/uloop-raycast/SKILL.md
@@ -33,6 +33,8 @@ unity_x = input_x
 unity_y = gameViewHeight - input_y
 ```
 
+- Device Simulator play view is supported. Prefer coordinates from `uloop screenshot --capture-mode rendering` (or its annotated `SimX`/`SimY`).
+
 ## Examples
 
 ```bash

--- a/.claude/skills/uloop-screenshot/SKILL.md
+++ b/.claude/skills/uloop-screenshot/SKILL.md
@@ -18,7 +18,7 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. |
+| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. When the Game tab is Device Simulator and the title is `Simulator`, default `Game` falls back to `Simulator`. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) |
 | `--match-mode` | enum | `exact` | Window name matching mode: `exact`, `prefix`, or `contains`. Ignored when `--capture-mode rendering`. |
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
@@ -36,7 +36,13 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 ## Window Name
 
-The window name is the text displayed in the window's title bar (tab). Common names: Game, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+The window name is the text displayed in the window's title bar (tab). Common names: Game, Simulator, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+
+## Device Simulator
+
+- Prefer `--capture-mode rendering` for the annotate → click flow. It works with both the normal Game view and Device Simulator, and coordinates match `simulate-mouse-ui` / `simulate-mouse-input` / `raycast`.
+- `--capture-mode window` captures Editor chrome (toolbar/borders). With Device Simulator as the play view, default `--window-name Game` falls back to `Simulator` when no Game tab exists; you can also pass `--window-name Simulator`.
+- Simulator Fit to Screen / Scale / Safe Area overlays are chrome-only and do not change rendering-mode input coordinates. After device rotation, re-run annotate (or re-read `Screen` size) before clicking.
 
 ## Output
 

--- a/.claude/skills/uloop-screenshot/references/annotated-elements.md
+++ b/.claude/skills/uloop-screenshot/references/annotated-elements.md
@@ -2,6 +2,8 @@
 
 Read this when using `uloop screenshot --capture-mode rendering --annotate-elements true` or `--annotate-raycast-grid true` output to find coordinates for `simulate-mouse-ui`, `simulate-mouse-input`, or `raycast`.
 
+Device Simulator is supported for this flow: prefer `--capture-mode rendering` (not `window`) so coordinates match the simulated device resolution.
+
 ## AnnotatedElements Fields
 
 `AnnotatedElements` is empty unless `--annotate-elements true` is used, or unless `--annotate-raycast-grid true` adds clustered 3D collider candidates (with or without `--raycast-layer-mask`). UI entries are sorted by z-order, frontmost first. Each item contains:

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -106,6 +106,7 @@ unity_y = gameViewHeight - input_y
 ```
 
 - `Mouse.current.position` uses bottom-left Unity coordinates, so the value read inside Unity may show the converted Y.
+- Device Simulator play view is supported. Prefer rendering-mode screenshots for coordinates; they match the simulated device resolution, not Simulator chrome scale.
 
 ## Prerequisites
 

--- a/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -67,6 +67,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 - Dragging on empty space (no draggable UI element) returns `Success = false`
 - `--bypass-raycast` still uses coordinates for pointer event positions, but chooses the clicked, long-pressed, or dragged GameObject by `--target-path`
 - If `--target-path` or `--drop-target-path` matches multiple active GameObjects, the command fails instead of choosing an arbitrary duplicate
+- Device Simulator play view is supported. Prefer `uloop screenshot --capture-mode rendering --annotate-elements` for coordinates; they use the simulated device resolution (`Handles.GetMainGameViewSize()` / `Screen`), not the Simulator chrome scale.
 
 ## Pause Point Inspection (Standard for E2E)
 

--- a/Packages/src/Editor/FirstPartyTools/Raycast/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Raycast/Skill/SKILL.md
@@ -33,6 +33,8 @@ unity_x = input_x
 unity_y = gameViewHeight - input_y
 ```
 
+- Device Simulator play view is supported. Prefer coordinates from `uloop screenshot --capture-mode rendering` (or its annotated `SimX`/`SimY`).
+
 ## Examples
 
 ```bash

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
@@ -18,7 +18,7 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. |
+| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. When the Game tab is Device Simulator and the title is `Simulator`, default `Game` falls back to `Simulator`. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) |
 | `--match-mode` | enum | `exact` | Window name matching mode: `exact`, `prefix`, or `contains`. Ignored when `--capture-mode rendering`. |
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
@@ -36,7 +36,13 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 ## Window Name
 
-The window name is the text displayed in the window's title bar (tab). Common names: Game, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+The window name is the text displayed in the window's title bar (tab). Common names: Game, Simulator, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+
+## Device Simulator
+
+- Prefer `--capture-mode rendering` for the annotate → click flow. It works with both the normal Game view and Device Simulator, and coordinates match `simulate-mouse-ui` / `simulate-mouse-input` / `raycast`.
+- `--capture-mode window` captures Editor chrome (toolbar/borders). With Device Simulator as the play view, default `--window-name Game` falls back to `Simulator` when no Game tab exists; you can also pass `--window-name Simulator`.
+- Simulator Fit to Screen / Scale / Safe Area overlays are chrome-only and do not change rendering-mode input coordinates. After device rotation, re-run annotate (or re-read `Screen` size) before clicking.
 
 ## Output
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/references/annotated-elements.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/references/annotated-elements.md
@@ -2,6 +2,8 @@
 
 Read this when using `uloop screenshot --capture-mode rendering --annotate-elements true` or `--annotate-raycast-grid true` output to find coordinates for `simulate-mouse-ui`, `simulate-mouse-input`, or `raycast`.
 
+Device Simulator is supported for this flow: prefer `--capture-mode rendering` (not `window`) so coordinates match the simulated device resolution.
+
 ## AnnotatedElements Fields
 
 `AnnotatedElements` is empty unless `--annotate-elements true` is used, or unless `--annotate-raycast-grid true` adds clustered 3D collider candidates (with or without `--raycast-layer-mask`). UI entries are sorted by z-order, frontmost first. Each item contains:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
@@ -106,6 +106,7 @@ unity_y = gameViewHeight - input_y
 ```
 
 - `Mouse.current.position` uses bottom-left Unity coordinates, so the value read inside Unity may show the converted Y.
+- Device Simulator play view is supported. Prefer rendering-mode screenshots for coordinates; they match the simulated device resolution, not Simulator chrome scale.
 
 ## Prerequisites
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
@@ -67,6 +67,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 - Dragging on empty space (no draggable UI element) returns `Success = false`
 - `--bypass-raycast` still uses coordinates for pointer event positions, but chooses the clicked, long-pressed, or dragged GameObject by `--target-path`
 - If `--target-path` or `--drop-target-path` matches multiple active GameObjects, the command fails instead of choosing an arbitrary duplicate
+- Device Simulator play view is supported. Prefer `uloop screenshot --capture-mode rendering --annotate-elements` for coordinates; they use the simulated device resolution (`Handles.GetMainGameViewSize()` / `Screen`), not the Simulator chrome scale.
 
 ## Pause Point Inspection (Standard for E2E)
 


### PR DESCRIPTION
Refs: MasaVault `2026-07-14_シミュレーターモードでのマウスシミュレート調査.md` PR-3 (To-Do 13–14)

## Summary
- Updated **source** skills for `screenshot`, `simulate-mouse-ui`, `simulate-mouse-input`, and `raycast` with Device Simulator notes from the investigation.
- Regenerated `.claude/skills` and `.agents/skills` copies via `uloop skills install --claude --agents --flat`.

## Key guidance added
- Prefer `--capture-mode rendering` for annotate → click (works with Game view and Simulator).
- Mouse simulate / raycast work under Simulator; coordinates use device resolution, not chrome scale.
- Window capture: default `Game` falls back to `Simulator` when needed.

## Test plan
- [x] Source and generated skill files match after `uloop skills install`
- [x] GHA: not applicable on this PR — base is umbrella `feature/simulator-view-support`. Full GHA on the final umbrella → `v3-beta` PR.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

