### PR TITLE
fix: restore runInBackground on the main thread after input simulation

### DIFF
--- a/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/InputSimulationRunInBackgroundScope.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/InputSimulationRunInBackgroundScope.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System;
 
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
     /// <summary>
@@ -29,6 +31,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         public void Dispose()
         {
+            // Precondition: Application.runInBackground is main-thread-only, so callers resuming
+            // from ConfigureAwait(false) continuations must switch back to the main thread first.
+            UnityEngine.Debug.Assert(
+                MainThreadSwitcher.IsMainThread,
+                "InputSimulationRunInBackgroundScope.Dispose must be called on the main thread.");
+
             if (_isDisposed)
             {
                 return;

--- a/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/UnityCLILoop.FirstPartyTools.Common.InputSimulation.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/InputSimulation/UnityCLILoop.FirstPartyTools.Common.InputSimulation.Editor.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "UnityCLILoop.FirstPartyTools.Common.InputSimulation.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
-    "references": [],
+    "references": [
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+    ],
     "includePlatforms": [
         "Editor"
     ],

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardUseCase.cs
@@ -104,49 +104,59 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 correlationId: correlationId
             );
 
-            using InputSimulationRunInBackgroundScope runInBackgroundScope = InputSimulationRunInBackgroundScope.Enable();
-
-            EnsureOverlayExists();
-
-            SimulateKeyboardResponse response;
-
-            switch (parameters.Action)
+            // Why not `using`: the executor awaits below use ConfigureAwait(false), so this method
+            // can resume on a thread-pool thread. Application.runInBackground is main-thread-only,
+            // so the scope must be disposed after switching back to the main thread.
+            InputSimulationRunInBackgroundScope runInBackgroundScope = InputSimulationRunInBackgroundScope.Enable();
+            try
             {
-                case UnityCliLoopKeyboardAction.Press:
-                    response = await KeyboardInputActionExecutor.ExecutePress(
-                        keyboard,
-                        key,
-                        parameters.Duration,
-                        ct).ConfigureAwait(false);
-                    break;
+                EnsureOverlayExists();
 
-                case UnityCliLoopKeyboardAction.KeyDown:
-                    response = await KeyboardInputActionExecutor.ExecuteKeyDown(keyboard, key, ct).ConfigureAwait(false);
-                    break;
+                SimulateKeyboardResponse response;
 
-                case UnityCliLoopKeyboardAction.KeyUp:
-                    response = await KeyboardInputActionExecutor.ExecuteKeyUp(keyboard, key, ct).ConfigureAwait(false);
-                    break;
+                switch (parameters.Action)
+                {
+                    case UnityCliLoopKeyboardAction.Press:
+                        response = await KeyboardInputActionExecutor.ExecutePress(
+                            keyboard,
+                            key,
+                            parameters.Duration,
+                            ct).ConfigureAwait(false);
+                        break;
 
-                default:
-                    // Only reachable when an out-of-range enum value is cast from an integer;
-                    // surface as a Success=false response so the CLI treats it as a normal validation failure.
-                    return new SimulateKeyboardResponse
-                    {
-                        Success = false,
-                        Message = $"Unknown keyboard action: {parameters.Action}",
-                        Action = parameters.Action.ToString()
-                    };
+                    case UnityCliLoopKeyboardAction.KeyDown:
+                        response = await KeyboardInputActionExecutor.ExecuteKeyDown(keyboard, key, ct).ConfigureAwait(false);
+                        break;
+
+                    case UnityCliLoopKeyboardAction.KeyUp:
+                        response = await KeyboardInputActionExecutor.ExecuteKeyUp(keyboard, key, ct).ConfigureAwait(false);
+                        break;
+
+                    default:
+                        // Only reachable when an out-of-range enum value is cast from an integer;
+                        // surface as a Success=false response so the CLI treats it as a normal validation failure.
+                        return new SimulateKeyboardResponse
+                        {
+                            Success = false,
+                            Message = $"Unknown keyboard action: {parameters.Action}",
+                            Action = parameters.Action.ToString()
+                        };
+                }
+
+                VibeLogger.LogInfo(
+                    "simulate_keyboard_complete",
+                    $"Keyboard simulation completed: {response.Message}",
+                    new { Action = parameters.Action.ToString(), Success = response.Success },
+                    correlationId: correlationId
+                );
+
+                return response;
             }
-
-            VibeLogger.LogInfo(
-                "simulate_keyboard_complete",
-                $"Keyboard simulation completed: {response.Message}",
-                new { Action = parameters.Action.ToString(), Success = response.Success },
-                correlationId: correlationId
-            );
-
-            return response;
+            finally
+            {
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+                runInBackgroundScope.Dispose();
+            }
 #endif
         }
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputUseCase.cs
@@ -97,46 +97,56 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 correlationId: correlationId
             );
 
-            using InputSimulationRunInBackgroundScope runInBackgroundScope = InputSimulationRunInBackgroundScope.Enable();
-
-            EnsureOverlayExists();
-
-            SimulateMouseInputResponse response;
-
-            switch (parameters.Action)
+            // Why not `using`: the executor awaits below use ConfigureAwait(false), so this method
+            // can resume on a thread-pool thread. Application.runInBackground is main-thread-only,
+            // so the scope must be disposed after switching back to the main thread.
+            InputSimulationRunInBackgroundScope runInBackgroundScope = InputSimulationRunInBackgroundScope.Enable();
+            try
             {
-                case UnityCliLoopMouseInputAction.Click:
-                    response = await MouseInputPressActionExecutor.ExecuteClick(mouse, parameters, ct).ConfigureAwait(false);
-                    break;
+                EnsureOverlayExists();
 
-                case UnityCliLoopMouseInputAction.LongPress:
-                    response = await MouseInputPressActionExecutor.ExecuteLongPress(mouse, parameters, ct).ConfigureAwait(false);
-                    break;
+                SimulateMouseInputResponse response;
 
-                case UnityCliLoopMouseInputAction.MoveDelta:
-                    response = await MouseInputMotionActionExecutor.ExecuteMoveDelta(mouse, parameters, ct).ConfigureAwait(false);
-                    break;
+                switch (parameters.Action)
+                {
+                    case UnityCliLoopMouseInputAction.Click:
+                        response = await MouseInputPressActionExecutor.ExecuteClick(mouse, parameters, ct).ConfigureAwait(false);
+                        break;
 
-                case UnityCliLoopMouseInputAction.Scroll:
-                    response = await MouseInputMotionActionExecutor.ExecuteScroll(mouse, parameters, ct).ConfigureAwait(false);
-                    break;
+                    case UnityCliLoopMouseInputAction.LongPress:
+                        response = await MouseInputPressActionExecutor.ExecuteLongPress(mouse, parameters, ct).ConfigureAwait(false);
+                        break;
 
-                case UnityCliLoopMouseInputAction.SmoothDelta:
-                    response = await MouseInputMotionActionExecutor.ExecuteSmoothDelta(mouse, parameters, ct).ConfigureAwait(false);
-                    break;
+                    case UnityCliLoopMouseInputAction.MoveDelta:
+                        response = await MouseInputMotionActionExecutor.ExecuteMoveDelta(mouse, parameters, ct).ConfigureAwait(false);
+                        break;
 
-                default:
-                    throw new ArgumentException($"Unknown mouse input action: {parameters.Action}");
+                    case UnityCliLoopMouseInputAction.Scroll:
+                        response = await MouseInputMotionActionExecutor.ExecuteScroll(mouse, parameters, ct).ConfigureAwait(false);
+                        break;
+
+                    case UnityCliLoopMouseInputAction.SmoothDelta:
+                        response = await MouseInputMotionActionExecutor.ExecuteSmoothDelta(mouse, parameters, ct).ConfigureAwait(false);
+                        break;
+
+                    default:
+                        throw new ArgumentException($"Unknown mouse input action: {parameters.Action}");
+                }
+
+                VibeLogger.LogInfo(
+                    "simulate_mouse_input_complete",
+                    $"Mouse input simulation completed: {response.Message}",
+                    new { Action = parameters.Action.ToString(), Success = response.Success },
+                    correlationId: correlationId
+                );
+
+                return response;
             }
-
-            VibeLogger.LogInfo(
-                "simulate_mouse_input_complete",
-                $"Mouse input simulation completed: {response.Message}",
-                new { Action = parameters.Action.ToString(), Success = response.Success },
-                correlationId: correlationId
-            );
-
-            return response;
+            finally
+            {
+                await InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None);
+                runInBackgroundScope.Dispose();
+            }
 #endif
         }
 


### PR DESCRIPTION
## Summary

`uloop simulate-mouse-input` and `uloop simulate-keyboard` failed on every invocation with `UNITY_RPC_ERROR / set_runInBackground can only be called from the main thread` (reproduced 5/5 on Windows during the v3 verification pass; the mechanism is platform-independent). The simulation itself succeeded (VibeLogs recorded `*_complete` with `Success:true`), but the successful response was discarded, and the escaped exception left PlayMode in Error Pause, blocking subsequent attempts.

## Root cause

- PR #1778's ConfigureAwait guard mechanically added `.ConfigureAwait(false)` to the executor awaits in `SimulateMouseInputUseCase` / `SimulateKeyboardUseCase`.
- Those awaits complete through a `TaskCompletionSource` created with `TaskCreationOptions.RunContinuationsAsynchronously` (`InputSystemConfiguredUpdateApplier`), so with `ConfigureAwait(false)` the continuation always resumes on a thread-pool thread instead of Unity's main thread.
- The `using InputSimulationRunInBackgroundScope` Dispose then ran on that pool thread and set `Application.runInBackground` — a main-thread-only API — which threw, replacing the successful response with an internal error.

## Fix

Follow the existing precedent in `PlayModeTestExecuter` (why-not-`using` + finally with a main-thread switch):

- `SimulateMouseInputUseCase` / `SimulateKeyboardUseCase`: replace `using` with an explicit scope + `try`/`finally`; the `finally` awaits `InputSystemUpdateHelper.SwitchToMainThreadIfNeeded(CancellationToken.None)` before `Dispose()`. (`SwitchToMainThreadIfNeeded` is a custom awaitable, so it is outside the ConfigureAwait guard's scope — no re-collision.)
- `InputSimulationRunInBackgroundScope.Dispose`: added `Debug.Assert(MainThreadSwitcher.IsMainThread, ...)` so any future off-main-thread disposal fails fast. This required referencing the ToolContracts asmdef from the InputSimulation asmdef (same dependency the sibling Common/InputSystem asmdef already has).

## Verification (Windows, Unity 2022.3.62f3, native uloop 3.1.0-beta.13)

- **Red**: existing PlayMode tests `SimulateMouseInputTests.LongPress_Should_RestoreRunInBackground_WhenOriginallyDisabled` and `SimulateKeyboardTests.Press_Should_RestoreRunInBackground_WhenOriginallyDisabled` both failed before the fix with exactly `set_runInBackground can only be called from the main thread.`
- **Green**: both tests pass after the fix.
- `uloop compile`: 0 errors, 0 warnings.
- E2E: PlayMode start → `uloop simulate-keyboard --action Press --key Space` x3 and `uloop simulate-mouse-input --action Click` x3 → all `Success:true` / exit 0 (previously 0/5); Unity console shows no errors or warnings afterwards; PlayMode stopped cleanly (no Error Pause).
- Regression: full PlayMode `SimulateMouseInputTests` + `SimulateKeyboardTests` suites → 49/49 passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

