### PR TITLE
chore: Keep Settings and wizard presentation sources under 500 lines

### DIFF
--- a/Assets/Tests/Editor/ToolSettingsSectionLayoutSignatureTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsSectionLayoutSignatureTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.Presentation;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Characterization tests for Tool Settings list layout signatures.
+    /// </summary>
+    public sealed class ToolSettingsSectionLayoutSignatureTests
+    {
+        [Test]
+        public void Create_WhenGroupsHaveTools_IncludesGroupMarkersAndToolFields()
+        {
+            // Pins the rebuild signature format used to decide whether the ListView must rebuild.
+            ToolSettingsSectionData data = new(
+                showToolSettings: true,
+                builtInTools: new[]
+                {
+                    new ToolToggleItem("compile", true, false, "Compile the project")
+                },
+                thirdPartyTools: new[]
+                {
+                    new ToolToggleItem("vendor.tool", false, true, "Vendor tool")
+                },
+                isRegistryAvailable: true);
+
+            string signature = ToolSettingsSectionLayoutSignature.Create(data);
+
+            Assert.That(signature, Is.EqualTo("B:compile|Compile the project|;T:vendor.tool|Vendor tool|;"));
+        }
+
+        [Test]
+        public void Create_WhenGroupsAreEmpty_KeepsEmptyGroupMarkers()
+        {
+            // Pins empty-group signatures so collapsed/empty catalogs stay stable across refreshes.
+            ToolSettingsSectionData data = new(
+                showToolSettings: true,
+                builtInTools: System.Array.Empty<ToolToggleItem>(),
+                thirdPartyTools: System.Array.Empty<ToolToggleItem>(),
+                isRegistryAvailable: true);
+
+            string signature = ToolSettingsSectionLayoutSignature.Create(data);
+
+            Assert.That(signature, Is.EqualTo("B:;T:;"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/ToolSettingsSectionLayoutSignatureTests.cs.meta
+++ b/Assets/Tests/Editor/ToolSettingsSectionLayoutSignatureTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c25e44ffdb1e4c2f928333fdfd7079cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Owns Setup Wizard CLI-step workflow state and async install/repair operations.
+    /// </summary>
+    internal sealed class SetupWizardCliWorkflowController
+    {
+        private readonly SetupWizardCliStepPresenter _cliStepPresenter;
+        private readonly CliSetupApplicationService _cliSetupApplicationService;
+        private readonly Action<bool> _refreshUi;
+
+        private bool _isInstallingCli;
+        private bool _needsCliPathSetup;
+
+        internal SetupWizardCliWorkflowController(
+            VisualElement cliStatusIcon,
+            Label cliStatusLabel,
+            Button installCliButton,
+            CliSetupApplicationService cliSetupApplicationService,
+            Action<bool> refreshUi)
+        {
+            Debug.Assert(cliSetupApplicationService != null, "cliSetupApplicationService must not be null");
+            Debug.Assert(refreshUi != null, "refreshUi must not be null");
+
+            _cliSetupApplicationService = cliSetupApplicationService
+                ?? throw new ArgumentNullException(nameof(cliSetupApplicationService));
+            _refreshUi = refreshUi
+                ?? throw new ArgumentNullException(nameof(refreshUi));
+
+            _cliStepPresenter = new SetupWizardCliStepPresenter(
+                cliStatusIcon,
+                cliStatusLabel,
+                installCliButton,
+                HandleInstallCli);
+        }
+
+        internal void ShowChecking()
+        {
+            _cliStepPresenter.ShowChecking();
+        }
+
+        internal async Task<bool> RefreshAndUpdateAsync(CancellationToken ct)
+        {
+            await _cliSetupApplicationService.ForceRefreshCliVersionAsync(ct);
+            _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
+            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
+            UpdateFromCachedState(cliVersion);
+            return IsCliInstalled(cliVersion);
+        }
+
+        private void UpdateFromCachedState(string cliVersion = null)
+        {
+            if (cliVersion == null)
+            {
+                cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
+            }
+
+            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
+            string requiredCliVersion = GetMinimumRequiredCliVersion();
+            bool cliInstalled = IsCliInstalled(cliVersion);
+            _cliStepPresenter.Update(
+                cliInstalled,
+                cliVersion,
+                cliIsDispatcher,
+                requiredCliVersion,
+                _isInstallingCli,
+                _needsCliPathSetup);
+        }
+
+        private void HandleInstallCli()
+        {
+            HandleInstallCliAsync(CancellationToken.None).Forget();
+        }
+
+        private async Task HandleInstallCliAsync(CancellationToken ct)
+        {
+            await RefreshCliPrimaryActionStateAsync(ct);
+
+            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
+            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
+            CliSetupCompatibilityState state = EvaluateCliSetupCompatibilityForSetupWizard(
+                cliVersion,
+                cliIsDispatcher,
+                GetMinimumRequiredCliVersion());
+            if (SetupWizardWindow.ShouldRepairCliPathFromPrimaryButton(_needsCliPathSetup, state.NeedsUpdate))
+            {
+                await HandleRepairCliPathSetup(ct);
+                return;
+            }
+
+            bool wasCliInstalledBeforeInstall = _cliSetupApplicationService.IsCliInstalled();
+            _needsCliPathSetup = false;
+            _isInstallingCli = true;
+            _cliStepPresenter.Update(
+                cliInstalled: false,
+                cliVersion: null,
+                cliIsDispatcher: false,
+                requiredCliVersion: GetMinimumRequiredCliVersion(),
+                isInstallingCli: _isInstallingCli,
+                needsCliPathSetup: _needsCliPathSetup);
+
+            try
+            {
+                CliInstallResult result = await _cliSetupApplicationService.InstallGlobalCliAsync(
+                    UnityEngine.Application.platform,
+                    ct);
+
+                if (!result.Success)
+                {
+                    NativeCliInstallCommand command = _cliSetupApplicationService.GetGlobalCliInstallCommand(
+                        UnityEngine.Application.platform,
+                        true);
+                    EditorUtility.DisplayDialog(
+                        "Installation Failed",
+                        $"Failed to install uloop CLI.\n\n{result.ErrorOutput}\n\n"
+                        + $"You can install manually:\n  {command.ManualCommand}",
+                        "OK");
+                    return;
+                }
+
+                await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
+                    UnityEngine.Application.platform,
+                    _cliSetupApplicationService,
+                    ct);
+                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
+            }
+            finally
+            {
+                _isInstallingCli = false;
+                _refreshUi(CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(
+                    wasCliInstalledBeforeInstall));
+            }
+        }
+
+        private async Task RefreshCliPrimaryActionStateAsync(CancellationToken ct)
+        {
+            _cliStepPresenter.ShowRefreshingPrimaryAction();
+
+            try
+            {
+                await _cliSetupApplicationService.ForceRefreshCliVersionAsync(ct);
+                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
+            }
+            finally
+            {
+                RefreshCliStepFromCachedState();
+            }
+        }
+
+        private void RefreshCliStepFromCachedState()
+        {
+            UpdateFromCachedState();
+        }
+
+        private async Task HandleRepairCliPathSetup(CancellationToken ct)
+        {
+            _isInstallingCli = true;
+            _cliStepPresenter.Update(
+                cliInstalled: true,
+                cliVersion: _cliSetupApplicationService.GetCachedCliVersion(),
+                cliIsDispatcher: _cliSetupApplicationService.GetCachedCliIsDispatcher(),
+                requiredCliVersion: GetMinimumRequiredCliVersion(),
+                isInstallingCli: _isInstallingCli,
+                needsCliPathSetup: _needsCliPathSetup);
+
+            try
+            {
+                await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
+                    UnityEngine.Application.platform,
+                    _cliSetupApplicationService,
+                    ct);
+                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
+            }
+            finally
+            {
+                _isInstallingCli = false;
+                _refreshUi(true);
+            }
+        }
+
+        private async Task<bool> ShouldRepairCliPathSetupAsync(CancellationToken ct)
+        {
+            bool hasPackageOwnedCurrentUserInstall =
+                _cliSetupApplicationService.HasPackageOwnedCurrentUserInstall(UnityEngine.Application.platform);
+            if (!SetupWizardWindow.ShouldCheckCliPathSetupForSetupWizard(
+                    UnityEngine.Application.platform,
+                    hasPackageOwnedCurrentUserInstall))
+            {
+                return false;
+            }
+
+            bool isCliVisibleFromShell = await _cliSetupApplicationService.IsCliVisibleFromShellAsync(
+                UnityEngine.Application.platform,
+                ct);
+            return !isCliVisibleFromShell;
+        }
+
+        private static CliSetupCompatibilityState EvaluateCliSetupCompatibilityForSetupWizard(
+            string cliVersion,
+            bool cliIsDispatcher,
+            string requiredCliVersion)
+        {
+            return CliSetupCompatibility.Evaluate(
+                cliVersion,
+                cliIsDispatcher,
+                requiredCliVersion);
+        }
+
+        private string GetMinimumRequiredCliVersion()
+        {
+            return _cliSetupApplicationService.GetMinimumRequiredCliVersion();
+        }
+
+        private static bool IsCliInstalled(string cliVersion)
+        {
+            return !string.IsNullOrEmpty(cliVersion);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs.meta
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardCliWorkflowController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a13fc2d47454255863d9f9f35f90719
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsWorkflowController.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Owns Setup Wizard skills-step workflow state and async install/refresh operations.
+    /// </summary>
+    internal sealed class SetupWizardSkillsWorkflowController
+    {
+        private readonly VisualElement _groupSkillsRow;
+        private readonly EnumField _skillsTargetField;
+        private readonly Toggle _groupSkillsToggle;
+        private readonly Label _groupSkillsLabel;
+        private readonly SetupWizardSkillsStepPresenter _skillsStepPresenter;
+        private readonly SkillSetupUseCase _skillSetupUseCase;
+        private readonly IUnityCliLoopEditorSettingsPort _editorSettingsPort;
+        private readonly CliSetupApplicationService _cliSetupApplicationService;
+        private readonly Action _scheduleResizeToContent;
+
+        private bool _isInstallingSkills;
+        private bool _isSkillsTargetFieldInitialized;
+        private bool _shouldUseFirstInstallSkillsUi;
+        private bool _installSkillsFlat;
+        private CancellationTokenSource _skillInstallStateRefreshCts;
+        private SkillsTarget _skillsTarget = SkillsTarget.Claude;
+
+        internal SetupWizardSkillsWorkflowController(
+            VisualElement groupSkillsRow,
+            EnumField skillsTargetField,
+            Toggle groupSkillsToggle,
+            Label groupSkillsLabel,
+            VisualElement skillsTargetRow,
+            VisualElement skillsTargetList,
+            VisualElement skillsStatusDivider,
+            Label skillsStatusLabel,
+            Button installSkillsButton,
+            SkillSetupUseCase skillSetupUseCase,
+            IUnityCliLoopEditorSettingsPort editorSettingsPort,
+            CliSetupApplicationService cliSetupApplicationService,
+            Action scheduleResizeToContent,
+            string lastSeenSetupWizardVersionBeforeOpen)
+        {
+            Debug.Assert(groupSkillsRow != null, "groupSkillsRow must not be null");
+            Debug.Assert(skillsTargetField != null, "skillsTargetField must not be null");
+            Debug.Assert(groupSkillsToggle != null, "groupSkillsToggle must not be null");
+            Debug.Assert(groupSkillsLabel != null, "groupSkillsLabel must not be null");
+            Debug.Assert(skillSetupUseCase != null, "skillSetupUseCase must not be null");
+            Debug.Assert(editorSettingsPort != null, "editorSettingsPort must not be null");
+            Debug.Assert(cliSetupApplicationService != null, "cliSetupApplicationService must not be null");
+            Debug.Assert(scheduleResizeToContent != null, "scheduleResizeToContent must not be null");
+
+            _groupSkillsRow = groupSkillsRow ?? throw new ArgumentNullException(nameof(groupSkillsRow));
+            _skillsTargetField = skillsTargetField
+                ?? throw new ArgumentNullException(nameof(skillsTargetField));
+            _groupSkillsToggle = groupSkillsToggle
+                ?? throw new ArgumentNullException(nameof(groupSkillsToggle));
+            _groupSkillsLabel = groupSkillsLabel
+                ?? throw new ArgumentNullException(nameof(groupSkillsLabel));
+            _skillSetupUseCase = skillSetupUseCase
+                ?? throw new ArgumentNullException(nameof(skillSetupUseCase));
+            _editorSettingsPort = editorSettingsPort
+                ?? throw new ArgumentNullException(nameof(editorSettingsPort));
+            _cliSetupApplicationService = cliSetupApplicationService
+                ?? throw new ArgumentNullException(nameof(cliSetupApplicationService));
+            _scheduleResizeToContent = scheduleResizeToContent
+                ?? throw new ArgumentNullException(nameof(scheduleResizeToContent));
+
+            _skillsStepPresenter = new SetupWizardSkillsStepPresenter(
+                skillsTargetRow,
+                skillsTargetList,
+                skillsStatusDivider,
+                skillsStatusLabel,
+                installSkillsButton,
+                HandleInstallSkills);
+
+            InitializeFirstInstallSkillsUiState(lastSeenSetupWizardVersionBeforeOpen);
+        }
+
+        internal void InitializeSkillsTargetField()
+        {
+            if (_isSkillsTargetFieldInitialized) return;
+
+            _skillsTargetField.Init(_skillsTarget);
+            _skillsTargetField.RegisterValueChangedCallback(evt =>
+            {
+                if (evt.newValue is SkillsTarget newTarget)
+                {
+                    _skillsTarget = newTarget;
+                    RefreshSkillsSection();
+                }
+            });
+            _isSkillsTargetFieldInitialized = true;
+        }
+
+        internal void InitializeGroupSkillsToggle()
+        {
+            ApplyFlatSkillInstallPreference();
+            ViewDataBinder.SetVisible(_groupSkillsRow, false);
+            _groupSkillsToggle.SetValueWithoutNotify(!_installSkillsFlat);
+            _groupSkillsToggle.RegisterValueChangedCallback(evt =>
+            {
+                evt.StopPropagation();
+                ApplyFlatSkillInstallPreference();
+                RefreshSkillsSection();
+            });
+            _groupSkillsLabel.RegisterCallback<ClickEvent>(HandleGroupSkillsRowClicked);
+        }
+
+        internal void ShowChecking()
+        {
+            ViewDataBinder.SetVisible(_groupSkillsRow, false);
+            _groupSkillsToggle.SetEnabled(false);
+            _skillsStepPresenter.ShowChecking(_shouldUseFirstInstallSkillsUi);
+        }
+
+        internal void RefreshSkillsSection()
+        {
+            string cachedCliVersion = _cliSetupApplicationService.GetCachedCliVersion();
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            bool cliInstalled = IsCliInstalled(cachedCliVersion);
+            List<SkillSetupTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
+            bool canManageSkills = SetupWizardWindow.CanManageSkills(cliInstalled);
+            UpdateSkillsStep(canManageSkills, targets);
+            BeginRefreshDisplayedSkillTargets(canManageSkills);
+            _scheduleResizeToContent();
+        }
+
+        internal void ApplyFastSkillsState(bool cliInstalled)
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            List<SkillSetupTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
+            bool canManageSkills = SetupWizardWindow.CanManageSkills(cliInstalled);
+            UpdateSkillsStep(canManageSkills, targets);
+            BeginRefreshDisplayedSkillTargets(canManageSkills);
+        }
+
+        internal void CancelSkillInstallStateRefresh()
+        {
+            if (_skillInstallStateRefreshCts == null)
+            {
+                return;
+            }
+
+            _skillInstallStateRefreshCts.Cancel();
+            _skillInstallStateRefreshCts.Dispose();
+            _skillInstallStateRefreshCts = null;
+        }
+
+        private void InitializeFirstInstallSkillsUiState(string lastSeenSetupWizardVersionBeforeOpen)
+        {
+            _shouldUseFirstInstallSkillsUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi(
+                lastSeenSetupWizardVersionBeforeOpen);
+        }
+
+        private List<SkillSetupTargetInfo> DetectDisplayedSkillTargets(string projectRoot)
+        {
+            return _skillSetupUseCase.DetectSkillTargetsForLayoutAtProjectRoot(projectRoot, !_installSkillsFlat);
+        }
+
+        private List<SkillSetupTargetInfo> DetectDisplayedSkillTargetsFast(string projectRoot)
+        {
+            return _skillSetupUseCase.DetectSkillTargetsForLayoutFastAtProjectRoot(projectRoot, !_installSkillsFlat);
+        }
+
+        private void BeginRefreshDisplayedSkillTargets(bool canManageSkills)
+        {
+            CancelSkillInstallStateRefresh();
+            if (!canManageSkills || _isInstallingSkills)
+            {
+                return;
+            }
+
+            CancellationTokenSource cts = new();
+            _skillInstallStateRefreshCts = cts;
+            RefreshDisplayedSkillTargetsAsync(cts.Token).Forget();
+        }
+
+        private async Task RefreshDisplayedSkillTargetsAsync(CancellationToken ct)
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            List<SkillSetupTargetInfo> targets =
+                await Task.Run(() => DetectDisplayedSkillTargets(projectRoot));
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            UpdateSkillsStep(canManageSkills: true, targets);
+            _scheduleResizeToContent();
+        }
+
+        private void UpdateSkillsStep(
+            bool canManageSkills,
+            List<SkillSetupTargetInfo> targets)
+        {
+            _groupSkillsToggle.SetEnabled(canManageSkills && !_isInstallingSkills);
+            _skillsStepPresenter.Update(
+                canManageSkills,
+                targets,
+                _shouldUseFirstInstallSkillsUi,
+                _skillsTarget,
+                !_installSkillsFlat,
+                _isInstallingSkills);
+        }
+
+        private void HandleInstallSkills()
+        {
+            HandleInstallSkillsAsync(CancellationToken.None).Forget();
+        }
+
+        private async Task HandleInstallSkillsAsync(CancellationToken ct)
+        {
+            CancelSkillInstallStateRefresh();
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            List<SkillSetupTargetInfo> targets = DetectDisplayedSkillTargets(projectRoot);
+            List<SkillSetupTargetInfo> installableTargets = _shouldUseFirstInstallSkillsUi
+                ? SetupWizardSkillsStepPresenter.GetFirstInstallableSkillTargets(
+                    targets,
+                    _skillsTarget,
+                    !_installSkillsFlat)
+                : SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
+            if (installableTargets.Count == 0) return;
+
+            bool shouldShowSkillsInstalledDialog =
+                SkillInstallDialogPolicy.ShouldShowForInstallableTargets(installableTargets);
+            _isInstallingSkills = true;
+            UpdateSkillsStep(true, targets);
+
+            try
+            {
+                await _skillSetupUseCase.InstallSkillFilesAsync(
+                    installableTargets,
+                    !_installSkillsFlat,
+                    ct);
+                if (shouldShowSkillsInstalledDialog)
+                {
+                    EditorDialogHelper.ShowSkillsInstalledDialog();
+                }
+            }
+            finally
+            {
+                _isInstallingSkills = false;
+                RefreshSkillsSection();
+            }
+        }
+
+        private void HandleGroupSkillsRowClicked(ClickEvent evt)
+        {
+            evt.StopPropagation();
+            if (!_groupSkillsToggle.enabledSelf)
+            {
+                return;
+            }
+
+            if (evt.target is VisualElement targetElement && _groupSkillsToggle.Contains(targetElement))
+            {
+                return;
+            }
+
+            bool newValue = !_groupSkillsToggle.value;
+            _groupSkillsToggle.SetValueWithoutNotify(newValue);
+            ApplyFlatSkillInstallPreference();
+            RefreshSkillsSection();
+        }
+
+        private void ApplyFlatSkillInstallPreference()
+        {
+            // Claude Code does not resolve nested skill folders, so setup keeps every editor target on the flat layout.
+            _installSkillsFlat = SetupWizardWindow.ForceFlatSkillInstall;
+            _editorSettingsPort.SetInstallSkillsFlat(_installSkillsFlat);
+        }
+
+        private static bool IsCliInstalled(string cliVersion)
+        {
+            return !string.IsNullOrEmpty(cliVersion);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsWorkflowController.cs.meta
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsWorkflowController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f941f9579e2c4ca0a3090b762b65261c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWindow.cs
@@ -1,7 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 using UnityEditor;
 using UnityEditor.UIElements;
@@ -192,18 +189,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return RegisteredSkillSetupUseCase;
         }
 
-        // Prerequisite
-        private VisualElement _nodejsWarning;
-        private VisualElement _nodejsOk;
         private Button _refreshButton;
-
-        // Step 2
-        private VisualElement _groupSkillsRow;
-        private EnumField _skillsTargetField;
-        private Toggle _groupSkillsToggle;
-        private Label _groupSkillsLabel;
-
-        // Footer
         private Toggle _suppressAutoShowToggle;
         private Button _openSettingsButton;
         private Button _closeButton;
@@ -211,23 +197,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private Label _githubLinkLabel;
         private Image _githubLinkIcon;
         private ScrollView _mainScrollView;
-        private SetupWizardCliStepPresenter _cliStepPresenter;
-        private SetupWizardSkillsStepPresenter _skillsStepPresenter;
+        private SetupWizardWorkflowController _controller;
 
-        // State
-        private bool _isInstallingCli;
-        private bool _isInstallingSkills;
-        private bool _needsCliPathSetup;
-        private bool _isSkillsTargetFieldInitialized;
-        private bool _shouldUseFirstInstallSkillsUi;
-        private bool _installSkillsFlat;
         [SerializeField]
         private string _lastSeenSetupWizardVersionBeforeOpen = string.Empty;
         [SerializeField]
         private bool _shouldRecordLastSeenVersionAfterCreateGui;
-        private IVisualElementScheduledItem _initialRefreshScheduledItem;
-        private CancellationTokenSource _skillInstallStateRefreshCts;
-        private SkillsTarget _skillsTarget = SkillsTarget.Claude;
         private SkillSetupUseCase _skillSetupUseCase;
         private IUnityCliLoopEditorSettingsPort _editorSettingsPort;
         private CliSetupApplicationService _cliSetupApplicationService;
@@ -236,14 +211,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void CreateGUI()
         {
             InitializeApplicationServices();
-            InitializeFirstInstallSkillsUiState();
             LoadLayout();
             BindElements();
             _resizer = new SetupWizardWindowResizer(this, _mainScrollView);
             BindEvents();
             BindSizeUpdates();
-            ApplyInitialCheckingState();
-            ScheduleInitialRefresh();
+            _controller.ApplyInitialCheckingState();
+            _controller.ScheduleInitialRefresh();
             ScheduleResizeToContent();
             RecordLastSeenSetupWizardStateAfterSuccessfulCreateGui();
         }
@@ -253,12 +227,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _skillSetupUseCase = GetSkillSetupUseCase();
             _editorSettingsPort = GetEditorSettingsPort();
             _cliSetupApplicationService = GetCliSetupApplicationService();
-        }
-
-        private void InitializeFirstInstallSkillsUiState()
-        {
-            _shouldUseFirstInstallSkillsUi = ShouldUseFirstInstallSkillsUi(
-                _lastSeenSetupWizardVersionBeforeOpen);
         }
 
         private void RecordLastSeenSetupWizardStateAfterSuccessfulCreateGui()
@@ -273,9 +241,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void OnDisable()
         {
-            _initialRefreshScheduledItem?.Pause();
+            _controller?.PauseInitialRefresh();
             _resizer?.Pause();
-            CancelSkillInstallStateRefresh();
+            _controller?.CancelSkillInstallStateRefresh();
         }
 
         private void LoadLayout()
@@ -293,35 +261,23 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void BindElements()
         {
-            _nodejsWarning = rootVisualElement.Q<VisualElement>("nodejs-warning");
-            _nodejsOk = rootVisualElement.Q<VisualElement>("nodejs-ok");
+            VisualElement nodejsWarning = rootVisualElement.Q<VisualElement>("nodejs-warning");
+            VisualElement nodejsOk = rootVisualElement.Q<VisualElement>("nodejs-ok");
             _refreshButton = rootVisualElement.Q<Button>("refresh-button");
 
             VisualElement cliStatusIcon = rootVisualElement.Q<VisualElement>("cli-status-icon");
             Label cliStatusLabel = rootVisualElement.Q<Label>("cli-status-label");
             Button installCliButton = rootVisualElement.Q<Button>("install-cli-button");
-            _cliStepPresenter = new SetupWizardCliStepPresenter(
-                cliStatusIcon,
-                cliStatusLabel,
-                installCliButton,
-                HandleInstallCli);
 
-            _groupSkillsRow = rootVisualElement.Q<VisualElement>("group-skills-row");
-            _skillsTargetField = rootVisualElement.Q<EnumField>("skills-target-field");
-            _groupSkillsToggle = rootVisualElement.Q<Toggle>("group-skills-toggle");
-            _groupSkillsLabel = rootVisualElement.Q<Label>("group-skills-label");
+            VisualElement groupSkillsRow = rootVisualElement.Q<VisualElement>("group-skills-row");
+            EnumField skillsTargetField = rootVisualElement.Q<EnumField>("skills-target-field");
+            Toggle groupSkillsToggle = rootVisualElement.Q<Toggle>("group-skills-toggle");
+            Label groupSkillsLabel = rootVisualElement.Q<Label>("group-skills-label");
             VisualElement skillsTargetRow = rootVisualElement.Q<VisualElement>("skills-target-row");
             VisualElement skillsTargetList = rootVisualElement.Q<VisualElement>("skills-target-list");
             VisualElement skillsStatusDivider = rootVisualElement.Q<VisualElement>("skills-status-divider");
             Label skillsStatusLabel = rootVisualElement.Q<Label>("skills-status-label");
             Button installSkillsButton = rootVisualElement.Q<Button>("install-skills-button");
-            _skillsStepPresenter = new SetupWizardSkillsStepPresenter(
-                skillsTargetRow,
-                skillsTargetList,
-                skillsStatusDivider,
-                skillsStatusLabel,
-                installSkillsButton,
-                HandleInstallSkills);
 
             _suppressAutoShowToggle = rootVisualElement.Q<Toggle>("suppress-auto-show-toggle");
             _openSettingsButton = rootVisualElement.Q<Button>("open-settings-button");
@@ -330,13 +286,36 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _githubLinkLabel = rootVisualElement.Q<Label>("github-link-label");
             _githubLinkIcon = rootVisualElement.Q<Image>("github-link-icon");
             _mainScrollView = rootVisualElement.Q<ScrollView>();
+
+            _controller = new SetupWizardWorkflowController(
+                rootVisualElement,
+                nodejsWarning,
+                nodejsOk,
+                cliStatusIcon,
+                cliStatusLabel,
+                installCliButton,
+                groupSkillsRow,
+                skillsTargetField,
+                groupSkillsToggle,
+                groupSkillsLabel,
+                skillsTargetRow,
+                skillsTargetList,
+                skillsStatusDivider,
+                skillsStatusLabel,
+                installSkillsButton,
+                _suppressAutoShowToggle,
+                _skillSetupUseCase,
+                _editorSettingsPort,
+                _cliSetupApplicationService,
+                ScheduleResizeToContent,
+                _lastSeenSetupWizardVersionBeforeOpen);
         }
 
         private void BindEvents()
         {
-            _refreshButton.clicked += () => RefreshUI();
-            InitializeSkillsTargetField();
-            InitializeGroupSkillsToggle();
+            _refreshButton.clicked += () => _controller.RefreshUI();
+            _controller.InitializeSkillsTargetField();
+            _controller.InitializeGroupSkillsToggle();
             _suppressAutoShowToggle.RegisterValueChangedCallback(evt => HandleSuppressAutoShowChanged(evt.newValue));
             _openSettingsButton.clicked += HandleOpenSettings;
             _closeButton.clicked += HandleClose;
@@ -362,180 +341,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _githubLinkIcon.image = iconTexture;
         }
 
-        private void InitializeSkillsTargetField()
-        {
-            if (_isSkillsTargetFieldInitialized) return;
-
-            _skillsTargetField.Init(_skillsTarget);
-            _skillsTargetField.RegisterValueChangedCallback(evt =>
-            {
-                if (evt.newValue is SkillsTarget newTarget)
-                {
-                    _skillsTarget = newTarget;
-                    RefreshSkillsSection();
-                }
-            });
-            _isSkillsTargetFieldInitialized = true;
-        }
-
-        private void InitializeGroupSkillsToggle()
-        {
-            ApplyFlatSkillInstallPreference();
-            ViewDataBinder.SetVisible(_groupSkillsRow, false);
-            _groupSkillsToggle.SetValueWithoutNotify(!_installSkillsFlat);
-            _groupSkillsToggle.RegisterValueChangedCallback(evt =>
-            {
-                evt.StopPropagation();
-                ApplyFlatSkillInstallPreference();
-                RefreshSkillsSection();
-            });
-            _groupSkillsLabel.RegisterCallback<ClickEvent>(HandleGroupSkillsRowClicked);
-        }
-
         private void BindSizeUpdates()
         {
             _resizer.BindSizeUpdates();
-        }
-
-        private void RefreshAutoShowToggle()
-        {
-            _suppressAutoShowToggle.SetValueWithoutNotify(_editorSettingsPort.GetSuppressSetupWizardAutoShow());
-        }
-
-        private void ApplyInitialCheckingState()
-        {
-            RefreshAutoShowToggle();
-            ViewDataBinder.SetVisible(_nodejsWarning, false);
-            ViewDataBinder.SetVisible(_nodejsOk, false);
-            _cliStepPresenter.ShowChecking();
-            ViewDataBinder.SetVisible(_groupSkillsRow, false);
-            _groupSkillsToggle.SetEnabled(false);
-            _skillsStepPresenter.ShowChecking(_shouldUseFirstInstallSkillsUi);
-        }
-
-        private void ScheduleInitialRefresh()
-        {
-            _initialRefreshScheduledItem?.Pause();
-            _initialRefreshScheduledItem = rootVisualElement.schedule.Execute(() => RefreshUI()).StartingIn(0);
-        }
-
-        private void RefreshSkillsSection()
-        {
-            string cachedCliVersion = _cliSetupApplicationService.GetCachedCliVersion();
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            bool cliInstalled = IsCliInstalled(cachedCliVersion);
-            List<SkillSetupTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
-            bool canManageSkills = CanManageSkills(cliInstalled);
-            UpdateSkillsStep(canManageSkills, targets);
-            BeginRefreshDisplayedSkillTargets(canManageSkills);
-            ScheduleResizeToContent();
-        }
-
-        private void RefreshUI(bool refreshSkillsSection = true)
-        {
-            RefreshUIAsync(refreshSkillsSection, CancellationToken.None).Forget();
-        }
-
-        private async Task RefreshUIAsync(
-            bool refreshSkillsSection,
-            CancellationToken ct)
-        {
-            CancelSkillInstallStateRefresh();
-            ct.ThrowIfCancellationRequested();
-            RefreshAutoShowToggle();
-            ViewDataBinder.SetVisible(_nodejsWarning, false);
-            ViewDataBinder.SetVisible(_nodejsOk, false);
-            _cliStepPresenter.ShowChecking();
-            if (refreshSkillsSection)
-            {
-                ViewDataBinder.SetVisible(_groupSkillsRow, false);
-                _groupSkillsToggle.SetEnabled(false);
-                _skillsStepPresenter.ShowChecking(_shouldUseFirstInstallSkillsUi);
-            }
-
-            await Task.Yield();
-            ct.ThrowIfCancellationRequested();
-
-            ViewDataBinder.SetVisible(_nodejsWarning, false);
-            ViewDataBinder.SetVisible(_nodejsOk, false);
-
-            await _cliSetupApplicationService.ForceRefreshCliVersionAsync(ct);
-            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
-            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            string requiredCliVersion = GetMinimumRequiredCliVersion();
-            bool cliInstalled = IsCliInstalled(cliVersion);
-            _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
-
-            _cliStepPresenter.Update(
-                cliInstalled,
-                cliVersion,
-                cliIsDispatcher,
-                requiredCliVersion,
-                _isInstallingCli,
-                _needsCliPathSetup);
-
-            if (!refreshSkillsSection)
-            {
-                ScheduleResizeToContent();
-                return;
-            }
-
-            List<SkillSetupTargetInfo> targets = DetectDisplayedSkillTargetsFast(projectRoot);
-            bool canManageSkills = CanManageSkills(cliInstalled);
-            UpdateSkillsStep(canManageSkills, targets);
-            BeginRefreshDisplayedSkillTargets(canManageSkills);
-
-            ScheduleResizeToContent();
-        }
-
-        private List<SkillSetupTargetInfo> DetectDisplayedSkillTargets(string projectRoot)
-        {
-            return _skillSetupUseCase.DetectSkillTargetsForLayoutAtProjectRoot(projectRoot, !_installSkillsFlat);
-        }
-
-        private List<SkillSetupTargetInfo> DetectDisplayedSkillTargetsFast(string projectRoot)
-        {
-            return _skillSetupUseCase.DetectSkillTargetsForLayoutFastAtProjectRoot(projectRoot, !_installSkillsFlat);
-        }
-
-        private void BeginRefreshDisplayedSkillTargets(bool canManageSkills)
-        {
-            CancelSkillInstallStateRefresh();
-            if (!canManageSkills || _isInstallingSkills)
-            {
-                return;
-            }
-
-            CancellationTokenSource cts = new();
-            _skillInstallStateRefreshCts = cts;
-            RefreshDisplayedSkillTargetsAsync(cts.Token).Forget();
-        }
-
-        private async Task RefreshDisplayedSkillTargetsAsync(CancellationToken ct)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            List<SkillSetupTargetInfo> targets =
-                await Task.Run(() => DetectDisplayedSkillTargets(projectRoot));
-            if (ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            UpdateSkillsStep(canManageSkills: true, targets);
-            ScheduleResizeToContent();
-        }
-
-        private void CancelSkillInstallStateRefresh()
-        {
-            if (_skillInstallStateRefreshCts == null)
-            {
-                return;
-            }
-
-            _skillInstallStateRefreshCts.Cancel();
-            _skillInstallStateRefreshCts.Dispose();
-            _skillInstallStateRefreshCts = null;
         }
 
         internal static bool ShouldShowSkillsInstalledDialog(
@@ -554,24 +362,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return cliInstalled;
         }
 
-        private static async Task<bool> ShouldRepairCliPathSetupAsync(CancellationToken ct)
-        {
-            CliSetupApplicationService cliSetupApplicationService = GetCliSetupApplicationService();
-            bool hasPackageOwnedCurrentUserInstall =
-                cliSetupApplicationService.HasPackageOwnedCurrentUserInstall(UnityEngine.Application.platform);
-            if (!ShouldCheckCliPathSetupForSetupWizard(
-                    UnityEngine.Application.platform,
-                    hasPackageOwnedCurrentUserInstall))
-            {
-                return false;
-            }
-
-            bool isCliVisibleFromShell = await cliSetupApplicationService.IsCliVisibleFromShellAsync(
-                UnityEngine.Application.platform,
-                ct);
-            return !isCliVisibleFromShell;
-        }
-
         internal static bool ShouldCheckCliPathSetupForSetupWizard(
             RuntimePlatform platform,
             bool hasPackageOwnedCurrentUserInstall)
@@ -581,132 +371,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 hasPackageOwnedCurrentUserInstall);
         }
 
-        private static CliSetupCompatibilityState EvaluateCliSetupCompatibilityForSetupWizard(
-            string cliVersion,
-            bool cliIsDispatcher)
-        {
-            return CliSetupCompatibility.Evaluate(
-                cliVersion,
-                cliIsDispatcher,
-                GetMinimumRequiredCliVersion());
-        }
-
         private static string GetMinimumRequiredCliVersion()
         {
             return GetCliSetupApplicationService().GetMinimumRequiredCliVersion();
-        }
-
-        private static bool IsCliInstalled(string cliVersion)
-        {
-            return !string.IsNullOrEmpty(cliVersion);
-        }
-
-        private void UpdateSkillsStep(
-            bool canManageSkills,
-            List<SkillSetupTargetInfo> targets)
-        {
-            _groupSkillsToggle.SetEnabled(canManageSkills && !_isInstallingSkills);
-            _skillsStepPresenter.Update(
-                canManageSkills,
-                targets,
-                _shouldUseFirstInstallSkillsUi,
-                _skillsTarget,
-                !_installSkillsFlat,
-                _isInstallingSkills);
-        }
-
-        private void HandleInstallCli()
-        {
-            HandleInstallCliAsync(CancellationToken.None).Forget();
-        }
-
-        private async Task HandleInstallCliAsync(CancellationToken ct)
-        {
-            await RefreshCliPrimaryActionStateAsync(ct);
-
-            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
-            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
-            CliSetupCompatibilityState state = EvaluateCliSetupCompatibilityForSetupWizard(
-                cliVersion,
-                cliIsDispatcher);
-            if (ShouldRepairCliPathFromPrimaryButton(_needsCliPathSetup, state.NeedsUpdate))
-            {
-                await HandleRepairCliPathSetup(ct);
-                return;
-            }
-
-            bool wasCliInstalledBeforeInstall = _cliSetupApplicationService.IsCliInstalled();
-            _needsCliPathSetup = false;
-            _isInstallingCli = true;
-            _cliStepPresenter.Update(
-                cliInstalled: false,
-                cliVersion: null,
-                cliIsDispatcher: false,
-                requiredCliVersion: GetMinimumRequiredCliVersion(),
-                isInstallingCli: _isInstallingCli,
-                needsCliPathSetup: _needsCliPathSetup);
-
-            try
-            {
-                CliInstallResult result = await _cliSetupApplicationService.InstallGlobalCliAsync(
-                    UnityEngine.Application.platform,
-                    ct);
-
-                if (!result.Success)
-                {
-                    NativeCliInstallCommand command = _cliSetupApplicationService.GetGlobalCliInstallCommand(
-                        UnityEngine.Application.platform,
-                        true);
-                    EditorUtility.DisplayDialog(
-                        "Installation Failed",
-                        $"Failed to install uloop CLI.\n\n{result.ErrorOutput}\n\n"
-                        + $"You can install manually:\n  {command.ManualCommand}",
-                        "OK");
-                    return;
-                }
-
-                await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
-                    UnityEngine.Application.platform,
-                    _cliSetupApplicationService,
-                    ct);
-                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
-            }
-            finally
-            {
-                _isInstallingCli = false;
-                RefreshUI(CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(
-                    wasCliInstalledBeforeInstall));
-            }
-        }
-
-        private async Task RefreshCliPrimaryActionStateAsync(CancellationToken ct)
-        {
-            _cliStepPresenter.ShowRefreshingPrimaryAction();
-
-            try
-            {
-                await _cliSetupApplicationService.ForceRefreshCliVersionAsync(ct);
-                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
-            }
-            finally
-            {
-                RefreshCliStepFromCachedState();
-            }
-        }
-
-        private void RefreshCliStepFromCachedState()
-        {
-            string cliVersion = _cliSetupApplicationService.GetCachedCliVersion();
-            bool cliIsDispatcher = _cliSetupApplicationService.GetCachedCliIsDispatcher();
-            string requiredCliVersion = GetMinimumRequiredCliVersion();
-            bool cliInstalled = IsCliInstalled(cliVersion);
-            _cliStepPresenter.Update(
-                cliInstalled,
-                cliVersion,
-                cliIsDispatcher,
-                requiredCliVersion,
-                _isInstallingCli,
-                _needsCliPathSetup);
         }
 
         internal static bool ShouldRepairCliPathFromPrimaryButton(
@@ -714,73 +381,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool needsUpdate)
         {
             return CliSetupPrimaryActionPolicy.ShouldRepairCliPath(needsCliPathSetup, needsUpdate);
-        }
-
-        private async Task HandleRepairCliPathSetup(CancellationToken ct)
-        {
-            _isInstallingCli = true;
-            _cliStepPresenter.Update(
-                cliInstalled: true,
-                cliVersion: _cliSetupApplicationService.GetCachedCliVersion(),
-                cliIsDispatcher: _cliSetupApplicationService.GetCachedCliIsDispatcher(),
-                requiredCliVersion: GetMinimumRequiredCliVersion(),
-                isInstallingCli: _isInstallingCli,
-                needsCliPathSetup: _needsCliPathSetup);
-
-            try
-            {
-                await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
-                    UnityEngine.Application.platform,
-                    _cliSetupApplicationService,
-                    ct);
-                _needsCliPathSetup = await ShouldRepairCliPathSetupAsync(ct);
-            }
-            finally
-            {
-                _isInstallingCli = false;
-                RefreshUI();
-            }
-        }
-
-        private void HandleInstallSkills()
-        {
-            HandleInstallSkillsAsync(CancellationToken.None).Forget();
-        }
-
-        private async Task HandleInstallSkillsAsync(CancellationToken ct)
-        {
-            CancelSkillInstallStateRefresh();
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            List<SkillSetupTargetInfo> targets = DetectDisplayedSkillTargets(projectRoot);
-            List<SkillSetupTargetInfo> installableTargets = _shouldUseFirstInstallSkillsUi
-                ? SetupWizardSkillsStepPresenter.GetFirstInstallableSkillTargets(
-                    targets,
-                    _skillsTarget,
-                    !_installSkillsFlat)
-                : SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
-            if (installableTargets.Count == 0) return;
-
-            bool shouldShowSkillsInstalledDialog =
-                SkillInstallDialogPolicy.ShouldShowForInstallableTargets(installableTargets);
-            _isInstallingSkills = true;
-            UpdateSkillsStep(true, targets);
-
-            try
-            {
-                await _skillSetupUseCase.InstallSkillFilesAsync(
-                    installableTargets,
-                    !_installSkillsFlat,
-                    ct);
-                if (shouldShowSkillsInstalledDialog)
-                {
-                    EditorDialogHelper.ShowSkillsInstalledDialog();
-                }
-            }
-            finally
-            {
-                _isInstallingSkills = false;
-                RefreshSkillsSection();
-            }
         }
 
         private void HandleOpenSettings()
@@ -816,36 +416,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             ViewDataBinder.ToggleClass(_githubLinkIcon, "setup-footer__github-link-icon--hover", isHovered);
         }
 
-        private void HandleGroupSkillsRowClicked(ClickEvent evt)
-        {
-            evt.StopPropagation();
-            if (!_groupSkillsToggle.enabledSelf)
-            {
-                return;
-            }
-
-            if (evt.target is VisualElement targetElement && _groupSkillsToggle.Contains(targetElement))
-            {
-                return;
-            }
-
-            bool newValue = !_groupSkillsToggle.value;
-            _groupSkillsToggle.SetValueWithoutNotify(newValue);
-            ApplyFlatSkillInstallPreference();
-            RefreshSkillsSection();
-        }
-
-        private void ApplyFlatSkillInstallPreference()
-        {
-            // Claude Code does not resolve nested skill folders, so setup keeps every editor target on the flat layout.
-            _installSkillsFlat = ForceFlatSkillInstall;
-            _editorSettingsPort.SetInstallSkillsFlat(_installSkillsFlat);
-        }
-
         private void ScheduleResizeToContent()
         {
             _resizer?.ScheduleResizeToContent();
         }
-
     }
 }

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWorkflowController.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+// Domain: IUnityCliLoopEditorSettingsPort / SkillSetupUseCase live across Application+Domain contracts used below.
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Owns Setup Wizard workflow orchestration across CLI and skills steps.
+    /// </summary>
+    internal sealed class SetupWizardWorkflowController
+    {
+        private readonly VisualElement _rootVisualElement;
+        private readonly VisualElement _nodejsWarning;
+        private readonly VisualElement _nodejsOk;
+        private readonly Toggle _suppressAutoShowToggle;
+        private readonly IUnityCliLoopEditorSettingsPort _editorSettingsPort;
+        private readonly Action _scheduleResizeToContent;
+        private readonly SetupWizardCliWorkflowController _cliWorkflow;
+        private readonly SetupWizardSkillsWorkflowController _skillsWorkflow;
+
+        private IVisualElementScheduledItem _initialRefreshScheduledItem;
+
+        internal SetupWizardWorkflowController(
+            VisualElement rootVisualElement,
+            VisualElement nodejsWarning,
+            VisualElement nodejsOk,
+            VisualElement cliStatusIcon,
+            Label cliStatusLabel,
+            Button installCliButton,
+            VisualElement groupSkillsRow,
+            EnumField skillsTargetField,
+            Toggle groupSkillsToggle,
+            Label groupSkillsLabel,
+            VisualElement skillsTargetRow,
+            VisualElement skillsTargetList,
+            VisualElement skillsStatusDivider,
+            Label skillsStatusLabel,
+            Button installSkillsButton,
+            Toggle suppressAutoShowToggle,
+            SkillSetupUseCase skillSetupUseCase,
+            IUnityCliLoopEditorSettingsPort editorSettingsPort,
+            CliSetupApplicationService cliSetupApplicationService,
+            Action scheduleResizeToContent,
+            string lastSeenSetupWizardVersionBeforeOpen)
+        {
+            Debug.Assert(rootVisualElement != null, "rootVisualElement must not be null");
+            Debug.Assert(nodejsWarning != null, "nodejsWarning must not be null");
+            Debug.Assert(nodejsOk != null, "nodejsOk must not be null");
+            Debug.Assert(suppressAutoShowToggle != null, "suppressAutoShowToggle must not be null");
+            Debug.Assert(editorSettingsPort != null, "editorSettingsPort must not be null");
+            Debug.Assert(scheduleResizeToContent != null, "scheduleResizeToContent must not be null");
+
+            _rootVisualElement = rootVisualElement
+                ?? throw new ArgumentNullException(nameof(rootVisualElement));
+            _nodejsWarning = nodejsWarning ?? throw new ArgumentNullException(nameof(nodejsWarning));
+            _nodejsOk = nodejsOk ?? throw new ArgumentNullException(nameof(nodejsOk));
+            _suppressAutoShowToggle = suppressAutoShowToggle
+                ?? throw new ArgumentNullException(nameof(suppressAutoShowToggle));
+            _editorSettingsPort = editorSettingsPort
+                ?? throw new ArgumentNullException(nameof(editorSettingsPort));
+            _scheduleResizeToContent = scheduleResizeToContent
+                ?? throw new ArgumentNullException(nameof(scheduleResizeToContent));
+
+            _cliWorkflow = new SetupWizardCliWorkflowController(
+                cliStatusIcon,
+                cliStatusLabel,
+                installCliButton,
+                cliSetupApplicationService,
+                RefreshUI);
+            _skillsWorkflow = new SetupWizardSkillsWorkflowController(
+                groupSkillsRow,
+                skillsTargetField,
+                groupSkillsToggle,
+                groupSkillsLabel,
+                skillsTargetRow,
+                skillsTargetList,
+                skillsStatusDivider,
+                skillsStatusLabel,
+                installSkillsButton,
+                skillSetupUseCase,
+                editorSettingsPort,
+                cliSetupApplicationService,
+                scheduleResizeToContent,
+                lastSeenSetupWizardVersionBeforeOpen);
+        }
+
+        internal void InitializeSkillsTargetField()
+        {
+            _skillsWorkflow.InitializeSkillsTargetField();
+        }
+
+        internal void InitializeGroupSkillsToggle()
+        {
+            _skillsWorkflow.InitializeGroupSkillsToggle();
+        }
+
+        internal void ApplyInitialCheckingState()
+        {
+            RefreshAutoShowToggle();
+            ViewDataBinder.SetVisible(_nodejsWarning, false);
+            ViewDataBinder.SetVisible(_nodejsOk, false);
+            _cliWorkflow.ShowChecking();
+            _skillsWorkflow.ShowChecking();
+        }
+
+        internal void ScheduleInitialRefresh()
+        {
+            _initialRefreshScheduledItem?.Pause();
+            _initialRefreshScheduledItem = _rootVisualElement.schedule.Execute(() => RefreshUI()).StartingIn(0);
+        }
+
+        internal void PauseInitialRefresh()
+        {
+            _initialRefreshScheduledItem?.Pause();
+        }
+
+        internal void CancelSkillInstallStateRefresh()
+        {
+            _skillsWorkflow.CancelSkillInstallStateRefresh();
+        }
+
+        internal void RefreshUI(bool refreshSkillsSection = true)
+        {
+            RefreshUIAsync(refreshSkillsSection, CancellationToken.None).Forget();
+        }
+
+        private void RefreshAutoShowToggle()
+        {
+            _suppressAutoShowToggle.SetValueWithoutNotify(_editorSettingsPort.GetSuppressSetupWizardAutoShow());
+        }
+
+        private async Task RefreshUIAsync(
+            bool refreshSkillsSection,
+            CancellationToken ct)
+        {
+            CancelSkillInstallStateRefresh();
+            ct.ThrowIfCancellationRequested();
+            RefreshAutoShowToggle();
+            ViewDataBinder.SetVisible(_nodejsWarning, false);
+            ViewDataBinder.SetVisible(_nodejsOk, false);
+            _cliWorkflow.ShowChecking();
+            if (refreshSkillsSection)
+            {
+                _skillsWorkflow.ShowChecking();
+            }
+
+            await Task.Yield();
+            ct.ThrowIfCancellationRequested();
+
+            ViewDataBinder.SetVisible(_nodejsWarning, false);
+            ViewDataBinder.SetVisible(_nodejsOk, false);
+
+            bool cliInstalled = await _cliWorkflow.RefreshAndUpdateAsync(ct);
+
+            if (!refreshSkillsSection)
+            {
+                _scheduleResizeToContent();
+                return;
+            }
+
+            _skillsWorkflow.ApplyFastSkillsState(cliInstalled);
+            _scheduleResizeToContent();
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardWorkflowController.cs.meta
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardWorkflowController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a51f9558400452da951800bb00a4aa6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWindow.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,7 +17,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     public class ThirdPartyToolMigrationWizardWindow : EditorWindow
     {
         private const string WindowTitle = "Unity CLI Loop Migration";
-        private const bool GroupMigrationSkillUnderUnityCliLoop = false;
         private static readonly Vector2 InitialWindowSize =
             ThirdPartyToolMigrationWizardWindowResizer.InitialWindowSize;
         private static readonly Vector2 MinimumWindowSize =
@@ -30,16 +28,10 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         [SerializeField]
         private bool _shouldRefreshAfterCreateGui;
 
-        private bool _isMigrating;
-        private bool _isUpdatingMigrationSkill;
-        private SkillsTarget _migrationSkillTarget = SkillsTarget.Claude;
-        private SkillInstallState _migrationSkillInstallState = SkillInstallState.Missing;
-        private string[] _pendingMigrationFilePaths = Array.Empty<string>();
-        private CancellationTokenSource _migrationOperationCts;
-        private CancellationTokenSource _migrationSkillOperationCts;
         private SkillSetupUseCase _skillSetupUseCase;
         private ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
         private ThirdPartyToolMigrationWizardView _view;
+        private ThirdPartyToolMigrationWizardWorkflowController _controller;
         private ThirdPartyToolMigrationWizardWindowResizer _resizer;
 
         internal static void InitializeEditorServices(
@@ -54,11 +46,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 "thirdPartyToolMigrationUseCase must not be null");
 
             RegisteredSessionFlagsRepository = sessionFlagsRepository
-                ?? throw new System.ArgumentNullException(nameof(sessionFlagsRepository));
+                ?? throw new ArgumentNullException(nameof(sessionFlagsRepository));
             RegisteredSkillSetupUseCase = skillSetupUseCase
-                ?? throw new System.ArgumentNullException(nameof(skillSetupUseCase));
+                ?? throw new ArgumentNullException(nameof(skillSetupUseCase));
             RegisteredThirdPartyToolMigrationUseCase = thirdPartyToolMigrationUseCase
-                ?? throw new System.ArgumentNullException(nameof(thirdPartyToolMigrationUseCase));
+                ?? throw new ArgumentNullException(nameof(thirdPartyToolMigrationUseCase));
         }
 
         [MenuItem("Window/Unity CLI Loop/Custom Tool Migration", priority = 4)]
@@ -79,11 +71,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         }
 
         internal static async Task<bool> RunAutoScanAsync(
-            System.Func<CancellationToken, Task<bool>> hasMigrationTargetsAsync,
-            System.Func<CancellationToken, Task> switchToMainThreadAsync,
-            System.Action openWindow,
-            System.Action consumeAutoScanSessionState,
-            System.Action<System.Exception> logException,
+            Func<CancellationToken, Task<bool>> hasMigrationTargetsAsync,
+            Func<CancellationToken, Task> switchToMainThreadAsync,
+            Action openWindow,
+            Action consumeAutoScanSessionState,
+            Action<Exception> logException,
             CancellationToken ct)
         {
             Debug.Assert(hasMigrationTargetsAsync != null, "hasMigrationTargetsAsync must not be null");
@@ -104,7 +96,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 openWindow();
                 return true;
             }
-            catch (System.Exception ex)
+            catch (Exception ex)
             {
                 logException(ex);
                 return false;
@@ -144,7 +136,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             GetSessionFlagsRepository().ConsumeShouldAutoScanThirdPartyToolMigration();
         }
 
-        private static void LogAutoScanException(System.Exception ex)
+        private static void LogAutoScanException(Exception ex)
         {
             Debug.Assert(ex != null, "ex must not be null");
 
@@ -325,7 +317,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             if (RegisteredSessionFlagsRepository == null)
             {
-                throw new System.InvalidOperationException(
+                throw new InvalidOperationException(
                     "Migration Wizard session flags repository is not initialized.");
             }
 
@@ -336,7 +328,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             if (RegisteredSkillSetupUseCase == null)
             {
-                throw new System.InvalidOperationException(
+                throw new InvalidOperationException(
                     "Migration Wizard skill setup use case is not initialized.");
             }
 
@@ -347,7 +339,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         {
             if (RegisteredThirdPartyToolMigrationUseCase == null)
             {
-                throw new System.InvalidOperationException(
+                throw new InvalidOperationException(
                     "Migration Wizard third-party tool migration use case is not initialized.");
             }
 
@@ -379,18 +371,23 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             InitializeApplicationServices();
             _view = ThirdPartyToolMigrationWizardView.Create(
                 rootVisualElement,
-                () => RefreshUI().Forget(),
-                () => HandleMigrateThirdPartyTools().Forget(),
-                HandleMigrationSkillTargetChanged,
-                () => HandleToggleMigrationSkill().Forget(),
+                () => _controller.RefreshUI().Forget(),
+                () => _controller.HandleMigrateThirdPartyTools().Forget(),
+                target => _controller.HandleMigrationSkillTargetChanged(target),
+                () => _controller.HandleToggleMigrationSkill().Forget(),
                 Close);
             _resizer = new ThirdPartyToolMigrationWizardWindowResizer(this, _view.MainScrollView);
             _resizer.BindSizeUpdates();
+            _controller = new ThirdPartyToolMigrationWizardWorkflowController(
+                _view,
+                _skillSetupUseCase,
+                _thirdPartyToolMigrationUseCase,
+                ScheduleResizeToContent);
 
             bool shouldStartInitialRefresh = ConsumeShouldStartInitialRefresh();
-            ShowInitialState(shouldStartInitialRefresh);
-            RefreshMigrationSkillState();
-            ScheduleInitialRefresh(shouldStartInitialRefresh);
+            _controller.ShowInitialState(shouldStartInitialRefresh);
+            _controller.RefreshMigrationSkillState();
+            _controller.ScheduleInitialRefresh(shouldStartInitialRefresh);
             ScheduleResizeToContent();
         }
 
@@ -403,348 +400,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void OnDisable()
         {
             _resizer?.Pause();
-            CancelMigrationOperation();
-            CancelMigrationSkillOperation();
-        }
-
-        private void ShowInitialState(bool shouldStartInitialRefresh)
-        {
-            if (shouldStartInitialRefresh)
-            {
-                ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
-                return;
-            }
-
-            ShowNotCheckedState();
-        }
-
-        private void ScheduleInitialRefresh(bool shouldStartInitialRefresh)
-        {
-            if (!shouldStartInitialRefresh)
-            {
-                return;
-            }
-
-            rootVisualElement.schedule.Execute(() => RefreshUI().Forget()).StartingIn(0);
-        }
-
-        private async Task RefreshUI()
-        {
-            CancellationToken ct = BeginMigrationOperation();
-            ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
-            await Task.Yield();
-
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            System.IProgress<ThirdPartyToolMigrationProgress> progress = CreateProgressReporter(ct);
-            ThirdPartyToolMigrationPreview preview;
-            try
-            {
-                preview = await Task.Run(async () =>
-                    await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct));
-                await MainThreadSwitcher.SwitchToMainThread();
-            }
-            catch (System.OperationCanceledException)
-            {
-                // Cancellation comes from window close or a superseding operation; that owner drives the UI.
-                return;
-            }
-            catch (System.Exception ex)
-            {
-                // Without this async-void boundary the exception hits the sync context, the window
-                // stays on "Scanning..." forever, and the operation CTS leaks.
-                Debug.LogException(ex);
-                if (IsMigrationOperationActive(ct))
-                {
-                    CompleteMigrationOperation(ct);
-                    ShowNotCheckedState();
-                }
-
-                return;
-            }
-
-            if (ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            CompleteMigrationOperation(ct);
-            if (!preview.HasTargets)
-            {
-                ShowNoMigrationTargetsState();
-                return;
-            }
-
-            ShowMigrationTargetsState(preview.FilePaths);
-        }
-
-        private async Task HandleMigrateThirdPartyTools()
-        {
-            if (!ConfirmMigrationApply(
-                _pendingMigrationFilePaths.Length,
-                (title, message, ok, cancel) => EditorUtility.DisplayDialog(title, message, ok, cancel)))
-            {
-                return;
-            }
-
-            CancellationToken ct = BeginMigrationOperation();
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            ThirdPartyToolMigrationResult result = default;
-            bool isMigrationCompletionPending = true;
-            _isMigrating = true;
-            ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
-            await Task.Yield();
-
-            try
-            {
-                System.IProgress<ThirdPartyToolMigrationProgress> progress = CreateProgressReporter(ct);
-                result = await Task.Run(async () =>
-                    await _thirdPartyToolMigrationUseCase.ApplyMigrationAsync(projectRoot, progress, ct));
-                if (!ShouldFinishMigrationOnMainThread(ct.IsCancellationRequested, result))
-                {
-                    return;
-                }
-
-                await MainThreadSwitcher.SwitchToMainThread();
-                if (!ShouldFinishMigrationOnMainThread(ct.IsCancellationRequested, result))
-                {
-                    return;
-                }
-
-                CompleteMigrationOperation(ct);
-                if (result.Changed)
-                {
-                    if (!ct.IsCancellationRequested)
-                    {
-                        ShowCheckingState(new ThirdPartyToolMigrationProgress(1, 1));
-                        await Task.Yield();
-                    }
-
-                    AssetDatabase.Refresh();
-                }
-
-                isMigrationCompletionPending = false;
-            }
-            catch (System.OperationCanceledException)
-            {
-                // The finally block already skips the interrupted-refresh when the token is canceled.
-                return;
-            }
-            catch (System.Exception ex)
-            {
-                // PR1 makes a mid-batch apply failure a designed path (rollback, then throw). Log it and
-                // return; the finally block sees the still-pending completion and rescans, so the UI
-                // reflects the rolled-back files.
-                Debug.LogException(ex);
-                return;
-            }
-            finally
-            {
-                _isMigrating = false;
-                bool shouldRefreshAfterInterruptedMigration = ShouldRefreshAfterInterruptedMigration(
-                    isMigrationCompletionPending,
-                    ct.IsCancellationRequested);
-                CompleteMigrationOperation(ct);
-                if (shouldRefreshAfterInterruptedMigration)
-                {
-                    await RefreshUI();
-                }
-            }
-
-            if (ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            if (ShouldRefreshAfterMigration(result))
-            {
-                await RefreshUI();
-                return;
-            }
-
-            ShowNoMigrationTargetsState();
-        }
-
-        private System.IProgress<ThirdPartyToolMigrationProgress> CreateProgressReporter(CancellationToken ct)
-        {
-            return new ThirdPartyToolMigrationProgressReporter(
-                ct,
-                IsMigrationOperationActive,
-                ShowCheckingState);
-        }
-
-        private void ShowNotCheckedState()
-        {
-            _view.ShowNotCheckedState(_isMigrating);
-            ScheduleResizeToContent();
-        }
-
-        private void ShowMigrationTargetsState(string[] filePaths)
-        {
-            Debug.Assert(filePaths != null, "filePaths must not be null");
-
-            _pendingMigrationFilePaths = filePaths;
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            _view.ShowMigrationTargetsState(filePaths, projectRoot, _isMigrating);
-            ScheduleResizeToContent();
-        }
-
-        private void ShowNoMigrationTargetsState()
-        {
-            _view.ShowNoMigrationTargetsState(_isMigrating);
-            ScheduleResizeToContent();
-        }
-
-        private void ShowCheckingState(ThirdPartyToolMigrationProgress progress)
-        {
-            _view.ShowCheckingState(progress, _isMigrating);
-            ScheduleResizeToContent();
-        }
-
-        private void RefreshMigrationSkillState()
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            SkillSetupTargetInfo target = CreateMigrationSkillTargetInfo(_migrationSkillTarget);
-            _migrationSkillInstallState = _skillSetupUseCase.GetV3MigrationSkillInstallStateAtProjectRoot(
-                projectRoot,
-                target,
-                GroupMigrationSkillUnderUnityCliLoop);
-            UpdateMigrationSkillState();
-        }
-
-        private void UpdateMigrationSkillState()
-        {
-            _view.SetMigrationSkillState(
-                _migrationSkillTarget,
-                _migrationSkillInstallState,
-                _isUpdatingMigrationSkill);
-            ScheduleResizeToContent();
-        }
-
-        private void HandleMigrationSkillTargetChanged(SkillsTarget target)
-        {
-            _migrationSkillTarget = target;
-            RefreshMigrationSkillState();
-        }
-
-        private async Task HandleToggleMigrationSkill()
-        {
-            CancellationToken ct = BeginMigrationSkillOperation();
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            SkillSetupTargetInfo target = CreateMigrationSkillTargetInfo(_migrationSkillTarget);
-            SkillInstallState currentInstallState =
-                _skillSetupUseCase.GetV3MigrationSkillInstallStateAtProjectRoot(
-                    projectRoot,
-                    target,
-                    GroupMigrationSkillUnderUnityCliLoop);
-            bool shouldRemoveMigrationSkill = ShouldRemoveMigrationSkill(currentInstallState);
-            List<SkillSetupTargetInfo> targets = new List<SkillSetupTargetInfo> { target };
-            _migrationSkillInstallState = currentInstallState;
-            _isUpdatingMigrationSkill = true;
-            UpdateMigrationSkillState();
-
-            try
-            {
-                if (shouldRemoveMigrationSkill)
-                {
-                    await _skillSetupUseCase.RemoveV3MigrationSkillFilesAsync(
-                        projectRoot,
-                        targets,
-                        GroupMigrationSkillUnderUnityCliLoop,
-                        ct);
-                }
-                else
-                {
-                    await _skillSetupUseCase.InstallV3MigrationSkillFilesAsync(
-                        projectRoot,
-                        targets,
-                        GroupMigrationSkillUnderUnityCliLoop,
-                        ct);
-                }
-            }
-            catch (System.OperationCanceledException)
-            {
-                // The window is closing or a newer toggle superseded this one; do not touch its UI.
-                return;
-            }
-            catch (System.Exception ex)
-            {
-                // Fall through so the tail refresh shows the real on-disk install state after a failure.
-                Debug.LogException(ex);
-            }
-            finally
-            {
-                _isUpdatingMigrationSkill = false;
-            }
-
-            // The use case may complete off the main thread; UI Toolkit access below requires it.
-            await MainThreadSwitcher.SwitchToMainThread();
-            if (!IsMigrationSkillOperationActive(ct))
-            {
-                return;
-            }
-
-            CompleteMigrationSkillOperation(ct);
-            RefreshMigrationSkillState();
-        }
-
-        private static SkillSetupTargetInfo CreateMigrationSkillTargetInfo(SkillsTarget target)
-        {
-            SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
-                target,
-                GroupMigrationSkillUnderUnityCliLoop);
-            return new SkillSetupTargetInfo(
-                selection.DisplayName,
-                selection.DirectoryName,
-                selection.InstallFlag,
-                hasSkillsDirectory: true,
-                hasExistingSkills: false,
-                hasDifferentLayoutSkills: false,
-                SkillInstallState.Missing);
+            _controller?.CancelMigrationOperation();
+            _controller?.CancelMigrationSkillOperation();
         }
 
         private void ScheduleResizeToContent()
         {
             _resizer?.ScheduleResizeToContent();
-        }
-
-        private CancellationToken BeginMigrationOperation()
-        {
-            CancelMigrationOperation();
-            CancellationTokenSource cts = new CancellationTokenSource();
-            _migrationOperationCts = cts;
-            return cts.Token;
-        }
-
-        private void CancelMigrationOperation()
-        {
-            if (_migrationOperationCts == null)
-            {
-                return;
-            }
-
-            _migrationOperationCts.Cancel();
-            _migrationOperationCts.Dispose();
-            _migrationOperationCts = null;
-        }
-
-        private CancellationToken BeginMigrationSkillOperation()
-        {
-            CancelMigrationSkillOperation();
-            CancellationTokenSource cts = new CancellationTokenSource();
-            _migrationSkillOperationCts = cts;
-            return cts.Token;
-        }
-
-        private void CancelMigrationSkillOperation()
-        {
-            if (_migrationSkillOperationCts == null)
-            {
-                return;
-            }
-
-            _migrationSkillOperationCts.Cancel();
-            _migrationSkillOperationCts.Dispose();
-            _migrationSkillOperationCts = null;
         }
 
         internal bool ConsumeShouldStartInitialRefresh()
@@ -760,46 +422,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void TryStartInitialRefresh()
         {
-            bool shouldStartInitialRefresh = ConsumeShouldStartInitialRefresh();
-            if (!shouldStartInitialRefresh)
+            if (_controller == null)
             {
                 return;
             }
 
-            ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
-            rootVisualElement.schedule.Execute(() => RefreshUI().Forget()).StartingIn(0);
-        }
-
-        private void CompleteMigrationOperation(CancellationToken ct)
-        {
-            if (!IsMigrationOperationActive(ct))
-            {
-                return;
-            }
-
-            _migrationOperationCts.Dispose();
-            _migrationOperationCts = null;
-        }
-
-        private bool IsMigrationOperationActive(CancellationToken ct)
-        {
-            return _migrationOperationCts != null && _migrationOperationCts.Token.Equals(ct);
-        }
-
-        private void CompleteMigrationSkillOperation(CancellationToken ct)
-        {
-            if (!IsMigrationSkillOperationActive(ct))
-            {
-                return;
-            }
-
-            _migrationSkillOperationCts.Dispose();
-            _migrationSkillOperationCts = null;
-        }
-
-        private bool IsMigrationSkillOperationActive(CancellationToken ct)
-        {
-            return _migrationSkillOperationCts != null && _migrationSkillOperationCts.Token.Equals(ct);
+            _controller.TryStartInitialRefresh(ConsumeShouldStartInitialRefresh());
         }
     }
 }

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Owns migration-wizard workflow state and async operations for the dedicated Editor window.
+    /// </summary>
+    internal sealed class ThirdPartyToolMigrationWizardWorkflowController
+    {
+        private const bool GroupMigrationSkillUnderUnityCliLoop = false;
+
+        private readonly ThirdPartyToolMigrationWizardView _view;
+        private readonly SkillSetupUseCase _skillSetupUseCase;
+        private readonly ThirdPartyToolMigrationUseCase _thirdPartyToolMigrationUseCase;
+        private readonly Action _scheduleResize;
+
+        private bool _isMigrating;
+        private bool _isUpdatingMigrationSkill;
+        private SkillsTarget _migrationSkillTarget = SkillsTarget.Claude;
+        private SkillInstallState _migrationSkillInstallState = SkillInstallState.Missing;
+        private string[] _pendingMigrationFilePaths = Array.Empty<string>();
+        private CancellationTokenSource _migrationOperationCts;
+        private CancellationTokenSource _migrationSkillOperationCts;
+
+        internal ThirdPartyToolMigrationWizardWorkflowController(
+            ThirdPartyToolMigrationWizardView view,
+            SkillSetupUseCase skillSetupUseCase,
+            ThirdPartyToolMigrationUseCase thirdPartyToolMigrationUseCase,
+            Action scheduleResize)
+        {
+            Debug.Assert(view != null, "view must not be null");
+            Debug.Assert(skillSetupUseCase != null, "skillSetupUseCase must not be null");
+            Debug.Assert(
+                thirdPartyToolMigrationUseCase != null,
+                "thirdPartyToolMigrationUseCase must not be null");
+            Debug.Assert(scheduleResize != null, "scheduleResize must not be null");
+
+            _view = view ?? throw new ArgumentNullException(nameof(view));
+            _skillSetupUseCase = skillSetupUseCase
+                ?? throw new ArgumentNullException(nameof(skillSetupUseCase));
+            _thirdPartyToolMigrationUseCase = thirdPartyToolMigrationUseCase
+                ?? throw new ArgumentNullException(nameof(thirdPartyToolMigrationUseCase));
+            _scheduleResize = scheduleResize
+                ?? throw new ArgumentNullException(nameof(scheduleResize));
+        }
+
+        internal void ShowInitialState(bool shouldStartInitialRefresh)
+        {
+            if (shouldStartInitialRefresh)
+            {
+                ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+                return;
+            }
+
+            ShowNotCheckedState();
+        }
+
+        internal void ScheduleInitialRefresh(bool shouldStartInitialRefresh)
+        {
+            if (!shouldStartInitialRefresh)
+            {
+                return;
+            }
+
+            _view.MainScrollView.schedule.Execute(() => RefreshUI().Forget()).StartingIn(0);
+        }
+
+        internal void TryStartInitialRefresh(bool shouldStartInitialRefresh)
+        {
+            if (!shouldStartInitialRefresh)
+            {
+                return;
+            }
+
+            ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+            _view.MainScrollView.schedule.Execute(() => RefreshUI().Forget()).StartingIn(0);
+        }
+
+        internal async Task RefreshUI()
+        {
+            CancellationToken ct = BeginMigrationOperation();
+            ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+            await Task.Yield();
+
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            IProgress<ThirdPartyToolMigrationProgress> progress = CreateProgressReporter(ct);
+            ThirdPartyToolMigrationPreview preview;
+            try
+            {
+                preview = await Task.Run(async () =>
+                    await _thirdPartyToolMigrationUseCase.PreviewMigrationAsync(projectRoot, progress, ct));
+                await MainThreadSwitcher.SwitchToMainThread();
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation comes from window close or a superseding operation; that owner drives the UI.
+                return;
+            }
+            catch (Exception ex)
+            {
+                // Without this async-void boundary the exception hits the sync context, the window
+                // stays on "Scanning..." forever, and the operation CTS leaks.
+                Debug.LogException(ex);
+                if (IsMigrationOperationActive(ct))
+                {
+                    CompleteMigrationOperation(ct);
+                    ShowNotCheckedState();
+                }
+
+                return;
+            }
+
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            CompleteMigrationOperation(ct);
+            if (!preview.HasTargets)
+            {
+                ShowNoMigrationTargetsState();
+                return;
+            }
+
+            ShowMigrationTargetsState(preview.FilePaths);
+        }
+
+        internal async Task HandleMigrateThirdPartyTools()
+        {
+            if (!ThirdPartyToolMigrationWizardWindow.ConfirmMigrationApply(
+                _pendingMigrationFilePaths.Length,
+                (title, message, ok, cancel) => EditorUtility.DisplayDialog(title, message, ok, cancel)))
+            {
+                return;
+            }
+
+            CancellationToken ct = BeginMigrationOperation();
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            ThirdPartyToolMigrationResult result = default;
+            bool isMigrationCompletionPending = true;
+            _isMigrating = true;
+            ShowCheckingState(new ThirdPartyToolMigrationProgress(0, 0));
+            await Task.Yield();
+
+            try
+            {
+                IProgress<ThirdPartyToolMigrationProgress> progress = CreateProgressReporter(ct);
+                result = await Task.Run(async () =>
+                    await _thirdPartyToolMigrationUseCase.ApplyMigrationAsync(projectRoot, progress, ct));
+                if (!ThirdPartyToolMigrationWizardWindow.ShouldFinishMigrationOnMainThread(
+                    ct.IsCancellationRequested,
+                    result))
+                {
+                    return;
+                }
+
+                await MainThreadSwitcher.SwitchToMainThread();
+                if (!ThirdPartyToolMigrationWizardWindow.ShouldFinishMigrationOnMainThread(
+                    ct.IsCancellationRequested,
+                    result))
+                {
+                    return;
+                }
+
+                CompleteMigrationOperation(ct);
+                if (result.Changed)
+                {
+                    if (!ct.IsCancellationRequested)
+                    {
+                        ShowCheckingState(new ThirdPartyToolMigrationProgress(1, 1));
+                        await Task.Yield();
+                    }
+
+                    AssetDatabase.Refresh();
+                }
+
+                isMigrationCompletionPending = false;
+            }
+            catch (OperationCanceledException)
+            {
+                // The finally block already skips the interrupted-refresh when the token is canceled.
+                return;
+            }
+            catch (Exception ex)
+            {
+                // PR1 makes a mid-batch apply failure a designed path (rollback, then throw). Log it and
+                // return; the finally block sees the still-pending completion and rescans, so the UI
+                // reflects the rolled-back files.
+                Debug.LogException(ex);
+                return;
+            }
+            finally
+            {
+                _isMigrating = false;
+                bool shouldRefreshAfterInterruptedMigration =
+                    ThirdPartyToolMigrationWizardWindow.ShouldRefreshAfterInterruptedMigration(
+                        isMigrationCompletionPending,
+                        ct.IsCancellationRequested);
+                CompleteMigrationOperation(ct);
+                if (shouldRefreshAfterInterruptedMigration)
+                {
+                    await RefreshUI();
+                }
+            }
+
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (ThirdPartyToolMigrationWizardWindow.ShouldRefreshAfterMigration(result))
+            {
+                await RefreshUI();
+                return;
+            }
+
+            ShowNoMigrationTargetsState();
+        }
+
+        internal IProgress<ThirdPartyToolMigrationProgress> CreateProgressReporter(CancellationToken ct)
+        {
+            return new ThirdPartyToolMigrationProgressReporter(
+                ct,
+                IsMigrationOperationActive,
+                ShowCheckingState);
+        }
+
+        internal void ShowNotCheckedState()
+        {
+            _view.ShowNotCheckedState(_isMigrating);
+            _scheduleResize();
+        }
+
+        internal void ShowMigrationTargetsState(string[] filePaths)
+        {
+            Debug.Assert(filePaths != null, "filePaths must not be null");
+
+            _pendingMigrationFilePaths = filePaths;
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            _view.ShowMigrationTargetsState(filePaths, projectRoot, _isMigrating);
+            _scheduleResize();
+        }
+
+        internal void ShowNoMigrationTargetsState()
+        {
+            _view.ShowNoMigrationTargetsState(_isMigrating);
+            _scheduleResize();
+        }
+
+        internal void ShowCheckingState(ThirdPartyToolMigrationProgress progress)
+        {
+            _view.ShowCheckingState(progress, _isMigrating);
+            _scheduleResize();
+        }
+
+        internal void RefreshMigrationSkillState()
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            SkillSetupTargetInfo target = CreateMigrationSkillTargetInfo(_migrationSkillTarget);
+            _migrationSkillInstallState = _skillSetupUseCase.GetV3MigrationSkillInstallStateAtProjectRoot(
+                projectRoot,
+                target,
+                GroupMigrationSkillUnderUnityCliLoop);
+            UpdateMigrationSkillState();
+        }
+
+        internal void UpdateMigrationSkillState()
+        {
+            _view.SetMigrationSkillState(
+                _migrationSkillTarget,
+                _migrationSkillInstallState,
+                _isUpdatingMigrationSkill);
+            _scheduleResize();
+        }
+
+        internal void HandleMigrationSkillTargetChanged(SkillsTarget target)
+        {
+            _migrationSkillTarget = target;
+            RefreshMigrationSkillState();
+        }
+
+        internal async Task HandleToggleMigrationSkill()
+        {
+            CancellationToken ct = BeginMigrationSkillOperation();
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            SkillSetupTargetInfo target = CreateMigrationSkillTargetInfo(_migrationSkillTarget);
+            SkillInstallState currentInstallState =
+                _skillSetupUseCase.GetV3MigrationSkillInstallStateAtProjectRoot(
+                    projectRoot,
+                    target,
+                    GroupMigrationSkillUnderUnityCliLoop);
+            bool shouldRemoveMigrationSkill =
+                ThirdPartyToolMigrationWizardWindow.ShouldRemoveMigrationSkill(currentInstallState);
+            List<SkillSetupTargetInfo> targets = new List<SkillSetupTargetInfo> { target };
+            _migrationSkillInstallState = currentInstallState;
+            _isUpdatingMigrationSkill = true;
+            UpdateMigrationSkillState();
+
+            try
+            {
+                if (shouldRemoveMigrationSkill)
+                {
+                    await _skillSetupUseCase.RemoveV3MigrationSkillFilesAsync(
+                        projectRoot,
+                        targets,
+                        GroupMigrationSkillUnderUnityCliLoop,
+                        ct);
+                }
+                else
+                {
+                    await _skillSetupUseCase.InstallV3MigrationSkillFilesAsync(
+                        projectRoot,
+                        targets,
+                        GroupMigrationSkillUnderUnityCliLoop,
+                        ct);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // The window is closing or a newer toggle superseded this one; do not touch its UI.
+                return;
+            }
+            catch (Exception ex)
+            {
+                // Fall through so the tail refresh shows the real on-disk install state after a failure.
+                Debug.LogException(ex);
+            }
+            finally
+            {
+                _isUpdatingMigrationSkill = false;
+            }
+
+            // The use case may complete off the main thread; UI Toolkit access below requires it.
+            await MainThreadSwitcher.SwitchToMainThread();
+            if (!IsMigrationSkillOperationActive(ct))
+            {
+                return;
+            }
+
+            CompleteMigrationSkillOperation(ct);
+            RefreshMigrationSkillState();
+        }
+
+        internal static SkillSetupTargetInfo CreateMigrationSkillTargetInfo(SkillsTarget target)
+        {
+            SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
+                target,
+                GroupMigrationSkillUnderUnityCliLoop);
+            return new SkillSetupTargetInfo(
+                selection.DisplayName,
+                selection.DirectoryName,
+                selection.InstallFlag,
+                hasSkillsDirectory: true,
+                hasExistingSkills: false,
+                hasDifferentLayoutSkills: false,
+                SkillInstallState.Missing);
+        }
+
+        internal CancellationToken BeginMigrationOperation()
+        {
+            CancelMigrationOperation();
+            CancellationTokenSource cts = new CancellationTokenSource();
+            _migrationOperationCts = cts;
+            return cts.Token;
+        }
+
+        internal void CancelMigrationOperation()
+        {
+            if (_migrationOperationCts == null)
+            {
+                return;
+            }
+
+            _migrationOperationCts.Cancel();
+            _migrationOperationCts.Dispose();
+            _migrationOperationCts = null;
+        }
+
+        internal CancellationToken BeginMigrationSkillOperation()
+        {
+            CancelMigrationSkillOperation();
+            CancellationTokenSource cts = new CancellationTokenSource();
+            _migrationSkillOperationCts = cts;
+            return cts.Token;
+        }
+
+        internal void CancelMigrationSkillOperation()
+        {
+            if (_migrationSkillOperationCts == null)
+            {
+                return;
+            }
+
+            _migrationSkillOperationCts.Cancel();
+            _migrationSkillOperationCts.Dispose();
+            _migrationSkillOperationCts = null;
+        }
+
+        internal void CompleteMigrationOperation(CancellationToken ct)
+        {
+            if (!IsMigrationOperationActive(ct))
+            {
+                return;
+            }
+
+            _migrationOperationCts.Dispose();
+            _migrationOperationCts = null;
+        }
+
+        internal bool IsMigrationOperationActive(CancellationToken ct)
+        {
+            return _migrationOperationCts != null && _migrationOperationCts.Token.Equals(ct);
+        }
+
+        internal void CompleteMigrationSkillOperation(CancellationToken ct)
+        {
+            if (!IsMigrationSkillOperationActive(ct))
+            {
+                return;
+            }
+
+            _migrationSkillOperationCts.Dispose();
+            _migrationSkillOperationCts = null;
+        }
+
+        internal bool IsMigrationSkillOperationActive(CancellationToken ct)
+        {
+            return _migrationSkillOperationCts != null && _migrationSkillOperationCts.Token.Equals(ct);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs.meta
+++ b/Packages/src/Editor/Presentation/Setup/ThirdPartyToolMigrationWizardWorkflowController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f148ff5a135443f9b980b8e076988243
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/ToolListRowData.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/ToolListRowData.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Row model for the Tool Settings virtualized list (header, tool, or details).
+    /// </summary>
+    internal sealed class ToolListRowData
+    {
+        public readonly bool IsHeader;
+        public readonly bool IsDetails;
+        public readonly string ToolName;
+        public readonly string Label;
+        public readonly string SkillDescription;
+        public bool IsEnabled;
+        public ToolSettingsSection Owner;
+        public bool IsTool => !IsHeader && !IsDetails;
+
+        private ToolListRowData(
+            bool isHeader,
+            bool isDetails,
+            string toolName,
+            string label,
+            string skillDescription,
+            bool isEnabled)
+        {
+            IsHeader = isHeader;
+            IsDetails = isDetails;
+            ToolName = toolName;
+            Label = label;
+            SkillDescription = skillDescription;
+            IsEnabled = isEnabled;
+        }
+
+        public static ToolListRowData CreateHeader(string label)
+        {
+            return new ToolListRowData(
+                true,
+                false,
+                string.Empty,
+                label,
+                string.Empty,
+                true);
+        }
+
+        public static ToolListRowData CreateTool(ToolToggleItem item)
+        {
+            return new ToolListRowData(
+                false,
+                false,
+                item.ToolName,
+                item.ToolName,
+                item.SkillDescription,
+                item.IsEnabled);
+        }
+
+        public static ToolListRowData CreateDetails(ToolListRowData toolRow)
+        {
+            Debug.Assert(toolRow != null, "toolRow must not be null");
+            Debug.Assert(toolRow.IsTool, "toolRow must be a tool row");
+
+            return new ToolListRowData(
+                false,
+                true,
+                toolRow.ToolName,
+                string.Empty,
+                toolRow.SkillDescription,
+                true);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/ToolListRowData.cs.meta
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/ToolListRowData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a032ce2e589496b96f98d44d1acde05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSection.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSection.cs
@@ -1,10 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
 using UnityEngine.UIElements;
-
-using io.github.hatayama.UnityCliLoop.Application;
 
 namespace io.github.hatayama.UnityCliLoop.Presentation
 {
@@ -14,23 +10,16 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     /// </summary>
     public class ToolSettingsSection
     {
-        private const int ToolListRowHeight = 24;
-        private const int ToolDetailsRowHeight = 132;
-        private const int InlineToolRowLimit = 40;
         private const string ToolSettingsInfoText = "Enable or disable tools. Disabled tools are hidden from AI agents.";
 
         private readonly Foldout _foldout;
         private readonly VisualElement _toolSettingsInfoContainer;
         private readonly VisualElement _toolListContainer;
         private readonly Label _toolListStatusLabel;
-        private readonly ListView _toolListView;
-        private readonly List<ToolListRowData> _toolListRows = new();
-        private readonly Dictionary<string, Toggle> _togglesByToolName = new();
-        private string _expandedDetailsToolName = string.Empty;
+        private readonly ToolSettingsSectionListViewController _listViewController;
         private bool _isRegistryAvailable;
         private bool _isUnavailableStateShown;
         private bool _isLoadingStateShown;
-        private string _layoutSignature = string.Empty;
 
         public event Action<bool> OnFoldoutChanged;
         public event Action<string, bool> OnToolToggled;
@@ -45,9 +34,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             SetupToolSettingsInfoText();
             _toolListStatusLabel = CreateToolListStatusLabel();
-            _toolListView = CreateToolListView();
+            _listViewController = new ToolSettingsSectionListViewController(
+                this,
+                (toolName, enabled) => OnToolToggled?.Invoke(toolName, enabled));
             _toolListContainer.Add(_toolListStatusLabel);
-            _toolListContainer.Add(_toolListView);
+            _toolListContainer.Add(_listViewController.ListView);
             ClearToolList();
 
             SetupBindings();
@@ -85,31 +76,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         public void UpdateSingleToggle(string toolName, bool enabled)
         {
-            for (int i = 0; i < _toolListRows.Count; i++)
-            {
-                ToolListRowData row = _toolListRows[i];
-                if (!row.IsTool || row.ToolName != toolName)
-                {
-                    continue;
-                }
-
-                row.IsEnabled = enabled;
-                break;
-            }
-
-            if (_togglesByToolName.TryGetValue(toolName, out Toggle toggle))
-            {
-                toggle.SetValueWithoutNotify(enabled);
-            }
-
-            RefreshToolListView();
+            _listViewController.UpdateSingleToggle(toolName, enabled);
         }
 
         private void UpdateDeferredState()
         {
-            if (_toolListRows.Count > 0 || _isUnavailableStateShown)
+            if (_listViewController.HasRows || _isUnavailableStateShown)
             {
-                RefreshToolListView();
+                _listViewController.RefreshToolListView();
                 return;
             }
 
@@ -118,13 +92,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateLoadingState()
         {
-            _toolListRows.Clear();
-            _togglesByToolName.Clear();
-            _layoutSignature = string.Empty;
-
-            HideToolDetails();
+            _listViewController.ResetRows();
             SetToolListStatus("Loading tools...");
-            ViewDataBinder.SetVisible(_toolListView, false);
+            _listViewController.SetListViewVisible(false);
             SetToolSettingsInfoVisible(false);
 
             _isRegistryAvailable = false;
@@ -134,13 +104,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateUnavailableState()
         {
-            _toolListRows.Clear();
-            _togglesByToolName.Clear();
-            _layoutSignature = string.Empty;
-
-            HideToolDetails();
+            _listViewController.ResetRows();
             SetToolListStatus("Tool registry not yet initialized. Start the server first.");
-            ViewDataBinder.SetVisible(_toolListView, false);
+            _listViewController.SetListViewVisible(false);
             SetToolSettingsInfoVisible(false);
 
             _isRegistryAvailable = false;
@@ -150,15 +116,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void ClearToolList()
         {
-            _toolListRows.Clear();
-            _togglesByToolName.Clear();
-            _layoutSignature = string.Empty;
-
-            HideToolDetails();
+            _listViewController.Clear();
             ViewDataBinder.SetVisible(_toolListStatusLabel, false);
-            ViewDataBinder.SetVisible(_toolListView, false);
             SetToolSettingsInfoVisible(false);
-            RefreshToolListView();
 
             _isRegistryAvailable = false;
             _isUnavailableStateShown = false;
@@ -192,111 +152,18 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
         private void UpdateToolList(ToolSettingsSectionData data)
         {
-            string layoutSignature = CreateLayoutSignature(data);
-            bool shouldRebuild = !_isRegistryAvailable
+            bool forceRebuild = !_isRegistryAvailable
                 || _isUnavailableStateShown
-                || _isLoadingStateShown
-                || _layoutSignature != layoutSignature;
+                || _isLoadingStateShown;
 
-            if (shouldRebuild)
-            {
-                Rebuild(data);
-                _layoutSignature = layoutSignature;
-            }
-            else
-            {
-                UpdateToggleStates(data.BuiltInTools);
-                UpdateToggleStates(data.ThirdPartyTools);
-            }
+            _listViewController.UpdateToolList(data, forceRebuild);
 
             ViewDataBinder.SetVisible(_toolListStatusLabel, false);
-            ViewDataBinder.SetVisible(_toolListView, true);
             SetToolSettingsInfoVisible(true);
-            RefreshToolListView();
 
             _isRegistryAvailable = true;
             _isUnavailableStateShown = false;
             _isLoadingStateShown = false;
-        }
-
-        private void Rebuild(ToolSettingsSectionData data)
-        {
-            _toolListRows.Clear();
-            _togglesByToolName.Clear();
-            HideToolDetails();
-
-            if (data.BuiltInTools.Length > 0)
-            {
-                _toolListRows.Add(ToolListRowData.CreateHeader("Built-in Tools"));
-                AddToolRows(data.BuiltInTools);
-            }
-
-            if (data.ThirdPartyTools.Length > 0)
-            {
-                _toolListRows.Add(ToolListRowData.CreateHeader("Third Party Tools"));
-                AddToolRows(data.ThirdPartyTools);
-            }
-
-            UpdateToolListHeight();
-            RefreshToolListView();
-        }
-
-        private void AddToolRows(IReadOnlyList<ToolToggleItem> items)
-        {
-            for (int i = 0; i < items.Count; i++)
-            {
-                ToolToggleItem item = items[i];
-                _toolListRows.Add(ToolListRowData.CreateTool(item));
-            }
-        }
-
-        private void UpdateToggleStates(IReadOnlyList<ToolToggleItem> items)
-        {
-            for (int i = 0; i < items.Count; i++)
-            {
-                ToolToggleItem item = items[i];
-                UpdateToggleState(item.ToolName, item.IsEnabled);
-            }
-        }
-
-        private void UpdateToggleState(string toolName, bool isEnabled)
-        {
-            for (int i = 0; i < _toolListRows.Count; i++)
-            {
-                ToolListRowData row = _toolListRows[i];
-                if (!row.IsTool || row.ToolName != toolName)
-                {
-                    continue;
-                }
-
-                row.IsEnabled = isEnabled;
-                return;
-            }
-        }
-
-        private static string CreateLayoutSignature(ToolSettingsSectionData data)
-        {
-            StringBuilder builder = new();
-            AppendGroupSignature(builder, data.BuiltInTools, "B");
-            AppendGroupSignature(builder, data.ThirdPartyTools, "T");
-            return builder.ToString();
-        }
-
-        private static void AppendGroupSignature(StringBuilder builder, IReadOnlyList<ToolToggleItem> items, string group)
-        {
-            builder.Append(group);
-            builder.Append(':');
-
-            for (int i = 0; i < items.Count; i++)
-            {
-                ToolToggleItem item = items[i];
-                builder.Append(item.ToolName);
-                builder.Append('|');
-                builder.Append(item.SkillDescription);
-                builder.Append('|');
-            }
-
-            builder.Append(';');
         }
 
         private static Label CreateToolListStatusLabel()
@@ -307,413 +174,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return label;
         }
 
-        private ListView CreateToolListView()
-        {
-            ListView listView = new();
-            listView.name = "tool-list-view";
-            listView.AddToClassList("unity-cli-loop-tool-list-view");
-            listView.virtualizationMethod = CollectionVirtualizationMethod.DynamicHeight;
-            listView.selectionType = SelectionType.None;
-            listView.itemsSource = _toolListRows;
-            listView.makeItem = CreateToolListRowElement;
-            listView.bindItem = BindToolListRowElement;
-            listView.unbindItem = UnbindToolListRowElement;
-            return listView;
-        }
-
-        private static VisualElement CreateToolListRowElement()
-        {
-            VisualElement row = new();
-            row.AddToClassList("unity-cli-loop-tool-toggle-row");
-            row.AddToClassList("unity-cli-loop-tool-list-row");
-
-            Toggle toggle = new();
-            toggle.name = "tool-list-row-toggle";
-            toggle.AddToClassList("unity-cli-loop-tool-toggle-row__toggle");
-            toggle.RegisterValueChangedCallback(evt =>
-            {
-                evt.StopPropagation();
-
-                if (row.userData is not ToolListRowData item || !item.IsTool)
-                {
-                    return;
-                }
-
-                item.Owner?.OnToolToggled?.Invoke(item.ToolName, evt.newValue);
-            });
-
-            Label label = new();
-            label.name = "tool-list-row-label";
-            label.AddToClassList("unity-cli-loop-tool-toggle-row__label");
-            label.RegisterCallback<ClickEvent>(evt =>
-            {
-                evt.StopPropagation();
-
-                if (row.userData is not ToolListRowData item || !item.IsTool)
-                {
-                    return;
-                }
-
-                Toggle rowToggle = row.Q<Toggle>("tool-list-row-toggle");
-                bool newValue = !rowToggle.value;
-                rowToggle.SetValueWithoutNotify(newValue);
-                item.Owner?.OnToolToggled?.Invoke(item.ToolName, newValue);
-            });
-
-            row.Add(toggle);
-            row.Add(label);
-            Button detailsButton = new();
-            detailsButton.name = "tool-list-row-details-button";
-            detailsButton.text = "Show Details";
-            detailsButton.tooltip = "Show tool description";
-            detailsButton.AddToClassList("unity-cli-loop-tool-toggle-row__details-button");
-            detailsButton.RegisterCallback<ClickEvent>(evt =>
-            {
-                evt.StopPropagation();
-
-                if (row.userData is not ToolListRowData item || !item.IsTool)
-                {
-                    return;
-                }
-
-                item.Owner?.ToggleToolDetailsForTool(item.ToolName);
-            });
-            row.Add(detailsButton);
-
-            VisualElement detailsPanel = new();
-            detailsPanel.name = "tool-list-row-details";
-            detailsPanel.AddToClassList("unity-cli-loop-tool-details-panel");
-
-            TextField detailsBody = new();
-            detailsBody.name = "tool-list-row-details-body";
-            detailsBody.isReadOnly = true;
-            detailsBody.multiline = true;
-            detailsBody.AddToClassList("unity-cli-loop-tool-details-panel__body");
-            detailsPanel.Add(detailsBody);
-
-            row.Add(detailsPanel);
-            return row;
-        }
-
-        private void BindToolListRowElement(VisualElement row, int index)
-        {
-            Debug.Assert(index >= 0 && index < _toolListRows.Count, "tool list index must be valid");
-
-            ToolListRowData item = _toolListRows[index];
-            item.Owner = this;
-            row.userData = item;
-
-            Toggle toggle = row.Q<Toggle>("tool-list-row-toggle");
-            Button detailsButton = row.Q<Button>("tool-list-row-details-button");
-            Label label = row.Q<Label>("tool-list-row-label");
-            VisualElement detailsPanel = row.Q<VisualElement>("tool-list-row-details");
-            TextField detailsBody = row.Q<TextField>("tool-list-row-details-body");
-            Debug.Assert(toggle != null, "tool-list-row-toggle must not be null");
-            Debug.Assert(detailsButton != null, "tool-list-row-details-button must not be null");
-            Debug.Assert(label != null, "tool-list-row-label must not be null");
-            Debug.Assert(detailsPanel != null, "tool-list-row-details must not be null");
-            Debug.Assert(detailsBody != null, "tool-list-row-details-body must not be null");
-
-            ResetRowClasses(row, label, detailsButton);
-
-            if (item.IsHeader)
-            {
-                BindHeaderRow(row, toggle, detailsButton, label, detailsPanel, item);
-                return;
-            }
-
-            if (item.IsDetails)
-            {
-                BindDetailsRow(row, toggle, detailsButton, label, detailsPanel, detailsBody, item);
-                return;
-            }
-
-            BindToolRow(row, toggle, detailsButton, label, detailsPanel, item);
-        }
-
-        private void BindHeaderRow(
-            VisualElement row,
-            Toggle toggle,
-            Button detailsButton,
-            Label label,
-            VisualElement detailsPanel,
-            ToolListRowData item)
-        {
-            ViewDataBinder.SetVisible(toggle, false);
-            ViewDataBinder.SetVisible(detailsButton, false);
-            ViewDataBinder.SetVisible(label, true);
-            ViewDataBinder.SetVisible(detailsPanel, false);
-            label.text = item.Label;
-            label.tooltip = string.Empty;
-            row.SetEnabled(true);
-            row.AddToClassList("unity-cli-loop-tool-list-row--header");
-            label.AddToClassList("unity-cli-loop-tool-group-header");
-        }
-
-        private void BindToolRow(
-            VisualElement row,
-            Toggle toggle,
-            Button detailsButton,
-            Label label,
-            VisualElement detailsPanel,
-            ToolListRowData item)
-        {
-            ViewDataBinder.SetVisible(toggle, true);
-            ViewDataBinder.SetVisible(label, true);
-            ViewDataBinder.SetVisible(detailsPanel, false);
-            toggle.SetValueWithoutNotify(item.IsEnabled);
-            bool hasDescription = !string.IsNullOrWhiteSpace(item.SkillDescription);
-            bool isDetailsExpanded = hasDescription && _expandedDetailsToolName == item.ToolName;
-            ViewDataBinder.SetVisible(detailsButton, hasDescription);
-            detailsButton.text = isDetailsExpanded ? "Hide Details" : "Show Details";
-            detailsButton.tooltip = isDetailsExpanded ? "Hide tool description" : "Show tool description";
-            if (isDetailsExpanded)
-            {
-                detailsButton.AddToClassList("unity-cli-loop-tool-toggle-row__details-button--selected");
-            }
-            label.text = item.ToolName;
-            label.tooltip = string.Empty;
-
-            row.SetEnabled(true);
-            _togglesByToolName[item.ToolName] = toggle;
-        }
-
-        private static void BindDetailsRow(
-            VisualElement row,
-            Toggle toggle,
-            Button detailsButton,
-            Label label,
-            VisualElement detailsPanel,
-            TextField detailsBody,
-            ToolListRowData item)
-        {
-            ViewDataBinder.SetVisible(toggle, false);
-            ViewDataBinder.SetVisible(detailsButton, false);
-            ViewDataBinder.SetVisible(label, false);
-            ViewDataBinder.SetVisible(detailsPanel, true);
-            detailsBody.SetValueWithoutNotify(item.SkillDescription);
-            row.SetEnabled(true);
-            row.AddToClassList("unity-cli-loop-tool-details-row");
-        }
-
-        private static void ResetRowClasses(VisualElement row, Label label, Button detailsButton)
-        {
-            row.RemoveFromClassList("unity-cli-loop-tool-list-row--header");
-            row.RemoveFromClassList("unity-cli-loop-tool-details-row");
-            label.RemoveFromClassList("unity-cli-loop-tool-group-header");
-            detailsButton.RemoveFromClassList("unity-cli-loop-tool-toggle-row__details-button--selected");
-        }
-
-        private void UnbindToolListRowElement(VisualElement row, int index)
-        {
-            if (row.userData is ToolListRowData item && item.IsTool)
-            {
-                _togglesByToolName.Remove(item.ToolName);
-            }
-
-            row.userData = null;
-        }
-
-        private void RefreshToolListView()
-        {
-            _togglesByToolName.Clear();
-            _toolListView.RefreshItems();
-        }
-
         internal void ToggleToolDetailsForTool(string toolName)
         {
-            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
-
-            ToolListRowData item = FindToolRowByName(toolName);
-            Debug.Assert(item != null, "tool row must exist");
-            Debug.Assert(!string.IsNullOrWhiteSpace(item.SkillDescription), "tool row must have details");
-
-            if (_expandedDetailsToolName == item.ToolName)
-            {
-                HideToolDetails();
-                UpdateToolListHeight();
-                RefreshToolListView();
-                return;
-            }
-
-            _expandedDetailsToolName = item.ToolName;
-            RebuildToolDetailsRow();
-            UpdateToolListHeight();
-            RefreshToolListView();
-        }
-
-        private ToolListRowData FindToolRowByName(string toolName)
-        {
-            int toolIndex = FindToolRowIndex(toolName);
-            if (toolIndex < 0)
-            {
-                return null;
-            }
-
-            return _toolListRows[toolIndex];
-        }
-
-        private int FindToolRowIndex(string toolName)
-        {
-            for (int i = 0; i < _toolListRows.Count; i++)
-            {
-                ToolListRowData item = _toolListRows[i];
-                if (!item.IsTool || item.ToolName != toolName)
-                {
-                    continue;
-                }
-
-                return i;
-            }
-
-            return -1;
-        }
-
-        private void HideToolDetails()
-        {
-            _expandedDetailsToolName = string.Empty;
-            RemoveToolDetailsRows();
-        }
-
-        private void RebuildToolDetailsRow()
-        {
-            RemoveToolDetailsRows();
-
-            if (string.IsNullOrEmpty(_expandedDetailsToolName))
-            {
-                return;
-            }
-
-            int toolIndex = FindToolRowIndex(_expandedDetailsToolName);
-            if (toolIndex < 0)
-            {
-                _expandedDetailsToolName = string.Empty;
-                return;
-            }
-
-            ToolListRowData toolRow = _toolListRows[toolIndex];
-            _toolListRows.Insert(toolIndex + 1, ToolListRowData.CreateDetails(toolRow));
-        }
-
-        private void RemoveToolDetailsRows()
-        {
-            for (int i = _toolListRows.Count - 1; i >= 0; i--)
-            {
-                if (!_toolListRows[i].IsDetails)
-                {
-                    continue;
-                }
-
-                _toolListRows.RemoveAt(i);
-            }
-        }
-
-        private void UpdateToolListHeight()
-        {
-            int visibleRows = Math.Min(CountNonDetailsRows(), InlineToolRowLimit);
-            if (visibleRows <= 0)
-            {
-                visibleRows = 1;
-            }
-
-            int detailsRowHeight = HasDetailsRow() ? ToolDetailsRowHeight : 0;
-            _toolListView.style.height = (visibleRows * ToolListRowHeight) + detailsRowHeight + 2;
-        }
-
-        private int CountNonDetailsRows()
-        {
-            int count = 0;
-            for (int i = 0; i < _toolListRows.Count; i++)
-            {
-                if (_toolListRows[i].IsDetails)
-                {
-                    continue;
-                }
-
-                count++;
-            }
-
-            return count;
-        }
-
-        private bool HasDetailsRow()
-        {
-            for (int i = 0; i < _toolListRows.Count; i++)
-            {
-                if (_toolListRows[i].IsDetails)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Holds serialized data for Tool List Row behavior.
-        /// </summary>
-        private sealed class ToolListRowData
-        {
-            public readonly bool IsHeader;
-            public readonly bool IsDetails;
-            public readonly string ToolName;
-            public readonly string Label;
-            public readonly string SkillDescription;
-            public bool IsEnabled;
-            public ToolSettingsSection Owner;
-            public bool IsTool => !IsHeader && !IsDetails;
-
-            private ToolListRowData(
-                bool isHeader,
-                bool isDetails,
-                string toolName,
-                string label,
-                string skillDescription,
-                bool isEnabled)
-            {
-                IsHeader = isHeader;
-                IsDetails = isDetails;
-                ToolName = toolName;
-                Label = label;
-                SkillDescription = skillDescription;
-                IsEnabled = isEnabled;
-            }
-
-            public static ToolListRowData CreateHeader(string label)
-            {
-                return new ToolListRowData(
-                    true,
-                    false,
-                    string.Empty,
-                    label,
-                    string.Empty,
-                    true);
-            }
-
-            public static ToolListRowData CreateTool(ToolToggleItem item)
-            {
-                return new ToolListRowData(
-                    false,
-                    false,
-                    item.ToolName,
-                    item.ToolName,
-                    item.SkillDescription,
-                    item.IsEnabled);
-            }
-
-            public static ToolListRowData CreateDetails(ToolListRowData toolRow)
-            {
-                Debug.Assert(toolRow != null, "toolRow must not be null");
-                Debug.Assert(toolRow.IsTool, "toolRow must be a tool row");
-
-                return new ToolListRowData(
-                    false,
-                    true,
-                    toolRow.ToolName,
-                    string.Empty,
-                    toolRow.SkillDescription,
-                    true);
-            }
+            _listViewController.ToggleToolDetailsForTool(toolName);
         }
     }
 }

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionLayoutSignature.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionLayoutSignature.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+using io.github.hatayama.UnityCliLoop.Application;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Builds a stable layout signature for Tool Settings list rebuild decisions.
+    /// </summary>
+    internal static class ToolSettingsSectionLayoutSignature
+    {
+        public static string Create(ToolSettingsSectionData data)
+        {
+            Debug.Assert(data != null, "data must not be null");
+
+            StringBuilder builder = new();
+            AppendGroup(builder, data.BuiltInTools, "B");
+            AppendGroup(builder, data.ThirdPartyTools, "T");
+            return builder.ToString();
+        }
+
+        private static void AppendGroup(
+            StringBuilder builder,
+            IReadOnlyList<ToolToggleItem> items,
+            string group)
+        {
+            Debug.Assert(builder != null, "builder must not be null");
+            Debug.Assert(items != null, "items must not be null");
+            Debug.Assert(!string.IsNullOrEmpty(group), "group must not be null or empty");
+
+            builder.Append(group);
+            builder.Append(':');
+            for (int i = 0; i < items.Count; i++)
+            {
+                ToolToggleItem item = items[i];
+                builder.Append(item.ToolName);
+                builder.Append('|');
+                builder.Append(item.SkillDescription);
+                builder.Append('|');
+            }
+
+            builder.Append(';');
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionLayoutSignature.cs.meta
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionLayoutSignature.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b37cc27791d4505a312c78a631066e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionListViewController.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionListViewController.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Owns the virtualized tool ListView and its row model for ToolSettingsSection.
+    /// </summary>
+    internal sealed class ToolSettingsSectionListViewController
+    {
+        private const int ToolListRowHeight = 24;
+        private const int ToolDetailsRowHeight = 132;
+        private const int InlineToolRowLimit = 40;
+
+        private readonly ListView _toolListView;
+        private readonly List<ToolListRowData> _toolListRows = new();
+        private readonly Dictionary<string, Toggle> _togglesByToolName = new();
+        private string _expandedDetailsToolName = string.Empty;
+        private string _layoutSignature = string.Empty;
+        private readonly ToolSettingsSectionRowBinder _rowBinder;
+
+        public ListView ListView => _toolListView;
+        public bool HasRows => _toolListRows.Count > 0;
+        public ToolSettingsSectionListViewController(
+            ToolSettingsSection owner,
+            Action<string, bool> onToolToggled)
+        {
+            Debug.Assert(owner != null, "owner must not be null");
+            Debug.Assert(onToolToggled != null, "onToolToggled must not be null");
+            _rowBinder = new ToolSettingsSectionRowBinder(
+                owner,
+                onToolToggled,
+                _toolListRows,
+                _togglesByToolName,
+                () => _expandedDetailsToolName);
+            _toolListView = CreateToolListView();
+        }
+
+        public void UpdateSingleToggle(string toolName, bool enabled)
+        {
+            for (int i = 0; i < _toolListRows.Count; i++)
+            {
+                ToolListRowData row = _toolListRows[i];
+                if (!row.IsTool || row.ToolName != toolName)
+                {
+                    continue;
+                }
+
+                row.IsEnabled = enabled;
+                break;
+            }
+
+            if (_togglesByToolName.TryGetValue(toolName, out Toggle toggle))
+            {
+                toggle.SetValueWithoutNotify(enabled);
+            }
+
+            RefreshToolListView();
+        }
+
+        public void Clear()
+        {
+            ResetRows();
+            ViewDataBinder.SetVisible(_toolListView, false);
+            RefreshToolListView();
+        }
+        public void ResetRows()
+        {
+            _toolListRows.Clear();
+            _togglesByToolName.Clear();
+            _layoutSignature = string.Empty;
+            HideToolDetails();
+        }
+
+        public void SetListViewVisible(bool visible) => ViewDataBinder.SetVisible(_toolListView, visible);
+
+        public void UpdateToolList(ToolSettingsSectionData data, bool forceRebuild)
+        {
+            string layoutSignature = ToolSettingsSectionLayoutSignature.Create(data);
+            bool shouldRebuild = forceRebuild || _layoutSignature != layoutSignature;
+            if (shouldRebuild)
+            {
+                Rebuild(data);
+                _layoutSignature = layoutSignature;
+            }
+            else
+            {
+                UpdateToggleStates(data.BuiltInTools);
+                UpdateToggleStates(data.ThirdPartyTools);
+            }
+
+            ViewDataBinder.SetVisible(_toolListView, true);
+            RefreshToolListView();
+        }
+
+        public void ToggleToolDetailsForTool(string toolName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(toolName), "toolName must not be null or empty");
+            ToolListRowData item = FindToolRowByName(toolName);
+            Debug.Assert(item != null, "tool row must exist");
+            Debug.Assert(!string.IsNullOrWhiteSpace(item.SkillDescription), "tool row must have details");
+
+            if (_expandedDetailsToolName == item.ToolName)
+            {
+                HideToolDetails();
+                UpdateToolListHeight();
+                RefreshToolListView();
+                return;
+            }
+
+            _expandedDetailsToolName = item.ToolName;
+            RebuildToolDetailsRow();
+            UpdateToolListHeight();
+            RefreshToolListView();
+        }
+
+        public void RefreshToolListView()
+        {
+            _togglesByToolName.Clear();
+            _toolListView.RefreshItems();
+        }
+
+        private void Rebuild(ToolSettingsSectionData data)
+        {
+            _toolListRows.Clear();
+            _togglesByToolName.Clear();
+            HideToolDetails();
+
+            if (data.BuiltInTools.Length > 0)
+            {
+                _toolListRows.Add(ToolListRowData.CreateHeader("Built-in Tools"));
+                AddToolRows(data.BuiltInTools);
+            }
+
+            if (data.ThirdPartyTools.Length > 0)
+            {
+                _toolListRows.Add(ToolListRowData.CreateHeader("Third Party Tools"));
+                AddToolRows(data.ThirdPartyTools);
+            }
+
+            UpdateToolListHeight();
+            RefreshToolListView();
+        }
+
+        private void AddToolRows(IReadOnlyList<ToolToggleItem> items)
+        {
+            for (int i = 0; i < items.Count; i++)
+            {
+                _toolListRows.Add(ToolListRowData.CreateTool(items[i]));
+            }
+        }
+
+        private void UpdateToggleStates(IReadOnlyList<ToolToggleItem> items)
+        {
+            for (int i = 0; i < items.Count; i++)
+            {
+                ToolToggleItem item = items[i];
+                UpdateToggleState(item.ToolName, item.IsEnabled);
+            }
+        }
+
+        private void UpdateToggleState(string toolName, bool isEnabled)
+        {
+            for (int i = 0; i < _toolListRows.Count; i++)
+            {
+                ToolListRowData row = _toolListRows[i];
+                if (!row.IsTool || row.ToolName != toolName)
+                {
+                    continue;
+                }
+
+                row.IsEnabled = isEnabled;
+                return;
+            }
+        }
+
+        private ListView CreateToolListView()
+        {
+            ListView listView = new();
+            listView.name = "tool-list-view";
+            listView.AddToClassList("unity-cli-loop-tool-list-view");
+            listView.virtualizationMethod = CollectionVirtualizationMethod.DynamicHeight;
+            listView.selectionType = SelectionType.None;
+            listView.itemsSource = _toolListRows;
+            listView.makeItem = _rowBinder.CreateToolListRowElement;
+            listView.bindItem = _rowBinder.BindToolListRowElement;
+            listView.unbindItem = _rowBinder.UnbindToolListRowElement;
+            return listView;
+        }
+
+        private ToolListRowData FindToolRowByName(string toolName)
+        {
+            int toolIndex = FindToolRowIndex(toolName);
+            return toolIndex < 0 ? null : _toolListRows[toolIndex];
+        }
+
+        private int FindToolRowIndex(string toolName)
+        {
+            for (int i = 0; i < _toolListRows.Count; i++)
+            {
+                ToolListRowData item = _toolListRows[i];
+                if (item.IsTool && item.ToolName == toolName)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private void HideToolDetails()
+        {
+            _expandedDetailsToolName = string.Empty;
+            RemoveToolDetailsRows();
+        }
+
+        private void RebuildToolDetailsRow()
+        {
+            RemoveToolDetailsRows();
+            if (string.IsNullOrEmpty(_expandedDetailsToolName))
+            {
+                return;
+            }
+
+            int toolIndex = FindToolRowIndex(_expandedDetailsToolName);
+            if (toolIndex < 0)
+            {
+                _expandedDetailsToolName = string.Empty;
+                return;
+            }
+
+            _toolListRows.Insert(toolIndex + 1, ToolListRowData.CreateDetails(_toolListRows[toolIndex]));
+        }
+
+        private void RemoveToolDetailsRows()
+        {
+            for (int i = _toolListRows.Count - 1; i >= 0; i--)
+            {
+                if (_toolListRows[i].IsDetails)
+                {
+                    _toolListRows.RemoveAt(i);
+                }
+            }
+        }
+
+        private void UpdateToolListHeight()
+        {
+            int visibleRows = Math.Min(CountNonDetailsRows(), InlineToolRowLimit);
+            if (visibleRows <= 0)
+            {
+                visibleRows = 1;
+            }
+
+            int detailsRowHeight = HasDetailsRow() ? ToolDetailsRowHeight : 0;
+            _toolListView.style.height = (visibleRows * ToolListRowHeight) + detailsRowHeight + 2;
+        }
+
+        private int CountNonDetailsRows()
+        {
+            int count = 0;
+            for (int i = 0; i < _toolListRows.Count; i++)
+            {
+                if (!_toolListRows[i].IsDetails)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private bool HasDetailsRow()
+        {
+            for (int i = 0; i < _toolListRows.Count; i++)
+            {
+                if (_toolListRows[i].IsDetails)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionListViewController.cs.meta
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionListViewController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8218bd41b6a24ab9b053956a5e921d45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionRowBinder.cs
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionRowBinder.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Creates and binds virtualized tool-list row VisualElements for Tool Settings.
+    /// </summary>
+    internal sealed class ToolSettingsSectionRowBinder
+    {
+        private readonly ToolSettingsSection _owner;
+        private readonly Action<string, bool> _onToolToggled;
+        private readonly IReadOnlyList<ToolListRowData> _toolListRows;
+        private readonly Dictionary<string, Toggle> _togglesByToolName;
+        private readonly Func<string> _getExpandedDetailsToolName;
+
+        internal ToolSettingsSectionRowBinder(
+            ToolSettingsSection owner,
+            Action<string, bool> onToolToggled,
+            IReadOnlyList<ToolListRowData> toolListRows,
+            Dictionary<string, Toggle> togglesByToolName,
+            Func<string> getExpandedDetailsToolName)
+        {
+            Debug.Assert(owner != null, "owner must not be null");
+            Debug.Assert(onToolToggled != null, "onToolToggled must not be null");
+            Debug.Assert(toolListRows != null, "toolListRows must not be null");
+            Debug.Assert(togglesByToolName != null, "togglesByToolName must not be null");
+            Debug.Assert(getExpandedDetailsToolName != null, "getExpandedDetailsToolName must not be null");
+
+            _owner = owner;
+            _onToolToggled = onToolToggled;
+            _toolListRows = toolListRows;
+            _togglesByToolName = togglesByToolName;
+            _getExpandedDetailsToolName = getExpandedDetailsToolName;
+        }
+
+        internal VisualElement CreateToolListRowElement()
+        {
+            VisualElement row = new();
+            row.AddToClassList("unity-cli-loop-tool-toggle-row");
+            row.AddToClassList("unity-cli-loop-tool-list-row");
+
+            Toggle toggle = new();
+            toggle.name = "tool-list-row-toggle";
+            toggle.AddToClassList("unity-cli-loop-tool-toggle-row__toggle");
+            toggle.RegisterValueChangedCallback(evt =>
+            {
+                evt.StopPropagation();
+                if (row.userData is not ToolListRowData item || !item.IsTool)
+                {
+                    return;
+                }
+
+                _onToolToggled.Invoke(item.ToolName, evt.newValue);
+            });
+
+            Label label = new();
+            label.name = "tool-list-row-label";
+            label.AddToClassList("unity-cli-loop-tool-toggle-row__label");
+            label.RegisterCallback<ClickEvent>(evt =>
+            {
+                evt.StopPropagation();
+                if (row.userData is not ToolListRowData item || !item.IsTool)
+                {
+                    return;
+                }
+
+                Toggle rowToggle = row.Q<Toggle>("tool-list-row-toggle");
+                bool newValue = !rowToggle.value;
+                rowToggle.SetValueWithoutNotify(newValue);
+                _onToolToggled.Invoke(item.ToolName, newValue);
+            });
+
+            row.Add(toggle);
+            row.Add(label);
+
+            Button detailsButton = new();
+            detailsButton.name = "tool-list-row-details-button";
+            detailsButton.text = "Show Details";
+            detailsButton.tooltip = "Show tool description";
+            detailsButton.AddToClassList("unity-cli-loop-tool-toggle-row__details-button");
+            detailsButton.RegisterCallback<ClickEvent>(evt =>
+            {
+                evt.StopPropagation();
+                if (row.userData is not ToolListRowData item || !item.IsTool)
+                {
+                    return;
+                }
+
+                item.Owner?.ToggleToolDetailsForTool(item.ToolName);
+            });
+            row.Add(detailsButton);
+
+            VisualElement detailsPanel = new();
+            detailsPanel.name = "tool-list-row-details";
+            detailsPanel.AddToClassList("unity-cli-loop-tool-details-panel");
+            TextField detailsBody = new();
+            detailsBody.name = "tool-list-row-details-body";
+            detailsBody.isReadOnly = true;
+            detailsBody.multiline = true;
+            detailsBody.AddToClassList("unity-cli-loop-tool-details-panel__body");
+            detailsPanel.Add(detailsBody);
+            row.Add(detailsPanel);
+            return row;
+        }
+
+        internal void BindToolListRowElement(VisualElement row, int index)
+        {
+            Debug.Assert(index >= 0 && index < _toolListRows.Count, "tool list index must be valid");
+            ToolListRowData item = _toolListRows[index];
+            item.Owner = _owner;
+            row.userData = item;
+
+            Toggle toggle = row.Q<Toggle>("tool-list-row-toggle");
+            Button detailsButton = row.Q<Button>("tool-list-row-details-button");
+            Label label = row.Q<Label>("tool-list-row-label");
+            VisualElement detailsPanel = row.Q<VisualElement>("tool-list-row-details");
+            TextField detailsBody = row.Q<TextField>("tool-list-row-details-body");
+            Debug.Assert(toggle != null, "tool-list-row-toggle must not be null");
+            Debug.Assert(detailsButton != null, "tool-list-row-details-button must not be null");
+            Debug.Assert(label != null, "tool-list-row-label must not be null");
+            Debug.Assert(detailsPanel != null, "tool-list-row-details must not be null");
+            Debug.Assert(detailsBody != null, "tool-list-row-details-body must not be null");
+            ResetRowClasses(row, label, detailsButton);
+
+            if (item.IsHeader)
+            {
+                BindHeaderRow(row, toggle, detailsButton, label, detailsPanel, item);
+                return;
+            }
+
+            if (item.IsDetails)
+            {
+                BindDetailsRow(row, toggle, detailsButton, label, detailsPanel, detailsBody, item);
+                return;
+            }
+
+            BindToolRow(row, toggle, detailsButton, label, detailsPanel, item);
+        }
+
+        private static void BindHeaderRow(
+            VisualElement row,
+            Toggle toggle,
+            Button detailsButton,
+            Label label,
+            VisualElement detailsPanel,
+            ToolListRowData item)
+        {
+            ViewDataBinder.SetVisible(toggle, false);
+            ViewDataBinder.SetVisible(detailsButton, false);
+            ViewDataBinder.SetVisible(label, true);
+            ViewDataBinder.SetVisible(detailsPanel, false);
+            label.text = item.Label;
+            label.tooltip = string.Empty;
+            row.SetEnabled(true);
+            row.AddToClassList("unity-cli-loop-tool-list-row--header");
+            label.AddToClassList("unity-cli-loop-tool-group-header");
+        }
+
+        private void BindToolRow(
+            VisualElement row,
+            Toggle toggle,
+            Button detailsButton,
+            Label label,
+            VisualElement detailsPanel,
+            ToolListRowData item)
+        {
+            ViewDataBinder.SetVisible(toggle, true);
+            ViewDataBinder.SetVisible(label, true);
+            ViewDataBinder.SetVisible(detailsPanel, false);
+            toggle.SetValueWithoutNotify(item.IsEnabled);
+            bool hasDescription = !string.IsNullOrWhiteSpace(item.SkillDescription);
+            bool isDetailsExpanded = hasDescription && _getExpandedDetailsToolName() == item.ToolName;
+            ViewDataBinder.SetVisible(detailsButton, hasDescription);
+            detailsButton.text = isDetailsExpanded ? "Hide Details" : "Show Details";
+            detailsButton.tooltip = isDetailsExpanded ? "Hide tool description" : "Show tool description";
+            if (isDetailsExpanded)
+            {
+                detailsButton.AddToClassList("unity-cli-loop-tool-toggle-row__details-button--selected");
+            }
+
+            label.text = item.ToolName;
+            label.tooltip = string.Empty;
+            row.SetEnabled(true);
+            _togglesByToolName[item.ToolName] = toggle;
+        }
+
+        private static void BindDetailsRow(
+            VisualElement row,
+            Toggle toggle,
+            Button detailsButton,
+            Label label,
+            VisualElement detailsPanel,
+            TextField detailsBody,
+            ToolListRowData item)
+        {
+            ViewDataBinder.SetVisible(toggle, false);
+            ViewDataBinder.SetVisible(detailsButton, false);
+            ViewDataBinder.SetVisible(label, false);
+            ViewDataBinder.SetVisible(detailsPanel, true);
+            detailsBody.SetValueWithoutNotify(item.SkillDescription);
+            row.SetEnabled(true);
+            row.AddToClassList("unity-cli-loop-tool-details-row");
+        }
+
+        private static void ResetRowClasses(VisualElement row, Label label, Button detailsButton)
+        {
+            row.RemoveFromClassList("unity-cli-loop-tool-list-row--header");
+            row.RemoveFromClassList("unity-cli-loop-tool-details-row");
+            label.RemoveFromClassList("unity-cli-loop-tool-group-header");
+            detailsButton.RemoveFromClassList("unity-cli-loop-tool-toggle-row__details-button--selected");
+        }
+
+        internal void UnbindToolListRowElement(VisualElement row, int index)
+        {
+            if (row.userData is ToolListRowData item && item.IsTool)
+            {
+                _togglesByToolName.Remove(item.ToolName);
+            }
+
+            row.userData = null;
+        }
+
+    }
+}

--- a/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionRowBinder.cs.meta
+++ b/Packages/src/Editor/Presentation/UIToolkit/Components/ToolSettingsSectionRowBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6c2af33f8d1429ea6464639e0fe676e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsCliSetupPresenter.cs
@@ -1,18 +1,32 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Presentation
 {
     /// <summary>
-    /// Presents the CLI setup section and owns Settings primary-action mediation decisions.
+    /// Presents the CLI setup section, owns Settings primary-action mediation,
+    /// and runs CLI install / path-setup / version-refresh workflows.
     /// </summary>
     internal sealed class UnityCliLoopSettingsCliSetupPresenter
     {
         private readonly UnityCliLoopSettingsWindowUI _view;
         private readonly CliSetupApplicationService _cliSetupApplicationService;
+
+        private Func<UnityCliLoopSettingsSkillsSnapshot> _getSkillsSnapshot;
+        private Action _refreshSkillsInstallStateInBackground;
+        private Action<bool> _refreshAllSections;
+
+        private bool _isInstallingCli;
+        private bool _isRefreshingVersion;
+        private bool _isRefreshingCliPathSetup;
+        private bool _needsCliPathSetup;
 
         internal UnityCliLoopSettingsCliSetupPresenter(
             UnityCliLoopSettingsWindowUI view,
@@ -24,6 +38,44 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _view = view ?? throw new ArgumentNullException(nameof(view));
             _cliSetupApplicationService = cliSetupApplicationService
                 ?? throw new ArgumentNullException(nameof(cliSetupApplicationService));
+        }
+
+        internal bool IsRefreshingVersion => _isRefreshingVersion;
+
+        internal void BindCoordination(
+            Func<UnityCliLoopSettingsSkillsSnapshot> getSkillsSnapshot,
+            Action refreshSkillsInstallStateInBackground,
+            Action<bool> refreshAllSections)
+        {
+            Debug.Assert(getSkillsSnapshot != null, "getSkillsSnapshot must not be null");
+            Debug.Assert(
+                refreshSkillsInstallStateInBackground != null,
+                "refreshSkillsInstallStateInBackground must not be null");
+            Debug.Assert(refreshAllSections != null, "refreshAllSections must not be null");
+
+            _getSkillsSnapshot = getSkillsSnapshot
+                ?? throw new ArgumentNullException(nameof(getSkillsSnapshot));
+            _refreshSkillsInstallStateInBackground = refreshSkillsInstallStateInBackground
+                ?? throw new ArgumentNullException(nameof(refreshSkillsInstallStateInBackground));
+            _refreshAllSections = refreshAllSections
+                ?? throw new ArgumentNullException(nameof(refreshAllSections));
+        }
+
+        internal void RefreshSection(bool includeSkillDirectoryChecks = true)
+        {
+            Debug.Assert(_getSkillsSnapshot != null, "BindCoordination must be called before RefreshSection");
+
+            UnityCliLoopSettingsSkillsSnapshot skills = _getSkillsSnapshot();
+            Update(
+                _needsCliPathSetup,
+                _isInstallingCli,
+                _isRefreshingVersion,
+                _isRefreshingCliPathSetup,
+                includeSkillDirectoryChecks,
+                skills.InstallSkillsFlat,
+                skills.SelectedTargetInstallState,
+                skills.SkillsTarget,
+                skills.IsInstallingSkills);
         }
 
         internal void Update(
@@ -131,6 +183,225 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 cliVersion,
                 cliIsDispatcher,
                 requiredCliVersion).NeedsUpdate;
+        }
+
+        internal async Task RefreshCliVersionInBackground()
+        {
+            if (_cliSetupApplicationService.IsCliCheckCompleted())
+            {
+                return;
+            }
+
+            await _cliSetupApplicationService.RefreshCliVersionAsync(CancellationToken.None);
+            RefreshCliPathSetupInBackground().Forget();
+            RefreshSection();
+            _refreshSkillsInstallStateInBackground();
+        }
+
+        internal async Task RefreshCliPathSetupInBackground()
+        {
+            if (_isRefreshingCliPathSetup)
+            {
+                return;
+            }
+
+            if (!ShouldCheckCliPathSetup())
+            {
+                _needsCliPathSetup = false;
+                return;
+            }
+
+            _isRefreshingCliPathSetup = true;
+            RefreshSection();
+
+            try
+            {
+                bool isCliVisibleFromShell = await _cliSetupApplicationService.IsCliVisibleFromShellAsync(
+                    UnityEngine.Application.platform,
+                    CancellationToken.None);
+                _needsCliPathSetup = !isCliVisibleFromShell;
+            }
+            finally
+            {
+                _isRefreshingCliPathSetup = false;
+                RefreshSection();
+            }
+        }
+
+        internal async Task HandleRefreshCliVersion()
+        {
+            if (_isRefreshingVersion)
+            {
+                return;
+            }
+
+            _isRefreshingVersion = true;
+            RefreshSection();
+
+            try
+            {
+                Task forceRefresh = _cliSetupApplicationService.ForceRefreshCliVersionAsync(CancellationToken.None);
+                Task minimumDelay = Task.Delay(500);
+                await Task.WhenAll(forceRefresh, minimumDelay);
+                RefreshCliPathSetupInBackground().Forget();
+            }
+            finally
+            {
+                _isRefreshingVersion = false;
+                RefreshSection();
+            }
+        }
+
+        internal async Task HandleInstallCli()
+        {
+            CliSetupPrimaryAction clickedAction = ResolveCurrentPrimaryButtonAction(_needsCliPathSetup);
+
+            await RefreshCliPrimaryActionStateAsync(CancellationToken.None);
+            CliSetupPrimaryAction refreshedAction = ResolveCurrentPrimaryButtonAction(_needsCliPathSetup);
+            CliSetupPrimaryAction executableAction = ResolveExecutableCliPrimaryButtonAction(
+                clickedAction,
+                refreshedAction);
+            if (executableAction == CliSetupPrimaryAction.None)
+            {
+                return;
+            }
+
+            if (executableAction == CliSetupPrimaryAction.RepairPath)
+            {
+                await HandleRepairCliPathSetup();
+                return;
+            }
+
+            if (executableAction == CliSetupPrimaryAction.Uninstall)
+            {
+                await HandleUninstallCli();
+                return;
+            }
+
+            bool wasCliInstalledBeforeInstall = _cliSetupApplicationService.IsCliInstalled();
+            _needsCliPathSetup = false;
+            _isInstallingCli = true;
+            RefreshSection();
+
+            try
+            {
+                CliInstallResult result = await _cliSetupApplicationService.InstallGlobalCliAsync(
+                    UnityEngine.Application.platform,
+                    CancellationToken.None);
+
+                if (!result.Success)
+                {
+                    NativeCliInstallCommand command = _cliSetupApplicationService.GetGlobalCliInstallCommand(
+                        UnityEngine.Application.platform,
+                        true);
+                    EditorUtility.DisplayDialog(
+                        "Installation Failed",
+                        $"Failed to install uLoop CLI.\n\n{result.ErrorOutput}\n\nYou can try manually:\n{command.ManualCommand}",
+                        "OK");
+                    return;
+                }
+
+                await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
+                    UnityEngine.Application.platform,
+                    _cliSetupApplicationService,
+                    CancellationToken.None);
+                await RefreshCliPathSetupAsync(CancellationToken.None);
+            }
+            finally
+            {
+                _isInstallingCli = false;
+                _refreshAllSections(
+                    CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(wasCliInstalledBeforeInstall));
+            }
+        }
+
+        private async Task RefreshCliPrimaryActionStateAsync(CancellationToken ct)
+        {
+            _isRefreshingVersion = true;
+            RefreshSection();
+
+            try
+            {
+                await _cliSetupApplicationService.ForceRefreshCliVersionAsync(ct);
+                await RefreshCliPathSetupAsync(ct);
+            }
+            finally
+            {
+                _isRefreshingVersion = false;
+                RefreshSection();
+            }
+        }
+
+        private async Task RefreshCliPathSetupAsync(CancellationToken ct)
+        {
+            if (!ShouldCheckCliPathSetup())
+            {
+                _needsCliPathSetup = false;
+                return;
+            }
+
+            bool isCliVisibleFromShell = await _cliSetupApplicationService.IsCliVisibleFromShellAsync(
+                UnityEngine.Application.platform,
+                ct);
+            _needsCliPathSetup = !isCliVisibleFromShell;
+        }
+
+        private async Task HandleRepairCliPathSetup()
+        {
+            _isInstallingCli = true;
+            RefreshSection();
+
+            try
+            {
+                await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
+                    UnityEngine.Application.platform,
+                    _cliSetupApplicationService,
+                    CancellationToken.None);
+                await RefreshCliPathSetupAsync(CancellationToken.None);
+            }
+            finally
+            {
+                _isInstallingCli = false;
+                _refreshAllSections(false);
+            }
+        }
+
+        private async Task HandleUninstallCli()
+        {
+            if (!CliUninstallPrompt.ConfirmUninstall())
+            {
+                return;
+            }
+
+            _isInstallingCli = true;
+            RefreshSection();
+
+            try
+            {
+                CliInstallResult result = await _cliSetupApplicationService.UninstallGlobalCliAsync(
+                    UnityEngine.Application.platform,
+                    CancellationToken.None);
+                if (!result.Success)
+                {
+                    EditorUtility.DisplayDialog(
+                        "Uninstallation Failed",
+                        $"Failed to uninstall uLoop CLI.\n\n{result.ErrorOutput}",
+                        "OK");
+                    return;
+                }
+            }
+            finally
+            {
+                _isInstallingCli = false;
+                _refreshAllSections(true);
+            }
+        }
+
+        private bool ShouldCheckCliPathSetup()
+        {
+            return ShouldCheckCliPathSetupForPlatform(
+                UnityEngine.Application.platform,
+                _cliSetupApplicationService.HasPackageOwnedCurrentUserInstall(UnityEngine.Application.platform));
         }
 
         private CliSetupData CreateCliSetupData(

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsSkillsPresenter.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsSkillsPresenter.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+using io.github.hatayama.UnityCliLoop.Application;
+using io.github.hatayama.UnityCliLoop.Domain;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.Presentation
+{
+    /// <summary>
+    /// Snapshot of skills UI state consumed by the CLI setup section refresh.
+    /// </summary>
+    internal readonly struct UnityCliLoopSettingsSkillsSnapshot
+    {
+        internal UnityCliLoopSettingsSkillsSnapshot(
+            bool installSkillsFlat,
+            SkillInstallState selectedTargetInstallState,
+            SkillsTarget skillsTarget,
+            bool isInstallingSkills)
+        {
+            InstallSkillsFlat = installSkillsFlat;
+            SelectedTargetInstallState = selectedTargetInstallState;
+            SkillsTarget = skillsTarget;
+            IsInstallingSkills = isInstallingSkills;
+        }
+
+        internal bool InstallSkillsFlat { get; }
+        internal SkillInstallState SelectedTargetInstallState { get; }
+        internal SkillsTarget SkillsTarget { get; }
+        internal bool IsInstallingSkills { get; }
+    }
+
+    /// <summary>
+    /// Presents skills install-state refresh and install workflows for Settings.
+    /// </summary>
+    internal sealed class UnityCliLoopSettingsSkillsPresenter
+    {
+        private const bool ForceFlatSkillInstall = true;
+
+        private readonly SkillSetupUseCase _skillSetupUseCase;
+        private readonly CliSetupApplicationService _cliSetupApplicationService;
+        private readonly IUnityCliLoopEditorSettingsPort _editorSettingsPort;
+
+        private Action<bool> _refreshCliSetupSection;
+        private Func<bool> _isRefreshingVersion;
+
+        private SkillsTarget _skillsTarget = SkillsTarget.Claude;
+        private bool _installSkillsFlat = ForceFlatSkillInstall;
+        private bool _isInstallingSkills;
+        private SkillInstallState _selectedTargetInstallState = SkillInstallState.Missing;
+        private CancellationTokenSource _skillInstallStateRefreshCts;
+
+        internal UnityCliLoopSettingsSkillsPresenter(
+            SkillSetupUseCase skillSetupUseCase,
+            CliSetupApplicationService cliSetupApplicationService,
+            IUnityCliLoopEditorSettingsPort editorSettingsPort)
+        {
+            Debug.Assert(skillSetupUseCase != null, "skillSetupUseCase must not be null");
+            Debug.Assert(cliSetupApplicationService != null, "cliSetupApplicationService must not be null");
+            Debug.Assert(editorSettingsPort != null, "editorSettingsPort must not be null");
+
+            _skillSetupUseCase = skillSetupUseCase
+                ?? throw new ArgumentNullException(nameof(skillSetupUseCase));
+            _cliSetupApplicationService = cliSetupApplicationService
+                ?? throw new ArgumentNullException(nameof(cliSetupApplicationService));
+            _editorSettingsPort = editorSettingsPort
+                ?? throw new ArgumentNullException(nameof(editorSettingsPort));
+        }
+
+        internal void BindCoordination(
+            Action<bool> refreshCliSetupSection,
+            Func<bool> isRefreshingVersion)
+        {
+            Debug.Assert(refreshCliSetupSection != null, "refreshCliSetupSection must not be null");
+            Debug.Assert(isRefreshingVersion != null, "isRefreshingVersion must not be null");
+
+            _refreshCliSetupSection = refreshCliSetupSection
+                ?? throw new ArgumentNullException(nameof(refreshCliSetupSection));
+            _isRefreshingVersion = isRefreshingVersion
+                ?? throw new ArgumentNullException(nameof(isRefreshingVersion));
+        }
+
+        internal UnityCliLoopSettingsSkillsSnapshot GetSnapshot()
+        {
+            return new UnityCliLoopSettingsSkillsSnapshot(
+                _installSkillsFlat,
+                _selectedTargetInstallState,
+                _skillsTarget,
+                _isInstallingSkills);
+        }
+
+        internal void MarkSelectedTargetInstallStateChecking()
+        {
+            _selectedTargetInstallState = SkillInstallState.Checking;
+        }
+
+        internal void HandleSkillsTargetChanged(SkillsTarget value)
+        {
+            _skillsTarget = value;
+            RefreshSelectedTargetInstallStateFast();
+            RefreshSelectedTargetInstallStateInBackground(allowDuringCliRefresh: true);
+        }
+
+        internal void HandleRefreshSkillsState()
+        {
+            RefreshSelectedTargetInstallStateFast();
+            RefreshSelectedTargetInstallStateInBackground(allowDuringCliRefresh: true);
+        }
+
+        internal void HandleGroupSkillsChanged(bool groupSkillsUnderUnityCliLoop)
+        {
+            ApplyFlatSkillInstallPreference();
+            RefreshSelectedTargetInstallStateFast();
+            RefreshSelectedTargetInstallStateInBackground();
+        }
+
+        internal void ApplyFlatSkillInstallPreference()
+        {
+            // Claude Code does not resolve nested skill folders, so editor-driven installs stay flat for every target.
+            _installSkillsFlat = ForceFlatSkillInstall;
+            _editorSettingsPort.SetInstallSkillsFlat(_installSkillsFlat);
+        }
+
+        internal void CancelSkillInstallStateRefresh()
+        {
+            if (_skillInstallStateRefreshCts == null)
+            {
+                return;
+            }
+
+            _skillInstallStateRefreshCts.Cancel();
+            _skillInstallStateRefreshCts.Dispose();
+            _skillInstallStateRefreshCts = null;
+        }
+
+        internal void RefreshSelectedTargetInstallStateFast()
+        {
+            if (!_cliSetupApplicationService.IsCliInstalled())
+            {
+                _selectedTargetInstallState = SkillInstallState.Missing;
+                RefreshCliSetupSection();
+                return;
+            }
+
+            _selectedTargetInstallState = GetSelectedTargetInstallStateForCurrentProject(includeFreshnessCheck: false);
+            RefreshCliSetupSection();
+        }
+
+        internal void RefreshSelectedTargetInstallStateInBackground(bool allowDuringCliRefresh = false)
+        {
+            CancelSkillInstallStateRefresh();
+            bool isCliInstalled = _cliSetupApplicationService.IsCliInstalled();
+            if (!UnityCliLoopSettingsWindowRefreshPolicy.ShouldStartSkillInstallStateRefresh(
+                    isCliInstalled,
+                    _isRefreshingVersion(),
+                    _isInstallingSkills,
+                    allowDuringCliRefresh))
+            {
+                SkillInstallState resolvedInstallState =
+                    UnityCliLoopSettingsWindowRefreshPolicy.ResolveSkillInstallStateWhenRefreshCannotStart(
+                        isCliInstalled,
+                        _selectedTargetInstallState);
+                if (_selectedTargetInstallState != resolvedInstallState)
+                {
+                    _selectedTargetInstallState = resolvedInstallState;
+                    RefreshCliSetupSection();
+                }
+                return;
+            }
+
+            CancellationTokenSource cts = new();
+            _skillInstallStateRefreshCts = cts;
+            RefreshSelectedTargetInstallStateAsync(cts.Token).Forget();
+        }
+
+        internal async Task HandleInstallSkills()
+        {
+            if (!_cliSetupApplicationService.IsCliInstalled())
+            {
+                EditorUtility.DisplayDialog(
+                    "CLI Not Found",
+                    "uloop CLI is not installed. Please install the CLI first.",
+                    "OK");
+                return;
+            }
+
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            SkillSetupTargetInfo selectedTargetInfo =
+                GetSelectedTargetInfo(projectRoot, includeFreshnessCheck: true);
+            bool shouldShowSkillsInstalledDialog =
+                SkillInstallDialogPolicy.ShouldShowForSelectedTarget(selectedTargetInfo);
+            CancelSkillInstallStateRefresh();
+            _isInstallingSkills = true;
+            RefreshCliSetupSection();
+
+            try
+            {
+                SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
+                    _skillsTarget,
+                    !_installSkillsFlat);
+                SkillSetupTargetInfo target = new(
+                    selection.DisplayName,
+                    selection.DirectoryName,
+                    selection.InstallFlag,
+                    hasSkillsDirectory: true,
+                    hasExistingSkills: false,
+                    hasDifferentLayoutSkills: false,
+                    SkillInstallState.Missing);
+                await _skillSetupUseCase.InstallSkillFilesAsync(
+                    new List<SkillSetupTargetInfo> { target },
+                    !_installSkillsFlat,
+                    CancellationToken.None);
+                if (shouldShowSkillsInstalledDialog)
+                {
+                    EditorDialogHelper.ShowSkillsInstalledDialog();
+                }
+            }
+            finally
+            {
+                _isInstallingSkills = false;
+                RefreshSelectedTargetInstallStateFast();
+                RefreshSelectedTargetInstallStateInBackground(allowDuringCliRefresh: true);
+                RefreshCliSetupSection();
+            }
+        }
+
+        internal async Task ApplyToolToggleSideEffects(string toolName, bool enabled)
+        {
+            if (!enabled)
+            {
+                _skillSetupUseCase.RemoveSkillFiles(toolName);
+            }
+            else
+            {
+                await _skillSetupUseCase.InstallSkillFilesForToolAsync(
+                    toolName,
+                    !_installSkillsFlat,
+                    CancellationToken.None);
+
+                if (!_skillSetupUseCase.IsSkillInstalled(toolName))
+                {
+                    Debug.LogWarning(
+                        $"[UnityCliLoop] Skill for '{toolName}' was not installed after enabling. " +
+                        "The skill source may have an incorrect directory structure " +
+                        "(expected: <ToolDir>/Skill/SKILL.md). Run 'uloop skills list' for details."
+                    );
+                }
+            }
+        }
+
+        private async Task RefreshSelectedTargetInstallStateAsync(CancellationToken ct)
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            SkillInstallState installState = await Task.Run(
+                () => GetSelectedTargetInstallStateAtProjectRoot(projectRoot, includeFreshnessCheck: true));
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _selectedTargetInstallState = installState;
+            RefreshCliSetupSection();
+        }
+
+        private SkillInstallState GetSelectedTargetInstallStateForCurrentProject(bool includeFreshnessCheck)
+        {
+            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
+            return GetSelectedTargetInstallStateAtProjectRoot(projectRoot, includeFreshnessCheck);
+        }
+
+        private SkillInstallState GetSelectedTargetInstallStateAtProjectRoot(
+            string projectRoot,
+            bool includeFreshnessCheck)
+        {
+            SkillSetupTargetInfo targetInfo = GetSelectedTargetInfo(projectRoot, includeFreshnessCheck);
+            return string.IsNullOrEmpty(targetInfo.DirName)
+                ? SkillInstallState.Missing
+                : targetInfo.InstallState;
+        }
+
+        private SkillSetupTargetInfo GetSelectedTargetInfo(
+            string projectRoot,
+            bool includeFreshnessCheck)
+        {
+            SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
+                _skillsTarget,
+                !_installSkillsFlat);
+            List<SkillSetupTargetInfo> targets = includeFreshnessCheck
+                ? _skillSetupUseCase.DetectSkillTargetsForLayoutAtProjectRoot(projectRoot, !_installSkillsFlat)
+                : _skillSetupUseCase.DetectSkillTargetsForLayoutFastAtProjectRoot(projectRoot, !_installSkillsFlat);
+            SkillSetupTargetInfo targetInfo = targets
+                .FirstOrDefault(target => target.DirName == selection.DirectoryName);
+
+            return targetInfo;
+        }
+
+        private void RefreshCliSetupSection(bool includeSkillDirectoryChecks = true)
+        {
+            Debug.Assert(_refreshCliSetupSection != null, "BindCoordination must be called before refresh");
+            _refreshCliSetupSection(includeSkillDirectoryChecks);
+        }
+    }
+}

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsSkillsPresenter.cs.meta
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsSkillsPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d9a08427e334f14aa3ad4cf74c38ac6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
+++ b/Packages/src/Editor/Presentation/UnityCliLoopSettingsWindow.cs
@@ -1,9 +1,5 @@
-using UnityEngine;
 using UnityEditor;
-using System.Collections.Generic;
-using System.Linq;
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 
 using io.github.hatayama.UnityCliLoop.Application;
@@ -17,7 +13,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
     /// </summary>
     public class UnityCliLoopSettingsWindow : EditorWindow
     {
-        private const bool ForceFlatSkillInstall = true;
         private const double DeferredInitialRefreshDelaySeconds = 0.05;
 
         private static IUnityCliLoopEditorSettingsPort RegisteredEditorSettingsPort;
@@ -31,6 +26,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private UnityCliLoopSettingsModel _model;
         private UnityCliLoopSettingsWindowEventHandler _eventHandler;
         private UnityCliLoopSettingsCliSetupPresenter _cliSetupPresenter;
+        private UnityCliLoopSettingsSkillsPresenter _skillsPresenter;
         private UnityCliLoopSettingsToolSettingsPresenter _toolSettingsPresenter;
         private SkillSetupUseCase _skillSetupUseCase;
         private ToolSettingsUseCase _toolSettingsUseCase;
@@ -39,18 +35,9 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private UnityCliLoopServerApplicationService _serverApplicationService;
         private CliSetupApplicationService _cliSetupApplicationService;
 
-        private SkillsTarget _skillsTarget = SkillsTarget.Claude;
-        private bool _installSkillsFlat;
-        private bool _isInstallingCli;
-        private bool _isInstallingSkills;
-        private bool _isRefreshingVersion;
-        private bool _isRefreshingCliPathSetup;
-        private bool _needsCliPathSetup;
         private bool _isDeferredInitialRefreshScheduled;
         private bool _hasCompletedDeferredInitialRefresh;
         private double _deferredInitialRefreshDueTime;
-        private SkillInstallState _selectedTargetInstallState = SkillInstallState.Missing;
-        private CancellationTokenSource _skillInstallStateRefreshCts;
 
         [MenuItem("Window/Unity CLI Loop/Settings", priority = 0)]
         public static void ShowWindow()
@@ -102,11 +89,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             CancelDeferredInitialRefresh();
             _toolSettingsPresenter?.CancelRegistryWarmup();
             _toolSettingsPresenter?.ResetRegistryWarmupAttemptCount();
-            CancelSkillInstallStateRefresh();
+            _skillsPresenter?.CancelSkillInstallStateRefresh();
             _toolSettingsPresenter?.SetViewReady(false);
             _view?.Dispose();
             _view = null;
             _cliSetupPresenter = null;
+            _skillsPresenter = null;
             _toolSettingsPresenter = null;
         }
 
@@ -150,26 +138,40 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _cliSetupPresenter = new UnityCliLoopSettingsCliSetupPresenter(
                 _view,
                 _cliSetupApplicationService);
+            _skillsPresenter = new UnityCliLoopSettingsSkillsPresenter(
+                _skillSetupUseCase,
+                _cliSetupApplicationService,
+                _editorSettingsPort);
             _toolSettingsPresenter = new UnityCliLoopSettingsToolSettingsPresenter(
                 _view,
                 _toolSettingsUseCase);
+            BindPresenterCoordination();
             _toolSettingsPresenter.SetViewReady(true);
             SetupViewCallbacks();
         }
 
+        private void BindPresenterCoordination()
+        {
+            _cliSetupPresenter.BindCoordination(
+                getSkillsSnapshot: () => _skillsPresenter.GetSnapshot(),
+                refreshSkillsInstallStateInBackground: () =>
+                    _skillsPresenter.RefreshSelectedTargetInstallStateInBackground(),
+                refreshAllSections: refreshSkillInstallState =>
+                    RefreshAllSections(refreshSkillInstallState: refreshSkillInstallState));
+            _skillsPresenter.BindCoordination(
+                refreshCliSetupSection: includeSkillDirectoryChecks =>
+                    _cliSetupPresenter.RefreshSection(includeSkillDirectoryChecks),
+                isRefreshingVersion: () => _cliSetupPresenter.IsRefreshingVersion);
+        }
+
         private void SetupViewCallbacks()
         {
-            _view.OnRefreshCliVersion += () => HandleRefreshCliVersion().Forget();
-            _view.OnInstallCli += () => HandleInstallCli().Forget();
-            _view.OnInstallSkills += () => HandleInstallSkills().Forget();
-            _view.OnRefreshSkillsState += HandleRefreshSkillsState;
-            _view.OnSkillsTargetChanged += value =>
-            {
-                _skillsTarget = value;
-                RefreshSelectedTargetInstallStateFast();
-                RefreshSelectedTargetInstallStateInBackground(allowDuringCliRefresh: true);
-            };
-            _view.OnGroupSkillsChanged += HandleGroupSkillsChanged;
+            _view.OnRefreshCliVersion += () => _cliSetupPresenter.HandleRefreshCliVersion().Forget();
+            _view.OnInstallCli += () => _cliSetupPresenter.HandleInstallCli().Forget();
+            _view.OnInstallSkills += () => _skillsPresenter.HandleInstallSkills().Forget();
+            _view.OnRefreshSkillsState += _skillsPresenter.HandleRefreshSkillsState;
+            _view.OnSkillsTargetChanged += _skillsPresenter.HandleSkillsTargetChanged;
+            _view.OnGroupSkillsChanged += _skillsPresenter.HandleGroupSkillsChanged;
             _view.OnConfigurationFoldoutChanged += UpdateShowConfiguration;
             _view.OnToolSettingsFoldoutChanged += UpdateShowToolSettings;
             _view.OnToolToggled += HandleToolToggled;
@@ -188,7 +190,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
         private void LoadSavedSettings()
         {
             _model.LoadFromSettings();
-            _installSkillsFlat = ForceFlatSkillInstall;
         }
 
         private async Task HandlePostCompileMode()
@@ -218,13 +219,14 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             CancelDeferredInitialRefresh();
             _toolSettingsPresenter?.CancelRegistryWarmup();
             _toolSettingsPresenter?.ResetRegistryWarmupAttemptCount();
-            CancelSkillInstallStateRefresh();
+            _skillsPresenter?.CancelSkillInstallStateRefresh();
             CleanupEventHandler();
             _model?.SaveToSessionState();
             _toolSettingsPresenter?.SetViewReady(false);
             _view?.Dispose();
             _view = null;
             _cliSetupPresenter = null;
+            _skillsPresenter = null;
             _toolSettingsPresenter = null;
         }
 
@@ -261,12 +263,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             }
 
             _hasCompletedDeferredInitialRefresh = true;
-            _selectedTargetInstallState = SkillInstallState.Checking;
-            ApplyFlatSkillInstallPreference();
+            _skillsPresenter.MarkSelectedTargetInstallStateChecking();
+            _skillsPresenter.ApplyFlatSkillInstallPreference();
             RefreshAllSections(
                 refreshSkillInstallState: false,
                 refreshMode: UnityCliLoopSettingsWindowRefreshMode.Full);
-            RefreshSelectedTargetInstallStateInBackground();
+            _skillsPresenter.RefreshSelectedTargetInstallStateInBackground();
         }
 
         private void CancelDeferredInitialRefresh()
@@ -305,91 +307,24 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             if (UnityCliLoopSettingsWindowRefreshPolicy.ShouldRefreshSkillInstallState(refreshMode, refreshSkillInstallState))
             {
-                RefreshSelectedTargetInstallStateFast();
+                _skillsPresenter.RefreshSelectedTargetInstallStateFast();
             }
 
             if (runExpensiveChecks)
             {
-                RefreshCliVersionInBackground().Forget();
-                RefreshCliPathSetupInBackground().Forget();
+                _cliSetupPresenter.RefreshCliVersionInBackground().Forget();
+                _cliSetupPresenter.RefreshCliPathSetupInBackground().Forget();
                 if (refreshSkillInstallState)
                 {
-                    RefreshSelectedTargetInstallStateInBackground();
+                    _skillsPresenter.RefreshSelectedTargetInstallStateInBackground();
                 }
             }
-            RefreshCliSetupSection(runExpensiveChecks);
+            _cliSetupPresenter.RefreshSection(runExpensiveChecks);
 
             RefreshToolSettingsHeader();
             if (runExpensiveChecks)
             {
                 _toolSettingsPresenter?.RefreshCatalogIfNeeded(_model.UI.ShowToolSettings);
-            }
-        }
-
-        private async Task RefreshCliVersionInBackground()
-        {
-            if (_cliSetupApplicationService.IsCliCheckCompleted())
-            {
-                return;
-            }
-
-            await _cliSetupApplicationService.RefreshCliVersionAsync(CancellationToken.None);
-            RefreshCliPathSetupInBackground().Forget();
-            RefreshCliSetupSection();
-            RefreshSelectedTargetInstallStateInBackground();
-        }
-
-        private async Task RefreshCliPathSetupInBackground()
-        {
-            if (_isRefreshingCliPathSetup)
-            {
-                return;
-            }
-
-            if (!ShouldCheckCliPathSetup())
-            {
-                _needsCliPathSetup = false;
-                return;
-            }
-
-            _isRefreshingCliPathSetup = true;
-            RefreshCliSetupSection();
-
-            try
-            {
-                bool isCliVisibleFromShell = await _cliSetupApplicationService.IsCliVisibleFromShellAsync(
-                    UnityEngine.Application.platform,
-                    CancellationToken.None);
-                _needsCliPathSetup = !isCliVisibleFromShell;
-            }
-            finally
-            {
-                _isRefreshingCliPathSetup = false;
-                RefreshCliSetupSection();
-            }
-        }
-
-        private async Task HandleRefreshCliVersion()
-        {
-            if (_isRefreshingVersion)
-            {
-                return;
-            }
-
-            _isRefreshingVersion = true;
-            RefreshCliSetupSection();
-
-            try
-            {
-                Task forceRefresh = _cliSetupApplicationService.ForceRefreshCliVersionAsync(CancellationToken.None);
-                Task minimumDelay = Task.Delay(500);
-                await Task.WhenAll(forceRefresh, minimumDelay);
-                RefreshCliPathSetupInBackground().Forget();
-            }
-            finally
-            {
-                _isRefreshingVersion = false;
-                RefreshCliSetupSection();
             }
         }
 
@@ -420,372 +355,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             _view?.UpdateSingleToolToggle(toolName, enabled);
 
             // Skill synchronization can touch many files, so defer it to keep UI input responsive.
-            EditorApplication.delayCall += () => ApplyToolToggleSideEffects(toolName, enabled).Forget();
-        }
-
-        private async Task ApplyToolToggleSideEffects(string toolName, bool enabled)
-        {
-            if (!enabled)
-            {
-                _skillSetupUseCase.RemoveSkillFiles(toolName);
-            }
-            else
-            {
-                await _skillSetupUseCase.InstallSkillFilesForToolAsync(
-                    toolName,
-                    !_installSkillsFlat,
-                    CancellationToken.None);
-
-                if (!_skillSetupUseCase.IsSkillInstalled(toolName))
-                {
-                    Debug.LogWarning(
-                        $"[UnityCliLoop] Skill for '{toolName}' was not installed after enabling. " +
-                        "The skill source may have an incorrect directory structure " +
-                        "(expected: <ToolDir>/Skill/SKILL.md). Run 'uloop skills list' for details."
-                    );
-                }
-            }
+            EditorApplication.delayCall += () => _skillsPresenter.ApplyToolToggleSideEffects(toolName, enabled).Forget();
         }
 
         private void UpdateShowConfiguration(bool show)
         {
             _model.UpdateShowConfiguration(show);
-        }
-
-        private void RefreshCliSetupSection(bool includeSkillDirectoryChecks = true)
-        {
-            if (_cliSetupPresenter == null)
-            {
-                return;
-            }
-
-            _cliSetupPresenter.Update(
-                _needsCliPathSetup,
-                _isInstallingCli,
-                _isRefreshingVersion,
-                _isRefreshingCliPathSetup,
-                includeSkillDirectoryChecks,
-                _installSkillsFlat,
-                _selectedTargetInstallState,
-                _skillsTarget,
-                _isInstallingSkills);
-        }
-
-        private bool ShouldCheckCliPathSetup()
-        {
-            return UnityCliLoopSettingsCliSetupPresenter.ShouldCheckCliPathSetupForPlatform(
-                UnityEngine.Application.platform,
-                _cliSetupApplicationService.HasPackageOwnedCurrentUserInstall(UnityEngine.Application.platform));
-        }
-
-        private void RefreshSelectedTargetInstallStateFast()
-        {
-            if (!_cliSetupApplicationService.IsCliInstalled())
-            {
-                _selectedTargetInstallState = SkillInstallState.Missing;
-                RefreshCliSetupSection();
-                return;
-            }
-
-            _selectedTargetInstallState = GetSelectedTargetInstallStateForCurrentProject(includeFreshnessCheck: false);
-            RefreshCliSetupSection();
-        }
-
-        private void RefreshSelectedTargetInstallStateInBackground(bool allowDuringCliRefresh = false)
-        {
-            CancelSkillInstallStateRefresh();
-            bool isCliInstalled = _cliSetupApplicationService.IsCliInstalled();
-            if (!UnityCliLoopSettingsWindowRefreshPolicy.ShouldStartSkillInstallStateRefresh(
-                    isCliInstalled,
-                    _isRefreshingVersion,
-                    _isInstallingSkills,
-                    allowDuringCliRefresh))
-            {
-                SkillInstallState resolvedInstallState =
-                    UnityCliLoopSettingsWindowRefreshPolicy.ResolveSkillInstallStateWhenRefreshCannotStart(
-                        isCliInstalled,
-                        _selectedTargetInstallState);
-                if (_selectedTargetInstallState != resolvedInstallState)
-                {
-                    _selectedTargetInstallState = resolvedInstallState;
-                    RefreshCliSetupSection();
-                }
-                return;
-            }
-
-            CancellationTokenSource cts = new();
-            _skillInstallStateRefreshCts = cts;
-            RefreshSelectedTargetInstallStateAsync(cts.Token).Forget();
-        }
-
-        private async Task RefreshSelectedTargetInstallStateAsync(CancellationToken ct)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            SkillInstallState installState = await Task.Run(
-                () => GetSelectedTargetInstallStateAtProjectRoot(projectRoot, includeFreshnessCheck: true));
-            if (ct.IsCancellationRequested)
-            {
-                return;
-            }
-
-            _selectedTargetInstallState = installState;
-            RefreshCliSetupSection();
-        }
-
-        private SkillInstallState GetSelectedTargetInstallStateForCurrentProject(bool includeFreshnessCheck)
-        {
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            return GetSelectedTargetInstallStateAtProjectRoot(projectRoot, includeFreshnessCheck);
-        }
-
-        private SkillInstallState GetSelectedTargetInstallStateAtProjectRoot(
-            string projectRoot,
-            bool includeFreshnessCheck)
-        {
-            SkillSetupTargetInfo targetInfo = GetSelectedTargetInfo(projectRoot, includeFreshnessCheck);
-            return string.IsNullOrEmpty(targetInfo.DirName)
-                ? SkillInstallState.Missing
-                : targetInfo.InstallState;
-        }
-
-        private SkillSetupTargetInfo GetSelectedTargetInfo(
-            string projectRoot,
-            bool includeFreshnessCheck)
-        {
-            SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
-                _skillsTarget,
-                !_installSkillsFlat);
-            List<SkillSetupTargetInfo> targets = includeFreshnessCheck
-                ? _skillSetupUseCase.DetectSkillTargetsForLayoutAtProjectRoot(projectRoot, !_installSkillsFlat)
-                : _skillSetupUseCase.DetectSkillTargetsForLayoutFastAtProjectRoot(projectRoot, !_installSkillsFlat);
-            SkillSetupTargetInfo targetInfo = targets
-                .FirstOrDefault(target => target.DirName == selection.DirectoryName);
-
-            return targetInfo;
-        }
-
-        private void CancelSkillInstallStateRefresh()
-        {
-            if (_skillInstallStateRefreshCts == null)
-            {
-                return;
-            }
-
-            _skillInstallStateRefreshCts.Cancel();
-            _skillInstallStateRefreshCts.Dispose();
-            _skillInstallStateRefreshCts = null;
-        }
-
-        private async Task HandleInstallCli()
-        {
-            CliSetupPrimaryAction clickedAction = _cliSetupPresenter.ResolveCurrentPrimaryButtonAction(_needsCliPathSetup);
-
-            await RefreshCliPrimaryActionStateAsync(CancellationToken.None);
-            CliSetupPrimaryAction refreshedAction = _cliSetupPresenter.ResolveCurrentPrimaryButtonAction(_needsCliPathSetup);
-            CliSetupPrimaryAction executableAction =
-                UnityCliLoopSettingsCliSetupPresenter.ResolveExecutableCliPrimaryButtonAction(
-                    clickedAction,
-                    refreshedAction);
-            if (executableAction == CliSetupPrimaryAction.None)
-            {
-                return;
-            }
-
-            if (executableAction == CliSetupPrimaryAction.RepairPath)
-            {
-                await HandleRepairCliPathSetup();
-                return;
-            }
-
-            if (executableAction == CliSetupPrimaryAction.Uninstall)
-            {
-                await HandleUninstallCli();
-                return;
-            }
-
-            bool wasCliInstalledBeforeInstall = _cliSetupApplicationService.IsCliInstalled();
-            _needsCliPathSetup = false;
-            _isInstallingCli = true;
-            RefreshCliSetupSection();
-
-            try
-            {
-                CliInstallResult result = await _cliSetupApplicationService.InstallGlobalCliAsync(
-                    UnityEngine.Application.platform,
-                    CancellationToken.None);
-
-                if (!result.Success)
-                {
-                    NativeCliInstallCommand command = _cliSetupApplicationService.GetGlobalCliInstallCommand(
-                        UnityEngine.Application.platform,
-                        true);
-                    EditorUtility.DisplayDialog(
-                        "Installation Failed",
-                        $"Failed to install uLoop CLI.\n\n{result.ErrorOutput}\n\nYou can try manually:\n{command.ManualCommand}",
-                        "OK");
-                    return;
-                }
-
-                await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
-                    UnityEngine.Application.platform,
-                    _cliSetupApplicationService,
-                    CancellationToken.None);
-                await RefreshCliPathSetupAsync(CancellationToken.None);
-            }
-            finally
-            {
-                _isInstallingCli = false;
-                RefreshAllSections(
-                    refreshSkillInstallState:
-                    CliInstallRefreshPolicy.ShouldRefreshSkillsAfterCliInstall(wasCliInstalledBeforeInstall));
-            }
-        }
-
-        private async Task RefreshCliPrimaryActionStateAsync(CancellationToken ct)
-        {
-            _isRefreshingVersion = true;
-            RefreshCliSetupSection();
-
-            try
-            {
-                await _cliSetupApplicationService.ForceRefreshCliVersionAsync(ct);
-                await RefreshCliPathSetupAsync(ct);
-            }
-            finally
-            {
-                _isRefreshingVersion = false;
-                RefreshCliSetupSection();
-            }
-        }
-
-        private async Task RefreshCliPathSetupAsync(CancellationToken ct)
-        {
-            if (!ShouldCheckCliPathSetup())
-            {
-                _needsCliPathSetup = false;
-                return;
-            }
-
-            bool isCliVisibleFromShell = await _cliSetupApplicationService.IsCliVisibleFromShellAsync(
-                UnityEngine.Application.platform,
-                ct);
-            _needsCliPathSetup = !isCliVisibleFromShell;
-        }
-
-        private async Task HandleRepairCliPathSetup()
-        {
-            _isInstallingCli = true;
-            RefreshCliSetupSection();
-
-            try
-            {
-                await CliPathSetupPrompt.EnsureVisibleAndShowResultAsync(
-                    UnityEngine.Application.platform,
-                    _cliSetupApplicationService,
-                    CancellationToken.None);
-                await RefreshCliPathSetupAsync(CancellationToken.None);
-            }
-            finally
-            {
-                _isInstallingCli = false;
-                RefreshAllSections();
-            }
-        }
-
-        private async Task HandleUninstallCli()
-        {
-            if (!CliUninstallPrompt.ConfirmUninstall())
-            {
-                return;
-            }
-
-            _isInstallingCli = true;
-            RefreshCliSetupSection();
-
-            try
-            {
-                CliInstallResult result = await _cliSetupApplicationService.UninstallGlobalCliAsync(
-                    UnityEngine.Application.platform,
-                    CancellationToken.None);
-                if (!result.Success)
-                {
-                    EditorUtility.DisplayDialog(
-                        "Uninstallation Failed",
-                        $"Failed to uninstall uLoop CLI.\n\n{result.ErrorOutput}",
-                        "OK");
-                    return;
-                }
-            }
-            finally
-            {
-                _isInstallingCli = false;
-                RefreshAllSections(refreshSkillInstallState: true);
-            }
-        }
-
-        private async Task HandleInstallSkills()
-        {
-            if (!_cliSetupApplicationService.IsCliInstalled())
-            {
-                EditorUtility.DisplayDialog(
-                    "CLI Not Found",
-                    "uloop CLI is not installed. Please install the CLI first.",
-                    "OK");
-                return;
-            }
-
-            string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
-            SkillSetupTargetInfo selectedTargetInfo =
-                GetSelectedTargetInfo(projectRoot, includeFreshnessCheck: true);
-            bool shouldShowSkillsInstalledDialog =
-                SkillInstallDialogPolicy.ShouldShowForSelectedTarget(selectedTargetInfo);
-            CancelSkillInstallStateRefresh();
-            _isInstallingSkills = true;
-            RefreshCliSetupSection();
-
-            try
-            {
-                SkillsTargetSelection selection = SkillsTargetSelectionResolver.Resolve(
-                    _skillsTarget,
-                    !_installSkillsFlat);
-                SkillSetupTargetInfo target = new(
-                    selection.DisplayName,
-                    selection.DirectoryName,
-                    selection.InstallFlag,
-                    hasSkillsDirectory: true,
-                    hasExistingSkills: false,
-                    hasDifferentLayoutSkills: false,
-                    SkillInstallState.Missing);
-                await _skillSetupUseCase.InstallSkillFilesAsync(
-                    new List<SkillSetupTargetInfo> { target },
-                    !_installSkillsFlat,
-                    CancellationToken.None);
-                if (shouldShowSkillsInstalledDialog)
-                {
-                    EditorDialogHelper.ShowSkillsInstalledDialog();
-                }
-            }
-            finally
-            {
-                _isInstallingSkills = false;
-                RefreshSelectedTargetInstallStateFast();
-                RefreshSelectedTargetInstallStateInBackground(allowDuringCliRefresh: true);
-                RefreshCliSetupSection();
-            }
-        }
-
-        private void HandleGroupSkillsChanged(bool groupSkillsUnderUnityCliLoop)
-        {
-            ApplyFlatSkillInstallPreference();
-            RefreshSelectedTargetInstallStateFast();
-            RefreshSelectedTargetInstallStateInBackground();
-        }
-
-        private void ApplyFlatSkillInstallPreference()
-        {
-            // Claude Code does not resolve nested skill folders, so editor-driven installs stay flat for every target.
-            _installSkillsFlat = ForceFlatSkillInstall;
-            _editorSettingsPort.SetInstallSkillsFlat(_installSkillsFlat);
         }
 
         private static IUnityCliLoopEditorSettingsPort GetEditorSettingsPort()
@@ -849,12 +424,5 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
 
             return RegisteredSkillSetupUseCase;
         }
-
-        private void HandleRefreshSkillsState()
-        {
-            RefreshSelectedTargetInstallStateFast();
-            RefreshSelectedTargetInstallStateInBackground(allowDuringCliRefresh: true);
-        }
-
     }
 }


### PR DESCRIPTION
## Summary
- Keep Settings / Setup Wizard / Migration Wizard / Tool Settings presentation sources under the 500-line budget via Fowler Extract Class / Move Method.
- No intentional end-user behavior change; UI shells stay in EditorWindows while workflow orchestration moves to presenters/controllers.

## User Impact
- Maintainability-only. Users should see the same Settings, Setup Wizard, Migration Wizard, and Tool Settings behavior.

## Changes
- ToolSettings: ListViewController + RowBinder + LayoutSignature (+ characterization tests for signature format)
- Settings: expand CliSetupPresenter; add SkillsPresenter
- Setup Wizard: WorkflowController composing CLI/Skills workflow controllers
- Migration Wizard: WorkflowController for scan/migrate/skill operations
- Resulting sizes all &lt; 500 (windows ~424–433; extracted helpers 47–461)

## Verification
- `uloop compile` → 0/0
- EditMode filter ToolSettings/SetupWizard/MigrationWizard/Settings related → 315 passed
- `dotnet test tests/UnityCliLoop.CodeComplexity.Tests` → 12 passed

## Merge gate
- **Do not merge until the author confirms manual UI smoke checks (`動作チェックOK`).**

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

