### PR TITLE
chore: Add OutputFileRetention helper and unit tests for output folder caps

### DIFF
--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
           dotnet test tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj --configuration Release
+          dotnet test tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj --configuration Release
 
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
           dotnet test tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj --configuration Release
+          dotnet test tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj --configuration Release
 
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4db03dad25b74e4cac446eff5437f3e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Keeps output directories from growing without bound by deleting oldest matching files.
+    /// </summary>
+    public static class OutputFileRetention
+    {
+        public const int MAX_FILES_PER_DIRECTORY = 20;
+
+        /// <summary>
+        /// Deletes matching files older than the newest MAX_FILES_PER_DIRECTORY entries.
+        /// Call after a successful write so the just-saved file is counted toward the limit.
+        /// </summary>
+        /// <param name="directory">Directory that already contains the newly written file.</param>
+        /// <param name="searchPattern">Glob used to count and delete (for example "*.png").</param>
+        public static void DeleteOldestBeyondLimit(string directory, string searchPattern)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(directory), "directory must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(searchPattern), "searchPattern must not be null or empty");
+
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
+            FileInfo[] matchingFiles = new DirectoryInfo(directory).GetFiles(searchPattern);
+            if (matchingFiles.Length <= MAX_FILES_PER_DIRECTORY)
+            {
+                return;
+            }
+
+            // Newest first; file name is the tie-breaker so equal timestamps stay deterministic.
+            List<FileInfo> orderedNewestFirst = matchingFiles
+                .OrderByDescending(file => file.LastWriteTimeUtc)
+                .ThenByDescending(file => file.Name, StringComparer.Ordinal)
+                .ToList();
+
+            for (int i = MAX_FILES_PER_DIRECTORY; i < orderedNewestFirst.Count; i++)
+            {
+                orderedNewestFirst[i].Delete();
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3737dd0bedd4a4beda66edb504e06b05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor",
+    "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": true
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor.asmdef.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 77087b1bb30a415e87a80cbf24e7430a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj
+++ b/tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs" Link="Production/OutputFileRetention.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/OutputFileRetention.UnitTests/OutputFileRetentionTests.cs
+++ b/tests/OutputFileRetention.UnitTests/OutputFileRetentionTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.UnitTests
+{
+    /// <summary>
+    /// Pure unit coverage for directory file-count retention used by uloop output exporters.
+    /// </summary>
+    [TestFixture]
+    public class OutputFileRetentionTests
+    {
+        private string _tempDirectory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "OutputFileRetentionTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDirectory);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (!string.IsNullOrEmpty(_tempDirectory) && Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, true);
+            }
+        }
+
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenFileCountIsAtOrBelowLimit_ShouldNotDeleteAnything()
+        {
+            // Verifies retention is a no-op when matching files are within the configured limit.
+            CreateFileWithWriteTime("file_01.png", DateTime.UtcNow.AddMinutes(-20));
+            CreateFileWithWriteTime("file_02.png", DateTime.UtcNow.AddMinutes(-10));
+            CreateFileWithWriteTime("file_03.png", DateTime.UtcNow.AddMinutes(-1));
+
+            OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.png");
+
+            string[] remaining = Directory.GetFiles(_tempDirectory, "*.png");
+            Assert.That(remaining.Length, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenFileCountExceedsLimit_ShouldKeepNewestFiles()
+        {
+            // Verifies oldest matching files are deleted until only MAX_FILES_PER_DIRECTORY remain.
+            DateTime baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            int totalFiles = OutputFileRetention.MAX_FILES_PER_DIRECTORY + 5;
+            for (int i = 0; i < totalFiles; i++)
+            {
+                string fileName = $"file_{i:D2}.png";
+                CreateFileWithWriteTime(fileName, baseTime.AddMinutes(i));
+            }
+
+            OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.png");
+
+            string[] remaining = Directory.GetFiles(_tempDirectory, "*.png")
+                .Select(Path.GetFileName)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+            Assert.That(remaining.Length, Is.EqualTo(OutputFileRetention.MAX_FILES_PER_DIRECTORY));
+            Assert.That(remaining[0], Is.EqualTo("file_05.png"));
+            Assert.That(remaining[remaining.Length - 1], Is.EqualTo("file_24.png"));
+        }
+
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenNonMatchingFilesExist_ShouldIgnoreThem()
+        {
+            // Verifies files outside searchPattern are neither counted toward the limit nor deleted.
+            DateTime baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            int matchingFiles = OutputFileRetention.MAX_FILES_PER_DIRECTORY + 2;
+            for (int i = 0; i < matchingFiles; i++)
+            {
+                CreateFileWithWriteTime($"match_{i:D2}.json", baseTime.AddMinutes(i));
+            }
+
+            CreateFileWithWriteTime(".DS_Store", baseTime.AddMinutes(-100));
+            CreateFileWithWriteTime("notes.txt", baseTime.AddMinutes(-50));
+
+            OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.json");
+
+            string[] remainingJson = Directory.GetFiles(_tempDirectory, "*.json");
+            Assert.That(remainingJson.Length, Is.EqualTo(OutputFileRetention.MAX_FILES_PER_DIRECTORY));
+            Assert.That(File.Exists(Path.Combine(_tempDirectory, ".DS_Store")), Is.True);
+            Assert.That(File.Exists(Path.Combine(_tempDirectory, "notes.txt")), Is.True);
+        }
+
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenDirectoryIsEmpty_ShouldNotThrow()
+        {
+            // Verifies an empty directory is accepted without throwing or creating files.
+            Assert.DoesNotThrow(() =>
+                OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.png"));
+
+            Assert.That(Directory.GetFiles(_tempDirectory).Length, Is.EqualTo(0));
+        }
+
+        private void CreateFileWithWriteTime(string fileName, DateTime lastWriteTimeUtc)
+        {
+            string path = Path.Combine(_tempDirectory, fileName);
+            File.WriteAllText(path, fileName);
+            File.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
+        }
+    }
+}

--- a/tests/OutputFileRetention.UnitTests/OutputFileRetentionTests.cs
+++ b/tests/OutputFileRetention.UnitTests/OutputFileRetentionTests.cs
@@ -30,10 +30,12 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
             }
         }
 
+        /// <summary>
+        /// Verifies retention is a no-op when matching files are below the configured limit.
+        /// </summary>
         [Test]
-        public void DeleteOldestBeyondLimit_WhenFileCountIsAtOrBelowLimit_ShouldNotDeleteAnything()
+        public void DeleteOldestBeyondLimit_WhenFileCountIsBelowLimit_ShouldNotDeleteAnything()
         {
-            // Verifies retention is a no-op when matching files are within the configured limit.
             CreateFileWithWriteTime("file_01.png", DateTime.UtcNow.AddMinutes(-20));
             CreateFileWithWriteTime("file_02.png", DateTime.UtcNow.AddMinutes(-10));
             CreateFileWithWriteTime("file_03.png", DateTime.UtcNow.AddMinutes(-1));
@@ -44,10 +46,30 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
             Assert.That(remaining.Length, Is.EqualTo(3));
         }
 
+        /// <summary>
+        /// Verifies retention is a no-op when matching files are exactly at MAX_FILES_PER_DIRECTORY.
+        /// </summary>
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenFileCountIsAtLimit_ShouldNotDeleteAnything()
+        {
+            DateTime baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            for (int i = 0; i < OutputFileRetention.MAX_FILES_PER_DIRECTORY; i++)
+            {
+                CreateFileWithWriteTime($"file_{i:D2}.png", baseTime.AddMinutes(i));
+            }
+
+            OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.png");
+
+            string[] remaining = Directory.GetFiles(_tempDirectory, "*.png");
+            Assert.That(remaining.Length, Is.EqualTo(OutputFileRetention.MAX_FILES_PER_DIRECTORY));
+        }
+
+        /// <summary>
+        /// Verifies oldest matching files are deleted until only MAX_FILES_PER_DIRECTORY remain.
+        /// </summary>
         [Test]
         public void DeleteOldestBeyondLimit_WhenFileCountExceedsLimit_ShouldKeepNewestFiles()
         {
-            // Verifies oldest matching files are deleted until only MAX_FILES_PER_DIRECTORY remain.
             DateTime baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             int totalFiles = OutputFileRetention.MAX_FILES_PER_DIRECTORY + 5;
             for (int i = 0; i < totalFiles; i++)
@@ -67,10 +89,12 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
             Assert.That(remaining[remaining.Length - 1], Is.EqualTo("file_24.png"));
         }
 
+        /// <summary>
+        /// Verifies files outside searchPattern are neither counted toward the limit nor deleted.
+        /// </summary>
         [Test]
         public void DeleteOldestBeyondLimit_WhenNonMatchingFilesExist_ShouldIgnoreThem()
         {
-            // Verifies files outside searchPattern are neither counted toward the limit nor deleted.
             DateTime baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             int matchingFiles = OutputFileRetention.MAX_FILES_PER_DIRECTORY + 2;
             for (int i = 0; i < matchingFiles; i++)
@@ -89,10 +113,12 @@ namespace io.github.hatayama.UnityCliLoop.UnitTests
             Assert.That(File.Exists(Path.Combine(_tempDirectory, "notes.txt")), Is.True);
         }
 
+        /// <summary>
+        /// Verifies an empty directory is accepted without throwing or creating files.
+        /// </summary>
         [Test]
         public void DeleteOldestBeyondLimit_WhenDirectoryIsEmpty_ShouldNotThrow()
         {
-            // Verifies an empty directory is accepted without throwing or creating files.
             Assert.DoesNotThrow(() =>
                 OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.png"));
 


### PR DESCRIPTION
## Summary
- Add a pure-C# `OutputFileRetention` helper that keeps at most 20 matching files per directory (oldest deleted first).
- Wire the new unit test project into CI so retention logic stays covered before exporters call it.

## User Impact
- No runtime behavior change yet — exporters are not wired in this PR.
- Enables the follow-up PR that applies retention to screenshot / test / hierarchy / find-game-objects outputs.

## Changes
- `OutputFileRetention.DeleteOldestBeyondLimit` in a dedicated `Common.OutputRetention` asmdef (`noEngineReferences: true`)
- `tests/OutputFileRetention.UnitTests` covering under-limit, over-limit, pattern ignore, and empty directory
- `dotnet test` lines in `unity-compile-check-and-test-runner.yml` and `unity-editmode-tests.yml`

## Verification
- `dotnet test tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj --configuration Release` (4 passed)
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` (0 errors, 0 warnings)