### PR TITLE
fix: Unity process matching now survives non-ASCII project paths on Windows

### DIFF
--- a/cli/common/unityprocess/process.go
+++ b/cli/common/unityprocess/process.go
@@ -2,6 +2,7 @@ package unityprocess
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -83,13 +84,20 @@ func listUnityProcessesWindows(ctx context.Context) ([]UnityProcess, error) {
 	return parseWindowsUnityProcesses(string(output)), nil
 }
 
+// windowsUnityProcessListScript builds the PowerShell script that lists Unity
+// processes as "pid|base64(UTF-8 command line)" lines.
+// why: Windows PowerShell 5.1 encodes redirected stdout with the OEM code page
+// (e.g. CP932 on Japanese Windows), so non-ASCII project paths in the command
+// line get corrupted when Go reads the output as UTF-8. Base64 over UTF-8
+// bytes keeps the stream ASCII-only regardless of the console code page.
 func windowsUnityProcessListScript() string {
 	scriptLines := []string{
 		"$ErrorActionPreference = 'Stop'",
 		"$processes = Get-CimInstance Win32_Process -Filter \"Name = 'Unity.exe'\" | Where-Object { $_.CommandLine }",
 		"foreach ($process in $processes) {",
 		"  $commandLine = $process.CommandLine -replace \"`r\", ' ' -replace \"`n\", ' '",
-		"  Write-Output (\"{0}|{1}\" -f $process.ProcessId, $commandLine)",
+		"  $encodedCommandLine = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($commandLine))",
+		"  Write-Output (\"{0}|{1}\" -f $process.ProcessId, $encodedCommandLine)",
 		"}",
 	}
 	return strings.Join(scriptLines, "\n")
@@ -140,7 +148,12 @@ func parseWindowsUnityProcesses(output string) []UnityProcess {
 			continue
 		}
 
-		command := strings.TrimSpace(trimmed[delimiterIndex+1:])
+		decodedCommand, err := base64.StdEncoding.DecodeString(strings.TrimSpace(trimmed[delimiterIndex+1:]))
+		if err != nil {
+			continue
+		}
+
+		command := strings.TrimSpace(string(decodedCommand))
 		if !isUnityEditorCommand(command, windowsUnityExecutablePattern) {
 			continue
 		}

--- a/cli/common/unityprocess/process.go
+++ b/cli/common/unityprocess/process.go
@@ -74,6 +74,16 @@ func listUnityProcessesMac(ctx context.Context) ([]UnityProcess, error) {
 }
 
 func listUnityProcessesWindows(ctx context.Context) ([]UnityProcess, error) {
+	commandContext, cancel := withCommandTimeout(ctx, ProcessListCommandTimeout)
+	defer cancel()
+	output, err := exec.CommandContext(commandContext, windowsPowerShellCommand, "-NoProfile", "-Command", windowsUnityProcessListScript()).Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve Unity process list on Windows: %w", err)
+	}
+	return parseWindowsUnityProcesses(string(output)), nil
+}
+
+func windowsUnityProcessListScript() string {
 	scriptLines := []string{
 		"$ErrorActionPreference = 'Stop'",
 		"$processes = Get-CimInstance Win32_Process -Filter \"Name = 'Unity.exe'\" | Where-Object { $_.CommandLine }",
@@ -82,13 +92,7 @@ func listUnityProcessesWindows(ctx context.Context) ([]UnityProcess, error) {
 		"  Write-Output (\"{0}|{1}\" -f $process.ProcessId, $commandLine)",
 		"}",
 	}
-	commandContext, cancel := withCommandTimeout(ctx, ProcessListCommandTimeout)
-	defer cancel()
-	output, err := exec.CommandContext(commandContext, windowsPowerShellCommand, "-NoProfile", "-Command", strings.Join(scriptLines, "\n")).Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Unity process list on Windows: %w", err)
-	}
-	return parseWindowsUnityProcesses(string(output)), nil
+	return strings.Join(scriptLines, "\n")
 }
 
 func parseMacUnityProcesses(output string) []UnityProcess {

--- a/cli/common/unityprocess/process_test.go
+++ b/cli/common/unityprocess/process_test.go
@@ -1,6 +1,7 @@
 package unityprocess
 
 import (
+	"encoding/base64"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -27,11 +28,13 @@ func TestParseMacUnityProcessesExtractsProjectPath(t *testing.T) {
 	}
 }
 
-// Verifies Windows Unity process parsing extracts project paths and skips batchmode workers.
+// Verifies Windows Unity process parsing decodes Base64 command lines, extracts project paths, and skips batchmode workers.
 func TestParseWindowsUnityProcessesExtractsProjectPath(t *testing.T) {
-	output := `123|C:\Program Files\Unity\Hub\Editor\6000.0.0f1\Editor\Unity.exe -projectPath "C:\Users\<USER_NAME>\My Project" -useHub
-456|C:\Program Files\Unity\Hub\Editor\6000.0.0f1\Editor\Unity.exe -batchmode -projectPath "C:\Users\<USER_NAME>\Batch"
-`
+	encode := func(commandLine string) string {
+		return base64.StdEncoding.EncodeToString([]byte(commandLine))
+	}
+	output := "123|" + encode(`C:\Program Files\Unity\Hub\Editor\6000.0.0f1\Editor\Unity.exe -projectPath "C:\Users\<USER_NAME>\My Project" -useHub`) + "\r\n" +
+		"456|" + encode(`C:\Program Files\Unity\Hub\Editor\6000.0.0f1\Editor\Unity.exe -batchmode -projectPath "C:\Users\<USER_NAME>\Batch"`) + "\r\n"
 
 	processes := parseWindowsUnityProcesses(output)
 
@@ -40,6 +43,50 @@ func TestParseWindowsUnityProcessesExtractsProjectPath(t *testing.T) {
 	}
 	if processes[0].Pid != 123 || processes[0].projectPath != `C:\Users\<USER_NAME>\My Project` {
 		t.Fatalf("process mismatch: %#v", processes[0])
+	}
+}
+
+// Verifies non-ASCII project paths survive the PowerShell boundary because command lines travel as UTF-8 Base64.
+func TestParseWindowsUnityProcessesPreservesNonASCIIProjectPath(t *testing.T) {
+	projectPath := `C:\Users\<USER_NAME>\test[1] 検証用\proj`
+	commandLine := `C:\Program Files\Unity\Hub\Editor\2022.3.62f3\Editor\Unity.exe -projectPath "` + projectPath + `" -useHub`
+	output := "123|" + base64.StdEncoding.EncodeToString([]byte(commandLine)) + "\r\n"
+
+	processes := parseWindowsUnityProcesses(output)
+
+	if len(processes) != 1 {
+		t.Fatalf("process count mismatch: %#v", processes)
+	}
+	if processes[0].projectPath != projectPath {
+		t.Fatalf("project path mismatch: %q", processes[0].projectPath)
+	}
+}
+
+// Verifies command fields that are not valid Base64 (e.g. legacy plain-text or OEM code page bytes) are skipped instead of mis-parsed.
+func TestParseWindowsUnityProcessesSkipsNonBase64CommandLines(t *testing.T) {
+	// 0x8C9F 0x8FD8 0x9770 is the measured CP932 byte sequence for "検証用"
+	// that Windows PowerShell 5.1 emitted before the Base64 contract.
+	cp932KenshouYou := string([]byte{0x8C, 0x9F, 0x8F, 0xD8, 0x97, 0x70})
+	output := "123|" + `C:\Editor\Unity.exe -projectPath "C:\Users\<USER_NAME>\` + cp932KenshouYou + `\proj"` + "\r\n"
+
+	processes := parseWindowsUnityProcesses(output)
+
+	if len(processes) != 0 {
+		t.Fatalf("non-Base64 command lines should be skipped: %#v", processes)
+	}
+}
+
+// Verifies the Windows process list script transports command lines as UTF-8 Base64 so the OEM console code page cannot corrupt non-ASCII paths.
+func TestWindowsUnityProcessListScriptEncodesCommandLineAsUTF8Base64(t *testing.T) {
+	script := windowsUnityProcessListScript()
+
+	for _, expected := range []string{
+		"[System.Text.Encoding]::UTF8.GetBytes($commandLine)",
+		"[Convert]::ToBase64String(",
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("script missing %q: %s", expected, script)
+		}
 	}
 }
 


### PR DESCRIPTION
# Summary

On Windows, Unity process matching fails for any project whose path contains non-ASCII characters (e.g. Japanese). `listUnityProcessesWindows` runs a Windows PowerShell 5.1 script (`Get-CimInstance Win32_Process`) and reads its stdout as UTF-8, but PowerShell 5.1 encodes redirected stdout with the **OEM code page** (CP932 on Japanese Windows). Non-ASCII path segments arrive as CP932 bytes, never match the UTF-8 normalized target path, and `FindRunningUnityProcess` always comes back empty.

Measured on a Japanese Windows 11 machine: the path segment `検証用` was delivered as the CP932 byte sequence `0x8C9F 0x8FD8 0x9770` instead of its UTF-8 encoding.

## Impact

For any non-ASCII project path, all Unity process matching is broken:

- `uloop launch -q` reports **"No Unity process is running for this project."** with `Success:true` / exit 0 while the editor keeps running (silent no-op)
- `uloop launch -r` cannot find the process to restart
- `AlreadyRunning` detection fails, so a plain `uloop launch` spawns a duplicate editor
- `uloop focus-window` cannot resolve its target PID

Non-ASCII project paths are common on Japanese/Korean/Chinese Windows, so this has real user impact.

## Fix

Transport each command line as **Base64 over UTF-8 bytes** inside the PowerShell script and decode it in the Go parser. The stdout stream becomes ASCII-only, so the console code page can no longer corrupt it.

```powershell
$encodedCommandLine = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($commandLine))
Write-Output ("{0}|{1}" -f $process.ProcessId, $encodedCommandLine)
```

### Why Base64 instead of `[Console]::OutputEncoding = UTF8`

- Setting `[Console]::OutputEncoding` is known to throw `IOException: The handle is invalid` when the process has no attached console (a realistic condition for a CLI that is itself spawned detached), so it is less robust.
- Base64 removes the encoding, quoting, and newline concerns in one move, and this codebase already uses the Base64 idiom for PowerShell boundaries (`-EncodedCommand` in the install/uninstall scripts).

Lines whose command field is not valid Base64 are skipped, consistent with how other malformed lines are handled.

### Cross-check of other PowerShell output readers

Audited every place that parses PowerShell stdout:

- `cli/common/unityprocess/focus_windows.go` (`focus_unity_process_with_restore.ps1`): stdout is a numeric window handle only (ASCII-safe) — not affected. Its captured **stderr** could contain localized CP932 error text on failure, but that only feeds error messages (cosmetic), not matching logic.
- All other `.Output()` call sites run git / osascript / self-exec JSON — not affected.

## Verification (Windows 11, Japanese locale, Unity 2022.3.62f3)

TDD, unit (Red -> Green):

- New tests specify the Base64 contract: script content assertion, Base64 round-trip parsing including a Japanese path (`test[1] 検証用`), and skipping of non-Base64 lines (using the measured CP932 bytes). All 4 failed before the fix, all pass after.

E2E (Red, pre-fix build): project at `...\検証用エンコーディング\proj`

- `launch` -> `Ready:true` (PID 27128), then `launch -q` -> `"No Unity process is running for this project."`, `Success:true`, exit 0, **process still alive**

E2E (Green, fixed build):

- `launch -q` -> `Quit:true`, `PreviousProcessId:27128`, `"Unity process stopped."`, process actually terminated
- `launch` -> `Ready:true` (PID 29960), second `launch` -> `AlreadyRunning:true`
- ASCII regression: separate ASCII-path project -> `AlreadyRunning:true` and `launch -q` -> `PreviousProcessId` returned, process stopped
- Isolation: quitting the ASCII project's editor left the Japanese-path editor and an unrelated editor untouched
- `go test ./...` across all four modules: only the pre-existing Windows-incompatible baseline failures (launch `/usr/bin/true` fixture, TCP-only fixture, git fixture); `common` module fully green

## Out of scope (recorded separately)

- `launch -q` returning `Success:true` / exit 0 when no process is found is itself questionable (it is what made this bug silent), but that is an intentional-looking behavior and is left as a separate design question.
- Localized CP932 stderr from the focus scripts rendering as mojibake in error messages (cosmetic).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

