### PR TITLE
fix: Harden IPC contracts, empty RPC errors, and Settings async UI

### DIFF
--- a/Assets/Tests/Editor/BridgeTransportEndpointTests.cs
+++ b/Assets/Tests/Editor/BridgeTransportEndpointTests.cs
@@ -1,7 +1,12 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 {
@@ -10,6 +15,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
     /// </summary>
     public class BridgeTransportEndpointTests
     {
+        private const string SharedEndpointContractPath = "tests/contracts/endpoint_contract.json";
+
         [Test]
         public void CanonicalizeProjectRoot_WhenPathIsFilesystemRoot_ShouldPreserveRoot()
         {
@@ -19,6 +26,71 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             string canonicalProjectRoot = ProjectRootCanonicalizer.Canonicalize(filesystemRoot);
 
             Assert.That(canonicalProjectRoot, Is.EqualTo(filesystemRoot));
+        }
+
+        [Test]
+        public void CreateProjectIpc_WhenCanonicalRootsFromSharedContract_MatchExpectedEndpointPaths()
+        {
+            // Verifies Go and C# derive the same IPC endpoint names from already-canonicalized roots
+            // listed in the shared endpoint contract (symlink resolution is out of scope).
+            foreach (JObject contractCase in ReadEndpointContractCases())
+            {
+                string caseId = contractCase.Value<string>("id");
+                string canonicalProjectRoot = contractCase.Value<string>("canonicalProjectRoot");
+                if (!CanExerciseProjectRootOnCurrentPlatform(canonicalProjectRoot))
+                {
+                    continue;
+                }
+
+                string expectedPath = ExpectedEndpointPathForCurrentPlatform(contractCase);
+                BridgeTransportEndpoint endpoint = BridgeTransportEndpoint.CreateProjectIpc(canonicalProjectRoot);
+                Assert.That(endpoint.Path, Is.EqualTo(expectedPath), $"case {caseId} canonical root");
+
+                JArray trimOnlyEquivalentRoots = contractCase.Value<JArray>("trimOnlyEquivalentRoots") ?? new JArray();
+                foreach (JToken equivalentRootToken in trimOnlyEquivalentRoots)
+                {
+                    string equivalentRoot = equivalentRootToken.Value<string>();
+                    BridgeTransportEndpoint trimmedEndpoint = BridgeTransportEndpoint.CreateProjectIpc(equivalentRoot);
+                    Assert.That(
+                        trimmedEndpoint.Path,
+                        Is.EqualTo(expectedPath),
+                        $"case {caseId} trim-only equivalent root {equivalentRoot}");
+                }
+            }
+        }
+
+        private static IEnumerable<JObject> ReadEndpointContractCases()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedEndpointContractPath));
+            JObject contract = JObject.Parse(json);
+            JArray cases = contract.Value<JArray>("cases");
+            Assert.That(cases, Is.Not.Null.And.Not.Empty);
+            foreach (JToken caseToken in cases)
+            {
+                yield return (JObject)caseToken;
+            }
+        }
+
+        private static bool CanExerciseProjectRootOnCurrentPlatform(string projectRoot)
+        {
+            bool looksLikeWindowsPath = projectRoot.Length >= 2 && projectRoot[1] == ':';
+            if (looksLikeWindowsPath)
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            }
+
+            return !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        private static string ExpectedEndpointPathForCurrentPlatform(JObject contractCase)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return contractCase.Value<string>("windowsPipePath");
+            }
+
+            return contractCase.Value<string>("unixSocketPath");
         }
     }
 }

--- a/Assets/Tests/Editor/CliUpdateRequiredErrorContractTests.cs
+++ b/Assets/Tests/Editor/CliUpdateRequiredErrorContractTests.cs
@@ -1,0 +1,90 @@
+using System.IO;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Freezes the cli_update_required JSON-RPC error.data frame that old CLIs must keep parsing forever.
+    /// </summary>
+    public sealed class CliUpdateRequiredErrorContractTests
+    {
+        private const string SharedContractPath = "tests/contracts/cli_update_required_error_contract.json";
+
+        [Test]
+        public void CreateCliProtocolMismatchResponse_WhenOlderProtocol_MatchesSharedErrorDataFieldShape()
+        {
+            // This frame must remain backward compatible forever — old CLIs parse it to learn they must update.
+            // Verifies JsonRpcResponseFactory still emits the frozen error.data field shape for older CLIs.
+            JObject expected = ReadSharedErrorDataFieldShape();
+            string responseJson = JsonRpcResponseFactory.CreateCliProtocolMismatchResponse(
+                id: "contract-test",
+                currentCliVersion: "3.0.0-beta.5",
+                currentProtocolVersion: 1);
+            JObject actualData = (JObject)JObject.Parse(responseJson)["error"]!["data"]!;
+            JObject actual = NormalizeFieldShape(actualData);
+
+            Assert.That(JToken.DeepEquals(actual, expected), Is.True, $"Expected {expected} but got {actual}");
+            Assert.That(actualData.Value<string>("type"), Is.EqualTo("cli_update_required"));
+            Assert.That(
+                actualData.Value<int>("requiredProtocolVersion"),
+                Is.EqualTo(CliConstants.REQUIRED_CLI_PROTOCOL_VERSION));
+            Assert.That(actualData.Value<string>("updateCommand"), Is.EqualTo("uloop update"));
+        }
+
+        private static JObject ReadSharedErrorDataFieldShape()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedContractPath));
+            JObject contract = JObject.Parse(json);
+            return NormalizeFieldShape((JObject)contract["errorData"]!);
+        }
+
+        private static JObject NormalizeFieldShape(JObject value)
+        {
+            JObject shape = new();
+            foreach (JProperty property in value.Properties())
+            {
+                shape[property.Name] = NormalizeTokenFieldShape(property.Value);
+            }
+            return shape;
+        }
+
+        private static JToken NormalizeTokenFieldShape(JToken value)
+        {
+            if (value is JObject objectValue)
+            {
+                return NormalizeFieldShape(objectValue);
+            }
+
+            if (value is JArray arrayValue)
+            {
+                JArray arrayShape = new();
+                if (arrayValue.Count > 0)
+                {
+                    arrayShape.Add(NormalizeTokenFieldShape(arrayValue[0]));
+                }
+                return arrayShape;
+            }
+
+            return new JValue(NormalizeScalarType(value.Type));
+        }
+
+        private static string NormalizeScalarType(JTokenType type)
+        {
+            return type switch
+            {
+                JTokenType.Boolean => "boolean",
+                JTokenType.Float => "number",
+                JTokenType.Integer => "number",
+                JTokenType.Null => "null",
+                JTokenType.String => "string",
+                _ => "unknown"
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/CliUpdateRequiredErrorContractTests.cs.meta
+++ b/Assets/Tests/Editor/CliUpdateRequiredErrorContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d9e7b1a5c4f48e2a6b0d8f1c2e4a7b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs
+++ b/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Test fixture that verifies Unity get-compile-status responses stay aligned with the shared Go CLI contract.
+    /// </summary>
+    public sealed class GetCompileStatusResponseContractTests
+    {
+        private const string SharedContractPath = "tests/contracts/compile_status_response_contract.json";
+
+        [Test]
+        public void GetCompileStatusResponse_WhenSerialized_MatchesSharedContractFieldShape()
+        {
+            // Verifies C# does not add, remove, or rename get-compile-status fields without updating the
+            // shared CLI contract. Result must come from a real CompileResponse serialization because that
+            // is what CompileStatusBridgeCommand restores from ResultJson for Go compileResultStatus.Success.
+            JObject expected = ReadSharedContractFieldShape();
+            JObject compileResultJson = SerializeCompileResponseResult();
+            GetCompileStatusResponse response = new()
+            {
+                Ready = true,
+                HasResult = true,
+                IsCompiling = true,
+                IsUpdating = true,
+                IsDomainReloadInProgress = true,
+                Result = compileResultJson,
+                Message = "Compile result is available."
+            };
+            string json = JsonConvert.SerializeObject(
+                response,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+            JObject actual = NormalizeFieldShape(JObject.Parse(json));
+
+            Assert.That(JToken.DeepEquals(actual, expected), Is.True, $"Expected {expected} but got {actual}");
+        }
+
+        [Test]
+        public void CompileResponse_WhenSerializedForCompileStatusResult_IncludesSuccessProperty()
+        {
+            // Verifies the wire Result payload still exposes Success under the name Go unmarshals into
+            // compileResultStatus — a rename on CompileResponse must fail this test.
+            JObject compileResultJson = SerializeCompileResponseResult();
+            Assert.That(compileResultJson.Property("Success"), Is.Not.Null);
+            Assert.That(compileResultJson["Success"]!.Type, Is.EqualTo(JTokenType.Boolean));
+        }
+
+        private static JObject SerializeCompileResponseResult()
+        {
+            CompileResponse compileResult = new(
+                success: true,
+                errorCount: 0,
+                warningCount: 0,
+                errors: Array.Empty<CompileIssue>(),
+                warnings: Array.Empty<CompileIssue>(),
+                message: "Compile result is available.");
+            string resultJson = JsonConvert.SerializeObject(
+                compileResult,
+                Formatting.None,
+                UnityCliLoopJsonResponseSerializerSettings.Settings);
+            return JObject.Parse(resultJson);
+        }
+
+        private static JObject ReadSharedContractFieldShape()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            string json = File.ReadAllText(Path.Combine(projectRoot, SharedContractPath));
+            return NormalizeFieldShape(JObject.Parse(json));
+        }
+
+        private static JObject NormalizeFieldShape(JObject value)
+        {
+            JObject shape = new();
+            foreach (JProperty property in value.Properties())
+            {
+                shape[property.Name] = NormalizeTokenFieldShape(property.Value);
+            }
+            return shape;
+        }
+
+        private static JToken NormalizeTokenFieldShape(JToken value)
+        {
+            if (value is JObject objectValue)
+            {
+                return NormalizeFieldShape(objectValue);
+            }
+
+            if (value is JArray arrayValue)
+            {
+                JArray arrayShape = new();
+                if (arrayValue.Count > 0)
+                {
+                    arrayShape.Add(NormalizeTokenFieldShape(arrayValue[0]));
+                }
+                return arrayShape;
+            }
+
+            return new JValue(NormalizeScalarType(value.Type));
+        }
+
+        private static string NormalizeScalarType(JTokenType type)
+        {
+            return type switch
+            {
+                JTokenType.Boolean => "boolean",
+                JTokenType.Float => "number",
+                JTokenType.Integer => "number",
+                JTokenType.Null => "null",
+                JTokenType.String => "string",
+                _ => "unknown"
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs.meta
+++ b/Assets/Tests/Editor/GetCompileStatusResponseContractTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f2a4c6e1d3b5a790c8e4f6a2b0d1e3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/JsonRpcResponseFactorySerializationFallbackTests.cs
+++ b/Assets/Tests/Editor/JsonRpcResponseFactorySerializationFallbackTests.cs
@@ -1,0 +1,35 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies JSON-RPC success serialization failures become error frames instead of fake success payloads.
+    /// </summary>
+    public sealed class JsonRpcResponseFactorySerializationFallbackTests
+    {
+        [Test]
+        public void CreateSuccessResponse_WhenResultCannotBeSerialized_ReturnsJsonRpcError()
+        {
+            // Verifies serialization failure returns INTERNAL_ERROR with internal_error data instead of a
+            // success frame that embeds an error-shaped object in result.
+            string responseJson = JsonRpcResponseFactory.CreateSuccessResponse(
+                id: 1,
+                result: new UnserializableToolResponse());
+            JObject response = JObject.Parse(responseJson);
+
+            Assert.That(response["result"], Is.Null);
+            Assert.That(response["error"], Is.Not.Null);
+            Assert.That(response["error"]!["code"]!.Value<int>(), Is.EqualTo(UnityCliLoopServerConfig.INTERNAL_ERROR_CODE));
+            Assert.That(response["error"]!["data"]!["type"]!.Value<string>(), Is.EqualTo(JsonRpcErrorTypes.InternalError));
+        }
+
+        private sealed class UnserializableToolResponse : UnityCliLoopToolResponse
+        {
+            public string Boom => throw new System.InvalidOperationException("intentional serialization failure");
+        }
+    }
+}

--- a/Assets/Tests/Editor/JsonRpcResponseFactorySerializationFallbackTests.cs.meta
+++ b/Assets/Tests/Editor/JsonRpcResponseFactorySerializationFallbackTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e8c1a2b4d6f7093a1c5e7b9d0f2a4c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
+++ b/Assets/Tests/Editor/RunTestsTestFrameworkResultTests.cs
@@ -192,7 +192,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 TestResultStatus.Failed,
                 0.1,
                 new List<ITestResultAdaptor>());
-            Regex warningPattern = new Regex("^Failed to save NUnit XML result file: ");
+            Regex warningPattern = new Regex("^Failed to save failure XML result file: ");
 
             LogAssert.Expect(LogType.Warning, warningPattern);
 

--- a/Assets/Tests/Editor/SettingsPresentationDecisionPolicyTests.cs
+++ b/Assets/Tests/Editor/SettingsPresentationDecisionPolicyTests.cs
@@ -1,0 +1,58 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Domain;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies UnityEditor-independent Settings decision policies extracted for Presentation Move Method.
+    /// </summary>
+    public class SettingsPresentationDecisionPolicyTests
+    {
+        [TestCase(false, true, true)]
+        [TestCase(false, false, false)]
+        [TestCase(true, true, false)]
+        [TestCase(true, false, false)]
+        public void CliPathSetupCheckPolicy_ShouldCheck_UsesWindowsAndOwnership(
+            bool isWindowsEditor,
+            bool hasPackageOwnedCurrentUserInstall,
+            bool expected)
+        {
+            // Verifies PATH checks stay off for Windows and non package-owned installs.
+            bool result = CliPathSetupCheckPolicy.ShouldCheck(
+                isWindowsEditor,
+                hasPackageOwnedCurrentUserInstall);
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void SkillInstallDialogPolicy_ShouldShowForInstallableTargets_RequiresAllEligible()
+        {
+            // Verifies wizard dialog policy requires every target to be first-install eligible.
+            SkillSetupTargetInfo[] targets =
+            {
+                CreateSkillTarget(SkillInstallState.Missing, false),
+                CreateSkillTarget(SkillInstallState.Outdated, false)
+            };
+
+            bool result = SkillInstallDialogPolicy.ShouldShowForInstallableTargets(targets);
+
+            Assert.That(result, Is.False);
+        }
+
+        private static SkillSetupTargetInfo CreateSkillTarget(
+            SkillInstallState installState,
+            bool hasDifferentLayoutSkills)
+        {
+            return new SkillSetupTargetInfo(
+                "Claude Code",
+                ".claude",
+                "--claude",
+                hasSkillsDirectory: true,
+                hasExistingSkills: true,
+                hasDifferentLayoutSkills,
+                installState);
+        }
+    }
+}

--- a/Assets/Tests/Editor/SettingsPresentationDecisionPolicyTests.cs.meta
+++ b/Assets/Tests/Editor/SettingsPresentationDecisionPolicyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fac85b7f95dfb4a3683922dfaea778f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
+++ b/Assets/Tests/Editor/StaticFacadeStateGuardTests.cs
@@ -334,7 +334,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(source, Does.Contain("await DynamicCodeMissingReturnRetryPolicy.RetryMissingReturnIfNeeded(\n                    executionResult,"));
             Assert.That(source, Does.Contain("cancellationToken).ConfigureAwait(false);"));
             Assert.That(source, Does.Contain("await _runtime.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);"));
-            Assert.That(source, Does.Contain("await _runtime.TryExecuteIfIdleAsync(\n                request,\n                cancellationToken).ConfigureAwait(false);"));
+            Assert.That(source, Does.Contain("await _runtime.TryExecuteIfIdleAsync(\n                    request,\n                    cancellationToken).ConfigureAwait(false);"));
             Assert.That(
                 retryPolicySource,
                 Does.Contain("await executeRetryAsync(codeWithReturn, ct)\n                .ConfigureAwait(false);"));

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -14,6 +14,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         private const string TestMinimumDispatcherVersion = "3.0.0";
 
         [TestCase(null, false, true, false)]
+        [TestCase("", false, true, false)]
         [TestCase("2.9.0", false, true, false)]
         [TestCase("3.0.0", false, true, false)]
         [TestCase("2.9.0", true, true, false)]
@@ -61,6 +62,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         [TestCase(false, "3.0.0", false, true, "InstallOrUpdate")]
         [TestCase(false, "3.0.0", true, false, "InstallOrUpdate")]
         [TestCase(false, null, false, true, "InstallOrUpdate")]
+        [TestCase(false, "", false, true, "InstallOrUpdate")]
         public void ResolveCliPrimaryButtonAction_ReturnsClickedPrimaryAction(
             bool needsCliPathSetup,
             string cliVersion,

--- a/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
+++ b/Assets/Tests/Editor/UnityCliLoopSettingsWindowCliActionTests.cs
@@ -27,7 +27,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool expected)
         {
             // Verifies that package-owned installs route to uninstall only when the dispatcher minimum is satisfied.
-            bool result = UnityCliLoopSettingsWindow.ShouldUninstallCliFromPrimaryButton(
+            bool result = UnityCliLoopSettingsCliSetupPresenter.ShouldUninstallCliFromPrimaryButton(
                 cliVersion,
                 cliIsDispatcher,
                 canUninstallCli,
@@ -45,7 +45,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool expected)
         {
             // Verifies that stale terminal PATH state routes to repair only when CLI replacement is not needed.
-            bool result = UnityCliLoopSettingsWindow.ShouldRepairCliPathFromPrimaryButton(
+            bool result = UnityCliLoopSettingsCliSetupPresenter.ShouldRepairCliPathFromPrimaryButton(
                 needsCliPathSetup,
                 needsUpdate);
 
@@ -70,7 +70,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies that the Settings window chooses repair only when dispatcher replacement is unnecessary.
             CliSetupPrimaryAction result =
-                UnityCliLoopSettingsWindow.ResolveCliPrimaryButtonAction(
+                UnityCliLoopSettingsCliSetupPresenter.ResolveCliPrimaryButtonAction(
                     needsCliPathSetup,
                     cliVersion,
                     cliIsDispatcher,
@@ -94,7 +94,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         {
             // Verifies that a refreshed Settings state cannot turn a stale click into a destructive action.
             CliSetupPrimaryAction result =
-                UnityCliLoopSettingsWindow.ResolveExecutableCliPrimaryButtonAction(
+                UnityCliLoopSettingsCliSetupPresenter.ResolveExecutableCliPrimaryButtonAction(
                     ParseAction(clickedAction),
                     ParseAction(refreshedAction));
 
@@ -111,7 +111,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool expected)
         {
             // Verifies that PATH repair only runs for POSIX package-owned current-user installs.
-            bool result = UnityCliLoopSettingsWindow.ShouldCheckCliPathSetupForPlatform(
+            bool result = UnityCliLoopSettingsCliSetupPresenter.ShouldCheckCliPathSetupForPlatform(
                 platform,
                 hasPackageOwnedCurrentUserInstall);
 
@@ -131,7 +131,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             bool expected)
         {
             // Verifies that the settings UI updates non-dispatcher or older dispatcher installs.
-            bool result = UnityCliLoopSettingsWindow.IsCliUpdateNeeded(
+            bool result = UnityCliLoopSettingsCliSetupPresenter.IsCliUpdateNeeded(
                 cliVersion,
                 cliIsDispatcher,
                 TestMinimumDispatcherVersion);
@@ -150,7 +150,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             // Verifies that Settings keeps the success dialog for first install only.
             SkillSetupTargetInfo targetInfo = CreateSkillTarget(installState, hasDifferentLayoutSkills);
 
-            bool result = UnityCliLoopSettingsWindow.ShouldShowSkillsInstalledDialog(targetInfo);
+            bool result = SkillInstallDialogPolicy.ShouldShowForSelectedTarget(targetInfo);
 
             Assert.That(result, Is.EqualTo(expected));
         }

--- a/Packages/src/Editor/Domain/CliPathSetupCheckPolicy.cs
+++ b/Packages/src/Editor/Domain/CliPathSetupCheckPolicy.cs
@@ -1,0 +1,18 @@
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Decides when Settings should run CLI PATH visibility checks.
+    /// </summary>
+    public static class CliPathSetupCheckPolicy
+    {
+        /// <summary>
+        /// PATH repair checks run only for non-Windows package-owned current-user installs.
+        /// </summary>
+        public static bool ShouldCheck(
+            bool isWindowsEditor,
+            bool hasPackageOwnedCurrentUserInstall)
+        {
+            return !isWindowsEditor && hasPackageOwnedCurrentUserInstall;
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/CliPathSetupCheckPolicy.cs.meta
+++ b/Packages/src/Editor/Domain/CliPathSetupCheckPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbe22adc4dab44338bd089a25d15c8fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Domain/SkillInstallDialogPolicy.cs
+++ b/Packages/src/Editor/Domain/SkillInstallDialogPolicy.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.Domain
+{
+    /// <summary>
+    /// Decides when the skills-installed success dialog should appear after an install attempt.
+    /// </summary>
+    public static class SkillInstallDialogPolicy
+    {
+        /// <summary>
+        /// Returns true when Settings should show the success dialog for a single selected target.
+        /// </summary>
+        public static bool ShouldShowForSelectedTarget(SkillSetupTargetInfo targetInfo)
+        {
+            return targetInfo.InstallState != SkillInstallState.Outdated
+                && !targetInfo.HasDifferentLayoutSkills;
+        }
+
+        /// <summary>
+        /// Returns true when Setup Wizard should show the success dialog for all installable targets.
+        /// </summary>
+        public static bool ShouldShowForInstallableTargets(IEnumerable<SkillSetupTargetInfo> targets)
+        {
+            Debug.Assert(targets != null, "targets must not be null");
+            return targets.All(ShouldShowForSelectedTarget);
+        }
+    }
+}

--- a/Packages/src/Editor/Domain/SkillInstallDialogPolicy.cs.meta
+++ b/Packages/src/Editor/Domain/SkillInstallDialogPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb88c5b20f2e34bab93527cb64cbcda7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompilationExecutionService.cs
@@ -47,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 _pendingCompileSessionRepository);
             compileController.SetResultRecordingContext(CompileResultRecordingContext.Create(request));
             compileController.SetExternalSceneChangePolicy(request.ReloadExternalSceneChanges);
-            return await compileController.TryCompileAsync(request.ForceRecompile, ct);
+            return await compileController.TryCompileAsync(request.ForceRecompile, ct).ConfigureAwait(false);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileController.cs
@@ -105,7 +105,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         {
                             ["requested_force_recompile"] = forceRecompile
                         }));
-                    return await _currentCompileTask.Task;
+                    return await _currentCompileTask.Task.ConfigureAwait(false);
                 }
                 throw new InvalidOperationException("Compilation is in progress, but the task could not be found.");
             }
@@ -180,7 +180,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 StartCompileLifecycleWatchdog(compileTask, ct);
                 compileTaskTransferred = true;
-                return await compileTask.Task;
+                return await compileTask.Task.ConfigureAwait(false);
             }
             finally
             {

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
@@ -102,7 +102,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 }
 
                 // The delay is not cancelled directly because the watchdog must convert cancellation into cleanup.
-                await _waitForPollAsync();
+                await _waitForPollAsync().ConfigureAwait(false);
                 if (!observedStart)
                 {
                     waitedForStartMs += UnityCliLoopConstants.COMPILE_START_POLL_INTERVAL_MS;

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
@@ -103,6 +103,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 // The delay is not cancelled directly because the watchdog must convert cancellation into cleanup.
                 await _waitForPollAsync().ConfigureAwait(false);
+                // Why switch back: the poll delay resumes off-thread, but _isEditorCompiling and
+                // completion callbacks use Unity Editor APIs that require the main thread.
+                await MainThreadSwitcher.SwitchToMainThread(ct);
                 if (!observedStart)
                 {
                     waitedForStartMs += UnityCliLoopConstants.COMPILE_START_POLL_INTERVAL_MS;

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileLifecycleWatchdog.cs
@@ -103,9 +103,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 // The delay is not cancelled directly because the watchdog must convert cancellation into cleanup.
                 await _waitForPollAsync().ConfigureAwait(false);
-                // Why switch back: the poll delay resumes off-thread, but _isEditorCompiling and
-                // completion callbacks use Unity Editor APIs that require the main thread.
-                await MainThreadSwitcher.SwitchToMainThread(ct);
+                // Why CancellationToken.None: a cancelled ct would throw OCE here and skip the
+                // loop-head _onCancelled conversion; cleanup must still run on the main thread.
+                await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
                 if (!observedStart)
                 {
                     waitedForStartMs += UnityCliLoopConstants.COMPILE_START_POLL_INTERVAL_MS;

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -103,7 +103,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     BuildCompileLogContext(request),
                     correlationId);
                 preparationService.StopPlayMode();
-                bool exited = await WaitForPlayModeExitAsync(ct);
+                bool exited = await WaitForPlayModeExitAsync(ct).ConfigureAwait(false);
+                // Why switch back: the poll loop uses ConfigureAwait(false), but subsequent
+                // validation and compile orchestration call Unity Editor APIs.
+                await MainThreadSwitcher.SwitchToMainThread(ct);
                 VibeLogger.LogInfo(
                     "compile_playmode_exit_observed",
                     exited ? "Play Mode exited before compile." : "Play Mode did not exit before compile.",
@@ -160,10 +163,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return successResponse;
         }
 
-        // Why these awaits do not use ConfigureAwait(false): StopPlayMode() clears isPaused
-        // before setting isPlaying=false, so by the time the poll loop's TimerDelay continuation
-        // is posted to UnitySynchronizationContext the pause is already lifted and the queue
-        // drains normally. Measured 2026-07-11: compile during pause self-resolved in ~5s.
+        // Why ConfigureAwait(false) is paired with SwitchToMainThread at the call site:
+        // StopPlayMode() clears isPaused before setting isPlaying=false, so by the time the
+        // poll loop's TimerDelay continuation is posted the pause is already lifted. Measured
+        // 2026-07-11: compile during pause self-resolved in ~5s. Off-thread resumes must still
+        // switch back before Unity API work after the wait returns.
         private async Task<bool> WaitForPlayModeExitAsync(CancellationToken ct)
         {
             int waitedMs = 0;
@@ -171,7 +175,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             while (EditorApplication.isPlaying && waitedMs < MAX_WAIT_MS)
             {
                 ct.ThrowIfCancellationRequested();
-                await TimerDelay.Wait(POLL_INTERVAL_MS, ct);
+                await TimerDelay.Wait(POLL_INTERVAL_MS, ct).ConfigureAwait(false);
+                // Why switch each poll: EditorApplication.isPlaying must be read on the main thread.
+                await MainThreadSwitcher.SwitchToMainThread(ct);
                 waitedMs += POLL_INTERVAL_MS;
             }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     BuildCompileLogContext(request),
                     correlationId);
                 preparationService.StopPlayMode();
-                bool exited = await WaitForPlayModeExitAsync(ct).ConfigureAwait(false);
+                bool exited = await WaitForPlayModeExitAsync(ct);
                 VibeLogger.LogInfo(
                     "compile_playmode_exit_observed",
                     exited ? "Play Mode exited before compile." : "Play Mode did not exit before compile.",
@@ -171,7 +171,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             while (EditorApplication.isPlaying && waitedMs < MAX_WAIT_MS)
             {
                 ct.ThrowIfCancellationRequested();
-                await TimerDelay.Wait(POLL_INTERVAL_MS, ct).ConfigureAwait(false);
+                await TimerDelay.Wait(POLL_INTERVAL_MS, ct);
                 waitedMs += POLL_INTERVAL_MS;
             }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileUseCase.cs
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     BuildCompileLogContext(request),
                     correlationId);
                 preparationService.StopPlayMode();
-                bool exited = await WaitForPlayModeExitAsync(ct);
+                bool exited = await WaitForPlayModeExitAsync(ct).ConfigureAwait(false);
                 VibeLogger.LogInfo(
                     "compile_playmode_exit_observed",
                     exited ? "Play Mode exited before compile." : "Play Mode did not exit before compile.",
@@ -151,7 +151,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // 3. Compilation execution
             ct.ThrowIfCancellationRequested();
-            CompileResult result = await _executeCompilationAsync(request, ct);
+            CompileResult result = await _executeCompilationAsync(request, ct).ConfigureAwait(false);
 
             // 4. Result formatting
             CompileResponse successResponse =
@@ -171,7 +171,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             while (EditorApplication.isPlaying && waitedMs < MAX_WAIT_MS)
             {
                 ct.ThrowIfCancellationRequested();
-                await TimerDelay.Wait(POLL_INTERVAL_MS, ct);
+                await TimerDelay.Wait(POLL_INTERVAL_MS, ct).ConfigureAwait(false);
                 waitedMs += POLL_INTERVAL_MS;
             }
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCodeServices.cs
@@ -149,8 +149,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static async Task ContinueAfterDrainAsync(Task currentDrainTask, Task nextDrainTask)
         {
-            await currentDrainTask;
-            await nextDrainTask;
+            await currentDrainTask.ConfigureAwait(false);
+            await nextDrainTask.ConfigureAwait(false);
         }
 
         private static Task ObserveDrainTask(Task drainTask)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AutoUsingResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AutoUsingResolver.cs
@@ -40,7 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 File.WriteAllText(sourcePath, currentSource);
                 // AssemblyBuilder retries must stay on Unity's main thread because the compiler API is not thread-safe.
-                CompilerMessage[] messages = await buildFunc(sourcePath, dllPath, mutableReferences, ct);
+                CompilerMessage[] messages = await buildFunc(sourcePath, dllPath, mutableReferences, ct).ConfigureAwait(false);
 
                 List<string> unresolvedTypes = ExtractUnresolvedTypes(messages);
                 if (unresolvedTypes.Count == 0)
@@ -103,7 +103,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Final compilation with all added usings
             File.WriteAllText(sourcePath, currentSource);
-            CompilerMessage[] finalMessages = await buildFunc(sourcePath, dllPath, mutableReferences, ct);
+            CompilerMessage[] finalMessages = await buildFunc(sourcePath, dllPath, mutableReferences, ct).ConfigureAwait(false);
             return new AutoUsingResult(
                 currentSource,
                 finalMessages,

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AutoUsingResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AutoUsingResolver.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor.Compilation;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -40,8 +42,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 File.WriteAllText(sourcePath, currentSource);
                 // AssemblyBuilder retries must stay on Unity's main thread because the compiler API is not thread-safe.
-                // Why no ConfigureAwait(false): the next File.WriteAllText / buildFunc iteration must remain on the Editor thread.
-                CompilerMessage[] messages = await buildFunc(sourcePath, dllPath, mutableReferences, ct);
+                CompilerMessage[] messages = await buildFunc(sourcePath, dllPath, mutableReferences, ct).ConfigureAwait(false);
+                // Why switch back: ConfigureAwait(false) resumes off-thread, but the next
+                // File.WriteAllText / buildFunc iteration must remain on the Editor thread.
+                await MainThreadSwitcher.SwitchToMainThread(ct);
 
                 List<string> unresolvedTypes = ExtractUnresolvedTypes(messages);
                 if (unresolvedTypes.Count == 0)
@@ -104,8 +108,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Final compilation with all added usings
             File.WriteAllText(sourcePath, currentSource);
-            // Why no ConfigureAwait(false): AssemblyBuilder must continue on the Unity main thread.
-            CompilerMessage[] finalMessages = await buildFunc(sourcePath, dllPath, mutableReferences, ct);
+            CompilerMessage[] finalMessages = await buildFunc(sourcePath, dllPath, mutableReferences, ct).ConfigureAwait(false);
+            // Why switch back: AssemblyBuilder continuations must return to the Unity main thread
+            // before the resolver returns to callers that may touch Editor state.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
             return new AutoUsingResult(
                 currentSource,
                 finalMessages,

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AutoUsingResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AutoUsingResolver.cs
@@ -40,7 +40,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 File.WriteAllText(sourcePath, currentSource);
                 // AssemblyBuilder retries must stay on Unity's main thread because the compiler API is not thread-safe.
-                CompilerMessage[] messages = await buildFunc(sourcePath, dllPath, mutableReferences, ct).ConfigureAwait(false);
+                // Why no ConfigureAwait(false): the next File.WriteAllText / buildFunc iteration must remain on the Editor thread.
+                CompilerMessage[] messages = await buildFunc(sourcePath, dllPath, mutableReferences, ct);
 
                 List<string> unresolvedTypes = ExtractUnresolvedTypes(messages);
                 if (unresolvedTypes.Count == 0)
@@ -103,7 +104,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             // Final compilation with all added usings
             File.WriteAllText(sourcePath, currentSource);
-            CompilerMessage[] finalMessages = await buildFunc(sourcePath, dllPath, mutableReferences, ct).ConfigureAwait(false);
+            // Why no ConfigureAwait(false): AssemblyBuilder must continue on the Unity main thread.
+            CompilerMessage[] finalMessages = await buildFunc(sourcePath, dllPath, mutableReferences, ct);
             return new AutoUsingResult(
                 currentSource,
                 finalMessages,

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/CompiledAssemblyBuilder.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/CompiledAssemblyBuilder.cs
@@ -101,14 +101,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         cancellationToken,
                         () => canDeleteTempFiles = false,
                         () => canDeleteTempFiles = true,
-                        () => buildCount++);
+                        () => buildCount++).ConfigureAwait(false);
                     compilationBackendKind = backendResult.BackendKind;
                     buildStopwatch.Stop();
                     buildMilliseconds += buildStopwatch.Elapsed.TotalMilliseconds;
                     return backendResult.CompilerMessages;
                 }
 
-                BuildAttemptResult attemptResult = await BuildPreparedCodeAsync(plan.PreparedCode, ct);
+                BuildAttemptResult attemptResult = await BuildPreparedCodeAsync(plan.PreparedCode, ct).ConfigureAwait(false);
                 bool shouldCacheResult = true;
 
                 if (ShouldRetryWithoutLiteralHoisting(plan.PreparedCode, attemptResult.Diagnostics))
@@ -117,7 +117,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         plan.OriginalRequest.Code,
                         plan.NamespaceName,
                         plan.ClassName);
-                    attemptResult = await BuildPreparedCodeAsync(fallbackPreparedCode, ct);
+                    attemptResult = await BuildPreparedCodeAsync(fallbackPreparedCode, ct).ConfigureAwait(false);
                     shouldCacheResult = false;
                 }
 
@@ -160,7 +160,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         wrappedCode,
                         initialReferences,
                         BuildFunc,
-                        cancellationToken);
+                        cancellationToken).ConfigureAwait(false);
                     referenceResolutionMilliseconds += autoResult.ReferenceResolutionMilliseconds;
 
                     wrappedCode = autoResult.UpdatedSource;
@@ -183,7 +183,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                             originalWrappedCode,
                             rollbackReferences,
                             BuildFunc,
-                            cancellationToken);
+                            cancellationToken).ConfigureAwait(false);
                         referenceResolutionMilliseconds += rollbackResult.ReferenceResolutionMilliseconds;
 
                         CompilerDiagnostics rollbackDiagnostics = CompilerDiagnostics.FromMessages(rollbackResult.Messages);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeCompiler.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/DynamicCodeCompiler.cs
@@ -95,7 +95,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             Stopwatch builderTotalStopwatch = Stopwatch.StartNew();
-            CompiledAssemblyBuildResult buildResult = await _assemblyBuilder.BuildAsync(plan, ct);
+            CompiledAssemblyBuildResult buildResult = await _assemblyBuilder.BuildAsync(plan, ct).ConfigureAwait(false);
             builderTotalStopwatch.Stop();
             LastBuildCount = buildResult.BuildCount;
 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -68,7 +68,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
             // Why switch first: callers often resume off-thread via ConfigureAwait(false), but
             // BeginUndoGroup / EndExecution use Unity Undo APIs that require the main thread.
-            await MainThreadSwitcher.SwitchToMainThread(context.CancellationToken);
+            try
+            {
+                await MainThreadSwitcher.SwitchToMainThread(context.CancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Why catch here: a pre-cancelled token throws before TryBeginExecution,
+                // and callers expect a cancelled ExecutionResult rather than a leaked OCE.
+                return CreateCancelledResult();
+            }
+
             if (!TryBeginExecution(out int undoGroup, out CancellationTokenSource executionCancellationTokenSource))
             {
                 return CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_IN_PROGRESS);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/CommandRunner.cs
@@ -66,6 +66,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public async Task<ExecutionResult> ExecuteAsync(ExecutionContext context)
         {
             string correlationId = UnityCliLoopConstants.GenerateCorrelationId();
+            // Why switch first: callers often resume off-thread via ConfigureAwait(false), but
+            // BeginUndoGroup / EndExecution use Unity Undo APIs that require the main thread.
+            await MainThreadSwitcher.SwitchToMainThread(context.CancellationToken);
             if (!TryBeginExecution(out int undoGroup, out CancellationTokenSource executionCancellationTokenSource))
             {
                 return CreateErrorResult(UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_IN_PROGRESS);
@@ -76,15 +79,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 using CancellationTokenSource combinedCts = CreateCombinedCancellationTokenSource(
                     context,
                     executionCancellationTokenSource);
-                return await ExecuteInternalAsync(context, combinedCts.Token);
+                ExecutionResult result = await ExecuteInternalAsync(context, combinedCts.Token).ConfigureAwait(false);
+                await MainThreadSwitcher.SwitchToMainThread();
+                return result;
             }
             catch (OperationCanceledException)
             {
+                await MainThreadSwitcher.SwitchToMainThread();
                 return CreateCancelledResult();
             }
             catch (Exception ex)
             {
                 LogExecutionError(ex, correlationId);
+                await MainThreadSwitcher.SwitchToMainThread();
 
                 return CreateErrorResult(
                     ex.Message,
@@ -296,7 +303,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         cancellationToken);
                     object invoked = executeAsyncMethod.Invoke(instance, callArgs);
 
-                    object awaitedResult = await AwaitableHelper.AwaitIfNeeded(invoked, cancellationToken);
+                    object awaitedResult = await AwaitableHelper.AwaitIfNeeded(invoked, cancellationToken).ConfigureAwait(false);
                     string resultString = awaitedResult?.ToString() ?? "";
 
                     return CreateSuccessResult(resultString);

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionFacade.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionFacade.cs
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ExecutionResult result = await _executionScheduler.RunForegroundAsync(
                 innerCancellationToken => ExecuteCoreAsync(request, innerCancellationToken),
                 CreateExecutionInProgressResult,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
             schedulerStopwatch.Stop();
             AppendTiming(result, $"[Perf] SchedulerTotal: {schedulerStopwatch.Elapsed.TotalMilliseconds:F1}ms");
             return result;
@@ -56,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             (bool entered, ExecutionResult result) = await _executionScheduler.TryRunIfIdleAsync(
                 request.YieldToForegroundRequests,
                 innerCancellationToken => ExecuteCoreAsync(request, innerCancellationToken),
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
             schedulerStopwatch.Stop();
             AppendTiming(result, $"[Perf] SchedulerTotal: {schedulerStopwatch.Elapsed.TotalMilliseconds:F1}ms");
             return (entered, result);
@@ -76,7 +76,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 request.ClassName,
                 request.Parameters,
                 cancellationToken,
-                request.CompileOnly);
+                request.CompileOnly).ConfigureAwait(false);
             executorTotalStopwatch.Stop();
 
             if (result.Timings == null)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionScheduler.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionScheduler.cs
@@ -67,13 +67,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ThrowIfDisposed();
             cancellationToken.ThrowIfCancellationRequested();
 
-            bool entered = await _executionSemaphore.WaitAsync(0, cancellationToken);
+            bool entered = await _executionSemaphore.WaitAsync(0, cancellationToken).ConfigureAwait(false);
             if (!entered)
             {
-                await _hooks.InvokeAfterBusySemaphoreProbeFailedAsync();
+                await _hooks.InvokeAfterBusySemaphoreProbeFailedAsync().ConfigureAwait(false);
                 if (!TryCancelBackgroundPrewarm())
                 {
-                    entered = await TryAcquireAfterBusyHandoffAsync(cancellationToken);
+                    entered = await TryAcquireAfterBusyHandoffAsync(cancellationToken).ConfigureAwait(false);
                     if (!entered)
                     {
                         return createBusyResult();
@@ -83,7 +83,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 {
                     entered = await TryAcquireAfterBusyHandoffAsync(
                         cancellationToken,
-                        _cancelledPrewarmHandoffWindowMilliseconds);
+                        _cancelledPrewarmHandoffWindowMilliseconds).ConfigureAwait(false);
                     if (!entered)
                     {
                         return createBusyResult();
@@ -99,7 +99,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 executionCancellationTokenSource =
                     CreateExecutionCancellationTokenSource(cancellationToken);
                 SetExecutionState(false, executionCancellationTokenSource);
-                return await action(executionCancellationTokenSource.Token);
+                return await action(executionCancellationTokenSource.Token).ConfigureAwait(false);
             }
             finally
             {
@@ -117,7 +117,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (!yieldToForegroundRequests)
             {
-                return await TryRunWithoutForegroundYieldAsync(action, cancellationToken);
+                return await TryRunWithoutForegroundYieldAsync(action, cancellationToken).ConfigureAwait(false);
             }
 
             bool entered;
@@ -149,9 +149,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                await _hooks.InvokeAfterBackgroundExecutionStatePublishedAsync();
+                await _hooks.InvokeAfterBackgroundExecutionStatePublishedAsync().ConfigureAwait(false);
                 _hooks.AfterSemaphoreEntered?.Invoke();
-                T result = await action(executionCancellationTokenSource.Token);
+                T result = await action(executionCancellationTokenSource.Token).ConfigureAwait(false);
                 return (true, result);
             }
             finally
@@ -209,7 +209,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);
 
-            Task completedTask = await Task.WhenAny(_shutdownCompletionSource.Task, delayTask);
+            Task completedTask = await Task.WhenAny(_shutdownCompletionSource.Task, delayTask).ConfigureAwait(false);
             if (completedTask == _shutdownCompletionSource.Task)
             {
                 timeoutCancellationTokenSource.Cancel();
@@ -227,7 +227,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Func<CancellationToken, Task<T>> action,
             CancellationToken cancellationToken)
         {
-            bool entered = await _executionSemaphore.WaitAsync(0, cancellationToken);
+            bool entered = await _executionSemaphore.WaitAsync(0, cancellationToken).ConfigureAwait(false);
             if (!entered)
             {
                 return (false, default);
@@ -241,7 +241,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 executionCancellationTokenSource =
                     CreateExecutionCancellationTokenSource(cancellationToken);
                 SetExecutionState(false, executionCancellationTokenSource);
-                T result = await action(executionCancellationTokenSource.Token);
+                T result = await action(executionCancellationTokenSource.Token).ConfigureAwait(false);
                 return (true, result);
             }
             finally
@@ -302,7 +302,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             try
             {
-                await _executionSemaphore.WaitAsync(handoffCancellationTokenSource.Token);
+                await _executionSemaphore.WaitAsync(handoffCancellationTokenSource.Token).ConfigureAwait(false);
                 return true;
             }
             catch (OperationCanceledException)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionSchedulerHooks.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutionSchedulerHooks.cs
@@ -38,7 +38,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            await AfterBackgroundExecutionStatePublishedAsync();
+            await AfterBackgroundExecutionStatePublishedAsync().ConfigureAwait(false);
         }
 
         public async Task InvokeAfterBusySemaphoreProbeFailedAsync()
@@ -48,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return;
             }
 
-            await AfterBusySemaphoreProbeFailedAsync();
+            await AfterBusySemaphoreProbeFailedAsync().ConfigureAwait(false);
         }
 
         public void InvokeLogWarning(string message)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeExecutor.cs
@@ -56,7 +56,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     className);
                 sourcePreparationStopwatch.Stop();
                 Stopwatch compileTotalStopwatch = Stopwatch.StartNew();
-                CompilationResult compilationResult = await CompileCodeAsync(code, className, cancellationToken);
+                CompilationResult compilationResult = await CompileCodeAsync(code, className, cancellationToken).ConfigureAwait(false);
                 compileTotalStopwatch.Stop();
 
                 ExecutionResult compilationFailureResult = TryCreateCompilationFailureResult(
@@ -88,7 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 };
 
                 Stopwatch executionStopwatch = Stopwatch.StartNew();
-                ExecutionResult executionResult = await _invoker.ExecuteAsync(context);
+                ExecutionResult executionResult = await _invoker.ExecuteAsync(context).ConfigureAwait(false);
                 executionStopwatch.Stop();
 
                 executionResult.ExecutionTime = totalStopwatch.Elapsed;
@@ -155,7 +155,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 Namespace = DynamicCodeConstants.DEFAULT_NAMESPACE
             };
 
-            CompilationResult result = await _compiler.CompileAsync(request, ct);
+            CompilationResult result = await _compiler.CompileAsync(request, ct).ConfigureAwait(false);
             if (!result.Success)
             {
                 lock (_statsLock)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeForegroundWarmupRunner.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Execution/DynamicCodeForegroundWarmupRunner.cs
@@ -22,7 +22,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 DynamicCodeExecutionRequest request = CreateRequest(
                     warmupCode,
                     yieldToForegroundRequests);
-                ExecutionResult result = await runtime.ExecuteAsync(request, ct);
+                ExecutionResult result = await runtime.ExecuteAsync(request, ct).ConfigureAwait(false);
                 if (!result.Success)
                 {
                     return false;
@@ -46,7 +46,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 DynamicCodeExecutionRequest request = CreateRequest(
                     warmupCode,
                     yieldToForegroundRequests);
-                (bool entered, ExecutionResult result) = await runtime.TryExecuteIfIdleAsync(request, ct);
+                (bool entered, ExecutionResult result) = await runtime.TryExecuteIfIdleAsync(request, ct).ConfigureAwait(false);
                 if (!entered || !result.Success)
                 {
                     return false;

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputUseCase.cs
@@ -86,7 +86,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 correlationId: correlationId
             );
 
-            await Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
             return response;
 #endif
         }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
@@ -108,7 +108,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     runGuid,
                     hooks,
                     stopWaitTimeoutMilliseconds,
-                    pollIntervalMilliseconds);
+                    pollIntervalMilliseconds).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -172,7 +172,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     () => !hooks.IsPlaying(),
                     hooks.DelayAsync,
                     stopWaitTimeoutMilliseconds,
-                    pollIntervalMilliseconds);
+                    pollIntervalMilliseconds).ConfigureAwait(false);
                 playModeExitConfirmed = confirmed;
                 stopWaitTimedOut = timedOut;
             }
@@ -182,7 +182,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     () => !hooks.IsRunActive(),
                     hooks.DelayAsync,
                     stopWaitTimeoutMilliseconds,
-                    pollIntervalMilliseconds);
+                    pollIntervalMilliseconds).ConfigureAwait(false);
                 stopWaitTimedOut = timedOut;
                 if (!confirmed)
                 {
@@ -221,7 +221,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     return (true, false);
                 }
 
-                await delayAsync(pollIntervalMilliseconds, CancellationToken.None);
+                await delayAsync(pollIntervalMilliseconds, CancellationToken.None).ConfigureAwait(false);
                 elapsedMilliseconds += pollIntervalMilliseconds;
             }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsCancelStopRestore.cs
@@ -4,6 +4,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -216,6 +218,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int elapsedMilliseconds = 0;
             while (elapsedMilliseconds < timeoutMilliseconds)
             {
+                await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
                 if (isDone())
                 {
                     return (true, false);
@@ -225,6 +228,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 elapsedMilliseconds += pollIntervalMilliseconds;
             }
 
+            await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
             return (isDone(), true);
         }
 

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -114,17 +114,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (parameters.TestMode == UnityCliLoopTestMode.PlayMode)
                 {
-                    result = await _executionService.ExecutePlayModeTestAsync(filter, executionCt);
+                    result = await _executionService.ExecutePlayModeTestAsync(filter, executionCt).ConfigureAwait(false);
                 }
                 else
                 {
-                    result = await _executionService.ExecuteEditModeTestAsync(filter, executionCt);
+                    result = await _executionService.ExecuteEditModeTestAsync(filter, executionCt).ConfigureAwait(false);
                 }
 
                 // Why parent ct (not executionCt): CancelAfter only guards the RunFinished wait.
                 // Using the linked token here would mis-report a successful run as timed out when
                 // the fixed cleanup delay straddles the deadline after RunFinished already arrived.
-                await _waitForTestRunnerCleanupAsync(ct);
+                await _waitForTestRunnerCleanupAsync(ct).ConfigureAwait(false);
             }
             catch (RunTestsExecutionCanceledException canceledException)
                 when (RunTestsExecutionTimeout.IsTimeoutCancellation(ct))
@@ -207,7 +207,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             // Why: Unity Test Framework exposes the real active-run signal only through internal API,
             // while the public RunFinished callback fires before cleanup tasks such as RestoreSceneSetupTask.
-            await TimerDelay.Wait(TestRunnerCleanupFallbackDelayMilliseconds, ct);
+            await TimerDelay.Wait(TestRunnerCleanupFallbackDelayMilliseconds, ct).ConfigureAwait(false);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsUseCase.cs
@@ -100,11 +100,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string[] clearedPausePointIds = _clearActivePausePoints();
 
             // 2. Test execution
-            // Why these awaits do not use ConfigureAwait(false): the entry clears all active
-            // pause points and the server is single-flight (BUSY rejects concurrent commands),
-            // so no CLI-originated pause can fire during test execution. The only remaining
-            // pause source is a human manually pausing via the Editor UI, which is native
-            // Unity behavior and out of scope.
+            // Why ConfigureAwait(false) is paired with SwitchToMainThread inside execution helpers:
+            // the server is single-flight (BUSY rejects concurrent commands), so no CLI-originated
+            // pause can fire during test execution. Off-thread resumes must switch back before any
+            // Unity API work (stop/restore, cleanup delay, callback dispose).
             ct.ThrowIfCancellationRequested();
             using CancellationTokenSource timeoutCancellationTokenSource =
                 RunTestsExecutionTimeout.CreateLinkedTimeoutSource(ct, parameters.TimeoutSeconds);
@@ -124,6 +123,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 // Why parent ct (not executionCt): CancelAfter only guards the RunFinished wait.
                 // Using the linked token here would mis-report a successful run as timed out when
                 // the fixed cleanup delay straddles the deadline after RunFinished already arrived.
+                await MainThreadSwitcher.SwitchToMainThread(ct);
                 await _waitForTestRunnerCleanupAsync(ct).ConfigureAwait(false);
             }
             catch (RunTestsExecutionCanceledException canceledException)

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using UnityEditor.TestTools.TestRunner.Api;
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Editor")]
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -56,6 +58,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             catch (OperationCanceledException originalException)
             {
+                // Why switch first: ExecuteTestWithEventNotification may resume off-thread via
+                // ConfigureAwait(false), but stop/restore hooks call Unity Play Mode APIs.
+                await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: true,
                     runGuid: runGuid,
@@ -64,6 +69,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             finally
             {
+                await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
                 scope.Dispose();
             }
         }
@@ -84,6 +90,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
             catch (OperationCanceledException originalException)
             {
+                await MainThreadSwitcher.SwitchToMainThread(CancellationToken.None);
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: false,
                     runGuid: runGuid,
@@ -124,6 +131,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             using CancellationTokenRegistration cancellationRegistration =
                 ct.Register(() => taskCompletionSource.TrySetCanceled(ct));
             SerializableTestResult result = await taskCompletionSource.Task.ConfigureAwait(false);
+            // Why switch back: UnifiedTestCallback.Dispose unregisters TestRunnerApi callbacks
+            // and must run on the Unity main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
             ct.ThrowIfCancellationRequested();
             return result;
         }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/TestFramework/PlayModeTestExecuter.cs
@@ -52,14 +52,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     TestMode.PlayMode,
                     filter,
                     ct,
-                    startedRunGuid => runGuid = startedRunGuid);
+                    startedRunGuid => runGuid = startedRunGuid).ConfigureAwait(false);
             }
             catch (OperationCanceledException originalException)
             {
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: true,
                     runGuid: runGuid,
-                    RunTestsCancelStopRestoreUnityHooks.Resolve());
+                    RunTestsCancelStopRestoreUnityHooks.Resolve()).ConfigureAwait(false);
                 throw new RunTestsExecutionCanceledException(originalException.CancellationToken, stopResult);
             }
             finally
@@ -80,14 +80,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     TestMode.EditMode,
                     filter,
                     ct,
-                    startedRunGuid => runGuid = startedRunGuid);
+                    startedRunGuid => runGuid = startedRunGuid).ConfigureAwait(false);
             }
             catch (OperationCanceledException originalException)
             {
                 RunTestsCancelStopRestoreResult stopResult = await RunTestsCancelStopRestore.StopAndRestoreAsync(
                     isPlayMode: false,
                     runGuid: runGuid,
-                    RunTestsCancelStopRestoreUnityHooks.Resolve());
+                    RunTestsCancelStopRestoreUnityHooks.Resolve()).ConfigureAwait(false);
                 throw new RunTestsExecutionCanceledException(originalException.CancellationToken, stopResult);
             }
         }
@@ -123,7 +123,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // keeping the TestRunnerApi callback subscription alive forever.
             using CancellationTokenRegistration cancellationRegistration =
                 ct.Register(() => taskCompletionSource.TrySetCanceled(ct));
-            SerializableTestResult result = await taskCompletionSource.Task;
+            SerializableTestResult result = await taskCompletionSource.Task.ConfigureAwait(false);
             ct.ThrowIfCancellationRequested();
             return result;
         }

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -117,15 +117,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         keyboard,
                         key,
                         parameters.Duration,
-                        ct);
+                        ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopKeyboardAction.KeyDown:
-                    response = await KeyboardInputActionExecutor.ExecuteKeyDown(keyboard, key, ct);
+                    response = await KeyboardInputActionExecutor.ExecuteKeyDown(keyboard, key, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopKeyboardAction.KeyUp:
-                    response = await KeyboardInputActionExecutor.ExecuteKeyUp(keyboard, key, ct);
+                    response = await KeyboardInputActionExecutor.ExecuteKeyUp(keyboard, key, ct).ConfigureAwait(false);
                     break;
 
                 default:

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -106,23 +106,23 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             switch (parameters.Action)
             {
                 case UnityCliLoopMouseInputAction.Click:
-                    response = await MouseInputPressActionExecutor.ExecuteClick(mouse, parameters, ct);
+                    response = await MouseInputPressActionExecutor.ExecuteClick(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopMouseInputAction.LongPress:
-                    response = await MouseInputPressActionExecutor.ExecuteLongPress(mouse, parameters, ct);
+                    response = await MouseInputPressActionExecutor.ExecuteLongPress(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopMouseInputAction.MoveDelta:
-                    response = await MouseInputMotionActionExecutor.ExecuteMoveDelta(mouse, parameters, ct);
+                    response = await MouseInputMotionActionExecutor.ExecuteMoveDelta(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopMouseInputAction.Scroll:
-                    response = await MouseInputMotionActionExecutor.ExecuteScroll(mouse, parameters, ct);
+                    response = await MouseInputMotionActionExecutor.ExecuteScroll(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 case UnityCliLoopMouseInputAction.SmoothDelta:
-                    response = await MouseInputMotionActionExecutor.ExecuteSmoothDelta(mouse, parameters, ct);
+                    response = await MouseInputMotionActionExecutor.ExecuteSmoothDelta(mouse, parameters, ct).ConfigureAwait(false);
                     break;
 
                 default:

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
@@ -190,6 +190,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             WatchCompilationResult compilationResult = await WatchExpressionServices.Compiler
                 .CompileAsync(parameters.Expression, ct).ConfigureAwait(false);
+            // Why switch back: CompileAsync resumes off-thread, but Registry/EnsureMonitorStarted
+            // touch EditorApplication.update and must run on the Unity main thread.
+            await MainThreadSwitcher.SwitchToMainThread(ct);
             if (!compilationResult.Success)
             {
                 return CreateCompilationFailure(compilationResult);

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
@@ -189,7 +189,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             WatchCompilationResult compilationResult = await WatchExpressionServices.Compiler
-                .CompileAsync(parameters.Expression, ct);
+                .CompileAsync(parameters.Expression, ct).ConfigureAwait(false);
             if (!compilationResult.Success)
             {
                 return CreateCompilationFailure(compilationResult);

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcRequestProcessor.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcRequestProcessor.cs
@@ -14,8 +14,6 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
     /// <summary>
     /// Class specialized in handling JSON-RPC 2.0 processing
     /// 
-    /// Design document reference: Packages/src/Editor/ARCHITECTURE.md
-    /// 
     /// Related classes:
     /// - UnityCliLoopExecutionRouter: Executes Unity requests based on JSON-RPC requests
     /// - Project IPC server: Receives JSON-RPC messages from CLI clients

--- a/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseFactory.cs
+++ b/Packages/src/Editor/Infrastructure/Api/JsonRpcResponseFactory.cs
@@ -34,21 +34,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 );
                 return JsonConvert.SerializeObject(response, Formatting.None, ResponseSerializerSettings);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // Return safe fallback response for any serialization errors
-                object fallbackResult = new
-                {
-                    error = "Serialization failed - returning safe fallback",
-                    commandType = result != null ? result.GetType().Name : "unknown"
-                };
-
-                JsonRpcSuccessResponse fallbackResponse = new(
+                // Why error frame instead of success+error object: clients treat jsonrpc success as
+                // completed tool results; a fake success would hide serialization failure from agents.
+                string commandType = result != null ? result.GetType().Name : "unknown";
+                JsonRpcErrorResponse errorResponse = new(
                     UnityCliLoopServerConfig.JSONRPC_VERSION,
                     id,
-                    fallbackResult
-                );
-                return JsonConvert.SerializeObject(fallbackResponse, Formatting.None, ResponseSerializerSettings);
+                    new JsonRpcError(
+                        UnityCliLoopServerConfig.INTERNAL_ERROR_CODE,
+                        "Failed to serialize the tool response.",
+                        new InternalErrorData(
+                            $"Serialization failed for response type '{commandType}': {ex.Message}")));
+                return JsonConvert.SerializeObject(errorResponse, Formatting.None, ResponseSerializerSettings);
             }
         }
 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardStartupFlow.cs
@@ -154,7 +154,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         internal void TryShowOnVersionChange()
         {
-            EvaluateVersionChange(CancellationToken.None);
+            EvaluateVersionChange(CancellationToken.None).Forget();
         }
 
         private static bool TryGetMajorVersion(string version, out int majorVersion)
@@ -170,7 +170,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return int.TryParse(majorText, out majorVersion);
         }
 
-        private async void EvaluateVersionChange(CancellationToken ct)
+        private async Task EvaluateVersionChange(CancellationToken ct)
         {
             string currentVersion = UnityCliLoopConstants.PackageInfo.version;
             string currentMinimumDispatcherVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -541,10 +541,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         internal static bool ShouldShowSkillsInstalledDialog(
             IEnumerable<SkillSetupTargetInfo> targets)
         {
-            Debug.Assert(targets != null, "targets must not be null");
-            return targets.All(target =>
-                target.InstallState != SkillInstallState.Outdated
-                && !target.HasDifferentLayoutSkills);
+            return SkillInstallDialogPolicy.ShouldShowForInstallableTargets(targets);
         }
 
         internal static bool ShouldUseFirstInstallSkillsUi(string lastSeenSetupWizardVersion)
@@ -579,8 +576,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             RuntimePlatform platform,
             bool hasPackageOwnedCurrentUserInstall)
         {
-            return platform != RuntimePlatform.WindowsEditor
-                && hasPackageOwnedCurrentUserInstall;
+            return CliPathSetupCheckPolicy.ShouldCheck(
+                isWindowsEditor: platform == RuntimePlatform.WindowsEditor,
+                hasPackageOwnedCurrentUserInstall);
         }
 
         private static CliSetupCompatibilityState EvaluateCliSetupCompatibilityForSetupWizard(
@@ -762,7 +760,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 : SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
             if (installableTargets.Count == 0) return;
 
-            bool shouldShowSkillsInstalledDialog = ShouldShowSkillsInstalledDialog(installableTargets);
+            bool shouldShowSkillsInstalledDialog =
+                SkillInstallDialogPolicy.ShouldShowForInstallableTargets(installableTargets);
             _isInstallingSkills = true;
             UpdateSkillsStep(true, targets);
 

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -379,10 +379,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             InitializeApplicationServices();
             _view = ThirdPartyToolMigrationWizardView.Create(
                 rootVisualElement,
-                RefreshUI,
-                HandleMigrateThirdPartyTools,
+                () => RefreshUI().Forget(),
+                () => HandleMigrateThirdPartyTools().Forget(),
                 HandleMigrationSkillTargetChanged,
-                HandleToggleMigrationSkill,
+                () => HandleToggleMigrationSkill().Forget(),
                 Close);
             _resizer = new ThirdPartyToolMigrationWizardWindowResizer(this, _view.MainScrollView);
             _resizer.BindSizeUpdates();
@@ -425,10 +425,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
-            rootVisualElement.schedule.Execute(RefreshUI).StartingIn(0);
+            rootVisualElement.schedule.Execute(() => RefreshUI().Forget()).StartingIn(0);
         }
 
-        private async void RefreshUI()
+        private async Task RefreshUI()
         {
             CancellationToken ct = BeginMigrationOperation();
             ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
@@ -477,7 +477,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ShowMigrationTargetsState(preview.FilePaths);
         }
 
-        private async void HandleMigrateThirdPartyTools()
+        private async Task HandleMigrateThirdPartyTools()
         {
             if (!ConfirmMigrationApply(
                 _pendingMigrationFilePaths.Length,
@@ -546,7 +546,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 CompleteMigrationOperation(ct);
                 if (shouldRefreshAfterInterruptedMigration)
                 {
-                    RefreshUI();
+                    await RefreshUI();
                 }
             }
 
@@ -557,7 +557,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (ShouldRefreshAfterMigration(result))
             {
-                RefreshUI();
+                await RefreshUI();
                 return;
             }
 
@@ -626,7 +626,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             RefreshMigrationSkillState();
         }
 
-        private async void HandleToggleMigrationSkill()
+        private async Task HandleToggleMigrationSkill()
         {
             CancellationToken ct = BeginMigrationSkillOperation();
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
@@ -767,7 +767,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
-            rootVisualElement.schedule.Execute(RefreshUI).StartingIn(0);
+            rootVisualElement.schedule.Execute(() => RefreshUI().Forget()).StartingIn(0);
         }
 
         private void CompleteMigrationOperation(CancellationToken ct)

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -7,7 +7,7 @@ using io.github.hatayama.UnityCliLoop.Domain;
 namespace io.github.hatayama.UnityCliLoop.Presentation
 {
     /// <summary>
-    /// Presents the CLI setup section in the Unity CLI Loop settings window.
+    /// Presents the CLI setup section and owns Settings primary-action mediation decisions.
     /// </summary>
     internal sealed class UnityCliLoopSettingsCliSetupPresenter
     {
@@ -48,6 +48,89 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 skillsTarget,
                 isInstallingSkills);
             _view.UpdateCliSetup(cliData);
+        }
+
+        internal CliSetupPrimaryAction ResolveCurrentPrimaryButtonAction(bool needsCliPathSetup)
+        {
+            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
+            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
+            string cliExecutablePath = _cliSetupApplicationService.GetCachedCliExecutablePath();
+            bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
+                cliExecutablePath,
+                UnityEngine.Application.platform);
+            string requiredCliVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
+            return ResolveCliPrimaryButtonAction(
+                needsCliPathSetup,
+                cliVersion,
+                cliIsDispatcher,
+                canUninstallCli,
+                requiredCliVersion);
+        }
+
+        internal static bool ShouldUninstallCliFromPrimaryButton(
+            string cliVersion,
+            bool cliIsDispatcher,
+            bool canUninstallCli,
+            string requiredCliVersion)
+        {
+            bool isCliInstalled = cliVersion != null;
+            bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
+            return CliSetupPrimaryActionPolicy.ShouldUninstallCli(
+                isCliInstalled,
+                needsUpdate,
+                canUninstallCli);
+        }
+
+        internal static CliSetupPrimaryAction ResolveCliPrimaryButtonAction(
+            bool needsCliPathSetup,
+            string cliVersion,
+            bool cliIsDispatcher,
+            bool canUninstallCli,
+            string requiredCliVersion)
+        {
+            bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
+            bool isCliInstalled = cliVersion != null;
+            return CliSetupPrimaryActionPolicy.ResolveSettingsPrimaryAction(
+                needsCliPathSetup,
+                needsUpdate,
+                isCliInstalled,
+                canUninstallCli);
+        }
+
+        internal static CliSetupPrimaryAction ResolveExecutableCliPrimaryButtonAction(
+            CliSetupPrimaryAction clickedAction,
+            CliSetupPrimaryAction refreshedAction)
+        {
+            return CliSetupPrimaryActionPolicy.ResolveExecutableSettingsAction(
+                clickedAction,
+                refreshedAction);
+        }
+
+        internal static bool ShouldRepairCliPathFromPrimaryButton(
+            bool needsCliPathSetup,
+            bool needsUpdate)
+        {
+            return CliSetupPrimaryActionPolicy.ShouldRepairCliPath(needsCliPathSetup, needsUpdate);
+        }
+
+        internal static bool ShouldCheckCliPathSetupForPlatform(
+            RuntimePlatform platform,
+            bool hasPackageOwnedCurrentUserInstall)
+        {
+            return CliPathSetupCheckPolicy.ShouldCheck(
+                isWindowsEditor: platform == RuntimePlatform.WindowsEditor,
+                hasPackageOwnedCurrentUserInstall);
+        }
+
+        internal static bool IsCliUpdateNeeded(
+            string cliVersion,
+            bool cliIsDispatcher,
+            string requiredCliVersion)
+        {
+            return CliSetupCompatibility.Evaluate(
+                cliVersion,
+                cliIsDispatcher,
+                requiredCliVersion).NeedsUpdate;
         }
 
         private CliSetupData CreateCliSetupData(

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -73,7 +73,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canUninstallCli,
             string requiredCliVersion)
         {
-            bool isCliInstalled = cliVersion != null;
+            bool isCliInstalled = !string.IsNullOrEmpty(cliVersion);
             bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
             return CliSetupPrimaryActionPolicy.ShouldUninstallCli(
                 isCliInstalled,
@@ -89,7 +89,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string requiredCliVersion)
         {
             bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
-            bool isCliInstalled = cliVersion != null;
+            bool isCliInstalled = !string.IsNullOrEmpty(cliVersion);
             return CliSetupPrimaryActionPolicy.ResolveSettingsPrimaryAction(
                 needsCliPathSetup,
                 needsUpdate,
@@ -149,7 +149,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string cliExecutablePath = _cliSetupApplicationService.GetCachedCliExecutablePath();
             string requiredCliVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
 
-            bool isCliInstalled = cliVersion != null || needsCliPathSetup;
+            bool isCliInstalled = !string.IsNullOrEmpty(cliVersion) || needsCliPathSetup;
             bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
                 cliExecutablePath,
                 UnityEngine.Application.platform);

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsToolSettingsPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsToolSettingsPresenter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Application;
@@ -7,12 +8,23 @@ using io.github.hatayama.UnityCliLoop.Application;
 namespace io.github.hatayama.UnityCliLoop.Presentation
 {
     /// <summary>
-    /// Presents the Tool Settings section in the Unity CLI Loop settings window.
+    /// Presents the Tool Settings section and owns catalog cache / registry warmup.
     /// </summary>
     internal sealed class UnityCliLoopSettingsToolSettingsPresenter
     {
+        private const double RegistryWarmupInitialDelaySeconds = 0.05;
+        private const double RegistryWarmupMaxDelaySeconds = 0.8;
+        private const int RegistryWarmupMaxAttempts = 5;
+
         private readonly UnityCliLoopSettingsWindowUI _view;
         private readonly ToolSettingsUseCase _toolSettingsUseCase;
+
+        private bool _isCatalogDirty = true;
+        private bool _isRegistryWarmupScheduled;
+        private double _registryWarmupDueTime;
+        private int _registryWarmupAttemptCount;
+        private bool _showToolSettings = true;
+        private bool _isViewReady;
 
         internal UnityCliLoopSettingsToolSettingsPresenter(
             UnityCliLoopSettingsWindowUI view,
@@ -26,25 +38,138 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 ?? throw new ArgumentNullException(nameof(toolSettingsUseCase));
         }
 
+        internal void SetViewReady(bool isViewReady)
+        {
+            _isViewReady = isViewReady;
+            if (!isViewReady)
+            {
+                CancelRegistryWarmup();
+            }
+        }
+
+        internal void InvalidateCatalog()
+        {
+            _isCatalogDirty = true;
+        }
+
         internal void UpdateHeader(bool showToolSettings)
         {
+            _showToolSettings = showToolSettings;
             ToolSettingsSectionData toolSettingsData = CreateToolSettingsHeaderData(showToolSettings);
             _view.UpdateToolSettings(toolSettingsData);
         }
 
-        internal ToolSettingsSectionData UpdateCatalog(bool showToolSettings)
+        internal void RefreshCatalogIfNeeded(bool showToolSettings)
+        {
+            _showToolSettings = showToolSettings;
+            if (!showToolSettings || !_isCatalogDirty || !_isViewReady)
+            {
+                return;
+            }
+
+            RefreshCatalog(showToolSettings);
+        }
+
+        internal void HandleShowToolSettingsChanged(bool show)
+        {
+            UpdateHeader(show);
+            if (!show)
+            {
+                _isCatalogDirty = true;
+                CancelRegistryWarmup();
+                ResetRegistryWarmupAttemptCount();
+                return;
+            }
+
+            RefreshCatalogIfNeeded(show);
+        }
+
+        internal void CancelRegistryWarmup()
+        {
+            if (!_isRegistryWarmupScheduled)
+            {
+                return;
+            }
+
+            EditorApplication.update -= RunRegistryWarmupWhenDue;
+            _isRegistryWarmupScheduled = false;
+        }
+
+        internal void ResetRegistryWarmupAttemptCount()
+        {
+            _registryWarmupAttemptCount = 0;
+        }
+
+        private void RefreshCatalog(bool showToolSettings)
         {
             ToolSettingsSectionData toolSettingsData = CreateToolSettingsData(showToolSettings);
             _view.UpdateToolSettings(toolSettingsData);
-            return toolSettingsData;
+
+            if (UnityCliLoopSettingsWindowRefreshPolicy.ShouldKeepToolSettingsCatalogDirty(toolSettingsData))
+            {
+                if (ScheduleRegistryWarmup())
+                {
+                    _isCatalogDirty = true;
+                    return;
+                }
+
+                _isCatalogDirty = false;
+                return;
+            }
+
+            CancelRegistryWarmup();
+            ResetRegistryWarmupAttemptCount();
+            _isCatalogDirty = false;
+        }
+
+        private bool ScheduleRegistryWarmup()
+        {
+            if (UnityCliLoopSettingsWindowRefreshPolicy.ShouldStartToolSettingsRegistryWarmup(
+                    _isRegistryWarmupScheduled,
+                    _registryWarmupAttemptCount,
+                    RegistryWarmupMaxAttempts))
+            {
+                double delaySeconds = UnityCliLoopSettingsWindowRefreshPolicy.CalculateToolSettingsRegistryWarmupDelaySeconds(
+                    RegistryWarmupInitialDelaySeconds,
+                    RegistryWarmupMaxDelaySeconds,
+                    _registryWarmupAttemptCount);
+
+                _isRegistryWarmupScheduled = true;
+                _registryWarmupDueTime = EditorApplication.timeSinceStartup + delaySeconds;
+                _registryWarmupAttemptCount++;
+                EditorApplication.update += RunRegistryWarmupWhenDue;
+                return true;
+            }
+
+            return _isRegistryWarmupScheduled;
+        }
+
+        private void RunRegistryWarmupWhenDue()
+        {
+            if (EditorApplication.timeSinceStartup < _registryWarmupDueTime)
+            {
+                return;
+            }
+
+            CancelRegistryWarmup();
+
+            if (!_isViewReady || !_showToolSettings)
+            {
+                ResetRegistryWarmupAttemptCount();
+                return;
+            }
+
+            _toolSettingsUseCase.WarmupRegistry();
+            InvalidateCatalog();
+            RefreshCatalogIfNeeded(_showToolSettings);
         }
 
         private static ToolSettingsSectionData CreateToolSettingsHeaderData(bool showToolSettings)
         {
             return new ToolSettingsSectionData(
                 showToolSettings,
-                System.Array.Empty<ToolToggleItem>(),
-                System.Array.Empty<ToolToggleItem>(),
+                Array.Empty<ToolToggleItem>(),
+                Array.Empty<ToolToggleItem>(),
                 true,
                 false);
         }
@@ -58,8 +183,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             {
                 return new ToolSettingsSectionData(
                     showToolSettings,
-                    System.Array.Empty<ToolToggleItem>(),
-                    System.Array.Empty<ToolToggleItem>(),
+                    Array.Empty<ToolToggleItem>(),
+                    Array.Empty<ToolToggleItem>(),
                     false,
                     true);
             }

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -19,9 +19,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     {
         private const bool ForceFlatSkillInstall = true;
         private const double DeferredInitialRefreshDelaySeconds = 0.05;
-        private const double ToolSettingsRegistryWarmupInitialDelaySeconds = 0.05;
-        private const double ToolSettingsRegistryWarmupMaxDelaySeconds = 0.8;
-        private const int ToolSettingsRegistryWarmupMaxAttempts = 5;
 
         private static IUnityCliLoopEditorSettingsPort RegisteredEditorSettingsPort;
         private static ISessionFlagsRepository RegisteredSessionFlagsRepository;
@@ -49,13 +46,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private bool _isRefreshingVersion;
         private bool _isRefreshingCliPathSetup;
         private bool _needsCliPathSetup;
-        private bool _isToolSettingsCatalogDirty = true;
         private bool _isDeferredInitialRefreshScheduled;
         private bool _hasCompletedDeferredInitialRefresh;
         private double _deferredInitialRefreshDueTime;
-        private bool _isToolSettingsRegistryWarmupScheduled;
-        private double _toolSettingsRegistryWarmupDueTime;
-        private int _toolSettingsRegistryWarmupAttemptCount;
         private SkillInstallState _selectedTargetInstallState = SkillInstallState.Missing;
         private CancellationTokenSource _skillInstallStateRefreshCts;
 
@@ -107,9 +100,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void OnDestroy()
         {
             CancelDeferredInitialRefresh();
-            CancelToolSettingsRegistryWarmup();
-            ResetToolSettingsRegistryWarmupAttemptCount();
+            _toolSettingsPresenter?.CancelRegistryWarmup();
+            _toolSettingsPresenter?.ResetRegistryWarmupAttemptCount();
             CancelSkillInstallStateRefresh();
+            _toolSettingsPresenter?.SetViewReady(false);
             _view?.Dispose();
             _view = null;
             _cliSetupPresenter = null;
@@ -129,8 +123,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             InitializeModel();
             InitializeEventHandler();
             LoadSavedSettings();
-            RestoreSessionState();
-            HandlePostCompileMode();
+            _model.LoadFromSessionState();
+            HandlePostCompileMode().Forget();
         }
 
         private void InitializeModel()
@@ -159,14 +153,15 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _toolSettingsPresenter = new UnityCliLoopSettingsToolSettingsPresenter(
                 _view,
                 _toolSettingsUseCase);
+            _toolSettingsPresenter.SetViewReady(true);
             SetupViewCallbacks();
         }
 
         private void SetupViewCallbacks()
         {
-            _view.OnRefreshCliVersion += HandleRefreshCliVersion;
-            _view.OnInstallCli += HandleInstallCli;
-            _view.OnInstallSkills += HandleInstallSkills;
+            _view.OnRefreshCliVersion += () => HandleRefreshCliVersion().Forget();
+            _view.OnInstallCli += () => HandleInstallCli().Forget();
+            _view.OnInstallSkills += () => HandleInstallSkills().Forget();
             _view.OnRefreshSkillsState += HandleRefreshSkillsState;
             _view.OnSkillsTargetChanged += value =>
             {
@@ -196,12 +191,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _installSkillsFlat = ForceFlatSkillInstall;
         }
 
-        private void RestoreSessionState()
-        {
-            _model.LoadFromSessionState();
-        }
-
-        private async void HandlePostCompileMode()
+        private async Task HandlePostCompileMode()
         {
             _model.EnablePostCompileMode();
             _sessionFlagsRepository.SetShowReconnectingUI(false);
@@ -226,11 +216,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void OnDisable()
         {
             CancelDeferredInitialRefresh();
-            CancelToolSettingsRegistryWarmup();
-            ResetToolSettingsRegistryWarmupAttemptCount();
+            _toolSettingsPresenter?.CancelRegistryWarmup();
+            _toolSettingsPresenter?.ResetRegistryWarmupAttemptCount();
             CancelSkillInstallStateRefresh();
             CleanupEventHandler();
-            SaveSessionState();
+            _model?.SaveToSessionState();
+            _toolSettingsPresenter?.SetViewReady(false);
             _view?.Dispose();
             _view = null;
             _cliSetupPresenter = null;
@@ -240,11 +231,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void CleanupEventHandler()
         {
             _eventHandler?.Cleanup();
-        }
-
-        private void SaveSessionState()
-        {
-            _model.SaveToSessionState();
         }
 
         private void ScheduleDeferredInitialRefresh()
@@ -324,8 +310,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (runExpensiveChecks)
             {
-                RefreshCliVersionInBackground();
-                RefreshCliPathSetupInBackground();
+                RefreshCliVersionInBackground().Forget();
+                RefreshCliPathSetupInBackground().Forget();
                 if (refreshSkillInstallState)
                 {
                     RefreshSelectedTargetInstallStateInBackground();
@@ -336,11 +322,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             RefreshToolSettingsHeader();
             if (runExpensiveChecks)
             {
-                RefreshToolSettingsCatalogIfNeeded();
+                _toolSettingsPresenter?.RefreshCatalogIfNeeded(_model.UI.ShowToolSettings);
             }
         }
 
-        private async void RefreshCliVersionInBackground()
+        private async Task RefreshCliVersionInBackground()
         {
             if (_cliSetupApplicationService.IsCliCheckCompleted())
             {
@@ -348,12 +334,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             await _cliSetupApplicationService.RefreshCliVersionAsync(CancellationToken.None);
-            RefreshCliPathSetupInBackground();
+            RefreshCliPathSetupInBackground().Forget();
             RefreshCliSetupSection();
             RefreshSelectedTargetInstallStateInBackground();
         }
 
-        private async void RefreshCliPathSetupInBackground()
+        private async Task RefreshCliPathSetupInBackground()
         {
             if (_isRefreshingCliPathSetup)
             {
@@ -383,7 +369,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
         }
 
-        private async void HandleRefreshCliVersion()
+        private async Task HandleRefreshCliVersion()
         {
             if (_isRefreshingVersion)
             {
@@ -398,7 +384,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 Task forceRefresh = _cliSetupApplicationService.ForceRefreshCliVersionAsync(CancellationToken.None);
                 Task minimumDelay = Task.Delay(500);
                 await Task.WhenAll(forceRefresh, minimumDelay);
-                RefreshCliPathSetupInBackground();
+                RefreshCliPathSetupInBackground().Forget();
             }
             finally
             {
@@ -409,7 +395,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         public void InvalidateToolSettingsCatalog()
         {
-            _isToolSettingsCatalogDirty = true;
+            _toolSettingsPresenter?.InvalidateCatalog();
         }
 
         private void RefreshToolSettingsHeader()
@@ -422,120 +408,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _toolSettingsPresenter.UpdateHeader(_model.UI.ShowToolSettings);
         }
 
-        private void RefreshToolSettingsCatalog()
-        {
-            if (_toolSettingsPresenter == null)
-            {
-                return;
-            }
-
-            ToolSettingsSectionData toolSettingsData =
-                _toolSettingsPresenter.UpdateCatalog(_model.UI.ShowToolSettings);
-
-            if (UnityCliLoopSettingsWindowRefreshPolicy.ShouldKeepToolSettingsCatalogDirty(toolSettingsData))
-            {
-                if (ScheduleToolSettingsRegistryWarmup())
-                {
-                    _isToolSettingsCatalogDirty = true;
-                    return;
-                }
-
-                _isToolSettingsCatalogDirty = false;
-                return;
-            }
-
-            CancelToolSettingsRegistryWarmup();
-            ResetToolSettingsRegistryWarmupAttemptCount();
-            _isToolSettingsCatalogDirty = false;
-        }
-
-        private void RefreshToolSettingsCatalogIfNeeded()
-        {
-            if (!_model.UI.ShowToolSettings || !_isToolSettingsCatalogDirty)
-            {
-                return;
-            }
-
-            if (_view == null)
-            {
-                return;
-            }
-
-            RefreshToolSettingsCatalog();
-        }
-
         private void UpdateShowToolSettings(bool show)
         {
             _model.UpdateShowToolSettings(show);
-            RefreshToolSettingsHeader();
-
-            if (!show)
-            {
-                _isToolSettingsCatalogDirty = true;
-                CancelToolSettingsRegistryWarmup();
-                ResetToolSettingsRegistryWarmupAttemptCount();
-                return;
-            }
-
-            RefreshToolSettingsCatalogIfNeeded();
-        }
-
-        private bool ScheduleToolSettingsRegistryWarmup()
-        {
-            if (UnityCliLoopSettingsWindowRefreshPolicy.ShouldStartToolSettingsRegistryWarmup(
-                    _isToolSettingsRegistryWarmupScheduled,
-                    _toolSettingsRegistryWarmupAttemptCount,
-                    ToolSettingsRegistryWarmupMaxAttempts))
-            {
-                double delaySeconds = UnityCliLoopSettingsWindowRefreshPolicy.CalculateToolSettingsRegistryWarmupDelaySeconds(
-                    ToolSettingsRegistryWarmupInitialDelaySeconds,
-                    ToolSettingsRegistryWarmupMaxDelaySeconds,
-                    _toolSettingsRegistryWarmupAttemptCount);
-
-                _isToolSettingsRegistryWarmupScheduled = true;
-                _toolSettingsRegistryWarmupDueTime = EditorApplication.timeSinceStartup + delaySeconds;
-                _toolSettingsRegistryWarmupAttemptCount++;
-                EditorApplication.update += RunToolSettingsRegistryWarmupWhenDue;
-                return true;
-            }
-
-            return _isToolSettingsRegistryWarmupScheduled;
-        }
-
-        private void RunToolSettingsRegistryWarmupWhenDue()
-        {
-            if (EditorApplication.timeSinceStartup < _toolSettingsRegistryWarmupDueTime)
-            {
-                return;
-            }
-
-            CancelToolSettingsRegistryWarmup();
-
-            if (_view == null || !_model.UI.ShowToolSettings)
-            {
-                ResetToolSettingsRegistryWarmupAttemptCount();
-                return;
-            }
-
-            _toolSettingsUseCase.WarmupRegistry();
-            InvalidateToolSettingsCatalog();
-            RefreshToolSettingsCatalogIfNeeded();
-        }
-
-        private void CancelToolSettingsRegistryWarmup()
-        {
-            if (!_isToolSettingsRegistryWarmupScheduled)
-            {
-                return;
-            }
-
-            EditorApplication.update -= RunToolSettingsRegistryWarmupWhenDue;
-            _isToolSettingsRegistryWarmupScheduled = false;
-        }
-
-        private void ResetToolSettingsRegistryWarmupAttemptCount()
-        {
-            _toolSettingsRegistryWarmupAttemptCount = 0;
+            _toolSettingsPresenter?.HandleShowToolSettingsChanged(show);
         }
 
         private void HandleToolToggled(string toolName, bool enabled)
@@ -544,10 +420,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _view?.UpdateSingleToolToggle(toolName, enabled);
 
             // Skill synchronization can touch many files, so defer it to keep UI input responsive.
-            EditorApplication.delayCall += () => ApplyToolToggleSideEffects(toolName, enabled);
+            EditorApplication.delayCall += () => ApplyToolToggleSideEffects(toolName, enabled).Forget();
         }
 
-        private async void ApplyToolToggleSideEffects(string toolName, bool enabled)
+        private async Task ApplyToolToggleSideEffects(string toolName, bool enabled)
         {
             if (!enabled)
             {
@@ -597,16 +473,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private bool ShouldCheckCliPathSetup()
         {
-            return ShouldCheckCliPathSetupForPlatform(
+            return UnityCliLoopSettingsCliSetupPresenter.ShouldCheckCliPathSetupForPlatform(
                 UnityEngine.Application.platform,
                 _cliSetupApplicationService.HasPackageOwnedCurrentUserInstall(UnityEngine.Application.platform));
-        }
-
-        internal static bool ShouldCheckCliPathSetupForPlatform(
-            RuntimePlatform platform,
-            bool hasPackageOwnedCurrentUserInstall)
-        {
-            return platform != RuntimePlatform.WindowsEditor && hasPackageOwnedCurrentUserInstall;
         }
 
         private void RefreshSelectedTargetInstallStateFast()
@@ -646,10 +515,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             CancellationTokenSource cts = new();
             _skillInstallStateRefreshCts = cts;
-            RefreshSelectedTargetInstallStateAsync(cts.Token);
+            RefreshSelectedTargetInstallStateAsync(cts.Token).Forget();
         }
 
-        private async void RefreshSelectedTargetInstallStateAsync(CancellationToken ct)
+        private async Task RefreshSelectedTargetInstallStateAsync(CancellationToken ct)
         {
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             SkillInstallState installState = await Task.Run(
@@ -707,15 +576,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _skillInstallStateRefreshCts = null;
         }
 
-        private async void HandleInstallCli()
+        private async Task HandleInstallCli()
         {
-            CliSetupPrimaryAction clickedAction = GetCurrentCliPrimaryButtonAction();
+            CliSetupPrimaryAction clickedAction = _cliSetupPresenter.ResolveCurrentPrimaryButtonAction(_needsCliPathSetup);
 
             await RefreshCliPrimaryActionStateAsync(CancellationToken.None);
-            CliSetupPrimaryAction refreshedAction = GetCurrentCliPrimaryButtonAction();
-            CliSetupPrimaryAction executableAction = ResolveExecutableCliPrimaryButtonAction(
-                clickedAction,
-                refreshedAction);
+            CliSetupPrimaryAction refreshedAction = _cliSetupPresenter.ResolveCurrentPrimaryButtonAction(_needsCliPathSetup);
+            CliSetupPrimaryAction executableAction =
+                UnityCliLoopSettingsCliSetupPresenter.ResolveExecutableCliPrimaryButtonAction(
+                    clickedAction,
+                    refreshedAction);
             if (executableAction == CliSetupPrimaryAction.None)
             {
                 return;
@@ -771,69 +641,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
         }
 
-        private CliSetupPrimaryAction GetCurrentCliPrimaryButtonAction()
-        {
-            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
-            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
-            string cliExecutablePath = _cliSetupApplicationService.GetCachedCliExecutablePath();
-            bool canUninstallCli = _cliSetupApplicationService.IsPackageOwnedCurrentUserInstallPath(
-                cliExecutablePath,
-                UnityEngine.Application.platform);
-            string requiredCliVersion = _cliSetupApplicationService.GetMinimumRequiredCliVersion();
-            return ResolveCliPrimaryButtonAction(
-                _needsCliPathSetup,
-                cliVersion,
-                cliIsDispatcher,
-                canUninstallCli,
-                requiredCliVersion);
-        }
-
-        internal static bool ShouldUninstallCliFromPrimaryButton(
-            string cliVersion,
-            bool cliIsDispatcher,
-            bool canUninstallCli,
-            string requiredCliVersion)
-        {
-            bool isCliInstalled = cliVersion != null;
-            bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
-            return CliSetupPrimaryActionPolicy.ShouldUninstallCli(
-                isCliInstalled,
-                needsUpdate,
-                canUninstallCli);
-        }
-
-        internal static CliSetupPrimaryAction ResolveCliPrimaryButtonAction(
-            bool needsCliPathSetup,
-            string cliVersion,
-            bool cliIsDispatcher,
-            bool canUninstallCli,
-            string requiredCliVersion)
-        {
-            bool needsUpdate = IsCliUpdateNeeded(cliVersion, cliIsDispatcher, requiredCliVersion);
-            bool isCliInstalled = cliVersion != null;
-            return CliSetupPrimaryActionPolicy.ResolveSettingsPrimaryAction(
-                needsCliPathSetup,
-                needsUpdate,
-                isCliInstalled,
-                canUninstallCli);
-        }
-
-        internal static CliSetupPrimaryAction ResolveExecutableCliPrimaryButtonAction(
-            CliSetupPrimaryAction clickedAction,
-            CliSetupPrimaryAction refreshedAction)
-        {
-            return CliSetupPrimaryActionPolicy.ResolveExecutableSettingsAction(
-                clickedAction,
-                refreshedAction);
-        }
-
-        internal static bool ShouldRepairCliPathFromPrimaryButton(
-            bool needsCliPathSetup,
-            bool needsUpdate)
-        {
-            return CliSetupPrimaryActionPolicy.ShouldRepairCliPath(needsCliPathSetup, needsUpdate);
-        }
-
         private async Task RefreshCliPrimaryActionStateAsync(CancellationToken ct)
         {
             _isRefreshingVersion = true;
@@ -885,34 +692,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
         }
 
-        internal static bool IsCliUpdateNeeded(
-            string cliVersion,
-            bool cliIsDispatcher,
-            string requiredCliVersion)
-        {
-            return EvaluateCliSetupCompatibility(
-                cliVersion,
-                cliIsDispatcher,
-                requiredCliVersion).NeedsUpdate;
-        }
-
-        internal static bool ShouldShowSkillsInstalledDialog(SkillSetupTargetInfo targetInfo)
-        {
-            return targetInfo.InstallState != SkillInstallState.Outdated
-                && !targetInfo.HasDifferentLayoutSkills;
-        }
-
-        private static CliSetupCompatibilityState EvaluateCliSetupCompatibility(
-            string cliVersion,
-            bool cliIsDispatcher,
-            string requiredCliVersion)
-        {
-            return CliSetupCompatibility.Evaluate(
-                cliVersion,
-                cliIsDispatcher,
-                requiredCliVersion);
-        }
-
         private async Task HandleUninstallCli()
         {
             if (!CliUninstallPrompt.ConfirmUninstall())
@@ -944,7 +723,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
         }
 
-        private async void HandleInstallSkills()
+        private async Task HandleInstallSkills()
         {
             if (!_cliSetupApplicationService.IsCliInstalled())
             {
@@ -958,7 +737,8 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             SkillSetupTargetInfo selectedTargetInfo =
                 GetSelectedTargetInfo(projectRoot, includeFreshnessCheck: true);
-            bool shouldShowSkillsInstalledDialog = ShouldShowSkillsInstalledDialog(selectedTargetInfo);
+            bool shouldShowSkillsInstalledDialog =
+                SkillInstallDialogPolicy.ShouldShowForSelectedTarget(selectedTargetInfo);
             CancelSkillInstallStateRefresh();
             _isInstallingSkills = true;
             RefreshCliSetupSection();

--- a/cli/common/errors/cli_update_required_error_contract_test.go
+++ b/cli/common/errors/cli_update_required_error_contract_test.go
@@ -1,0 +1,76 @@
+package clierrors
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
+)
+
+const cliUpdateRequiredErrorContractPath = "tests/contracts/cli_update_required_error_contract.json"
+
+type cliUpdateRequiredErrorContractFile struct {
+	// This frame must remain backward compatible forever — old CLIs parse it to learn they must update.
+	Comment   string          `json:"comment"`
+	ErrorData json.RawMessage `json:"errorData"`
+}
+
+// Verifies the frozen cli_update_required error.data frame still classifies as CLI_UPDATE_REQUIRED.
+// This frame must remain backward compatible forever — old CLIs parse it to learn they must update.
+func TestClassifyError_WhenCliUpdateRequiredContractFixture_ClassifiesAsCLIUpdateRequired(t *testing.T) {
+	contract := readCliUpdateRequiredErrorContract(t)
+
+	err := &unityipc.RPCError{
+		Code:    -32603,
+		Message: "The installed uloop CLI uses an IPC protocol that does not match this Unity package.",
+		Data:    contract.ErrorData,
+	}
+
+	cliErr := ClassifyError(err, ErrorContext{ProjectRoot: "/tmp/MyProject", Command: "compile"})
+	if cliErr.ErrorCode != ErrorCodeCLIUpdateRequired {
+		t.Fatalf("expected %s, got %#v", ErrorCodeCLIUpdateRequired, cliErr)
+	}
+}
+
+func readCliUpdateRequiredErrorContract(t *testing.T) cliUpdateRequiredErrorContractFile {
+	t.Helper()
+
+	path := findRepoRelativeFile(t, cliUpdateRequiredErrorContractPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read cli_update_required error contract: %v", err)
+	}
+
+	var contract cliUpdateRequiredErrorContractFile
+	if err := json.Unmarshal(data, &contract); err != nil {
+		t.Fatalf("failed to unmarshal cli_update_required error contract: %v", err)
+	}
+	if len(contract.ErrorData) == 0 {
+		t.Fatal("cli_update_required error contract must include errorData")
+	}
+	return contract
+}
+
+func findRepoRelativeFile(t *testing.T, relativePath string) string {
+	t.Helper()
+
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to resolve current directory: %v", err)
+	}
+
+	for {
+		candidate := filepath.Join(directory, relativePath)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			t.Fatalf("failed to find %s from %s", relativePath, directory)
+		}
+		directory = parent
+	}
+}

--- a/cli/common/errors/transport_errors.go
+++ b/cli/common/errors/transport_errors.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"syscall"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
 // Reports whether the error means the transport dropped mid-request. Domain reload
@@ -27,10 +29,14 @@ func IsTransportDisconnectError(err error) bool {
 		return true
 	}
 
+	var noResponseErr *unityipc.NoResponseError
+	if errors.As(err, &noResponseErr) {
+		return true
+	}
+
 	// Fallback for errors that expose no typed cause.
 	message := err.Error()
-	return message == "UNITY_NO_RESPONSE" ||
-		strings.Contains(message, "EOF") ||
+	return strings.Contains(message, "EOF") ||
 		strings.Contains(message, "connection reset") ||
 		strings.Contains(message, "broken pipe") ||
 		strings.Contains(message, "use of closed network connection")

--- a/cli/common/errors/transport_errors_test.go
+++ b/cli/common/errors/transport_errors_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"syscall"
 	"testing"
+
+	"github.com/hatayama/unity-cli-loop/common/unityipc"
 )
 
 // Test support type that exposes a typed cause behind an opaque message, simulating
@@ -73,7 +75,6 @@ func TestIsTransportDisconnectErrorRejectsUnrelatedErrors(t *testing.T) {
 // Verifies the legacy string fallback still classifies errors without a typed cause.
 func TestIsTransportDisconnectErrorKeepsStringFallback(t *testing.T) {
 	fallbackErrors := []error{
-		fmt.Errorf("UNITY_NO_RESPONSE"),
 		fmt.Errorf("read tcp 127.0.0.1:1: connection reset by peer"),
 	}
 
@@ -81,6 +82,15 @@ func TestIsTransportDisconnectErrorKeepsStringFallback(t *testing.T) {
 		if !IsTransportDisconnectError(err) {
 			t.Fatalf("string fallback did not classify: %v", err)
 		}
+	}
+}
+
+// Verifies a wrapped NoResponseError is classified as a disconnect even when the
+// outer error message no longer matches the legacy UNITY_NO_RESPONSE sentinel.
+func TestIsTransportDisconnectErrorMatchesWrappedNoResponseError(t *testing.T) {
+	wrapped := fmt.Errorf("rpc failed: %w", &unityipc.NoResponseError{})
+	if !IsTransportDisconnectError(wrapped) {
+		t.Fatalf("wrapped NoResponseError was not classified as disconnect: %v", wrapped)
 	}
 }
 

--- a/cli/common/project/endpoint_contract_test.go
+++ b/cli/common/project/endpoint_contract_test.go
@@ -1,0 +1,100 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const endpointContractPath = "tests/contracts/endpoint_contract.json"
+
+type endpointContractFile struct {
+	Comment string                 `json:"comment"`
+	Cases   []endpointContractCase `json:"cases"`
+}
+
+type endpointContractCase struct {
+	ID                      string   `json:"id"`
+	CanonicalProjectRoot    string   `json:"canonicalProjectRoot"`
+	TrimOnlyEquivalentRoots []string `json:"trimOnlyEquivalentRoots"`
+	UnixSocketPath          string   `json:"unixSocketPath"`
+	WindowsPipePath         string   `json:"windowsPipePath"`
+}
+
+// Verifies Go CreateEndpoint matches the shared endpoint contract for already-canonicalized roots.
+func TestCreateEndpointMatchesSharedContract(t *testing.T) {
+	contract := readEndpointContract(t)
+	for _, contractCase := range contract.Cases {
+		contractCase := contractCase
+		t.Run(contractCase.ID, func(t *testing.T) {
+			assertEndpointMatchesContract(t, contractCase.CanonicalProjectRoot, contractCase)
+			for _, equivalentRoot := range contractCase.TrimOnlyEquivalentRoots {
+				trimmed := trimTrailingSeparators(equivalentRoot)
+				if trimmed != contractCase.CanonicalProjectRoot {
+					t.Fatalf(
+						"trimOnlyEquivalentRoot %q should trim to canonical %q, got %q",
+						equivalentRoot,
+						contractCase.CanonicalProjectRoot,
+						trimmed)
+				}
+				assertEndpointMatchesContract(t, trimmed, contractCase)
+			}
+		})
+	}
+}
+
+func assertEndpointMatchesContract(t *testing.T, projectRoot string, contractCase endpointContractCase) {
+	t.Helper()
+
+	endpoint := CreateEndpoint(projectRoot)
+	expected := contractCase.UnixSocketPath
+	if runtime.GOOS == "windows" {
+		expected = contractCase.WindowsPipePath
+	}
+	if endpoint.Address != expected {
+		t.Fatalf("endpoint mismatch for %q\nexpected: %s\nactual:   %s", projectRoot, expected, endpoint.Address)
+	}
+}
+
+func readEndpointContract(t *testing.T) endpointContractFile {
+	t.Helper()
+
+	path := findRepoRelativeFile(t, endpointContractPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read shared endpoint contract: %v", err)
+	}
+
+	var contract endpointContractFile
+	if err := json.Unmarshal(data, &contract); err != nil {
+		t.Fatalf("failed to unmarshal shared endpoint contract: %v", err)
+	}
+	if len(contract.Cases) == 0 {
+		t.Fatal("endpoint contract must contain at least one case")
+	}
+	return contract
+}
+
+func findRepoRelativeFile(t *testing.T, relativePath string) string {
+	t.Helper()
+
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to resolve current directory: %v", err)
+	}
+
+	for {
+		candidate := filepath.Join(directory, relativePath)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			t.Fatalf("failed to find %s from %s", relativePath, directory)
+		}
+		directory = parent
+	}
+}

--- a/cli/common/unityipc/client.go
+++ b/cli/common/unityipc/client.go
@@ -118,6 +118,14 @@ func (err *RPCError) Error() string {
 	return fmt.Sprintf("unity error: %s", err.Message)
 }
 
+// Signals that Unity accepted the request but returned an empty JSON-RPC result.
+// Domain-reload recovery treats this as a transport disconnect so status polling can continue.
+type NoResponseError struct{}
+
+func (err *NoResponseError) Error() string {
+	return "unity returned no RPC result"
+}
+
 func NewClient(connection Connection, clientVersion string, options ...ClientOption) *Client {
 	clientOptions := ClientOptions{}
 	for _, option := range options {
@@ -375,7 +383,7 @@ func finishRPCResponse(
 		})
 	}
 	if len(response.Result) == 0 {
-		return finishOutcomeWithError(outcome, timing, startedAt, fmt.Errorf("UNITY_NO_RESPONSE"))
+		return finishOutcomeWithError(outcome, timing, startedAt, &NoResponseError{})
 	}
 
 	outcome.Result = response.Result

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "fbbc3c34d301331c513155ea2bab2a33a4b5de97"
+  "sharedInputsHash": "677ac7b5437d18efa8a09b575d0ec2619de4a1fa"
 }

--- a/cli/project-runner/internal/projectrunner/compile_status_response_contract_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_status_response_contract_test.go
@@ -1,0 +1,72 @@
+package projectrunner
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+const compileStatusResponseContractPath = "tests/contracts/compile_status_response_contract.json"
+
+// Verifies the Go compileStatusResponse DTO preserves every field in the shared Unity
+// get-compile-status response contract, including nested Result.Success used by compileResultStatus.
+func TestCompileStatusResponseMatchesSharedContract(t *testing.T) {
+	fixturePath := findRepoRelativeFile(t, compileStatusResponseContractPath)
+	fixture, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("failed to read shared compile status response contract: %v", err)
+	}
+
+	var response compileStatusResponse
+	if err := json.Unmarshal(fixture, &response); err != nil {
+		t.Fatalf("failed to unmarshal shared compile status response contract: %v", err)
+	}
+
+	assertCompileStatusResponseFieldsPopulated(t, response)
+
+	var resultStatus compileResultStatus
+	if err := json.Unmarshal(response.Result, &resultStatus); err != nil {
+		t.Fatalf("failed to unmarshal Result into compileResultStatus: %v", err)
+	}
+	if resultStatus.Success == nil {
+		t.Fatal("compileResultStatus.Success must be non-nil after unmarshaling the shared contract")
+	}
+
+	roundTripped, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("failed to marshal Go compile status response: %v", err)
+	}
+
+	expected := readJSONFieldShape(t, fixture)
+	actual := readJSONFieldShape(t, roundTripped)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("compile status response field shape drifted\nexpected: %#v\nactual:   %#v", expected, actual)
+	}
+}
+
+func assertCompileStatusResponseFieldsPopulated(t *testing.T, response compileStatusResponse) {
+	t.Helper()
+
+	if !response.Ready {
+		t.Fatal("Ready must be true in the shared contract fixture")
+	}
+	if !response.HasResult {
+		t.Fatal("HasResult must be true in the shared contract fixture")
+	}
+	if !response.IsCompiling {
+		t.Fatal("IsCompiling must be true in the shared contract fixture")
+	}
+	if !response.IsUpdating {
+		t.Fatal("IsUpdating must be true in the shared contract fixture")
+	}
+	if !response.IsDomainReloadInProgress {
+		t.Fatal("IsDomainReloadInProgress must be true in the shared contract fixture")
+	}
+	if len(response.Result) == 0 {
+		t.Fatal("Result must be non-empty in the shared contract fixture")
+	}
+	if response.Message == "" {
+		t.Fatal("Message must be non-empty in the shared contract fixture")
+	}
+}

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "581697442cd42c4467c8a80ab3bce98f403890c6"
+  "sharedInputsHash": "c25f44bebdff747f69e1e6c653a4d8d9a5fc7c4f"
 }

--- a/tests/UnityCliLoop.CodeComplexity.Tests/ConfigureAwaitGuardTests.cs
+++ b/tests/UnityCliLoop.CodeComplexity.Tests/ConfigureAwaitGuardTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using UnityCliLoop.CodeComplexity;
+
+namespace UnityCliLoop.CodeComplexity.Tests
+{
+    [TestFixture]
+    public sealed class ConfigureAwaitGuardTests
+    {
+        // Verifies Task-like awaits without ConfigureAwait(false) are reported while custom
+        // awaitables (intentional main-thread hops) are excluded by return type.
+        [Test]
+        public void FindMissingConfigureAwait_WhenSampleHasTaskAwaitWithoutConfigureAwait_ReportsViolation()
+        {
+            string rootPath = Path.Combine(
+                TestContext.CurrentContext.WorkDirectory,
+                $"configure-await-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(rootPath);
+            try
+            {
+                string toolsDir = Path.Combine(rootPath, "Packages", "src", "Editor", "FirstPartyTools", "Sample");
+                string contractsDir = Path.Combine(rootPath, "Packages", "src", "Editor", "ToolContracts");
+                Directory.CreateDirectory(toolsDir);
+                Directory.CreateDirectory(contractsDir);
+                File.WriteAllText(
+                    Path.Combine(contractsDir, "MainThreadSwitcher.cs"),
+                    """
+                    using System;
+                    using System.Runtime.CompilerServices;
+                    using System.Threading;
+                    namespace io.github.hatayama.UnityCliLoop.ToolContracts
+                    {
+                        public static class MainThreadSwitcher
+                        {
+                            public static SwitchToMainThreadAwaitable SwitchToMainThread(CancellationToken ct = default)
+                                => new SwitchToMainThreadAwaitable(ct);
+                        }
+                        public struct SwitchToMainThreadAwaitable
+                        {
+                            public SwitchToMainThreadAwaitable(CancellationToken cancellationToken) { }
+                            public Awaiter GetAwaiter() => new Awaiter();
+                            public struct Awaiter : INotifyCompletion
+                            {
+                                public bool IsCompleted => true;
+                                public void GetResult() { }
+                                public void OnCompleted(Action continuation) => continuation();
+                            }
+                        }
+                    }
+                    """);
+                File.WriteAllText(
+                    Path.Combine(toolsDir, "SampleTool.cs"),
+                    """
+                    using System.Threading.Tasks;
+                    using io.github.hatayama.UnityCliLoop.ToolContracts;
+                    namespace Sample
+                    {
+                        public static class SampleTool
+                        {
+                            public static async Task RunAsync()
+                            {
+                                await Task.Delay(1);
+                                await MainThreadSwitcher.SwitchToMainThread();
+                                await Task.CompletedTask;
+                            }
+                        }
+                    }
+                    """);
+
+                ConfigureAwaitGuard guard = new();
+                IReadOnlyList<ConfigureAwaitViolation> violations = guard.FindMissingConfigureAwait(rootPath);
+
+                Assert.That(violations.Count, Is.EqualTo(2));
+                Assert.That(violations.All(violation =>
+                    violation.AwaitExpression.Contains("Task.Delay", StringComparison.Ordinal)
+                    || violation.AwaitExpression.Contains("Task.CompletedTask", StringComparison.Ordinal)), Is.True);
+                Assert.That(violations.Any(violation =>
+                    violation.AwaitExpression.Contains("SwitchToMainThread", StringComparison.Ordinal)), Is.False);
+            }
+            finally
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+
+        // Verifies FirstPartyTools Task-like awaits all use ConfigureAwait(false) so paused
+        // Play Mode cannot hang tool continuations captured on Unity's SynchronizationContext.
+        [Test]
+        public void FindMissingConfigureAwait_ForRepositoryFirstPartyTools_HasNoViolations()
+        {
+            string repositoryRoot = FindRepositoryRoot();
+            ConfigureAwaitGuard guard = new();
+            IReadOnlyList<ConfigureAwaitViolation> violations = guard.FindMissingConfigureAwait(repositoryRoot);
+
+            if (violations.Count == 0)
+            {
+                return;
+            }
+
+            StringBuilder message = new();
+            message.AppendLine($"Found {violations.Count} Task-like await(s) missing ConfigureAwait(false):");
+            foreach (ConfigureAwaitViolation violation in violations.Take(40))
+            {
+                message.AppendLine($"{violation.FilePath}:{violation.Line}: {violation.AwaitExpression}");
+            }
+
+            Assert.Fail(message.ToString());
+        }
+
+        private static string FindRepositoryRoot()
+        {
+            string? directory = TestContext.CurrentContext.TestDirectory;
+            while (!string.IsNullOrEmpty(directory))
+            {
+                if (File.Exists(Path.Combine(directory, "Packages", "src", "package.json"))
+                    || File.Exists(Path.Combine(directory, "Packages", "manifest.json")))
+                {
+                    return directory;
+                }
+
+                directory = Directory.GetParent(directory)?.FullName;
+            }
+
+            Assert.Fail("Failed to locate repository root from test directory.");
+            return string.Empty;
+        }
+    }
+}

--- a/tests/contracts/cli_update_required_error_contract.json
+++ b/tests/contracts/cli_update_required_error_contract.json
@@ -1,0 +1,12 @@
+{
+  "comment": "This frame must remain backward compatible forever — old CLIs parse it to learn they must update.",
+  "errorData": {
+    "type": "cli_update_required",
+    "message": "Install matching uloop CLI and Unity package versions, then retry the original command.",
+    "currentCliVersion": "3.0.0-beta.5",
+    "currentProtocolVersion": 1,
+    "requiredProtocolVersion": 3,
+    "updateCommand": "uloop update",
+    "retryableAfterUpdate": true
+  }
+}

--- a/tests/contracts/compile_status_response_contract.json
+++ b/tests/contracts/compile_status_response_contract.json
@@ -1,0 +1,18 @@
+{
+  "Ready": true,
+  "HasResult": true,
+  "IsCompiling": true,
+  "IsUpdating": true,
+  "IsDomainReloadInProgress": true,
+  "Result": {
+    "Success": true,
+    "ErrorCount": 0,
+    "WarningCount": 0,
+    "Errors": [],
+    "Warnings": [],
+    "Message": "Compile result is available.",
+    "NextActions": null,
+    "ProjectRoot": null
+  },
+  "Message": "Compile result is available."
+}

--- a/tests/contracts/endpoint_contract.json
+++ b/tests/contracts/endpoint_contract.json
@@ -1,0 +1,30 @@
+{
+  "comment": "Maps already-canonicalized project roots to IPC endpoint names. Symlink/realpath resolution (Go filepath.EvalSymlinks / C# realpath) is intentionally out of scope because it depends on the live filesystem. Each canonicalProjectRoot is the post-resolution string that both sides hash. trimOnlyEquivalentRoots are trailing-separator variants that must hash identically after separator trimming only.",
+  "cases": [
+    {
+      "id": "unix-stable",
+      "canonicalProjectRoot": "/Users/example/MyProject",
+      "trimOnlyEquivalentRoots": [
+        "/Users/example/MyProject/"
+      ],
+      "unixSocketPath": "/tmp/uloop/UnityCliLoop-bebe6bce5923715b.sock",
+      "windowsPipePath": "\\\\.\\pipe\\uloop-UnityCliLoop-bebe6bce5923715b"
+    },
+    {
+      "id": "unix-case-sensitive",
+      "canonicalProjectRoot": "/Users/example/myproject",
+      "trimOnlyEquivalentRoots": [],
+      "unixSocketPath": "/tmp/uloop/UnityCliLoop-6b4ae0bfeab42b19.sock",
+      "windowsPipePath": "\\\\.\\pipe\\uloop-UnityCliLoop-6b4ae0bfeab42b19"
+    },
+    {
+      "id": "windows-stable",
+      "canonicalProjectRoot": "C:\\Users\\example\\MyProject",
+      "trimOnlyEquivalentRoots": [
+        "C:\\Users\\example\\MyProject\\"
+      ],
+      "unixSocketPath": "/tmp/uloop/UnityCliLoop-4abce6d9d9e51244.sock",
+      "windowsPipePath": "\\\\.\\pipe\\uloop-UnityCliLoop-4abce6d9d9e51244"
+    }
+  ]
+}

--- a/tools/UnityCliLoop.CodeComplexity/ConfigureAwaitGuard.cs
+++ b/tools/UnityCliLoop.CodeComplexity/ConfigureAwaitGuard.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace UnityCliLoop.CodeComplexity
+{
+    /// <summary>
+    /// Finds Task-like awaits in tool assemblies that omit ConfigureAwait(false).
+    /// </summary>
+    public sealed class ConfigureAwaitGuard
+    {
+        private static readonly string[] DefaultPreprocessorSymbols =
+        {
+            "UNITY_EDITOR",
+            "UNITY_EDITOR_OSX",
+            "UNITY_2022_3_OR_NEWER",
+            "UNITY_6000_0_OR_NEWER",
+            "UNITY_6000_3_OR_NEWER",
+            "UNITY_6000_4_OR_NEWER",
+            "ULOOP_HAS_INPUT_SYSTEM",
+            "ULOOP_DEBUG",
+            "ULOOP_HAS_TEST_FRAMEWORK"
+        };
+
+        /// <summary>
+        /// Scans FirstPartyTools for await expressions of Task/Task&lt;T&gt;/ValueTask/ValueTask&lt;T&gt;
+        /// that are missing ConfigureAwait(false).
+        /// Custom awaitables (e.g. SwitchToMainThreadAwaitable) are excluded by return type —
+        /// intentional main-thread hops are the mechanism, not the hazard.
+        /// </summary>
+        public IReadOnlyList<ConfigureAwaitViolation> FindMissingConfigureAwait(string repositoryRoot)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(repositoryRoot), "repositoryRoot must not be empty");
+
+            string[] sourceFiles = CollectToolAssemblySourceFiles(repositoryRoot);
+            if (sourceFiles.Length == 0)
+            {
+                return Array.Empty<ConfigureAwaitViolation>();
+            }
+
+            CSharpCompilation compilation = CreateCompilation(sourceFiles);
+            List<ConfigureAwaitViolation> violations = new();
+            foreach (SyntaxTree syntaxTree in compilation.SyntaxTrees)
+            {
+                if (!IsFirstPartyToolsPath(syntaxTree.FilePath, repositoryRoot))
+                {
+                    continue;
+                }
+
+                SemanticModel semanticModel = compilation.GetSemanticModel(syntaxTree);
+                CompilationUnitSyntax root = syntaxTree.GetCompilationUnitRoot();
+                foreach (AwaitExpressionSyntax awaitExpression in root.DescendantNodes().OfType<AwaitExpressionSyntax>())
+                {
+                    if (HasConfigureAwaitFalse(awaitExpression.Expression))
+                    {
+                        continue;
+                    }
+
+                    ITypeSymbol? awaitedType = semanticModel.GetTypeInfo(awaitExpression.Expression).Type;
+                    if (awaitedType == null || !IsTaskLike(awaitedType))
+                    {
+                        // Why skip non-Task awaitables: SwitchToMainThreadAwaitable and similar
+                        // intentional main-thread hops are the mechanism, not the hazard.
+                        continue;
+                    }
+
+                    FileLinePositionSpan lineSpan = awaitExpression.GetLocation().GetLineSpan();
+                    violations.Add(new ConfigureAwaitViolation(
+                        CreateReportPath(repositoryRoot, syntaxTree.FilePath),
+                        lineSpan.StartLinePosition.Line + 1,
+                        lineSpan.StartLinePosition.Character + 1,
+                        awaitExpression.ToString()));
+                }
+            }
+
+            return violations
+                .OrderBy(violation => violation.FilePath, StringComparer.Ordinal)
+                .ThenBy(violation => violation.Line)
+                .ThenBy(violation => violation.Column)
+                .ToArray();
+        }
+
+        private static string[] CollectToolAssemblySourceFiles(string repositoryRoot)
+        {
+            string firstPartyToolsPath = Path.Combine(repositoryRoot, "Packages", "src", "Editor", "FirstPartyTools");
+            string toolContractsPath = Path.Combine(repositoryRoot, "Packages", "src", "Editor", "ToolContracts");
+            return CollectCsFiles(firstPartyToolsPath)
+                .Concat(CollectCsFiles(toolContractsPath))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static IEnumerable<string> CollectCsFiles(string directoryPath)
+        {
+            if (!Directory.Exists(directoryPath))
+            {
+                return Array.Empty<string>();
+            }
+
+            return Directory.GetFiles(directoryPath, "*.cs", SearchOption.AllDirectories);
+        }
+
+        private static bool IsFirstPartyToolsPath(string filePath, string repositoryRoot)
+        {
+            string relativePath = CreateReportPath(repositoryRoot, filePath);
+            return relativePath.StartsWith("Packages/src/Editor/FirstPartyTools/", StringComparison.Ordinal);
+        }
+
+        private static bool HasConfigureAwaitFalse(ExpressionSyntax expression)
+        {
+            if (expression is not InvocationExpressionSyntax invocation)
+            {
+                return false;
+            }
+
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            {
+                return false;
+            }
+
+            if (!string.Equals(memberAccess.Name.Identifier.ValueText, "ConfigureAwait", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (invocation.ArgumentList.Arguments.Count != 1)
+            {
+                return false;
+            }
+
+            ExpressionSyntax argumentExpression = invocation.ArgumentList.Arguments[0].Expression;
+            return argumentExpression is LiteralExpressionSyntax literal
+                && literal.IsKind(SyntaxKind.FalseLiteralExpression);
+        }
+
+        private static bool IsTaskLike(ITypeSymbol type)
+        {
+            ITypeSymbol unbound = type.OriginalDefinition;
+            string? fullName = unbound.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return fullName is
+                "global::System.Threading.Tasks.Task" or
+                "global::System.Threading.Tasks.Task<TResult>" or
+                "global::System.Threading.Tasks.ValueTask" or
+                "global::System.Threading.Tasks.ValueTask<TResult>";
+        }
+
+        private static CSharpCompilation CreateCompilation(IReadOnlyList<string> sourceFiles)
+        {
+            List<SyntaxTree> syntaxTrees = new();
+            foreach (string sourceFile in sourceFiles)
+            {
+                SourceText sourceText = SourceText.From(File.ReadAllText(sourceFile));
+                syntaxTrees.Add(CSharpSyntaxTree.ParseText(
+                    sourceText,
+                    CSharpParseOptions.Default
+                        .WithLanguageVersion(LanguageVersion.Latest)
+                        .WithPreprocessorSymbols(DefaultPreprocessorSymbols),
+                    path: sourceFile));
+            }
+
+            return CSharpCompilation.Create(
+                "UnityCliLoop.ConfigureAwaitGuard.Analysis",
+                syntaxTrees,
+                CreateMetadataReferences(),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        }
+
+        private static ImmutableArray<MetadataReference> CreateMetadataReferences()
+        {
+            string? trustedPlatformAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+            if (string.IsNullOrEmpty(trustedPlatformAssemblies))
+            {
+                return ImmutableArray<MetadataReference>.Empty;
+            }
+
+            return trustedPlatformAssemblies
+                .Split(Path.PathSeparator)
+                .Where(File.Exists)
+                .Distinct(StringComparer.Ordinal)
+                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+                .ToImmutableArray();
+        }
+
+        private static string CreateReportPath(string rootPath, string filePath)
+        {
+            string fullRootPath = Path.GetFullPath(rootPath);
+            string fullFilePath = Path.GetFullPath(filePath);
+            return Path.GetRelativePath(fullRootPath, fullFilePath)
+                .Replace(Path.DirectorySeparatorChar, '/')
+                .Replace(Path.AltDirectorySeparatorChar, '/');
+        }
+    }
+
+    /// <summary>
+    /// One Task-like await that omitted ConfigureAwait(false).
+    /// </summary>
+    public sealed class ConfigureAwaitViolation
+    {
+        public string FilePath { get; }
+        public int Line { get; }
+        public int Column { get; }
+        public string AwaitExpression { get; }
+
+        public ConfigureAwaitViolation(string filePath, int line, int column, string awaitExpression)
+        {
+            FilePath = filePath;
+            Line = line;
+            Column = column;
+            AwaitExpression = awaitExpression;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Freezes shared IPC response/error contracts so Go and C# stay aligned on compile-status, endpoints, and CLI-update-required frames.
- Makes empty Unity RPC results a typed transport error, hardens JSON-RPC serialization failures, and stops Settings/Setup `async void` from swallowing UI exceptions.

## User Impact
- Before: contract drift could go unnoticed, empty Unity replies looked like generic failures, JSON serialization faults could escape as uncaught exceptions, and Settings/Setup fire-and-forget handlers could fail silently.
- After: shared fixtures lock the wire shapes, empty replies become actionable `NoResponseError`s, serialization faults return error frames, and Settings/Setup async failures are logged while UI behavior stays the same.

## Changes
Child PRs merged into `feature/design-review-fixes-integration`:
- #1773 compile-status response contract fixture + Go/C# tests
- #1774 endpoint + `cli_update_required` contract fixtures
- #1775 typed `NoResponseError` for empty Unity RPC results (+ release-input stamps)
- #1776 JSON-RPC serialization → error frame, ConfigureAwait guard (FirstPartyTools Task-like only), dead ARCHITECTURE.md ref, CommandRunner main-thread Undo fix
- #1777 Presentation `async void` → `Task` + `Forget()`, shallow Settings presenter split, Domain dialog/PATH policies

Out of scope by design: protocolVersion / pin / CHANGELOG bumps; deeper Settings View construction split (SettingsWindow still ~860 lines; further cut to &lt;500 is a follow-up).

## Verification
- Per-child PR: `uloop compile` 0/0 and EditMode suites as recorded on each PR
- PR-5 (#1777) additional: full EditMode after 5b = 2048 passed / 0 failed / 7 skipped; manual Settings / Setup Wizard / Migration Wizard check = OK (user-confirmed, no bugs)
- Fable LGTM on each child PR; PR-5 also ran `/review` with no required fixes

## Manual check (already completed for Presentation)
- Settings window sections, foldouts, CLI actions, skills install, tool toggles
- Setup Wizard end-to-end
- Third-party migration wizard open/refresh/actions

## Review notes
- Final review should include Fable manual review **and** `/review` (bugbot or security)
- Do not bump protocolVersion / project-runner-pin / CHANGELOGs in this PR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

