### PR TITLE
feat: Cap .uloop/outputs folders at 20 files automatically

### DIFF
--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
           dotnet test tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj --configuration Release
+          dotnet test tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj --configuration Release
 
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'

--- a/.github/workflows/unity-editmode-tests.yml
+++ b/.github/workflows/unity-editmode-tests.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
           dotnet test tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj --configuration Release
+          dotnet test tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj --configuration Release
 
       - name: Cache Library folder
         if: env.HAS_UNITY_LICENSE == 'true'

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4db03dad25b74e4cac446eff5437f3e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Keeps output directories from growing without bound by deleting oldest matching files.
+    /// </summary>
+    public static class OutputFileRetention
+    {
+        public const int MAX_FILES_PER_DIRECTORY = 20;
+
+        /// <summary>
+        /// Deletes matching files older than the newest MAX_FILES_PER_DIRECTORY entries.
+        /// Call after a successful write so the just-saved file is counted toward the limit.
+        /// </summary>
+        /// <param name="directory">Directory that already contains the newly written file.</param>
+        /// <param name="searchPattern">Glob used to count and delete (for example "*.png").</param>
+        public static void DeleteOldestBeyondLimit(string directory, string searchPattern)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(directory), "directory must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(searchPattern), "searchPattern must not be null or empty");
+
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
+            FileInfo[] matchingFiles = new DirectoryInfo(directory).GetFiles(searchPattern);
+            if (matchingFiles.Length <= MAX_FILES_PER_DIRECTORY)
+            {
+                return;
+            }
+
+            // Newest first; file name is the tie-breaker so equal timestamps stay deterministic.
+            List<FileInfo> orderedNewestFirst = matchingFiles
+                .OrderByDescending(file => file.LastWriteTimeUtc)
+                .ThenByDescending(file => file.Name, StringComparer.Ordinal)
+                .ToList();
+
+            for (int i = MAX_FILES_PER_DIRECTORY; i < orderedNewestFirst.Count; i++)
+            {
+                orderedNewestFirst[i].Delete();
+            }
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3737dd0bedd4a4beda66edb504e06b05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor",
+    "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": true
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor.asmdef.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/OutputRetention/UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 77087b1bb30a415e87a80cbf24e7430a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/Application/FindGameObjectsResultExporter.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/Application/FindGameObjectsResultExporter.cs
@@ -55,6 +55,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
             string jsonContent = JsonConvert.SerializeObject(exportData, settings);
             File.WriteAllText(filePath, jsonContent);
+            OutputFileRetention.DeleteOldestBeyondLimit(exportDir, "*.json");
 
             // Return relative path
             return Path.Combine(EXPORT_DIR, filename);

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/UnityCLILoop.FirstPartyTools.FindGameObjects.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/UnityCLILoop.FirstPartyTools.FindGameObjects.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "UnityCLILoop.FirstPartyTools.FindGameObjects.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:77087b1bb30a415e87a80cbf24e7430a"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/GetHierarchy/Application/HierarchyResultExporter.cs
+++ b/Packages/src/Editor/FirstPartyTools/GetHierarchy/Application/HierarchyResultExporter.cs
@@ -61,7 +61,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             };
             string jsonContent = JsonConvert.SerializeObject(exportData, settings);
             File.WriteAllText(filePath, jsonContent);
-            
+            OutputFileRetention.DeleteOldestBeyondLimit(exportDir, "*.json");
+
             // Return relative path
             return Path.Combine(EXPORT_DIR, filename);
         }

--- a/Packages/src/Editor/FirstPartyTools/GetHierarchy/UnityCLILoop.FirstPartyTools.GetHierarchy.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/GetHierarchy/UnityCLILoop.FirstPartyTools.GetHierarchy.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "UnityCLILoop.FirstPartyTools.GetHierarchy.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:77087b1bb30a415e87a80cbf24e7430a"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/NUnitXmlResultExporter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/NUnitXmlResultExporter.cs
@@ -44,6 +44,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string filePath = Path.Combine(testResultsDirectory, fileName);
             string xmlContent = GenerateNUnitXml(testResult);
             File.WriteAllText(filePath, xmlContent, Encoding.UTF8);
+            OutputFileRetention.DeleteOldestBeyondLimit(testResultsDirectory, "*.xml");
             AssetDatabase.Refresh();
             return filePath;
         }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/UnityCLILoop.FirstPartyTools.RunTests.TestFramework.Editor.asmdef
@@ -4,6 +4,7 @@
     "references": [
         "UnityCLILoop.FirstPartyTools.RunTests.Editor",
         "UnityCLILoop.FirstPartyTools.Common.EditorUtility.Editor",
+        "UnityCLILoop.FirstPartyTools.Common.OutputRetention.Editor",
         "UnityCLILoop.ToolContracts",
         "UnityEditor.TestRunner",
         "UnityEngine.TestRunner"

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -207,6 +207,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 string savedPath = Path.Combine(outputDirectory, $"Rendering_{timestamp}.png");
 
                 SaveTextureAsPng(texture, savedPath);
+                // why: only prune the package default Screenshots folder; never delete files in a user-specified OutputDirectory
+                if (string.IsNullOrEmpty(request.OutputDirectory))
+                {
+                    OutputFileRetention.DeleteOldestBeyondLimit(outputDirectory, "*.png");
+                }
 
                 FileInfo savedFileInfo = new(savedPath);
                 ScreenshotInfo info = new()
@@ -360,6 +365,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     UnityEngine.Object.DestroyImmediate(texture);
                 }
+            }
+
+            // why: only prune the package default Screenshots folder; never delete files in a user-specified OutputDirectory
+            if (string.IsNullOrEmpty(request.OutputDirectory))
+            {
+                OutputFileRetention.DeleteOldestBeyondLimit(outputDirectory, "*.png");
             }
 
             VibeLogger.LogInfo(

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UnityCLILoop.FirstPartyTools.Screenshot.Editor.asmdef
@@ -6,7 +6,8 @@
         "GUID:5079a8d3a72924a81aa1cbc25f65ed1b",
         "GUID:a2d87883023de4cf59b7d1962d5dd8aa",
         "GUID:fc3fd32eddbee40e39c2d76dc184957b",
-        "GUID:96b8d4624fb74ea2849fed17e7ad69d3"
+        "GUID:96b8d4624fb74ea2849fed17e7ad69d3",
+        "GUID:77087b1bb30a415e87a80cbf24e7430a"
     ],
     "includePlatforms": [
         "Editor"

--- a/tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj
+++ b/tests/OutputFileRetention.UnitTests/OutputFileRetention.UnitTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../Packages/src/Editor/FirstPartyTools/Common/OutputRetention/OutputFileRetention.cs" Link="Production/OutputFileRetention.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/OutputFileRetention.UnitTests/OutputFileRetentionTests.cs
+++ b/tests/OutputFileRetention.UnitTests/OutputFileRetentionTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.UnitTests
+{
+    /// <summary>
+    /// Pure unit coverage for directory file-count retention used by uloop output exporters.
+    /// </summary>
+    [TestFixture]
+    public class OutputFileRetentionTests
+    {
+        private string _tempDirectory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "OutputFileRetentionTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDirectory);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (!string.IsNullOrEmpty(_tempDirectory) && Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies retention is a no-op when matching files are below the configured limit.
+        /// </summary>
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenFileCountIsBelowLimit_ShouldNotDeleteAnything()
+        {
+            CreateFileWithWriteTime("file_01.png", DateTime.UtcNow.AddMinutes(-20));
+            CreateFileWithWriteTime("file_02.png", DateTime.UtcNow.AddMinutes(-10));
+            CreateFileWithWriteTime("file_03.png", DateTime.UtcNow.AddMinutes(-1));
+
+            OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.png");
+
+            string[] remaining = Directory.GetFiles(_tempDirectory, "*.png");
+            Assert.That(remaining.Length, Is.EqualTo(3));
+        }
+
+        /// <summary>
+        /// Verifies retention is a no-op when matching files are exactly at MAX_FILES_PER_DIRECTORY.
+        /// </summary>
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenFileCountIsAtLimit_ShouldNotDeleteAnything()
+        {
+            DateTime baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            for (int i = 0; i < OutputFileRetention.MAX_FILES_PER_DIRECTORY; i++)
+            {
+                CreateFileWithWriteTime($"file_{i:D2}.png", baseTime.AddMinutes(i));
+            }
+
+            OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.png");
+
+            string[] remaining = Directory.GetFiles(_tempDirectory, "*.png");
+            Assert.That(remaining.Length, Is.EqualTo(OutputFileRetention.MAX_FILES_PER_DIRECTORY));
+        }
+
+        /// <summary>
+        /// Verifies oldest matching files are deleted until only MAX_FILES_PER_DIRECTORY remain.
+        /// </summary>
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenFileCountExceedsLimit_ShouldKeepNewestFiles()
+        {
+            DateTime baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            int totalFiles = OutputFileRetention.MAX_FILES_PER_DIRECTORY + 5;
+            for (int i = 0; i < totalFiles; i++)
+            {
+                string fileName = $"file_{i:D2}.png";
+                CreateFileWithWriteTime(fileName, baseTime.AddMinutes(i));
+            }
+
+            OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.png");
+
+            string[] remaining = Directory.GetFiles(_tempDirectory, "*.png")
+                .Select(Path.GetFileName)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+            Assert.That(remaining.Length, Is.EqualTo(OutputFileRetention.MAX_FILES_PER_DIRECTORY));
+            Assert.That(remaining[0], Is.EqualTo("file_05.png"));
+            Assert.That(remaining[remaining.Length - 1], Is.EqualTo("file_24.png"));
+        }
+
+        /// <summary>
+        /// Verifies files outside searchPattern are neither counted toward the limit nor deleted.
+        /// </summary>
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenNonMatchingFilesExist_ShouldIgnoreThem()
+        {
+            DateTime baseTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            int matchingFiles = OutputFileRetention.MAX_FILES_PER_DIRECTORY + 2;
+            for (int i = 0; i < matchingFiles; i++)
+            {
+                CreateFileWithWriteTime($"match_{i:D2}.json", baseTime.AddMinutes(i));
+            }
+
+            CreateFileWithWriteTime(".DS_Store", baseTime.AddMinutes(-100));
+            CreateFileWithWriteTime("notes.txt", baseTime.AddMinutes(-50));
+
+            OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.json");
+
+            string[] remainingJson = Directory.GetFiles(_tempDirectory, "*.json");
+            Assert.That(remainingJson.Length, Is.EqualTo(OutputFileRetention.MAX_FILES_PER_DIRECTORY));
+            Assert.That(File.Exists(Path.Combine(_tempDirectory, ".DS_Store")), Is.True);
+            Assert.That(File.Exists(Path.Combine(_tempDirectory, "notes.txt")), Is.True);
+        }
+
+        /// <summary>
+        /// Verifies an empty directory is accepted without throwing or creating files.
+        /// </summary>
+        [Test]
+        public void DeleteOldestBeyondLimit_WhenDirectoryIsEmpty_ShouldNotThrow()
+        {
+            Assert.DoesNotThrow(() =>
+                OutputFileRetention.DeleteOldestBeyondLimit(_tempDirectory, "*.png"));
+
+            Assert.That(Directory.GetFiles(_tempDirectory).Length, Is.EqualTo(0));
+        }
+
+        private void CreateFileWithWriteTime(string fileName, DateTime lastWriteTimeUtc)
+        {
+            string path = Path.Combine(_tempDirectory, fileName);
+            File.WriteAllText(path, fileName);
+            File.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Automatically keep default `.uloop/outputs` folders from growing forever by retaining at most 20 matching files per directory.
- Covers Screenshots, TestResults, HierarchyResults, and FindGameObjectsResults.

## User Impact
- Before: tool output files accumulated without cleanup.
- After: on each save into the default output folders, oldest matching files are deleted once the count exceeds 20.
- Screenshot custom `--output-directory` paths are never pruned.
- InputRecordings / VibeLogs remain out of scope by design.

## Changes
- Add pure-C# `OutputFileRetention` helper with unit tests and CI wiring
- Apply retention after screenshot / test / hierarchy / find-game-objects writes
- Dedicated `Common.OutputRetention` asmdef (`noEngineReferences: true`) referenced by the tool assemblies

## Verification
- `dotnet test tests/OutputFileRetention.UnitTests` → 5 passed
- `uloop compile` → 0 errors, 0 warnings
- Live check: Screenshots 290→20, HierarchyResults 247→20 after one save each

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

