### PR TITLE
fix: Create release tags explicitly before draft release creation

### DIFF
--- a/.github/workflows/dispatcher-publish.yml
+++ b/.github/workflows/dispatcher-publish.yml
@@ -252,6 +252,12 @@ jobs:
             echo "Release tag ${RELEASE_TAG} does not match approved build commit ${GITHUB_SHA}." >&2
             exit 1
           fi
+          if [ -z "${tag_sha}" ]; then
+            # Why the tag is created before the release: with an active tag ruleset the
+            # workflow token cannot create a release for a not-yet-existing tag, while
+            # explicit ref creation is permitted and pins the tag to the verified commit.
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${RELEASE_TAG}" -f sha="${GITHUB_SHA}"
+          fi
           if gh release view "${RELEASE_TAG}" --json isDraft,targetCommitish > release-input/release-state.json 2>/dev/null; then
             is_draft=$(jq -r '.isDraft' release-input/release-state.json)
             if [ "${is_draft}" = "false" ]; then

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -301,6 +301,12 @@ jobs:
             echo "Release tag ${RELEASE_TAG} does not match approved release commit ${RELEASE_SHA}." >&2
             exit 1
           fi
+          if [ -z "${tag_sha}" ]; then
+            # Why the tag is created before the release: with an active tag ruleset the
+            # workflow token cannot create a release for a not-yet-existing tag, while
+            # explicit ref creation is permitted and pins the tag to the verified commit.
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${RELEASE_TAG}" -f sha="${RELEASE_SHA}"
+          fi
           if gh release view "${RELEASE_TAG}" --json isDraft,targetCommitish > release-input/release-state.json 2>/dev/null; then
             is_draft=$(jq -r '.isDraft' release-input/release-state.json)
             if [ "${is_draft}" = "false" ]; then

--- a/scripts/test-dispatcher-publish-workflow.sh
+++ b/scripts/test-dispatcher-publish-workflow.sh
@@ -166,6 +166,11 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
   assert_not_contains "release-input/dist/dispatcher-release"
 }
 
+test_release_tag_is_created_before_the_release() {
+  assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${RELEASE_TAG}" -f sha="${GITHUB_SHA}"'
+  assert_before 'gh api "repos/${GITHUB_REPOSITORY}/git/refs"' 'gh release create "${RELEASE_TAG}"'
+}
+
 test_draft_creation_accepts_only_the_known_missing_tag_responses() {
   assert_contains '*"HTTP 404"*) tag_sha="" ;;'
   assert_contains '*"HTTP 422"*"No commit found for SHA"*|*"No commit found for SHA"*"HTTP 422"*) tag_sha="" ;;'
@@ -214,6 +219,7 @@ test_checkout_free_publish_has_explicit_repository_context
 test_dispatcher_assets_are_attested_after_the_manifest_is_verified
 test_dispatcher_verifies_tagged_installers_after_draft_creation
 test_publish_rejects_manifest_and_existing_tag_mismatches
+test_release_tag_is_created_before_the_release
 test_draft_creation_accepts_only_the_known_missing_tag_responses
 test_dispatcher_publish_rechecks_the_tag_before_publishing
 test_dispatcher_build_preserves_release_checks

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -177,6 +177,11 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
   assert_not_contains "release-input/dist/release"
 }
 
+test_release_tag_is_created_before_the_release() {
+  assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${RELEASE_TAG}" -f sha="${RELEASE_SHA}"'
+  assert_before 'gh api "repos/${GITHUB_REPOSITORY}/git/refs"' 'gh release create "${RELEASE_TAG}"'
+}
+
 test_draft_creation_accepts_only_the_known_missing_tag_responses() {
   assert_contains '*"HTTP 404"*) tag_sha="" ;;'
   assert_contains '*"HTTP 422"*"No commit found for SHA"*|*"No commit found for SHA"*"HTTP 422"*) tag_sha="" ;;'
@@ -224,6 +229,7 @@ test_publish_validates_metadata_without_checking_out_source
 test_checkout_free_publish_has_explicit_repository_context
 test_assets_are_attested_after_the_manifest_is_verified
 test_publish_rejects_manifest_and_existing_tag_mismatches
+test_release_tag_is_created_before_the_release
 test_draft_creation_accepts_only_the_known_missing_tag_responses
 test_publish_rechecks_the_tag_and_uses_least_privilege_post_publish_permissions
 test_build_verifies_assets_before_writing_the_publish_input


### PR DESCRIPTION
## Summary

Both privileged publish jobs now create the release tag ref through the git refs API at the verified release commit before creating the draft release. This unblocks the `uloop-project-runner-v3.0.0-beta.48` recovery and fixes release publishing for every future release.

## Root cause

The recovery dispatch reached `gh release create` with correct inputs (`RELEASE_SHA=2d8d1b94…`, tag `uloop-project-runner-v3.0.0-beta.48`) and failed with `HTTP 403: Resource not accessible by integration` (run 29426478997). The pre-hardening workflow always ran `git tag` + `git push` before `gh release create`, so releases were only ever created for tags that already existed — that is why `uloop-project-runner-v3.0.0-beta.47` published successfully on 2026-07-11 with the "Protect release tags" ruleset already active (created 2026-07-10). The hardening rewrite dropped the tag-first step; with the active tag ruleset, the workflow token cannot create a release for a not-yet-existing tag, while creating the tag ref itself is permitted (the ruleset only restricts deletion, update, and non-fast-forward).

## Fix

- After the existing tag-mismatch rejection and only when the tag is absent, the publish job runs `gh api repos/…/git/refs -f ref="refs/tags/${RELEASE_TAG}" -f sha=<verified commit>` — `RELEASE_SHA` for the native workflow, the approved event commit for the dispatcher workflow.
- No checkout is added; the publish jobs remain checkout-free and script-free.
- Reruns stay idempotent: a tag already pointing at the verified commit skips creation; a mismatched tag is still rejected.
- Both workflow test scripts assert the ref creation exists and precedes `gh release create`.

## Verification

- `scripts/test-native-cli-publish-workflow.sh`
- `scripts/test-dispatcher-publish-workflow.sh`
- YAML syntax validation
- `go run ./cmd/check-release-triggers --base origin/v3-beta --head HEAD`
- Live evidence for the mechanism: beta.47 (tag-first) succeeded under the same ruleset; this recovery run (release-first) received 403 at the same API with an otherwise identical token and permissions.

## After merge

Re-dispatch the recovery:

```text
gh workflow run native-cli-publish.yml --ref v3-beta -f dry-run=false -f recovery-target=true
gh workflow run dispatcher-publish.yml --ref v3-beta -f dry-run=false
```

The native build artifacts are rebuilt by the new run; both publish jobs again require `cli-release` environment approval.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

