### PR TITLE
chore: add get-compile-status response contract fixture

### DIFF
--- a/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
@@ -18,9 +20,11 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [Test]
         public void GetCompileStatusResponse_WhenSerialized_MatchesSharedContractFieldShape()
         {
-            // Verifies C# does not add, remove, or rename get-compile-status fields (including Result.Success)
-            // without updating the shared CLI contract that Go unmarshals during domain-reload waits.
+            // Verifies C# does not add, remove, or rename get-compile-status fields without updating the
+            // shared CLI contract. Result must come from a real CompileResponse serialization because that
+            // is what CompileStatusBridgeCommand restores from ResultJson for Go compileResultStatus.Success.
             JObject expected = ReadSharedContractFieldShape();
+            JObject compileResultJson = SerializeCompileResponseResult();
             GetCompileStatusResponse response = new()
             {
                 Ready = true,
@@ -28,10 +32,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 IsCompiling = true,
                 IsUpdating = true,
                 IsDomainReloadInProgress = true,
-                Result = new JObject
-                {
-                    ["Success"] = true
-                },
+                Result = compileResultJson,
                 Message = "Compile result is available."
             };
             string json = JsonConvert.SerializeObject(
@@ -41,6 +42,32 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             JObject actual = NormalizeFieldShape(JObject.Parse(json));
 
             Assert.That(JToken.DeepEquals(actual, expected), Is.True, $"Expected {expected} but got {actual}");
+        }
+
+        [Test]
+        public void CompileResponse_WhenSerializedForCompileStatusResult_IncludesSuccessProperty()
+        {
+            // Verifies the wire Result payload still exposes Success under the name Go unmarshals into
+            // compileResultStatus — a rename on CompileResponse must fail this test.
+            JObject compileResultJson = SerializeCompileResponseResult();
+            Assert.That(compileResultJson.Property("Success"), Is.Not.Null);
+            Assert.That(compileResultJson["Success"]!.Type, Is.EqualTo(JTokenType.Boolean));
+        }
+
+        private static JObject SerializeCompileResponseResult()
+        {
+            CompileResponse compileResult = new(
+                success: true,
+                errorCount: 0,
+                warningCount: 0,
+                errors: Array.Empty<CompileIssue>(),
+                warnings: Array.Empty<CompileIssue>(),
+                message: "Compile result is available.");
+            string resultJson = JsonConvert.SerializeObject(
+                compileResult,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+            return JObject.Parse(resultJson);
         }
 
         private static JObject ReadSharedContractFieldShape()

--- a/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs
@@ -1,0 +1,96 @@
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies Unity get-compile-status responses stay aligned with the shared Go CLI contract.
+    /// </summary>
+    public sealed class GetCompileStatusResponseContractTests
+    {
+        private const string SharedContractPath = "tests/contracts/compile_status_response_contract.json";
+
+        [Test]
+        public void GetCompileStatusResponse_WhenSerialized_MatchesSharedContractFieldShape()
+        {
+            // Verifies C# does not add, remove, or rename get-compile-status fields (including Result.Success)
+            // without updating the shared CLI contract that Go unmarshals during domain-reload waits.
+            JObject expected = ReadSharedContractFieldShape();
+            GetCompileStatusResponse response = new()
+            {
+                Ready = true,
+                HasResult = true,
+                IsCompiling = true,
+                IsUpdating = true,
+                IsDomainReloadInProgress = true,
+                Result = new JObject
+                {
+                    ["Success"] = true
+                },
+                Message = "Compile result is available."
+            };
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+            JObject actual = NormalizeFieldShape(JObject.Parse(json));
+
+            Assert.That(JToken.DeepEquals(actual, expected), Is.True, $"Expected {expected} but got {actual}");
+        }
+
+        private static JObject ReadSharedContractFieldShape()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedContractPath));
+            return NormalizeFieldShape(JObject.Parse(json));
+        }
+
+        private static JObject NormalizeFieldShape(JObject value)
+        {
+            JObject shape = new();
+            foreach (JProperty property in value.Properties())
+            {
+                shape[property.Name] = NormalizeTokenFieldShape(property.Value);
+            }
+            return shape;
+        }
+
+        private static JToken NormalizeTokenFieldShape(JToken value)
+        {
+            if (value is JObject objectValue)
+            {
+                return NormalizeFieldShape(objectValue);
+            }
+
+            if (value is JArray arrayValue)
+            {
+                JArray arrayShape = new();
+                if (arrayValue.Count > 0)
+                {
+                    arrayShape.Add(NormalizeTokenFieldShape(arrayValue[0]));
+                }
+                return arrayShape;
+            }
+
+            return new JValue(NormalizeScalarType(value.Type));
+        }
+
+        private static string NormalizeScalarType(JTokenType type)
+        {
+            return type switch
+            {
+                JTokenType.Boolean => "boolean",
+                JTokenType.Float => "number",
+                JTokenType.Integer => "number",
+                JTokenType.Null => "null",
+                JTokenType.String => "string",
+                _ => "unknown"
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs.meta
+++ b/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f2a4c6e1d3b5a790c8e4f6a2b0d1e3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/project-runner/internal/projectrunner/compile_status_response_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_status_response_contract_test.go
@@ -1,0 +1,72 @@
+package projectrunner
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+const compileStatusResponseContractPath = "tests/contracts/compile_status_response_contract.json"
+
+// Verifies the Go compileStatusResponse DTO preserves every field in the shared Unity
+// get-compile-status response contract, including nested Result.Success used by compileResultStatus.
+func TestCompileStatusResponseMatchesSharedContract(t *testing.T) {
+	fixturePath := findRepoRelativeFile(t, compileStatusResponseContractPath)
+	fixture, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("failed to read shared compile status response contract: %v", err)
+	}
+
+	var response compileStatusResponse
+	if err := json.Unmarshal(fixture, &response); err != nil {
+		t.Fatalf("failed to unmarshal shared compile status response contract: %v", err)
+	}
+
+	assertCompileStatusResponseFieldsPopulated(t, response)
+
+	var resultStatus compileResultStatus
+	if err := json.Unmarshal(response.Result, &resultStatus); err != nil {
+		t.Fatalf("failed to unmarshal Result into compileResultStatus: %v", err)
+	}
+	if resultStatus.Success == nil {
+		t.Fatal("compileResultStatus.Success must be non-nil after unmarshaling the shared contract")
+	}
+
+	roundTripped, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("failed to marshal Go compile status response: %v", err)
+	}
+
+	expected := readJSONFieldShape(t, fixture)
+	actual := readJSONFieldShape(t, roundTripped)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("compile status response field shape drifted\nexpected: %#v\nactual:   %#v", expected, actual)
+	}
+}
+
+func assertCompileStatusResponseFieldsPopulated(t *testing.T, response compileStatusResponse) {
+	t.Helper()
+
+	if !response.Ready {
+		t.Fatal("Ready must be true in the shared contract fixture")
+	}
+	if !response.HasResult {
+		t.Fatal("HasResult must be true in the shared contract fixture")
+	}
+	if !response.IsCompiling {
+		t.Fatal("IsCompiling must be true in the shared contract fixture")
+	}
+	if !response.IsUpdating {
+		t.Fatal("IsUpdating must be true in the shared contract fixture")
+	}
+	if !response.IsDomainReloadInProgress {
+		t.Fatal("IsDomainReloadInProgress must be true in the shared contract fixture")
+	}
+	if len(response.Result) == 0 {
+		t.Fatal("Result must be non-empty in the shared contract fixture")
+	}
+	if response.Message == "" {
+		t.Fatal("Message must be non-empty in the shared contract fixture")
+	}
+}

--- a/tests/contracts/compile_status_response_contract.json
+++ b/tests/contracts/compile_status_response_contract.json
@@ -5,7 +5,14 @@
   "IsUpdating": true,
   "IsDomainReloadInProgress": true,
   "Result": {
-    "Success": true
+    "Success": true,
+    "ErrorCount": 0,
+    "WarningCount": 0,
+    "Errors": [],
+    "Warnings": [],
+    "Message": "Compile result is available.",
+    "NextActions": null,
+    "ProjectRoot": null
   },
   "Message": "Compile result is available."
 }

--- a/tests/contracts/compile_status_response_contract.json
+++ b/tests/contracts/compile_status_response_contract.json
@@ -1,0 +1,11 @@
+{
+  "Ready": true,
+  "HasResult": true,
+  "IsCompiling": true,
+  "IsUpdating": true,
+  "IsDomainReloadInProgress": true,
+  "Result": {
+    "Success": true
+  },
+  "Message": "Compile result is available."
+}


### PR DESCRIPTION
Refs: 2026-07-14 design-review fixes plan (PR-1 / todos 2–5)

## Summary
- Add shared fixture `tests/contracts/compile_status_response_contract.json` covering `GetCompileStatusResponse` fields and nested `Result.Success` (`compileResultStatus`).
- Add Go contract test that unmarshals into `compileStatusResponse` / `compileResultStatus` and asserts non-zero fields plus field-shape round-trip.
- Add C# EditMode contract test that serializes `GetCompileStatusResponse` and matches the fixture field shape.

## User Impact
None at runtime. Prevents silent IPC field drift from turning into 10-minute compile timeouts for agents.

## Test plan
- [x] `cd cli/project-runner && go test ./internal/projectrunner/ -run CompileStatus`
- [x] Intentional fixture field rename fails Go test (Ready / Success)
- [x] `scripts/check-go-cli.sh`
- [x] `dist/darwin-arm64/uloop compile`
- [x] EditMode exact filter for `GetCompileStatusResponseContractTests`
- [x] No changes to `protocolVersion` / pin files / CHANGELOG


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

