### PR TITLE
Fix checkout-free publish repository context

### DIFF
--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -134,6 +134,8 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Download packaged dispatcher assets
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -144,6 +144,8 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Download packaged release assets
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -122,6 +122,13 @@ test_publish_validates_metadata_without_checking_out_source() {
   fi
 }
 
+test_checkout_free_publish_has_explicit_repository_context() {
+  if ! publish_section | grep -F '    GH_REPO: ${{ github.repository }}' >/dev/null 2>&1; then
+    echo "Checkout-free publish job must define GH_REPO for gh release commands." >&2
+    exit 1
+  fi
+}
+
 test_dispatcher_assets_are_attested_after_the_manifest_is_verified() {
   assert_contains "      - name: Verify release asset manifest"
   assert_contains "      - name: Attest dispatcher release assets"
@@ -203,6 +210,7 @@ test_dispatcher_release_target_and_prerelease_state_remain_verified() {
 test_build_and_publish_jobs_have_separate_trust_boundaries
 test_unprivileged_build_uses_only_the_approved_event_commit
 test_publish_validates_metadata_without_checking_out_source
+test_checkout_free_publish_has_explicit_repository_context
 test_dispatcher_assets_are_attested_after_the_manifest_is_verified
 test_dispatcher_verifies_tagged_installers_after_draft_creation
 test_publish_rejects_manifest_and_existing_tag_mismatches

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -122,6 +122,13 @@ test_publish_validates_metadata_without_checking_out_source() {
   fi
 }
 
+test_checkout_free_publish_has_explicit_repository_context() {
+  if ! publish_section | grep -F '    GH_REPO: ${{ github.repository }}' >/dev/null 2>&1; then
+    echo "Checkout-free publish job must define GH_REPO for gh release commands." >&2
+    exit 1
+  fi
+}
+
 test_assets_are_attested_after_the_manifest_is_verified() {
   assert_contains "      - name: Verify release asset manifest"
   assert_contains "      - name: Attest native CLI release assets"
@@ -192,6 +199,7 @@ test_post_publish_automation_remains_outside_the_privileged_job() {
 test_build_and_publish_jobs_have_separate_trust_boundaries
 test_unprivileged_build_uses_only_the_approved_event_commit
 test_publish_validates_metadata_without_checking_out_source
+test_checkout_free_publish_has_explicit_repository_context
 test_assets_are_attested_after_the_manifest_is_verified
 test_publish_rejects_manifest_and_existing_tag_mismatches
 test_draft_creation_accepts_only_the_known_missing_tag_responses


### PR DESCRIPTION
## Summary

Fix checkout-free native and dispatcher publish jobs so every `gh release` operation has explicit repository context.

## Root cause and fix

The PR-1 publish boundary intentionally has no repository checkout. `gh release view/create/upload/edit` nevertheless attempted to infer the repository from a local git remote, producing `fatal: not a git repository` during the first real release. The publish jobs now set `GH_REPO: ${{ github.repository }}` at job scope, and both workflow tests assert that this context remains present.

## Security and residual risk

The change does not add checkout, repository-script execution, or broader token permissions. It only makes the target repository explicit for the already-approved privileged release operations. Release metadata, target SHA, tag, manifest, attestation, and environment protections remain unchanged. A malformed or unavailable GitHub context still fails the `gh` operation closed.

## Verification

- `scripts/test-native-cli-publish-workflow.sh`
- `scripts/test-dispatcher-publish-workflow.sh`
- `go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD`
- `git diff --check`

## Recovery sequence (owner approval required; not executed by this PR)

After this fix is merged into `v3-beta`, confirm the merge commit is the workflow head and that no target tag or release was created by the failed runs. Then, after owner approval, dispatch each workflow from `v3-beta` with `dry-run=false`:

```text
gh workflow run native-cli-publish.yml --ref v3-beta -f dry-run=false
gh workflow run dispatcher-publish.yml --ref v3-beta -f dry-run=false
```

Before allowing publish, inspect each run's resolver output: the native target must be `uloop-project-runner-v3.0.0-beta.48` and the dispatcher target must be `dispatcher-v3.1.0-beta.13`, with each resolved target SHA equal to that run's `github.sha`. Confirm the approved-commit guard passes on the post-merge fix head, then monitor draft creation, asset upload, attestation verification, and final publish. Do not release the Unity package until the runner release and pin-advance ordering requirements are satisfied.
