### PR TITLE
docs: Explain V2 and V3 project coexistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ Select Window > Unity CLI Loop > Settings. A dedicated window will open. If the 
 
 The installer places the global `uloop` dispatcher on PATH. Project-specific `uloop-project-runner` binaries are downloaded into the user cache automatically from each project's `.uloop/project-runner-pin.json`.
 
-To return to the v2 line, press **Uninstall CLI** in Settings, downgrade the U-LOOP package to a v2 version such as `2.1.1`, then press **Install CLI** again from Settings.
+Keep the v3 dispatcher installed when working with both v2 and v3 projects. If a Unity project has a v2 `io.github.hatayama.uloopmcp` package and no v3 project-runner pin, the dispatcher automatically installs the matching v2 `uloop-cli` release into its versioned user cache and delegates the command to it. The initial npm installation and the v2-mode notice are written to stderr so stdout remains the delegated command's output. V3 projects continue to use the project runner selected by their pin.
+
+The global `install`, `update`, `uninstall`, `completion`, and `launch` commands remain owned by the v3 dispatcher in every project. Other project commands, help, and the project-scoped version request are delegated for detected v2 projects.
+
+V2 delegation requires Node.js 22 or later, including npm for the first command that populates the cache. Do not press **Update CLI** or **Downgrade CLI** in a v2 project's Settings window. These buttons are normally hidden because the delegated CLI reports the matching v2 version, but using one can restore a global npm CLI that hides the v3 dispatcher depending on PATH order.
 
 <details>
 <summary>CLI-only terminal install</summary>
@@ -128,11 +132,11 @@ If npm is unavailable or the old command belongs to a different Node prefix, the
 npm uninstall -g uloop-cli
 ```
 
-If the Unity UI path is not available or your terminal still resolves `uloop` to the v3 CLI, remove that command first, then install the v2 version you want:
+Do not install a v2 CLI globally to switch projects. If your terminal resolves `uloop` to an old npm installation instead of the native dispatcher, remove the npm installation and reinstall the native dispatcher:
 
 ```bash
-rm -f "$HOME/.local/bin/uloop"
-npm install -g uloop-cli@2.1.1
+npm uninstall -g uloop-cli
+# Run the verified native installer above again.
 which uloop
 uloop --version
 ```
@@ -140,8 +144,8 @@ uloop --version
 On Windows PowerShell:
 
 ```powershell
-Remove-Item "$env:LOCALAPPDATA\Programs\uloop\bin\uloop.exe" -Force -ErrorAction SilentlyContinue
-npm install -g uloop-cli@2.1.1
+npm uninstall -g uloop-cli
+# Run the verified native installer above again.
 Get-Command uloop
 uloop --version
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -74,7 +74,13 @@ Scope(s): io.github.hatayama.uloopmcp
 
 Window > Unity CLI Loop > Settingsを選択します。専用ウィンドウが開くので、**CLI** ボタンが青くなっていなければ **Install CLI** を押してください。
 
-v2系に戻したい場合は、Settings で **Uninstall CLI** を押し、Unity Package Manager か `manifest.json` で U-LOOP package を `2.1.1` などのv2系のバージョンへ下げてから、もう一度 Settings で **Install CLI** を押してください。
+installerはグローバルな`uloop` dispatcherをPATH上に配置します。プロジェクト固有の`uloop-project-runner` binaryは、各プロジェクトの`.uloop/project-runner-pin.json`に従ってuser cacheへ自動的にdownloadされます。
+
+v2とv3のプロジェクトを併用するときも、v3 dispatcherをインストールしたままにしてください。Unityプロジェクトにv2系の`io.github.hatayama.uloopmcp` packageがあり、v3のproject-runner pinがない場合、dispatcherは同じバージョンのv2 `uloop-cli` releaseをバージョン別user cacheへ自動的にインストールし、コマンドを委譲します。初回のnpmインストールとv2モードの注記はstderrへ出力されるため、stdoutには委譲先コマンドの出力だけが残ります。v3プロジェクトはpinで選ばれたproject runnerを引き続き使用します。
+
+グローバルな`install`、`update`、`uninstall`、`completion`、`launch`コマンドは、どのプロジェクトでもv3 dispatcherが処理します。検出されたv2プロジェクトでは、それ以外のプロジェクトコマンド、help、プロジェクトスコープのversion表示が委譲されます。
+
+v2への委譲には、初回コマンドでcacheを作成するnpmを含むNode.js 22以降が必要です。v2プロジェクトのSettingsウィンドウでは、**Update CLI**または**Downgrade CLI**を押さないでください。委譲先CLIが同じv2バージョンを返すため通常はボタン自体が表示されませんが、使用するとグローバルnpm版CLIが復活し、PATHの順序によってv3 dispatcherが隠れる可能性があります。
 
 <details>
 <summary>CLIだけをterminalからinstallする場合はこちら</summary>
@@ -125,11 +131,11 @@ npm が見つからない場合や、古い command が別の Node prefix に属
 npm uninstall -g uloop-cli
 ```
 
-Unity UIから戻せない場合や、ターミナルの `uloop` がまだv3系のCLIを指している場合は、先にその `uloop` コマンドを削除してから、戻したいv2系のバージョンをインストールしてください。
+プロジェクトを切り替えるためにv2 CLIをグローバルインストールしないでください。ターミナルの`uloop`がnative dispatcherではなく古いnpm版を指している場合は、npm版を削除してnative dispatcherを再インストールしてください。
 
 ```bash
-rm -f "$HOME/.local/bin/uloop"
-npm install -g uloop-cli@2.1.1
+npm uninstall -g uloop-cli
+# 上記の検証済みnative installerをもう一度実行します。
 which uloop
 uloop --version
 ```
@@ -137,8 +143,8 @@ uloop --version
 Windows PowerShell の場合:
 
 ```powershell
-Remove-Item "$env:LOCALAPPDATA\Programs\uloop\bin\uloop.exe" -Force -ErrorAction SilentlyContinue
-npm install -g uloop-cli@2.1.1
+npm uninstall -g uloop-cli
+# 上記の検証済みnative installerをもう一度実行します。
 Get-Command uloop
 uloop --version
 ```


### PR DESCRIPTION
## Summary

- explain automatic delegation from the native v3 dispatcher to matching v2 CLIs
- document the Node.js 22+ and initial npm cache requirements
- clarify dispatcher-owned commands and warn against v2 Setup UI update or downgrade actions
- replace global v2 switching instructions in both English and Japanese documentation

## Validation

- `git diff --check`
- confirmed the removed global v2 installation command no longer appears in either README
- compared the documented detection, cache, routing, stderr, and version behavior with the merged dispatcher implementation

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

