### PR TITLE
fix: Device Simulator support for screenshot and mouse flow

### DIFF
--- a/.agents/skills/uloop-raycast/SKILL.md
+++ b/.agents/skills/uloop-raycast/SKILL.md
@@ -33,6 +33,8 @@ unity_x = input_x
 unity_y = gameViewHeight - input_y
 ```
 
+- Device Simulator play view is supported. Prefer coordinates from `uloop screenshot --capture-mode rendering` (or its annotated `SimX`/`SimY`).
+
 ## Examples
 
 ```bash

--- a/.agents/skills/uloop-screenshot/SKILL.md
+++ b/.agents/skills/uloop-screenshot/SKILL.md
@@ -18,7 +18,7 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. |
+| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. When the Game tab is Device Simulator and the title is `Simulator`, default `Game` falls back to `Simulator`. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) |
 | `--match-mode` | enum | `exact` | Window name matching mode: `exact`, `prefix`, or `contains`. Ignored when `--capture-mode rendering`. |
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
@@ -36,7 +36,13 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 ## Window Name
 
-The window name is the text displayed in the window's title bar (tab). Common names: Game, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+The window name is the text displayed in the window's title bar (tab). Common names: Game, Simulator, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+
+## Device Simulator
+
+- Prefer `--capture-mode rendering` for the annotate → click flow. It works with both the normal Game view and Device Simulator, and coordinates match `simulate-mouse-ui` / `simulate-mouse-input` / `raycast`.
+- `--capture-mode window` captures Editor chrome (toolbar/borders). With Device Simulator as the play view, default `--window-name Game` falls back to `Simulator` when no Game tab exists; you can also pass `--window-name Simulator`.
+- Simulator Fit to Screen / Scale / Safe Area overlays are chrome-only and do not change rendering-mode input coordinates. After device rotation, re-run annotate (or re-read `Screen` size) before clicking.
 
 ## Output
 

--- a/.agents/skills/uloop-screenshot/references/annotated-elements.md
+++ b/.agents/skills/uloop-screenshot/references/annotated-elements.md
@@ -2,6 +2,8 @@
 
 Read this when using `uloop screenshot --capture-mode rendering --annotate-elements true` or `--annotate-raycast-grid true` output to find coordinates for `simulate-mouse-ui`, `simulate-mouse-input`, or `raycast`.
 
+Device Simulator is supported for this flow: prefer `--capture-mode rendering` (not `window`) so coordinates match the simulated device resolution.
+
 ## AnnotatedElements Fields
 
 `AnnotatedElements` is empty unless `--annotate-elements true` is used, or unless `--annotate-raycast-grid true` adds clustered 3D collider candidates (with or without `--raycast-layer-mask`). UI entries are sorted by z-order, frontmost first. Each item contains:

--- a/.agents/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-input/SKILL.md
@@ -106,6 +106,7 @@ unity_y = gameViewHeight - input_y
 ```
 
 - `Mouse.current.position` uses bottom-left Unity coordinates, so the value read inside Unity may show the converted Y.
+- Device Simulator play view is supported. Prefer rendering-mode screenshots for coordinates; they match the simulated device resolution, not Simulator chrome scale.
 
 ## Prerequisites
 

--- a/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.agents/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -67,6 +67,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 - Dragging on empty space (no draggable UI element) returns `Success = false`
 - `--bypass-raycast` still uses coordinates for pointer event positions, but chooses the clicked, long-pressed, or dragged GameObject by `--target-path`
 - If `--target-path` or `--drop-target-path` matches multiple active GameObjects, the command fails instead of choosing an arbitrary duplicate
+- Device Simulator play view is supported. Prefer `uloop screenshot --capture-mode rendering --annotate-elements` for coordinates; they use the simulated device resolution (`Handles.GetMainGameViewSize()` / `Screen`), not the Simulator chrome scale.
 
 ## Pause Point Inspection (Standard for E2E)
 

--- a/.claude/skills/uloop-raycast/SKILL.md
+++ b/.claude/skills/uloop-raycast/SKILL.md
@@ -33,6 +33,8 @@ unity_x = input_x
 unity_y = gameViewHeight - input_y
 ```
 
+- Device Simulator play view is supported. Prefer coordinates from `uloop screenshot --capture-mode rendering` (or its annotated `SimX`/`SimY`).
+
 ## Examples
 
 ```bash

--- a/.claude/skills/uloop-screenshot/SKILL.md
+++ b/.claude/skills/uloop-screenshot/SKILL.md
@@ -18,7 +18,7 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. |
+| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. When the Game tab is Device Simulator and the title is `Simulator`, default `Game` falls back to `Simulator`. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) |
 | `--match-mode` | enum | `exact` | Window name matching mode: `exact`, `prefix`, or `contains`. Ignored when `--capture-mode rendering`. |
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
@@ -36,7 +36,13 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 ## Window Name
 
-The window name is the text displayed in the window's title bar (tab). Common names: Game, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+The window name is the text displayed in the window's title bar (tab). Common names: Game, Simulator, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+
+## Device Simulator
+
+- Prefer `--capture-mode rendering` for the annotate → click flow. It works with both the normal Game view and Device Simulator, and coordinates match `simulate-mouse-ui` / `simulate-mouse-input` / `raycast`.
+- `--capture-mode window` captures Editor chrome (toolbar/borders). With Device Simulator as the play view, default `--window-name Game` falls back to `Simulator` when no Game tab exists; you can also pass `--window-name Simulator`.
+- Simulator Fit to Screen / Scale / Safe Area overlays are chrome-only and do not change rendering-mode input coordinates. After device rotation, re-run annotate (or re-read `Screen` size) before clicking.
 
 ## Output
 

--- a/.claude/skills/uloop-screenshot/references/annotated-elements.md
+++ b/.claude/skills/uloop-screenshot/references/annotated-elements.md
@@ -2,6 +2,8 @@
 
 Read this when using `uloop screenshot --capture-mode rendering --annotate-elements true` or `--annotate-raycast-grid true` output to find coordinates for `simulate-mouse-ui`, `simulate-mouse-input`, or `raycast`.
 
+Device Simulator is supported for this flow: prefer `--capture-mode rendering` (not `window`) so coordinates match the simulated device resolution.
+
 ## AnnotatedElements Fields
 
 `AnnotatedElements` is empty unless `--annotate-elements true` is used, or unless `--annotate-raycast-grid true` adds clustered 3D collider candidates (with or without `--raycast-layer-mask`). UI entries are sorted by z-order, frontmost first. Each item contains:

--- a/.claude/skills/uloop-simulate-mouse-input/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-input/SKILL.md
@@ -106,6 +106,7 @@ unity_y = gameViewHeight - input_y
 ```
 
 - `Mouse.current.position` uses bottom-left Unity coordinates, so the value read inside Unity may show the converted Y.
+- Device Simulator play view is supported. Prefer rendering-mode screenshots for coordinates; they match the simulated device resolution, not Simulator chrome scale.
 
 ## Prerequisites
 

--- a/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
+++ b/.claude/skills/uloop-simulate-mouse-ui/SKILL.md
@@ -67,6 +67,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 - Dragging on empty space (no draggable UI element) returns `Success = false`
 - `--bypass-raycast` still uses coordinates for pointer event positions, but chooses the clicked, long-pressed, or dragged GameObject by `--target-path`
 - If `--target-path` or `--drop-target-path` matches multiple active GameObjects, the command fails instead of choosing an arbitrary duplicate
+- Device Simulator play view is supported. Prefer `uloop screenshot --capture-mode rendering --annotate-elements` for coordinates; they use the simulated device resolution (`Handles.GetMainGameViewSize()` / `Screen`), not the Simulator chrome scale.
 
 ## Pause Point Inspection (Standard for E2E)
 

--- a/Assets/Tests/Editor/GameViewBridgeTests.cs
+++ b/Assets/Tests/Editor/GameViewBridgeTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.InternalAPIBridge;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies PlayModeView RenderTexture field resolution used by GameViewBridge.
+    /// </summary>
+    public class GameViewBridgeTests
+    {
+        private class FakePlayModeView
+        {
+#pragma warning disable CS0414 // Field is assigned for reflection-based tests only.
+            private object m_TargetTexture = "texture";
+#pragma warning restore CS0414
+        }
+
+        private class FakeSimulatorWindow : FakePlayModeView
+        {
+        }
+
+        [Test]
+        public void ResolveTargetTextureField_WhenCalledOnDeclaringType_FindsPrivateBaseField()
+        {
+            // Verifies GetField on the PlayModeView declaring type finds m_TargetTexture.
+            FieldInfo field = GameViewBridge.ResolveTargetTextureField(typeof(FakePlayModeView));
+
+            Assert.That(field, Is.Not.Null);
+            Assert.That(field.Name, Is.EqualTo("m_TargetTexture"));
+            Assert.That(field.DeclaringType, Is.EqualTo(typeof(FakePlayModeView)));
+        }
+
+        [Test]
+        public void ResolveTargetTextureField_WhenDerivedTypeGetFieldMissesPrivateBaseField_DeclaringTypeStillResolves()
+        {
+            // Verifies the reflection pitfall: derived-type GetField cannot see private base fields.
+            FieldInfo fromDerived = typeof(FakeSimulatorWindow).GetField(
+                "m_TargetTexture",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo fromDeclaring = GameViewBridge.ResolveTargetTextureField(typeof(FakePlayModeView));
+
+            Assert.That(fromDerived, Is.Null);
+            Assert.That(fromDeclaring, Is.Not.Null);
+
+            FakeSimulatorWindow instance = new();
+            object value = fromDeclaring.GetValue(instance);
+            Assert.That(value, Is.EqualTo("texture"));
+        }
+
+        [Test]
+        public void GetRenderTexture_WhenMembersResolved_DoesNotThrow()
+        {
+            // Verifies PlayModeView type/method/field resolution completes without throwing.
+            Assert.DoesNotThrow(() => GameViewBridge.GetRenderTexture());
+        }
+    }
+}

--- a/Assets/Tests/Editor/GameViewBridgeTests.cs.meta
+++ b/Assets/Tests/Editor/GameViewBridgeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72e1206d01daa484da9b23ccb96473ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs
+++ b/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs
@@ -1,0 +1,85 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies window-name fallback from Game to Device Simulator for screenshot capture.
+    /// </summary>
+    public class ScreenshotWindowNameResolverTests
+    {
+        [Test]
+        public void ShouldFallbackToSimulator_WhenDefaultGameExactMisses_ReturnsTrue()
+        {
+            // Verifies the default Game exact lookup falls back when no window matched.
+            bool shouldFallback = ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.exact,
+                matchCount: 0);
+
+            Assert.That(shouldFallback, Is.True);
+        }
+
+        [Test]
+        public void ShouldFallbackToSimulator_WhenGameAlreadyMatched_ReturnsFalse()
+        {
+            // Verifies fallback is skipped when the Game window was found.
+            bool shouldFallback = ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.exact,
+                matchCount: 1);
+
+            Assert.That(shouldFallback, Is.False);
+        }
+
+        [Test]
+        public void ShouldFallbackToSimulator_WhenRequestedNameIsNotGame_ReturnsFalse()
+        {
+            // Verifies explicit non-Game names do not silently switch to Simulator.
+            bool shouldFallback = ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                "Inspector",
+                WindowMatchMode.exact,
+                matchCount: 0);
+
+            Assert.That(shouldFallback, Is.False);
+        }
+
+        [Test]
+        public void ShouldFallbackToSimulator_WhenMatchModeIsNotExact_ReturnsFalse()
+        {
+            // Verifies prefix/contains Game lookups do not trigger Simulator fallback.
+            bool shouldFallback = ScreenshotWindowNameResolver.ShouldFallbackToSimulator(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.contains,
+                matchCount: 0);
+
+            Assert.That(shouldFallback, Is.False);
+        }
+
+        [Test]
+        public void ResolveCaptureWindowName_WhenFallbackApplies_ReturnsSimulator()
+        {
+            // Verifies the resolved capture title becomes Simulator after a Game miss.
+            string resolved = ScreenshotWindowNameResolver.ResolveCaptureWindowName(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.exact,
+                primaryMatchCount: 0);
+
+            Assert.That(resolved, Is.EqualTo(UnityCliLoopConstants.SCREENSHOT_SIMULATOR_WINDOW_NAME));
+        }
+
+        [Test]
+        public void ResolveCaptureWindowName_WhenFallbackDoesNotApply_ReturnsRequestedName()
+        {
+            // Verifies Resolve keeps the requested title when Game already matched.
+            string resolved = ScreenshotWindowNameResolver.ResolveCaptureWindowName(
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                WindowMatchMode.exact,
+                primaryMatchCount: 1);
+
+            Assert.That(resolved, Is.EqualTo(UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs.meta
+++ b/Assets/Tests/Editor/ScreenshotWindowNameResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a5f3a68bb5c448d591afcddae2e273a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef
+++ b/Assets/Tests/Editor/UnityCLILoop.Tests.Editor.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "io.github.hatayama.UnityCliLoop.Tests.Editor",
     "references": [
         "GUID:214998e563c124e8a88199b2dd1f522d",
+        "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
         "GUID:5c4588558a3624eacbce0f50007cf1eb",
         "GUID:18e6dd30a99d14f32a045f79a2956f46",
         "GUID:2fca906c8834d45aea12a5cc143c032d",

--- a/Packages/src/Editor/FirstPartyTools/Raycast/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Raycast/Skill/SKILL.md
@@ -33,6 +33,8 @@ unity_x = input_x
 unity_y = gameViewHeight - input_y
 ```
 
+- Device Simulator play view is supported. Prefer coordinates from `uloop screenshot --capture-mode rendering` (or its annotated `SimX`/`SimY`).
+
 ## Examples
 
 ```bash

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/EditorWindowCaptureUtility.cs
@@ -162,7 +162,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return names.ToArray();
         }
 
-        // Captures game rendering by reading GameView's composited RenderTexture (PlayMode only).
+        // Captures game rendering by reading the Play Mode view RenderTexture (PlayMode only).
+        // Works for both GameView and Device Simulator via PlayModeView.m_TargetTexture.
         // Contains all cameras + Screen Space Overlay Canvas, without tab bar or borders.
         internal static async Task<(Texture2D? texture, GameRenderingImageInfo renderingImageInfo, bool timedOut)> CaptureGameRenderingAsync(
             float resolutionScale,
@@ -189,13 +190,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             RenderTexture rt = GameViewBridge.GetRenderTexture();
             if (rt == null)
             {
-                Debug.LogWarning("[EditorWindowCaptureUtility] GameView RenderTexture is not available");
+                Debug.LogWarning("[EditorWindowCaptureUtility] Play Mode view RenderTexture is not available");
                 GameRenderingImageInfo unavailableInfo = renderingImageInfo ??
                     CreateUnavailableGameRenderingImageInfo(Handles.GetMainGameViewSize());
                 return (null, unavailableInfo, false);
             }
 
-            // GameView RenderTexture can be shorter than the full input area, so raw image Y needs this offset.
+            // Play Mode view RenderTexture can be shorter than the full input area, so raw image Y needs this offset.
             GameRenderingImageInfo captureInfo = renderingImageInfo ??
                 CreateGameRenderingImageInfo(Handles.GetMainGameViewSize(), rt.width, rt.height);
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -168,7 +168,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 if (captureTimedOut)
                 {
                     return CreateTimedOutResult(
-                        "GameView rendering capture",
+                        "Play Mode view rendering capture",
                         correlationId,
                         new List<ScreenshotInfo>());
                 }
@@ -190,7 +190,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 VibeLogger.LogError(
                     "screenshot_rendering_unavailable",
-                    "GameView RenderTexture is not available. Open the Game view and wait for a frame before retrying.",
+                    "Play Mode view RenderTexture is not available. Open the Game view or Device Simulator and wait for a frame before retrying.",
                     correlationId: correlationId
                 );
                 return new ScreenshotResponse();

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -256,18 +256,47 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SynchronizationContext editorContext =
                 CapturedEditorSynchronizationContext.RequireCurrent("window screenshot use case");
             EditorWindow[] windows = EditorWindowCaptureUtility.FindWindowsByName(request.WindowName, request.MatchMode);
+            string captureWindowName = ScreenshotWindowNameResolver.ResolveCaptureWindowName(
+                request.WindowName,
+                request.MatchMode,
+                windows.Length);
+            bool usedSimulatorFallback = !string.Equals(
+                captureWindowName,
+                request.WindowName,
+                StringComparison.OrdinalIgnoreCase);
+            if (usedSimulatorFallback)
+            {
+                // why: Device Simulator replaces the Game tab, so the default "Game" title miss should retry Simulator
+                windows = EditorWindowCaptureUtility.FindWindowsByName(captureWindowName, request.MatchMode);
+                if (windows.Length > 0)
+                {
+                    VibeLogger.LogInfo(
+                        "screenshot_window_fallback_simulator",
+                        $"Window '{request.WindowName}' not found; capturing '{captureWindowName}' instead",
+                        correlationId: correlationId
+                    );
+                }
+            }
+
             if (windows.Length == 0)
             {
+                string notFoundMessage = usedSimulatorFallback
+                    ? "Neither Game nor Simulator window found; open the Game view or Device Simulator and retry"
+                    : $"Window '{request.WindowName}' not found (MatchMode: {request.MatchMode})";
+
                 VibeLogger.LogError(
                     "screenshot_window_not_found",
-                    $"Window '{request.WindowName}' not found (MatchMode: {request.MatchMode})",
+                    notFoundMessage,
                     correlationId: correlationId
                 );
-                return new ScreenshotResponse();
+                return new ScreenshotResponse
+                {
+                    Message = notFoundMessage,
+                };
             }
 
             string outputDirectory = EnsureOutputDirectoryExists(request.OutputDirectory);
-            string safeWindowName = SanitizeFileName(request.WindowName);
+            string safeWindowName = SanitizeFileName(captureWindowName);
             string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss_fff");
             List<ScreenshotInfo> screenshots = new();
 
@@ -336,7 +365,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             VibeLogger.LogInfo(
                 "screenshot_success",
                 $"Captured {screenshots.Count} window(s)",
-                new { WindowName = request.WindowName, ScreenshotCount = screenshots.Count },
+                new { WindowName = captureWindowName, RequestedWindowName = request.WindowName, ScreenshotCount = screenshots.Count },
                 correlationId: correlationId
             );
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotWindowNameResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotWindowNameResolver.cs
@@ -1,0 +1,51 @@
+using System;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Resolves which Editor window title to capture for screenshot --capture-mode window.
+    /// </summary>
+    internal static class ScreenshotWindowNameResolver
+    {
+        /// <summary>
+        /// Decide whether to retry with the Device Simulator title after a Game window miss.
+        /// why: CLI default window name is Game, but Device Simulator replaces that tab so the title is Simulator.
+        /// </summary>
+        internal static bool ShouldFallbackToSimulator(
+            string requestedWindowName,
+            WindowMatchMode matchMode,
+            int matchCount)
+        {
+            if (matchCount > 0)
+            {
+                return false;
+            }
+
+            // why: only the default Game exact lookup means "capture the play view chrome"
+            if (matchMode != WindowMatchMode.exact)
+            {
+                return false;
+            }
+
+            return string.Equals(
+                requestedWindowName,
+                UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static string ResolveCaptureWindowName(
+            string requestedWindowName,
+            WindowMatchMode matchMode,
+            int primaryMatchCount)
+        {
+            if (ShouldFallbackToSimulator(requestedWindowName, matchMode, primaryMatchCount))
+            {
+                return UnityCliLoopConstants.SCREENSHOT_SIMULATOR_WINDOW_NAME;
+            }
+
+            return requestedWindowName;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotWindowNameResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotWindowNameResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a11098664166e4ad6a3bf77ad41fb85b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/SKILL.md
@@ -18,7 +18,7 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. |
+| `--window-name` | string | `Game` | Window name to capture. Ignored when `--capture-mode rendering`. When the Game tab is Device Simulator and the title is `Simulator`, default `Game` falls back to `Simulator`. |
 | `--resolution-scale` | number | `1.0` | Resolution scale (0.1 to 1.0) |
 | `--match-mode` | enum | `exact` | Window name matching mode: `exact`, `prefix`, or `contains`. Ignored when `--capture-mode rendering`. |
 | `--capture-mode` | enum | `window` | `window`=capture EditorWindow including toolbar, `rendering`=capture game rendering only (PlayMode required, coordinates match simulate-mouse) |
@@ -36,7 +36,13 @@ uloop screenshot [--window-name <name>] [--resolution-scale <scale>] [--match-mo
 
 ## Window Name
 
-The window name is the text displayed in the window's title bar (tab). Common names: Game, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+The window name is the text displayed in the window's title bar (tab). Common names: Game, Simulator, Scene, Console, Inspector, Project, Hierarchy, Animation, Animator, Profiler. Custom EditorWindow titles are also supported.
+
+## Device Simulator
+
+- Prefer `--capture-mode rendering` for the annotate → click flow. It works with both the normal Game view and Device Simulator, and coordinates match `simulate-mouse-ui` / `simulate-mouse-input` / `raycast`.
+- `--capture-mode window` captures Editor chrome (toolbar/borders). With Device Simulator as the play view, default `--window-name Game` falls back to `Simulator` when no Game tab exists; you can also pass `--window-name Simulator`.
+- Simulator Fit to Screen / Scale / Safe Area overlays are chrome-only and do not change rendering-mode input coordinates. After device rotation, re-run annotate (or re-read `Screen` size) before clicking.
 
 ## Output
 

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/references/annotated-elements.md
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/Skill/references/annotated-elements.md
@@ -2,6 +2,8 @@
 
 Read this when using `uloop screenshot --capture-mode rendering --annotate-elements true` or `--annotate-raycast-grid true` output to find coordinates for `simulate-mouse-ui`, `simulate-mouse-input`, or `raycast`.
 
+Device Simulator is supported for this flow: prefer `--capture-mode rendering` (not `window`) so coordinates match the simulated device resolution.
+
 ## AnnotatedElements Fields
 
 `AnnotatedElements` is empty unless `--annotate-elements true` is used, or unless `--annotate-raycast-grid true` adds clustered 3D collider candidates (with or without `--raycast-layer-mask`). UI entries are sorted by z-order, frontmost first. Each item contains:

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UIElementAnnotator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UIElementAnnotator.cs
@@ -9,7 +9,7 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     // Creates a temporary Screen Space Overlay Canvas that draws bounding boxes and labels
-    // over interactive UI elements. The overlay is captured by GameView's m_RenderTexture
+    // over interactive UI elements. The overlay is captured by PlayModeView.m_TargetTexture
     // (OnGUI-based overlays are NOT included in the RT).
     /// <summary>
     /// Provides UI Element Annotator behavior for Unity CLI Loop.

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/Skill/SKILL.md
@@ -106,6 +106,7 @@ unity_y = gameViewHeight - input_y
 ```
 
 - `Mouse.current.position` uses bottom-left Unity coordinates, so the value read inside Unity may show the converted Y.
+- Device Simulator play view is supported. Prefer rendering-mode screenshots for coordinates; they match the simulated device resolution, not Simulator chrome scale.
 
 ## Prerequisites
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/Skill/SKILL.md
@@ -67,6 +67,7 @@ uloop simulate-mouse-ui --action <action> --x <x> --y <y> [options]
 - Dragging on empty space (no draggable UI element) returns `Success = false`
 - `--bypass-raycast` still uses coordinates for pointer event positions, but chooses the clicked, long-pressed, or dragged GameObject by `--target-path`
 - If `--target-path` or `--drop-target-path` matches multiple active GameObjects, the command fails instead of choosing an arbitrary duplicate
+- Device Simulator play view is supported. Prefer `uloop screenshot --capture-mode rendering --annotate-elements` for coordinates; they use the simulated device resolution (`Handles.GetMainGameViewSize()` / `Screen`), not the Simulator chrome scale.
 
 ## Pause Point Inspection (Standard for E2E)
 

--- a/Packages/src/Editor/InternalAPIBridge/AssemblyInfo.cs
+++ b/Packages/src/Editor/InternalAPIBridge/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]

--- a/Packages/src/Editor/InternalAPIBridge/AssemblyInfo.cs.meta
+++ b/Packages/src/Editor/InternalAPIBridge/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df8bc76e5b3594fb98fc546217349bb1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/InternalAPIBridge/GameViewBridge.cs
+++ b/Packages/src/Editor/InternalAPIBridge/GameViewBridge.cs
@@ -6,56 +6,59 @@ using UnityEngine;
 namespace io.github.hatayama.UnityCliLoop.InternalAPIBridge
 {
     /// <summary>
-    /// Bridge class for accessing Unity GameView internal APIs via reflection.
-    /// GameView is an internal class; this bridge discovers members dynamically.
+    /// Bridge for the active Play Mode view RenderTexture via reflection.
+    /// Uses PlayModeView so both GameView and Device Simulator windows work.
     /// </summary>
     public static class GameViewBridge
     {
-        private static Type _gameViewType;
-        private static FieldInfo _renderTextureField;
+        private const string PlayModeViewTypeName = "UnityEditor.PlayModeView";
+        private const string GetMainPlayModeViewMethodName = "GetMainPlayModeView";
+        private const string TargetTextureFieldName = "m_TargetTexture";
+
+        private static Type _playModeViewType;
+        private static MethodInfo _getMainPlayModeViewMethod;
+        private static FieldInfo _targetTextureField;
         private static bool _memberSearchDone;
 
         /// <summary>
-        /// Get the GameView's composited RenderTexture containing all cameras + Screen Space Overlay Canvas.
+        /// Get the active Play Mode view's composited RenderTexture
+        /// (cameras + Screen Space Overlay Canvas).
         /// </summary>
-        /// <returns>The RenderTexture, or null if GameView not found or field not accessible</returns>
+        /// <returns>The RenderTexture, or null if the view or field is unavailable</returns>
         public static RenderTexture GetRenderTexture()
         {
             EnsureMembersResolved();
 
-            EditorWindow gameView = FindMainGameView();
-            if (gameView == null || _renderTextureField == null)
+            EditorWindow playModeView = FindMainPlayModeView();
+            if (playModeView == null || _targetTextureField == null)
             {
                 return null;
             }
 
-            return _renderTextureField.GetValue(gameView) as RenderTexture;
+            return _targetTextureField.GetValue(playModeView) as RenderTexture;
         }
 
-        private static EditorWindow FindMainGameView()
+        /// <summary>
+        /// Resolve m_TargetTexture on the PlayModeView declaring type.
+        /// Must not use a derived Type: GetField does not return private fields declared on base types.
+        /// </summary>
+        internal static FieldInfo ResolveTargetTextureField(Type playModeViewType)
         {
-            if (_gameViewType == null)
+            Debug.Assert(playModeViewType != null, "playModeViewType must not be null");
+
+            return playModeViewType.GetField(
+                TargetTextureFieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+        }
+
+        private static EditorWindow FindMainPlayModeView()
+        {
+            if (_getMainPlayModeViewMethod == null)
             {
                 return null;
             }
 
-            UnityEngine.Object[] gameViews = Resources.FindObjectsOfTypeAll(_gameViewType);
-            if (gameViews.Length == 0)
-            {
-                return null;
-            }
-
-            // Prefer focused window to match editor's active view context
-            foreach (UnityEngine.Object gv in gameViews)
-            {
-                EditorWindow window = gv as EditorWindow;
-                if (window != null && window.hasFocus)
-                {
-                    return window;
-                }
-            }
-
-            return gameViews[0] as EditorWindow;
+            return _getMainPlayModeViewMethod.Invoke(null, null) as EditorWindow;
         }
 
         private static void EnsureMembersResolved()
@@ -66,18 +69,27 @@ namespace io.github.hatayama.UnityCliLoop.InternalAPIBridge
             }
             _memberSearchDone = true;
 
-            _gameViewType = typeof(Editor).Assembly.GetType("UnityEditor.GameView");
-            if (_gameViewType == null)
+            _playModeViewType = typeof(Editor).Assembly.GetType(PlayModeViewTypeName);
+            if (_playModeViewType == null)
             {
-                Debug.LogWarning("[GameViewBridge] GameView type not found");
+                Debug.LogWarning("[GameViewBridge] PlayModeView type not found");
                 return;
             }
 
-            _renderTextureField = _gameViewType.GetField("m_RenderTexture",
-                BindingFlags.Instance | BindingFlags.NonPublic);
-            if (_renderTextureField == null)
+            _getMainPlayModeViewMethod = _playModeViewType.GetMethod(
+                GetMainPlayModeViewMethodName,
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+            if (_getMainPlayModeViewMethod == null)
             {
-                Debug.LogWarning("[GameViewBridge] m_RenderTexture field not found");
+                Debug.LogWarning("[GameViewBridge] GetMainPlayModeView method not found");
+                return;
+            }
+
+            // why: private base fields are invisible to GetField on derived types (GameView / SimulatorWindow)
+            _targetTextureField = ResolveTargetTextureField(_playModeViewType);
+            if (_targetTextureField == null)
+            {
+                Debug.LogWarning("[GameViewBridge] m_TargetTexture field not found on PlayModeView");
             }
         }
     }

--- a/Packages/src/Editor/ToolContracts/ScreenshotSchema.cs
+++ b/Packages/src/Editor/ToolContracts/ScreenshotSchema.cs
@@ -5,7 +5,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     /// </summary>
     public class ScreenshotSchema : UnityCliLoopToolSchema
     {
-        public string WindowName { get; set; } = "Game";
+        public string WindowName { get; set; } = UnityCliLoopConstants.SCREENSHOT_DEFAULT_WINDOW_NAME;
         public float ResolutionScale { get; set; } = 1.0f;
         public WindowMatchMode MatchMode { get; set; } = WindowMatchMode.exact;
         public string OutputDirectory { get; set; } = "";

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopConstants.cs
@@ -103,6 +103,8 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
             "simulate_mouse_x = image_x / resolutionScale; simulate_mouse_y = image_y / resolutionScale + imageToInputOffsetY";
         public const string SCREENSHOT_WINDOW_TO_INPUT_FORMULA_UNAVAILABLE =
             "unavailable: window screenshots include Unity Editor chrome; use capture-mode rendering for mouse input coordinates";
+        public const string SCREENSHOT_DEFAULT_WINDOW_NAME = "Game";
+        public const string SCREENSHOT_SIMULATOR_WINDOW_NAME = "Simulator";
 
         public const int CORRELATION_ID_LENGTH = 8;
         public const string GUID_FORMAT_NO_HYPHENS = "N";


### PR DESCRIPTION
Refs: MasaVault `2026-07-14_シミュレーターモードでのマウスシミュレート調査.md` (final PR / To-Do 15)

## Summary
Umbrella PR for Device Simulator support. Merges stacked work from `feature/simulator-view-support`:

- #1766 — `GameViewBridge` reads `PlayModeView.m_TargetTexture` via `GetMainPlayModeView()` so rendering screenshots work under Device Simulator
- #1767 — `--capture-mode window` falls back from default `Game` to `Simulator` when the Game tab is absent
- #1768 — Skill docs: prefer rendering capture; simulate/raycast work under Simulator

## Goal verification

| Condition | Result |
|-----------|--------|
| Simulator view + Play Mode: `screenshot --capture-mode rendering --annotate-elements` → `simulate-mouse-ui Click` hits button | **Pass** — PNG returned (e.g. 2048×1536), annotate coords hit `ClickButton1`, `[Demo] Clicked 'ClickButton1'` in logs |
| Normal Game View: same annotate → click flow still works (no regression) | **Pass** — rendering capture + annotate + click succeeded after switching main play view back to GameView |

Additional Simulator checks (Fit to Screen / Scale / portrait rotation / Safe Area ON): annotate → click still hit. Fit/Scale/Safe Area are chrome-only; re-annotate after rotation.

## User Impact
- Agents can use the standard screenshot-annotate-click loop while the Game tab is Device Simulator.
- Default window screenshots no longer return 0 results when only Simulator is open.

## Test plan
- [x] Local: compile 0/0; GameViewBridge + ScreenshotWindowNameResolver unit tests
- [x] Local device: Simulator + Game View acceptance flows above
- [ ] CI green on this PR (`v3-beta` base — full GHA applies)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

