### PR TITLE
fix: classify empty Unity RPC results via typed NoResponseError

### DIFF
--- a/cli/common/errors/transport_errors.go
+++ b/cli/common/errors/transport_errors.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"syscall"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
 // Reports whether the error means the transport dropped mid-request. Domain reload
@@ -27,10 +29,14 @@ func IsTransportDisconnectError(err error) bool {
 		return true
 	}
 
+	var noResponseErr *unityipc.NoResponseError
+	if errors.As(err, &noResponseErr) {
+		return true
+	}
+
 	// Fallback for errors that expose no typed cause.
 	message := err.Error()
-	return message == "UNITY_NO_RESPONSE" ||
-		strings.Contains(message, "EOF") ||
+	return strings.Contains(message, "EOF") ||
 		strings.Contains(message, "connection reset") ||
 		strings.Contains(message, "broken pipe") ||
 		strings.Contains(message, "use of closed network connection")

--- a/cli/common/errors/transport_errors_test.go
+++ b/cli/common/errors/transport_errors_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"syscall"
 	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
 // Test support type that exposes a typed cause behind an opaque message, simulating
@@ -73,7 +75,6 @@ func TestIsTransportDisconnectErrorRejectsUnrelatedErrors(t *testing.T) {
 // Verifies the legacy string fallback still classifies errors without a typed cause.
 func TestIsTransportDisconnectErrorKeepsStringFallback(t *testing.T) {
 	fallbackErrors := []error{
-		fmt.Errorf("UNITY_NO_RESPONSE"),
 		fmt.Errorf("read tcp 127.0.0.1:1: connection reset by peer"),
 	}
 
@@ -81,6 +82,15 @@ func TestIsTransportDisconnectErrorKeepsStringFallback(t *testing.T) {
 		if !IsTransportDisconnectError(err) {
 			t.Fatalf("string fallback did not classify: %v", err)
 		}
+	}
+}
+
+// Verifies a wrapped NoResponseError is classified as a disconnect even when the
+// outer error message no longer matches the legacy UNITY_NO_RESPONSE sentinel.
+func TestIsTransportDisconnectErrorMatchesWrappedNoResponseError(t *testing.T) {
+	wrapped := fmt.Errorf("rpc failed: %w", &unityipc.NoResponseError{})
+	if !IsTransportDisconnectError(wrapped) {
+		t.Fatalf("wrapped NoResponseError was not classified as disconnect: %v", wrapped)
 	}
 }
 

--- a/cli/common/unityipc/client.go
+++ b/cli/common/unityipc/client.go
@@ -118,6 +118,14 @@ func (err *RPCError) Error() string {
 	return fmt.Sprintf("unity error: %s", err.Message)
 }
 
+// Signals that Unity accepted the request but returned an empty JSON-RPC result.
+// Domain-reload recovery treats this as a transport disconnect so status polling can continue.
+type NoResponseError struct{}
+
+func (err *NoResponseError) Error() string {
+	return "unity returned no RPC result"
+}
+
 func NewClient(connection Connection, clientVersion string, options ...ClientOption) *Client {
 	clientOptions := ClientOptions{}
 	for _, option := range options {
@@ -375,7 +383,7 @@ func finishRPCResponse(
 		})
 	}
 	if len(response.Result) == 0 {
-		return finishOutcomeWithError(outcome, timing, startedAt, fmt.Errorf("UNITY_NO_RESPONSE"))
+		return finishOutcomeWithError(outcome, timing, startedAt, &NoResponseError{})
 	}
 
 	outcome.Result = response.Result

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "fbbc3c34d301331c513155ea2bab2a33a4b5de97"
+  "sharedInputsHash": "677ac7b5437d18efa8a09b575d0ec2619de4a1fa"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "581697442cd42c4467c8a80ab3bce98f403890c6"
+  "sharedInputsHash": "c25f44bebdff747f69e1e6c653a4d8d9a5fc7c4f"
 }


### PR DESCRIPTION
Refs: 2026-07-14 design-review fixes plan (PR-3 / todos 9–11)

## Summary
- Introduce `unityipc.NoResponseError` for empty JSON-RPC results (replacing `fmt.Errorf(\"UNITY_NO_RESPONSE\")`).
- Classify disconnects with `errors.As` so wrapped no-response errors still trigger domain-reload recovery.
- Stamp shared release inputs for dispatcher and project-runner after the `cli/common` non-test change.

## User Impact
Domain-reload compile waits keep recovering when Unity returns an empty RPC result that is wrapped by callers, instead of failing the transport classification.

## Test plan
- [x] Red then Green: wrapped `NoResponseError` disconnect classification
- [x] `go test ./errors/ ./unityipc/`
- [x] `scripts/check-go-cli.sh`
- [x] Shared input stamps updated
- [x] No `protocolVersion` / pin / CHANGELOG changes; other string Contains fallbacks untouched


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

