### PR TITLE
fix: Settings no longer shows watch tools as separate toggles

### DIFF
--- a/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
+++ b/Assets/Tests/Editor/ToolSettingsUseCaseTests.cs
@@ -103,6 +103,55 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void TryGetToolCatalog_WhenRegistryAvailable_ExcludesWatchAuxiliaryTools()
+        {
+            // Verifies Tool Settings hides the watch tools because they belong to the pause-point family toggle.
+            IToolSettingsPort toolSettingsPort = new InMemoryToolSettingsPort();
+            UnityCliLoopToolRegistrarService toolRegistrarService = new(
+                new EmptyInternalToolNameProvider(),
+                toolSettingsPort,
+                new UnityCliLoopToolExecutionService(new NoOpEditorRuntimeStatePort()),
+                UnityCliLoopToolDiscovery.DiscoverTools);
+            ToolSettingsUseCase useCase = new(
+                toolSettingsPort,
+                toolRegistrarService,
+                new StaticToolSkillDescriptionProvider(new Dictionary<string, string>()));
+            useCase.WarmupRegistry();
+
+            bool isAvailable = useCase.TryGetToolCatalog(out ToolSettingsUseCase.ToolCatalogItem[] allTools);
+            string[] toolNames = allTools.Select(tool => tool.Name).ToArray();
+
+            Assert.That(isAvailable, Is.True);
+            Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.TOOL_NAME_ENABLE_WATCH));
+            Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.TOOL_NAME_CLEAR_WATCH));
+            Assert.That(toolNames, Does.Not.Contain(UnityCliLoopConstants.TOOL_NAME_GET_WATCH_VALUES));
+        }
+
+        [Test]
+        public void ToolSettingsToolLinkPolicy_WhenWatchToolRequested_IsNotUserFacingAndMapsToPausePoint()
+        {
+            // Verifies each watch tool is auxiliary and resolves to the pause-point settings key.
+            string[] watchToolNames =
+            {
+                UnityCliLoopConstants.TOOL_NAME_ENABLE_WATCH,
+                UnityCliLoopConstants.TOOL_NAME_CLEAR_WATCH,
+                UnityCliLoopConstants.TOOL_NAME_GET_WATCH_VALUES
+            };
+
+            foreach (string watchToolName in watchToolNames)
+            {
+                Assert.That(
+                    ToolSettingsToolLinkPolicy.IsUserFacingToolSettingsTool(watchToolName),
+                    Is.False,
+                    watchToolName);
+                Assert.That(
+                    ToolSettingsToolLinkPolicy.GetSettingsToolName(watchToolName),
+                    Is.EqualTo(UnityCliLoopConstants.SETTINGS_TOOL_NAME_PAUSE_POINT),
+                    watchToolName);
+            }
+        }
+
+        [Test]
         public void TryGetToolCatalog_WhenSkillDescriptionExists_IncludesDescription()
         {
             // Verifies Tool Settings can show source skill descriptions without changing public tool metadata.

--- a/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs
+++ b/Packages/src/Editor/Domain/ToolSettingsToolLinkPolicy.cs
@@ -15,7 +15,10 @@ namespace io.github.hatayama.UnityCliLoop.Domain
             UnityCliLoopConstants.COMMAND_NAME_AWAIT_PAUSE_POINT,
             UnityCliLoopConstants.TOOL_NAME_ENABLE_PAUSE_POINT,
             UnityCliLoopConstants.TOOL_NAME_CLEAR_PAUSE_POINT,
-            UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS
+            UnityCliLoopConstants.COMMAND_NAME_PAUSE_POINT_STATUS,
+            UnityCliLoopConstants.TOOL_NAME_ENABLE_WATCH,
+            UnityCliLoopConstants.TOOL_NAME_CLEAR_WATCH,
+            UnityCliLoopConstants.TOOL_NAME_GET_WATCH_VALUES
         };
 
         internal static bool IsUserFacingToolSettingsTool(string toolName)


### PR DESCRIPTION
## Summary
- The Settings window's Built-in Tools list no longer shows `enable-watch`, `clear-watch`, and `get-watch-values` as individual checkboxes.
- The watch tools now follow the `pause-point` toggle, since they are auxiliary options of the pause-point feature.

## User Impact
- Before: three watch tools appeared as standalone toggles in Settings, even though they only make sense together with pause-point, and they could be enabled/disabled independently of it.
- After: Settings shows only the `pause-point` entry for the whole family. Turning pause-point off also disables the watch tools, matching how the other pause-point auxiliary tools already behave.

## Changes
- Added the three watch tool names to `PausePointAuxiliaryToolNames` in `ToolSettingsToolLinkPolicy`, which both hides them from the Settings catalog and maps their enabled state to the `pause-point` settings key.
- Added tests verifying the watch tools are excluded from the tool catalog and resolve to the `pause-point` settings key.

## Verification
- `uloop compile`: 0 errors, 0 warnings
- `uloop run-tests` (EditMode, full suite): 2128 tests, 2121 passed, 0 failed, 7 skipped (pre-existing skips)
- TDD: the two new tests were confirmed failing before the implementation change

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

