### PR TITLE
fix: JSON-RPC serialization errors, ConfigureAwait guard, dead doc ref

### DIFF
--- a/Assets/Tests/Editor/JsonRpcResponseFactorySerializationFallbackTests.cs
+++ b/Assets/Tests/Editor/JsonRpcResponseFactorySerializationFallbackTests.cs
@@ -1,0 +1,35 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies JSON-RPC success serialization failures become error frames instead of fake success payloads.
+    /// </summary>
+    public sealed class JsonRpcResponseFactorySerializationFallbackTests
+    {
+        [Test]
+        public void CreateSuccessResponse_WhenResultCannotBeSerialized_ReturnsJsonRpcError()
+        {
+            // Verifies serialization failure returns INTERNAL_ERROR with internal_error data instead of a
+            // success frame that embeds an error-shaped object in result.
+            string responseJson = JsonRpcResponseFactory.CreateSuccessResponse(
+                id: 1,
+                result: new UnserializableToolResponse());
+            JObject response = JObject.Parse(responseJson);
+
+            Assert.That(response["result"], Is.Null);
+            Assert.That(response["error"], Is.Not.Null);
+            Assert.That(response["error"]!["code"]!.Value<int>(), Is.EqualTo(UnityCliLoopServerConfig.INTERNAL_ERROR_CODE));
+            Assert.That(response["error"]!["data"]!["type"]!.Value<string>(), Is.EqualTo(JsonRpcErrorTypes.InternalError));
+        }
+
+        private sealed class UnserializableToolResponse : UnityCliLoopToolResponse
+        {
+            public string Boom => throw new System.InvalidOperationException("intentional serialization failure");
+        }
+    }
+}

--- a/Assets/Tests/Editor/JsonRpcResponseFactorySerializationFallbackTests.cs.meta
+++ b/Assets/Tests/Editor/JsonRpcResponseFactorySerializationFallbackTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e8c1a2b4d6f7093a1c5e7b9d0f2a4c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
@@ -192,7 +192,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 TestResultStatus.Failed,
                 0.1,
                 new List<ITestResultAdaptor>());
-            Regex warningPattern = new Regex("^Failed to save NUnit XML result file: ");
+            Regex warningPattern = new Regex("^Failed to save failure XML result file: ");
 
             LogAssert.Expect(LogType.Warning, warningPattern);
 

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -334,7 +334,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(source, Does.Contain("await DynamicCodeMissingReturnRetryPolicy.RetryMissingReturnIfNeeded(\n                    executionResult,"));
             Assert.That(source, Does.Contain("cancellationToken).ConfigureAwait(false);"));
             Assert.That(source, Does.Contain("await _runtime.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);"));
-            Assert.That(source, Does.Contain("await _runtime.TryExecuteIfIdleAsync(\n                request,\n                cancellationToken).ConfigureAwait(false);"));
+            Assert.That(source, Does.Contain("await _runtime.TryExecuteIfIdleAsync(\n                    request,\n                    cancellationToken).ConfigureAwait(false);"));
             Assert.That(
                 retryPolicySource,
                 Does.Contain("await executeRetryAsync(codeWithReturn, ct)\n                .ConfigureAwait(false);"));

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
@@ -47,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _pendingCompileSessionRepository);
             compileController.SetResultRecordingContext(CompileResultRecordingContext.Create(request));
             compileController.SetExternalSceneChangePolicy(request.ReloadExternalSceneChanges);
-            return await compileController.TryCompileAsync(request.ForceRecompile, ct);
+            return await compileController.TryCompileAsync(request.ForceRecompile, ct).ConfigureAwait(false);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -105,7 +105,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         {
                             ["requested_force_recompile"] = forceRecompile
                         }));
-                    return await _currentCompileTask.Task;
+                    return await _currentCompileTask.Task.ConfigureAwait(false);
                 }
                 throw new InvalidOperationException("Compilation is in progress, but the task could not be found.");
             }
@@ -180,7 +180,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 StartCompileLifecycleWatchdog(compileTask, ct);
                 compileTaskTransferred = true;
-                return await compileTask.Task;
+                return await compileTask.Task.ConfigureAwait(false);
             }
             finally
             {

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
@@ -102,7 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 // The delay is not cancelled directly because the watchdog must convert cancellation into cleanup.
-                await _waitForPollAsync();
+                await _waitForPollAsync().ConfigureAwait(false);
                 if (!observedStart)
                 {
                     waitedForStartMs += UnityCliLoopConstants.COMPILE_START_POLL_INTERVAL_MS;

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     BuildCompileLogContext(request),
                     correlationId);
                 preparationService.StopPlayMode();
-                bool exited = await WaitForPlayModeExitAsync(ct);
+                bool exited = await WaitForPlayModeExitAsync(ct).ConfigureAwait(false);
                 VibeLogger.LogInfo(
                     "compile_playmode_exit_observed",
                     exited ? "Play Mode exited before compile." : "Play Mode did not exit before compile.",
@@ -151,7 +151,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // 3. Compilation execution
             ct.ThrowIfCancellationRequested();
-            CompileResult result = await _executeCompilationAsync(request, ct);
+            CompileResult result = await _executeCompilationAsync(request, ct).ConfigureAwait(false);
 
             // 4. Result formatting
             CompileResponse successResponse =
@@ -171,7 +171,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             while (EditorApplication.isPlaying && waitedMs < MAX_WAIT_MS)
             {
                 ct.ThrowIfCancellationRequested();
-                await TimerDelay.Wait(POLL_INTERVAL_MS, ct);
+                await TimerDelay.Wait(POLL_INTERVAL_MS, ct).ConfigureAwait(false);
                 waitedMs += POLL_INTERVAL_MS;
             }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
@@ -149,8 +149,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static async Task ContinueAfterDrainAsync(Task currentDrainTask, Task nextDrainTask)
         {
-            await currentDrainTask;
-            await nextDrainTask;
+            await currentDrainTask.ConfigureAwait(false);
+            await nextDrainTask.ConfigureAwait(false);
         }
 
         private static Task ObserveDrainTask(Task drainTask)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AutoUsingResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AutoUsingResolver.cs
@@ -40,7 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 File.WriteAllText(sourcePath, currentSource);
                 // AssemblyBuilder retries must stay on Unity's main thread because the compiler API is not thread-safe.
-                CompilerMessage[] messages = await buildFunc(sourcePath, dllPath, mutableReferences, ct);
+                CompilerMessage[] messages = await buildFunc(sourcePath, dllPath, mutableReferences, ct).ConfigureAwait(false);
 
                 List<string> unresolvedTypes = ExtractUnresolvedTypes(messages);
                 if (unresolvedTypes.Count == 0)
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Final compilation with all added usings
             File.WriteAllText(sourcePath, currentSource);
-            CompilerMessage[] finalMessages = await buildFunc(sourcePath, dllPath, mutableReferences, ct);
+            CompilerMessage[] finalMessages = await buildFunc(sourcePath, dllPath, mutableReferences, ct).ConfigureAwait(false);
             return new AutoUsingResult(
                 currentSource,
                 finalMessages,

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/CompiledAssemblyBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/CompiledAssemblyBuilder.cs
@@ -101,14 +101,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         cancellationToken,
                         () => canDeleteTempFiles = false,
                         () => canDeleteTempFiles = true,
-                        () => buildCount++);
+                        () => buildCount++).ConfigureAwait(false);
                     compilationBackendKind = backendResult.BackendKind;
                     buildStopwatch.Stop();
                     buildMilliseconds += buildStopwatch.Elapsed.TotalMilliseconds;
                     return backendResult.CompilerMessages;
                 }
 
-                BuildAttemptResult attemptResult = await BuildPreparedCodeAsync(plan.PreparedCode, ct);
+                BuildAttemptResult attemptResult = await BuildPreparedCodeAsync(plan.PreparedCode, ct).ConfigureAwait(false);
                 bool shouldCacheResult = true;
 
                 if (ShouldRetryWithoutLiteralHoisting(plan.PreparedCode, attemptResult.Diagnostics))
@@ -117,7 +117,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         plan.OriginalRequest.Code,
                         plan.NamespaceName,
                         plan.ClassName);
-                    attemptResult = await BuildPreparedCodeAsync(fallbackPreparedCode, ct);
+                    attemptResult = await BuildPreparedCodeAsync(fallbackPreparedCode, ct).ConfigureAwait(false);
                     shouldCacheResult = false;
                 }
 
@@ -160,7 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         wrappedCode,
                         initialReferences,
                         BuildFunc,
-                        cancellationToken);
+                        cancellationToken).ConfigureAwait(false);
                     referenceResolutionMilliseconds += autoResult.ReferenceResolutionMilliseconds;
 
                     wrappedCode = autoResult.UpdatedSource;
@@ -183,7 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                             originalWrappedCode,
                             rollbackReferences,
                             BuildFunc,
-                            cancellationToken);
+                            cancellationToken).ConfigureAwait(false);
                         referenceResolutionMilliseconds += rollbackResult.ReferenceResolutionMilliseconds;
 
                         CompilerDiagnostics rollbackDiagnostics = CompilerDiagnostics.FromMessages(rollbackResult.Messages);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeCompiler.cs
@@ -95,7 +95,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Stopwatch builderTotalStopwatch = Stopwatch.StartNew();
-            CompiledAssemblyBuildResult buildResult = await _assemblyBuilder.BuildAsync(plan, ct);
+            CompiledAssemblyBuildResult buildResult = await _assemblyBuilder.BuildAsync(plan, ct).ConfigureAwait(false);
             builderTotalStopwatch.Stop();
             LastBuildCount = buildResult.BuildCount;
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -66,6 +66,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public async Task<ExecutionResult> ExecuteAsync(ExecutionContext context)
         {
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
+            // Why switch first: callers often resume off-thread via ConfigureAwait(false), but
+            // BeginUndoGroup / EndExecution use Unity Undo APIs that require the main thread.
+            await MainThreadSwitcher.SwitchToMainThread(context.CancellationToken);
             if (!TryBeginExecution(out int undoGroup, out CancellationTokenSource executionCancellationTokenSource))
             {
                 return CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_IN_PROGRESS);
@@ -76,15 +79,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 using CancellationTokenSource combinedCts = CreateCombinedCancellationTokenSource(
                     context,
                     executionCancellationTokenSource);
-                return await ExecuteInternalAsync(context, combinedCts.Token).ConfigureAwait(false);
+                ExecutionResult result = await ExecuteInternalAsync(context, combinedCts.Token).ConfigureAwait(false);
+                await MainThreadSwitcher.SwitchToMainThread();
+                return result;
             }
             catch (OperationCanceledException)
             {
+                await MainThreadSwitcher.SwitchToMainThread();
                 return CreateCancelledResult();
             }
             catch (Exception ex)
             {
                 LogExecutionError(ex, correlationId);
+                await MainThreadSwitcher.SwitchToMainThread();
 
                 return CreateErrorResult(
                     ex.Message,

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -76,7 +76,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 using CancellationTokenSource combinedCts = CreateCombinedCancellationTokenSource(
                     context,
                     executionCancellationTokenSource);
-                return await ExecuteInternalAsync(context, combinedCts.Token);
+                return await ExecuteInternalAsync(context, combinedCts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -296,7 +296,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         cancellationToken);
                     object invoked = executeAsyncMethod.Invoke(instance, callArgs);
 
-                    object awaitedResult = await AwaitableHelper.AwaitIfNeeded(invoked, cancellationToken);
+                    object awaitedResult = await AwaitableHelper.AwaitIfNeeded(invoked, cancellationToken).ConfigureAwait(false);
                     string resultString = awaitedResult?.ToString() ?? "";
 
                     return CreateSuccessResult(resultString);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionFacade.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionFacade.cs
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ExecutionResult result = await _executionScheduler.RunForegroundAsync(
                 innerCancellationToken => ExecuteCoreAsync(request, innerCancellationToken),
                 CreateExecutionInProgressResult,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
             schedulerStopwatch.Stop();
             AppendTiming(result, $"[Perf] SchedulerTotal: {schedulerStopwatch.Elapsed.TotalMilliseconds:F1}ms");
             return result;
@@ -56,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             (bool entered, ExecutionResult result) = await _executionScheduler.TryRunIfIdleAsync(
                 request.YieldToForegroundRequests,
                 innerCancellationToken => ExecuteCoreAsync(request, innerCancellationToken),
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
             schedulerStopwatch.Stop();
             AppendTiming(result, $"[Perf] SchedulerTotal: {schedulerStopwatch.Elapsed.TotalMilliseconds:F1}ms");
             return (entered, result);
@@ -76,7 +76,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 request.ClassName,
                 request.Parameters,
                 cancellationToken,
-                request.CompileOnly);
+                request.CompileOnly).ConfigureAwait(false);
             executorTotalStopwatch.Stop();
 
             if (result.Timings == null)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionScheduler.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionScheduler.cs
@@ -67,13 +67,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ThrowIfDisposed();
             cancellationToken.ThrowIfCancellationRequested();
 
-            bool entered = await _executionSemaphore.WaitAsync(0, cancellationToken);
+            bool entered = await _executionSemaphore.WaitAsync(0, cancellationToken).ConfigureAwait(false);
             if (!entered)
             {
-                await _hooks.InvokeAfterBusySemaphoreProbeFailedAsync();
+                await _hooks.InvokeAfterBusySemaphoreProbeFailedAsync().ConfigureAwait(false);
                 if (!TryCancelBackgroundPrewarm())
                 {
-                    entered = await TryAcquireAfterBusyHandoffAsync(cancellationToken);
+                    entered = await TryAcquireAfterBusyHandoffAsync(cancellationToken).ConfigureAwait(false);
                     if (!entered)
                     {
                         return createBusyResult();
@@ -83,7 +83,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     entered = await TryAcquireAfterBusyHandoffAsync(
                         cancellationToken,
-                        _cancelledPrewarmHandoffWindowMilliseconds);
+                        _cancelledPrewarmHandoffWindowMilliseconds).ConfigureAwait(false);
                     if (!entered)
                     {
                         return createBusyResult();
@@ -99,7 +99,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 executionCancellationTokenSource =
                     CreateExecutionCancellationTokenSource(cancellationToken);
                 SetExecutionState(false, executionCancellationTokenSource);
-                return await action(executionCancellationTokenSource.Token);
+                return await action(executionCancellationTokenSource.Token).ConfigureAwait(false);
             }
             finally
             {
@@ -117,7 +117,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (!yieldToForegroundRequests)
             {
-                return await TryRunWithoutForegroundYieldAsync(action, cancellationToken);
+                return await TryRunWithoutForegroundYieldAsync(action, cancellationToken).ConfigureAwait(false);
             }
 
             bool entered;
@@ -149,9 +149,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                await _hooks.InvokeAfterBackgroundExecutionStatePublishedAsync();
+                await _hooks.InvokeAfterBackgroundExecutionStatePublishedAsync().ConfigureAwait(false);
                 _hooks.AfterSemaphoreEntered?.Invoke();
-                T result = await action(executionCancellationTokenSource.Token);
+                T result = await action(executionCancellationTokenSource.Token).ConfigureAwait(false);
                 return (true, result);
             }
             finally
@@ -209,7 +209,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);
 
-            Task completedTask = await Task.WhenAny(_shutdownCompletionSource.Task, delayTask);
+            Task completedTask = await Task.WhenAny(_shutdownCompletionSource.Task, delayTask).ConfigureAwait(false);
             if (completedTask == _shutdownCompletionSource.Task)
             {
                 timeoutCancellationTokenSource.Cancel();
@@ -227,7 +227,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Func<CancellationToken, Task<T>> action,
             CancellationToken cancellationToken)
         {
-            bool entered = await _executionSemaphore.WaitAsync(0, cancellationToken);
+            bool entered = await _executionSemaphore.WaitAsync(0, cancellationToken).ConfigureAwait(false);
             if (!entered)
             {
                 return (false, default);
@@ -241,7 +241,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 executionCancellationTokenSource =
                     CreateExecutionCancellationTokenSource(cancellationToken);
                 SetExecutionState(false, executionCancellationTokenSource);
-                T result = await action(executionCancellationTokenSource.Token);
+                T result = await action(executionCancellationTokenSource.Token).ConfigureAwait(false);
                 return (true, result);
             }
             finally
@@ -302,7 +302,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                await _executionSemaphore.WaitAsync(handoffCancellationTokenSource.Token);
+                await _executionSemaphore.WaitAsync(handoffCancellationTokenSource.Token).ConfigureAwait(false);
                 return true;
             }
             catch (OperationCanceledException)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionSchedulerHooks.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionSchedulerHooks.cs
@@ -38,7 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            await AfterBackgroundExecutionStatePublishedAsync();
+            await AfterBackgroundExecutionStatePublishedAsync().ConfigureAwait(false);
         }
 
         public async Task InvokeAfterBusySemaphoreProbeFailedAsync()
@@ -48,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            await AfterBusySemaphoreProbeFailedAsync();
+            await AfterBusySemaphoreProbeFailedAsync().ConfigureAwait(false);
         }
 
         public void InvokeLogWarning(string message)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutor.cs
@@ -56,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     className);
                 sourcePreparationStopwatch.Stop();
                 Stopwatch compileTotalStopwatch = Stopwatch.StartNew();
-                CompilationResult compilationResult = await CompileCodeAsync(code, className, cancellationToken);
+                CompilationResult compilationResult = await CompileCodeAsync(code, className, cancellationToken).ConfigureAwait(false);
                 compileTotalStopwatch.Stop();
 
                 ExecutionResult compilationFailureResult = TryCreateCompilationFailureResult(
@@ -88,7 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 };
 
                 Stopwatch executionStopwatch = Stopwatch.StartNew();
-                ExecutionResult executionResult = await _invoker.ExecuteAsync(context);
+                ExecutionResult executionResult = await _invoker.ExecuteAsync(context).ConfigureAwait(false);
                 executionStopwatch.Stop();
 
                 executionResult.ExecutionTime = totalStopwatch.Elapsed;
@@ -155,7 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Namespace = DynamicCodeConstants.DEFAULT_NAMESPACE
             };
 
-            CompilationResult result = await _compiler.CompileAsync(request, ct);
+            CompilationResult result = await _compiler.CompileAsync(request, ct).ConfigureAwait(false);
             if (!result.Success)
             {
                 lock (_statsLock)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeForegroundWarmupRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeForegroundWarmupRunner.cs
@@ -22,7 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 DynamicCodeExecutionRequest request = CreateRequest(
                     warmupCode,
                     yieldToForegroundRequests);
-                ExecutionResult result = await runtime.ExecuteAsync(request, ct);
+                ExecutionResult result = await runtime.ExecuteAsync(request, ct).ConfigureAwait(false);
                 if (!result.Success)
                 {
                     return false;
@@ -46,7 +46,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 DynamicCodeExecutionRequest request = CreateRequest(
                     warmupCode,
                     yieldToForegroundRequests);
-                (bool entered, ExecutionResult result) = await runtime.TryExecuteIfIdleAsync(request, ct);
+                (bool entered, ExecutionResult result) = await runtime.TryExecuteIfIdleAsync(request, ct).ConfigureAwait(false);
                 if (!entered || !result.Success)
                 {
                     return false;

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
@@ -86,7 +86,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 correlationId: correlationId
             );
 
-            await Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
             return response;
 #endif
         }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
@@ -108,7 +108,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     runGuid,
                     hooks,
                     stopWaitTimeoutMilliseconds,
-                    pollIntervalMilliseconds);
+                    pollIntervalMilliseconds).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -172,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     () => !hooks.IsPlaying(),
                     hooks.DelayAsync,
                     stopWaitTimeoutMilliseconds,
-                    pollIntervalMilliseconds);
+                    pollIntervalMilliseconds).ConfigureAwait(false);
                 playModeExitConfirmed = confirmed;
                 stopWaitTimedOut = timedOut;
             }
@@ -182,7 +182,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     () => !hooks.IsRunActive(),
                     hooks.DelayAsync,
                     stopWaitTimeoutMilliseconds,
-                    pollIntervalMilliseconds);
+                    pollIntervalMilliseconds).ConfigureAwait(false);
                 stopWaitTimedOut = timedOut;
                 if (!confirmed)
                 {
@@ -221,7 +221,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return (true, false);
                 }
 
-                await delayAsync(pollIntervalMilliseconds, CancellationToken.None);
+                await delayAsync(pollIntervalMilliseconds, CancellationToken.None).ConfigureAwait(false);
                 elapsedMilliseconds += pollIntervalMilliseconds;
             }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -114,17 +114,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)
                 {
-                    result = await _executionService.ExecutePlayModeTestAsync(filter, executionCt);
+                    result = await _executionService.ExecutePlayModeTestAsync(filter, executionCt).ConfigureAwait(false);
                 }
                 else
                 {
-                    result = await _executionService.ExecuteEditModeTestAsync(filter, executionCt);
+                    result = await _executionService.ExecuteEditModeTestAsync(filter, executionCt).ConfigureAwait(false);
                 }
 
                 // Why parent ct (not executionCt): CancelAfter only guards the RunFinished wait.
                 // Using the linked token here would mis-report a successful run as timed out when
                 // the fixed cleanup delay straddles the deadline after RunFinished already arrived.
-                await _waitForTestRunnerCleanupAsync(ct);
+                await _waitForTestRunnerCleanupAsync(ct).ConfigureAwait(false);
             }
             catch (RunTestsExecutionCanceledException canceledException)
                 when (RunTestsExecutionTimeout.IsTimeoutCancellation(ct))
@@ -207,7 +207,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             // Why: Unity Test Framework exposes the real active-run signal only through internal API,
             // while the public RunFinished callback fires before cleanup tasks such as RestoreSceneSetupTask.
-            await TimerDelay.Wait(TestRunnerCleanupFallbackDelayMilliseconds, ct);
+            await TimerDelay.Wait(TestRunnerCleanupFallbackDelayMilliseconds, ct).ConfigureAwait(false);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -52,14 +52,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     TestMode.PlayMode,
                     filter,
                     ct,
-                    startedRunGuid => runGuid = startedRunGuid);
+                    startedRunGuid => runGuid = startedRunGuid).ConfigureAwait(false);
             }
             catch (OperationCanceledException originalException)
             {
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: true,
                     runGuid: runGuid,
-                    RunTestsCancelStopRestoreUnityHooks.Resolve());
+                    RunTestsCancelStopRestoreUnityHooks.Resolve()).ConfigureAwait(false);
                 throw new RunTestsExecutionCanceledException(originalException.CancellationToken, stopResult);
             }
             finally
@@ -80,14 +80,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     TestMode.EditMode,
                     filter,
                     ct,
-                    startedRunGuid => runGuid = startedRunGuid);
+                    startedRunGuid => runGuid = startedRunGuid).ConfigureAwait(false);
             }
             catch (OperationCanceledException originalException)
             {
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: false,
                     runGuid: runGuid,
-                    RunTestsCancelStopRestoreUnityHooks.Resolve());
+                    RunTestsCancelStopRestoreUnityHooks.Resolve()).ConfigureAwait(false);
                 throw new RunTestsExecutionCanceledException(originalException.CancellationToken, stopResult);
             }
         }
@@ -123,7 +123,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // keeping the TestRunnerApi callback subscription alive forever.
             using CancellationTokenRegistration cancellationRegistration =
                 ct.Register(() => taskCompletionSource.TrySetCanceled(ct));
-            SerializableTestResult result = await taskCompletionSource.Task;
+            SerializableTestResult result = await taskCompletionSource.Task.ConfigureAwait(false);
             ct.ThrowIfCancellationRequested();
             return result;
         }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -117,15 +117,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         keyboard,
                         key,
                         parameters.Duration,
-                        ct);
+                        ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopKeyboardAction.KeyDown:
-                    response = await KeyboardInputActionExecutor.ExecuteKeyDown(keyboard, key, ct);
+                    response = await KeyboardInputActionExecutor.ExecuteKeyDown(keyboard, key, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopKeyboardAction.KeyUp:
-                    response = await KeyboardInputActionExecutor.ExecuteKeyUp(keyboard, key, ct);
+                    response = await KeyboardInputActionExecutor.ExecuteKeyUp(keyboard, key, ct).ConfigureAwait(false);
                     break;
 
                 default:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -106,23 +106,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             switch (parameters.Action)
             {
                 case UnityCliLoopMouseInputAction.Click:
-                    response = await MouseInputPressActionExecutor.ExecuteClick(mouse, parameters, ct);
+                    response = await MouseInputPressActionExecutor.ExecuteClick(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopMouseInputAction.LongPress:
-                    response = await MouseInputPressActionExecutor.ExecuteLongPress(mouse, parameters, ct);
+                    response = await MouseInputPressActionExecutor.ExecuteLongPress(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopMouseInputAction.MoveDelta:
-                    response = await MouseInputMotionActionExecutor.ExecuteMoveDelta(mouse, parameters, ct);
+                    response = await MouseInputMotionActionExecutor.ExecuteMoveDelta(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopMouseInputAction.Scroll:
-                    response = await MouseInputMotionActionExecutor.ExecuteScroll(mouse, parameters, ct);
+                    response = await MouseInputMotionActionExecutor.ExecuteScroll(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopMouseInputAction.SmoothDelta:
-                    response = await MouseInputMotionActionExecutor.ExecuteSmoothDelta(mouse, parameters, ct);
+                    response = await MouseInputMotionActionExecutor.ExecuteSmoothDelta(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 default:

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
@@ -189,7 +189,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             WatchCompilationResult compilationResult = await WatchExpressionServices.Compiler
-                .CompileAsync(parameters.Expression, ct);
+                .CompileAsync(parameters.Expression, ct).ConfigureAwait(false);
             if (!compilationResult.Success)
             {
                 return CreateCompilationFailure(compilationResult);

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcRequestProcessor.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcRequestProcessor.cs
@@ -14,8 +14,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// <summary>
     /// Class specialized in handling JSON-RPC 2.0 processing
     /// 
-    /// Design document reference: Packages/src/Editor/ARCHITECTURE.md
-    /// 
     /// Related classes:
     /// - UnityCliLoopExecutionRouter: Executes Unity requests based on JSON-RPC requests
     /// - Project IPC server: Receives JSON-RPC messages from CLI clients

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseFactory.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseFactory.cs
@@ -34,21 +34,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 );
                 return JsonConvert.SerializeObject(response, Formatting.None, ResponseSerializerSettings);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // Return safe fallback response for any serialization errors
-                object fallbackResult = new
-                {
-                    error = "Serialization failed - returning safe fallback",
-                    commandType = result != null ? result.GetType().Name : "unknown"
-                };
-
-                JsonRpcSuccessResponse fallbackResponse = new(
+                // Why error frame instead of success+error object: clients treat jsonrpc success as
+                // completed tool results; a fake success would hide serialization failure from agents.
+                string commandType = result != null ? result.GetType().Name : "unknown";
+                JsonRpcErrorResponse errorResponse = new(
                     UnityCliLoopServerConfig.JSONRPC_VERSION,
                     id,
-                    fallbackResult
-                );
-                return JsonConvert.SerializeObject(fallbackResponse, Formatting.None, ResponseSerializerSettings);
+                    new JsonRpcError(
+                        UnityCliLoopServerConfig.INTERNAL_ERROR_CODE,
+                        "Failed to serialize the tool response.",
+                        new InternalErrorData(
+                            $"Serialization failed for response type '{commandType}': {ex.Message}")));
+                return JsonConvert.SerializeObject(errorResponse, Formatting.None, ResponseSerializerSettings);
             }
         }
 

--- a/tests/UnityCliLoop.CodeComplexity.Tests/ConfigureAwaitGuardTests.cs
+++ b/tests/UnityCliLoop.CodeComplexity.Tests/ConfigureAwaitGuardTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using UnityCliLoop.CodeComplexity;
+
+namespace UnityCliLoop.CodeComplexity.Tests
+{
+    [TestFixture]
+    public sealed class ConfigureAwaitGuardTests
+    {
+        // Verifies Task-like awaits without ConfigureAwait(false) are reported while custom
+        // awaitables (intentional main-thread hops) are excluded by return type.
+        [Test]
+        public void FindMissingConfigureAwait_WhenSampleHasTaskAwaitWithoutConfigureAwait_ReportsViolation()
+        {
+            string rootPath = Path.Combine(
+                TestContext.CurrentContext.WorkDirectory,
+                $"configure-await-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(rootPath);
+            try
+            {
+                string toolsDir = Path.Combine(rootPath, "Packages", "src", "Editor", "FirstPartyTools", "Sample");
+                string contractsDir = Path.Combine(rootPath, "Packages", "src", "Editor", "ToolContracts");
+                Directory.CreateDirectory(toolsDir);
+                Directory.CreateDirectory(contractsDir);
+                File.WriteAllText(
+                    Path.Combine(contractsDir, "MainThreadSwitcher.cs"),
+                    """
+                    using System;
+                    using System.Runtime.CompilerServices;
+                    using System.Threading;
+                    namespace io.github.hatayama.UnityCliLoop.ToolContracts
+                    {
+                        public static class MainThreadSwitcher
+                        {
+                            public static SwitchToMainThreadAwaitable SwitchToMainThread(CancellationToken ct = default)
+                                => new SwitchToMainThreadAwaitable(ct);
+                        }
+                        public struct SwitchToMainThreadAwaitable
+                        {
+                            public SwitchToMainThreadAwaitable(CancellationToken cancellationToken) { }
+                            public Awaiter GetAwaiter() => new Awaiter();
+                            public struct Awaiter : INotifyCompletion
+                            {
+                                public bool IsCompleted => true;
+                                public void GetResult() { }
+                                public void OnCompleted(Action continuation) => continuation();
+                            }
+                        }
+                    }
+                    """);
+                File.WriteAllText(
+                    Path.Combine(toolsDir, "SampleTool.cs"),
+                    """
+                    using System.Threading.Tasks;
+                    using io.github.hatayama.UnityCliLoop.ToolContracts;
+                    namespace Sample
+                    {
+                        public static class SampleTool
+                        {
+                            public static async Task RunAsync()
+                            {
+                                await Task.Delay(1);
+                                await MainThreadSwitcher.SwitchToMainThread();
+                                await Task.CompletedTask;
+                            }
+                        }
+                    }
+                    """);
+
+                ConfigureAwaitGuard guard = new();
+                IReadOnlyList<ConfigureAwaitViolation> violations = guard.FindMissingConfigureAwait(rootPath);
+
+                Assert.That(violations.Count, Is.EqualTo(2));
+                Assert.That(violations.All(violation =>
+                    violation.AwaitExpression.Contains("Task.Delay", StringComparison.Ordinal)
+                    || violation.AwaitExpression.Contains("Task.CompletedTask", StringComparison.Ordinal)), Is.True);
+                Assert.That(violations.Any(violation =>
+                    violation.AwaitExpression.Contains("SwitchToMainThread", StringComparison.Ordinal)), Is.False);
+            }
+            finally
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+
+        // Verifies FirstPartyTools Task-like awaits all use ConfigureAwait(false) so paused
+        // Play Mode cannot hang tool continuations captured on Unity's SynchronizationContext.
+        [Test]
+        public void FindMissingConfigureAwait_ForRepositoryFirstPartyTools_HasNoViolations()
+        {
+            string repositoryRoot = FindRepositoryRoot();
+            ConfigureAwaitGuard guard = new();
+            IReadOnlyList<ConfigureAwaitViolation> violations = guard.FindMissingConfigureAwait(repositoryRoot);
+
+            if (violations.Count == 0)
+            {
+                return;
+            }
+
+            StringBuilder message = new();
+            message.AppendLine($"Found {violations.Count} Task-like await(s) missing ConfigureAwait(false):");
+            foreach (ConfigureAwaitViolation violation in violations.Take(40))
+            {
+                message.AppendLine($"{violation.FilePath}:{violation.Line}: {violation.AwaitExpression}");
+            }
+
+            Assert.Fail(message.ToString());
+        }
+
+        private static string FindRepositoryRoot()
+        {
+            string? directory = TestContext.CurrentContext.TestDirectory;
+            while (!string.IsNullOrEmpty(directory))
+            {
+                if (File.Exists(Path.Combine(directory, "Packages", "src", "package.json"))
+                    || File.Exists(Path.Combine(directory, "Packages", "manifest.json")))
+                {
+                    return directory;
+                }
+
+                directory = Directory.GetParent(directory)?.FullName;
+            }
+
+            Assert.Fail("Failed to locate repository root from test directory.");
+            return string.Empty;
+        }
+    }
+}

--- a/tools/UnityCliLoop.CodeComplexity/ConfigureAwaitGuard.cs
+++ b/tools/UnityCliLoop.CodeComplexity/ConfigureAwaitGuard.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace UnityCliLoop.CodeComplexity
+{
+    /// <summary>
+    /// Finds Task-like awaits in tool assemblies that omit ConfigureAwait(false).
+    /// </summary>
+    public sealed class ConfigureAwaitGuard
+    {
+        private static readonly string[] DefaultPreprocessorSymbols =
+        {
+            "UNITY_EDITOR",
+            "UNITY_EDITOR_OSX",
+            "UNITY_2022_3_OR_NEWER",
+            "UNITY_6000_0_OR_NEWER",
+            "UNITY_6000_3_OR_NEWER",
+            "UNITY_6000_4_OR_NEWER",
+            "ULOOP_HAS_INPUT_SYSTEM",
+            "ULOOP_DEBUG",
+            "ULOOP_HAS_TEST_FRAMEWORK"
+        };
+
+        /// <summary>
+        /// Scans FirstPartyTools for await expressions of Task/Task&lt;T&gt;/ValueTask/ValueTask&lt;T&gt;
+        /// that are missing ConfigureAwait(false).
+        /// Custom awaitables (e.g. SwitchToMainThreadAwaitable) are excluded by return type —
+        /// intentional main-thread hops are the mechanism, not the hazard.
+        /// </summary>
+        public IReadOnlyList<ConfigureAwaitViolation> FindMissingConfigureAwait(string repositoryRoot)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(repositoryRoot), "repositoryRoot must not be empty");
+
+            string[] sourceFiles = CollectToolAssemblySourceFiles(repositoryRoot);
+            if (sourceFiles.Length == 0)
+            {
+                return Array.Empty<ConfigureAwaitViolation>();
+            }
+
+            CSharpCompilation compilation = CreateCompilation(sourceFiles);
+            List<ConfigureAwaitViolation> violations = new();
+            foreach (SyntaxTree syntaxTree in compilation.SyntaxTrees)
+            {
+                if (!IsFirstPartyToolsPath(syntaxTree.FilePath, repositoryRoot))
+                {
+                    continue;
+                }
+
+                SemanticModel semanticModel = compilation.GetSemanticModel(syntaxTree);
+                CompilationUnitSyntax root = syntaxTree.GetCompilationUnitRoot();
+                foreach (AwaitExpressionSyntax awaitExpression in root.DescendantNodes().OfType<AwaitExpressionSyntax>())
+                {
+                    if (HasConfigureAwaitFalse(awaitExpression.Expression))
+                    {
+                        continue;
+                    }
+
+                    ITypeSymbol? awaitedType = semanticModel.GetTypeInfo(awaitExpression.Expression).Type;
+                    if (awaitedType == null || !IsTaskLike(awaitedType))
+                    {
+                        // Why skip non-Task awaitables: SwitchToMainThreadAwaitable and similar
+                        // intentional main-thread hops are the mechanism, not the hazard.
+                        continue;
+                    }
+
+                    FileLinePositionSpan lineSpan = awaitExpression.GetLocation().GetLineSpan();
+                    violations.Add(new ConfigureAwaitViolation(
+                        CreateReportPath(repositoryRoot, syntaxTree.FilePath),
+                        lineSpan.StartLinePosition.Line + 1,
+                        lineSpan.StartLinePosition.Character + 1,
+                        awaitExpression.ToString()));
+                }
+            }
+
+            return violations
+                .OrderBy(violation => violation.FilePath, StringComparer.Ordinal)
+                .ThenBy(violation => violation.Line)
+                .ThenBy(violation => violation.Column)
+                .ToArray();
+        }
+
+        private static string[] CollectToolAssemblySourceFiles(string repositoryRoot)
+        {
+            string firstPartyToolsPath = Path.Combine(repositoryRoot, "Packages", "src", "Editor", "FirstPartyTools");
+            string toolContractsPath = Path.Combine(repositoryRoot, "Packages", "src", "Editor", "ToolContracts");
+            return CollectCsFiles(firstPartyToolsPath)
+                .Concat(CollectCsFiles(toolContractsPath))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static IEnumerable<string> CollectCsFiles(string directoryPath)
+        {
+            if (!Directory.Exists(directoryPath))
+            {
+                return Array.Empty<string>();
+            }
+
+            return Directory.GetFiles(directoryPath, "*.cs", SearchOption.AllDirectories);
+        }
+
+        private static bool IsFirstPartyToolsPath(string filePath, string repositoryRoot)
+        {
+            string relativePath = CreateReportPath(repositoryRoot, filePath);
+            return relativePath.StartsWith("Packages/src/Editor/FirstPartyTools/", StringComparison.Ordinal);
+        }
+
+        private static bool HasConfigureAwaitFalse(ExpressionSyntax expression)
+        {
+            if (expression is not InvocationExpressionSyntax invocation)
+            {
+                return false;
+            }
+
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            {
+                return false;
+            }
+
+            if (!string.Equals(memberAccess.Name.Identifier.ValueText, "ConfigureAwait", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (invocation.ArgumentList.Arguments.Count != 1)
+            {
+                return false;
+            }
+
+            ExpressionSyntax argumentExpression = invocation.ArgumentList.Arguments[0].Expression;
+            return argumentExpression is LiteralExpressionSyntax literal
+                && literal.IsKind(SyntaxKind.FalseLiteralExpression);
+        }
+
+        private static bool IsTaskLike(ITypeSymbol type)
+        {
+            ITypeSymbol unbound = type.OriginalDefinition;
+            string? fullName = unbound.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return fullName is
+                "global::System.Threading.Tasks.Task" or
+                "global::System.Threading.Tasks.Task<TResult>" or
+                "global::System.Threading.Tasks.ValueTask" or
+                "global::System.Threading.Tasks.ValueTask<TResult>";
+        }
+
+        private static CSharpCompilation CreateCompilation(IReadOnlyList<string> sourceFiles)
+        {
+            List<SyntaxTree> syntaxTrees = new();
+            foreach (string sourceFile in sourceFiles)
+            {
+                SourceText sourceText = SourceText.From(File.ReadAllText(sourceFile));
+                syntaxTrees.Add(CSharpSyntaxTree.ParseText(
+                    sourceText,
+                    CSharpParseOptions.Default
+                        .WithLanguageVersion(LanguageVersion.Latest)
+                        .WithPreprocessorSymbols(DefaultPreprocessorSymbols),
+                    path: sourceFile));
+            }
+
+            return CSharpCompilation.Create(
+                "UnityCliLoop.ConfigureAwaitGuard.Analysis",
+                syntaxTrees,
+                CreateMetadataReferences(),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        }
+
+        private static ImmutableArray<MetadataReference> CreateMetadataReferences()
+        {
+            string? trustedPlatformAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+            if (string.IsNullOrEmpty(trustedPlatformAssemblies))
+            {
+                return ImmutableArray<MetadataReference>.Empty;
+            }
+
+            return trustedPlatformAssemblies
+                .Split(Path.PathSeparator)
+                .Where(File.Exists)
+                .Distinct(StringComparer.Ordinal)
+                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+                .ToImmutableArray();
+        }
+
+        private static string CreateReportPath(string rootPath, string filePath)
+        {
+            string fullRootPath = Path.GetFullPath(rootPath);
+            string fullFilePath = Path.GetFullPath(filePath);
+            return Path.GetRelativePath(fullRootPath, fullFilePath)
+                .Replace(Path.DirectorySeparatorChar, '/')
+                .Replace(Path.AltDirectorySeparatorChar, '/');
+        }
+    }
+
+    /// <summary>
+    /// One Task-like await that omitted ConfigureAwait(false).
+    /// </summary>
+    public sealed class ConfigureAwaitViolation
+    {
+        public string FilePath { get; }
+        public int Line { get; }
+        public int Column { get; }
+        public string AwaitExpression { get; }
+
+        public ConfigureAwaitViolation(string filePath, int line, int column, string awaitExpression)
+        {
+            FilePath = filePath;
+            Line = line;
+            Column = column;
+            AwaitExpression = awaitExpression;
+        }
+    }
+}


### PR DESCRIPTION
Refs: 2026-07-14 design-review fixes plan (PR-4 / todos 12–15)

## Summary
- Return a JSON-RPC `internal_error` frame when success-response serialization fails (instead of a fake success payload).
- Add Roslyn ConfigureAwait guard for FirstPartyTools: Task/Task&lt;T&gt;/ValueTask only; custom main-thread hop awaitables excluded by return type.
- Add missing `ConfigureAwait(false)` across FirstPartyTools Task-like awaits.
- Remove the dead `Packages/src/Editor/ARCHITECTURE.md` comment reference.

## User Impact
- Agents no longer see serialization failures disguised as successful tool results.
- Tool awaits are less likely to hang when Play Mode is paused mid-command.

## Test plan
- [x] EditMode: `JsonRpcResponseFactorySerializationFallbackTests` (Red→Green)
- [x] `dotnet test tests/UnityCliLoop.CodeComplexity.Tests`
- [x] `uloop compile` + EditMode JsonRpcResponseFactory tests
- [x] No `protocolVersion` / pin / CHANGELOG changes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

