### PR TITLE
fix: V2 delegation now recognizes SCP Git dependencies with path queries

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect.go
@@ -119,10 +119,11 @@ func isDispatcherGitPackageDependency(dependency json.RawMessage) bool {
 		return false
 	}
 	withoutRevision, _, _ := strings.Cut(strings.TrimSpace(value), "#")
-	if strings.HasPrefix(withoutRevision, "git@") {
-		return strings.HasSuffix(withoutRevision, ".git")
+	withoutQuery, _, _ := strings.Cut(withoutRevision, "?")
+	if strings.HasPrefix(withoutQuery, "git@") {
+		return strings.HasSuffix(withoutQuery, ".git")
 	}
-	parsed, err := url.Parse(withoutRevision)
+	parsed, err := url.Parse(withoutQuery)
 	if err != nil {
 		return false
 	}

--- a/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_v2_detect_test.go
@@ -229,6 +229,28 @@ func TestDetectV2DispatcherProjectRejectsNonGitManifestFallbackWithoutLockEntry(
 	}
 }
 
+func TestIsDispatcherGitPackageDependencyAcceptsPathQueries(t *testing.T) {
+	// Verifies Unity Git dependencies with path queries remain eligible for PackageCache fallback.
+	testCases := []struct {
+		name       string
+		dependency string
+	}{
+		{name: "scp", dependency: "git@example.invalid:package.git?path=/sub"},
+		{name: "https", dependency: "https://example.invalid/package.git?path=/sub"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dependency, err := json.Marshal(testCase.dependency)
+			if err != nil {
+				t.Fatalf("marshal dependency: %v", err)
+			}
+			if !isDispatcherGitPackageDependency(dependency) {
+				t.Fatalf("Git dependency was rejected: %s", testCase.dependency)
+			}
+		})
+	}
+}
+
 func TestRunDispatcherReportsV2ProjectGuidanceWhenPinIsMissing(t *testing.T) {
 	// Verifies pinless V2 projects receive migration guidance instead of the missing-pin error.
 	projectRoot := createDispatcherUnityProject(t)


### PR DESCRIPTION
## Summary
- Recognize Unity SCP-style Git dependencies that include a `?path=` query when resolving lockless V2 projects.

## User Impact
- V2 delegation no longer falls back to the pin path solely because an SCP Git dependency selects a package subdirectory.
- HTTPS Git dependencies with path queries remain supported.

## Changes
- Remove the query segment before validating Git dependency suffixes.
- Add regression coverage for SCP and HTTPS Git URLs with path queries.

## Verification
- `go test ./internal/dispatcher -run TestIsDispatcherGitPackageDependencyAcceptsPathQueries -count=1`
- `go test ./internal/dispatcher -run "TestIsDispatcherGitPackageDependency|TestDetectV2DispatcherProject" -count=1`
- `go clean -testcache`
- `scripts/check-go-cli.sh`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

