### PR TITLE
fix: uloop update no longer fails on Windows over the locked running exe

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -494,6 +494,8 @@ function Invoke-CompatibilityWindowsInstall {
 
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("uloop-stage-" + [System.Guid]::NewGuid().ToString("N"))
 $StagedUloopPath = $null
+$FinalUloopPath = Join-Path $InstallDir "uloop.exe"
+$ReplacedUloopBackupPath = $null
 New-Item -ItemType Directory -Path $TempDir | Out-Null
 
 try {
@@ -535,12 +537,28 @@ try {
     Expand-UloopArchive -ArchivePath $ArchivePath -DestinationPath $TempDir
 
     New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+
+    # Why: earlier installs rename the then-running uloop.exe aside (see below);
+    # those processes have exited by now, so reclaim the leftovers. A backup
+    # whose process is still running stays locked and is skipped silently until
+    # a later install can remove it.
+    Get-ChildItem -LiteralPath $InstallDir -Filter "uloop.exe.old-*" -File -ErrorAction SilentlyContinue |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+
     $StagedUloopPath = Join-Path $InstallDir ("uloop-staged-" + [System.Guid]::NewGuid().ToString("N") + ".exe")
     Copy-Item -Path (Join-Path $TempDir "uloop.exe") -Destination $StagedUloopPath -Force
     Assert-UloopVersionSucceeds -UloopPath $StagedUloopPath -Quiet
     $NativeInstallSupported = Test-UloopNativeInstallSupported -UloopPath $StagedUloopPath
 
-    $FinalUloopPath = Join-Path $InstallDir "uloop.exe"
+    # Why: Windows locks the image file of a running executable against
+    # overwrite and delete but still allows rename. `uloop update` runs this
+    # script as a child of the running uloop.exe, so overwriting the target in
+    # place can never succeed there. Move the existing binary aside first; the
+    # finally block restores it if the new binary was not placed.
+    if (Test-Path -LiteralPath $FinalUloopPath) {
+        $ReplacedUloopBackupPath = $FinalUloopPath + ".old-" + [System.Guid]::NewGuid().ToString("N")
+        Move-Item -LiteralPath $FinalUloopPath -Destination $ReplacedUloopBackupPath -Force
+    }
     Copy-Item -Path $StagedUloopPath -Destination $FinalUloopPath -Force
     Remove-Item -Path $StagedUloopPath -Force
     $StagedUloopPath = $null
@@ -555,6 +573,11 @@ try {
     Assert-UloopVersionSucceeds -UloopPath $FinalUloopPath
 }
 finally {
+    # Why: if the install failed after the old binary was moved aside, put it
+    # back so a failed update never leaves the user without a working uloop.
+    if ($ReplacedUloopBackupPath -and (Test-Path -LiteralPath $ReplacedUloopBackupPath) -and -not (Test-Path -LiteralPath $FinalUloopPath)) {
+        Move-Item -LiteralPath $ReplacedUloopBackupPath -Destination $FinalUloopPath -Force
+    }
     if ($StagedUloopPath -and (Test-Path $StagedUloopPath)) {
         Remove-Item -Path $StagedUloopPath -Force -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
## Problem

`uloop update` always fails on Windows (verified on a real Windows 11 machine with the released `dispatcher-v3.1.0-beta.13`). Download, SHA-256, and attestation verification all pass, then the installer dies:

```
Copy-Item : The process cannot access the file '...\uloop.exe' because it is being used by another process.
At ...\install.ps1:544
```

The same code path is used by the automatic dispatcher self-update (both the periodic optional update and the required update driven by `minimumDispatcherVersion` in the project pin), so every cold-start project command on Windows also logs `warning: dispatcher self-update skipped: exit status 1`, and a required update can never succeed automatically.

## Root cause

`runUpdateCommand` (`cli/dispatcher/internal/dispatcher/update.go`) executes `install.ps1` as a child process of the running `uloop.exe`. Windows locks the image file of a running executable against overwrite and delete, so the installer's `Copy-Item -Destination $FinalUloopPath -Force` can never succeed in the update flow. macOS is unaffected (unlink of a running binary is allowed). The uninstall flow already handles self-removal (Wait-Process based deferred delete), but the install/update flow had no self-replacement strategy.

The binary copy exists only in `scripts/install.ps1`; the embedded `cli/dispatcher/internal/install/scripts/install_windows.ps1` only configures PATH and cleans legacy npm shims, so no change is needed there.

## Fix: rename-swap

Windows does allow renaming a running image. Before placing the new binary:

- reclaim stale `uloop.exe.old-*` backups best-effort (a still-running one stays locked and is skipped silently until a later install),
- move an existing `uloop.exe` aside to `uloop.exe.old-<guid>`,
- copy the staged, verified binary to the final path,
- in `finally`, if the install failed after the rename and no new binary was placed, move the backup back so a failed update never leaves the user without a working `uloop`.

This is simpler and fully synchronous compared to the uninstall-style deferred Wait-Process approach, and it also covers a manual reinstall performed while some `uloop.exe` process happens to be running. POSIX `install.sh` is untouched (Windows-specific problem).

## Implication for already-released binaries

The update flow downloads `install.ps1` from the **target** release: `resolveUpdateTargetVersion` promotes an implicit "latest" into an explicit target version, and `update.ScriptVersion` builds the installer URL from it. Therefore, once a dispatcher release carries this fix, already-shipped broken binaries (<= 3.1.0-beta.13) heal themselves via plain `uloop update` and via the automatic self-update — no manual reinstall required. The only path that keeps failing is an explicit downgrade (`--to-version` to a release that still carries the old script) executed while the target exe is running.

## Verification (Windows 11 real machine, sandboxed via ULOOP_INSTALL_DIR / ULOOP_CACHE_DIR)

- Red (real path): released 3.1.0-beta.13 binary in a sandbox install dir, `uloop update` -> exit 1, IOException at `install.ps1:544` (exact production failure reproduced; old exe intact afterwards).
- Red (script level): pre-fix `scripts/install.ps1` run with env/args matching `runUpdateCommand` while a real `uloop.exe` process (started `CREATE_SUSPENDED`) locked the target -> same IOException.
- Green: fixed script under the same locked-target condition -> exit 0; locked exe renamed to `uloop.exe.old-<guid>`; new `uloop.exe --version` returns 3.1.0-beta.13; the running process keeps working from the renamed image.
- Cleanup: while the old process lives, `Remove-Item` on the backup is denied (skipped silently); after it exits, the next installer run reclaims the stale backup.
- Rollback: fault injected between rename and copy -> exit 1 and the old `uloop.exe` is restored byte-identical by the `finally` block.
- `[scriptblock]::Create` parse check (CI equivalent) passes under Windows PowerShell 5.1 and pwsh 7.
- `go test ./...` per `cli/go.work` module: only the known pre-existing Windows-incompatible failures (dispatcher launch fixture `/usr/bin/true`, project-runner TCP fixture, release-automation git fixtures) — unchanged baseline, no Go code touched.

Note: a real-path green `uloop update` cannot be demonstrated before a release ships, because the installer script is always fetched (checksum- and attestation-verified) from a published release.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

