### PR TITLE
feat: Run compatible legacy projects from one launcher

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_delegate.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_delegate.go
@@ -1,0 +1,62 @@
+package dispatcher
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const dispatcherNodeCommandName = "node"
+
+type dispatcherV2CLIPackageJSON struct {
+	Bin json.RawMessage `json:"bin"`
+}
+
+// resolveDispatcherV2CLIEntrypoint resolves the JavaScript file declared by the installed V2 CLI package.
+// Why: executing the package entrypoint directly avoids platform-dependent node_modules/.bin shims.
+func resolveDispatcherV2CLIEntrypoint(installPath string) (string, error) {
+	packageDirectory := filepath.Join(installPath, "node_modules", dispatcherV2CLIPackageName)
+	packagePath := filepath.Join(packageDirectory, dispatcherPackageJSONFileName)
+	content, err := os.ReadFile(packagePath)
+	if err != nil {
+		return "", err
+	}
+	packageInfo := dispatcherV2CLIPackageJSON{}
+	if err := json.Unmarshal(content, &packageInfo); err != nil {
+		return "", fmt.Errorf("parse %s: %w", packagePath, err)
+	}
+	entrypoint, err := dispatcherV2BinEntrypoint(packageInfo.Bin)
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(entrypoint) {
+		return "", fmt.Errorf("%s bin entrypoint must be relative", dispatcherV2CLIPackageName)
+	}
+	return filepath.Join(packageDirectory, entrypoint), nil
+}
+
+func dispatcherV2BinEntrypoint(bin json.RawMessage) (string, error) {
+	entrypoint := ""
+	if err := json.Unmarshal(bin, &entrypoint); err == nil {
+		return entrypoint, nil
+	}
+	entries := map[string]string{}
+	if err := json.Unmarshal(bin, &entries); err != nil {
+		return "", fmt.Errorf("%s package bin must be a string or object: %w", dispatcherV2CLIPackageName, err)
+	}
+	entrypoint, found := entries["uloop"]
+	if !found || entrypoint == "" {
+		return "", fmt.Errorf("%s package bin does not define uloop", dispatcherV2CLIPackageName)
+	}
+	return entrypoint, nil
+}
+
+func resolveDispatcherV2Node(lookPath func(string) (string, error)) (string, error) {
+	return lookPath(dispatcherNodeCommandName)
+}
+
+func defaultDispatcherV2NodePath() (string, error) {
+	return resolveDispatcherV2Node(exec.LookPath)
+}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_delegate_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_delegate_test.go
@@ -1,0 +1,59 @@
+package dispatcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDispatcherV2CLIEntrypointReadsObjectBin(t *testing.T) {
+	// Verifies the V2 CLI entrypoint is resolved from the published object-form bin declaration.
+	installPath := t.TempDir()
+	writeDispatcherV2PackageBin(t, installPath, `{"uloop":"dist/cli.bundle.cjs"}`)
+
+	entrypoint, err := resolveDispatcherV2CLIEntrypoint(installPath)
+	if err != nil {
+		t.Fatalf("resolve V2 CLI entrypoint: %v", err)
+	}
+	want := filepath.Join(installPath, "node_modules", dispatcherV2CLIPackageName, "dist", "cli.bundle.cjs")
+	if entrypoint != want {
+		t.Fatalf("entrypoint = %q, want %q", entrypoint, want)
+	}
+}
+
+func TestResolveDispatcherV2CLIEntrypointReadsStringBin(t *testing.T) {
+	// Verifies the V2 CLI entrypoint also supports a string-form bin declaration.
+	installPath := t.TempDir()
+	writeDispatcherV2PackageBin(t, installPath, `"dist/cli.bundle.cjs"`)
+
+	entrypoint, err := resolveDispatcherV2CLIEntrypoint(installPath)
+	if err != nil {
+		t.Fatalf("resolve V2 CLI entrypoint: %v", err)
+	}
+	want := filepath.Join(installPath, "node_modules", dispatcherV2CLIPackageName, "dist", "cli.bundle.cjs")
+	if entrypoint != want {
+		t.Fatalf("entrypoint = %q, want %q", entrypoint, want)
+	}
+}
+
+func TestResolveDispatcherV2NodeReportsMissingNode(t *testing.T) {
+	// Verifies a missing Node executable is returned to the caller as an error.
+	_, err := resolveDispatcherV2Node(func(string) (string, error) {
+		return "", os.ErrNotExist
+	})
+	if err == nil {
+		t.Fatal("expected missing Node error")
+	}
+}
+
+func writeDispatcherV2PackageBin(t *testing.T, installPath string, bin string) {
+	t.Helper()
+	packagePath := filepath.Join(installPath, "node_modules", dispatcherV2CLIPackageName, dispatcherPackageJSONFileName)
+	if err := os.MkdirAll(filepath.Dir(packagePath), 0o755); err != nil {
+		t.Fatalf("create V2 package directory: %v", err)
+	}
+	content := "{\n  \"bin\": " + bin + "\n}\n"
+	if err := os.WriteFile(packagePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write V2 package.json: %v", err)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -142,7 +143,11 @@ func TestRunDispatcherReportsV2ProjectGuidanceWhenPinIsMissing(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := RunDispatcher(context.Background(), []string{"compile"}, &stdout, &stderr)
+	deps := defaultDispatcherRunDeps()
+	deps.runV2CLI = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		return 0, os.ErrNotExist
+	}
+	code := runDispatcherWithDeps(context.Background(), []string{"compile"}, &stdout, &stderr, deps)
 
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1; stderr=%s", code, stderr.String())
@@ -157,6 +162,34 @@ func TestRunDispatcherReportsV2ProjectGuidanceWhenPinIsMissing(t *testing.T) {
 	if len(envelope.Error.NextActions) < 2 {
 		t.Fatalf("next actions = %#v, want Node and npx guidance", envelope.Error.NextActions)
 	}
+}
+
+func TestRunDispatcherDelegatesV2ProjectWithOriginalArguments(t *testing.T) {
+	// Verifies V2 delegation preserves the original argument sequence.
+	projectRoot := createDispatcherUnityProject(t)
+	writeV2PackageManifest(t, projectRoot)
+	writeV2PackageCachePackageJSON(t, projectRoot, "abc123", "2.2.0")
+	t.Chdir(projectRoot)
+	deps := defaultDispatcherRunDeps()
+	var actualVersion string
+	var actualArgs []string
+	deps.runV2CLI = func(ctx context.Context, version string, args []string, stdout io.Writer, stderr io.Writer) (int, error) {
+		actualVersion = version
+		actualArgs = append([]string{}, args...)
+		return 7, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runDispatcherWithDeps(context.Background(), []string{"compile", "--project-path", projectRoot}, &stdout, &stderr, deps)
+
+	if code != 7 {
+		t.Fatalf("exit code = %d, want 7", code)
+	}
+	if actualVersion != "2.2.0" {
+		t.Fatalf("V2 version = %q, want 2.2.0", actualVersion)
+	}
+	assertStringSliceEqual(t, actualArgs, []string{"compile", "--project-path", projectRoot})
 }
 
 func writeV2PackageManifest(t *testing.T, projectRoot string) {

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
@@ -192,6 +192,68 @@ func TestRunDispatcherDelegatesV2ProjectWithOriginalArguments(t *testing.T) {
 	assertStringSliceEqual(t, actualArgs, []string{"compile", "--project-path", projectRoot})
 }
 
+func TestRunDispatcherDelegatesBareVersionForV2Project(t *testing.T) {
+	// Verifies a V2 project receives its own CLI version for the Setup window check.
+	projectRoot := createDispatcherUnityProject(t)
+	writeV2PackageManifest(t, projectRoot)
+	writeV2PackageCachePackageJSON(t, projectRoot, "abc123", "2.2.0")
+	t.Chdir(projectRoot)
+	deps := defaultDispatcherRunDeps()
+	delegated := false
+	deps.runV2CLI = func(ctx context.Context, version string, args []string, stdout io.Writer, stderr io.Writer) (int, error) {
+		delegated = true
+		assertStringSliceEqual(t, args, []string{"--version"})
+		return 0, nil
+	}
+
+	code := runDispatcherWithDeps(context.Background(), []string{"--version"}, io.Discard, io.Discard, deps)
+	if code != 0 || !delegated {
+		t.Fatalf("V2 version was not delegated: code=%d delegated=%v", code, delegated)
+	}
+}
+
+func TestRunDispatcherReturnsDispatcherVersionOutsideProject(t *testing.T) {
+	// Verifies a version request outside a project remains handled by the dispatcher.
+	t.Chdir(t.TempDir())
+	deps := defaultDispatcherRunDeps()
+	deps.runV2CLI = func(context.Context, string, []string, io.Writer, io.Writer) (int, error) {
+		t.Fatal("V2 CLI must not run outside a project")
+		return 0, nil
+	}
+	var stdout bytes.Buffer
+	code := runDispatcherWithDeps(context.Background(), []string{"--version"}, &stdout, io.Discard, deps)
+	if code != 0 || stdout.String() != dispatcherVersion+"\n" {
+		t.Fatalf("dispatcher version output = %q, code=%d", stdout.String(), code)
+	}
+}
+
+func TestRunDispatcherDelegatesSkillsForV2Project(t *testing.T) {
+	// Verifies the project-scoped skills command is delegated to the V2 CLI.
+	projectRoot := createDispatcherUnityProject(t)
+	writeV2PackageManifest(t, projectRoot)
+	writeV2PackageCachePackageJSON(t, projectRoot, "abc123", "2.2.0")
+	t.Chdir(projectRoot)
+	deps := defaultDispatcherRunDeps()
+	delegated := false
+	deps.runV2CLI = func(ctx context.Context, version string, args []string, stdout io.Writer, stderr io.Writer) (int, error) {
+		delegated = true
+		assertStringSliceEqual(t, args, []string{"skills", "list"})
+		return 0, nil
+	}
+
+	code := runDispatcherWithDeps(context.Background(), []string{"skills", "list"}, io.Discard, io.Discard, deps)
+	if code != 0 || !delegated {
+		t.Fatalf("V2 skills was not delegated: code=%d delegated=%v", code, delegated)
+	}
+}
+
+func TestShouldKeepDispatcherProcessCommandKeepsUpdate(t *testing.T) {
+	// Verifies global update remains owned by the V3 dispatcher.
+	if !shouldKeepDispatcherProcessCommand([]string{"update"}) {
+		t.Fatal("update must remain in the dispatcher")
+	}
+}
+
 func writeV2PackageManifest(t *testing.T, projectRoot string) {
 	t.Helper()
 	manifestPath := filepath.Join(projectRoot, "Packages", "manifest.json")

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_install.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_install.go
@@ -1,0 +1,93 @@
+package dispatcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const (
+	dispatcherV2CacheDirectoryName  = "v2"
+	dispatcherV2CLIPackageName      = "uloop-cli"
+	dispatcherNPMCommandName        = "npm"
+	dispatcherNPMWindowsCommandName = "npm.cmd"
+)
+
+type dispatcherV2InstallDeps struct {
+	runCommand func(context.Context, string, []string) error
+}
+
+func defaultDispatcherV2InstallDeps() dispatcherV2InstallDeps {
+	return dispatcherV2InstallDeps{runCommand: runDispatcherV2InstallCommand}
+}
+
+// installDispatcherV2CLI installs the exact V2 CLI version into its isolated cache directory.
+// Why: each Unity package version requires its matching CLI, so a shared cache slot would reinstall on every project switch.
+func installDispatcherV2CLI(ctx context.Context, cacheRoot string, version string, goos string, deps dispatcherV2InstallDeps) (string, error) {
+	installPath := dispatcherV2InstallPath(cacheRoot, version)
+	if isInstalledDispatcherV2CLI(installPath, version) {
+		return installPath, nil
+	}
+
+	parentDirectory := filepath.Dir(installPath)
+	if err := os.MkdirAll(parentDirectory, 0o755); err != nil {
+		return "", err
+	}
+	temporaryDirectory, err := os.MkdirTemp(parentDirectory, ".install-")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = os.RemoveAll(temporaryDirectory)
+	}()
+
+	args := []string{"install", "--prefix", temporaryDirectory, dispatcherV2CLIPackageName + "@" + version}
+	if err := deps.runCommand(ctx, dispatcherV2NPMCommandName(goos), args); err != nil {
+		return "", err
+	}
+	if !isInstalledDispatcherV2CLI(temporaryDirectory, version) {
+		return "", fmt.Errorf("npm did not install %s@%s", dispatcherV2CLIPackageName, version)
+	}
+	if err := os.Rename(temporaryDirectory, installPath); err == nil {
+		return installPath, nil
+	}
+	if isInstalledDispatcherV2CLI(installPath, version) {
+		return installPath, nil
+	}
+	if err := os.RemoveAll(installPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	if err := os.Rename(temporaryDirectory, installPath); err != nil {
+		return "", err
+	}
+	return installPath, nil
+}
+
+func dispatcherV2InstallPath(cacheRoot string, version string) string {
+	return filepath.Join(cacheRoot, dispatcherV2CacheDirectoryName, version)
+}
+
+func isInstalledDispatcherV2CLI(installPath string, version string) bool {
+	packagePath := filepath.Join(installPath, "node_modules", dispatcherV2CLIPackageName, dispatcherPackageJSONFileName)
+	installedVersion, err := readDispatcherPackageVersion(packagePath)
+	return err == nil && installedVersion == version
+}
+
+func dispatcherV2NPMCommandName(goos string) string {
+	if goos == "windows" {
+		return dispatcherNPMWindowsCommandName
+	}
+	return dispatcherNPMCommandName
+}
+
+func runDispatcherV2InstallCommand(ctx context.Context, name string, args []string) error {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Stdin = os.Stdin
+	command.Env = os.Environ()
+	return command.Run()
+}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_install.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_install.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,7 +18,7 @@ const (
 )
 
 type dispatcherV2InstallDeps struct {
-	runCommand func(context.Context, string, []string) error
+	runCommand func(context.Context, string, []string, io.Writer) error
 }
 
 func defaultDispatcherV2InstallDeps() dispatcherV2InstallDeps {
@@ -26,7 +27,7 @@ func defaultDispatcherV2InstallDeps() dispatcherV2InstallDeps {
 
 // installDispatcherV2CLI installs the exact V2 CLI version into its isolated cache directory.
 // Why: each Unity package version requires its matching CLI, so a shared cache slot would reinstall on every project switch.
-func installDispatcherV2CLI(ctx context.Context, cacheRoot string, version string, goos string, deps dispatcherV2InstallDeps) (string, error) {
+func installDispatcherV2CLI(ctx context.Context, cacheRoot string, version string, goos string, stderr io.Writer, deps dispatcherV2InstallDeps) (string, error) {
 	installPath := dispatcherV2InstallPath(cacheRoot, version)
 	if isInstalledDispatcherV2CLI(installPath, version) {
 		return installPath, nil
@@ -45,7 +46,7 @@ func installDispatcherV2CLI(ctx context.Context, cacheRoot string, version strin
 	}()
 
 	args := []string{"install", "--prefix", temporaryDirectory, dispatcherV2CLIPackageName + "@" + version}
-	if err := deps.runCommand(ctx, dispatcherV2NPMCommandName(goos), args); err != nil {
+	if err := deps.runCommand(ctx, dispatcherV2NPMCommandName(goos), args, stderr); err != nil {
 		return "", err
 	}
 	if !isInstalledDispatcherV2CLI(temporaryDirectory, version) {
@@ -83,11 +84,10 @@ func dispatcherV2NPMCommandName(goos string) string {
 	return dispatcherNPMCommandName
 }
 
-func runDispatcherV2InstallCommand(ctx context.Context, name string, args []string) error {
+func runDispatcherV2InstallCommand(ctx context.Context, name string, args []string, stderr io.Writer) error {
 	command := exec.CommandContext(ctx, name, args...)
-	command.Stdout = os.Stdout
-	command.Stderr = os.Stderr
-	command.Stdin = os.Stdin
+	command.Stdout = stderr
+	command.Stderr = stderr
 	command.Env = os.Environ()
 	return command.Run()
 }

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_install_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_install_test.go
@@ -1,0 +1,85 @@
+package dispatcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallDispatcherV2CLIInstallsVersionIntoVersionedCache(t *testing.T) {
+	// Verifies the installer uses npm with an isolated cache directory for the requested version.
+	cacheRoot := t.TempDir()
+	var commandName string
+	var commandArgs []string
+	deps := dispatcherV2InstallDeps{
+		runCommand: func(ctx context.Context, name string, args []string) error {
+			commandName = name
+			commandArgs = append([]string{}, args...)
+			installPath := args[2]
+			writeInstalledDispatcherV2Package(t, installPath, "2.2.0")
+			return nil
+		},
+	}
+
+	installPath, err := installDispatcherV2CLI(context.Background(), cacheRoot, "2.2.0", "darwin", deps)
+	if err != nil {
+		t.Fatalf("install V2 CLI: %v", err)
+	}
+	wantPath := filepath.Join(cacheRoot, dispatcherV2CacheDirectoryName, "2.2.0")
+	if installPath != wantPath {
+		t.Fatalf("install path = %q, want %q", installPath, wantPath)
+	}
+	if commandName != dispatcherNPMCommandName {
+		t.Fatalf("command name = %q, want %q", commandName, dispatcherNPMCommandName)
+	}
+	if len(commandArgs) != 4 || commandArgs[0] != "install" || commandArgs[1] != "--prefix" || commandArgs[3] != dispatcherV2CLIPackageName+"@2.2.0" {
+		t.Fatalf("npm arguments = %#v", commandArgs)
+	}
+	if !filepath.IsAbs(commandArgs[2]) || filepath.Dir(commandArgs[2]) != filepath.Join(cacheRoot, dispatcherV2CacheDirectoryName) {
+		t.Fatalf("npm prefix = %q, want temporary directory under version cache", commandArgs[2])
+	}
+	if !isInstalledDispatcherV2CLI(installPath, "2.2.0") {
+		t.Fatalf("installed V2 CLI missing from %s", installPath)
+	}
+}
+
+func TestInstallDispatcherV2CLISkipsNPMWhenRequestedVersionIsInstalled(t *testing.T) {
+	// Verifies an already installed matching version does not invoke npm again.
+	cacheRoot := t.TempDir()
+	installPath := filepath.Join(cacheRoot, dispatcherV2CacheDirectoryName, "2.2.0")
+	writeInstalledDispatcherV2Package(t, installPath, "2.2.0")
+	deps := dispatcherV2InstallDeps{
+		runCommand: func(context.Context, string, []string) error {
+			t.Fatal("npm must not run for an installed matching V2 CLI")
+			return nil
+		},
+	}
+
+	actualPath, err := installDispatcherV2CLI(context.Background(), cacheRoot, "2.2.0", "darwin", deps)
+	if err != nil {
+		t.Fatalf("install V2 CLI: %v", err)
+	}
+	if actualPath != installPath {
+		t.Fatalf("install path = %q, want %q", actualPath, installPath)
+	}
+}
+
+func TestDispatcherV2NPMCommandNameUsesCmdOnWindows(t *testing.T) {
+	// Verifies the Windows npm command uses the cmd shim executable.
+	if actual := dispatcherV2NPMCommandName("windows"); actual != dispatcherNPMWindowsCommandName {
+		t.Fatalf("npm command = %q, want %q", actual, dispatcherNPMWindowsCommandName)
+	}
+}
+
+func writeInstalledDispatcherV2Package(t *testing.T, installPath string, version string) {
+	t.Helper()
+	packagePath := filepath.Join(installPath, "node_modules", dispatcherV2CLIPackageName, dispatcherPackageJSONFileName)
+	if err := os.MkdirAll(filepath.Dir(packagePath), 0o755); err != nil {
+		t.Fatalf("create installed package directory: %v", err)
+	}
+	content := "{\n  \"version\": \"" + version + "\"\n}\n"
+	if err := os.WriteFile(packagePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write installed package: %v", err)
+	}
+}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_install_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_install_test.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +14,7 @@ func TestInstallDispatcherV2CLIInstallsVersionIntoVersionedCache(t *testing.T) {
 	var commandName string
 	var commandArgs []string
 	deps := dispatcherV2InstallDeps{
-		runCommand: func(ctx context.Context, name string, args []string) error {
+		runCommand: func(ctx context.Context, name string, args []string, stderr io.Writer) error {
 			commandName = name
 			commandArgs = append([]string{}, args...)
 			installPath := args[2]
@@ -22,7 +23,7 @@ func TestInstallDispatcherV2CLIInstallsVersionIntoVersionedCache(t *testing.T) {
 		},
 	}
 
-	installPath, err := installDispatcherV2CLI(context.Background(), cacheRoot, "2.2.0", "darwin", deps)
+	installPath, err := installDispatcherV2CLI(context.Background(), cacheRoot, "2.2.0", "darwin", io.Discard, deps)
 	if err != nil {
 		t.Fatalf("install V2 CLI: %v", err)
 	}
@@ -50,13 +51,13 @@ func TestInstallDispatcherV2CLISkipsNPMWhenRequestedVersionIsInstalled(t *testin
 	installPath := filepath.Join(cacheRoot, dispatcherV2CacheDirectoryName, "2.2.0")
 	writeInstalledDispatcherV2Package(t, installPath, "2.2.0")
 	deps := dispatcherV2InstallDeps{
-		runCommand: func(context.Context, string, []string) error {
+		runCommand: func(context.Context, string, []string, io.Writer) error {
 			t.Fatal("npm must not run for an installed matching V2 CLI")
 			return nil
 		},
 	}
 
-	actualPath, err := installDispatcherV2CLI(context.Background(), cacheRoot, "2.2.0", "darwin", deps)
+	actualPath, err := installDispatcherV2CLI(context.Background(), cacheRoot, "2.2.0", "darwin", io.Discard, deps)
 	if err != nil {
 		t.Fatalf("install V2 CLI: %v", err)
 	}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_run.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_run.go
@@ -1,0 +1,48 @@
+package dispatcher
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// runDispatcherV2CLI installs and executes the V2 CLI while preserving the original command arguments.
+// Why: the dispatcher must select the CLI generation before command parsing can change user-supplied arguments.
+func runDispatcherV2CLI(ctx context.Context, version string, args []string, stdout io.Writer, stderr io.Writer) (int, error) {
+	cacheRoot, err := dispatcherCacheRoot(runtime.GOOS)
+	if err != nil {
+		return 0, err
+	}
+	installPath, err := installDispatcherV2CLI(ctx, cacheRoot, version, runtime.GOOS, defaultDispatcherV2InstallDeps())
+	if err != nil {
+		return 0, err
+	}
+	entrypoint, err := resolveDispatcherV2CLIEntrypoint(installPath)
+	if err != nil {
+		return 0, err
+	}
+	nodePath, err := defaultDispatcherV2NodePath()
+	if err != nil {
+		return 0, err
+	}
+	_, err = io.WriteString(stderr, "uloop: executing in V2 mode\n")
+	if err != nil {
+		return 0, err
+	}
+	command := exec.CommandContext(ctx, nodePath, append([]string{entrypoint}, args...)...)
+	command.Stdout = stdout
+	command.Stderr = stderr
+	command.Stdin = os.Stdin
+	command.Env = os.Environ()
+	if err := command.Run(); err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			return exitError.ExitCode(), nil
+		}
+		return 0, err
+	}
+	return 0, nil
+}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_run.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_run.go
@@ -16,7 +16,7 @@ func runDispatcherV2CLI(ctx context.Context, version string, args []string, stdo
 	if err != nil {
 		return 0, err
 	}
-	installPath, err := installDispatcherV2CLI(ctx, cacheRoot, version, runtime.GOOS, defaultDispatcherV2InstallDeps())
+	installPath, err := installDispatcherV2CLI(ctx, cacheRoot, version, runtime.GOOS, stderr, defaultDispatcherV2InstallDeps())
 	if err != nil {
 		return 0, err
 	}

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -41,6 +41,7 @@ type dispatcherUpdateState struct {
 type dispatcherRunDeps struct {
 	now        func() time.Time
 	runRealCLI func(context.Context, string, []string, io.Writer, io.Writer) int
+	runV2CLI   func(context.Context, string, []string, io.Writer, io.Writer) (int, error)
 	runUpdate  func(context.Context) error
 	launch     launchDeps
 }
@@ -49,6 +50,7 @@ func defaultDispatcherRunDeps() dispatcherRunDeps {
 	return dispatcherRunDeps{
 		now:        time.Now,
 		runRealCLI: runRealCLICommand,
+		runV2CLI:   runDispatcherV2CLI,
 		runUpdate:  runDispatcherUpdateCommand,
 		launch:     defaultLaunchDeps(),
 	}
@@ -59,18 +61,31 @@ func RunDispatcher(ctx context.Context, args []string, stdout io.Writer, stderr 
 }
 
 func runDispatcherWithDeps(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, deps dispatcherRunDeps) int {
-	if handled, code := tryHandleDispatcherInfoRequest(args, stdout); handled {
-		return code
-	}
-
 	remainingArgs, projectPath, err := clicore.ParseGlobalProjectPath(args)
 	if err != nil {
 		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{})
 		return 1
 	}
+	if len(args) == 0 || clicore.IsHelpRequest(remainingArgs) || clicore.IsVersionRequest(remainingArgs) || clicore.IsVersionJSONRequest(remainingArgs) {
+		if startPath, workingDirectoryErr := os.Getwd(); workingDirectoryErr == nil {
+			if projectRoot, resolveErr := resolveDispatcherProjectRoot(startPath, projectPath, remainingArgs); resolveErr == nil {
+				if v2Project, detectErr := detectV2DispatcherProject(projectRoot); detectErr == nil && v2Project.IsV2 {
+					code, runErr := deps.runV2CLI(ctx, v2Project.PackageVersion, args, stdout, stderr)
+					if runErr == nil {
+						return code
+					}
+					clierrors.WriteErrorEnvelope(stderr, dispatcherV2ProjectDetectedError(projectRoot, v2Project.PackageVersion))
+					return 1
+				}
+			}
+		}
+		if handled, code := tryHandleDispatcherInfoRequest(args, stdout); handled {
+			return code
+		}
+	}
 
 	if shouldRunInDispatcherProcess(remainingArgs) {
-		return runDispatcherProcessCommandWithDeps(ctx, remainingArgs, projectPath, stdout, stderr, deps)
+		return runDispatcherProcessCommandWithDeps(ctx, args, remainingArgs, projectPath, stdout, stderr, deps)
 	}
 
 	startPath, err := os.Getwd()
@@ -89,6 +104,10 @@ func runDispatcherWithDeps(ctx context.Context, args []string, stdout io.Writer,
 	if err != nil {
 		v2Project, detectErr := detectV2DispatcherProject(projectRoot)
 		if detectErr == nil && v2Project.IsV2 {
+			code, runErr := deps.runV2CLI(ctx, v2Project.PackageVersion, args, stdout, stderr)
+			if runErr == nil {
+				return code
+			}
 			clierrors.WriteErrorEnvelope(stderr, dispatcherV2ProjectDetectedError(projectRoot, v2Project.PackageVersion))
 			return 1
 		}
@@ -115,24 +134,36 @@ func runDispatcherWithDeps(ctx context.Context, args []string, stdout io.Writer,
 // execution path must not run through RunProjectLocal.
 func runDispatcherProcessCommandWithDeps(
 	ctx context.Context,
+	args []string,
 	remainingArgs []string,
 	projectPath string,
 	stdout io.Writer,
 	stderr io.Writer,
 	deps dispatcherRunDeps,
 ) int {
+	startPath, err := os.Getwd()
+	if err != nil {
+		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{})
+		return 1
+	}
+	if !shouldKeepDispatcherProcessCommand(remainingArgs) {
+		if projectRoot, resolveErr := resolveDispatcherProjectRoot(startPath, projectPath, remainingArgs); resolveErr == nil {
+			if v2Project, detectErr := detectV2DispatcherProject(projectRoot); detectErr == nil && v2Project.IsV2 {
+				code, runErr := deps.runV2CLI(ctx, v2Project.PackageVersion, args, stdout, stderr)
+				if runErr == nil {
+					return code
+				}
+				clierrors.WriteErrorEnvelope(stderr, dispatcherV2ProjectDetectedError(projectRoot, v2Project.PackageVersion))
+				return 1
+			}
+		}
+	}
 	if handled, code := tryHandleProjectScopeHelpRequest(remainingArgs, projectPath, stdout); handled {
 		return code
 	}
 
 	command := remainingArgs[0]
 	commandArgs := remainingArgs[1:]
-
-	startPath, err := os.Getwd()
-	if err != nil {
-		clierrors.WriteClassifiedError(stderr, err, clierrors.ErrorContext{Command: command})
-		return 1
-	}
 
 	if handled, code := tryHandlePreConnectionRequestWithDeps(
 		ctx,
@@ -155,6 +186,18 @@ func runDispatcherProcessCommandWithDeps(
 		clierrors.ErrorContext{Command: command},
 	))
 	return 1
+}
+
+func shouldKeepDispatcherProcessCommand(args []string) bool {
+	if len(args) == 0 || clicore.ShouldHandleCompletionRequest(args) {
+		return true
+	}
+	switch args[0] {
+	case clicore.InstallCommandName, clicore.UpdateCommandName, clicore.UninstallCommandName, clicore.LaunchCommandName:
+		return true
+	default:
+		return false
+	}
 }
 
 func shouldRunInDispatcherProcess(args []string) bool {


### PR DESCRIPTION
Refs: V3 dispatcher to V2 CLI delegation — To-Do 5–8

## Summary
- Runs compatible legacy projects through the installed launcher without global CLI switching.
- Stores each required legacy CLI version separately and forwards command arguments unchanged.

## User Impact
- Projects from both CLI generations can share one launcher.
- Missing Node or installation failures retain actionable guidance.

## Changes
- Install the matching legacy package into a versioned cache through npm.
- Resolve the package bin entrypoint and invoke it through Node.
- Keep global management commands and launch handling in the dispatcher.

## Verification
- `scripts/check-go-cli.sh` (pass)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

