### PR TITLE
feat: Identify compatible legacy projects automatically

### DIFF
--- a/cli/common/errors/error_envelope.go
+++ b/cli/common/errors/error_envelope.go
@@ -23,6 +23,7 @@ const (
 	errorCodeUnityRPCError                   = "UNITY_RPC_ERROR"
 	errorCodeUnityServerBusy                 = "UNITY_SERVER_BUSY"
 	ErrorCodeCLIUpdateRequired               = "CLI_UPDATE_REQUIRED"
+	ErrorCodeV2ProjectDetected               = "V2_PROJECT_DETECTED"
 	ErrorCodeToolDisabled                    = "TOOL_DISABLED"
 	ErrorCodeCompileWaitTimeout              = "COMPILE_WAIT_TIMEOUT"
 	ErrorCodeControlPlayModeWaitTimeout      = "CONTROL_PLAY_MODE_WAIT_TIMEOUT"

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect.go
@@ -107,15 +107,24 @@ func dispatcherProjectHasUnityPackage(projectRoot string) (bool, error) {
 }
 
 func dispatcherV2PackageCacheVersion(projectRoot string) (string, bool, error) {
-	pattern := filepath.Join(projectRoot, "Library", "PackageCache", dispatcherUnityPackageName+"@*", dispatcherPackageJSONFileName)
-	packagePaths, err := filepath.Glob(pattern)
+	cacheDirectory := filepath.Join(projectRoot, "Library", "PackageCache")
+	entries, err := os.ReadDir(cacheDirectory)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
 	if err != nil {
 		return "", false, err
 	}
-	for _, packagePath := range packagePaths {
+
+	prefix := dispatcherUnityPackageName + "@"
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		packagePath := filepath.Join(cacheDirectory, entry.Name(), dispatcherPackageJSONFileName)
 		version, err := readDispatcherPackageVersion(packagePath)
 		if err != nil {
-			return "", false, err
+			continue
 		}
 		if isDispatcherV2PackageVersion(version) {
 			return version, true, nil

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect.go
@@ -1,0 +1,167 @@
+package dispatcher
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sharedversion "github.com/hatayama/unity-cli-loop/common/version"
+)
+
+const (
+	dispatcherPackagesManifestRelativePath = "Packages/manifest.json"
+	dispatcherPackagesLockRelativePath     = "Packages/packages-lock.json"
+	dispatcherPackageJSONFileName          = "package.json"
+	dispatcherV2MajorVersion               = "2"
+)
+
+type dispatcherV2Project struct {
+	IsV2           bool
+	PackageVersion string
+}
+
+type dispatcherPackagesManifest struct {
+	Dependencies map[string]json.RawMessage `json:"dependencies"`
+}
+
+type dispatcherPackagesLock struct {
+	Dependencies map[string]dispatcherPackageLockEntry `json:"dependencies"`
+}
+
+type dispatcherPackageLockEntry struct {
+	Version string `json:"version"`
+}
+
+type dispatcherPackageJSON struct {
+	Version string `json:"version"`
+}
+
+// detectV2DispatcherProject identifies pinless Unity projects that use the V2 package.
+// Why: V2 projects have no project runner pin, but pin absence alone can also indicate a broken V3 installation.
+func detectV2DispatcherProject(projectRoot string) (dispatcherV2Project, error) {
+	hasPin, err := dispatcherProjectHasPin(projectRoot)
+	if err != nil {
+		return dispatcherV2Project{}, err
+	}
+	if hasPin {
+		return dispatcherV2Project{}, nil
+	}
+
+	hasPackage, err := dispatcherProjectHasUnityPackage(projectRoot)
+	if err != nil {
+		return dispatcherV2Project{}, err
+	}
+	if !hasPackage {
+		return dispatcherV2Project{}, nil
+	}
+
+	packageVersion, found, err := dispatcherV2PackageCacheVersion(projectRoot)
+	if err != nil {
+		return dispatcherV2Project{}, err
+	}
+	if !found {
+		packageVersion, found, err = dispatcherV2PackageLockVersion(projectRoot)
+		if err != nil {
+			return dispatcherV2Project{}, err
+		}
+	}
+	if !found || !isDispatcherV2PackageVersion(packageVersion) {
+		return dispatcherV2Project{}, nil
+	}
+
+	return dispatcherV2Project{IsV2: true, PackageVersion: packageVersion}, nil
+}
+
+func dispatcherProjectHasPin(projectRoot string) (bool, error) {
+	for _, candidate := range dispatcherPinCandidatePaths(projectRoot) {
+		_, err := os.Stat(candidate.Path)
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
+func dispatcherProjectHasUnityPackage(projectRoot string) (bool, error) {
+	manifestPath := filepath.Join(projectRoot, filepath.FromSlash(dispatcherPackagesManifestRelativePath))
+	content, err := os.ReadFile(manifestPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	manifest := dispatcherPackagesManifest{}
+	if err := json.Unmarshal(content, &manifest); err != nil {
+		return false, fmt.Errorf("parse %s: %w", manifestPath, err)
+	}
+	_, found := manifest.Dependencies[dispatcherUnityPackageName]
+	return found, nil
+}
+
+func dispatcherV2PackageCacheVersion(projectRoot string) (string, bool, error) {
+	pattern := filepath.Join(projectRoot, "Library", "PackageCache", dispatcherUnityPackageName+"@*", dispatcherPackageJSONFileName)
+	packagePaths, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", false, err
+	}
+	for _, packagePath := range packagePaths {
+		version, err := readDispatcherPackageVersion(packagePath)
+		if err != nil {
+			return "", false, err
+		}
+		if isDispatcherV2PackageVersion(version) {
+			return version, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func dispatcherV2PackageLockVersion(projectRoot string) (string, bool, error) {
+	lockPath := filepath.Join(projectRoot, filepath.FromSlash(dispatcherPackagesLockRelativePath))
+	content, err := os.ReadFile(lockPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+
+	lock := dispatcherPackagesLock{}
+	if err := json.Unmarshal(content, &lock); err != nil {
+		return "", false, fmt.Errorf("parse %s: %w", lockPath, err)
+	}
+	entry, found := lock.Dependencies[dispatcherUnityPackageName]
+	if !found {
+		return "", false, nil
+	}
+	return entry.Version, entry.Version != "", nil
+}
+
+func readDispatcherPackageVersion(packagePath string) (string, error) {
+	content, err := os.ReadFile(packagePath)
+	if err != nil {
+		return "", err
+	}
+	packageInfo := dispatcherPackageJSON{}
+	if err := json.Unmarshal(content, &packageInfo); err != nil {
+		return "", fmt.Errorf("parse %s: %w", packagePath, err)
+	}
+	return packageInfo.Version, nil
+}
+
+func isDispatcherV2PackageVersion(version string) bool {
+	trimmed := strings.TrimSpace(version)
+	if !sharedversion.IsValid(trimmed) {
+		return false
+	}
+	major, _, _ := strings.Cut(strings.TrimLeft(trimmed, "vV"), ".")
+	return major == dispatcherV2MajorVersion
+}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
@@ -29,6 +29,48 @@ func TestDetectV2DispatcherProjectFindsPackageCacheVersion(t *testing.T) {
 	}
 }
 
+func TestDetectV2DispatcherProjectFindsPackageCacheVersionWithBracketedProjectPath(t *testing.T) {
+	// Verifies PackageCache discovery treats glob characters in project paths literally.
+	projectRoot := filepath.Join(t.TempDir(), "project[legacy]")
+	for _, directory := range []string{"Assets", "ProjectSettings"} {
+		if err := os.MkdirAll(filepath.Join(projectRoot, directory), 0o755); err != nil {
+			t.Fatalf("create Unity project directory: %v", err)
+		}
+	}
+	writeV2PackageManifest(t, projectRoot)
+	writeV2PackageCachePackageJSON(t, projectRoot, "abc123", "2.2.0")
+
+	v2Project, err := detectV2DispatcherProject(projectRoot)
+	if err != nil {
+		t.Fatalf("detect V2 project: %v", err)
+	}
+	if !v2Project.IsV2 {
+		t.Fatal("expected V2 project")
+	}
+}
+
+func TestDetectV2DispatcherProjectSkipsInvalidPackageCacheEntry(t *testing.T) {
+	// Verifies an invalid stale PackageCache entry does not hide another valid V2 package.
+	projectRoot := createDispatcherUnityProject(t)
+	writeV2PackageManifest(t, projectRoot)
+	invalidPackagePath := filepath.Join(projectRoot, "Library", "PackageCache", dispatcherUnityPackageName+"@broken", "package.json")
+	if err := os.MkdirAll(filepath.Dir(invalidPackagePath), 0o755); err != nil {
+		t.Fatalf("create invalid package cache: %v", err)
+	}
+	if err := os.WriteFile(invalidPackagePath, []byte("{"), 0o644); err != nil {
+		t.Fatalf("write invalid package.json: %v", err)
+	}
+	writeV2PackageCachePackageJSON(t, projectRoot, "valid", "2.2.0")
+
+	v2Project, err := detectV2DispatcherProject(projectRoot)
+	if err != nil {
+		t.Fatalf("detect V2 project: %v", err)
+	}
+	if !v2Project.IsV2 {
+		t.Fatal("expected V2 project")
+	}
+}
+
 func TestDetectV2DispatcherProjectSkipsProjectWithPin(t *testing.T) {
 	// Verifies a project with a dispatcher pin is not classified as V2.
 	projectRoot := createDispatcherUnityProject(t)

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
@@ -1,0 +1,109 @@
+package dispatcher
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	clierrors "github.com/hatayama/unity-cli-loop/common/errors"
+)
+
+func TestDetectV2DispatcherProjectFindsPackageCacheVersion(t *testing.T) {
+	// Verifies a V2 package is detected from package.json even when its cache directory has a hash suffix.
+	projectRoot := createDispatcherUnityProject(t)
+	writeV2PackageManifest(t, projectRoot)
+	writeV2PackageCachePackageJSON(t, projectRoot, "abc123", "2.2.0")
+
+	v2Project, err := detectV2DispatcherProject(projectRoot)
+	if err != nil {
+		t.Fatalf("detect V2 project: %v", err)
+	}
+	if !v2Project.IsV2 {
+		t.Fatal("expected V2 project")
+	}
+	if v2Project.PackageVersion != "2.2.0" {
+		t.Fatalf("package version = %q, want 2.2.0", v2Project.PackageVersion)
+	}
+}
+
+func TestDetectV2DispatcherProjectSkipsProjectWithPin(t *testing.T) {
+	// Verifies a project with a dispatcher pin is not classified as V2.
+	projectRoot := createDispatcherUnityProject(t)
+	writeV2PackageManifest(t, projectRoot)
+	writeV2PackageCachePackageJSON(t, projectRoot, "abc123", "2.2.0")
+	writeDispatcherProjectPin(t, projectRoot, "3.0.0")
+
+	v2Project, err := detectV2DispatcherProject(projectRoot)
+	if err != nil {
+		t.Fatalf("detect V2 project: %v", err)
+	}
+	if v2Project.IsV2 {
+		t.Fatalf("unexpected V2 project: %#v", v2Project)
+	}
+}
+
+func TestDetectV2DispatcherProjectSkipsProjectWithoutPackage(t *testing.T) {
+	// Verifies a missing Unity package does not classify a pinless project as V2.
+	projectRoot := createDispatcherUnityProject(t)
+
+	v2Project, err := detectV2DispatcherProject(projectRoot)
+	if err != nil {
+		t.Fatalf("detect V2 project: %v", err)
+	}
+	if v2Project.IsV2 {
+		t.Fatalf("unexpected V2 project: %#v", v2Project)
+	}
+}
+
+func TestRunDispatcherReportsV2ProjectGuidanceWhenPinIsMissing(t *testing.T) {
+	// Verifies pinless V2 projects receive migration guidance instead of the missing-pin error.
+	projectRoot := createDispatcherUnityProject(t)
+	writeV2PackageManifest(t, projectRoot)
+	writeV2PackageCachePackageJSON(t, projectRoot, "abc123", "2.2.0")
+	t.Chdir(projectRoot)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunDispatcher(context.Background(), []string{"compile"}, &stdout, &stderr)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	envelope := clierrors.CLIErrorEnvelope{}
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse error envelope: %v; stderr=%s", err, stderr.String())
+	}
+	if envelope.Error.ErrorCode != clierrors.ErrorCodeV2ProjectDetected {
+		t.Fatalf("error code = %q, want %q", envelope.Error.ErrorCode, clierrors.ErrorCodeV2ProjectDetected)
+	}
+	if len(envelope.Error.NextActions) < 2 {
+		t.Fatalf("next actions = %#v, want Node and npx guidance", envelope.Error.NextActions)
+	}
+}
+
+func writeV2PackageManifest(t *testing.T, projectRoot string) {
+	t.Helper()
+	manifestPath := filepath.Join(projectRoot, "Packages", "manifest.json")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatalf("create Packages directory: %v", err)
+	}
+	content := "{\n  \"dependencies\": {\n    \"" + dispatcherUnityPackageName + "\": \"https://example.invalid/package.git\"\n  }\n}\n"
+	if err := os.WriteFile(manifestPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func writeV2PackageCachePackageJSON(t *testing.T, projectRoot string, suffix string, version string) {
+	t.Helper()
+	packagePath := filepath.Join(projectRoot, "Library", "PackageCache", dispatcherUnityPackageName+"@"+suffix, "package.json")
+	if err := os.MkdirAll(filepath.Dir(packagePath), 0o755); err != nil {
+		t.Fatalf("create package cache: %v", err)
+	}
+	content := "{\n  \"version\": \"" + version + "\"\n}\n"
+	if err := os.WriteFile(packagePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
@@ -58,6 +58,39 @@ func TestDetectV2DispatcherProjectSkipsProjectWithoutPackage(t *testing.T) {
 	}
 }
 
+func TestDetectV2DispatcherProjectFindsPackageLockVersionWithoutPackageCache(t *testing.T) {
+	// Verifies a V2 package is detected from packages-lock.json when PackageCache is unavailable.
+	projectRoot := createDispatcherUnityProject(t)
+	writeV2PackageManifest(t, projectRoot)
+	writeV2PackagesLock(t, projectRoot, "2.2.0")
+
+	v2Project, err := detectV2DispatcherProject(projectRoot)
+	if err != nil {
+		t.Fatalf("detect V2 project: %v", err)
+	}
+	if !v2Project.IsV2 {
+		t.Fatal("expected V2 project")
+	}
+	if v2Project.PackageVersion != "2.2.0" {
+		t.Fatalf("package version = %q, want 2.2.0", v2Project.PackageVersion)
+	}
+}
+
+func TestDetectV2DispatcherProjectSkipsV3PackageLockVersion(t *testing.T) {
+	// Verifies a non-V2 packages-lock.json version does not classify a project as V2.
+	projectRoot := createDispatcherUnityProject(t)
+	writeV2PackageManifest(t, projectRoot)
+	writeV2PackagesLock(t, projectRoot, "3.0.0")
+
+	v2Project, err := detectV2DispatcherProject(projectRoot)
+	if err != nil {
+		t.Fatalf("detect V2 project: %v", err)
+	}
+	if v2Project.IsV2 {
+		t.Fatalf("unexpected V2 project: %#v", v2Project)
+	}
+}
+
 func TestRunDispatcherReportsV2ProjectGuidanceWhenPinIsMissing(t *testing.T) {
 	// Verifies pinless V2 projects receive migration guidance instead of the missing-pin error.
 	projectRoot := createDispatcherUnityProject(t)
@@ -105,5 +138,14 @@ func writeV2PackageCachePackageJSON(t *testing.T, projectRoot string, suffix str
 	content := "{\n  \"version\": \"" + version + "\"\n}\n"
 	if err := os.WriteFile(packagePath, []byte(content), 0o644); err != nil {
 		t.Fatalf("write package.json: %v", err)
+	}
+}
+
+func writeV2PackagesLock(t *testing.T, projectRoot string, version string) {
+	t.Helper()
+	lockPath := filepath.Join(projectRoot, "Packages", "packages-lock.json")
+	content := "{\n  \"dependencies\": {\n    \"" + dispatcherUnityPackageName + "\": {\n      \"version\": \"" + version + "\"\n    }\n  }\n}\n"
+	if err := os.WriteFile(lockPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write packages-lock.json: %v", err)
 	}
 }

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -87,6 +87,11 @@ func runDispatcherWithDeps(ctx context.Context, args []string, stdout io.Writer,
 
 	pin, err := loadDispatcherPin(projectRoot)
 	if err != nil {
+		v2Project, detectErr := detectV2DispatcherProject(projectRoot)
+		if detectErr == nil && v2Project.IsV2 {
+			clierrors.WriteErrorEnvelope(stderr, dispatcherV2ProjectDetectedError(projectRoot, v2Project.PackageVersion))
+			return 1
+		}
 		clierrors.WriteErrorEnvelope(stderr, dispatcherPinResolutionError(projectRoot, err))
 		return 1
 	}
@@ -429,6 +434,24 @@ func dispatcherPinResolutionError(projectRoot string, cause error) clierrors.CLI
 		},
 		Details: map[string]any{
 			"Cause": cause.Error(),
+		},
+	}
+}
+
+func dispatcherV2ProjectDetectedError(projectRoot string, packageVersion string) clierrors.CLIError {
+	return clierrors.CLIError{
+		ErrorCode:   clierrors.ErrorCodeV2ProjectDetected,
+		Phase:       clierrors.ErrorPhaseProjectResolve,
+		Message:     "This Unity project uses uloop V2 and requires Node.js 22 or later.",
+		Retryable:   true,
+		SafeToRetry: true,
+		ProjectRoot: projectRoot,
+		NextActions: []string{
+			"Install Node.js 22 or later, then retry the command.",
+			"As a last resort, run `npx uloop-cli@" + packageVersion + " <command>` from this project.",
+		},
+		Details: map[string]any{
+			"V2PackageVersion": packageVersion,
 		},
 	}
 }

--- a/cli/dispatcher/shared-inputs-stamp.json
+++ b/cli/dispatcher/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "d59d3b093b55893ccd07b5906f02658f23030bc5"
+  "sharedInputsHash": "ff3f40c09d8fd92060e19a8c7eed079f9293fb23"
 }

--- a/cli/project-runner/shared-inputs-stamp.json
+++ b/cli/project-runner/shared-inputs-stamp.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "sharedInputsHash": "1d0b11deca98e51fd880037a967a21e881619ed7"
+  "sharedInputsHash": "358bda67ddca27ff0f3e01a2a9ecd44630cb37ff"
 }


### PR DESCRIPTION
Refs: V3 dispatcher to V2 CLI delegation — To-Do 2–4

## Summary
- Identifies pinless projects that use the compatible legacy package generation.
- Gives actionable guidance instead of reporting a generic missing configuration error.

## User Impact
- Users receive clear Node.js and fallback command guidance when invoking the new launcher on a legacy project.

## Changes
- Read the installed package metadata rather than inferring its version from cache directory names.
- Preserve normal runner resolution whenever a project pin is present or no legacy package is installed.

## Verification
- `scripts/check-go-cli.sh` (pass)
- `go test ./dispatcher/internal/dispatcher -run TestDetectV2DispatcherProject -count=1` (pass)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

