### PR TITLE
feat: Cap screenshot and tool output folders at 20 files

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/Application/FindGameObjectsResultExporter.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/Application/FindGameObjectsResultExporter.cs
@@ -55,6 +55,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
             string jsonContent = JsonConvert.SerializeObject(exportData, settings);
             File.WriteAllText(filePath, jsonContent);
+            OutputFileRetention.DeleteOldestBeyondLimit(exportDir, "*.json");
 
             // Return relative path
             return Path.Combine(EXPORT_DIR, filename);

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/UnityCLILoop.FirstPartyTools.FindGameObjects.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/UnityCLILoop.FirstPartyTools.FindGameObjects.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "UnityCLILoop.FirstPartyTools.FindGameObjects.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:77087b1bb30a415e87a80cbf24e7430a"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/GetHierarchy/Application/HierarchyResultExporter.cs
+++ b/Packages/src/Editor/FirstPartyTools/GetHierarchy/Application/HierarchyResultExporter.cs
@@ -61,7 +61,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
             string jsonContent = JsonConvert.SerializeObject(exportData, settings);
             File.WriteAllText(filePath, jsonContent);
-            
+            OutputFileRetention.DeleteOldestBeyondLimit(exportDir, "*.json");
+
             // Return relative path
             return Path.Combine(EXPORT_DIR, filename);
         }

--- a/Packages/src/Editor/FirstPartyTools/GetHierarchy/UnityCLILoop.FirstPartyTools.GetHierarchy.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/GetHierarchy/UnityCLILoop.FirstPartyTools.GetHierarchy.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "UnityCLILoop.FirstPartyTools.GetHierarchy.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:77087b1bb30a415e87a80cbf24e7430a"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/NUnitXmlResultExporter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/NUnitXmlResultExporter.cs
@@ -44,6 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string filePath = Path.Combine(testResultsDirectory, fileName);
             string xmlContent = GenerateNUnitXml(testResult);
             File.WriteAllText(filePath, xmlContent, Encoding.UTF8);
+            OutputFileRetention.DeleteOldestBeyondLimit(testResultsDirectory, "*.xml");
             AssetDatabase.Refresh();
             return filePath;
         }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor.asmdef
@@ -4,6 +4,7 @@
     "references": [
         "UnityCLILoop.FirstPartyTools.RunTests.Editor",
         "UnityCLILoop.FirstPartyTools.Common.EditorUtility.Editor",
+        "UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor",
         "UnityCLILoop.ToolContracts",
         "UnityEditor.TestRunner",
         "UnityEngine.TestRunner"

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -207,6 +207,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string savedPath = Path.Combine(outputDirectory, $"Rendering_{timestamp}.png");
 
                 SaveTextureAsPng(texture, savedPath);
+                // why: only prune the package default Screenshots folder; never delete files in a user-specified OutputDirectory
+                if (string.IsNullOrEmpty(request.OutputDirectory))
+                {
+                    OutputFileRetention.DeleteOldestBeyondLimit(outputDirectory, "*.png");
+                }
 
                 FileInfo savedFileInfo = new(savedPath);
                 ScreenshotInfo info = new()
@@ -360,6 +365,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     UnityEngine.Object.DestroyImmediate(texture);
                 }
+            }
+
+            // why: only prune the package default Screenshots folder; never delete files in a user-specified OutputDirectory
+            if (string.IsNullOrEmpty(request.OutputDirectory))
+            {
+                OutputFileRetention.DeleteOldestBeyondLimit(outputDirectory, "*.png");
             }
 
             VibeLogger.LogInfo(

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
@@ -6,7 +6,8 @@
         "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
         "GUID:a2d87883023de4cf59b7d1962d5dd8aa",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
-        "GUID:96b8d4624fb74ea2849fed17e7ad69d3"
+        "GUID:96b8d4624fb74ea2849fed17e7ad69d3",
+        "GUID:77087b1bb30a415e87a80cbf24e7430a"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
## Summary
- Automatically delete the oldest files in default `.uloop/outputs` folders once they exceed 20 matching files.
- Applies after screenshot, test-result, hierarchy, and find-game-objects saves.

## User Impact
- Before: Screenshots / TestResults / HierarchyResults / FindGameObjectsResults grew without limit.
- After: each of those default folders keeps at most 20 matching files; older ones are removed on the next save.
- Custom `--output-directory` for screenshots is never pruned.

## Changes
- Call `OutputFileRetention.DeleteOldestBeyondLimit` from the four write paths
- Wire `Common.OutputRetention` into Screenshot / GetHierarchy / FindGameObjects / RunTests.TestFramework asmdefs

## Verification
- `dist/darwin-arm64/uloop compile` → 0 errors, 0 warnings
- `uloop screenshot` reduced Screenshots from 290 → 20 PNGs
- `uloop get-hierarchy` reduced HierarchyResults from 247 → 20 JSONs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

