### PR TITLE
fix: Project commands now work from paths containing glob characters

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_pin.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_pin.go
@@ -53,16 +53,16 @@ func dispatcherPinCandidatePaths(projectRoot string) []dispatcherPinCandidatePat
 		{Path: filepath.Join(projectRoot, "Packages", "src", dispatcherPackagePinFileName)},
 		{Path: filepath.Join(projectRoot, "Packages", dispatcherUnityPackageName, dispatcherPackagePinFileName)},
 	}
-	packageCachePattern := filepath.Join(
-		projectRoot,
-		"Library",
-		"PackageCache",
-		dispatcherUnityPackageName+"@*",
-		dispatcherPackagePinFileName)
-	matches, err := filepath.Glob(packageCachePattern)
+	packageCacheDirectory := filepath.Join(projectRoot, "Library", "PackageCache")
+	entries, err := os.ReadDir(packageCacheDirectory)
 	if err == nil {
-		for _, match := range matches {
-			paths = append(paths, dispatcherPinCandidatePath{Path: match})
+		packageDirectoryPrefix := dispatcherUnityPackageName + "@"
+		for _, entry := range entries {
+			if !entry.IsDir() || !strings.HasPrefix(entry.Name(), packageDirectoryPrefix) {
+				continue
+			}
+			pinPath := filepath.Join(packageCacheDirectory, entry.Name(), dispatcherPackagePinFileName)
+			paths = append(paths, dispatcherPinCandidatePath{Path: pinPath})
 		}
 	}
 	return paths

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -852,6 +852,26 @@ func TestLoadDispatcherPinSkipsInvalidPackageCandidate(t *testing.T) {
 	}
 }
 
+func TestLoadDispatcherPinFindsPackageCachePinWithBracketedProjectPath(t *testing.T) {
+	// Verifies PackageCache pin discovery treats glob metacharacters in the project path literally.
+	projectRoot := filepath.Join(t.TempDir(), "project[legacy]")
+	for _, directory := range []string{"Assets", "ProjectSettings"} {
+		if err := os.MkdirAll(filepath.Join(projectRoot, directory), 0o755); err != nil {
+			t.Fatalf("failed to create Unity project directory: %v", err)
+		}
+	}
+	cachePackageRoot := filepath.Join(projectRoot, "Library", "PackageCache", dispatcherUnityPackageName+"@3.0.0-beta.57")
+	writeDispatcherPinFile(t, filepath.Join(cachePackageRoot, dispatcherPackagePinFileName), "3.0.0-beta.57")
+
+	pin, err := loadDispatcherPin(projectRoot)
+	if err != nil {
+		t.Fatalf("loadDispatcherPin failed: %v", err)
+	}
+	if pin.ProjectRunnerVersion != "3.0.0-beta.57" {
+		t.Fatalf("projectRunnerVersion mismatch: %s", pin.ProjectRunnerVersion)
+	}
+}
+
 func TestLoadDispatcherPinNormalizesVersionPrefixes(t *testing.T) {
 	// Verifies v-prefixed pin versions are normalized before semantic-version validation.
 	projectRoot := createDispatcherUnityProject(t)


### PR DESCRIPTION
## Summary
- Ensure V3 project-runner pins are discovered when a Unity project path contains glob metacharacters such as brackets.

## User Impact
- Project-scoped commands no longer report a missing runner pin solely because the project path contains `[` or `]`.

## Changes
- Replace glob-based PackageCache pin discovery with literal directory traversal.
- Preserve package directory filtering and candidate ordering.
- Add regression coverage for a bracketed project path.

## Verification
- `go test ./internal/dispatcher -run TestLoadDispatcherPinFindsPackageCachePinWithBracketedProjectPath -count=1`
- `go test ./internal/dispatcher -run TestLoadDispatcherPin -count=1`
- `go clean -testcache`
- `scripts/check-go-cli.sh`

Closes #1808

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

