### PR TITLE
fix: Add resolver-bound recovery dispatch mode to native CLI publish

### DIFF
--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -11,6 +11,10 @@ on:
         description: "Dry run (skip release upload)"
         type: boolean
         default: false
+      recovery-target:
+        description: "Build and tag the resolver-derived release commit instead of the branch head"
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -41,14 +45,29 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: scripts/resolve-native-cli-release-target.sh >> "$GITHUB_OUTPUT"
 
+      - name: Check out resolver-derived recovery target
+        if: github.event_name == 'workflow_dispatch' && inputs.recovery-target && (steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true')
+        env:
+          TARGET_SHA: ${{ steps.release.outputs.sha }}
+        run: |
+          set -eu
+          # Why the ancestor check: recovery may only rebuild a commit that already
+          # landed on the approved branch; any other target must fail closed.
+          if ! git merge-base --is-ancestor "${TARGET_SHA}" "${GITHUB_SHA}"; then
+            echo "Recovery target ${TARGET_SHA} is not an ancestor of approved event commit ${GITHUB_SHA}." >&2
+            exit 1
+          fi
+          git checkout --detach "${TARGET_SHA}"
+
       - name: Verify release target matches build commit
         if: steps.release.outputs.publish == 'true' || steps.release.outputs.release == 'true'
         env:
           TARGET_SHA: ${{ steps.release.outputs.sha }}
         run: |
           set -eu
-          if [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then
-            echo "Release target ${TARGET_SHA} does not match approved build commit ${GITHUB_SHA}." >&2
+          build_sha=$(git rev-parse HEAD)
+          if [ "${TARGET_SHA}" != "${build_sha}" ]; then
+            echo "Release target ${TARGET_SHA} does not match build source commit ${build_sha}." >&2
             exit 1
           fi
 
@@ -104,7 +123,7 @@ jobs:
           set -eu
           mkdir -p release-input
           {
-            printf 'build_sha=%s\n' "${GITHUB_SHA}"
+            printf 'build_sha=%s\n' "$(git rev-parse HEAD)"
             printf 'target_sha=%s\n' "${TARGET_SHA}"
             printf 'release_tag=%s\n' "${RELEASE_TAG}"
             printf 'version=%s\n' "${RELEASE_VERSION}"
@@ -156,6 +175,8 @@ jobs:
       - name: Verify release metadata
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RECOVERY_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.recovery-target }}
         run: |
           set -eu
           metadata_value() {
@@ -178,9 +199,26 @@ jobs:
           event_ref=$(metadata_value event_ref)
           BUILD_SHA="${build_sha}"
           TARGET_SHA="${target_sha}"
-          if [ "${BUILD_SHA}" != "${GITHUB_SHA}" ] || [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then
-            echo "Build SHA and release target must match the approved event commit." >&2
-            exit 1
+          if [ "${RECOVERY_TARGET}" = "true" ]; then
+            if [ "${BUILD_SHA}" != "${TARGET_SHA}" ]; then
+              echo "Recovery build SHA must match the release target commit." >&2
+              exit 1
+            fi
+            # Why an API comparison: the metadata artifact comes from the unprivileged
+            # build job, so ancestry on the approved event commit is re-verified from
+            # an independent source before the privileged job tags that commit.
+            compare_status=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${TARGET_SHA}...${GITHUB_SHA}" --jq '.status')
+            if [ "${compare_status}" != "ahead" ] && [ "${compare_status}" != "identical" ]; then
+              echo "Recovery target ${TARGET_SHA} is not an ancestor of approved event commit ${GITHUB_SHA}." >&2
+              exit 1
+            fi
+            release_sha="${TARGET_SHA}"
+          else
+            if [ "${BUILD_SHA}" != "${GITHUB_SHA}" ] || [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then
+              echo "Build SHA and release target must match the approved event commit." >&2
+              exit 1
+            fi
+            release_sha="${GITHUB_SHA}"
           fi
           if [ "${event_ref}" != "refs/heads/main" ] && [ "${event_ref}" != "refs/heads/v3-beta" ]; then
             echo "Unsupported release ref ${event_ref}." >&2
@@ -201,6 +239,7 @@ jobs:
           validate_boolean publish "${should_publish}"
           validate_boolean release "${should_release}"
           validate_boolean dry_run "${dry_run}"
+          printf 'RELEASE_SHA=%s\n' "${release_sha}" >> "$GITHUB_ENV"
           printf 'RELEASE_TAG=%s\n' "${release_tag}" >> "$GITHUB_ENV"
           printf 'SHOULD_PUBLISH=%s\n' "${should_publish}" >> "$GITHUB_ENV"
           printf 'SHOULD_RELEASE=%s\n' "${should_release}" >> "$GITHUB_ENV"
@@ -258,8 +297,8 @@ jobs:
               *) printf '%s\n' "${tag_error}" >&2; exit "${tag_status}" ;;
             esac
           fi
-          if [ -n "${tag_sha}" ] && [ "${tag_sha}" != "${GITHUB_SHA}" ]; then
-            echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
+          if [ -n "${tag_sha}" ] && [ "${tag_sha}" != "${RELEASE_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved release commit ${RELEASE_SHA}." >&2
             exit 1
           fi
           if gh release view "${RELEASE_TAG}" --json isDraft,targetCommitish > release-input/release-state.json 2>/dev/null; then
@@ -273,7 +312,7 @@ jobs:
           fi
           prerelease_flag=""
           case "${RELEASE_TAG}" in *-beta.*) prerelease_flag="--prerelease" ;; esac
-          gh release create "${RELEASE_TAG}" --draft --title "${RELEASE_TAG}" --notes-file release-input/release-notes.md --target "${GITHUB_SHA}" ${prerelease_flag}
+          gh release create "${RELEASE_TAG}" --draft --title "${RELEASE_TAG}" --notes-file release-input/release-notes.md --target "${RELEASE_SHA}" ${prerelease_flag}
           echo "release_published=false" >> "$GITHUB_OUTPUT"
 
       - name: Attest native CLI release assets
@@ -312,8 +351,8 @@ jobs:
         run: |
           set -eu
           tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha')
-          if [ "${tag_sha}" != "${GITHUB_SHA}" ]; then
-            echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
+          if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved release commit ${RELEASE_SHA}." >&2
             exit 1
           fi
           while IFS=' ' read -r checksum asset_path; do
@@ -348,8 +387,8 @@ jobs:
         run: |
           set -eu
           tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha')
-          if [ "${tag_sha}" != "${GITHUB_SHA}" ]; then
-            echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
+          if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved release commit ${RELEASE_SHA}." >&2
             exit 1
           fi
           case "${RELEASE_TAG}" in *-beta.*) gh release edit "${RELEASE_TAG}" --draft=false --prerelease ;; *) gh release edit "${RELEASE_TAG}" --draft=false ;; esac

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -129,6 +129,27 @@ test_checkout_free_publish_has_explicit_repository_context() {
   fi
 }
 
+test_recovery_dispatch_is_bound_to_the_resolver_target() {
+  assert_contains "      recovery-target:"
+  assert_not_contains "inputs.sha"
+  assert_not_contains "INPUT_SHA"
+  assert_contains "      - name: Check out resolver-derived recovery target"
+  assert_contains 'if ! git merge-base --is-ancestor "${TARGET_SHA}" "${GITHUB_SHA}"; then'
+  assert_contains 'git checkout --detach "${TARGET_SHA}"'
+  assert_before "      - name: Check out resolver-derived recovery target" "      - name: Verify release target matches build commit"
+  assert_contains 'build_sha=$(git rev-parse HEAD)'
+  assert_contains 'if [ "${TARGET_SHA}" != "${build_sha}" ]; then'
+  assert_contains "          RECOVERY_TARGET: \${{ github.event_name == 'workflow_dispatch' && inputs.recovery-target }}"
+  assert_contains 'if [ "${BUILD_SHA}" != "${TARGET_SHA}" ]; then'
+  assert_contains 'compare_status=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${TARGET_SHA}...${GITHUB_SHA}" --jq '\''.status'\'')'
+  assert_contains 'if [ "${compare_status}" != "ahead" ] && [ "${compare_status}" != "identical" ]; then'
+  assert_contains 'printf '\''RELEASE_SHA=%s\n'\'' "${release_sha}" >> "$GITHUB_ENV"'
+  assert_count 2 'if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then'
+  assert_contains 'if [ -n "${tag_sha}" ] && [ "${tag_sha}" != "${RELEASE_SHA}" ]; then'
+  assert_not_contains '--target "${GITHUB_SHA}"'
+  assert_contains '--target "${RELEASE_SHA}"'
+}
+
 test_assets_are_attested_after_the_manifest_is_verified() {
   assert_contains "      - name: Verify release asset manifest"
   assert_contains "      - name: Attest native CLI release assets"
@@ -152,7 +173,7 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
   assert_contains "Unexpected release files are not listed in the manifest."
   assert_contains "Release manifest is missing files or has duplicate entries."
   assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'''
-  assert_contains 'Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}.'
+  assert_contains 'Release tag ${RELEASE_TAG} does not match approved release commit ${RELEASE_SHA}.'
   assert_not_contains "release-input/dist/release"
 }
 
@@ -198,6 +219,7 @@ test_post_publish_automation_remains_outside_the_privileged_job() {
 
 test_build_and_publish_jobs_have_separate_trust_boundaries
 test_unprivileged_build_uses_only_the_approved_event_commit
+test_recovery_dispatch_is_bound_to_the_resolver_target
 test_publish_validates_metadata_without_checking_out_source
 test_checkout_free_publish_has_explicit_repository_context
 test_assets_are_attested_after_the_manifest_is_verified


### PR DESCRIPTION
## Summary

Adds a `recovery-target` workflow_dispatch input to `native-cli-publish.yml` so a pending release whose assets were never published can be rebuilt and tagged at its release commit, while the workflow definition runs from the fixed branch head.

## Root cause

The publish trust boundary requires the resolver-derived release target to equal the built commit. When a workflow bug is fixed after a release commit exists but before its assets publish (the current `uloop-project-runner-v3.0.0-beta.48` situation), the branch head moves past the release commit and the guard correctly fails every re-dispatch. No path existed that builds the release commit source under the fixed workflow definition.

## Fix

- New `recovery-target` boolean dispatch input (default `false`). Push-event and default-dispatch semantics are unchanged.
- Build job (unprivileged): when recovery is requested, verifies with `git merge-base --is-ancestor` that the resolver target is an ancestor of the approved event commit, then checks out that target. The existing guard now compares the target against the actual build source commit (`git rev-parse HEAD`), which is identical to the previous check outside recovery.
- Publish job (privileged, checkout-free): computes a single `RELEASE_SHA` for all tag operations. Outside recovery it must equal the event commit exactly as before. In recovery it must equal the build SHA, and ancestry against the event commit is re-verified through the GitHub compare API — an input independent of the unprivileged build artifact.
- No free-form SHA/ref/tag input exists; the recovery target is always bound to the resolver output. The `cli-release` environment approval continues to gate publishing.
- `scripts/test-native-cli-publish-workflow.sh` gains `test_recovery_dispatch_is_bound_to_the_resolver_target` covering the input, ancestor checks, ordering, and the `RELEASE_SHA` anchoring; the existing no-checkout/no-scripts publish assertions still pass.

The dispatcher workflow needs no change: its resolver falls back to the branch head for an absent tag, and the dispatcher source is identical between the release commit and the current head, with the pin gating dispatchers by semver floor.

## Verification

- `scripts/test-native-cli-publish-workflow.sh`
- `scripts/test-dispatcher-publish-workflow.sh`
- YAML syntax check of the workflow
- `go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD`
- `git diff --check`
- Compare API semantics verified against live data: release-commit-to-head resolves to `ahead`, self-compare to `identical`

## Recovery sequence after merge (owner approval already granted)

```text
gh workflow run native-cli-publish.yml --ref v3-beta -f dry-run=false -f recovery-target=true
gh workflow run dispatcher-publish.yml --ref v3-beta -f dry-run=false
```

Expected: native resolver target `uloop-project-runner-v3.0.0-beta.48` tagged at `2d8d1b9443843f45b48479134f846b6f540e928b`; dispatcher target `dispatcher-v3.1.0-beta.13` tagged at the branch head. Both publish jobs then wait for `cli-release` environment approval.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

