### PR TITLE
chore: add endpoint and cli_update_required contract fixtures

### DIFF
--- a/Assets/Tests/Editor/BridgeTransportEndpointTests.cs
+++ b/Assets/Tests/Editor/BridgeTransportEndpointTests.cs
@@ -1,7 +1,12 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -10,6 +15,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public class BridgeTransportEndpointTests
     {
+        private const string SharedEndpointContractPath = "tests/contracts/endpoint_contract.json";
+
         [Test]
         public void CanonicalizeProjectRoot_WhenPathIsFilesystemRoot_ShouldPreserveRoot()
         {
@@ -19,6 +26,71 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string canonicalProjectRoot = ProjectRootCanonicalizer.Canonicalize(filesystemRoot);
 
             Assert.That(canonicalProjectRoot, Is.EqualTo(filesystemRoot));
+        }
+
+        [Test]
+        public void CreateProjectIpc_WhenCanonicalRootsFromSharedContract_MatchExpectedEndpointPaths()
+        {
+            // Verifies Go and C# derive the same IPC endpoint names from already-canonicalized roots
+            // listed in the shared endpoint contract (symlink resolution is out of scope).
+            foreach (JObject contractCase in ReadEndpointContractCases())
+            {
+                string caseId = contractCase.Value<string>("id");
+                string canonicalProjectRoot = contractCase.Value<string>("canonicalProjectRoot");
+                if (!CanExerciseProjectRootOnCurrentPlatform(canonicalProjectRoot))
+                {
+                    continue;
+                }
+
+                string expectedPath = ExpectedEndpointPathForCurrentPlatform(contractCase);
+                BridgeTransportEndpoint endpoint = BridgeTransportEndpoint.CreateProjectIpc(canonicalProjectRoot);
+                Assert.That(endpoint.Path, Is.EqualTo(expectedPath), $"case {caseId} canonical root");
+
+                JArray trimOnlyEquivalentRoots = contractCase.Value<JArray>("trimOnlyEquivalentRoots") ?? new JArray();
+                foreach (JToken equivalentRootToken in trimOnlyEquivalentRoots)
+                {
+                    string equivalentRoot = equivalentRootToken.Value<string>();
+                    BridgeTransportEndpoint trimmedEndpoint = BridgeTransportEndpoint.CreateProjectIpc(equivalentRoot);
+                    Assert.That(
+                        trimmedEndpoint.Path,
+                        Is.EqualTo(expectedPath),
+                        $"case {caseId} trim-only equivalent root {equivalentRoot}");
+                }
+            }
+        }
+
+        private static IEnumerable<JObject> ReadEndpointContractCases()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedEndpointContractPath));
+            JObject contract = JObject.Parse(json);
+            JArray cases = contract.Value<JArray>("cases");
+            Assert.That(cases, Is.Not.Null.And.Not.Empty);
+            foreach (JToken caseToken in cases)
+            {
+                yield return (JObject)caseToken;
+            }
+        }
+
+        private static bool CanExerciseProjectRootOnCurrentPlatform(string projectRoot)
+        {
+            bool looksLikeWindowsPath = projectRoot.Length >= 2 && projectRoot[1] == ':';
+            if (looksLikeWindowsPath)
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            }
+
+            return !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        private static string ExpectedEndpointPathForCurrentPlatform(JObject contractCase)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return contractCase.Value<string>("windowsPipePath");
+            }
+
+            return contractCase.Value<string>("unixSocketPath");
         }
     }
 }

--- a/Assets/Tests/Editor/CliUpdateRequiredErrorContractTests.cs
+++ b/Assets/Tests/Editor/CliUpdateRequiredErrorContractTests.cs
@@ -1,0 +1,90 @@
+using System.IO;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Freezes the cli_update_required JSON-RPC error.data frame that old CLIs must keep parsing forever.
+    /// </summary>
+    public sealed class CliUpdateRequiredErrorContractTests
+    {
+        private const string SharedContractPath = "tests/contracts/cli_update_required_error_contract.json";
+
+        [Test]
+        public void CreateCliProtocolMismatchResponse_WhenOlderProtocol_MatchesSharedErrorDataFieldShape()
+        {
+            // This frame must remain backward compatible forever — old CLIs parse it to learn they must update.
+            // Verifies JsonRpcResponseFactory still emits the frozen error.data field shape for older CLIs.
+            JObject expected = ReadSharedErrorDataFieldShape();
+            string responseJson = JsonRpcResponseFactory.CreateCliProtocolMismatchResponse(
+                id: "contract-test",
+                currentCliVersion: "3.0.0-beta.5",
+                currentProtocolVersion: 1);
+            JObject actualData = (JObject)JObject.Parse(responseJson)["error"]!["data"]!;
+            JObject actual = NormalizeFieldShape(actualData);
+
+            Assert.That(JToken.DeepEquals(actual, expected), Is.True, $"Expected {expected} but got {actual}");
+            Assert.That(actualData.Value<string>("type"), Is.EqualTo("cli_update_required"));
+            Assert.That(
+                actualData.Value<int>("requiredProtocolVersion"),
+                Is.EqualTo(CliConstants.REQUIRED_CLI_PROTOCOL_VERSION));
+            Assert.That(actualData.Value<string>("updateCommand"), Is.EqualTo("uloop update"));
+        }
+
+        private static JObject ReadSharedErrorDataFieldShape()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedContractPath));
+            JObject contract = JObject.Parse(json);
+            return NormalizeFieldShape((JObject)contract["errorData"]!);
+        }
+
+        private static JObject NormalizeFieldShape(JObject value)
+        {
+            JObject shape = new();
+            foreach (JProperty property in value.Properties())
+            {
+                shape[property.Name] = NormalizeTokenFieldShape(property.Value);
+            }
+            return shape;
+        }
+
+        private static JToken NormalizeTokenFieldShape(JToken value)
+        {
+            if (value is JObject objectValue)
+            {
+                return NormalizeFieldShape(objectValue);
+            }
+
+            if (value is JArray arrayValue)
+            {
+                JArray arrayShape = new();
+                if (arrayValue.Count > 0)
+                {
+                    arrayShape.Add(NormalizeTokenFieldShape(arrayValue[0]));
+                }
+                return arrayShape;
+            }
+
+            return new JValue(NormalizeScalarType(value.Type));
+        }
+
+        private static string NormalizeScalarType(JTokenType type)
+        {
+            return type switch
+            {
+                JTokenType.Boolean => "boolean",
+                JTokenType.Float => "number",
+                JTokenType.Integer => "number",
+                JTokenType.Null => "null",
+                JTokenType.String => "string",
+                _ => "unknown"
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/CliUpdateRequiredErrorContractTests.cs.meta
+++ b/Assets/Tests/Editor/CliUpdateRequiredErrorContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d9e7b1a5c4f48e2a6b0d8f1c2e4a7b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/common/errors/cli_update_required_error_contract_test.go
+++ b/cli/common/errors/cli_update_required_error_contract_test.go
@@ -1,0 +1,76 @@
+package clierrors
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+const cliUpdateRequiredErrorContractPath = "tests/contracts/cli_update_required_error_contract.json"
+
+type cliUpdateRequiredErrorContractFile struct {
+	// This frame must remain backward compatible forever — old CLIs parse it to learn they must update.
+	Comment   string          `json:"comment"`
+	ErrorData json.RawMessage `json:"errorData"`
+}
+
+// Verifies the frozen cli_update_required error.data frame still classifies as CLI_UPDATE_REQUIRED.
+// This frame must remain backward compatible forever — old CLIs parse it to learn they must update.
+func TestClassifyError_WhenCliUpdateRequiredContractFixture_ClassifiesAsCLIUpdateRequired(t *testing.T) {
+	contract := readCliUpdateRequiredErrorContract(t)
+
+	err := &unityipc.RPCError{
+		Code:    -32603,
+		Message: "The installed uloop CLI uses an IPC protocol that does not match this Unity package.",
+		Data:    contract.ErrorData,
+	}
+
+	cliErr := ClassifyError(err, ErrorContext{ProjectRoot: "/tmp/MyProject", Command: "compile"})
+	if cliErr.ErrorCode != ErrorCodeCLIUpdateRequired {
+		t.Fatalf("expected %s, got %#v", ErrorCodeCLIUpdateRequired, cliErr)
+	}
+}
+
+func readCliUpdateRequiredErrorContract(t *testing.T) cliUpdateRequiredErrorContractFile {
+	t.Helper()
+
+	path := findRepoRelativeFile(t, cliUpdateRequiredErrorContractPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read cli_update_required error contract: %v", err)
+	}
+
+	var contract cliUpdateRequiredErrorContractFile
+	if err := json.Unmarshal(data, &contract); err != nil {
+		t.Fatalf("failed to unmarshal cli_update_required error contract: %v", err)
+	}
+	if len(contract.ErrorData) == 0 {
+		t.Fatal("cli_update_required error contract must include errorData")
+	}
+	return contract
+}
+
+func findRepoRelativeFile(t *testing.T, relativePath string) string {
+	t.Helper()
+
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to resolve current directory: %v", err)
+	}
+
+	for {
+		candidate := filepath.Join(directory, relativePath)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			t.Fatalf("failed to find %s from %s", relativePath, directory)
+		}
+		directory = parent
+	}
+}

--- a/cli/common/project/endpoint_contract_test.go
+++ b/cli/common/project/endpoint_contract_test.go
@@ -1,0 +1,100 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const endpointContractPath = "tests/contracts/endpoint_contract.json"
+
+type endpointContractFile struct {
+	Comment string                 `json:"comment"`
+	Cases   []endpointContractCase `json:"cases"`
+}
+
+type endpointContractCase struct {
+	ID                      string   `json:"id"`
+	CanonicalProjectRoot    string   `json:"canonicalProjectRoot"`
+	TrimOnlyEquivalentRoots []string `json:"trimOnlyEquivalentRoots"`
+	UnixSocketPath          string   `json:"unixSocketPath"`
+	WindowsPipePath         string   `json:"windowsPipePath"`
+}
+
+// Verifies Go CreateEndpoint matches the shared endpoint contract for already-canonicalized roots.
+func TestCreateEndpointMatchesSharedContract(t *testing.T) {
+	contract := readEndpointContract(t)
+	for _, contractCase := range contract.Cases {
+		contractCase := contractCase
+		t.Run(contractCase.ID, func(t *testing.T) {
+			assertEndpointMatchesContract(t, contractCase.CanonicalProjectRoot, contractCase)
+			for _, equivalentRoot := range contractCase.TrimOnlyEquivalentRoots {
+				trimmed := trimTrailingSeparators(equivalentRoot)
+				if trimmed != contractCase.CanonicalProjectRoot {
+					t.Fatalf(
+						"trimOnlyEquivalentRoot %q should trim to canonical %q, got %q",
+						equivalentRoot,
+						contractCase.CanonicalProjectRoot,
+						trimmed)
+				}
+				assertEndpointMatchesContract(t, trimmed, contractCase)
+			}
+		})
+	}
+}
+
+func assertEndpointMatchesContract(t *testing.T, projectRoot string, contractCase endpointContractCase) {
+	t.Helper()
+
+	endpoint := CreateEndpoint(projectRoot)
+	expected := contractCase.UnixSocketPath
+	if runtime.GOOS == "windows" {
+		expected = contractCase.WindowsPipePath
+	}
+	if endpoint.Address != expected {
+		t.Fatalf("endpoint mismatch for %q\nexpected: %s\nactual:   %s", projectRoot, expected, endpoint.Address)
+	}
+}
+
+func readEndpointContract(t *testing.T) endpointContractFile {
+	t.Helper()
+
+	path := findRepoRelativeFile(t, endpointContractPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read shared endpoint contract: %v", err)
+	}
+
+	var contract endpointContractFile
+	if err := json.Unmarshal(data, &contract); err != nil {
+		t.Fatalf("failed to unmarshal shared endpoint contract: %v", err)
+	}
+	if len(contract.Cases) == 0 {
+		t.Fatal("endpoint contract must contain at least one case")
+	}
+	return contract
+}
+
+func findRepoRelativeFile(t *testing.T, relativePath string) string {
+	t.Helper()
+
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to resolve current directory: %v", err)
+	}
+
+	for {
+		candidate := filepath.Join(directory, relativePath)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			t.Fatalf("failed to find %s from %s", relativePath, directory)
+		}
+		directory = parent
+	}
+}

--- a/tests/contracts/cli_update_required_error_contract.json
+++ b/tests/contracts/cli_update_required_error_contract.json
@@ -1,0 +1,12 @@
+{
+  "comment": "This frame must remain backward compatible forever — old CLIs parse it to learn they must update.",
+  "errorData": {
+    "type": "cli_update_required",
+    "message": "Install matching uloop CLI and Unity package versions, then retry the original command.",
+    "currentCliVersion": "3.0.0-beta.5",
+    "currentProtocolVersion": 1,
+    "requiredProtocolVersion": 3,
+    "updateCommand": "uloop update",
+    "retryableAfterUpdate": true
+  }
+}

--- a/tests/contracts/endpoint_contract.json
+++ b/tests/contracts/endpoint_contract.json
@@ -1,0 +1,30 @@
+{
+  "comment": "Maps already-canonicalized project roots to IPC endpoint names. Symlink/realpath resolution (Go filepath.EvalSymlinks / C# realpath) is intentionally out of scope because it depends on the live filesystem. Each canonicalProjectRoot is the post-resolution string that both sides hash. trimOnlyEquivalentRoots are trailing-separator variants that must hash identically after separator trimming only.",
+  "cases": [
+    {
+      "id": "unix-stable",
+      "canonicalProjectRoot": "/Users/example/MyProject",
+      "trimOnlyEquivalentRoots": [
+        "/Users/example/MyProject/"
+      ],
+      "unixSocketPath": "/tmp/uloop/UnityCliLoop-bebe6bce5923715b.sock",
+      "windowsPipePath": "\\\\.\\pipe\\uloop-UnityCliLoop-bebe6bce5923715b"
+    },
+    {
+      "id": "unix-case-sensitive",
+      "canonicalProjectRoot": "/Users/example/myproject",
+      "trimOnlyEquivalentRoots": [],
+      "unixSocketPath": "/tmp/uloop/UnityCliLoop-6b4ae0bfeab42b19.sock",
+      "windowsPipePath": "\\\\.\\pipe\\uloop-UnityCliLoop-6b4ae0bfeab42b19"
+    },
+    {
+      "id": "windows-stable",
+      "canonicalProjectRoot": "C:\\Users\\example\\MyProject",
+      "trimOnlyEquivalentRoots": [
+        "C:\\Users\\example\\MyProject\\"
+      ],
+      "unixSocketPath": "/tmp/uloop/UnityCliLoop-4abce6d9d9e51244.sock",
+      "windowsPipePath": "\\\\.\\pipe\\uloop-UnityCliLoop-4abce6d9d9e51244"
+    }
+  ]
+}


### PR DESCRIPTION
Refs: 2026-07-14 design-review fixes plan (PR-2 / todos 6–8)

## Summary
- Add `tests/contracts/endpoint_contract.json` mapping already-canonicalized project roots to unix socket / Windows pipe paths (symlink resolution explicitly out of scope).
- Add Go + C# tests that both sides derive the same endpoint names, including trailing-separator trim-only equivalents and case-sensitive hash differences.
- Add `tests/contracts/cli_update_required_error_contract.json` freezing the mismatch `error.data` frame, with C# factory shape coverage and Go `CLI_UPDATE_REQUIRED` classification coverage.

## User Impact
None at runtime. Prevents Go/C# endpoint drift and accidental breakage of the permanent CLI-update error frame.

## Test plan
- [x] `go test ./project/ -run CreateEndpointMatchesSharedContract` (and intentional 1-char fixture break fails)
- [x] `go test ./errors/ -run CliUpdateRequiredContract` (and type rename fails)
- [x] `scripts/check-go-cli.sh`
- [x] `uloop compile` + EditMode regex `BridgeTransportEndpointTests|CliUpdateRequiredErrorContractTests`
- [x] No `protocolVersion` / pin / CHANGELOG changes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

