### PR TITLE
chore: Keep Input recording editor sources under 500 lines

### DIFF
--- a/Assets/Tests/PlayMode/InputReplayEventProcessorCharacterizationTests.cs
+++ b/Assets/Tests/PlayMode/InputReplayEventProcessorCharacterizationTests.cs
@@ -1,0 +1,41 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using NUnit.Framework;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.PlayMode
+{
+    /// <summary>
+    /// Characterization tests for InputReplayEventProcessor loop-restart held-state clearing.
+    /// </summary>
+    public class InputReplayEventProcessorCharacterizationTests
+    {
+        /// <summary>
+        /// Pins ReleaseAllHeldInputs clearing virtual mouse position so loop restart matches pre-split ResetUiReplayState.
+        /// </summary>
+        [Test]
+        public void ReleaseAllHeldInputs_WhenMousePositionWasSet_ShouldClearVirtualMousePosition()
+        {
+            InputReplayEventProcessor processor = new();
+            Vector2 unusedDelta = Vector2.zero;
+            Vector2 unusedScroll = Vector2.zero;
+            processor.ProcessEvent(
+                new RecordedInputEvent
+                {
+                    Type = InputEventTypes.MOUSE_POSITION,
+                    Data = InputRecorder.FormatVector2(new Vector2(120f, 340f))
+                },
+                ref unusedDelta,
+                ref unusedScroll);
+
+            Assert.That(processor.MousePosition, Is.EqualTo(new Vector2(120f, 340f)));
+
+            processor.ReleaseAllHeldInputs();
+
+            Assert.That(processor.MousePosition, Is.Null);
+        }
+    }
+}
+#endif

--- a/Assets/Tests/PlayMode/InputReplayEventProcessorCharacterizationTests.cs.meta
+++ b/Assets/Tests/PlayMode/InputReplayEventProcessorCharacterizationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7ae036faecb4691ab839de0630ed319
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorder.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorder.cs
@@ -2,14 +2,11 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
 
-using RuntimeMouseButton = io.github.hatayama.UnityCliLoop.Runtime.MouseButton;
 using io.github.hatayama.UnityCliLoop.Runtime;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -19,37 +16,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal sealed class InputRecorderService
     {
-        private readonly Key[] _defaultScanKeys =
-        {
-            Key.A, Key.B, Key.C, Key.D, Key.E, Key.F, Key.G, Key.H,
-            Key.I, Key.J, Key.K, Key.L, Key.M, Key.N, Key.O, Key.P,
-            Key.Q, Key.R, Key.S, Key.T, Key.U, Key.V, Key.W, Key.X,
-            Key.Y, Key.Z,
-            Key.Digit0, Key.Digit1, Key.Digit2, Key.Digit3, Key.Digit4,
-            Key.Digit5, Key.Digit6, Key.Digit7, Key.Digit8, Key.Digit9,
-            Key.Space, Key.LeftShift, Key.RightShift,
-            Key.LeftCtrl, Key.RightCtrl, Key.LeftAlt, Key.RightAlt,
-            Key.Tab, Key.Escape, Key.Enter, Key.Backspace,
-            Key.UpArrow, Key.DownArrow, Key.LeftArrow, Key.RightArrow
-        };
-
-        private readonly RuntimeMouseButton[] _mouseButtons =
-        {
-            RuntimeMouseButton.Left, RuntimeMouseButton.Right, RuntimeMouseButton.Middle
-        };
+        private readonly InputRecorderFrameCapture _frameCapture = new InputRecorderFrameCapture();
+        private readonly List<RecordedInputEvent> _frameEvents = new();
 
         private bool _isRecording;
         private int _startFrameCount;
         private float _startTime;
         private List<InputFrameEvents> _recordedFrames = new();
-        private Key[]? _cachedKeysToScan;
-        private readonly HashSet<Key> _previousKeyStates = new();
-        private readonly HashSet<RuntimeMouseButton> _previousButtonStates = new();
-
-        // Reused per-frame to avoid GC allocations in OnAfterUpdate
-        private readonly List<RecordedInputEvent> _frameEvents = new();
-        private readonly HashSet<Key> _currentKeyStates = new();
-        private readonly HashSet<RuntimeMouseButton> _currentButtonStates = new();
 
         public event Action? RecordingStarted;
         public event Action? RecordingStopped;
@@ -69,10 +42,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Debug.Assert(EditorApplication.isPlaying, "PlayMode must be active to start recording");
 
             LastAutoSavePath = null;
-            _cachedKeysToScan = BuildKeysToScan(keyFilter);
             _recordedFrames = new List<InputFrameEvents>();
-            _previousKeyStates.Clear();
-            _previousButtonStates.Clear();
+            _frameCapture.BeginCapture(keyFilter);
             _startFrameCount = Time.frameCount;
             _startTime = Time.realtimeSinceStartup;
             _isRecording = true;
@@ -81,8 +52,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // so it doesn't linger from a previous tool call.
             SimulateMouseInputOverlayState.Clear();
 
-            CaptureInitialKeyStates();
-            CaptureInitialButtonStates();
             EmitInitialHeldEvents();
 
             InputSystem.onAfterUpdate -= OnAfterUpdate;
@@ -102,7 +71,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int totalFrames = Time.frameCount - _startFrameCount;
             float duration = Time.realtimeSinceStartup - _startTime;
 
-            InputRecordingData data = new()            {
+            InputRecordingData data = new()
+            {
                 Metadata = new InputRecordingMetadata
                 {
                     RecordedAt = DateTime.UtcNow.ToString("o"),
@@ -140,9 +110,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private void Reset()
         {
             _recordedFrames = new List<InputFrameEvents>();
-            _previousKeyStates.Clear();
-            _previousButtonStates.Clear();
-            _cachedKeysToScan = null;
+            _frameCapture.Reset();
         }
 
         private void OnAfterUpdate()
@@ -174,11 +142,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             int relativeFrame = Time.frameCount - _startFrameCount;
             _frameEvents.Clear();
 
-            RecordKeyboardEvents(_frameEvents);
-            RecordMouseButtonEvents(_frameEvents);
-            RecordMouseDeltaEvents(_frameEvents);
-            RecordMouseScrollEvents(_frameEvents);
-            RecordMousePositionEvents(_frameEvents);
+            _frameCapture.CaptureFrameEvents(_frameEvents);
 
             if (_frameEvents.Count > 0)
             {
@@ -191,212 +155,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private void RecordKeyboardEvents(List<RecordedInputEvent> events)
-        {
-            Keyboard? keyboard = Keyboard.current;
-            if (keyboard == null)
-            {
-                return;
-            }
-
-            Key[] keysToScan = _cachedKeysToScan ?? _defaultScanKeys;
-            _currentKeyStates.Clear();
-
-            for (int i = 0; i < keysToScan.Length; i++)
-            {
-                Key key = keysToScan[i];
-                KeyControl? control = keyboard[key];
-                if (control != null && control.isPressed)
-                {
-                    _currentKeyStates.Add(key);
-                }
-            }
-
-            foreach (Key key in _currentKeyStates)
-            {
-                if (!_previousKeyStates.Contains(key))
-                {
-                    events.Add(new RecordedInputEvent
-                    {
-                        Type = InputEventTypes.KEY_DOWN,
-                        Data = key.ToString()
-                    });
-                }
-            }
-
-            foreach (Key key in _previousKeyStates)
-            {
-                if (!_currentKeyStates.Contains(key))
-                {
-                    events.Add(new RecordedInputEvent
-                    {
-                        Type = InputEventTypes.KEY_UP,
-                        Data = key.ToString()
-                    });
-                }
-            }
-
-            _previousKeyStates.Clear();
-            foreach (Key key in _currentKeyStates)
-            {
-                _previousKeyStates.Add(key);
-            }
-        }
-
-        private void RecordMouseButtonEvents(List<RecordedInputEvent> events)
-        {
-            Mouse? mouse = Mouse.current;
-            if (mouse == null)
-            {
-                return;
-            }
-
-            _currentButtonStates.Clear();
-
-            for (int i = 0; i < _mouseButtons.Length; i++)
-            {
-                RuntimeMouseButton button = _mouseButtons[i];
-                if (MouseButtonControlResolver.GetButtonControl(mouse, button).isPressed)
-                {
-                    _currentButtonStates.Add(button);
-                }
-            }
-
-            foreach (RuntimeMouseButton button in _currentButtonStates)
-            {
-                if (!_previousButtonStates.Contains(button))
-                {
-                    events.Add(new RecordedInputEvent
-                    {
-                        Type = InputEventTypes.MOUSE_CLICK,
-                        Data = button.ToString()
-                    });
-                }
-            }
-
-            foreach (RuntimeMouseButton button in _previousButtonStates)
-            {
-                if (!_currentButtonStates.Contains(button))
-                {
-                    events.Add(new RecordedInputEvent
-                    {
-                        Type = InputEventTypes.MOUSE_RELEASE,
-                        Data = button.ToString()
-                    });
-                }
-            }
-
-            _previousButtonStates.Clear();
-            foreach (RuntimeMouseButton button in _currentButtonStates)
-            {
-                _previousButtonStates.Add(button);
-            }
-        }
-
-        private static void RecordMouseDeltaEvents(List<RecordedInputEvent> events)
-        {
-            Mouse? mouse = Mouse.current;
-            if (mouse == null)
-            {
-                return;
-            }
-
-            Vector2 delta = mouse.delta.ReadValue();
-            if (delta == Vector2.zero)
-            {
-                return;
-            }
-
-            events.Add(new RecordedInputEvent
-            {
-                Type = InputEventTypes.MOUSE_DELTA,
-                Data = FormatVector2(delta)
-            });
-        }
-
-        private static void RecordMousePositionEvents(List<RecordedInputEvent> events)
-        {
-            Mouse? mouse = Mouse.current;
-            if (mouse == null)
-            {
-                return;
-            }
-
-            Vector2 position = mouse.position.ReadValue();
-            events.Add(new RecordedInputEvent
-            {
-                Type = InputEventTypes.MOUSE_POSITION,
-                Data = FormatVector2(position)
-            });
-        }
-
-        private static void RecordMouseScrollEvents(List<RecordedInputEvent> events)
-        {
-            Mouse? mouse = Mouse.current;
-            if (mouse == null)
-            {
-                return;
-            }
-
-            Vector2 scroll = mouse.scroll.ReadValue();
-            if (scroll.y == 0f)
-            {
-                return;
-            }
-
-            events.Add(new RecordedInputEvent
-            {
-                Type = InputEventTypes.MOUSE_SCROLL,
-                Data = scroll.y.ToString(CultureInfo.InvariantCulture)
-            });
-        }
-
-        private Key[] BuildKeysToScan(HashSet<Key>? keyFilter)
-        {
-            if (keyFilter == null || keyFilter.Count == 0)
-            {
-                return _defaultScanKeys;
-            }
-
-            Key[] filtered = new Key[keyFilter.Count];
-            keyFilter.CopyTo(filtered);
-            return filtered;
-        }
-
         // Keys/buttons already held when recording starts need explicit DOWN events,
         // otherwise replay starts with those controls released until a state change occurs.
         private void EmitInitialHeldEvents()
         {
-            List<RecordedInputEvent> events = new();
-
-            foreach (Key key in _previousKeyStates)
-            {
-                events.Add(new RecordedInputEvent
-                {
-                    Type = InputEventTypes.KEY_DOWN,
-                    Data = key.ToString()
-                });
-            }
-
-            foreach (RuntimeMouseButton button in _previousButtonStates)
-            {
-                events.Add(new RecordedInputEvent
-                {
-                    Type = InputEventTypes.MOUSE_CLICK,
-                    Data = button.ToString()
-                });
-            }
-
-            Mouse? mouse = Mouse.current;
-            if (mouse != null)
-            {
-                events.Add(new RecordedInputEvent
-                {
-                    Type = InputEventTypes.MOUSE_POSITION,
-                    Data = FormatVector2(mouse.position.ReadValue())
-                });
-            }
-
+            List<RecordedInputEvent> events = _frameCapture.BuildInitialHeldEvents();
             if (events.Count > 0)
             {
                 _recordedFrames.Add(new InputFrameEvents
@@ -405,71 +168,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     Events = events
                 });
             }
-        }
-
-        private void CaptureInitialKeyStates()
-        {
-            Keyboard? keyboard = Keyboard.current;
-            if (keyboard == null)
-            {
-                return;
-            }
-
-            Key[] keysToScan = _cachedKeysToScan ?? _defaultScanKeys;
-            for (int i = 0; i < keysToScan.Length; i++)
-            {
-                KeyControl? control = keyboard[keysToScan[i]];
-                if (control != null && control.isPressed)
-                {
-                    _previousKeyStates.Add(keysToScan[i]);
-                }
-            }
-        }
-
-        private void CaptureInitialButtonStates()
-        {
-            Mouse? mouse = Mouse.current;
-            if (mouse == null)
-            {
-                return;
-            }
-
-            for (int i = 0; i < _mouseButtons.Length; i++)
-            {
-                if (MouseButtonControlResolver.GetButtonControl(mouse, _mouseButtons[i]).isPressed)
-                {
-                    _previousButtonStates.Add(_mouseButtons[i]);
-                }
-            }
-        }
-
-        internal static string FormatVector2(Vector2 v)
-        {
-            return v.x.ToString(CultureInfo.InvariantCulture) + "," + v.y.ToString(CultureInfo.InvariantCulture);
-        }
-
-        internal static Vector2 ParseVector2(string data)
-        {
-            int commaIndex = data.IndexOf(',');
-            if (commaIndex < 0)
-            {
-                return Vector2.zero;
-            }
-
-            string xStr = data.Substring(0, commaIndex);
-            string yStr = data.Substring(commaIndex + 1);
-
-            if (!float.TryParse(xStr, NumberStyles.Float, CultureInfo.InvariantCulture, out float x))
-            {
-                return Vector2.zero;
-            }
-
-            if (!float.TryParse(yStr, NumberStyles.Float, CultureInfo.InvariantCulture, out float y))
-            {
-                return Vector2.zero;
-            }
-
-            return new Vector2(x, y);
         }
 
         private void OnPlayModeStateChanged(PlayModeStateChange state)
@@ -543,12 +241,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         internal static string FormatVector2(Vector2 v)
         {
-            return InputRecorderService.FormatVector2(v);
+            return InputRecordingVectorFormat.FormatVector2(v);
         }
 
         internal static Vector2 ParseVector2(string data)
         {
-            return InputRecorderService.ParseVector2(data);
+            return InputRecordingVectorFormat.ParseVector2(data);
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorderFrameCapture.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorderFrameCapture.cs
@@ -1,0 +1,314 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+
+using RuntimeMouseButton = io.github.hatayama.UnityCliLoop.Runtime.MouseButton;
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Captures per-frame keyboard and mouse events from the active Input System devices.
+    /// </summary>
+    internal sealed class InputRecorderFrameCapture
+    {
+        private readonly Key[] _defaultScanKeys =
+        {
+            Key.A, Key.B, Key.C, Key.D, Key.E, Key.F, Key.G, Key.H,
+            Key.I, Key.J, Key.K, Key.L, Key.M, Key.N, Key.O, Key.P,
+            Key.Q, Key.R, Key.S, Key.T, Key.U, Key.V, Key.W, Key.X,
+            Key.Y, Key.Z,
+            Key.Digit0, Key.Digit1, Key.Digit2, Key.Digit3, Key.Digit4,
+            Key.Digit5, Key.Digit6, Key.Digit7, Key.Digit8, Key.Digit9,
+            Key.Space, Key.LeftShift, Key.RightShift,
+            Key.LeftCtrl, Key.RightCtrl, Key.LeftAlt, Key.RightAlt,
+            Key.Tab, Key.Escape, Key.Enter, Key.Backspace,
+            Key.UpArrow, Key.DownArrow, Key.LeftArrow, Key.RightArrow
+        };
+
+        private readonly RuntimeMouseButton[] _mouseButtons =
+        {
+            RuntimeMouseButton.Left, RuntimeMouseButton.Right, RuntimeMouseButton.Middle
+        };
+
+        private readonly HashSet<Key> _previousKeyStates = new();
+        private readonly HashSet<RuntimeMouseButton> _previousButtonStates = new();
+        private readonly HashSet<Key> _currentKeyStates = new();
+        private readonly HashSet<RuntimeMouseButton> _currentButtonStates = new();
+
+        private Key[]? _cachedKeysToScan;
+
+        public void BeginCapture(HashSet<Key>? keyFilter)
+        {
+            _cachedKeysToScan = BuildKeysToScan(keyFilter);
+            _previousKeyStates.Clear();
+            _previousButtonStates.Clear();
+            CaptureInitialKeyStates();
+            CaptureInitialButtonStates();
+        }
+
+        public void Reset()
+        {
+            _previousKeyStates.Clear();
+            _previousButtonStates.Clear();
+            _cachedKeysToScan = null;
+        }
+
+        public List<RecordedInputEvent> BuildInitialHeldEvents()
+        {
+            List<RecordedInputEvent> events = new();
+
+            foreach (Key key in _previousKeyStates)
+            {
+                events.Add(new RecordedInputEvent
+                {
+                    Type = InputEventTypes.KEY_DOWN,
+                    Data = key.ToString()
+                });
+            }
+
+            foreach (RuntimeMouseButton button in _previousButtonStates)
+            {
+                events.Add(new RecordedInputEvent
+                {
+                    Type = InputEventTypes.MOUSE_CLICK,
+                    Data = button.ToString()
+                });
+            }
+
+            Mouse? mouse = Mouse.current;
+            if (mouse != null)
+            {
+                events.Add(new RecordedInputEvent
+                {
+                    Type = InputEventTypes.MOUSE_POSITION,
+                    Data = InputRecordingVectorFormat.FormatVector2(mouse.position.ReadValue())
+                });
+            }
+
+            return events;
+        }
+
+        public void CaptureFrameEvents(List<RecordedInputEvent> events)
+        {
+            RecordKeyboardEvents(events);
+            RecordMouseButtonEvents(events);
+            RecordMouseDeltaEvents(events);
+            RecordMouseScrollEvents(events);
+            RecordMousePositionEvents(events);
+        }
+
+        private void RecordKeyboardEvents(List<RecordedInputEvent> events)
+        {
+            Keyboard? keyboard = Keyboard.current;
+            if (keyboard == null)
+            {
+                return;
+            }
+
+            Key[] keysToScan = _cachedKeysToScan ?? _defaultScanKeys;
+            _currentKeyStates.Clear();
+
+            for (int i = 0; i < keysToScan.Length; i++)
+            {
+                Key key = keysToScan[i];
+                KeyControl? control = keyboard[key];
+                if (control != null && control.isPressed)
+                {
+                    _currentKeyStates.Add(key);
+                }
+            }
+
+            foreach (Key key in _currentKeyStates)
+            {
+                if (!_previousKeyStates.Contains(key))
+                {
+                    events.Add(new RecordedInputEvent
+                    {
+                        Type = InputEventTypes.KEY_DOWN,
+                        Data = key.ToString()
+                    });
+                }
+            }
+
+            foreach (Key key in _previousKeyStates)
+            {
+                if (!_currentKeyStates.Contains(key))
+                {
+                    events.Add(new RecordedInputEvent
+                    {
+                        Type = InputEventTypes.KEY_UP,
+                        Data = key.ToString()
+                    });
+                }
+            }
+
+            _previousKeyStates.Clear();
+            foreach (Key key in _currentKeyStates)
+            {
+                _previousKeyStates.Add(key);
+            }
+        }
+
+        private void RecordMouseButtonEvents(List<RecordedInputEvent> events)
+        {
+            Mouse? mouse = Mouse.current;
+            if (mouse == null)
+            {
+                return;
+            }
+
+            _currentButtonStates.Clear();
+
+            for (int i = 0; i < _mouseButtons.Length; i++)
+            {
+                RuntimeMouseButton button = _mouseButtons[i];
+                if (MouseButtonControlResolver.GetButtonControl(mouse, button).isPressed)
+                {
+                    _currentButtonStates.Add(button);
+                }
+            }
+
+            foreach (RuntimeMouseButton button in _currentButtonStates)
+            {
+                if (!_previousButtonStates.Contains(button))
+                {
+                    events.Add(new RecordedInputEvent
+                    {
+                        Type = InputEventTypes.MOUSE_CLICK,
+                        Data = button.ToString()
+                    });
+                }
+            }
+
+            foreach (RuntimeMouseButton button in _previousButtonStates)
+            {
+                if (!_currentButtonStates.Contains(button))
+                {
+                    events.Add(new RecordedInputEvent
+                    {
+                        Type = InputEventTypes.MOUSE_RELEASE,
+                        Data = button.ToString()
+                    });
+                }
+            }
+
+            _previousButtonStates.Clear();
+            foreach (RuntimeMouseButton button in _currentButtonStates)
+            {
+                _previousButtonStates.Add(button);
+            }
+        }
+
+        private static void RecordMouseDeltaEvents(List<RecordedInputEvent> events)
+        {
+            Mouse? mouse = Mouse.current;
+            if (mouse == null)
+            {
+                return;
+            }
+
+            Vector2 delta = mouse.delta.ReadValue();
+            if (delta == Vector2.zero)
+            {
+                return;
+            }
+
+            events.Add(new RecordedInputEvent
+            {
+                Type = InputEventTypes.MOUSE_DELTA,
+                Data = InputRecordingVectorFormat.FormatVector2(delta)
+            });
+        }
+
+        private static void RecordMousePositionEvents(List<RecordedInputEvent> events)
+        {
+            Mouse? mouse = Mouse.current;
+            if (mouse == null)
+            {
+                return;
+            }
+
+            Vector2 position = mouse.position.ReadValue();
+            events.Add(new RecordedInputEvent
+            {
+                Type = InputEventTypes.MOUSE_POSITION,
+                Data = InputRecordingVectorFormat.FormatVector2(position)
+            });
+        }
+
+        private static void RecordMouseScrollEvents(List<RecordedInputEvent> events)
+        {
+            Mouse? mouse = Mouse.current;
+            if (mouse == null)
+            {
+                return;
+            }
+
+            Vector2 scroll = mouse.scroll.ReadValue();
+            if (scroll.y == 0f)
+            {
+                return;
+            }
+
+            events.Add(new RecordedInputEvent
+            {
+                Type = InputEventTypes.MOUSE_SCROLL,
+                Data = scroll.y.ToString(CultureInfo.InvariantCulture)
+            });
+        }
+
+        private Key[] BuildKeysToScan(HashSet<Key>? keyFilter)
+        {
+            if (keyFilter == null || keyFilter.Count == 0)
+            {
+                return _defaultScanKeys;
+            }
+
+            Key[] filtered = new Key[keyFilter.Count];
+            keyFilter.CopyTo(filtered);
+            return filtered;
+        }
+
+        private void CaptureInitialKeyStates()
+        {
+            Keyboard? keyboard = Keyboard.current;
+            if (keyboard == null)
+            {
+                return;
+            }
+
+            Key[] keysToScan = _cachedKeysToScan ?? _defaultScanKeys;
+            for (int i = 0; i < keysToScan.Length; i++)
+            {
+                KeyControl? control = keyboard[keysToScan[i]];
+                if (control != null && control.isPressed)
+                {
+                    _previousKeyStates.Add(keysToScan[i]);
+                }
+            }
+        }
+
+        private void CaptureInitialButtonStates()
+        {
+            Mouse? mouse = Mouse.current;
+            if (mouse == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < _mouseButtons.Length; i++)
+            {
+                if (MouseButtonControlResolver.GetButtonControl(mouse, _mouseButtons[i]).isPressed)
+                {
+                    _previousButtonStates.Add(_mouseButtons[i]);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorderFrameCapture.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecorderFrameCapture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db2f63be712542fb816e560aa10cbf7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecordingVectorFormat.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecordingVectorFormat.cs
@@ -1,0 +1,43 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Globalization;
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Formats and parses comma-separated vector values stored in recorded input events.
+    /// </summary>
+    internal static class InputRecordingVectorFormat
+    {
+        public static string FormatVector2(Vector2 v)
+        {
+            return v.x.ToString(CultureInfo.InvariantCulture) + "," + v.y.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public static Vector2 ParseVector2(string data)
+        {
+            int commaIndex = data.IndexOf(',');
+            if (commaIndex < 0)
+            {
+                return Vector2.zero;
+            }
+
+            string xStr = data.Substring(0, commaIndex);
+            string yStr = data.Substring(commaIndex + 1);
+
+            if (!float.TryParse(xStr, NumberStyles.Float, CultureInfo.InvariantCulture, out float x))
+            {
+                return Vector2.zero;
+            }
+
+            if (!float.TryParse(yStr, NumberStyles.Float, CultureInfo.InvariantCulture, out float y))
+            {
+                return Vector2.zero;
+            }
+
+            return new Vector2(x, y);
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecordingVectorFormat.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputRecordingVectorFormat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4816c504fbbd4a0897ed40f554399b3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayEventProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayEventProcessor.cs
@@ -1,0 +1,331 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+using UnityEngine.InputSystem.LowLevel;
+
+using RuntimeMouseButton = io.github.hatayama.UnityCliLoop.Runtime.MouseButton;
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Translates recorded input events into held device state and Input System snapshots.
+    /// </summary>
+    internal sealed class InputReplayEventProcessor
+    {
+        private readonly Dictionary<string, Key> _keyLookup = BuildKeyLookup();
+        private readonly Key[] _allKeys = BuildAllKeys();
+        private readonly Dictionary<string, RuntimeMouseButton> _buttonLookup =
+            new Dictionary<string, RuntimeMouseButton>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Left", RuntimeMouseButton.Left },
+            { "Right", RuntimeMouseButton.Right },
+            { "Middle", RuntimeMouseButton.Middle }
+        };
+        private readonly Key[] _emptyKeys = Array.Empty<Key>();
+        private readonly RuntimeMouseButton[] _emptyButtons = Array.Empty<RuntimeMouseButton>();
+
+        private readonly HashSet<Key> _replayHeldKeys = new HashSet<Key>();
+        private readonly HashSet<RuntimeMouseButton> _replayHeldButtons = new HashSet<RuntimeMouseButton>();
+        private Vector2? _replayMousePosition;
+
+        public bool HasMousePosition { get; private set; }
+
+        public Vector2? MousePosition => _replayMousePosition;
+
+        public bool IsLeftButtonHeld()
+        {
+            return _replayHeldButtons.Contains(RuntimeMouseButton.Left);
+        }
+
+        public void InitializeForRecording(InputRecordingData data)
+        {
+            HasMousePosition = DetectMousePositionEvents(data);
+            _replayHeldKeys.Clear();
+            _replayHeldButtons.Clear();
+            _replayMousePosition = null;
+        }
+
+        public void ClearHeldState()
+        {
+            _replayHeldKeys.Clear();
+            _replayHeldButtons.Clear();
+            _replayMousePosition = null;
+        }
+
+        public void ProcessEvent(
+            RecordedInputEvent evt,
+            ref Vector2 frameDelta,
+            ref Vector2 frameScroll)
+        {
+            switch (evt.Type)
+            {
+                case InputEventTypes.KEY_DOWN:
+                    ProcessKeyDown(evt.Data);
+                    break;
+                case InputEventTypes.KEY_UP:
+                    ProcessKeyUp(evt.Data);
+                    break;
+                case InputEventTypes.MOUSE_CLICK:
+                    ProcessMouseClick(evt.Data);
+                    break;
+                case InputEventTypes.MOUSE_RELEASE:
+                    ProcessMouseRelease(evt.Data);
+                    break;
+                case InputEventTypes.MOUSE_DELTA:
+                    ProcessMouseDelta(evt.Data, ref frameDelta);
+                    break;
+                case InputEventTypes.MOUSE_SCROLL:
+                    ProcessMouseScroll(evt.Data, ref frameScroll);
+                    break;
+                case InputEventTypes.MOUSE_POSITION:
+                    ProcessMousePosition(evt.Data);
+                    break;
+            }
+        }
+
+        public void ApplyCurrentFrameSnapshot(
+            Keyboard? keyboard,
+            Mouse? mouse,
+            Vector2 frameDelta,
+            Vector2 frameScroll)
+        {
+            if (keyboard != null)
+            {
+                ApplyKeyboardSnapshot(keyboard, _replayHeldKeys);
+            }
+
+            if (mouse != null)
+            {
+                ApplyMouseSnapshot(mouse, _replayHeldButtons, frameDelta, frameScroll, _replayMousePosition);
+            }
+        }
+
+        public void ReleaseAllHeldInputs()
+        {
+            Keyboard? keyboard = Keyboard.current;
+            if (keyboard != null)
+            {
+                ApplyKeyboardSnapshot(keyboard, _emptyKeys);
+            }
+
+            Mouse? mouse = Mouse.current;
+            if (mouse != null)
+            {
+                ApplyMouseSnapshot(mouse, _emptyButtons, Vector2.zero, Vector2.zero, null);
+            }
+
+            foreach (Key key in _replayHeldKeys)
+            {
+                SimulateKeyboardOverlayState.RemoveHeldKey(key.ToString());
+            }
+
+            foreach (RuntimeMouseButton button in _replayHeldButtons)
+            {
+                SimulateMouseInputOverlayState.SetButtonHeld(button, false);
+            }
+
+            SimulateMouseInputOverlayState.SetMoveDelta(Vector2.zero);
+            SimulateMouseInputOverlayState.SetScrollDirection(0);
+            _replayHeldKeys.Clear();
+            _replayHeldButtons.Clear();
+        }
+
+        private void ProcessKeyDown(string keyName)
+        {
+            if (!_keyLookup.TryGetValue(keyName, out Key key))
+            {
+                return;
+            }
+
+            _replayHeldKeys.Add(key);
+            SimulateKeyboardOverlayState.AddHeldKey(keyName);
+        }
+
+        private void ProcessKeyUp(string keyName)
+        {
+            if (!_keyLookup.TryGetValue(keyName, out Key key))
+            {
+                return;
+            }
+
+            _replayHeldKeys.Remove(key);
+            SimulateKeyboardOverlayState.RemoveHeldKey(keyName);
+        }
+
+        private void ProcessMouseClick(string buttonName)
+        {
+            if (!_buttonLookup.TryGetValue(buttonName, out RuntimeMouseButton button))
+            {
+                return;
+            }
+
+            _replayHeldButtons.Add(button);
+            if (!HasMousePosition)
+            {
+                SimulateMouseInputOverlayState.SetButtonHeld(button, true);
+            }
+        }
+
+        private void ProcessMouseRelease(string buttonName)
+        {
+            if (!_buttonLookup.TryGetValue(buttonName, out RuntimeMouseButton button))
+            {
+                return;
+            }
+
+            _replayHeldButtons.Remove(button);
+            if (!HasMousePosition)
+            {
+                SimulateMouseInputOverlayState.SetButtonHeld(button, false);
+            }
+        }
+
+        private void ProcessMouseDelta(string data, ref Vector2 frameDelta)
+        {
+            frameDelta = InputRecorder.ParseVector2(data);
+            if (!HasMousePosition)
+            {
+                SimulateMouseInputOverlayState.SetMoveDelta(frameDelta);
+            }
+        }
+
+        private void ProcessMousePosition(string data)
+        {
+            _replayMousePosition = InputRecorder.ParseVector2(data);
+        }
+
+        private void ProcessMouseScroll(string data, ref Vector2 frameScroll)
+        {
+            if (!float.TryParse(data, NumberStyles.Float, CultureInfo.InvariantCulture, out float scrollY))
+            {
+                return;
+            }
+
+            frameScroll = new Vector2(0f, scrollY);
+            if (!HasMousePosition)
+            {
+                int direction = scrollY > 0f ? 1 : scrollY < 0f ? -1 : 0;
+                SimulateMouseInputOverlayState.SetScrollDirection(direction);
+            }
+        }
+
+        private void ApplyKeyboardSnapshot(Keyboard keyboard, IReadOnlyCollection<Key> heldKeys)
+        {
+            InputUpdateType updateType = InputUpdateTypeResolver.Resolve();
+            using (StateEvent.From(keyboard, out InputEventPtr eventPtr))
+            {
+                // StateEvent carries the previous frame's state; without zeroing first,
+                // released keys would remain pressed until explicitly cleared.
+                for (int i = 0; i < _allKeys.Length; i++)
+                {
+                    KeyControl? control = keyboard[_allKeys[i]];
+                    if (control != null)
+                    {
+                        control.WriteValueIntoEvent(0f, eventPtr);
+                    }
+                }
+
+                foreach (Key key in heldKeys)
+                {
+                    KeyControl? control = keyboard[key];
+                    if (control != null)
+                    {
+                        control.WriteValueIntoEvent(1f, eventPtr);
+                    }
+                }
+
+                InputState.Change(keyboard, eventPtr, updateType);
+            }
+        }
+
+        private void ApplyMouseSnapshot(
+            Mouse mouse,
+            IReadOnlyCollection<RuntimeMouseButton> heldButtons,
+            Vector2 delta,
+            Vector2 scroll,
+            Vector2? position)
+        {
+            InputUpdateType updateType = InputUpdateTypeResolver.Resolve();
+            using (StateEvent.From(mouse, out InputEventPtr eventPtr))
+            {
+                mouse.leftButton.WriteValueIntoEvent(0f, eventPtr);
+                mouse.rightButton.WriteValueIntoEvent(0f, eventPtr);
+                mouse.middleButton.WriteValueIntoEvent(0f, eventPtr);
+                mouse.delta.WriteValueIntoEvent(delta, eventPtr);
+                mouse.scroll.WriteValueIntoEvent(scroll, eventPtr);
+
+                if (position.HasValue)
+                {
+                    mouse.position.WriteValueIntoEvent(position.Value, eventPtr);
+                }
+
+                foreach (RuntimeMouseButton button in heldButtons)
+                {
+                    MouseButtonControlResolver.GetButtonControl(mouse, button).WriteValueIntoEvent(1f, eventPtr);
+                }
+
+                InputState.Change(mouse, eventPtr, updateType);
+            }
+        }
+
+        private static Key[] BuildAllKeys()
+        {
+            List<Key> keys = new();
+            foreach (Key key in Enum.GetValues(typeof(Key)))
+            {
+                if (key == Key.None)
+                {
+                    continue;
+                }
+
+                keys.Add(key);
+            }
+
+            return keys.ToArray();
+        }
+
+        private static Dictionary<string, Key> BuildKeyLookup()
+        {
+            Dictionary<string, Key> lookup = new(StringComparer.OrdinalIgnoreCase);
+            foreach (Key key in Enum.GetValues(typeof(Key)))
+            {
+                if (key == Key.None)
+                {
+                    continue;
+                }
+
+                string name = key.ToString();
+                if (!lookup.ContainsKey(name))
+                {
+                    lookup[name] = key;
+                }
+            }
+
+            return lookup;
+        }
+
+        private static bool DetectMousePositionEvents(InputRecordingData data)
+        {
+            for (int i = 0; i < data.Frames.Count; i++)
+            {
+                List<RecordedInputEvent> events = data.Frames[i].Events;
+                for (int j = 0; j < events.Count; j++)
+                {
+                    if (events[j].Type == InputEventTypes.MOUSE_POSITION)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayEventProcessor.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayEventProcessor.cs
@@ -134,6 +134,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             SimulateMouseInputOverlayState.SetScrollDirection(0);
             _replayHeldKeys.Clear();
             _replayHeldButtons.Clear();
+            // why: old ResetUiReplayState cleared virtual mouse position on loop restart; without this, loop iteration 2+ keeps the previous pass's last position until the next position event
+            _replayMousePosition = null;
         }
 
         private void ProcessKeyDown(string keyName)

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayEventProcessor.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayEventProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8c30e4b47ef493b8b0cb0db0027c627
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs
@@ -1,0 +1,381 @@
+#if ULOOP_HAS_INPUT_SYSTEM
+#nullable enable
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+using RuntimeMouseButton = io.github.hatayama.UnityCliLoop.Runtime.MouseButton;
+using io.github.hatayama.UnityCliLoop.Runtime;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Replays pointer UI interactions through ExecuteEvents during input recording playback.
+    /// </summary>
+    internal sealed class InputReplayUiController
+    {
+        private readonly InputReplayEventProcessor _eventProcessor;
+        private readonly List<BaseInputModule> _disabledInputModules = new List<BaseInputModule>();
+
+        private bool _prevLeftButtonHeld;
+        private Vector2? _previousReplayMousePosition;
+        private bool _suppressIdleUiOverlay;
+        private PointerEventData? _pointerData;
+        private GameObject? _currentPressTarget;
+        private GameObject? _currentDragTarget;
+        private bool _isDragging;
+        private Vector2 _pressScreenPosition;
+        private float _pressTime;
+
+        public InputReplayUiController(InputReplayEventProcessor eventProcessor)
+        {
+            _eventProcessor = eventProcessor;
+        }
+
+        public void ApplyUiEvents()
+        {
+            UiReplayFrame? replayFrame = CreateUiReplayFrame();
+            if (!replayFrame.HasValue)
+            {
+                RestoreUiInputModules();
+                return;
+            }
+
+            ApplyUiPointerActivity(replayFrame.Value);
+            ApplyUiPointerRelease(replayFrame.Value);
+        }
+
+        public void Reset()
+        {
+            _previousReplayMousePosition = null;
+            _prevLeftButtonHeld = false;
+            _suppressIdleUiOverlay = false;
+            _pointerData = null;
+            _currentPressTarget = null;
+            _currentDragTarget = null;
+            _isDragging = false;
+            _pressTime = 0f;
+        }
+
+        public void RestoreUiInputModules()
+        {
+            for (int i = 0; i < _disabledInputModules.Count; i++)
+            {
+                BaseInputModule module = _disabledInputModules[i];
+                if (module != null)
+                {
+                    module.enabled = true;
+                }
+            }
+
+            _disabledInputModules.Clear();
+        }
+
+        private void ApplyUiPointerActivity(UiReplayFrame replayFrame)
+        {
+            if (replayFrame.JustPressed)
+            {
+                _suppressIdleUiOverlay = false;
+                _pressTime = Time.realtimeSinceStartup;
+                OnUiPointerDown(replayFrame.ScreenPosition, replayFrame.EventSystem);
+                SimulateMouseUiOverlayState.Update(
+                    MouseAction.Click,
+                    replayFrame.InputPosition,
+                    null,
+                    _currentPressTarget?.name,
+                    replayFrame.GameViewSize);
+                SimulateMouseUiOverlayState.RequestExpandAnimation();
+                return;
+            }
+
+            if (replayFrame.LeftHeld && (_currentPressTarget != null || _currentDragTarget != null))
+            {
+                ApplyUiPointerHold(replayFrame);
+                return;
+            }
+
+            if (!_suppressIdleUiOverlay || replayFrame.MouseMoved)
+            {
+                // Keeping the overlay hidden until the pointer actually moves prevents release fade-out
+                // from being cancelled by the next idle frame at the same position.
+                _suppressIdleUiOverlay = false;
+                SimulateMouseUiOverlayState.Update(
+                    MouseAction.Click,
+                    replayFrame.InputPosition,
+                    null,
+                    null,
+                    replayFrame.GameViewSize);
+            }
+        }
+
+        private void ApplyUiPointerHold(UiReplayFrame replayFrame)
+        {
+            OnUiDrag(replayFrame.ScreenPosition);
+
+            if (_isDragging)
+            {
+                Vector2 pressInputPos = new(
+                    _pressScreenPosition.x,
+                    replayFrame.GameViewSize.y - _pressScreenPosition.y);
+                SimulateMouseUiOverlayState.Update(
+                    MouseAction.Drag,
+                    replayFrame.InputPosition,
+                    pressInputPos,
+                    null,
+                    replayFrame.GameViewSize);
+                return;
+            }
+
+            float elapsed = Time.realtimeSinceStartup - _pressTime;
+            if (elapsed < 0.5f)
+            {
+                return;
+            }
+
+            SimulateMouseUiOverlayState.Update(
+                MouseAction.LongPress,
+                replayFrame.InputPosition,
+                null,
+                _currentPressTarget?.name,
+                replayFrame.GameViewSize);
+            SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
+        }
+
+        private void ApplyUiPointerRelease(UiReplayFrame replayFrame)
+        {
+            if (!replayFrame.JustReleased)
+            {
+                return;
+            }
+
+            OnUiPointerUp(replayFrame.ScreenPosition, replayFrame.EventSystem);
+            _suppressIdleUiOverlay = true;
+            SimulateMouseUiOverlayState.RequestDissipateAnimation();
+            SimulateMouseUiOverlayState.Clear();
+        }
+
+        private UiReplayFrame? CreateUiReplayFrame()
+        {
+            if (!_eventProcessor.MousePosition.HasValue)
+            {
+                return null;
+            }
+
+            EventSystem? eventSystem = EventSystem.current;
+            if (eventSystem == null)
+            {
+                return null;
+            }
+
+            Vector2 screenPos = _eventProcessor.MousePosition.Value;
+            bool mouseMoved = !_previousReplayMousePosition.HasValue
+                              || _previousReplayMousePosition.Value != screenPos;
+            _previousReplayMousePosition = screenPos;
+
+            bool leftHeld = _eventProcessor.IsLeftButtonHeld();
+            bool justPressed = leftHeld && !_prevLeftButtonHeld;
+            bool justReleased = !leftHeld && _prevLeftButtonHeld;
+            _prevLeftButtonHeld = leftHeld;
+            SetUiInputModulesSuppressed(leftHeld || justReleased);
+
+            Vector2 gameViewSize = Handles.GetMainGameViewSize();
+            Vector2 inputPos = new(screenPos.x, gameViewSize.y - screenPos.y);
+
+            return new UiReplayFrame(
+                eventSystem,
+                screenPos,
+                inputPos,
+                gameViewSize,
+                leftHeld,
+                justPressed,
+                justReleased,
+                mouseMoved);
+        }
+
+        private void OnUiPointerDown(Vector2 screenPos, EventSystem eventSystem)
+        {
+            RaycastResult? hit = UiRaycastHelper.RaycastUI(screenPos, eventSystem);
+
+            _pointerData = new PointerEventData(eventSystem)
+            {
+                position = screenPos,
+                pressPosition = screenPos,
+                button = PointerEventData.InputButton.Left
+            };
+            _pressScreenPosition = screenPos;
+            _isDragging = false;
+            _currentDragTarget = null;
+
+            if (hit == null)
+            {
+                _currentPressTarget = null;
+                return;
+            }
+
+            GameObject rawTarget = hit.Value.gameObject;
+            _pointerData.pointerCurrentRaycast = hit.Value;
+            _pointerData.pointerPressRaycast = hit.Value;
+
+            _currentPressTarget = ExecuteEvents.GetEventHandler<IPointerDownHandler>(rawTarget)
+                                  ?? ExecuteEvents.GetEventHandler<IPointerClickHandler>(rawTarget);
+
+            if (_currentPressTarget != null)
+            {
+                _pointerData.pointerPress = _currentPressTarget;
+                _pointerData.rawPointerPress = rawTarget;
+                ExecuteEvents.ExecuteHierarchy(rawTarget, _pointerData, ExecuteEvents.pointerDownHandler);
+            }
+
+            // initializePotentialDrag must fire before beginDrag per StandaloneInputModule contract
+            _currentDragTarget = ExecuteEvents.GetEventHandler<IDragHandler>(rawTarget);
+            if (_currentDragTarget != null)
+            {
+                ExecuteEvents.Execute(_currentDragTarget, _pointerData, ExecuteEvents.initializePotentialDrag);
+            }
+        }
+
+        private void OnUiDrag(Vector2 screenPos)
+        {
+            if (_pointerData == null)
+            {
+                return;
+            }
+
+            Vector2 delta = screenPos - _pointerData.position;
+            if (delta == Vector2.zero)
+            {
+                return;
+            }
+
+            _pointerData.position = screenPos;
+            _pointerData.delta = delta;
+
+            if (!_isDragging && _currentDragTarget != null)
+            {
+                float distance = (screenPos - _pressScreenPosition).magnitude;
+                if (distance > EventSystem.current.pixelDragThreshold)
+                {
+                    _isDragging = true;
+                    _pointerData.dragging = true;
+                    _pointerData.pointerDrag = _currentDragTarget;
+                    ExecuteEvents.Execute(_currentDragTarget, _pointerData, ExecuteEvents.beginDragHandler);
+                }
+            }
+
+            if (_isDragging && _currentDragTarget != null)
+            {
+                ExecuteEvents.Execute(_currentDragTarget, _pointerData, ExecuteEvents.dragHandler);
+            }
+        }
+
+        private void OnUiPointerUp(Vector2 screenPos, EventSystem eventSystem)
+        {
+            if (_pointerData == null)
+            {
+                return;
+            }
+
+            _pointerData.position = screenPos;
+
+            if (_currentPressTarget != null)
+            {
+                ExecuteEvents.Execute(_currentPressTarget, _pointerData, ExecuteEvents.pointerUpHandler);
+            }
+
+            if (_isDragging && _currentDragTarget != null)
+            {
+                RaycastResult? dropHit = UiRaycastHelper.RaycastUI(screenPos, eventSystem);
+                if (dropHit != null)
+                {
+                    _pointerData.pointerCurrentRaycast = dropHit.Value;
+                    GameObject? dropTarget = ExecuteEvents.GetEventHandler<IDropHandler>(dropHit.Value.gameObject);
+                    if (dropTarget != null)
+                    {
+                        ExecuteEvents.Execute(dropTarget, _pointerData, ExecuteEvents.dropHandler);
+                    }
+                }
+
+                ExecuteEvents.Execute(_currentDragTarget, _pointerData, ExecuteEvents.endDragHandler);
+            }
+            else if (_currentPressTarget != null)
+            {
+                // StandaloneInputModule skips click when dragged; match that behavior
+                GameObject? clickTarget = ExecuteEvents.GetEventHandler<IPointerClickHandler>(
+                    _pointerData.rawPointerPress ?? _currentPressTarget);
+                if (clickTarget != null)
+                {
+                    ExecuteEvents.Execute(clickTarget, _pointerData, ExecuteEvents.pointerClickHandler);
+                }
+            }
+
+            _currentPressTarget = null;
+            _currentDragTarget = null;
+            _isDragging = false;
+            _pointerData = null;
+        }
+
+        private void SetUiInputModulesSuppressed(bool suppressed)
+        {
+            if (!suppressed)
+            {
+                RestoreUiInputModules();
+                return;
+            }
+
+            EventSystem? eventSystem = EventSystem.current;
+            if (eventSystem == null)
+            {
+                return;
+            }
+
+            BaseInputModule[] modules = eventSystem.GetComponents<BaseInputModule>();
+            for (int i = 0; i < modules.Length; i++)
+            {
+                BaseInputModule module = modules[i];
+                if (!module.enabled)
+                {
+                    continue;
+                }
+
+                // Replay synthesizes ExecuteEvents directly; leaving input modules enabled
+                // lets them consume the same injected Mouse.current state a second time.
+                module.enabled = false;
+                _disabledInputModules.Add(module);
+            }
+        }
+
+        private readonly struct UiReplayFrame
+        {
+            public UiReplayFrame(
+                EventSystem eventSystem,
+                Vector2 screenPosition,
+                Vector2 inputPosition,
+                Vector2 gameViewSize,
+                bool leftHeld,
+                bool justPressed,
+                bool justReleased,
+                bool mouseMoved)
+            {
+                EventSystem = eventSystem;
+                ScreenPosition = screenPosition;
+                InputPosition = inputPosition;
+                GameViewSize = gameViewSize;
+                LeftHeld = leftHeld;
+                JustPressed = justPressed;
+                JustReleased = justReleased;
+                MouseMoved = mouseMoved;
+            }
+
+            public EventSystem EventSystem { get; }
+            public Vector2 ScreenPosition { get; }
+            public Vector2 InputPosition { get; }
+            public Vector2 GameViewSize { get; }
+            public bool LeftHeld { get; }
+            public bool JustPressed { get; }
+            public bool JustReleased { get; }
+            public bool MouseMoved { get; }
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayUiController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e37633930b7478b97555a4524e2d452
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayer.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputRecording/InputReplayer.cs
@@ -1,16 +1,11 @@
 #if ULOOP_HAS_INPUT_SYSTEM
 #nullable enable
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
 
-using RuntimeMouseButton = io.github.hatayama.UnityCliLoop.Runtime.MouseButton;
 using io.github.hatayama.UnityCliLoop.Runtime;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -20,17 +15,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     internal sealed class InputReplayerService
     {
-        private readonly Dictionary<string, Key> _keyLookup = BuildKeyLookup();
-        private readonly Key[] _allKeys = BuildAllKeys();
-        private readonly Dictionary<string, RuntimeMouseButton> _buttonLookup =
-            new Dictionary<string, RuntimeMouseButton>(StringComparer.OrdinalIgnoreCase)
-        {
-            { "Left", RuntimeMouseButton.Left },
-            { "Right", RuntimeMouseButton.Right },
-            { "Middle", RuntimeMouseButton.Middle }
-        };
-        private readonly Key[] _emptyKeys = Array.Empty<Key>();
-        private readonly RuntimeMouseButton[] _emptyButtons = Array.Empty<RuntimeMouseButton>();
+        private readonly InputReplayEventProcessor _eventProcessor = new InputReplayEventProcessor();
+        private readonly InputReplayUiController _uiController;
 
         private bool _isReplaying;
         private InputRecordingData? _data;
@@ -38,23 +24,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private int _currentFrame;
         private bool _loop;
         private bool _showOverlay;
-        private readonly HashSet<Key> _replayHeldKeys = new HashSet<Key>();
-        private readonly HashSet<RuntimeMouseButton> _replayHeldButtons = new HashSet<RuntimeMouseButton>();
-        private readonly List<BaseInputModule> _disabledInputModules = new List<BaseInputModule>();
-        private Vector2? _replayMousePosition;
 
-        // UI replay goes through ExecuteEvents so verification does not depend on
-        // GameView focus or the active input module's update timing.
-        private bool _hasMousePosition;
-        private bool _prevLeftButtonHeld;
-        private Vector2? _previousReplayMousePosition;
-        private bool _suppressIdleUiOverlay;
-        private PointerEventData? _pointerData;
-        private GameObject? _currentPressTarget;
-        private GameObject? _currentDragTarget;
-        private bool _isDragging;
-        private Vector2 _pressScreenPosition;
-        private float _pressTime;
+        public InputReplayerService()
+        {
+            _uiController = new InputReplayUiController(_eventProcessor);
+        }
 
         public event Action? ReplayStarted;
         public event Action? ReplayCompleted;
@@ -94,14 +68,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 RecordReplayOverlayFactory.EnsureReplayOverlay();
             }
 
-            _replayHeldKeys.Clear();
-            _replayHeldButtons.Clear();
-            _hasMousePosition = DetectMousePositionEvents(data!);
-            ResetUiReplayState();
-            if (_hasMousePosition)
+            _eventProcessor.InitializeForRecording(data!);
+            _uiController.Reset();
+            if (_eventProcessor.HasMousePosition)
             {
                 SimulateMouseInputOverlayState.Clear();
             }
+
             _isReplaying = true;
 
             InputSystem.onAfterUpdate -= OnAfterUpdate;
@@ -120,18 +93,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             InputSystem.onAfterUpdate -= OnAfterUpdate;
             _isReplaying = false;
 
-            ReleaseAllHeldInputs();
+            _eventProcessor.ReleaseAllHeldInputs();
 
             _data = null;
             _eventIndex = 0;
             _currentFrame = 0;
-            _replayHeldKeys.Clear();
-            _replayHeldButtons.Clear();
-            RestoreUiInputModules();
-            ResetUiReplayState();
+            _eventProcessor.ClearHeldState();
+            _uiController.RestoreUiInputModules();
+            _uiController.Reset();
 
             ReplayInputOverlayState.Clear();
-            if (_hasMousePosition)
+            if (_eventProcessor.HasMousePosition)
             {
                 SimulateMouseUiOverlayState.Clear();
             }
@@ -155,11 +127,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             Vector2 frameScroll = Vector2.zero;
 
             CollectFrameState(ref frameDelta, ref frameScroll);
-            ApplyCurrentFrameSnapshot(Keyboard.current, Mouse.current, frameDelta, frameScroll);
+            _eventProcessor.ApplyCurrentFrameSnapshot(Keyboard.current, Mouse.current, frameDelta, frameScroll);
 
-            if (_hasMousePosition)
+            if (_eventProcessor.HasMousePosition)
             {
-                ApplyUiEvents();
+                _uiController.ApplyUiEvents();
             }
 
             if (_showOverlay)
@@ -173,10 +145,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 if (_loop)
                 {
-                    ReleaseAllHeldInputs();
+                    _eventProcessor.ReleaseAllHeldInputs();
                     _eventIndex = 0;
                     _currentFrame = 0;
-                    ResetUiReplayState();
+                    _uiController.Reset();
                 }
                 else
                 {
@@ -195,592 +167,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 InputFrameEvents frameEvents = _data.Frames[_eventIndex];
                 for (int i = 0; i < frameEvents.Events.Count; i++)
                 {
-                    ProcessEvent(frameEvents.Events[i], ref frameDelta, ref frameScroll);
+                    _eventProcessor.ProcessEvent(frameEvents.Events[i], ref frameDelta, ref frameScroll);
                 }
 
                 _eventIndex++;
             }
-        }
-
-        private void ApplyCurrentFrameSnapshot(
-            Keyboard? keyboard,
-            Mouse? mouse,
-            Vector2 frameDelta,
-            Vector2 frameScroll)
-        {
-            if (keyboard != null)
-            {
-                ApplyKeyboardSnapshot(keyboard, _replayHeldKeys);
-            }
-
-            if (mouse != null)
-            {
-                ApplyMouseSnapshot(mouse, _replayHeldButtons, frameDelta, frameScroll, _replayMousePosition);
-            }
-        }
-
-        private void ProcessEvent(
-            RecordedInputEvent evt,
-            ref Vector2 frameDelta,
-            ref Vector2 frameScroll)
-        {
-            switch (evt.Type)
-            {
-                case InputEventTypes.KEY_DOWN:
-                    ProcessKeyDown(evt.Data);
-                    break;
-                case InputEventTypes.KEY_UP:
-                    ProcessKeyUp(evt.Data);
-                    break;
-                case InputEventTypes.MOUSE_CLICK:
-                    ProcessMouseClick(evt.Data);
-                    break;
-                case InputEventTypes.MOUSE_RELEASE:
-                    ProcessMouseRelease(evt.Data);
-                    break;
-                case InputEventTypes.MOUSE_DELTA:
-                    ProcessMouseDelta(evt.Data, ref frameDelta);
-                    break;
-                case InputEventTypes.MOUSE_SCROLL:
-                    ProcessMouseScroll(evt.Data, ref frameScroll);
-                    break;
-                case InputEventTypes.MOUSE_POSITION:
-                    ProcessMousePosition(evt.Data);
-                    break;
-            }
-        }
-
-        private void ProcessKeyDown(string keyName)
-        {
-            if (!_keyLookup.TryGetValue(keyName, out Key key))
-            {
-                return;
-            }
-
-            _replayHeldKeys.Add(key);
-            SimulateKeyboardOverlayState.AddHeldKey(keyName);
-        }
-
-        private void ProcessKeyUp(string keyName)
-        {
-            if (!_keyLookup.TryGetValue(keyName, out Key key))
-            {
-                return;
-            }
-
-            _replayHeldKeys.Remove(key);
-            SimulateKeyboardOverlayState.RemoveHeldKey(keyName);
-        }
-
-        private void ProcessMouseClick(string buttonName)
-        {
-            if (!_buttonLookup.TryGetValue(buttonName, out RuntimeMouseButton button))
-            {
-                return;
-            }
-
-            _replayHeldButtons.Add(button);
-            if (!_hasMousePosition)
-            {
-                SimulateMouseInputOverlayState.SetButtonHeld(button, true);
-            }
-        }
-
-        private void ProcessMouseRelease(string buttonName)
-        {
-            if (!_buttonLookup.TryGetValue(buttonName, out RuntimeMouseButton button))
-            {
-                return;
-            }
-
-            _replayHeldButtons.Remove(button);
-            if (!_hasMousePosition)
-            {
-                SimulateMouseInputOverlayState.SetButtonHeld(button, false);
-            }
-        }
-
-        private void ProcessMouseDelta(string data, ref Vector2 frameDelta)
-        {
-            frameDelta = InputRecorder.ParseVector2(data);
-            if (!_hasMousePosition)
-            {
-                SimulateMouseInputOverlayState.SetMoveDelta(frameDelta);
-            }
-        }
-
-        private void ProcessMousePosition(string data)
-        {
-            _replayMousePosition = InputRecorder.ParseVector2(data);
-        }
-
-        private void ProcessMouseScroll(string data, ref Vector2 frameScroll)
-        {
-            if (!float.TryParse(data, NumberStyles.Float, CultureInfo.InvariantCulture, out float scrollY))
-            {
-                return;
-            }
-
-            frameScroll = new Vector2(0f, scrollY);
-            if (!_hasMousePosition)
-            {
-                int direction = scrollY > 0f ? 1 : scrollY < 0f ? -1 : 0;
-                SimulateMouseInputOverlayState.SetScrollDirection(direction);
-            }
-        }
-
-        private void ApplyKeyboardSnapshot(Keyboard keyboard, IReadOnlyCollection<Key> heldKeys)
-        {
-            InputUpdateType updateType = InputUpdateTypeResolver.Resolve();
-            using (StateEvent.From(keyboard, out InputEventPtr eventPtr))
-            {
-                // StateEvent carries the previous frame's state; without zeroing first,
-                // released keys would remain pressed until explicitly cleared.
-                for (int i = 0; i < _allKeys.Length; i++)
-                {
-                    KeyControl? control = keyboard[_allKeys[i]];
-                    if (control != null)
-                    {
-                        control.WriteValueIntoEvent(0f, eventPtr);
-                    }
-                }
-
-                foreach (Key key in heldKeys)
-                {
-                    KeyControl? control = keyboard[key];
-                    if (control != null)
-                    {
-                        control.WriteValueIntoEvent(1f, eventPtr);
-                    }
-                }
-
-                InputState.Change(keyboard, eventPtr, updateType);
-            }
-        }
-
-        private void ApplyMouseSnapshot(
-            Mouse mouse,
-            IReadOnlyCollection<RuntimeMouseButton> heldButtons,
-            Vector2 delta,
-            Vector2 scroll,
-            Vector2? position)
-        {
-            InputUpdateType updateType = InputUpdateTypeResolver.Resolve();
-            using (StateEvent.From(mouse, out InputEventPtr eventPtr))
-            {
-                mouse.leftButton.WriteValueIntoEvent(0f, eventPtr);
-                mouse.rightButton.WriteValueIntoEvent(0f, eventPtr);
-                mouse.middleButton.WriteValueIntoEvent(0f, eventPtr);
-                mouse.delta.WriteValueIntoEvent(delta, eventPtr);
-                mouse.scroll.WriteValueIntoEvent(scroll, eventPtr);
-
-                if (position.HasValue)
-                {
-                    mouse.position.WriteValueIntoEvent(position.Value, eventPtr);
-                }
-
-                foreach (RuntimeMouseButton button in heldButtons)
-                {
-                    MouseButtonControlResolver.GetButtonControl(mouse, button).WriteValueIntoEvent(1f, eventPtr);
-                }
-
-                InputState.Change(mouse, eventPtr, updateType);
-            }
-        }
-
-        private void ReleaseAllHeldInputs()
-        {
-            Keyboard? keyboard = Keyboard.current;
-            if (keyboard != null)
-            {
-                ApplyKeyboardSnapshot(keyboard, _emptyKeys);
-            }
-
-            Mouse? mouse = Mouse.current;
-            if (mouse != null)
-            {
-                ApplyMouseSnapshot(mouse, _emptyButtons, Vector2.zero, Vector2.zero, null);
-            }
-
-            foreach (Key key in _replayHeldKeys)
-            {
-                SimulateKeyboardOverlayState.RemoveHeldKey(key.ToString());
-            }
-
-            foreach (RuntimeMouseButton button in _replayHeldButtons)
-            {
-                SimulateMouseInputOverlayState.SetButtonHeld(button, false);
-            }
-
-            SimulateMouseInputOverlayState.SetMoveDelta(Vector2.zero);
-            SimulateMouseInputOverlayState.SetScrollDirection(0);
-            _replayHeldKeys.Clear();
-            _replayHeldButtons.Clear();
-        }
-
-        private static Key[] BuildAllKeys()
-        {
-            List<Key> keys = new();
-            foreach (Key key in Enum.GetValues(typeof(Key)))
-            {
-                if (key == Key.None)
-                {
-                    continue;
-                }
-
-                keys.Add(key);
-            }
-
-            return keys.ToArray();
-        }
-
-        private static Dictionary<string, Key> BuildKeyLookup()
-        {
-            Dictionary<string, Key> lookup = new(StringComparer.OrdinalIgnoreCase);
-            foreach (Key key in Enum.GetValues(typeof(Key)))
-            {
-                if (key == Key.None)
-                {
-                    continue;
-                }
-
-                string name = key.ToString();
-                if (!lookup.ContainsKey(name))
-                {
-                    lookup[name] = key;
-                }
-            }
-
-            return lookup;
-        }
-
-        private void ApplyUiEvents()
-        {
-            UiReplayFrame? replayFrame = CreateUiReplayFrame();
-            if (!replayFrame.HasValue)
-            {
-                RestoreUiInputModules();
-                return;
-            }
-
-            ApplyUiPointerActivity(replayFrame.Value);
-            ApplyUiPointerRelease(replayFrame.Value);
-        }
-
-        private UiReplayFrame? CreateUiReplayFrame()
-        {
-            if (!_replayMousePosition.HasValue)
-            {
-                return null;
-            }
-
-            EventSystem? eventSystem = EventSystem.current;
-            if (eventSystem == null)
-            {
-                return null;
-            }
-
-            Vector2 screenPos = _replayMousePosition.Value;
-            bool mouseMoved = !_previousReplayMousePosition.HasValue
-                              || _previousReplayMousePosition.Value != screenPos;
-            _previousReplayMousePosition = screenPos;
-
-            bool leftHeld = _replayHeldButtons.Contains(RuntimeMouseButton.Left);
-            bool justPressed = leftHeld && !_prevLeftButtonHeld;
-            bool justReleased = !leftHeld && _prevLeftButtonHeld;
-            _prevLeftButtonHeld = leftHeld;
-            SetUiInputModulesSuppressed(leftHeld || justReleased);
-
-            Vector2 gameViewSize = Handles.GetMainGameViewSize();
-            Vector2 inputPos = new(screenPos.x, gameViewSize.y - screenPos.y);
-
-            return new UiReplayFrame(
-                eventSystem,
-                screenPos,
-                inputPos,
-                gameViewSize,
-                leftHeld,
-                justPressed,
-                justReleased,
-                mouseMoved);
-        }
-
-        private void ApplyUiPointerActivity(UiReplayFrame replayFrame)
-        {
-            if (replayFrame.JustPressed)
-            {
-                _suppressIdleUiOverlay = false;
-                _pressTime = Time.realtimeSinceStartup;
-                OnUiPointerDown(replayFrame.ScreenPosition, replayFrame.EventSystem);
-                SimulateMouseUiOverlayState.Update(
-                    MouseAction.Click,
-                    replayFrame.InputPosition,
-                    null,
-                    _currentPressTarget?.name,
-                    replayFrame.GameViewSize);
-                SimulateMouseUiOverlayState.RequestExpandAnimation();
-                return;
-            }
-
-            if (replayFrame.LeftHeld && (_currentPressTarget != null || _currentDragTarget != null))
-            {
-                ApplyUiPointerHold(replayFrame);
-                return;
-            }
-
-            if (!_suppressIdleUiOverlay || replayFrame.MouseMoved)
-            {
-                // Keeping the overlay hidden until the pointer actually moves prevents release fade-out
-                // from being cancelled by the next idle frame at the same position.
-                _suppressIdleUiOverlay = false;
-                SimulateMouseUiOverlayState.Update(
-                    MouseAction.Click,
-                    replayFrame.InputPosition,
-                    null,
-                    null,
-                    replayFrame.GameViewSize);
-            }
-        }
-
-        private void ApplyUiPointerHold(UiReplayFrame replayFrame)
-        {
-            OnUiDrag(replayFrame.ScreenPosition);
-
-            if (_isDragging)
-            {
-                Vector2 pressInputPos = new(
-                    _pressScreenPosition.x,
-                    replayFrame.GameViewSize.y - _pressScreenPosition.y);
-                SimulateMouseUiOverlayState.Update(
-                    MouseAction.Drag,
-                    replayFrame.InputPosition,
-                    pressInputPos,
-                    null,
-                    replayFrame.GameViewSize);
-                return;
-            }
-
-            float elapsed = Time.realtimeSinceStartup - _pressTime;
-            if (elapsed < 0.5f)
-            {
-                return;
-            }
-
-            SimulateMouseUiOverlayState.Update(
-                MouseAction.LongPress,
-                replayFrame.InputPosition,
-                null,
-                _currentPressTarget?.name,
-                replayFrame.GameViewSize);
-            SimulateMouseUiOverlayState.UpdateLongPressElapsed(elapsed);
-        }
-
-        private void ApplyUiPointerRelease(UiReplayFrame replayFrame)
-        {
-            if (!replayFrame.JustReleased)
-            {
-                return;
-            }
-
-            OnUiPointerUp(replayFrame.ScreenPosition, replayFrame.EventSystem);
-            _suppressIdleUiOverlay = true;
-            SimulateMouseUiOverlayState.RequestDissipateAnimation();
-            SimulateMouseUiOverlayState.Clear();
-        }
-
-        private void OnUiPointerDown(Vector2 screenPos, EventSystem eventSystem)
-        {
-            RaycastResult? hit = UiRaycastHelper.RaycastUI(screenPos, eventSystem);
-
-            _pointerData = new PointerEventData(eventSystem)
-            {
-                position = screenPos,
-                pressPosition = screenPos,
-                button = PointerEventData.InputButton.Left
-            };
-            _pressScreenPosition = screenPos;
-            _isDragging = false;
-            _currentDragTarget = null;
-
-            if (hit == null)
-            {
-                _currentPressTarget = null;
-                return;
-            }
-
-            GameObject rawTarget = hit.Value.gameObject;
-            _pointerData.pointerCurrentRaycast = hit.Value;
-            _pointerData.pointerPressRaycast = hit.Value;
-
-            _currentPressTarget = ExecuteEvents.GetEventHandler<IPointerDownHandler>(rawTarget)
-                                  ?? ExecuteEvents.GetEventHandler<IPointerClickHandler>(rawTarget);
-
-            if (_currentPressTarget != null)
-            {
-                _pointerData.pointerPress = _currentPressTarget;
-                _pointerData.rawPointerPress = rawTarget;
-                ExecuteEvents.ExecuteHierarchy(rawTarget, _pointerData, ExecuteEvents.pointerDownHandler);
-            }
-
-            // initializePotentialDrag must fire before beginDrag per StandaloneInputModule contract
-            _currentDragTarget = ExecuteEvents.GetEventHandler<IDragHandler>(rawTarget);
-            if (_currentDragTarget != null)
-            {
-                ExecuteEvents.Execute(_currentDragTarget, _pointerData, ExecuteEvents.initializePotentialDrag);
-            }
-        }
-
-        private void OnUiDrag(Vector2 screenPos)
-        {
-            if (_pointerData == null)
-            {
-                return;
-            }
-
-            Vector2 delta = screenPos - _pointerData.position;
-            if (delta == Vector2.zero)
-            {
-                return;
-            }
-
-            _pointerData.position = screenPos;
-            _pointerData.delta = delta;
-
-            if (!_isDragging && _currentDragTarget != null)
-            {
-                float distance = (screenPos - _pressScreenPosition).magnitude;
-                if (distance > EventSystem.current.pixelDragThreshold)
-                {
-                    _isDragging = true;
-                    _pointerData.dragging = true;
-                    _pointerData.pointerDrag = _currentDragTarget;
-                    ExecuteEvents.Execute(_currentDragTarget, _pointerData, ExecuteEvents.beginDragHandler);
-                }
-            }
-
-            if (_isDragging && _currentDragTarget != null)
-            {
-                ExecuteEvents.Execute(_currentDragTarget, _pointerData, ExecuteEvents.dragHandler);
-            }
-        }
-
-        private void OnUiPointerUp(Vector2 screenPos, EventSystem eventSystem)
-        {
-            if (_pointerData == null)
-            {
-                return;
-            }
-
-            _pointerData.position = screenPos;
-
-            if (_currentPressTarget != null)
-            {
-                ExecuteEvents.Execute(_currentPressTarget, _pointerData, ExecuteEvents.pointerUpHandler);
-            }
-
-            if (_isDragging && _currentDragTarget != null)
-            {
-                RaycastResult? dropHit = UiRaycastHelper.RaycastUI(screenPos, eventSystem);
-                if (dropHit != null)
-                {
-                    _pointerData.pointerCurrentRaycast = dropHit.Value;
-                    GameObject? dropTarget = ExecuteEvents.GetEventHandler<IDropHandler>(dropHit.Value.gameObject);
-                    if (dropTarget != null)
-                    {
-                        ExecuteEvents.Execute(dropTarget, _pointerData, ExecuteEvents.dropHandler);
-                    }
-                }
-
-                ExecuteEvents.Execute(_currentDragTarget, _pointerData, ExecuteEvents.endDragHandler);
-            }
-            else if (_currentPressTarget != null)
-            {
-                // StandaloneInputModule skips click when dragged; match that behavior
-                GameObject? clickTarget = ExecuteEvents.GetEventHandler<IPointerClickHandler>(
-                    _pointerData.rawPointerPress ?? _currentPressTarget);
-                if (clickTarget != null)
-                {
-                    ExecuteEvents.Execute(clickTarget, _pointerData, ExecuteEvents.pointerClickHandler);
-                }
-            }
-
-            _currentPressTarget = null;
-            _currentDragTarget = null;
-            _isDragging = false;
-            _pointerData = null;
-        }
-
-        private static bool DetectMousePositionEvents(InputRecordingData data)
-        {
-            for (int i = 0; i < data.Frames.Count; i++)
-            {
-                List<RecordedInputEvent> events = data.Frames[i].Events;
-                for (int j = 0; j < events.Count; j++)
-                {
-                    if (events[j].Type == InputEventTypes.MOUSE_POSITION)
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        private void SetUiInputModulesSuppressed(bool suppressed)
-        {
-            if (!suppressed)
-            {
-                RestoreUiInputModules();
-                return;
-            }
-
-            EventSystem? eventSystem = EventSystem.current;
-            if (eventSystem == null)
-            {
-                return;
-            }
-
-            BaseInputModule[] modules = eventSystem.GetComponents<BaseInputModule>();
-            for (int i = 0; i < modules.Length; i++)
-            {
-                BaseInputModule module = modules[i];
-                if (!module.enabled)
-                {
-                    continue;
-                }
-
-                // Replay synthesizes ExecuteEvents directly; leaving input modules enabled
-                // lets them consume the same injected Mouse.current state a second time.
-                module.enabled = false;
-                _disabledInputModules.Add(module);
-            }
-        }
-
-        private void RestoreUiInputModules()
-        {
-            for (int i = 0; i < _disabledInputModules.Count; i++)
-            {
-                BaseInputModule module = _disabledInputModules[i];
-                if (module != null)
-                {
-                    module.enabled = true;
-                }
-            }
-
-            _disabledInputModules.Clear();
-        }
-
-        private void ResetUiReplayState()
-        {
-            _replayMousePosition = null;
-            _previousReplayMousePosition = null;
-            _prevLeftButtonHeld = false;
-            _suppressIdleUiOverlay = false;
-            _pointerData = null;
-            _currentPressTarget = null;
-            _currentDragTarget = null;
-            _isDragging = false;
-            _pressTime = 0f;
         }
 
         private void OnPlayModeStateChanged(PlayModeStateChange state)
@@ -789,38 +180,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 StopReplay();
             }
-        }
-
-        private readonly struct UiReplayFrame
-        {
-            public UiReplayFrame(
-                EventSystem eventSystem,
-                Vector2 screenPosition,
-                Vector2 inputPosition,
-                Vector2 gameViewSize,
-                bool leftHeld,
-                bool justPressed,
-                bool justReleased,
-                bool mouseMoved)
-            {
-                EventSystem = eventSystem;
-                ScreenPosition = screenPosition;
-                InputPosition = inputPosition;
-                GameViewSize = gameViewSize;
-                LeftHeld = leftHeld;
-                JustPressed = justPressed;
-                JustReleased = justReleased;
-                MouseMoved = mouseMoved;
-            }
-
-            public EventSystem EventSystem { get; }
-            public Vector2 ScreenPosition { get; }
-            public Vector2 InputPosition { get; }
-            public Vector2 GameViewSize { get; }
-            public bool LeftHeld { get; }
-            public bool JustPressed { get; }
-            public bool JustReleased { get; }
-            public bool MouseMoved { get; }
         }
     }
 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSimulationWaitTypes.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSimulationWaitTypes.cs
@@ -1,0 +1,17 @@
+#nullable enable
+#if ULOOP_HAS_INPUT_SYSTEM
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reports whether input observation finished normally, paused, or exceeded the wall-clock guard.
+    /// </summary>
+    internal enum InputSimulationWaitOutcome
+    {
+        Completed = 0,
+        Paused = 1,
+        TimedOut = 2
+    }
+
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSimulationWaitTypes.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSimulationWaitTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c436823b41f74b9aa0d56e2d07493671
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemConfiguredUpdateApplier.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemConfiguredUpdateApplier.cs
@@ -1,0 +1,179 @@
+#nullable enable
+#if ULOOP_HAS_INPUT_SYSTEM
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.LowLevel;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Applies input mutations on the next Input System update that matches the configured update type.
+    /// </summary>
+    internal static class InputSystemConfiguredUpdateApplier
+    {
+        private const int ApplyWaitStateWaiting = 0;
+        private const int ApplyWaitStateApplying = 1;
+        private const int ApplyWaitStateFinishedWithoutApply = 2;
+
+        public static async Task<InputSimulationWaitOutcome> ApplyOnNextConfiguredUpdate(
+            Action apply,
+            CancellationToken ct)
+        {
+            Debug.Assert(apply != null, "apply must not be null");
+            if (apply == null)
+            {
+                throw new ArgumentNullException(nameof(apply));
+            }
+
+            InputUpdateType targetUpdateType = InputUpdateTypeResolver.Resolve();
+            if (InputUpdateTypeResolver.RequiresExplicitUpdate())
+            {
+                return ApplyOnExplicitUpdate(apply, targetUpdateType, ct);
+            }
+
+            TaskCompletionSource<InputSimulationWaitOutcome> tcs =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            CancellationTokenRegistration registration = default;
+            int applyWaitState = ApplyWaitStateWaiting;
+            Action? callback = null;
+            InputSystemUpdateSubscription? subscription = null;
+
+            callback = () =>
+            {
+                Debug.Assert(callback != null, "callback must be assigned before subscription");
+                Debug.Assert(subscription != null, "subscription must be assigned before callback invocation");
+                if (Interlocked.CompareExchange(
+                        ref applyWaitState,
+                        ApplyWaitStateWaiting,
+                        ApplyWaitStateWaiting) != ApplyWaitStateWaiting)
+                {
+                    subscription?.Dispose();
+                    return;
+                }
+
+                InputUpdateType currentUpdateType = InputState.currentUpdateType;
+                if (!InputUpdateTypeResolver.IsMatch(currentUpdateType, targetUpdateType))
+                {
+                    return;
+                }
+
+                if (Interlocked.CompareExchange(
+                        ref applyWaitState,
+                        ApplyWaitStateApplying,
+                        ApplyWaitStateWaiting) != ApplyWaitStateWaiting)
+                {
+                    subscription?.Dispose();
+                    return;
+                }
+
+                subscription?.Dispose();
+                try
+                {
+                    apply();
+                    tcs.TrySetResult(InputSimulationWaitOutcome.Completed);
+                }
+                catch (Exception exception)
+                {
+                    // Convert apply failures into the awaited task result so timeout paths never wait on an orphaned TCS.
+                    tcs.TrySetException(exception);
+                }
+            };
+
+            subscription = new InputSystemUpdateSubscription(callback);
+            try
+            {
+                if (ct.CanBeCanceled)
+                {
+                    registration = ct.Register(() =>
+                    {
+                        if (Interlocked.CompareExchange(
+                                ref applyWaitState,
+                                ApplyWaitStateFinishedWithoutApply,
+                                ApplyWaitStateWaiting) == ApplyWaitStateWaiting)
+                        {
+                            subscription?.Dispose();
+                            tcs.TrySetCanceled(ct);
+                        }
+                    });
+                }
+
+                using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                Task timeoutTask = TimerDelay.Wait(
+                    InputSystemUpdateHelper.ApplyTimeoutMilliseconds,
+                    timeoutCts.Token);
+                Task completedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
+                if (completedTask == timeoutTask)
+                {
+                    await timeoutTask.ConfigureAwait(false);
+                    if (Interlocked.CompareExchange(
+                            ref applyWaitState,
+                            ApplyWaitStateFinishedWithoutApply,
+                            ApplyWaitStateWaiting) == ApplyWaitStateWaiting)
+                    {
+                        subscription.Dispose();
+                        return InputSimulationWaitOutcome.TimedOut;
+                    }
+
+                    InputSimulationWaitOutcome appliedOutcome = await tcs.Task.ConfigureAwait(false);
+                    await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+                    return appliedOutcome;
+                }
+
+                timeoutCts.Cancel();
+                InputSimulationWaitOutcome outcome = await tcs.Task.ConfigureAwait(false);
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+                return outcome;
+            }
+            finally
+            {
+                registration.Dispose();
+                subscription?.Dispose();
+            }
+        }
+
+        private static InputSimulationWaitOutcome ApplyOnExplicitUpdate(
+            Action apply,
+            InputUpdateType targetUpdateType,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            Action? callback = null;
+            bool applied = false;
+
+            callback = () =>
+            {
+                InputUpdateType currentUpdateType = InputState.currentUpdateType;
+                if (!InputUpdateTypeResolver.IsMatch(currentUpdateType, targetUpdateType))
+                {
+                    return;
+                }
+
+                Debug.Assert(callback != null, "callback must be assigned before subscription");
+                InputSystem.onBeforeUpdate -= callback;
+                apply();
+                applied = true;
+            };
+
+            InputSystem.onBeforeUpdate += callback;
+
+            InputSystemUpdateHelper.RunExplicitUpdate(targetUpdateType);
+            if (!applied)
+            {
+                Debug.Assert(callback != null, "callback must be assigned before explicit update fallback");
+                InputSystem.onBeforeUpdate -= callback;
+                apply();
+                InputSystemUpdateHelper.RunExplicitUpdate(targetUpdateType);
+            }
+
+            return InputSimulationWaitOutcome.Completed;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemConfiguredUpdateApplier.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemConfiguredUpdateApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 683f070c18194627aa491d46cdf750f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemMainThreadAwaitable.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemMainThreadAwaitable.cs
@@ -1,0 +1,58 @@
+#nullable enable
+#if ULOOP_HAS_INPUT_SYSTEM
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Switches input simulation continuations back to Unity's main thread without wrapping the switch in a Task.
+    /// </summary>
+    internal readonly struct InputSystemMainThreadAwaitable
+    {
+        private readonly CancellationToken _ct;
+
+        public InputSystemMainThreadAwaitable(CancellationToken ct)
+        {
+            _ct = ct;
+        }
+
+        public Awaiter GetAwaiter()
+        {
+            return new Awaiter(_ct);
+        }
+
+        public readonly struct Awaiter : INotifyCompletion
+        {
+            private readonly CancellationToken _ct;
+
+            public Awaiter(CancellationToken ct)
+            {
+                _ct = ct;
+            }
+
+            public bool IsCompleted
+            {
+                get
+                {
+                    _ct.ThrowIfCancellationRequested();
+                    return MainThreadSwitcher.IsMainThread;
+                }
+            }
+
+            public void GetResult()
+            {
+                _ct.ThrowIfCancellationRequested();
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                MainThreadSwitcher.SwitchToMainThread(_ct).GetAwaiter().OnCompleted(continuation);
+            }
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemMainThreadAwaitable.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemMainThreadAwaitable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1779f2469cd44bc2b63c7d68c9d6cbe7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs
@@ -1,0 +1,174 @@
+#nullable enable
+#if ULOOP_HAS_INPUT_SYSTEM
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Waits for runtime frames and press lifetimes while honoring pause and timeout guards.
+    /// </summary>
+    internal static class InputSystemRuntimeFrameWaiter
+    {
+        private const int PressDurationTimeoutGraceMilliseconds = 5000;
+
+        public static async Task<InputSimulationWaitOutcome> WaitForRuntimeFrames(int frameCount, CancellationToken ct)
+        {
+            Debug.Assert(frameCount >= 0, "frameCount must be non-negative");
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+
+            int startFrameCount = Time.frameCount;
+            int observedFrames = 0;
+            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            while (observedFrames < frameCount)
+            {
+                if (InputSystemUpdateHelper.IsPaused())
+                {
+                    return InputSimulationWaitOutcome.Paused;
+                }
+
+                InputSimulationWaitOutcome frameOutcome = await WaitOneRuntimeFrameOrTimeout(
+                    InputSystemUpdateHelper.FrameObservationTimeoutMilliseconds,
+                    stopwatch,
+                    ct).ConfigureAwait(false);
+                if (frameOutcome == InputSimulationWaitOutcome.TimedOut)
+                {
+                    return InputSimulationWaitOutcome.TimedOut;
+                }
+
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+                if (InputSystemUpdateHelper.IsPaused())
+                {
+                    return InputSimulationWaitOutcome.Paused;
+                }
+
+                observedFrames = Time.frameCount - startFrameCount;
+            }
+
+            return InputSimulationWaitOutcome.Completed;
+        }
+
+        public static async Task<InputSystemUpdateHelper.PressLifetimeWaitResult> WaitForPressLifetime(
+            float duration,
+            Func<bool>? isPressEdgeObserved,
+            CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+
+            int minimumObservationFrames = InputSystemUpdateHelper.GetMinimumObservationFrameCount();
+            int startFrameCount = Time.frameCount;
+            float startTime = Time.realtimeSinceStartup;
+            float elapsed = 0f;
+            int observedFrames = 0;
+            int baseSatisfiedFrameCount = -1;
+            int timeoutMilliseconds = GetPressLifetimeTimeoutMilliseconds(duration);
+            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            while (true)
+            {
+                bool baseWaitSatisfied = PressHoldUntilEdgeLogic.IsBaseWaitSatisfied(
+                    observedFrames,
+                    minimumObservationFrames,
+                    elapsed,
+                    duration);
+                if (baseWaitSatisfied && baseSatisfiedFrameCount < 0)
+                {
+                    baseSatisfiedFrameCount = observedFrames;
+                }
+
+                bool pressEdgeObserved = isPressEdgeObserved != null && isPressEdgeObserved();
+                bool shouldExtendForEdge = isPressEdgeObserved != null &&
+                    PressHoldUntilEdgeLogic.ShouldExtendHoldForEdge(
+                        pressEdgeObserved,
+                        baseWaitSatisfied,
+                        stopwatch.ElapsedMilliseconds,
+                        timeoutMilliseconds);
+
+                if (baseWaitSatisfied && !shouldExtendForEdge)
+                {
+                    int extendedFrames = baseSatisfiedFrameCount < 0
+                        ? 0
+                        : PressHoldUntilEdgeLogic.CountExtendedFrames(observedFrames, baseSatisfiedFrameCount);
+                    return new InputSystemUpdateHelper.PressLifetimeWaitResult(
+                        InputSimulationWaitOutcome.Completed,
+                        extendedFrames);
+                }
+
+                if (InputSystemUpdateHelper.IsPaused())
+                {
+                    return new InputSystemUpdateHelper.PressLifetimeWaitResult(InputSimulationWaitOutcome.Paused, 0);
+                }
+
+                InputSimulationWaitOutcome frameOutcome = await WaitOneRuntimeFrameOrTimeout(
+                    timeoutMilliseconds,
+                    stopwatch,
+                    ct).ConfigureAwait(false);
+                if (frameOutcome == InputSimulationWaitOutcome.TimedOut)
+                {
+                    // Why: timeout during edge-extension still completes Press successfully with
+                    // PressEdgeObserved=false — same contract as before, not a hard failure.
+                    if (baseWaitSatisfied)
+                    {
+                        int extendedFrames = baseSatisfiedFrameCount < 0
+                            ? 0
+                            : PressHoldUntilEdgeLogic.CountExtendedFrames(observedFrames, baseSatisfiedFrameCount);
+                        return new InputSystemUpdateHelper.PressLifetimeWaitResult(
+                            InputSimulationWaitOutcome.Completed,
+                            extendedFrames);
+                    }
+
+                    return new InputSystemUpdateHelper.PressLifetimeWaitResult(InputSimulationWaitOutcome.TimedOut, 0);
+                }
+
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+                if (InputSystemUpdateHelper.IsPaused())
+                {
+                    return new InputSystemUpdateHelper.PressLifetimeWaitResult(InputSimulationWaitOutcome.Paused, 0);
+                }
+
+                observedFrames = Time.frameCount - startFrameCount;
+                elapsed = Time.realtimeSinceStartup - startTime;
+            }
+        }
+
+        private static async Task<InputSimulationWaitOutcome> WaitOneRuntimeFrameOrTimeout(
+            int timeoutMilliseconds,
+            System.Diagnostics.Stopwatch stopwatch,
+            CancellationToken ct)
+        {
+            int remainingMilliseconds = timeoutMilliseconds - (int)stopwatch.ElapsedMilliseconds;
+            if (remainingMilliseconds <= 0)
+            {
+                return InputSimulationWaitOutcome.TimedOut;
+            }
+
+            bool frameObserved = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
+                1,
+                remainingMilliseconds,
+                ct).ConfigureAwait(false);
+            return frameObserved
+                ? InputSimulationWaitOutcome.Completed
+                : InputSimulationWaitOutcome.TimedOut;
+        }
+
+        private static int GetPressLifetimeTimeoutMilliseconds(float duration)
+        {
+            double durationMilliseconds = Math.Ceiling(duration * 1000d);
+            double timeoutMilliseconds = durationMilliseconds + PressDurationTimeoutGraceMilliseconds;
+            if (timeoutMilliseconds > int.MaxValue)
+            {
+                return int.MaxValue;
+            }
+
+            return Math.Max(
+                InputSystemUpdateHelper.FrameObservationTimeoutMilliseconds,
+                (int)timeoutMilliseconds);
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemRuntimeFrameWaiter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e495c703ea7e4da199307925db350077
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateHelper.cs
@@ -1,7 +1,6 @@
 #nullable enable
 #if ULOOP_HAS_INPUT_SYSTEM
 using System;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -14,16 +13,6 @@ using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
-    /// <summary>
-    /// Reports whether input observation finished normally, paused, or exceeded the wall-clock guard.
-    /// </summary>
-    internal enum InputSimulationWaitOutcome
-    {
-        Completed = 0,
-        Paused = 1,
-        TimedOut = 2
-    }
-
     // Shared helper for applying Input System state changes at the correct update phase.
     // Both keyboard and mouse simulation need frame-precise timing so that
     // wasPressedThisFrame / wasReleasedThisFrame detect the injected state.
@@ -36,125 +25,21 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         private const int ManualPressObservationFrames = 3;
         private const int DefaultApplyTimeoutMilliseconds = UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS;
         private const int DefaultFrameObservationTimeoutMilliseconds = UnityCliLoopConstants.EDITOR_FRAME_WAIT_TIMEOUT_MS;
-        private const int PressDurationTimeoutGraceMilliseconds = 5000;
-        private const int ApplyWaitStateWaiting = 0;
-        private const int ApplyWaitStateApplying = 1;
-        private const int ApplyWaitStateFinishedWithoutApply = 2;
+
         private static Func<bool> isPausedProvider = () => EditorApplication.isPaused;
         private static int applyTimeoutMilliseconds = DefaultApplyTimeoutMilliseconds;
         private static int frameObservationTimeoutMilliseconds = DefaultFrameObservationTimeoutMilliseconds;
-        private static int pendingConfiguredUpdateCallbackCount;
+
+        internal static int PendingConfiguredUpdateCallbackCountValue;
+
+        internal static int ApplyTimeoutMilliseconds => applyTimeoutMilliseconds;
+
+        internal static int FrameObservationTimeoutMilliseconds => frameObservationTimeoutMilliseconds;
 
         public static async Task<InputSimulationWaitOutcome> ApplyOnNextConfiguredUpdate(Action apply, CancellationToken ct)
         {
-            Debug.Assert(apply != null, "apply must not be null");
-            if (apply == null)
-            {
-                throw new ArgumentNullException(nameof(apply));
-            }
-
-            InputUpdateType targetUpdateType = InputUpdateTypeResolver.Resolve();
-            if (InputUpdateTypeResolver.RequiresExplicitUpdate())
-            {
-                return ApplyOnExplicitUpdate(apply, targetUpdateType, ct);
-            }
-
-            TaskCompletionSource<InputSimulationWaitOutcome> tcs =
-                new(TaskCreationOptions.RunContinuationsAsynchronously);
-            CancellationTokenRegistration registration = default;
-            int applyWaitState = ApplyWaitStateWaiting;
-            Action? callback = null;
-            InputSystemUpdateSubscription? subscription = null;
-
-            callback = () =>
-            {
-                Debug.Assert(callback != null, "callback must be assigned before subscription");
-                Debug.Assert(subscription != null, "subscription must be assigned before callback invocation");
-                if (Interlocked.CompareExchange(
-                        ref applyWaitState,
-                        ApplyWaitStateWaiting,
-                        ApplyWaitStateWaiting) != ApplyWaitStateWaiting)
-                {
-                    subscription?.Dispose();
-                    return;
-                }
-
-                InputUpdateType currentUpdateType = InputState.currentUpdateType;
-                if (!InputUpdateTypeResolver.IsMatch(currentUpdateType, targetUpdateType))
-                {
-                    return;
-                }
-
-                if (Interlocked.CompareExchange(
-                        ref applyWaitState,
-                        ApplyWaitStateApplying,
-                        ApplyWaitStateWaiting) != ApplyWaitStateWaiting)
-                {
-                    subscription?.Dispose();
-                    return;
-                }
-
-                subscription?.Dispose();
-                try
-                {
-                    apply();
-                    tcs.TrySetResult(InputSimulationWaitOutcome.Completed);
-                }
-                catch (Exception exception)
-                {
-                    // Convert apply failures into the awaited task result so timeout paths never wait on an orphaned TCS.
-                    tcs.TrySetException(exception);
-                }
-            };
-
-            subscription = new InputSystemUpdateSubscription(callback);
-            try
-            {
-                if (ct.CanBeCanceled)
-                {
-                    registration = ct.Register(() =>
-                    {
-                        if (Interlocked.CompareExchange(
-                                ref applyWaitState,
-                                ApplyWaitStateFinishedWithoutApply,
-                                ApplyWaitStateWaiting) == ApplyWaitStateWaiting)
-                        {
-                            subscription?.Dispose();
-                            tcs.TrySetCanceled(ct);
-                        }
-                    });
-                }
-
-                using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                Task timeoutTask = TimerDelay.Wait(applyTimeoutMilliseconds, timeoutCts.Token);
-                Task completedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
-                if (completedTask == timeoutTask)
-                {
-                    await timeoutTask.ConfigureAwait(false);
-                    if (Interlocked.CompareExchange(
-                            ref applyWaitState,
-                            ApplyWaitStateFinishedWithoutApply,
-                            ApplyWaitStateWaiting) == ApplyWaitStateWaiting)
-                    {
-                        subscription.Dispose();
-                        return InputSimulationWaitOutcome.TimedOut;
-                    }
-
-                    InputSimulationWaitOutcome appliedOutcome = await tcs.Task.ConfigureAwait(false);
-                    await SwitchToMainThreadIfNeeded(CancellationToken.None);
-                    return appliedOutcome;
-                }
-
-                timeoutCts.Cancel();
-                InputSimulationWaitOutcome outcome = await tcs.Task.ConfigureAwait(false);
-                await SwitchToMainThreadIfNeeded(CancellationToken.None);
-                return outcome;
-            }
-            finally
-            {
-                registration.Dispose();
-                subscription?.Dispose();
-            }
+            return await InputSystemConfiguredUpdateApplier.ApplyOnNextConfiguredUpdate(apply, ct)
+                .ConfigureAwait(false);
         }
 
         public static int GetMinimumObservationFrameCount()
@@ -193,94 +78,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         }
 
         /// <summary>
-        /// Waits for duration + min frames, then optionally holds release until a press edge is observed.
-        /// Why: when wasPressedThisFrame never becomes true in the normal window, delaying release
-        /// gives gameplay more frames without reinjecting down/up (which would double-fire actions).
-        /// </summary>
-        public static async Task<PressLifetimeWaitResult> WaitForPressLifetime(
-            float duration,
-            Func<bool>? isPressEdgeObserved,
-            CancellationToken ct)
-        {
-            await SwitchToMainThreadIfNeeded(ct);
-
-            int minimumObservationFrames = GetMinimumObservationFrameCount();
-            int startFrameCount = Time.frameCount;
-            float startTime = Time.realtimeSinceStartup;
-            float elapsed = 0f;
-            int observedFrames = 0;
-            int baseSatisfiedFrameCount = -1;
-            int timeoutMilliseconds = GetPressLifetimeTimeoutMilliseconds(duration);
-            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
-
-            while (true)
-            {
-                bool baseWaitSatisfied = PressHoldUntilEdgeLogic.IsBaseWaitSatisfied(
-                    observedFrames,
-                    minimumObservationFrames,
-                    elapsed,
-                    duration);
-                if (baseWaitSatisfied && baseSatisfiedFrameCount < 0)
-                {
-                    baseSatisfiedFrameCount = observedFrames;
-                }
-
-                bool pressEdgeObserved = isPressEdgeObserved != null && isPressEdgeObserved();
-                bool shouldExtendForEdge = isPressEdgeObserved != null &&
-                    PressHoldUntilEdgeLogic.ShouldExtendHoldForEdge(
-                        pressEdgeObserved,
-                        baseWaitSatisfied,
-                        stopwatch.ElapsedMilliseconds,
-                        timeoutMilliseconds);
-
-                if (baseWaitSatisfied && !shouldExtendForEdge)
-                {
-                    int extendedFrames = baseSatisfiedFrameCount < 0
-                        ? 0
-                        : PressHoldUntilEdgeLogic.CountExtendedFrames(observedFrames, baseSatisfiedFrameCount);
-                    return new PressLifetimeWaitResult(
-                        InputSimulationWaitOutcome.Completed,
-                        extendedFrames);
-                }
-
-                if (IsPaused())
-                {
-                    return new PressLifetimeWaitResult(InputSimulationWaitOutcome.Paused, 0);
-                }
-
-                InputSimulationWaitOutcome frameOutcome = await WaitOneRuntimeFrameOrTimeout(
-                    timeoutMilliseconds,
-                    stopwatch,
-                    ct).ConfigureAwait(false);
-                if (frameOutcome == InputSimulationWaitOutcome.TimedOut)
-                {
-                    // Why: timeout during edge-extension still completes Press successfully with
-                    // PressEdgeObserved=false — same contract as before, not a hard failure.
-                    if (baseWaitSatisfied)
-                    {
-                        int extendedFrames = baseSatisfiedFrameCount < 0
-                            ? 0
-                            : PressHoldUntilEdgeLogic.CountExtendedFrames(observedFrames, baseSatisfiedFrameCount);
-                        return new PressLifetimeWaitResult(
-                            InputSimulationWaitOutcome.Completed,
-                            extendedFrames);
-                    }
-
-                    return new PressLifetimeWaitResult(InputSimulationWaitOutcome.TimedOut, 0);
-                }
-
-                await SwitchToMainThreadIfNeeded(ct);
-                if (IsPaused())
-                {
-                    return new PressLifetimeWaitResult(InputSimulationWaitOutcome.Paused, 0);
-                }
-
-                observedFrames = Time.frameCount - startFrameCount;
-                elapsed = Time.realtimeSinceStartup - startTime;
-            }
-        }
-
-        /// <summary>
         /// Outcome of a Press duration wait, including how many frames release was delayed for edge observation.
         /// </summary>
         internal readonly struct PressLifetimeWaitResult
@@ -296,6 +93,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             public int ExtendedObservationFrames { get; }
         }
 
+        /// <summary>
+        /// Waits for duration + min frames, then optionally holds release until a press edge is observed.
+        /// Why: when wasPressedThisFrame never becomes true in the normal window, delaying release
+        /// gives gameplay more frames without reinjecting down/up (which would double-fire actions).
+        /// </summary>
+        public static async Task<PressLifetimeWaitResult> WaitForPressLifetime(
+            float duration,
+            Func<bool>? isPressEdgeObserved,
+            CancellationToken ct)
+        {
+            return await InputSystemRuntimeFrameWaiter.WaitForPressLifetime(duration, isPressEdgeObserved, ct)
+                .ConfigureAwait(false);
+        }
 
         public static void RunExplicitUpdate(InputUpdateType targetUpdateType)
         {
@@ -325,101 +135,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
         }
 
-        private static InputSimulationWaitOutcome ApplyOnExplicitUpdate(
-            Action apply,
-            InputUpdateType targetUpdateType,
-            CancellationToken ct)
-        {
-            ct.ThrowIfCancellationRequested();
-
-            Action? callback = null;
-            bool applied = false;
-
-            callback = () =>
-            {
-                InputUpdateType currentUpdateType = InputState.currentUpdateType;
-                if (!InputUpdateTypeResolver.IsMatch(currentUpdateType, targetUpdateType))
-                {
-                    return;
-                }
-
-                Debug.Assert(callback != null, "callback must be assigned before subscription");
-                InputSystem.onBeforeUpdate -= callback;
-                apply();
-                applied = true;
-            };
-
-            InputSystem.onBeforeUpdate += callback;
-
-            RunExplicitUpdate(targetUpdateType);
-            if (!applied)
-            {
-                Debug.Assert(callback != null, "callback must be assigned before explicit update fallback");
-                InputSystem.onBeforeUpdate -= callback;
-                apply();
-                RunExplicitUpdate(targetUpdateType);
-            }
-
-            return InputSimulationWaitOutcome.Completed;
-        }
-
-        private static InputSettings.UpdateMode GetExplicitUpdateMode(
-            InputUpdateType targetUpdateType,
-            InputSettings.UpdateMode fallbackUpdateMode)
-        {
-            if (targetUpdateType == InputUpdateType.Dynamic)
-            {
-                return InputSettings.UpdateMode.ProcessEventsInDynamicUpdate;
-            }
-
-            if (targetUpdateType == InputUpdateType.Fixed)
-            {
-                return InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
-            }
-
-            if (targetUpdateType == InputUpdateType.Manual)
-            {
-                return InputSettings.UpdateMode.ProcessEventsManually;
-            }
-
-            return fallbackUpdateMode;
-        }
-
         public static async Task<InputSimulationWaitOutcome> WaitForRuntimeFrames(int frameCount, CancellationToken ct)
         {
-            Debug.Assert(frameCount >= 0, "frameCount must be non-negative");
-            await SwitchToMainThreadIfNeeded(ct);
-
-            int startFrameCount = Time.frameCount;
-            int observedFrames = 0;
-            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
-
-            while (observedFrames < frameCount)
-            {
-                if (IsPaused())
-                {
-                    return InputSimulationWaitOutcome.Paused;
-                }
-
-                InputSimulationWaitOutcome frameOutcome = await WaitOneRuntimeFrameOrTimeout(
-                    frameObservationTimeoutMilliseconds,
-                    stopwatch,
-                    ct).ConfigureAwait(false);
-                if (frameOutcome == InputSimulationWaitOutcome.TimedOut)
-                {
-                    return InputSimulationWaitOutcome.TimedOut;
-                }
-
-                await SwitchToMainThreadIfNeeded(ct);
-                if (IsPaused())
-                {
-                    return InputSimulationWaitOutcome.Paused;
-                }
-
-                observedFrames = Time.frameCount - startFrameCount;
-            }
-
-            return InputSimulationWaitOutcome.Completed;
+            return await InputSystemRuntimeFrameWaiter.WaitForRuntimeFrames(frameCount, ct).ConfigureAwait(false);
         }
 
         public static InputSystemMainThreadAwaitable SwitchToMainThreadIfNeeded(CancellationToken ct)
@@ -467,131 +185,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             frameObservationTimeoutMilliseconds = DefaultFrameObservationTimeoutMilliseconds;
         }
 
-        internal static int PendingConfiguredUpdateCallbackCount => Volatile.Read(ref pendingConfiguredUpdateCallbackCount);
+        internal static int PendingConfiguredUpdateCallbackCount => Volatile.Read(ref PendingConfiguredUpdateCallbackCountValue);
 
-        private static bool IsPaused()
+        internal static bool IsPaused()
         {
             return isPausedProvider();
         }
 
-        private static async Task<InputSimulationWaitOutcome> WaitOneRuntimeFrameOrTimeout(
-            int timeoutMilliseconds,
-            System.Diagnostics.Stopwatch stopwatch,
-            CancellationToken ct)
+        private static InputSettings.UpdateMode GetExplicitUpdateMode(
+            InputUpdateType targetUpdateType,
+            InputSettings.UpdateMode fallbackUpdateMode)
         {
-            int remainingMilliseconds = timeoutMilliseconds - (int)stopwatch.ElapsedMilliseconds;
-            if (remainingMilliseconds <= 0)
+            if (targetUpdateType == InputUpdateType.Dynamic)
             {
-                return InputSimulationWaitOutcome.TimedOut;
+                return InputSettings.UpdateMode.ProcessEventsInDynamicUpdate;
             }
 
-            bool frameObserved = await EditorFrameWaiter.WaitFramesOrTimeoutAsync(
-                1,
-                remainingMilliseconds,
-                ct).ConfigureAwait(false);
-            return frameObserved
-                ? InputSimulationWaitOutcome.Completed
-                : InputSimulationWaitOutcome.TimedOut;
-        }
-
-        private static int GetPressLifetimeTimeoutMilliseconds(float duration)
-        {
-            double durationMilliseconds = Math.Ceiling(duration * 1000d);
-            double timeoutMilliseconds = durationMilliseconds + PressDurationTimeoutGraceMilliseconds;
-            if (timeoutMilliseconds > int.MaxValue)
+            if (targetUpdateType == InputUpdateType.Fixed)
             {
-                return int.MaxValue;
+                return InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
             }
 
-            return Math.Max(frameObservationTimeoutMilliseconds, (int)timeoutMilliseconds);
-        }
-
-        /// <summary>
-        /// Owns one Input System update subscription so timeout and cancellation paths remove it exactly once.
-        /// </summary>
-        private sealed class InputSystemUpdateSubscription : IDisposable
-        {
-            private readonly Action callback;
-            private int isDisposed;
-
-            public InputSystemUpdateSubscription(Action callback)
+            if (targetUpdateType == InputUpdateType.Manual)
             {
-                Debug.Assert(callback != null, "callback must not be null");
-
-                this.callback = callback ?? throw new ArgumentNullException(nameof(callback));
-                InputSystem.onBeforeUpdate += this.callback;
-                Interlocked.Increment(ref pendingConfiguredUpdateCallbackCount);
+                return InputSettings.UpdateMode.ProcessEventsManually;
             }
 
-            public void Dispose()
-            {
-                if (Interlocked.Exchange(ref isDisposed, 1) != 0)
-                {
-                    return;
-                }
-
-                Interlocked.Decrement(ref pendingConfiguredUpdateCallbackCount);
-                if (MainThreadSwitcher.IsMainThread)
-                {
-                    InputSystem.onBeforeUpdate -= callback;
-                    return;
-                }
-
-                RemoveOnMainThreadAsync(CancellationToken.None).Forget();
-            }
-
-            private async Task RemoveOnMainThreadAsync(CancellationToken ct)
-            {
-                await SwitchToMainThreadIfNeeded(ct);
-                InputSystem.onBeforeUpdate -= callback;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Switches input simulation continuations back to Unity's main thread without wrapping the switch in a Task.
-    /// </summary>
-    internal readonly struct InputSystemMainThreadAwaitable
-    {
-        private readonly CancellationToken _ct;
-
-        public InputSystemMainThreadAwaitable(CancellationToken ct)
-        {
-            _ct = ct;
-        }
-
-        public Awaiter GetAwaiter()
-        {
-            return new Awaiter(_ct);
-        }
-
-        public readonly struct Awaiter : INotifyCompletion
-        {
-            private readonly CancellationToken _ct;
-
-            public Awaiter(CancellationToken ct)
-            {
-                _ct = ct;
-            }
-
-            public bool IsCompleted
-            {
-                get
-                {
-                    _ct.ThrowIfCancellationRequested();
-                    return MainThreadSwitcher.IsMainThread;
-                }
-            }
-
-            public void GetResult()
-            {
-                _ct.ThrowIfCancellationRequested();
-            }
-
-            public void OnCompleted(Action continuation)
-            {
-                MainThreadSwitcher.SwitchToMainThread(_ct).GetAwaiter().OnCompleted(continuation);
-            }
+            return fallbackUpdateMode;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateSubscription.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateSubscription.cs
@@ -1,0 +1,55 @@
+#nullable enable
+#if ULOOP_HAS_INPUT_SYSTEM
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Owns one Input System update subscription so timeout and cancellation paths remove it exactly once.
+    /// </summary>
+    internal sealed class InputSystemUpdateSubscription : IDisposable
+    {
+        private readonly Action callback;
+        private int isDisposed;
+
+        public InputSystemUpdateSubscription(Action callback)
+        {
+            Debug.Assert(callback != null, "callback must not be null");
+
+            this.callback = callback ?? throw new ArgumentNullException(nameof(callback));
+            InputSystem.onBeforeUpdate += this.callback;
+            Interlocked.Increment(ref InputSystemUpdateHelper.PendingConfiguredUpdateCallbackCountValue);
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref isDisposed, 1) != 0)
+            {
+                return;
+            }
+
+            Interlocked.Decrement(ref InputSystemUpdateHelper.PendingConfiguredUpdateCallbackCountValue);
+            if (MainThreadSwitcher.IsMainThread)
+            {
+                InputSystem.onBeforeUpdate -= callback;
+                return;
+            }
+
+            RemoveOnMainThreadAsync(CancellationToken.None).Forget();
+        }
+
+        private async Task RemoveOnMainThreadAsync(CancellationToken ct)
+        {
+            await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(ct);
+            InputSystem.onBeforeUpdate -= callback;
+        }
+    }
+}
+#endif

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateSubscription.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSystem/InputSystemUpdateSubscription.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4239026933f94ca286c891d4f8b9fe2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Split InputReplayer, InputRecorder, and InputSystemUpdateHelper so each implementation file stays under 500 lines without changing record/replay behavior.

## User Impact
- No user-facing behavior change for input recording, replay, or Input System update waiting.
- Maintainability improves by separating event processing, UI replay, frame capture, and runtime frame waiting.

## Changes
- `InputReplayer` → orchestration + `InputReplayEventProcessor` / `InputReplayUiController`
- `InputRecorder` → orchestration + `InputRecorderFrameCapture` / `InputRecordingVectorFormat`
- `InputSystemUpdateHelper` → facade + configured update applier / runtime frame waiter / subscription / main-thread awaitable / wait types

## Verification
- `uloop compile` → 0/0
- All target + extracted files < 500 lines
- EditMode `Input` → 47 passed
- PlayMode `InputReplay` → 2 passed
- `dotnet test tests/UnityCliLoop.CodeComplexity.Tests` → 12 passed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

