### PR TITLE
fix: make historical release recovery actionable

### DIFF
--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -282,6 +282,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          RECOVERY_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.recovery-target }}
         run: |
           set -eu
           tag_error_path="${RUNNER_TEMP}/native-cli-release-tag-error"
@@ -305,7 +306,22 @@ jobs:
             # Why the tag is created before the release: with an active tag ruleset the
             # workflow token cannot create a release for a not-yet-existing tag, while
             # explicit ref creation is permitted and pins the tag to the verified commit.
-            gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${RELEASE_TAG}" -f sha="${RELEASE_SHA}"
+            tag_create_error_path="${RUNNER_TEMP}/native-cli-release-tag-create-error"
+            set +e
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${RELEASE_TAG}" \
+              -f sha="${RELEASE_SHA}" > "${tag_create_error_path}" 2>&1
+            tag_create_status=$?
+            set -e
+            if [ "${tag_create_status}" -ne 0 ]; then
+              cat "${tag_create_error_path}" >&2
+              if [ "${RECOVERY_TARGET}" = "true" ] && grep -qE 'HTTP 403|Resource not accessible by integration' "${tag_create_error_path}"; then
+                echo "Recovery-target release creation was rejected for a historical commit by GitHub." >&2
+                echo "Create the tag and draft release as the repository owner, then rerun this workflow." >&2
+                echo "See docs/release-recovery-runbook.md for the recovery procedure." >&2
+              fi
+              exit "${tag_create_status}"
+            fi
           fi
           if gh release view "${RELEASE_TAG}" --json isDraft,targetCommitish > release-input/release-state.json 2>/dev/null; then
             is_draft=$(jq -r '.isDraft' release-input/release-state.json)
@@ -318,7 +334,20 @@ jobs:
           fi
           prerelease_flag=""
           case "${RELEASE_TAG}" in *-beta.*) prerelease_flag="--prerelease" ;; esac
-          gh release create "${RELEASE_TAG}" --draft --title "${RELEASE_TAG}" --notes-file release-input/release-notes.md --target "${RELEASE_SHA}" ${prerelease_flag}
+          release_create_error_path="${RUNNER_TEMP}/native-cli-release-create-error"
+          set +e
+          gh release create "${RELEASE_TAG}" --draft --title "${RELEASE_TAG}" --notes-file release-input/release-notes.md --target "${RELEASE_SHA}" ${prerelease_flag} > "${release_create_error_path}" 2>&1
+          release_create_status=$?
+          set -e
+          if [ "${release_create_status}" -ne 0 ]; then
+            cat "${release_create_error_path}" >&2
+            if [ "${RECOVERY_TARGET}" = "true" ] && grep -qE 'HTTP 403|Resource not accessible by integration' "${release_create_error_path}"; then
+              echo "Recovery-target draft release creation was rejected for a historical commit by GitHub." >&2
+              echo "Create the tag and draft release as the repository owner, then rerun this workflow." >&2
+              echo "See docs/release-recovery-runbook.md for the recovery procedure." >&2
+            fi
+            exit "${release_create_status}"
+          fi
           echo "release_published=false" >> "$GITHUB_OUTPUT"
 
       - name: Attest native CLI release assets

--- a/docs/release-recovery-runbook.md
+++ b/docs/release-recovery-runbook.md
@@ -1,0 +1,134 @@
+# Release recovery runbook
+
+## Root cause
+
+In `recovery-target` mode, the release target is an earlier commit than the
+workflow run's `GITHUB_SHA`. GitHub rejects the Actions `GITHUB_TOKEN` when it
+tries to create a tag or release for that different commit, even when the token
+has `contents: write`. This is neither a missing permission nor a tag ruleset
+failure.
+
+The behavior was confirmed with the same token and `contents: write`
+permission in reproduction runs [29459199798](https://github.com/hatayama/unity-cli-loop/actions/runs/29459199798)
+and [29459266044](https://github.com/hatayama/unity-cli-loop/actions/runs/29459266044):
+
+- A tag pointing at the run head returned HTTP 201.
+- A tag pointing at `2d8d1b9443843f45b48479134f846b6f540e928b`, an ancestor of
+  the run head, returned HTTP 403 `Resource not accessible by integration`.
+- Creating a draft release directly at that past commit also returned HTTP 403.
+
+The precise condition is a ref target different from the run's `GITHUB_SHA`,
+not merely an unreachable commit. Normal head-based releases are unaffected.
+
+## Recovery procedure
+
+Run these commands with an owner-authenticated `gh` session. Replace every
+`<placeholder>` before running a command.
+
+1. Confirm the authenticated account and repository.
+
+   ```sh
+   gh auth status
+   gh api user --jq .login
+   gh api repos/<owner>/<repo> --jq .full_name
+   ```
+
+2. Determine the release commit and release tag from the release PR and the
+   failed workflow run.
+
+   ```sh
+   gh pr view <release-pr> --repo <owner>/<repo> --json mergeCommit --jq .mergeCommit.oid
+   gh run view <run-id> --repo <owner>/<repo> --json headSha
+   ```
+
+   The release commit must be the commit validated by the workflow. Do not use
+   the current branch head when recovering an older release.
+
+3. Create the release tag at the validated release commit.
+
+   ```sh
+   gh api repos/<owner>/<repo>/git/refs \
+     -f ref=refs/tags/<tag> \
+     -f sha=<release-commit-sha>
+   ```
+
+4. Download the native release input artifact and create the draft release.
+   Creating only the tag is not sufficient: the Actions token also receives
+   HTTP 403 when it tries to create the draft release.
+
+   ```sh
+   gh run download <run-id> --repo <owner>/<repo> \
+     -n native-cli-release-input -D <native-release-input-dir>
+   gh release create <tag> --repo <owner>/<repo> \
+     --draft --title <tag> \
+     --notes-file <native-release-input-dir>/release-input/release-notes.md \
+     --target <release-commit-sha>
+   ```
+
+   Add `--prerelease` when the release tag is a prerelease tag.
+
+5. Rerun the failed publish job and approve the release environment if
+   prompted.
+
+   ```sh
+   gh run rerun <run-id> --repo <owner>/<repo> --failed
+   ```
+
+6. If an older `dispatcher-publish` run is waiting for the `cli-release`
+   environment, cancel it before retrying the recovery. The workflow uses a
+   concurrency group without automatic cancellation, so an old approval-waiting
+   run can block the newer run indefinitely.
+
+   ```sh
+   gh run list --repo <owner>/<repo> --workflow dispatcher-publish.yml \
+     --branch <branch> --limit 20
+   gh run cancel <blocked-run-id> --repo <owner>/<repo>
+   ```
+
+7. Recover the Unity package release only after the runner release has
+   completed and its assets are available. The package sync script creates a
+   release at the historical release commit and can hit the same 403; create
+   that release as the owner before rerunning the sync.
+
+   ```sh
+   gh release create v<package-version> --repo <owner>/<repo> \
+     --title v<package-version> \
+     --notes-file <package-release-notes> \
+     --target <package-release-commit-sha>
+   ```
+
+   Add `--prerelease` when the package release is a prerelease.
+
+   Run the package sync or the relevant post-publish job after the runner
+   release assets are complete. The sync reuses an existing correctly targeted
+   release.
+
+8. Complete the workflow-dispatch recovery manually. Push-only post-publish
+   steps are intentionally skipped for a `workflow_dispatch` run.
+
+   ```sh
+   gh pr edit <release-pr> --repo <owner>/<repo> \
+     --remove-label 'autorelease: pending' \
+     --add-label 'autorelease: tagged'
+   gh workflow run release-please.yml --repo <owner>/<repo> --ref <branch> \
+     -f branch=<branch>
+   ```
+
+## Scope of the workflows
+
+`native-cli-publish.yml` is the workflow with `recovery-target` and now emits
+this runbook path when tag or draft-release creation returns the observed 403.
+The creation and reuse logic is unchanged.
+
+`dispatcher-publish.yml` has no recovery-target input and requires its release
+target to equal `GITHUB_SHA`, so it has no historical-commit creation path.
+Its concurrency group still matters during recovery because an older run can
+block a retry.
+
+`scripts/sync-release-please-package-releases.sh` can create package releases
+at release-please commits from the repository history. This runbook's owner
+pre-creation step covers that path; the runner release must be recovered first.
+
+Do not add GitHub Actions to the tag-ruleset bypass actors. That would grant
+the bot tag deletion and force-update capabilities without addressing the
+historical-commit restriction.

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -178,8 +178,18 @@ test_publish_rejects_manifest_and_existing_tag_mismatches() {
 }
 
 test_release_tag_is_created_before_the_release() {
-  assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${RELEASE_TAG}" -f sha="${RELEASE_SHA}"'
+  assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/git/refs" \'
+  assert_contains '  -f ref="refs/tags/${RELEASE_TAG}" \'
+  assert_contains '  -f sha="${RELEASE_SHA}" > "${tag_create_error_path}" 2>&1'
   assert_before 'gh api "repos/${GITHUB_REPOSITORY}/git/refs"' 'gh release create "${RELEASE_TAG}"'
+}
+
+test_recovery_target_403_errors_explain_the_manual_recovery() {
+  assert_contains 'RECOVERY_TARGET: ${{ github.event_name == '\''workflow_dispatch'\'' && inputs.recovery-target }}'
+  assert_contains 'grep -qE '\''HTTP 403|Resource not accessible by integration'\'''
+  assert_contains 'Recovery-target release creation was rejected for a historical commit by GitHub.'
+  assert_contains 'Recovery-target draft release creation was rejected for a historical commit by GitHub.'
+  assert_contains 'See docs/release-recovery-runbook.md for the recovery procedure.'
 }
 
 test_draft_creation_accepts_only_the_known_missing_tag_responses() {

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -185,6 +185,7 @@ test_release_tag_is_created_before_the_release() {
 }
 
 test_recovery_target_403_errors_explain_the_manual_recovery() {
+  # Verify recovery-target 403 failures explain the owner-assisted recovery procedure.
   assert_contains 'RECOVERY_TARGET: ${{ github.event_name == '\''workflow_dispatch'\'' && inputs.recovery-target }}'
   assert_contains 'grep -qE '\''HTTP 403|Resource not accessible by integration'\'''
   assert_contains 'Recovery-target release creation was rejected for a historical commit by GitHub.'
@@ -240,6 +241,7 @@ test_checkout_free_publish_has_explicit_repository_context
 test_assets_are_attested_after_the_manifest_is_verified
 test_publish_rejects_manifest_and_existing_tag_mismatches
 test_release_tag_is_created_before_the_release
+test_recovery_target_403_errors_explain_the_manual_recovery
 test_draft_creation_accepts_only_the_known_missing_tag_responses
 test_publish_rechecks_the_tag_and_uses_least_privilege_post_publish_permissions
 test_build_verifies_assets_before_writing_the_publish_input


### PR DESCRIPTION
## Summary
- Formalize owner-assisted recovery for historical release targets.
- Guide operators when recovery-target tag or draft-release creation is rejected with GitHub's 403 integration error.

## User Impact
- Future release recovery failures identify the cause and point to an executable runbook instead of requiring rediscovery of the workaround.
- The runbook covers native CLI recovery, dispatcher concurrency, runner-first package release sync, and workflow-dispatch cleanup.

## Changes
- Add docs/release-recovery-runbook.md with the confirmed reproduction evidence from runs 29459199798 and 29459266044.
- Preserve the existing native release creation and reuse flow; add recovery-only guidance for 403 failures from tag and draft release creation.
- Confirm dispatcher-publish has no historical-target creation path and cover the package sync historical-release path in the runbook.

## Verification
- go test ./internal/architecture -run 'TestWorkflowActions|TestPullRequestWorkflow' -count=1 from cli/release-automation
- Ruby YAML parse
- bash -n for the modified native publish step
- git diff --check
- PR #1799 review: CodeRabbit approved; advisor final review LGTM

The recovery guidance path cannot be fully E2E-tested without an actual historical release recovery. The next real recovery will validate the complete workflow; this PR validates the error handling and documented owner-assisted procedure.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

