### PR TITLE
fix: Restrict release publishing to approved commits

### DIFF
--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -379,6 +379,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: cli/.go-version
+          cache-dependency-path: '**/go.sum'
+
       - name: Sync release-please package releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -79,13 +79,6 @@ jobs:
         if: steps.release.outputs.publish == 'true'
         run: scripts/verify-dispatcher-release-assets.sh
 
-      - name: Verify release-tagged installer scripts
-        if: steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true'
-        shell: pwsh
-        env:
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-        run: ./scripts/check-release-installer.ps1 -Version $env:RELEASE_TAG
-
       - name: Write release metadata
         if: steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true'
         env:
@@ -275,6 +268,17 @@ jobs:
           if [ "${RELEASE_PRERELEASE}" = "true" ]; then prerelease_flag="--prerelease"; latest_flag="--latest=false"; fi
           gh release create "${RELEASE_TAG}" --draft --title "${RELEASE_TAG}" --notes "Dispatcher release ${RELEASE_TAG}." --target "${GITHUB_SHA}" ${prerelease_flag} ${latest_flag}
           echo "release_published=false" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tagged dispatcher installer scripts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -eu
+          for installer_path in scripts/install.ps1 scripts/install.sh; do
+            installer_size=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${installer_path}?ref=${RELEASE_TAG}" --jq '.size')
+            [ "${installer_size}" -gt 0 ]
+          done
 
       - name: Attest dispatcher release assets
         id: attest

--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -7,53 +7,30 @@ on:
       - v3-beta
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Git ref to build from (tag, branch, or SHA). Defaults to default branch."
-        required: false
-        default: ""
       dry-run:
         description: "Dry run (skip release upload)"
         type: boolean
         default: false
-
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
-  artifact-metadata: write
 
 concurrency:
   group: dispatcher-publish-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'
+    permissions:
+      contents: read
+    outputs:
+      should_publish: ${{ steps.release.outputs.publish }}
+      should_release: ${{ steps.release.outputs.release }}
+      dry_run: ${{ steps.release.outputs.dry_run }}
     steps:
-      - name: Resolve checkout ref
-        id: checkout
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_REF: ${{ github.ref }}
-          EVENT_SHA: ${{ github.sha }}
-          INPUT_REF: ${{ inputs.ref }}
-        run: |
-          set -eu
-
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            CHECKOUT_REF="${INPUT_REF:-${EVENT_REF}}"
-          else
-            CHECKOUT_REF="${EVENT_SHA}"
-          fi
-
-          echo "ref=${CHECKOUT_REF}" >> "$GITHUB_OUTPUT"
-          echo "Checkout ref: ${CHECKOUT_REF}"
-
-      - name: Checkout repository
+      - name: Checkout approved event commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ steps.checkout.outputs.ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Resolve dispatcher release target
@@ -63,8 +40,18 @@ jobs:
           EVENT_REF_NAME: ${{ github.ref_name }}
           INPUT_DRY_RUN: ${{ inputs.dry-run }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: scripts/resolve-dispatcher-release-target.sh >> "$GITHUB_OUTPUT"
+
+      - name: Verify release target matches build commit
+        if: steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true'
+        env:
+          TARGET_SHA: ${{ steps.release.outputs.sha }}
         run: |
-          scripts/resolve-dispatcher-release-target.sh >> "$GITHUB_OUTPUT"
+          set -eu
+          if [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then
+            echo "Release target ${TARGET_SHA} does not match approved build commit ${GITHUB_SHA}." >&2
+            exit 1
+          fi
 
       - name: Setup Go
         if: steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true'
@@ -91,181 +78,234 @@ jobs:
         if: steps.release.outputs.publish == 'true'
         run: scripts/verify-dispatcher-release-assets.sh
 
+      - name: Verify release-tagged installer scripts
+        if: steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true'
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: ./scripts/check-release-installer.ps1 -Version $env:RELEASE_TAG
+
+      - name: Write release metadata
+        if: steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true'
+        env:
+          TARGET_SHA: ${{ steps.release.outputs.sha }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          PRERELEASE: ${{ steps.release.outputs.prerelease }}
+          SHOULD_PUBLISH: ${{ steps.release.outputs.publish }}
+          SHOULD_RELEASE: ${{ steps.release.outputs.release }}
+          DRY_RUN: ${{ steps.release.outputs.dry_run }}
+        run: |
+          set -eu
+          mkdir -p release-input
+          {
+            printf 'build_sha=%s\n' "${GITHUB_SHA}"
+            printf 'target_sha=%s\n' "${TARGET_SHA}"
+            printf 'release_tag=%s\n' "${RELEASE_TAG}"
+            printf 'version=%s\n' "${RELEASE_VERSION}"
+            printf 'prerelease=%s\n' "${PRERELEASE}"
+            printf 'publish=%s\n' "${SHOULD_PUBLISH}"
+            printf 'release=%s\n' "${SHOULD_RELEASE}"
+            printf 'dry_run=%s\n' "${DRY_RUN}"
+            printf 'event_ref=%s\n' "${GITHUB_REF}"
+          } > release-input/release-metadata.env
+          if [ "${SHOULD_PUBLISH}" = "true" ]; then
+            shasum -a 256 dist/dispatcher-release/* > release-input/release-assets.manifest
+          else
+            : > release-input/release-assets.manifest
+          fi
+
+      - name: Upload packaged dispatcher assets
+        if: steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: dispatcher-release-input
+          path: |
+            dist/dispatcher-release/*
+            release-input/*
+          if-no-files-found: error
+
+      - name: Dry run summary
+        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run == 'true'
+        run: ls -lh dist/dispatcher-release
+
+  publish:
+    needs: build
+    if: (needs.build.outputs.should_publish == 'true' || needs.build.outputs.should_release == 'true') && needs.build.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    environment: cli-release
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download packaged dispatcher assets
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: dispatcher-release-input
+          path: release-input
+
+      - name: Verify release metadata
+        run: |
+          set -eu
+          metadata_value() {
+            key=$1
+            value=$(grep "^${key}=" release-input/release-metadata.env | cut -d= -f2-)
+            if [ -z "${value}" ]; then
+              echo "Missing release metadata: ${key}." >&2
+              exit 1
+            fi
+            printf '%s\n' "${value}"
+          }
+
+          build_sha=$(metadata_value build_sha)
+          target_sha=$(metadata_value target_sha)
+          release_tag=$(metadata_value release_tag)
+          version=$(metadata_value version)
+          prerelease=$(metadata_value prerelease)
+          should_publish=$(metadata_value publish)
+          should_release=$(metadata_value release)
+          dry_run=$(metadata_value dry_run)
+          event_ref=$(metadata_value event_ref)
+          BUILD_SHA="${build_sha}"
+          TARGET_SHA="${target_sha}"
+          if [ "${BUILD_SHA}" != "${GITHUB_SHA}" ] || [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then
+            echo "Build SHA and release target must match the approved event commit." >&2
+            exit 1
+          fi
+          if [ "${event_ref}" != "refs/heads/main" ] && [ "${event_ref}" != "refs/heads/v3-beta" ]; then
+            echo "Unsupported release ref ${event_ref}." >&2
+            exit 1
+          fi
+          if [ "${release_tag}" != "dispatcher-v${version}" ]; then
+            echo "Release tag does not match the resolved version." >&2
+            exit 1
+          fi
+          if [ "${prerelease}" != "true" ] && [ "${prerelease}" != "false" ]; then exit 1; fi
+          if [ "${should_publish}" != "true" ] && [ "${should_publish}" != "false" ]; then exit 1; fi
+          if [ "${should_release}" != "true" ] && [ "${should_release}" != "false" ]; then exit 1; fi
+          if [ "${dry_run}" != "true" ] && [ "${dry_run}" != "false" ]; then exit 1; fi
+          printf 'RELEASE_TAG=%s\n' "${release_tag}" >> "$GITHUB_ENV"
+          printf 'RELEASE_PRERELEASE=%s\n' "${prerelease}" >> "$GITHUB_ENV"
+          printf 'SHOULD_PUBLISH=%s\n' "${should_publish}" >> "$GITHUB_ENV"
+          printf 'DRY_RUN=%s\n' "${dry_run}" >> "$GITHUB_ENV"
+
+      - name: Verify release asset manifest
+        if: env.SHOULD_PUBLISH == 'true'
+        run: |
+          set -eu
+          asset_count=0
+          while IFS=' ' read -r checksum asset_path; do
+            case "${checksum}" in [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]* ) ;; *) exit 1 ;; esac
+            case "${asset_path}" in dist/dispatcher-release/[A-Za-z0-9._+-]* ) ;; *) exit 1 ;; esac
+            full_path="release-input/${asset_path}"
+            [ -s "${full_path}" ]
+            actual_checksum=$(shasum -a 256 "${full_path}" | awk '{print $1}')
+            [ "${actual_checksum}" = "${checksum}" ]
+            asset_count=$((asset_count + 1))
+          done < release-input/release-assets.manifest
+          [ "${asset_count}" -gt 0 ]
+
+      - name: Create or reuse draft dispatcher release
+        id: draft
+        if: env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -eu
+          if gh release view "${RELEASE_TAG}" --json isDraft,targetCommitish > release-input/release-state.json 2>/dev/null; then
+            target_sha=$(jq -r '.targetCommitish' release-input/release-state.json)
+            [ "${target_sha}" = "${GITHUB_SHA}" ]
+            is_draft=$(jq -r '.isDraft' release-input/release-state.json)
+            if [ "${is_draft}" = "false" ]; then
+              if [ "${RELEASE_PRERELEASE}" = "true" ]; then
+                release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.id')
+                gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" -F prerelease=true -F make_latest=false >/dev/null
+              fi
+              echo "release_published=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "release_published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          prerelease_flag=""
+          latest_flag=""
+          if [ "${RELEASE_PRERELEASE}" = "true" ]; then prerelease_flag="--prerelease"; latest_flag="--latest=false"; fi
+          gh release create "${RELEASE_TAG}" --draft --title "${RELEASE_TAG}" --notes "Dispatcher release ${RELEASE_TAG}." --target "${GITHUB_SHA}" ${prerelease_flag} ${latest_flag}
+          echo "release_published=false" >> "$GITHUB_OUTPUT"
+
       - name: Attest dispatcher release assets
         id: attest
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
-          subject-path: dist/dispatcher-release/*
+          subject-path: release-input/dist/dispatcher-release/*
 
       - name: Verify dispatcher asset attestations
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/dispatcher-publish.yml
         run: |
           set -eu
+          while IFS=' ' read -r checksum asset_path; do
+            gh attestation verify "release-input/${asset_path}" --repo "${GITHUB_REPOSITORY}" --signer-workflow "${SIGNER_WORKFLOW}"
+          done < release-input/release-assets.manifest
 
-          for asset_path in dist/dispatcher-release/*; do
-            gh attestation verify "${asset_path}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --signer-workflow "${SIGNER_WORKFLOW}"
-          done
-
-      - name: Distribute attestation bundles per asset
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
+      - name: Attach attestation bundles to dispatcher assets
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
         env:
           BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
         run: |
-          scripts/distribute-attestation-bundles.sh \
-            --bundle "${BUNDLE_PATH}" \
-            --release-dir dist/dispatcher-release
-
-      - name: Upload dispatcher release assets artifact
-        if: steps.release.outputs.publish == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: dispatcher-release-assets-${{ steps.release.outputs.tag }}
-          path: dist/dispatcher-release/*
-          if-no-files-found: error
-
-      - name: Create or reuse draft dispatcher release
-        id: draft
-        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-          RELEASE_PRERELEASE: ${{ steps.release.outputs.prerelease }}
-          TARGET_SHA: ${{ steps.release.outputs.sha }}
-        run: |
           set -eu
-          git fetch --force --tags origin
-
-          EXISTING_TAG_SHA=$(git rev-list -n 1 "${RELEASE_TAG}" 2>/dev/null || true)
-          if [ -n "${EXISTING_TAG_SHA}" ] && [ "${EXISTING_TAG_SHA}" != "${TARGET_SHA}" ]; then
-            echo "Dispatcher release tag ${RELEASE_TAG} points at ${EXISTING_TAG_SHA}, expected ${TARGET_SHA}." >&2
-            exit 1
-          fi
-
-          if [ -z "${EXISTING_TAG_SHA}" ]; then
-            git tag "${RELEASE_TAG}" "${TARGET_SHA}"
-            git push origin "refs/tags/${RELEASE_TAG}"
-          fi
-
-          DRAFT_STATE_PATH="${RUNNER_TEMP}/dispatcher-release-draft-${GITHUB_RUN_ID}"
-          if gh release view "${RELEASE_TAG}" --json isDraft --jq '.isDraft' >"${DRAFT_STATE_PATH}" 2>/dev/null; then
-            IS_DRAFT=$(cat "${DRAFT_STATE_PATH}")
-            if [ "${IS_DRAFT}" != "true" ]; then
-              if [ "${RELEASE_PRERELEASE}" = "true" ]; then
-                RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.id')
-                gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F prerelease=true -F make_latest=false >/dev/null
-              fi
-
-              echo "release_published=true" >> "$GITHUB_OUTPUT"
-              echo "Dispatcher release ${RELEASE_TAG} is already published; verifying existing assets."
-              exit 0
-            fi
-
-            echo "release_published=false" >> "$GITHUB_OUTPUT"
-            echo "Reusing draft dispatcher release ${RELEASE_TAG}."
-            exit 0
-          fi
-
-          PRERELEASE_FLAG=""
-          LATEST_FLAG=""
-          if [ "${RELEASE_PRERELEASE}" = "true" ]; then
-            PRERELEASE_FLAG="--prerelease"
-            LATEST_FLAG="--latest=false"
-          fi
-
-          gh release create "${RELEASE_TAG}" \
-            --draft \
-            --title "${RELEASE_TAG}" \
-            --notes "Dispatcher release ${RELEASE_TAG}." \
-            --target "${TARGET_SHA}" \
-            ${PRERELEASE_FLAG} \
-            ${LATEST_FLAG}
-
-          echo "release_published=false" >> "$GITHUB_OUTPUT"
-
-      - name: Verify release-tagged installer scripts
-        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
-        shell: pwsh
-        env:
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          ./scripts/check-release-installer.ps1 -Version $env:RELEASE_TAG
+          [ -s "${BUNDLE_PATH}" ]
+          while IFS=' ' read -r checksum asset_path; do
+            cp "${BUNDLE_PATH}" "release-input/${asset_path}.sigstore.json"
+          done < release-input/release-assets.manifest
 
       - name: Upload dispatcher assets
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          gh release upload "${RELEASE_TAG}" dist/dispatcher-release/* --clobber
-
-      - name: Verify remote dispatcher release assets
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -eu
-          ASSETS_JSON=$(gh release view "${RELEASE_TAG}" --json assets)
-
-          for asset_name in $(scripts/verify-dispatcher-release-assets.sh --list); do
-            ASSET_SIZE=$(printf '%s' "${ASSETS_JSON}" | jq -r --arg name "${asset_name}" '.assets[] | select(.name == $name) | .size')
-            if [ -z "${ASSET_SIZE}" ] || [ "${ASSET_SIZE}" = "null" ]; then
-              echo "Missing remote dispatcher release asset: ${asset_name}" >&2
-              exit 1
-            fi
-
-            if [ "${ASSET_SIZE}" -le 0 ]; then
-              echo "Remote dispatcher release asset is empty: ${asset_name}" >&2
-              exit 1
-            fi
-
-            BUNDLE_NAME="${asset_name}.sigstore.json"
-            BUNDLE_SIZE=$(printf '%s' "${ASSETS_JSON}" | jq -r --arg name "${BUNDLE_NAME}" '.assets[] | select(.name == $name) | .size')
-            if [ -z "${BUNDLE_SIZE}" ] || [ "${BUNDLE_SIZE}" = "null" ]; then
-              echo "Missing remote dispatcher attestation bundle: ${BUNDLE_NAME}" >&2
-              exit 1
-            fi
-
-            if [ "${BUNDLE_SIZE}" -le 0 ]; then
-              echo "Remote dispatcher attestation bundle is empty: ${BUNDLE_NAME}" >&2
-              exit 1
-            fi
-          done
+          while IFS=' ' read -r checksum asset_path; do
+            gh release upload "${RELEASE_TAG}" "release-input/${asset_path}" "release-input/${asset_path}.sigstore.json" --clobber
+          done < release-input/release-assets.manifest
 
       - name: Publish draft dispatcher release
-        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true' && steps.draft.outputs.release_published != 'true'
+        if: env.DRY_RUN != 'true' && steps.draft.outputs.release_published != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-          RELEASE_PRERELEASE: ${{ steps.release.outputs.prerelease }}
         run: |
           set -eu
           if [ "${RELEASE_PRERELEASE}" = "true" ]; then
             gh release edit "${RELEASE_TAG}" --draft=false --prerelease
-            RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.id')
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F prerelease=true -F make_latest=false >/dev/null
+            release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.id')
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" -F prerelease=true -F make_latest=false >/dev/null
           else
             gh release edit "${RELEASE_TAG}" --draft=false
           fi
 
+  post-publish:
+    needs: [build, publish]
+    if: needs.build.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout approved event commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
       - name: Sync release-please package releases
-        id: package_release_sync
-        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: scripts/sync-release-please-package-releases.sh
-
-      - name: Dry run summary
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run == 'true'
-        run: |
-          ls -lh dist/dispatcher-release

--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve dispatcher release target
         id: release
@@ -121,8 +122,8 @@ jobs:
         with:
           name: dispatcher-release-input
           path: |
-            dist/dispatcher-release/*
-            release-input/*
+            dist/dispatcher-release
+            release-input
           if-no-files-found: error
 
       - name: Dry run summary
@@ -139,12 +140,13 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Download packaged dispatcher assets
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: dispatcher-release-input
-          path: release-input
+          path: .
 
       - name: Verify release metadata
         run: |
@@ -182,10 +184,18 @@ jobs:
             echo "Release tag does not match the resolved version." >&2
             exit 1
           fi
-          if [ "${prerelease}" != "true" ] && [ "${prerelease}" != "false" ]; then exit 1; fi
-          if [ "${should_publish}" != "true" ] && [ "${should_publish}" != "false" ]; then exit 1; fi
-          if [ "${should_release}" != "true" ] && [ "${should_release}" != "false" ]; then exit 1; fi
-          if [ "${dry_run}" != "true" ] && [ "${dry_run}" != "false" ]; then exit 1; fi
+          validate_boolean() {
+            field_name=$1
+            field_value=$2
+            if [ "${field_value}" != "true" ] && [ "${field_value}" != "false" ]; then
+              echo "Invalid boolean metadata value for ${field_name}: ${field_value}." >&2
+              exit 1
+            fi
+          }
+          validate_boolean prerelease "${prerelease}"
+          validate_boolean publish "${should_publish}"
+          validate_boolean release "${should_release}"
+          validate_boolean dry_run "${dry_run}"
           printf 'RELEASE_TAG=%s\n' "${release_tag}" >> "$GITHUB_ENV"
           printf 'RELEASE_PRERELEASE=%s\n' "${prerelease}" >> "$GITHUB_ENV"
           printf 'SHOULD_PUBLISH=%s\n' "${should_publish}" >> "$GITHUB_ENV"
@@ -195,6 +205,21 @@ jobs:
         if: env.SHOULD_PUBLISH == 'true'
         run: |
           set -eu
+          manifest_paths="${RUNNER_TEMP}/dispatcher-manifest-paths"
+          actual_paths="${RUNNER_TEMP}/dispatcher-actual-paths"
+          awk '{ print $2 }' release-input/release-assets.manifest | sed 's#^dist/dispatcher-release/##' | sort > "${manifest_paths}"
+          find release-input/dist/dispatcher-release -maxdepth 1 -type f -printf '%f\n' | sort > "${actual_paths}"
+          manifest_count=$(wc -l < "${manifest_paths}" | tr -d ' ')
+          unique_manifest_count=$(uniq "${manifest_paths}" | wc -l | tr -d ' ')
+          if [ "${manifest_count}" -ne "${unique_manifest_count}" ]; then
+            echo "Release manifest is missing files or has duplicate entries." >&2
+            exit 1
+          fi
+          if ! cmp -s "${manifest_paths}" "${actual_paths}"; then
+            echo "Unexpected release files are not listed in the manifest." >&2
+            echo "Release manifest is missing files or has duplicate entries." >&2
+            exit 1
+          fi
           asset_count=0
           while IFS=' ' read -r checksum asset_path; do
             case "${checksum}" in [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]* ) ;; *) exit 1 ;; esac
@@ -215,9 +240,23 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -eu
+          tag_error_path="${RUNNER_TEMP}/dispatcher-release-tag-error"
+          set +e
+          tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha' 2> "${tag_error_path}")
+          tag_status=$?
+          set -e
+          if [ "${tag_status}" -ne 0 ]; then
+            tag_error=$(cat "${tag_error_path}")
+            case "${tag_error}" in
+              *"HTTP 404"*|*"Not Found"*) tag_sha="" ;;
+              *) printf '%s\n' "${tag_error}" >&2; exit "${tag_status}" ;;
+            esac
+          fi
+          if [ -n "${tag_sha}" ] && [ "${tag_sha}" != "${GITHUB_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
+            exit 1
+          fi
           if gh release view "${RELEASE_TAG}" --json isDraft,targetCommitish > release-input/release-state.json 2>/dev/null; then
-            target_sha=$(jq -r '.targetCommitish' release-input/release-state.json)
-            [ "${target_sha}" = "${GITHUB_SHA}" ]
             is_draft=$(jq -r '.isDraft' release-input/release-state.json)
             if [ "${is_draft}" = "false" ]; then
               if [ "${RELEASE_PRERELEASE}" = "true" ]; then
@@ -272,6 +311,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
+          tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha')
+          if [ "${tag_sha}" != "${GITHUB_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
+            exit 1
+          fi
           while IFS=' ' read -r checksum asset_path; do
             gh release upload "${RELEASE_TAG}" "release-input/${asset_path}" "release-input/${asset_path}.sigstore.json" --clobber
           done < release-input/release-assets.manifest
@@ -296,13 +340,14 @@ jobs:
     if: needs.build.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout approved event commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Sync release-please package releases
         env:

--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -208,7 +208,7 @@ jobs:
           manifest_paths="${RUNNER_TEMP}/dispatcher-manifest-paths"
           actual_paths="${RUNNER_TEMP}/dispatcher-actual-paths"
           awk '{ print $2 }' release-input/release-assets.manifest | sed 's#^dist/dispatcher-release/##' | sort > "${manifest_paths}"
-          find release-input/dist/dispatcher-release -maxdepth 1 -type f -printf '%f\n' | sort > "${actual_paths}"
+          find dist/dispatcher-release -maxdepth 1 -type f -printf '%f\n' | sort > "${actual_paths}"
           manifest_count=$(wc -l < "${manifest_paths}" | tr -d ' ')
           unique_manifest_count=$(uniq "${manifest_paths}" | wc -l | tr -d ' ')
           if [ "${manifest_count}" -ne "${unique_manifest_count}" ]; then
@@ -224,7 +224,7 @@ jobs:
           while IFS=' ' read -r checksum asset_path; do
             case "${checksum}" in [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]* ) ;; *) exit 1 ;; esac
             case "${asset_path}" in dist/dispatcher-release/[A-Za-z0-9._+-]* ) ;; *) exit 1 ;; esac
-            full_path="release-input/${asset_path}"
+            full_path="${asset_path}"
             [ -s "${full_path}" ]
             actual_checksum=$(shasum -a 256 "${full_path}" | awk '{print $1}')
             [ "${actual_checksum}" = "${checksum}" ]
@@ -280,7 +280,7 @@ jobs:
         if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
-          subject-path: release-input/dist/dispatcher-release/*
+          subject-path: dist/dispatcher-release/*
 
       - name: Verify dispatcher asset attestations
         if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
@@ -291,7 +291,7 @@ jobs:
         run: |
           set -eu
           while IFS=' ' read -r checksum asset_path; do
-            gh attestation verify "release-input/${asset_path}" --repo "${GITHUB_REPOSITORY}" --signer-workflow "${SIGNER_WORKFLOW}"
+            gh attestation verify "${asset_path}" --repo "${GITHUB_REPOSITORY}" --signer-workflow "${SIGNER_WORKFLOW}"
           done < release-input/release-assets.manifest
 
       - name: Attach attestation bundles to dispatcher assets
@@ -302,7 +302,7 @@ jobs:
           set -eu
           [ -s "${BUNDLE_PATH}" ]
           while IFS=' ' read -r checksum asset_path; do
-            cp "${BUNDLE_PATH}" "release-input/${asset_path}.sigstore.json"
+            cp "${BUNDLE_PATH}" "${asset_path}.sigstore.json"
           done < release-input/release-assets.manifest
 
       - name: Upload dispatcher assets
@@ -317,7 +317,27 @@ jobs:
             exit 1
           fi
           while IFS=' ' read -r checksum asset_path; do
-            gh release upload "${RELEASE_TAG}" "release-input/${asset_path}" "release-input/${asset_path}.sigstore.json" --clobber
+            gh release upload "${RELEASE_TAG}" "${asset_path}" "${asset_path}.sigstore.json" --clobber
+          done < release-input/release-assets.manifest
+
+      - name: Verify remote dispatcher release assets
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          release_assets=$(gh release view "${RELEASE_TAG}" --json assets)
+          while IFS=' ' read -r checksum asset_path; do
+            asset_name=$(basename "${asset_path}")
+            bundle_name="${asset_name}.sigstore.json"
+            asset_count=$(printf '%s' "${release_assets}" | jq --arg name "${asset_name}" '[.assets[] | select(.name == $name)] | length')
+            bundle_count=$(printf '%s' "${release_assets}" | jq --arg name "${bundle_name}" '[.assets[] | select(.name == $name)] | length')
+            asset_size=$(printf '%s' "${release_assets}" | jq -r --arg name "${asset_name}" '[.assets[] | select(.name == $name) | .size] | .[0]')
+            bundle_size=$(printf '%s' "${release_assets}" | jq -r --arg name "${bundle_name}" '[.assets[] | select(.name == $name) | .size] | .[0]')
+            if [ "${asset_count}" -ne 1 ] || [ "${bundle_count}" -ne 1 ] || [ "${asset_size}" -le 0 ] || [ "${bundle_size}" -le 0 ]; then
+              echo "Dispatcher release asset or attestation bundle is missing or empty: ${asset_name}." >&2
+              exit 1
+            fi
           done < release-input/release-assets.manifest
 
       - name: Publish draft dispatcher release
@@ -327,6 +347,11 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -eu
+          tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha')
+          if [ "${tag_sha}" != "${GITHUB_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
+            exit 1
+          fi
           if [ "${RELEASE_PRERELEASE}" = "true" ]; then
             gh release edit "${RELEASE_TAG}" --draft=false --prerelease
             release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '.id')

--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -249,7 +249,7 @@ jobs:
             tag_error=$(cat "${tag_error_path}")
             case "${tag_error}" in
               *"HTTP 404"*) tag_sha="" ;;
-              *"HTTP 422"*"No commit found for SHA"*) tag_sha="" ;;
+              *"HTTP 422"*"No commit found for SHA"*|*"No commit found for SHA"*"HTTP 422"*) tag_sha="" ;;
               *) printf '%s\n' "${tag_error}" >&2; exit "${tag_status}" ;;
             esac
           fi

--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -248,7 +248,8 @@ jobs:
           if [ "${tag_status}" -ne 0 ]; then
             tag_error=$(cat "${tag_error_path}")
             case "${tag_error}" in
-              *"HTTP 404"*|*"Not Found"*) tag_sha="" ;;
+              *"HTTP 404"*) tag_sha="" ;;
+              *"HTTP 422"*"No commit found for SHA"*) tag_sha="" ;;
               *) printf '%s\n' "${tag_error}" >&2; exit "${tag_status}" ;;
             esac
           fi

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -251,7 +251,8 @@ jobs:
           if [ "${tag_status}" -ne 0 ]; then
             tag_error=$(cat "${tag_error_path}")
             case "${tag_error}" in
-              *"HTTP 404"*|*"Not Found"*) tag_sha="" ;;
+              *"HTTP 404"*) tag_sha="" ;;
+              *"HTTP 422"*"No commit found for SHA"*) tag_sha="" ;;
               *) printf '%s\n' "${tag_error}" >&2; exit "${tag_status}" ;;
             esac
           fi

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -211,7 +211,7 @@ jobs:
           manifest_paths="${RUNNER_TEMP}/native-cli-manifest-paths"
           actual_paths="${RUNNER_TEMP}/native-cli-actual-paths"
           awk '{ print $2 }' release-input/release-assets.manifest | sed 's#^dist/release/##' | sort > "${manifest_paths}"
-          find release-input/dist/release -maxdepth 1 -type f -printf '%f\n' | sort > "${actual_paths}"
+          find dist/release -maxdepth 1 -type f -printf '%f\n' | sort > "${actual_paths}"
           manifest_count=$(wc -l < "${manifest_paths}" | tr -d ' ')
           unique_manifest_count=$(uniq "${manifest_paths}" | wc -l | tr -d ' ')
           if [ "${manifest_count}" -ne "${unique_manifest_count}" ]; then
@@ -227,7 +227,7 @@ jobs:
           while IFS=' ' read -r checksum asset_path; do
             case "${checksum}" in [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]* ) ;; *) exit 1 ;; esac
             case "${asset_path}" in dist/release/[A-Za-z0-9._+-]* ) ;; *) exit 1 ;; esac
-            full_path="release-input/${asset_path}"
+            full_path="${asset_path}"
             [ -s "${full_path}" ]
             actual_checksum=$(shasum -a 256 "${full_path}" | awk '{print $1}')
             [ "${actual_checksum}" = "${checksum}" ]
@@ -278,7 +278,7 @@ jobs:
         if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
-          subject-path: release-input/dist/release/*
+          subject-path: dist/release/*
 
       - name: Verify native CLI asset attestations
         if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
@@ -288,7 +288,7 @@ jobs:
         run: |
           set -eu
           while IFS=' ' read -r checksum asset_path; do
-            gh attestation verify "release-input/${asset_path}" --repo "${GITHUB_REPOSITORY}" --signer-workflow "${SIGNER_WORKFLOW}"
+            gh attestation verify "${asset_path}" --repo "${GITHUB_REPOSITORY}" --signer-workflow "${SIGNER_WORKFLOW}"
           done < release-input/release-assets.manifest
 
       - name: Attach attestation bundles to release assets
@@ -299,7 +299,7 @@ jobs:
           set -eu
           [ -s "${BUNDLE_PATH}" ]
           while IFS=' ' read -r checksum asset_path; do
-            cp "${BUNDLE_PATH}" "release-input/${asset_path}.sigstore.json"
+            cp "${BUNDLE_PATH}" "${asset_path}.sigstore.json"
           done < release-input/release-assets.manifest
 
       - name: Upload native CLI assets
@@ -314,15 +314,41 @@ jobs:
             exit 1
           fi
           while IFS=' ' read -r checksum asset_path; do
-            gh release upload "${RELEASE_TAG}" "release-input/${asset_path}" "release-input/${asset_path}.sigstore.json" --clobber
+            gh release upload "${RELEASE_TAG}" "${asset_path}" "${asset_path}.sigstore.json" --clobber
+          done < release-input/release-assets.manifest
+
+      - name: Verify remote release assets
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          release_assets=$(gh release view "${RELEASE_TAG}" --json assets)
+          while IFS=' ' read -r checksum asset_path; do
+            asset_name=$(basename "${asset_path}")
+            bundle_name="${asset_name}.sigstore.json"
+            asset_count=$(printf '%s' "${release_assets}" | jq --arg name "${asset_name}" '[.assets[] | select(.name == $name)] | length')
+            bundle_count=$(printf '%s' "${release_assets}" | jq --arg name "${bundle_name}" '[.assets[] | select(.name == $name)] | length')
+            asset_size=$(printf '%s' "${release_assets}" | jq -r --arg name "${asset_name}" '[.assets[] | select(.name == $name) | .size] | .[0]')
+            bundle_size=$(printf '%s' "${release_assets}" | jq -r --arg name "${bundle_name}" '[.assets[] | select(.name == $name) | .size] | .[0]')
+            if [ "${asset_count}" -ne 1 ] || [ "${bundle_count}" -ne 1 ] || [ "${asset_size}" -le 0 ] || [ "${bundle_size}" -le 0 ]; then
+              echo "Release asset or attestation bundle is missing or empty: ${asset_name}." >&2
+              exit 1
+            fi
           done < release-input/release-assets.manifest
 
       - name: Publish draft release
         if: env.DRY_RUN != 'true' && steps.draft.outputs.release_published != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -eu
+          tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha')
+          if [ "${tag_sha}" != "${GITHUB_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
+            exit 1
+          fi
           case "${RELEASE_TAG}" in *-beta.*) gh release edit "${RELEASE_TAG}" --draft=false --prerelease ;; *) gh release edit "${RELEASE_TAG}" --draft=false ;; esac
 
   post-publish:
@@ -332,7 +358,6 @@ jobs:
     permissions:
       actions: write
       contents: write
-      issues: write
       pull-requests: write
     steps:
       - name: Checkout approved event commit

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -7,56 +7,27 @@ on:
       - v3-beta
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Git ref to build from (tag, branch, or SHA). Defaults to default branch."
-        required: false
-        default: ""
-      release-tag:
-        description: "Project runner release tag to upload assets to. Defaults to uloop-project-runner-v{version}."
-        required: false
-        default: ""
       dry-run:
         description: "Dry run (skip release upload)"
         type: boolean
         default: false
 
-permissions:
-  actions: write
-  contents: write
-  id-token: write
-  attestations: write
-  artifact-metadata: write
-  issues: write
-  pull-requests: write
-
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'
+    permissions:
+      contents: read
+    outputs:
+      should_publish: ${{ steps.release.outputs.publish }}
+      should_release: ${{ steps.release.outputs.release }}
+      dry_run: ${{ steps.release.outputs.dry_run }}
+      release_tag: ${{ steps.release.outputs.tag }}
     steps:
-      - name: Resolve checkout ref
-        id: checkout
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_REF: ${{ github.ref }}
-          EVENT_SHA: ${{ github.sha }}
-          INPUT_REF: ${{ inputs.ref }}
-        run: |
-          set -eu
-
-          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
-            CHECKOUT_REF="${INPUT_REF:-${EVENT_REF}}"
-          else
-            CHECKOUT_REF="${EVENT_SHA}"
-          fi
-
-          echo "ref=${CHECKOUT_REF}" >> "$GITHUB_OUTPUT"
-          echo "Checkout ref: ${CHECKOUT_REF}"
-
-      - name: Checkout repository
+      - name: Checkout approved event commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ steps.checkout.outputs.ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Resolve release target
@@ -65,11 +36,20 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_REF_NAME: ${{ github.ref_name }}
           BEFORE_SHA: ${{ github.event.before }}
-          INPUT_RELEASE_TAG: ${{ inputs.release-tag }}
           INPUT_DRY_RUN: ${{ inputs.dry-run }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: scripts/resolve-native-cli-release-target.sh >> "$GITHUB_OUTPUT"
+
+      - name: Verify release target matches build commit
+        if: steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true'
+        env:
+          TARGET_SHA: ${{ steps.release.outputs.sha }}
         run: |
-          scripts/resolve-native-cli-release-target.sh >> "$GITHUB_OUTPUT"
+          set -eu
+          if [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then
+            echo "Release target ${TARGET_SHA} does not match approved build commit ${GITHUB_SHA}." >&2
+            exit 1
+          fi
 
       - name: Setup Go
         if: steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true'
@@ -96,211 +76,246 @@ jobs:
         if: steps.release.outputs.publish == 'true'
         run: scripts/verify-native-cli-release-assets.sh
 
-      - name: Attest native CLI release assets
-        id: attest
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
-        with:
-          subject-path: dist/release/*
-
-      - name: Verify native CLI asset attestations
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/native-cli-publish.yml
-        run: |
-          set -eu
-
-          for asset_path in dist/release/*; do
-            gh attestation verify "${asset_path}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --signer-workflow "${SIGNER_WORKFLOW}"
-          done
-
-      - name: Distribute attestation bundles per asset
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
-        env:
-          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
-        run: |
-          scripts/distribute-attestation-bundles.sh \
-            --bundle "${BUNDLE_PATH}" \
-            --release-dir dist/release
-
-      - name: Upload packaged release assets artifact
-        if: steps.release.outputs.publish == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: native-cli-release-assets-${{ steps.release.outputs.tag }}
-          path: dist/release/*
-          if-no-files-found: error
-
       - name: Write release notes
         if: steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true'
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -eu
-          NOTES_FILE="$RUNNER_TEMP/native-cli-release-notes.md"
-
+          mkdir -p release-input
           awk -v version="${RELEASE_VERSION}" '
-            $0 ~ "^## \\[" version "\\]" {
-              found = 1
-              printing = 1
-              print
-              next
-            }
-            printing && /^## \[/ {
-              exit
-            }
-            printing {
-              print
-            }
-            END {
-              if (!found) {
-                exit 1
-              }
-            }
-          ' cli/project-runner/CHANGELOG.md > "${NOTES_FILE}"
+            $0 ~ "^## \\[" version "\\]" { found = 1; printing = 1; print; next }
+            printing && /^## \[/ { exit }
+            printing { print }
+            END { if (!found) exit 1 }
+          ' cli/project-runner/CHANGELOG.md > release-input/release-notes.md
 
-          echo "RELEASE_NOTES_FILE=${NOTES_FILE}" >> "$GITHUB_ENV"
+      - name: Write release metadata
+        if: steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true'
+        env:
+          TARGET_SHA: ${{ steps.release.outputs.sha }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          SHOULD_PUBLISH: ${{ steps.release.outputs.publish }}
+          SHOULD_RELEASE: ${{ steps.release.outputs.release }}
+          DRY_RUN: ${{ steps.release.outputs.dry_run }}
+        run: |
+          set -eu
+          mkdir -p release-input
+          {
+            printf 'build_sha=%s\n' "${GITHUB_SHA}"
+            printf 'target_sha=%s\n' "${TARGET_SHA}"
+            printf 'release_tag=%s\n' "${RELEASE_TAG}"
+            printf 'version=%s\n' "${RELEASE_VERSION}"
+            printf 'publish=%s\n' "${SHOULD_PUBLISH}"
+            printf 'release=%s\n' "${SHOULD_RELEASE}"
+            printf 'dry_run=%s\n' "${DRY_RUN}"
+            printf 'event_ref=%s\n' "${GITHUB_REF}"
+          } > release-input/release-metadata.env
+          if [ "${SHOULD_PUBLISH}" = "true" ]; then
+            shasum -a 256 dist/release/* > release-input/release-assets.manifest
+          else
+            : > release-input/release-assets.manifest
+          fi
+
+      - name: Upload packaged release assets
+        if: steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: native-cli-release-input
+          path: |
+            dist/release/*
+            release-input/*
+          if-no-files-found: error
+
+      - name: Dry run summary
+        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run == 'true'
+        run: ls -lh dist/release
+
+  publish:
+    needs: build
+    if: (needs.build.outputs.should_publish == 'true' || needs.build.outputs.should_release == 'true') && needs.build.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    environment: cli-release
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download packaged release assets
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: native-cli-release-input
+          path: release-input
+
+      - name: Verify release metadata
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -eu
+          metadata_value() {
+            key=$1
+            value=$(grep "^${key}=" release-input/release-metadata.env | cut -d= -f2-)
+            if [ -z "${value}" ]; then
+              echo "Missing release metadata: ${key}." >&2
+              exit 1
+            fi
+            printf '%s\n' "${value}"
+          }
+
+          build_sha=$(metadata_value build_sha)
+          target_sha=$(metadata_value target_sha)
+          release_tag=$(metadata_value release_tag)
+          version=$(metadata_value version)
+          should_publish=$(metadata_value publish)
+          should_release=$(metadata_value release)
+          dry_run=$(metadata_value dry_run)
+          event_ref=$(metadata_value event_ref)
+          BUILD_SHA="${build_sha}"
+          TARGET_SHA="${target_sha}"
+          if [ "${BUILD_SHA}" != "${GITHUB_SHA}" ] || [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then
+            echo "Build SHA and release target must match the approved event commit." >&2
+            exit 1
+          fi
+          if [ "${event_ref}" != "refs/heads/main" ] && [ "${event_ref}" != "refs/heads/v3-beta" ]; then
+            echo "Unsupported release ref ${event_ref}." >&2
+            exit 1
+          fi
+          if [ "${release_tag}" != "uloop-project-runner-v${version}" ]; then
+            echo "Release tag does not match the resolved version." >&2
+            exit 1
+          fi
+          if [ "${should_publish}" != "true" ] && [ "${should_publish}" != "false" ]; then exit 1; fi
+          if [ "${should_release}" != "true" ] && [ "${should_release}" != "false" ]; then exit 1; fi
+          if [ "${dry_run}" != "true" ] && [ "${dry_run}" != "false" ]; then exit 1; fi
+          printf 'RELEASE_TAG=%s\n' "${release_tag}" >> "$GITHUB_ENV"
+          printf 'SHOULD_PUBLISH=%s\n' "${should_publish}" >> "$GITHUB_ENV"
+          printf 'SHOULD_RELEASE=%s\n' "${should_release}" >> "$GITHUB_ENV"
+          printf 'DRY_RUN=%s\n' "${dry_run}" >> "$GITHUB_ENV"
+
+      - name: Verify release asset manifest
+        if: env.SHOULD_PUBLISH == 'true'
+        run: |
+          set -eu
+          asset_count=0
+          while IFS=' ' read -r checksum asset_path; do
+            case "${checksum}" in [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]* ) ;; *) exit 1 ;; esac
+            case "${asset_path}" in dist/release/[A-Za-z0-9._+-]* ) ;; *) exit 1 ;; esac
+            full_path="release-input/${asset_path}"
+            [ -s "${full_path}" ]
+            actual_checksum=$(shasum -a 256 "${full_path}" | awk '{print $1}')
+            [ "${actual_checksum}" = "${checksum}" ]
+            asset_count=$((asset_count + 1))
+          done < release-input/release-assets.manifest
+          [ "${asset_count}" -gt 0 ]
 
       - name: Create or reuse draft release
         id: draft
-        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
+        if: env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-          TARGET_SHA: ${{ steps.release.outputs.sha }}
         run: |
           set -eu
-          git fetch --force --tags origin
-
-          EXISTING_TAG_SHA=$(git rev-list -n 1 "${RELEASE_TAG}" 2>/dev/null || true)
-          if [ -n "${EXISTING_TAG_SHA}" ] && [ "${EXISTING_TAG_SHA}" != "${TARGET_SHA}" ]; then
-            echo "Release tag ${RELEASE_TAG} points at ${EXISTING_TAG_SHA}, expected ${TARGET_SHA}." >&2
-            exit 1
-          fi
-
-          if [ -z "${EXISTING_TAG_SHA}" ]; then
-            git tag "${RELEASE_TAG}" "${TARGET_SHA}"
-            git push origin "refs/tags/${RELEASE_TAG}"
-          fi
-
-          if gh release view "${RELEASE_TAG}" --json isDraft --jq '.isDraft' >/tmp/native-cli-release-draft 2>/dev/null; then
-            IS_DRAFT=$(cat /tmp/native-cli-release-draft)
-            if [ "${IS_DRAFT}" != "true" ]; then
+          if gh release view "${RELEASE_TAG}" --json isDraft,targetCommitish > release-input/release-state.json 2>/dev/null; then
+            target_sha=$(jq -r '.targetCommitish' release-input/release-state.json)
+            [ "${target_sha}" = "${GITHUB_SHA}" ]
+            is_draft=$(jq -r '.isDraft' release-input/release-state.json)
+            if [ "${is_draft}" = "false" ]; then
               echo "release_published=true" >> "$GITHUB_OUTPUT"
-              echo "Release ${RELEASE_TAG} is already published; verifying existing assets."
               exit 0
             fi
-
             echo "release_published=false" >> "$GITHUB_OUTPUT"
-            echo "Reusing draft release ${RELEASE_TAG}."
             exit 0
           fi
-
-          PRERELEASE_FLAG=""
-          case "${RELEASE_TAG}" in
-            *-beta.*)
-              PRERELEASE_FLAG="--prerelease"
-              ;;
-          esac
-
-          gh release create "${RELEASE_TAG}" \
-            --draft \
-            --title "${RELEASE_TAG}" \
-            --notes-file "${RELEASE_NOTES_FILE}" \
-            --target "${TARGET_SHA}" \
-            ${PRERELEASE_FLAG}
-
+          prerelease_flag=""
+          case "${RELEASE_TAG}" in *-beta.*) prerelease_flag="--prerelease" ;; esac
+          gh release create "${RELEASE_TAG}" --draft --title "${RELEASE_TAG}" --notes-file release-input/release-notes.md --target "${GITHUB_SHA}" ${prerelease_flag}
           echo "release_published=false" >> "$GITHUB_OUTPUT"
 
-      - name: Upload native CLI assets
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          gh release upload "${RELEASE_TAG}" dist/release/* --clobber
+      - name: Attest native CLI release assets
+        id: attest
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        with:
+          subject-path: release-input/dist/release/*
 
-      - name: Verify remote release assets
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
+      - name: Verify native CLI asset attestations
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/native-cli-publish.yml
         run: |
           set -eu
-          ASSETS_JSON=$(gh release view "${RELEASE_TAG}" --json assets)
+          while IFS=' ' read -r checksum asset_path; do
+            gh attestation verify "release-input/${asset_path}" --repo "${GITHUB_REPOSITORY}" --signer-workflow "${SIGNER_WORKFLOW}"
+          done < release-input/release-assets.manifest
 
-          for asset_name in $(scripts/verify-native-cli-release-assets.sh --list); do
-            ASSET_SIZE=$(printf '%s' "${ASSETS_JSON}" | jq -r --arg name "${asset_name}" '.assets[] | select(.name == $name) | .size')
-            if [ -z "${ASSET_SIZE}" ] || [ "${ASSET_SIZE}" = "null" ]; then
-              echo "Missing remote release asset: ${asset_name}" >&2
-              exit 1
-            fi
+      - name: Attach attestation bundles to release assets
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -eu
+          [ -s "${BUNDLE_PATH}" ]
+          while IFS=' ' read -r checksum asset_path; do
+            cp "${BUNDLE_PATH}" "release-input/${asset_path}.sigstore.json"
+          done < release-input/release-assets.manifest
 
-            if [ "${ASSET_SIZE}" -le 0 ]; then
-              echo "Remote release asset is empty: ${asset_name}" >&2
-              exit 1
-            fi
-
-            BUNDLE_NAME="${asset_name}.sigstore.json"
-            BUNDLE_SIZE=$(printf '%s' "${ASSETS_JSON}" | jq -r --arg name "${BUNDLE_NAME}" '.assets[] | select(.name == $name) | .size')
-            if [ -z "${BUNDLE_SIZE}" ] || [ "${BUNDLE_SIZE}" = "null" ]; then
-              echo "Missing remote native CLI attestation bundle: ${BUNDLE_NAME}" >&2
-              exit 1
-            fi
-
-            if [ "${BUNDLE_SIZE}" -le 0 ]; then
-              echo "Remote native CLI attestation bundle is empty: ${BUNDLE_NAME}" >&2
-              exit 1
-            fi
-          done
+      - name: Upload native CLI assets
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          while IFS=' ' read -r checksum asset_path; do
+            gh release upload "${RELEASE_TAG}" "release-input/${asset_path}" "release-input/${asset_path}.sigstore.json" --clobber
+          done < release-input/release-assets.manifest
 
       - name: Publish draft release
-        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true' && steps.draft.outputs.release_published != 'true'
+        if: env.DRY_RUN != 'true' && steps.draft.outputs.release_published != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -eu
-          case "${RELEASE_TAG}" in
-            *-beta.*)
-              gh release edit "${RELEASE_TAG}" --draft=false --prerelease
-              ;;
-            *)
-              gh release edit "${RELEASE_TAG}" --draft=false
-              ;;
-          esac
+          case "${RELEASE_TAG}" in *-beta.*) gh release edit "${RELEASE_TAG}" --draft=false --prerelease ;; *) gh release edit "${RELEASE_TAG}" --draft=false ;; esac
+
+  post-publish:
+    needs: [build, publish]
+    if: needs.build.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout approved event commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
 
       - name: Dispatch release-please after native CLI publish
-        if: github.event_name == 'push' && steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'
+        if: needs.build.outputs.should_publish == 'true' && github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ github.ref_name }}
-        run: |
-          gh workflow run release-please.yml --ref "${TARGET_BRANCH}" -f branch="${TARGET_BRANCH}"
+        run: gh workflow run release-please.yml --ref "${TARGET_BRANCH}" -f branch="${TARGET_BRANCH}"
 
       - name: Sync release-please package releases
         id: package_release_sync
-        if: (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: scripts/sync-release-please-package-releases.sh
 
       - name: Mark release PR as tagged
-        if: github.event_name == 'push' && (steps.release.outputs.release == 'true' || steps.release.outputs.publish == 'true') && steps.release.outputs.dry_run != 'true' && steps.package_release_sync.outputs.ready != 'false'
+        if: github.event_name == 'push' && steps.package_release_sync.outputs.ready != 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-          TARGET_SHA: ${{ steps.release.outputs.sha }}
+          RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
+          TARGET_SHA: ${{ github.sha }}
           TARGET_BRANCH: ${{ github.ref_name }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: scripts/mark-release-pr-tagged.sh
-
-      - name: Dry run summary
-        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run == 'true'
-        run: |
-          ls -lh dist/release

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -252,7 +252,7 @@ jobs:
             tag_error=$(cat "${tag_error_path}")
             case "${tag_error}" in
               *"HTTP 404"*) tag_sha="" ;;
-              *"HTTP 422"*"No commit found for SHA"*) tag_sha="" ;;
+              *"HTTP 422"*"No commit found for SHA"*|*"No commit found for SHA"*"HTTP 422"*) tag_sha="" ;;
               *) printf '%s\n' "${tag_error}" >&2; exit "${tag_status}" ;;
             esac
           fi

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve release target
         id: release
@@ -124,8 +125,8 @@ jobs:
         with:
           name: native-cli-release-input
           path: |
-            dist/release/*
-            release-input/*
+            dist/release
+            release-input
           if-no-files-found: error
 
       - name: Dry run summary
@@ -142,12 +143,13 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Download packaged release assets
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: native-cli-release-input
-          path: release-input
+          path: .
 
       - name: Verify release metadata
         env:
@@ -186,9 +188,17 @@ jobs:
             echo "Release tag does not match the resolved version." >&2
             exit 1
           fi
-          if [ "${should_publish}" != "true" ] && [ "${should_publish}" != "false" ]; then exit 1; fi
-          if [ "${should_release}" != "true" ] && [ "${should_release}" != "false" ]; then exit 1; fi
-          if [ "${dry_run}" != "true" ] && [ "${dry_run}" != "false" ]; then exit 1; fi
+          validate_boolean() {
+            field_name=$1
+            field_value=$2
+            if [ "${field_value}" != "true" ] && [ "${field_value}" != "false" ]; then
+              echo "Invalid boolean metadata value for ${field_name}: ${field_value}." >&2
+              exit 1
+            fi
+          }
+          validate_boolean publish "${should_publish}"
+          validate_boolean release "${should_release}"
+          validate_boolean dry_run "${dry_run}"
           printf 'RELEASE_TAG=%s\n' "${release_tag}" >> "$GITHUB_ENV"
           printf 'SHOULD_PUBLISH=%s\n' "${should_publish}" >> "$GITHUB_ENV"
           printf 'SHOULD_RELEASE=%s\n' "${should_release}" >> "$GITHUB_ENV"
@@ -198,6 +208,21 @@ jobs:
         if: env.SHOULD_PUBLISH == 'true'
         run: |
           set -eu
+          manifest_paths="${RUNNER_TEMP}/native-cli-manifest-paths"
+          actual_paths="${RUNNER_TEMP}/native-cli-actual-paths"
+          awk '{ print $2 }' release-input/release-assets.manifest | sed 's#^dist/release/##' | sort > "${manifest_paths}"
+          find release-input/dist/release -maxdepth 1 -type f -printf '%f\n' | sort > "${actual_paths}"
+          manifest_count=$(wc -l < "${manifest_paths}" | tr -d ' ')
+          unique_manifest_count=$(uniq "${manifest_paths}" | wc -l | tr -d ' ')
+          if [ "${manifest_count}" -ne "${unique_manifest_count}" ]; then
+            echo "Release manifest is missing files or has duplicate entries." >&2
+            exit 1
+          fi
+          if ! cmp -s "${manifest_paths}" "${actual_paths}"; then
+            echo "Unexpected release files are not listed in the manifest." >&2
+            echo "Release manifest is missing files or has duplicate entries." >&2
+            exit 1
+          fi
           asset_count=0
           while IFS=' ' read -r checksum asset_path; do
             case "${checksum}" in [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]* ) ;; *) exit 1 ;; esac
@@ -215,11 +240,26 @@ jobs:
         if: env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -eu
+          tag_error_path="${RUNNER_TEMP}/native-cli-release-tag-error"
+          set +e
+          tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha' 2> "${tag_error_path}")
+          tag_status=$?
+          set -e
+          if [ "${tag_status}" -ne 0 ]; then
+            tag_error=$(cat "${tag_error_path}")
+            case "${tag_error}" in
+              *"HTTP 404"*|*"Not Found"*) tag_sha="" ;;
+              *) printf '%s\n' "${tag_error}" >&2; exit "${tag_status}" ;;
+            esac
+          fi
+          if [ -n "${tag_sha}" ] && [ "${tag_sha}" != "${GITHUB_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
+            exit 1
+          fi
           if gh release view "${RELEASE_TAG}" --json isDraft,targetCommitish > release-input/release-state.json 2>/dev/null; then
-            target_sha=$(jq -r '.targetCommitish' release-input/release-state.json)
-            [ "${target_sha}" = "${GITHUB_SHA}" ]
             is_draft=$(jq -r '.isDraft' release-input/release-state.json)
             if [ "${is_draft}" = "false" ]; then
               echo "release_published=true" >> "$GITHUB_OUTPUT"
@@ -268,6 +308,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
+          tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha')
+          if [ "${tag_sha}" != "${GITHUB_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
+            exit 1
+          fi
           while IFS=' ' read -r checksum asset_path; do
             gh release upload "${RELEASE_TAG}" "release-input/${asset_path}" "release-input/${asset_path}.sigstore.json" --clobber
           done < release-input/release-assets.manifest
@@ -286,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
     steps:
@@ -295,6 +340,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Dispatch release-please after native CLI publish
         if: needs.build.outputs.should_publish == 'true' && github.event_name == 'push'

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -368,6 +368,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: cli/.go-version
+          cache-dependency-path: '**/go.sum'
+
       - name: Dispatch release-please after native CLI publish
         if: needs.build.outputs.should_publish == 'true' && github.event_name == 'push'
         env:

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -130,6 +130,13 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
   assert_not_contains "release-input/dist/dispatcher-release"
 }
 
+test_draft_creation_accepts_only_the_known_missing_tag_responses() {
+  assert_contains '*"HTTP 404"*) tag_sha="" ;;'
+  assert_contains '*"HTTP 422"*"No commit found for SHA"*) tag_sha="" ;;'
+  assert_not_contains '*"HTTP 422"*) tag_sha="" ;;'
+  assert_contains '*) printf '\''%s\n'\'' "${tag_error}" >&2; exit "${tag_status}" ;;'
+}
+
 test_dispatcher_publish_rechecks_the_tag_before_publishing() {
   assert_contains "      - name: Publish draft dispatcher release"
   if ! publish_draft_section | grep -F 'tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'')' >/dev/null 2>&1; then
@@ -162,6 +169,7 @@ test_unprivileged_build_uses_only_the_approved_event_commit
 test_publish_validates_metadata_without_checking_out_source
 test_dispatcher_assets_are_attested_after_the_manifest_is_verified
 test_publish_rejects_manifest_and_existing_tag_mismatches
+test_draft_creation_accepts_only_the_known_missing_tag_responses
 test_dispatcher_publish_rechecks_the_tag_before_publishing
 test_dispatcher_build_preserves_release_checks
 test_dispatcher_release_target_and_prerelease_state_remain_verified

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -62,6 +62,24 @@ publish_draft_section() {
   ' "$WORKFLOW"
 }
 
+post_publish_section() {
+  awk '
+    /^  post-publish:/ { printing = 1 }
+    printing { print }
+  ' "$WORKFLOW"
+}
+
+assert_post_publish_before() {
+  earlier=$1
+  later=$2
+  earlier_line=$(post_publish_section | grep -nF -- "$earlier" | head -n 1 | cut -d: -f 1)
+  later_line=$(post_publish_section | grep -nF -- "$later" | head -n 1 | cut -d: -f 1)
+  if [ -z "$earlier_line" ] || [ -z "$later_line" ] || [ "$earlier_line" -ge "$later_line" ]; then
+    echo "Expected post-publish '$earlier' to appear before '$later'." >&2
+    exit 1
+  fi
+}
+
 test_build_and_publish_jobs_have_separate_trust_boundaries() {
   assert_contains "  build:"
   assert_contains "  publish:"
@@ -97,7 +115,8 @@ test_publish_validates_metadata_without_checking_out_source() {
     echo "Publish job must not check out repository source." >&2
     exit 1
   fi
-  if publish_section | grep -E '^[[:space:]]+(run:[[:space:]]+)?(\./)?scripts/' >/dev/null 2>&1; then
+  installer_path_lines=$(publish_section | grep -F "scripts/" || true)
+  if [ "${installer_path_lines}" != "          for installer_path in scripts/install.ps1 scripts/install.sh; do" ]; then
     echo "Publish job must not execute repository scripts." >&2
     exit 1
   fi
@@ -170,6 +189,15 @@ test_dispatcher_release_target_and_prerelease_state_remain_verified() {
   assert_contains 'gh release edit "${RELEASE_TAG}" --draft=false --prerelease'
   assert_contains "      - name: Sync release-please package releases"
   assert_count 2 "      contents: write"
+  if ! post_publish_section | grep -F "      - name: Setup Go" >/dev/null 2>&1; then
+    echo "Post-publish job must set up the pinned Go toolchain." >&2
+    exit 1
+  fi
+  if ! post_publish_section | grep -F "          go-version-file: cli/.go-version" >/dev/null 2>&1 || ! post_publish_section | grep -F "          cache-dependency-path: '**/go.sum'" >/dev/null 2>&1; then
+    echo "Post-publish Go setup must use the repository pin and cache dependency path." >&2
+    exit 1
+  fi
+  assert_post_publish_before "      - name: Setup Go" "      - name: Sync release-please package releases"
 }
 
 test_build_and_publish_jobs_have_separate_trust_boundaries

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -54,6 +54,14 @@ publish_section() {
   ' "$WORKFLOW"
 }
 
+publish_draft_section() {
+  awk '
+    /^      - name: Publish draft dispatcher release$/ { printing = 1; next }
+    printing && /^      - name:/ { exit }
+    printing { print }
+  ' "$WORKFLOW"
+}
+
 test_build_and_publish_jobs_have_separate_trust_boundaries() {
   assert_contains "  build:"
   assert_contains "  publish:"
@@ -98,14 +106,20 @@ test_publish_validates_metadata_without_checking_out_source() {
 test_dispatcher_assets_are_attested_after_the_manifest_is_verified() {
   assert_contains "      - name: Verify release asset manifest"
   assert_contains "      - name: Attest dispatcher release assets"
-  assert_contains "          subject-path: release-input/dist/dispatcher-release/*"
+  assert_contains "          subject-path: dist/dispatcher-release/*"
   assert_contains "      - name: Attach attestation bundles to dispatcher assets"
   assert_contains "      - name: Upload dispatcher assets"
+  assert_contains "      - name: Verify remote dispatcher release assets"
+  assert_contains 'gh release view "${RELEASE_TAG}" --json assets'
+  assert_contains 'bundle_name="${asset_name}.sigstore.json"'
+  assert_contains '[ "${asset_count}" -ne 1 ] || [ "${bundle_count}" -ne 1 ] || [ "${asset_size}" -le 0 ] || [ "${bundle_size}" -le 0 ]'
   assert_contains "      - name: Verify dispatcher asset attestations"
   assert_before "      - name: Verify release asset manifest" "      - name: Attest dispatcher release assets"
   assert_before "      - name: Attest dispatcher release assets" "      - name: Verify dispatcher asset attestations"
   assert_before "      - name: Verify dispatcher asset attestations" "      - name: Attach attestation bundles to dispatcher assets"
   assert_before "      - name: Attach attestation bundles to dispatcher assets" "      - name: Upload dispatcher assets"
+  assert_before "      - name: Upload dispatcher assets" "      - name: Verify remote dispatcher release assets"
+  assert_before "      - name: Verify remote dispatcher release assets" "      - name: Publish draft dispatcher release"
 }
 
 test_publish_rejects_manifest_and_existing_tag_mismatches() {
@@ -113,6 +127,15 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
   assert_contains "Release manifest is missing files or has duplicate entries."
   assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'''
   assert_contains 'Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}.'
+  assert_not_contains "release-input/dist/dispatcher-release"
+}
+
+test_dispatcher_publish_rechecks_the_tag_before_publishing() {
+  assert_contains "      - name: Publish draft dispatcher release"
+  if ! publish_draft_section | grep -F 'tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'')' >/dev/null 2>&1; then
+    echo "Publish draft dispatcher release must recheck the release tag SHA." >&2
+    exit 1
+  fi
 }
 
 test_dispatcher_build_preserves_release_checks() {
@@ -139,5 +162,6 @@ test_unprivileged_build_uses_only_the_approved_event_commit
 test_publish_validates_metadata_without_checking_out_source
 test_dispatcher_assets_are_attested_after_the_manifest_is_verified
 test_publish_rejects_manifest_and_existing_tag_mismatches
+test_dispatcher_publish_rechecks_the_tag_before_publishing
 test_dispatcher_build_preserves_release_checks
 test_dispatcher_release_target_and_prerelease_state_remain_verified

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -97,7 +97,7 @@ test_publish_validates_metadata_without_checking_out_source() {
     echo "Publish job must not check out repository source." >&2
     exit 1
   fi
-  if publish_section | grep -E '^[[:space:]]+run:[[:space:]]+(\./)?scripts/' >/dev/null 2>&1; then
+  if publish_section | grep -E '^[[:space:]]+(run:[[:space:]]+)?(\./)?scripts/' >/dev/null 2>&1; then
     echo "Publish job must not execute repository scripts." >&2
     exit 1
   fi

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -5,120 +5,110 @@ ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
 WORKFLOW="$ROOT_DIR/.github/workflows/dispatcher-publish.yml"
 
 assert_contains() {
-  file=$1
-  expected=$2
-  if ! grep -F -- "$expected" "$file" >/dev/null 2>&1; then
-    echo "Expected $file to contain: $expected" >&2
+  expected=$1
+  if ! grep -F -- "$expected" "$WORKFLOW" >/dev/null 2>&1; then
+    echo "Expected workflow to contain: $expected" >&2
     exit 1
   fi
 }
 
 assert_not_contains() {
-  file=$1
-  unexpected=$2
-  if grep -F -- "$unexpected" "$file" >/dev/null 2>&1; then
-    echo "Expected $file not to contain: $unexpected" >&2
+  unexpected=$1
+  if grep -F -- "$unexpected" "$WORKFLOW" >/dev/null 2>&1; then
+    echo "Expected workflow not to contain: $unexpected" >&2
     exit 1
   fi
 }
 
 line_number() {
-  file=$1
-  text=$2
-  grep -nF -- "$text" "$file" | head -n 1 | cut -d: -f 1
+  text=$1
+  grep -nF -- "$text" "$WORKFLOW" | head -n 1 | cut -d: -f 1
 }
 
 assert_before() {
-  file=$1
-  earlier=$2
-  later=$3
-  earlier_line=$(line_number "$file" "$earlier")
-  later_line=$(line_number "$file" "$later")
+  earlier=$1
+  later=$2
+  earlier_line=$(line_number "$earlier")
+  later_line=$(line_number "$later")
   if [ -z "$earlier_line" ] || [ -z "$later_line" ] || [ "$earlier_line" -ge "$later_line" ]; then
-    echo "Expected '$earlier' to appear before '$later' in $file." >&2
+    echo "Expected '$earlier' to appear before '$later'." >&2
     exit 1
   fi
 }
 
-test_dispatcher_resolver_is_used() {
-  assert_contains "$WORKFLOW" "      - name: Resolve dispatcher release target"
-  assert_contains "$WORKFLOW" '          scripts/resolve-dispatcher-release-target.sh >> "$GITHUB_OUTPUT"'
+publish_section() {
+  awk '
+    /^  publish:/ { printing = 1 }
+    /^  post-publish:/ { exit }
+    printing { print }
+  ' "$WORKFLOW"
 }
 
-test_dispatcher_publish_is_serialized_by_branch() {
-  assert_contains "$WORKFLOW" "concurrency:"
-  assert_contains "$WORKFLOW" '  group: dispatcher-publish-${{ github.ref }}'
-  assert_contains "$WORKFLOW" "  cancel-in-progress: false"
+test_build_and_publish_jobs_have_separate_trust_boundaries() {
+  assert_contains "  build:"
+  assert_contains "  publish:"
+  assert_contains "    needs: build"
+  assert_contains "    environment: cli-release"
+  assert_contains "      contents: read"
+  assert_contains "      contents: write"
+  assert_contains "      id-token: write"
+  assert_contains "      attestations: write"
 }
 
-test_dispatcher_assets_are_packaged_and_verified() {
-  assert_contains "$WORKFLOW" "      - name: Package dispatcher release assets"
-  assert_contains "$WORKFLOW" "        run: scripts/package-dispatcher.sh"
-  assert_contains "$WORKFLOW" "      - name: Verify packaged dispatcher release assets"
-  assert_contains "$WORKFLOW" "        run: scripts/verify-dispatcher-release-assets.sh"
-  assert_before "$WORKFLOW" "      - name: Package dispatcher release assets" "      - name: Verify packaged dispatcher release assets"
+test_unprivileged_build_uses_only_the_approved_event_commit() {
+  assert_not_contains "inputs.ref"
+  assert_not_contains "INPUT_REF"
+  assert_contains '          ref: ${{ github.sha }}'
+  assert_contains "github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'"
 }
 
-test_installer_scripts_are_verified_before_upload() {
-  assert_contains "$WORKFLOW" "      - name: Verify release-tagged installer scripts"
-  assert_contains "$WORKFLOW" "          ./scripts/check-release-installer.ps1 -Version \$env:RELEASE_TAG"
-  assert_before "$WORKFLOW" "      - name: Create or reuse draft dispatcher release" "      - name: Verify release-tagged installer scripts"
-  assert_before "$WORKFLOW" "      - name: Verify release-tagged installer scripts" "      - name: Upload dispatcher assets"
+test_publish_validates_metadata_without_checking_out_source() {
+  assert_contains "      - name: Write release metadata"
+  assert_contains "release-metadata.env"
+  assert_contains "release-assets.manifest"
+  assert_contains "      - name: Verify release metadata"
+  assert_contains 'BUILD_SHA="${build_sha}"'
+  assert_contains 'if [ "${BUILD_SHA}" != "${GITHUB_SHA}" ] || [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then'
+  assert_contains "      - name: Download packaged dispatcher assets"
+  if publish_section | grep -F "actions/checkout" >/dev/null 2>&1; then
+    echo "Publish job must not check out repository source." >&2
+    exit 1
+  fi
+  if publish_section | grep -F "scripts/" >/dev/null 2>&1; then
+    echo "Publish job must not execute repository scripts." >&2
+    exit 1
+  fi
 }
 
-test_existing_dispatcher_tag_target_is_checked() {
-  assert_contains "$WORKFLOW" '          EXISTING_TAG_SHA=$(git rev-list -n 1 "${RELEASE_TAG}" 2>/dev/null || true)'
-  assert_contains "$WORKFLOW" '          if [ -n "${EXISTING_TAG_SHA}" ] && [ "${EXISTING_TAG_SHA}" != "${TARGET_SHA}" ]; then'
-  assert_contains "$WORKFLOW" '            echo "Dispatcher release tag ${RELEASE_TAG} points at ${EXISTING_TAG_SHA}, expected ${TARGET_SHA}." >&2'
-  assert_before "$WORKFLOW" '          EXISTING_TAG_SHA=$(git rev-list -n 1 "${RELEASE_TAG}" 2>/dev/null || true)' '      - name: Verify release-tagged installer scripts'
+test_dispatcher_assets_are_attested_after_the_manifest_is_verified() {
+  assert_contains "      - name: Verify release asset manifest"
+  assert_contains "      - name: Attest dispatcher release assets"
+  assert_contains "          subject-path: release-input/dist/dispatcher-release/*"
+  assert_contains "      - name: Attach attestation bundles to dispatcher assets"
+  assert_contains "      - name: Upload dispatcher assets"
 }
 
-test_dispatcher_draft_state_uses_runner_temp() {
-  assert_contains "$WORKFLOW" '          DRAFT_STATE_PATH="${RUNNER_TEMP}/dispatcher-release-draft-${GITHUB_RUN_ID}"'
-  assert_contains "$WORKFLOW" '          if gh release view "${RELEASE_TAG}" --json isDraft --jq '"'"'.isDraft'"'"' >"${DRAFT_STATE_PATH}" 2>/dev/null; then'
-  assert_contains "$WORKFLOW" '            IS_DRAFT=$(cat "${DRAFT_STATE_PATH}")'
-  assert_not_contains "$WORKFLOW" "/tmp/dispatcher-release-draft"
+test_dispatcher_build_preserves_release_checks() {
+  assert_contains "concurrency:"
+  assert_contains '  group: dispatcher-publish-${{ github.ref }}'
+  assert_contains "      - name: Package dispatcher release assets"
+  assert_contains "      - name: Verify packaged dispatcher release assets"
+  assert_contains "      - name: Verify release-tagged installer scripts"
+  assert_before "      - name: Package dispatcher release assets" "      - name: Verify packaged dispatcher release assets"
+  assert_before "      - name: Verify packaged dispatcher release assets" "      - name: Verify release-tagged installer scripts"
+  assert_before "      - name: Verify release-tagged installer scripts" "      - name: Write release metadata"
 }
 
-test_dispatcher_beta_releases_are_marked_prerelease() {
-  assert_contains "$WORKFLOW" '          RELEASE_PRERELEASE: ${{ steps.release.outputs.prerelease }}'
-  assert_contains "$WORKFLOW" '          GITHUB_REPOSITORY: ${{ github.repository }}'
-  assert_contains "$WORKFLOW" '          PRERELEASE_FLAG=""'
-  assert_contains "$WORKFLOW" '          LATEST_FLAG=""'
-  assert_contains "$WORKFLOW" '          if [ "${RELEASE_PRERELEASE}" = "true" ]; then'
-  assert_contains "$WORKFLOW" '            PRERELEASE_FLAG="--prerelease"'
-  assert_contains "$WORKFLOW" '            LATEST_FLAG="--latest=false"'
-  assert_contains "$WORKFLOW" '            ${PRERELEASE_FLAG} \'
-  assert_contains "$WORKFLOW" '            ${LATEST_FLAG}'
-  assert_contains "$WORKFLOW" '            gh release edit "${RELEASE_TAG}" --draft=false --prerelease'
-  assert_contains "$WORKFLOW" '            RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq '"'"'.id'"'"')'
-  assert_contains "$WORKFLOW" '            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F prerelease=true -F make_latest=false >/dev/null'
-  assert_before "$WORKFLOW" '            PRERELEASE_FLAG="--prerelease"' '          gh release create "${RELEASE_TAG}" \'
-  assert_before "$WORKFLOW" '            gh release edit "${RELEASE_TAG}" --draft=false --prerelease' '      - name: Sync release-please package releases'
+test_dispatcher_release_target_and_prerelease_state_remain_verified() {
+  assert_contains 'target_sha=$(jq -r '\''.targetCommitish'\'' release-input/release-state.json)'
+  assert_contains '[ "${target_sha}" = "${GITHUB_SHA}" ]'
+  assert_contains 'gh release edit "${RELEASE_TAG}" --draft=false --prerelease'
+  assert_contains "      - name: Sync release-please package releases"
 }
 
-test_package_release_sync_runs_after_dispatcher_publish() {
-  assert_contains "$WORKFLOW" "      - name: Sync release-please package releases"
-  assert_before "$WORKFLOW" "      - name: Publish draft dispatcher release" "      - name: Sync release-please package releases"
-}
-
-test_dispatcher_attestation_bundles_are_distributed_per_asset() {
-  assert_contains "$WORKFLOW" "      - name: Distribute attestation bundles per asset"
-  assert_contains "$WORKFLOW" "          scripts/distribute-attestation-bundles.sh \\"
-  assert_contains "$WORKFLOW" "            --bundle \"\${BUNDLE_PATH}\" \\"
-  assert_contains "$WORKFLOW" "            --release-dir dist/dispatcher-release"
-  assert_before "$WORKFLOW" "      - name: Verify dispatcher asset attestations" "      - name: Distribute attestation bundles per asset"
-  assert_before "$WORKFLOW" "      - name: Distribute attestation bundles per asset" "      - name: Upload dispatcher assets"
-  assert_contains "$WORKFLOW" "          BUNDLE_NAME=\"\${asset_name}.sigstore.json\""
-  assert_contains "$WORKFLOW" "              echo \"Missing remote dispatcher attestation bundle: \${BUNDLE_NAME}\" >&2"
-}
-
-test_dispatcher_resolver_is_used
-test_dispatcher_publish_is_serialized_by_branch
-test_dispatcher_assets_are_packaged_and_verified
-test_installer_scripts_are_verified_before_upload
-test_existing_dispatcher_tag_target_is_checked
-test_dispatcher_draft_state_uses_runner_temp
-test_dispatcher_beta_releases_are_marked_prerelease
-test_package_release_sync_runs_after_dispatcher_publish
-test_dispatcher_attestation_bundles_are_distributed_per_asset
+test_build_and_publish_jobs_have_separate_trust_boundaries
+test_unprivileged_build_uses_only_the_approved_event_commit
+test_publish_validates_metadata_without_checking_out_source
+test_dispatcher_assets_are_attested_after_the_manifest_is_verified
+test_dispatcher_build_preserves_release_checks
+test_dispatcher_release_target_and_prerelease_state_remain_verified

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -132,8 +132,8 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
 
 test_draft_creation_accepts_only_the_known_missing_tag_responses() {
   assert_contains '*"HTTP 404"*) tag_sha="" ;;'
-  assert_contains '*"HTTP 422"*"No commit found for SHA"*) tag_sha="" ;;'
-  assert_not_contains '*"HTTP 422"*) tag_sha="" ;;'
+  assert_contains '*"HTTP 422"*"No commit found for SHA"*|*"No commit found for SHA"*"HTTP 422"*) tag_sha="" ;;'
+  assert_count 2 'tag_sha="" ;;'
   assert_contains '*) printf '\''%s\n'\'' "${tag_error}" >&2; exit "${tag_status}" ;;'
 }
 

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -36,6 +36,16 @@ assert_before() {
   fi
 }
 
+assert_count() {
+  expected_count=$1
+  text=$2
+  actual_count=$(grep -Fc -- "$text" "$WORKFLOW")
+  if [ "$actual_count" -ne "$expected_count" ]; then
+    echo "Expected '$text' to appear $expected_count times, found $actual_count." >&2
+    exit 1
+  fi
+}
+
 publish_section() {
   awk '
     /^  publish:/ { printing = 1 }
@@ -53,12 +63,14 @@ test_build_and_publish_jobs_have_separate_trust_boundaries() {
   assert_contains "      contents: write"
   assert_contains "      id-token: write"
   assert_contains "      attestations: write"
+  assert_contains "      artifact-metadata: write"
 }
 
 test_unprivileged_build_uses_only_the_approved_event_commit() {
   assert_not_contains "inputs.ref"
   assert_not_contains "INPUT_REF"
   assert_contains '          ref: ${{ github.sha }}'
+  assert_count 2 "          persist-credentials: false"
   assert_contains "github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'"
 }
 
@@ -70,6 +82,9 @@ test_publish_validates_metadata_without_checking_out_source() {
   assert_contains 'BUILD_SHA="${build_sha}"'
   assert_contains 'if [ "${BUILD_SHA}" != "${GITHUB_SHA}" ] || [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then'
   assert_contains "      - name: Download packaged dispatcher assets"
+  assert_contains "          path: ."
+  assert_contains "            dist/dispatcher-release"
+  assert_contains "            release-input"
   if publish_section | grep -F "actions/checkout" >/dev/null 2>&1; then
     echo "Publish job must not check out repository source." >&2
     exit 1
@@ -86,6 +101,18 @@ test_dispatcher_assets_are_attested_after_the_manifest_is_verified() {
   assert_contains "          subject-path: release-input/dist/dispatcher-release/*"
   assert_contains "      - name: Attach attestation bundles to dispatcher assets"
   assert_contains "      - name: Upload dispatcher assets"
+  assert_contains "      - name: Verify dispatcher asset attestations"
+  assert_before "      - name: Verify release asset manifest" "      - name: Attest dispatcher release assets"
+  assert_before "      - name: Attest dispatcher release assets" "      - name: Verify dispatcher asset attestations"
+  assert_before "      - name: Verify dispatcher asset attestations" "      - name: Attach attestation bundles to dispatcher assets"
+  assert_before "      - name: Attach attestation bundles to dispatcher assets" "      - name: Upload dispatcher assets"
+}
+
+test_publish_rejects_manifest_and_existing_tag_mismatches() {
+  assert_contains "Unexpected release files are not listed in the manifest."
+  assert_contains "Release manifest is missing files or has duplicate entries."
+  assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'''
+  assert_contains 'Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}.'
 }
 
 test_dispatcher_build_preserves_release_checks() {
@@ -100,15 +127,17 @@ test_dispatcher_build_preserves_release_checks() {
 }
 
 test_dispatcher_release_target_and_prerelease_state_remain_verified() {
-  assert_contains 'target_sha=$(jq -r '\''.targetCommitish'\'' release-input/release-state.json)'
-  assert_contains '[ "${target_sha}" = "${GITHUB_SHA}" ]'
+  assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'''
+  assert_contains 'Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}.'
   assert_contains 'gh release edit "${RELEASE_TAG}" --draft=false --prerelease'
   assert_contains "      - name: Sync release-please package releases"
+  assert_count 2 "      contents: write"
 }
 
 test_build_and_publish_jobs_have_separate_trust_boundaries
 test_unprivileged_build_uses_only_the_approved_event_commit
 test_publish_validates_metadata_without_checking_out_source
 test_dispatcher_assets_are_attested_after_the_manifest_is_verified
+test_publish_rejects_manifest_and_existing_tag_mismatches
 test_dispatcher_build_preserves_release_checks
 test_dispatcher_release_target_and_prerelease_state_remain_verified

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -97,7 +97,7 @@ test_publish_validates_metadata_without_checking_out_source() {
     echo "Publish job must not check out repository source." >&2
     exit 1
   fi
-  if publish_section | grep -F "scripts/" >/dev/null 2>&1; then
+  if publish_section | grep -E '^[[:space:]]+run:[[:space:]]+(\./)?scripts/' >/dev/null 2>&1; then
     echo "Publish job must not execute repository scripts." >&2
     exit 1
   fi
@@ -120,6 +120,16 @@ test_dispatcher_assets_are_attested_after_the_manifest_is_verified() {
   assert_before "      - name: Attach attestation bundles to dispatcher assets" "      - name: Upload dispatcher assets"
   assert_before "      - name: Upload dispatcher assets" "      - name: Verify remote dispatcher release assets"
   assert_before "      - name: Verify remote dispatcher release assets" "      - name: Publish draft dispatcher release"
+}
+
+test_dispatcher_verifies_tagged_installers_after_draft_creation() {
+  assert_contains "      - name: Verify tagged dispatcher installer scripts"
+  assert_contains 'for installer_path in scripts/install.ps1 scripts/install.sh; do'
+  assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/contents/${installer_path}?ref=${RELEASE_TAG}" --jq '\''.size'\'''
+  assert_contains '[ "${installer_size}" -gt 0 ]'
+  assert_before "      - name: Create or reuse draft dispatcher release" "      - name: Verify tagged dispatcher installer scripts"
+  assert_before "      - name: Verify tagged dispatcher installer scripts" "      - name: Upload dispatcher assets"
+  assert_before "      - name: Verify tagged dispatcher installer scripts" "      - name: Publish draft dispatcher release"
 }
 
 test_publish_rejects_manifest_and_existing_tag_mismatches() {
@@ -150,10 +160,8 @@ test_dispatcher_build_preserves_release_checks() {
   assert_contains '  group: dispatcher-publish-${{ github.ref }}'
   assert_contains "      - name: Package dispatcher release assets"
   assert_contains "      - name: Verify packaged dispatcher release assets"
-  assert_contains "      - name: Verify release-tagged installer scripts"
   assert_before "      - name: Package dispatcher release assets" "      - name: Verify packaged dispatcher release assets"
-  assert_before "      - name: Verify packaged dispatcher release assets" "      - name: Verify release-tagged installer scripts"
-  assert_before "      - name: Verify release-tagged installer scripts" "      - name: Write release metadata"
+  assert_before "      - name: Verify packaged dispatcher release assets" "      - name: Write release metadata"
 }
 
 test_dispatcher_release_target_and_prerelease_state_remain_verified() {
@@ -168,6 +176,7 @@ test_build_and_publish_jobs_have_separate_trust_boundaries
 test_unprivileged_build_uses_only_the_approved_event_commit
 test_publish_validates_metadata_without_checking_out_source
 test_dispatcher_assets_are_attested_after_the_manifest_is_verified
+test_dispatcher_verifies_tagged_installers_after_draft_creation
 test_publish_rejects_manifest_and_existing_tag_mismatches
 test_draft_creation_accepts_only_the_known_missing_tag_responses
 test_dispatcher_publish_rechecks_the_tag_before_publishing

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -131,6 +131,13 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
   assert_not_contains "release-input/dist/release"
 }
 
+test_draft_creation_accepts_only_the_known_missing_tag_responses() {
+  assert_contains '*"HTTP 404"*) tag_sha="" ;;'
+  assert_contains '*"HTTP 422"*"No commit found for SHA"*) tag_sha="" ;;'
+  assert_not_contains '*"HTTP 422"*) tag_sha="" ;;'
+  assert_contains '*) printf '\''%s\n'\'' "${tag_error}" >&2; exit "${tag_status}" ;;'
+}
+
 test_publish_rechecks_the_tag_and_uses_least_privilege_post_publish_permissions() {
   assert_contains "      - name: Publish draft release"
   if ! publish_draft_section | grep -F 'tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'')' >/dev/null 2>&1; then
@@ -160,6 +167,7 @@ test_unprivileged_build_uses_only_the_approved_event_commit
 test_publish_validates_metadata_without_checking_out_source
 test_assets_are_attested_after_the_manifest_is_verified
 test_publish_rejects_manifest_and_existing_tag_mismatches
+test_draft_creation_accepts_only_the_known_missing_tag_responses
 test_publish_rechecks_the_tag_and_uses_least_privilege_post_publish_permissions
 test_build_verifies_assets_before_writing_the_publish_input
 test_post_publish_automation_remains_outside_the_privileged_job

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -133,8 +133,8 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
 
 test_draft_creation_accepts_only_the_known_missing_tag_responses() {
   assert_contains '*"HTTP 404"*) tag_sha="" ;;'
-  assert_contains '*"HTTP 422"*"No commit found for SHA"*) tag_sha="" ;;'
-  assert_not_contains '*"HTTP 422"*) tag_sha="" ;;'
+  assert_contains '*"HTTP 422"*"No commit found for SHA"*|*"No commit found for SHA"*"HTTP 422"*) tag_sha="" ;;'
+  assert_count 2 'tag_sha="" ;;'
   assert_contains '*) printf '\''%s\n'\'' "${tag_error}" >&2; exit "${tag_status}" ;;'
 }
 

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -36,6 +36,16 @@ assert_before() {
   fi
 }
 
+assert_count() {
+  expected_count=$1
+  text=$2
+  actual_count=$(grep -Fc -- "$text" "$WORKFLOW")
+  if [ "$actual_count" -ne "$expected_count" ]; then
+    echo "Expected '$text' to appear $expected_count times, found $actual_count." >&2
+    exit 1
+  fi
+}
+
 publish_section() {
   awk '
     /^  publish:/ { printing = 1 }
@@ -53,6 +63,7 @@ test_build_and_publish_jobs_have_separate_trust_boundaries() {
   assert_contains "      contents: write"
   assert_contains "      id-token: write"
   assert_contains "      attestations: write"
+  assert_contains "      artifact-metadata: write"
 }
 
 test_unprivileged_build_uses_only_the_approved_event_commit() {
@@ -60,6 +71,7 @@ test_unprivileged_build_uses_only_the_approved_event_commit() {
   assert_not_contains "inputs.release-tag"
   assert_not_contains "INPUT_REF"
   assert_contains '          ref: ${{ github.sha }}'
+  assert_count 2 "          persist-credentials: false"
   assert_contains "github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'"
 }
 
@@ -71,6 +83,9 @@ test_publish_validates_metadata_without_checking_out_source() {
   assert_contains 'BUILD_SHA="${build_sha}"'
   assert_contains 'if [ "${BUILD_SHA}" != "${GITHUB_SHA}" ] || [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then'
   assert_contains "      - name: Download packaged release assets"
+  assert_contains "          path: ."
+  assert_contains "            dist/release"
+  assert_contains "            release-input"
   if publish_section | grep -F "actions/checkout" >/dev/null 2>&1; then
     echo "Publish job must not check out repository source." >&2
     exit 1
@@ -87,6 +102,18 @@ test_assets_are_attested_after_the_manifest_is_verified() {
   assert_contains "          subject-path: release-input/dist/release/*"
   assert_contains "      - name: Attach attestation bundles to release assets"
   assert_contains "      - name: Upload native CLI assets"
+  assert_contains "      - name: Verify native CLI asset attestations"
+  assert_before "      - name: Verify release asset manifest" "      - name: Attest native CLI release assets"
+  assert_before "      - name: Attest native CLI release assets" "      - name: Verify native CLI asset attestations"
+  assert_before "      - name: Verify native CLI asset attestations" "      - name: Attach attestation bundles to release assets"
+  assert_before "      - name: Attach attestation bundles to release assets" "      - name: Upload native CLI assets"
+}
+
+test_publish_rejects_manifest_and_existing_tag_mismatches() {
+  assert_contains "Unexpected release files are not listed in the manifest."
+  assert_contains "Release manifest is missing files or has duplicate entries."
+  assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'''
+  assert_contains 'Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}.'
 }
 
 test_build_verifies_assets_before_writing_the_publish_input() {
@@ -101,11 +128,13 @@ test_post_publish_automation_remains_outside_the_privileged_job() {
   assert_contains "      - name: Dispatch release-please after native CLI publish"
   assert_contains "      - name: Sync release-please package releases"
   assert_contains "      - name: Mark release PR as tagged"
+  assert_count 2 "      contents: write"
 }
 
 test_build_and_publish_jobs_have_separate_trust_boundaries
 test_unprivileged_build_uses_only_the_approved_event_commit
 test_publish_validates_metadata_without_checking_out_source
 test_assets_are_attested_after_the_manifest_is_verified
+test_publish_rejects_manifest_and_existing_tag_mismatches
 test_build_verifies_assets_before_writing_the_publish_input
 test_post_publish_automation_remains_outside_the_privileged_job

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -5,88 +5,107 @@ ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
 WORKFLOW="$ROOT_DIR/.github/workflows/native-cli-publish.yml"
 
 assert_contains() {
-  file=$1
-  expected=$2
-  if ! grep -F -- "$expected" "$file" >/dev/null 2>&1; then
-    echo "Expected $file to contain: $expected" >&2
+  expected=$1
+  if ! grep -F -- "$expected" "$WORKFLOW" >/dev/null 2>&1; then
+    echo "Expected workflow to contain: $expected" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  unexpected=$1
+  if grep -F -- "$unexpected" "$WORKFLOW" >/dev/null 2>&1; then
+    echo "Expected workflow not to contain: $unexpected" >&2
     exit 1
   fi
 }
 
 line_number() {
-  file=$1
-  text=$2
-  grep -nF -- "$text" "$file" | head -n 1 | cut -d: -f 1
+  text=$1
+  grep -nF -- "$text" "$WORKFLOW" | head -n 1 | cut -d: -f 1
 }
 
 assert_before() {
-  file=$1
-  earlier=$2
-  later=$3
-  earlier_line=$(line_number "$file" "$earlier")
-  later_line=$(line_number "$file" "$later")
+  earlier=$1
+  later=$2
+  earlier_line=$(line_number "$earlier")
+  later_line=$(line_number "$later")
   if [ -z "$earlier_line" ] || [ -z "$later_line" ] || [ "$earlier_line" -ge "$later_line" ]; then
-    echo "Expected '$earlier' to appear before '$later' in $file." >&2
+    echo "Expected '$earlier' to appear before '$later'." >&2
     exit 1
   fi
 }
 
-test_attestation_permissions() {
-  assert_contains "$WORKFLOW" "  actions: write"
-  assert_contains "$WORKFLOW" "  id-token: write"
-  assert_contains "$WORKFLOW" "  attestations: write"
-  assert_contains "$WORKFLOW" "  artifact-metadata: write"
+publish_section() {
+  awk '
+    /^  publish:/ { printing = 1 }
+    /^  post-publish:/ { exit }
+    printing { print }
+  ' "$WORKFLOW"
 }
 
-test_go_is_available_for_package_release_sync() {
-  assert_contains "$WORKFLOW" "      - name: Setup Go"
-  assert_contains "$WORKFLOW" "        if: steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true'"
-  assert_before "$WORKFLOW" "      - name: Setup Go" "      - name: Sync release-please package releases"
+test_build_and_publish_jobs_have_separate_trust_boundaries() {
+  assert_contains "  build:"
+  assert_contains "  publish:"
+  assert_contains "    needs: build"
+  assert_contains "    environment: cli-release"
+  assert_contains "      contents: read"
+  assert_contains "      contents: write"
+  assert_contains "      id-token: write"
+  assert_contains "      attestations: write"
 }
 
-test_release_assets_are_attested() {
-  assert_contains "$WORKFLOW" "      - name: Attest native CLI release assets"
-  assert_contains "$WORKFLOW" "        if: steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'"
-  assert_contains "$WORKFLOW" "        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26"
-  assert_contains "$WORKFLOW" "          subject-path: dist/release/*"
-  assert_before "$WORKFLOW" "      - name: Verify packaged release assets" "      - name: Attest native CLI release assets"
-  assert_before "$WORKFLOW" "      - name: Attest native CLI release assets" "      - name: Upload native CLI assets"
+test_unprivileged_build_uses_only_the_approved_event_commit() {
+  assert_not_contains "inputs.ref"
+  assert_not_contains "inputs.release-tag"
+  assert_not_contains "INPUT_REF"
+  assert_contains '          ref: ${{ github.sha }}'
+  assert_contains "github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v3-beta'"
 }
 
-test_release_asset_attestations_are_verified() {
-  assert_contains "$WORKFLOW" "      - name: Verify native CLI asset attestations"
-  assert_contains "$WORKFLOW" '          SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/native-cli-publish.yml'
-  assert_contains "$WORKFLOW" '          for asset_path in dist/release/*; do'
-  assert_contains "$WORKFLOW" '            gh attestation verify "${asset_path}" \'
-  assert_contains "$WORKFLOW" '              --repo "${GITHUB_REPOSITORY}" \'
-  assert_contains "$WORKFLOW" '              --signer-workflow "${SIGNER_WORKFLOW}"'
-  assert_before "$WORKFLOW" "      - name: Attest native CLI release assets" "      - name: Verify native CLI asset attestations"
-  assert_before "$WORKFLOW" "      - name: Verify native CLI asset attestations" "      - name: Upload native CLI assets"
+test_publish_validates_metadata_without_checking_out_source() {
+  assert_contains "      - name: Write release metadata"
+  assert_contains "release-metadata.env"
+  assert_contains "release-assets.manifest"
+  assert_contains "      - name: Verify release metadata"
+  assert_contains 'BUILD_SHA="${build_sha}"'
+  assert_contains 'if [ "${BUILD_SHA}" != "${GITHUB_SHA}" ] || [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then'
+  assert_contains "      - name: Download packaged release assets"
+  if publish_section | grep -F "actions/checkout" >/dev/null 2>&1; then
+    echo "Publish job must not check out repository source." >&2
+    exit 1
+  fi
+  if publish_section | grep -F "scripts/" >/dev/null 2>&1; then
+    echo "Publish job must not execute repository scripts." >&2
+    exit 1
+  fi
 }
 
-test_release_please_is_dispatched_after_publish() {
-  assert_contains "$WORKFLOW" "      - name: Dispatch release-please after native CLI publish"
-  assert_contains "$WORKFLOW" "        if: github.event_name == 'push' && steps.release.outputs.publish == 'true' && steps.release.outputs.dry_run != 'true'"
-  assert_contains "$WORKFLOW" '          TARGET_BRANCH: ${{ github.ref_name }}'
-  assert_contains "$WORKFLOW" '          gh workflow run release-please.yml --ref "${TARGET_BRANCH}" -f branch="${TARGET_BRANCH}"'
-  assert_before "$WORKFLOW" "      - name: Publish draft release" "      - name: Dispatch release-please after native CLI publish"
-  assert_before "$WORKFLOW" "      - name: Dispatch release-please after native CLI publish" "      - name: Sync release-please package releases"
+test_assets_are_attested_after_the_manifest_is_verified() {
+  assert_contains "      - name: Verify release asset manifest"
+  assert_contains "      - name: Attest native CLI release assets"
+  assert_contains "          subject-path: release-input/dist/release/*"
+  assert_contains "      - name: Attach attestation bundles to release assets"
+  assert_contains "      - name: Upload native CLI assets"
 }
 
-test_native_cli_attestation_bundles_are_distributed_per_asset() {
-  assert_contains "$WORKFLOW" "      - name: Distribute attestation bundles per asset"
-  assert_contains "$WORKFLOW" "          scripts/distribute-attestation-bundles.sh \\"
-  assert_contains "$WORKFLOW" "            --bundle \"\${BUNDLE_PATH}\" \\"
-  assert_contains "$WORKFLOW" "            --release-dir dist/release"
-  assert_before "$WORKFLOW" "      - name: Verify native CLI asset attestations" "      - name: Distribute attestation bundles per asset"
-  assert_before "$WORKFLOW" "      - name: Distribute attestation bundles per asset" "      - name: Upload native CLI assets"
-  assert_contains "$WORKFLOW" "          BUNDLE_NAME=\"\${asset_name}.sigstore.json\""
-  assert_contains "$WORKFLOW" "              echo \"Missing remote native CLI attestation bundle: \${BUNDLE_NAME}\" >&2"
+test_build_verifies_assets_before_writing_the_publish_input() {
+  assert_contains "      - name: Package native CLI release assets"
+  assert_contains "      - name: Verify packaged release assets"
+  assert_before "      - name: Package native CLI release assets" "      - name: Verify packaged release assets"
+  assert_before "      - name: Verify packaged release assets" "      - name: Write release metadata"
 }
 
-test_attestation_permissions
-test_go_is_available_for_package_release_sync
-test_release_assets_are_attested
-test_release_asset_attestations_are_verified
-test_release_please_is_dispatched_after_publish
-test_native_cli_attestation_bundles_are_distributed_per_asset
+test_post_publish_automation_remains_outside_the_privileged_job() {
+  assert_contains "  post-publish:"
+  assert_contains "      - name: Dispatch release-please after native CLI publish"
+  assert_contains "      - name: Sync release-please package releases"
+  assert_contains "      - name: Mark release PR as tagged"
+}
+
+test_build_and_publish_jobs_have_separate_trust_boundaries
+test_unprivileged_build_uses_only_the_approved_event_commit
+test_publish_validates_metadata_without_checking_out_source
+test_assets_are_attested_after_the_manifest_is_verified
+test_build_verifies_assets_before_writing_the_publish_input
+test_post_publish_automation_remains_outside_the_privileged_job

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -54,6 +54,14 @@ publish_section() {
   ' "$WORKFLOW"
 }
 
+publish_draft_section() {
+  awk '
+    /^      - name: Publish draft release$/ { printing = 1; next }
+    printing && /^      - name:/ { exit }
+    printing { print }
+  ' "$WORKFLOW"
+}
+
 test_build_and_publish_jobs_have_separate_trust_boundaries() {
   assert_contains "  build:"
   assert_contains "  publish:"
@@ -99,14 +107,20 @@ test_publish_validates_metadata_without_checking_out_source() {
 test_assets_are_attested_after_the_manifest_is_verified() {
   assert_contains "      - name: Verify release asset manifest"
   assert_contains "      - name: Attest native CLI release assets"
-  assert_contains "          subject-path: release-input/dist/release/*"
+  assert_contains "          subject-path: dist/release/*"
   assert_contains "      - name: Attach attestation bundles to release assets"
   assert_contains "      - name: Upload native CLI assets"
+  assert_contains "      - name: Verify remote release assets"
+  assert_contains 'gh release view "${RELEASE_TAG}" --json assets'
+  assert_contains 'bundle_name="${asset_name}.sigstore.json"'
+  assert_contains '[ "${asset_count}" -ne 1 ] || [ "${bundle_count}" -ne 1 ] || [ "${asset_size}" -le 0 ] || [ "${bundle_size}" -le 0 ]'
   assert_contains "      - name: Verify native CLI asset attestations"
   assert_before "      - name: Verify release asset manifest" "      - name: Attest native CLI release assets"
   assert_before "      - name: Attest native CLI release assets" "      - name: Verify native CLI asset attestations"
   assert_before "      - name: Verify native CLI asset attestations" "      - name: Attach attestation bundles to release assets"
   assert_before "      - name: Attach attestation bundles to release assets" "      - name: Upload native CLI assets"
+  assert_before "      - name: Upload native CLI assets" "      - name: Verify remote release assets"
+  assert_before "      - name: Verify remote release assets" "      - name: Publish draft release"
 }
 
 test_publish_rejects_manifest_and_existing_tag_mismatches() {
@@ -114,6 +128,16 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
   assert_contains "Release manifest is missing files or has duplicate entries."
   assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'''
   assert_contains 'Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}.'
+  assert_not_contains "release-input/dist/release"
+}
+
+test_publish_rechecks_the_tag_and_uses_least_privilege_post_publish_permissions() {
+  assert_contains "      - name: Publish draft release"
+  if ! publish_draft_section | grep -F 'tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'')' >/dev/null 2>&1; then
+    echo "Publish draft release must recheck the release tag SHA." >&2
+    exit 1
+  fi
+  assert_not_contains "      issues: write"
 }
 
 test_build_verifies_assets_before_writing_the_publish_input() {
@@ -136,5 +160,6 @@ test_unprivileged_build_uses_only_the_approved_event_commit
 test_publish_validates_metadata_without_checking_out_source
 test_assets_are_attested_after_the_manifest_is_verified
 test_publish_rejects_manifest_and_existing_tag_mismatches
+test_publish_rechecks_the_tag_and_uses_least_privilege_post_publish_permissions
 test_build_verifies_assets_before_writing_the_publish_input
 test_post_publish_automation_remains_outside_the_privileged_job

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -62,6 +62,24 @@ publish_draft_section() {
   ' "$WORKFLOW"
 }
 
+post_publish_section() {
+  awk '
+    /^  post-publish:/ { printing = 1 }
+    printing { print }
+  ' "$WORKFLOW"
+}
+
+assert_post_publish_before() {
+  earlier=$1
+  later=$2
+  earlier_line=$(post_publish_section | grep -nF -- "$earlier" | head -n 1 | cut -d: -f 1)
+  later_line=$(post_publish_section | grep -nF -- "$later" | head -n 1 | cut -d: -f 1)
+  if [ -z "$earlier_line" ] || [ -z "$later_line" ] || [ "$earlier_line" -ge "$later_line" ]; then
+    echo "Expected post-publish '$earlier' to appear before '$later'." >&2
+    exit 1
+  fi
+}
+
 test_build_and_publish_jobs_have_separate_trust_boundaries() {
   assert_contains "  build:"
   assert_contains "  publish:"
@@ -160,6 +178,15 @@ test_post_publish_automation_remains_outside_the_privileged_job() {
   assert_contains "      - name: Sync release-please package releases"
   assert_contains "      - name: Mark release PR as tagged"
   assert_count 2 "      contents: write"
+  if ! post_publish_section | grep -F "      - name: Setup Go" >/dev/null 2>&1; then
+    echo "Post-publish job must set up the pinned Go toolchain." >&2
+    exit 1
+  fi
+  if ! post_publish_section | grep -F "          go-version-file: cli/.go-version" >/dev/null 2>&1 || ! post_publish_section | grep -F "          cache-dependency-path: '**/go.sum'" >/dev/null 2>&1; then
+    echo "Post-publish Go setup must use the repository pin and cache dependency path." >&2
+    exit 1
+  fi
+  assert_post_publish_before "      - name: Setup Go" "      - name: Sync release-please package releases"
 }
 
 test_build_and_publish_jobs_have_separate_trust_boundaries


### PR DESCRIPTION
Refs: CLI distribution security hardening plan, PR-1 (To-Do 2-6)

## Summary
- Release builds now run with read-only repository access.
- A protected publish job verifies the build commit, release target, version, tag, and asset manifest before it attests or uploads any asset.

## Critical finding
A collaborator with write access, or an attacker using a compromised maintainer account, could previously submit an arbitrary ref to a privileged manual workflow. That ref could execute repository scripts with release-write and OIDC credentials.

## Trust boundary
```text
approved github.sha
  -> read-only build job
  -> verified asset manifest + build metadata
  -> cli-release Environment approval
  -> publish job verifies build SHA = tag target SHA = github.sha
  -> OIDC attestation and Release upload
```
The publish job neither checks out repository source nor executes repository scripts. It only processes the artifact produced by the read-only build job.

## Changes
- Removed manual ref and release-tag selection. Both workflows explicitly allow only main and v3-beta event refs and checkout github.sha.
- Split each workflow into build, protected publish, and lower-privilege post-publish jobs.
- Added fail-closed metadata and digest-manifest validation before attestation and upload.
- Added workflow regression tests for permission separation, SHA equality, and the no-checkout publish boundary.

## Rollback
Disable the affected publish workflow, remove any assets created by the affected run, then revert this PR. Do not bypass the cli-release Environment while investigating an incident.

## Deployment blocker
Before this PR is merged or a non-dry publish is run, repository owners must create and protect the cli-release Environment with required reviewers and branch restrictions for main and v3-beta.

## Verification
- scripts/test-native-cli-publish-workflow.sh
- scripts/test-dispatcher-publish-workflow.sh
- scripts/test-resolve-native-cli-release-target.sh
- scripts/test-resolve-dispatcher-release-target.sh
- scripts/test-verify-native-cli-release-assets.sh
- scripts/test-verify-dispatcher-release-assets.sh
- scripts/test-distribute-attestation-bundles.sh
- actionlint 1.7.7
- release trigger guard

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

