### PR TITLE
fix: make cli Go tests pass on Windows and run them in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -119,12 +119,16 @@ jobs:
           cache: false
 
       # Windows-only code paths (named pipe transport, winio deadlines, typed error
-      # classification) are otherwise never executed by CI. Scoped to the transport
-      # package: the wider test suite still has Windows-incompatible tests (path
-      # separators, missing .exe suffixes, TCP-only fixtures) that predate this job.
-      - name: Test native Go CLI transport on Windows
+      # classification, process management) are otherwise never executed by CI.
+      # Runs every go.work module: the formerly Windows-incompatible tests (POSIX-only
+      # fake executables, TCP-only fixtures, shell-script git/gh mocks) now install
+      # portable fixtures on Windows.
+      - name: Test native Go CLI on Windows
         shell: bash
-        run: cd cli/common && go test ./unityipc/
+        run: |
+          for module in common dispatcher project-runner release-automation; do
+            (cd "cli/$module" && go test ./...)
+          done
 
       - name: Test install release filter in Git Bash
         shell: bash

--- a/cli/dispatcher/internal/dispatcher/launch_test.go
+++ b/cli/dispatcher/internal/dispatcher/launch_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -264,8 +265,9 @@ func TestRunLaunchWritesReadyResponseAfterToolReadiness(t *testing.T) {
 	deps.findRunningUnityProcess = func(context.Context, string) (*clicore.UnityProcess, error) {
 		return nil, nil
 	}
+	fakeUnityPath := fakeUnityExecutablePath(t)
 	deps.resolveUnityExecutablePath = func(string) (string, error) {
-		return "/usr/bin/true", nil
+		return fakeUnityPath, nil
 	}
 	deps.waitForUnityStartupMarker = func(context.Context, string, time.Duration, time.Duration) error {
 		return nil
@@ -506,8 +508,9 @@ func TestRunLaunchRestartWritesProcessTransitionResponse(t *testing.T) {
 		waitedPid = pid
 		return nil
 	}
+	fakeUnityPath := fakeUnityExecutablePath(t)
 	deps.resolveUnityExecutablePath = func(string) (string, error) {
-		return "/usr/bin/true", nil
+		return fakeUnityPath, nil
 	}
 	deps.waitForUnityStartupMarker = func(context.Context, string, time.Duration, time.Duration) error {
 		return nil
@@ -609,9 +612,10 @@ func TestRunLaunchRestartReportsProcessExitWaitFailure(t *testing.T) {
 	deps.waitForUnityProcessExit = func(ctx context.Context, projectRoot string, pid int, pollInterval time.Duration, timeout time.Duration) error {
 		return errors.New("still exiting")
 	}
+	fakeUnityPath := fakeUnityExecutablePath(t)
 	deps.resolveUnityExecutablePath = func(string) (string, error) {
 		resolverCalled = true
-		return "/usr/bin/true", nil
+		return fakeUnityPath, nil
 	}
 
 	projectRoot := createLaunchTestProject(t)
@@ -828,6 +832,22 @@ func TestResolveExistingUnityExecutablePathReportsSearchedCandidates(t *testing.
 	if !strings.Contains(err.Error(), missingPath) {
 		t.Fatalf("error should include searched candidate: %v", err)
 	}
+}
+
+// fakeUnityExecutablePath returns a no-op executable standing in for Unity in
+// launch tests that really spawn the resolved path. Why: /usr/bin/true does
+// not exist on Windows, so Windows needs a native no-op batch file instead.
+func fakeUnityExecutablePath(t *testing.T) string {
+	t.Helper()
+
+	if runtime.GOOS != "windows" {
+		return "/usr/bin/true"
+	}
+	path := filepath.Join(t.TempDir(), "fake-unity.bat")
+	if err := os.WriteFile(path, []byte("@exit /b 0\r\n"), 0o755); err != nil {
+		t.Fatalf("failed to write fake Unity executable: %v", err)
+	}
+	return path
 }
 
 func createLaunchTestProject(t *testing.T) string {

--- a/cli/dispatcher/internal/install/command_test.go
+++ b/cli/dispatcher/internal/install/command_test.go
@@ -714,13 +714,19 @@ func TestWindowsInstallScriptParsesOnWindows(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+	// The script path must be embedded in the command text: powershell -Command
+	// concatenates trailing arguments into the command instead of exposing them
+	// via $args, so a trailing path argument would be invoked as a command and
+	// execute the installer setup for real.
+	parseCommand := `$parseErrors = $null; $null = [System.Management.Automation.PSParser]::Tokenize((Get-Content -Raw -LiteralPath ` +
+		powerShellSingleQuote(scriptPath) +
+		`), [ref]$parseErrors); if ($parseErrors) { $parseErrors | Out-String; exit 1 }`
 	command := exec.CommandContext(
 		ctx,
 		"powershell",
 		"-NoProfile",
 		"-Command",
-		`$parseErrors = $null; $null = [System.Management.Automation.PSParser]::Tokenize((Get-Content -Raw $args[0]), [ref]$parseErrors); if ($parseErrors) { $parseErrors | Out-String; exit 1 }`,
-		scriptPath)
+		parseCommand)
 	output, err := command.CombinedOutput()
 	if err != nil {
 		t.Fatalf("embedded setup script does not parse: %v\n%s", err, output)

--- a/cli/project-runner/go.mod
+++ b/cli/project-runner/go.mod
@@ -2,11 +2,11 @@ module github.com/hatayama/unity-cli-loop/project-runner
 
 go 1.26
 
-require github.com/hatayama/unity-cli-loop/common v0.0.0-00010101000000-000000000000
-
 require (
-	github.com/Microsoft/go-winio v0.6.2 // indirect
-	golang.org/x/sys v0.10.0 // indirect
+	github.com/Microsoft/go-winio v0.6.2
+	github.com/hatayama/unity-cli-loop/common v0.0.0-00010101000000-000000000000
 )
+
+require golang.org/x/sys v0.10.0 // indirect
 
 replace github.com/hatayama/unity-cli-loop/common => ../common

--- a/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/control_play_mode_wait_test.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -23,13 +25,7 @@ func TestRunControlPlayModeWithStateWaitPollsStatusAfterStaleInitialResponse(t *
 		controlPlayModeStatePoll = originalPoll
 	})
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to listen: %v", err)
-	}
-	defer func() {
-		_ = listener.Close()
-	}()
+	listener := newLoopbackIpcListener(t)
 
 	requests := make(chan map[string]any, 2)
 	serverErr := make(chan error, 1)
@@ -44,7 +40,7 @@ func TestRunControlPlayModeWithStateWaitPollsStatusAfterStaleInitialResponse(t *
 
 	connection := unityipc.Connection{
 		Endpoint: unityipc.Endpoint{
-			Network: "tcp",
+			Network: listener.Addr().Network(),
 			Address: listener.Addr().String(),
 		},
 		ProjectRoot: t.TempDir(),
@@ -101,13 +97,7 @@ func TestRunControlPlayModeWithStateWaitPreservesStopChangeFields(t *testing.T) 
 		controlPlayModeStatePoll = originalPoll
 	})
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to listen: %v", err)
-	}
-	defer func() {
-		_ = listener.Close()
-	}()
+	listener := newLoopbackIpcListener(t)
 
 	serverErr := make(chan error, 1)
 	go serveControlPlayModeResponses(
@@ -121,7 +111,7 @@ func TestRunControlPlayModeWithStateWaitPreservesStopChangeFields(t *testing.T) 
 
 	connection := unityipc.Connection{
 		Endpoint: unityipc.Endpoint{
-			Network: "tcp",
+			Network: listener.Addr().Network(),
 			Address: listener.Addr().String(),
 		},
 		ProjectRoot: t.TempDir(),
@@ -184,13 +174,7 @@ func TestRunControlPlayModeWithStateWaitFailsWhenStateNeverMatches(t *testing.T)
 		controlPlayModeStatePoll = originalPoll
 	})
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to listen: %v", err)
-	}
-	defer func() {
-		_ = listener.Close()
-	}()
+	listener := newLoopbackIpcListener(t)
 
 	serverErr := make(chan error, 1)
 	go serveRepeatedControlPlayModeResponse(
@@ -200,7 +184,7 @@ func TestRunControlPlayModeWithStateWaitFailsWhenStateNeverMatches(t *testing.T)
 
 	connection := unityipc.Connection{
 		Endpoint: unityipc.Endpoint{
-			Network: "tcp",
+			Network: listener.Addr().Network(),
 			Address: listener.Addr().String(),
 		},
 		ProjectRoot: t.TempDir(),
@@ -240,13 +224,7 @@ func TestRunControlPlayModeWithStateWaitFailsImmediatelyWhenCompileErrorsBlockPl
 		controlPlayModeStatePoll = originalPoll
 	})
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to listen: %v", err)
-	}
-	defer func() {
-		_ = listener.Close()
-	}()
+	listener := newLoopbackIpcListener(t)
 
 	requests := make(chan map[string]any, 2)
 	serverErr := make(chan error, 1)
@@ -260,7 +238,7 @@ func TestRunControlPlayModeWithStateWaitFailsImmediatelyWhenCompileErrorsBlockPl
 
 	connection := unityipc.Connection{
 		Endpoint: unityipc.Endpoint{
-			Network: "tcp",
+			Network: listener.Addr().Network(),
 			Address: listener.Addr().String(),
 		},
 		ProjectRoot: t.TempDir(),
@@ -321,13 +299,7 @@ func TestRunControlPlayModeWithStateWaitFailsWhenCompileErrorsAppearDuringPollin
 		controlPlayModeStatePoll = originalPoll
 	})
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to listen: %v", err)
-	}
-	defer func() {
-		_ = listener.Close()
-	}()
+	listener := newLoopbackIpcListener(t)
 
 	requests := make(chan map[string]any, 3)
 	serverErr := make(chan error, 1)
@@ -342,7 +314,7 @@ func TestRunControlPlayModeWithStateWaitFailsWhenCompileErrorsAppearDuringPollin
 
 	connection := unityipc.Connection{
 		Endpoint: unityipc.Endpoint{
-			Network: "tcp",
+			Network: listener.Addr().Network(),
 			Address: listener.Addr().String(),
 		},
 		ProjectRoot: t.TempDir(),
@@ -421,6 +393,14 @@ func serveRepeatedControlPlayModeResponse(
 
 		if _, err := unityipc.Read(bufio.NewReader(conn)); err != nil {
 			_ = conn.Close()
+			// Why tolerated: when the client's wait deadline expires it closes a
+			// freshly dialed poll connection without sending a request. TCP hides
+			// this because the request is already buffered in the socket, but a
+			// named pipe surfaces it as EOF here; either way it is client-side
+			// cancellation, not a server failure.
+			if isClientAbandonedConnectionError(err) {
+				continue
+			}
 			serverErr <- err
 			return
 		}
@@ -479,6 +459,12 @@ func serveControlPlayModeResponses(
 		}
 		_ = conn.Close()
 	}
+}
+
+// isClientAbandonedConnectionError reports whether a fixture-server read
+// failed only because the client hung up before sending a request.
+func isClientAbandonedConnectionError(err error) bool {
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, net.ErrClosed)
 }
 
 func readControlPlayModeRequest(t *testing.T, requests <-chan map[string]any) map[string]any {

--- a/cli/project-runner/internal/projectrunner/ipc_listener_fixture_unix_test.go
+++ b/cli/project-runner/internal/projectrunner/ipc_listener_fixture_unix_test.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package projectrunner
+
+import (
+	"net"
+	"testing"
+)
+
+// newLoopbackIpcListener creates a local listener that the shared client dial
+// path can reach in tests. On POSIX the client dials the endpoint network
+// verbatim, so a loopback TCP listener stands in for the Unity server.
+func newLoopbackIpcListener(t *testing.T) net.Listener {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+	return listener
+}

--- a/cli/project-runner/internal/projectrunner/ipc_listener_fixture_windows_test.go
+++ b/cli/project-runner/internal/projectrunner/ipc_listener_fixture_windows_test.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package projectrunner
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net"
+	"testing"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// newLoopbackIpcListener creates a local listener that the shared client dial
+// path can reach in tests. Why a named pipe: the Windows client dial always
+// targets a named pipe, so a TCP fixture would never receive the connection.
+// A random suffix keeps concurrently running tests on distinct pipes.
+func newLoopbackIpcListener(t *testing.T) net.Listener {
+	t.Helper()
+
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		t.Fatalf("failed to generate pipe name suffix: %v", err)
+	}
+	pipeName := `\\.\pipe\uloop-test-` + hex.EncodeToString(suffix)
+	listener, err := winio.ListenPipe(pipeName, nil)
+	if err != nil {
+		t.Fatalf("failed to listen on named pipe %s: %v", pipeName, err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+	return listener
+}

--- a/cli/release-automation/internal/automation/contract_file_at_ref_test.go
+++ b/cli/release-automation/internal/automation/contract_file_at_ref_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -406,6 +407,10 @@ func writeSleepingMockGit(t *testing.T, binDir string) {
 	t.Helper()
 
 	path := filepath.Join(binDir, "git")
+	if runtime.GOOS == "windows" {
+		installMockCliExecutable(t, path, mockCliExecutableConfig{Mode: "sleeping"})
+		return
+	}
 	writeFile(t, path, "#!/bin/sh\nsleep 10\n")
 	if err := os.Chmod(path, 0o755); err != nil {
 		t.Fatalf("failed to chmod mock git: %v", err)

--- a/cli/release-automation/internal/automation/dispatcher_minimum_version_guard_test.go
+++ b/cli/release-automation/internal/automation/dispatcher_minimum_version_guard_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -216,6 +217,11 @@ func buildDispatcherMinimumVersionPin(projectRunnerVersion string, minimumDispat
 
 func writeDispatcherMinimumVersionMockGit(t *testing.T, path string) {
 	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		installMockCliExecutable(t, path, mockCliExecutableConfig{Mode: "dispatcherMinimumVersionGit"})
+		return
+	}
 
 	content := `#!/bin/sh
 set -eu

--- a/cli/release-automation/internal/automation/mock_cli_executable_for_tests_test.go
+++ b/cli/release-automation/internal/automation/mock_cli_executable_for_tests_test.go
@@ -1,0 +1,147 @@
+package automation
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+)
+
+// This file provides the Windows counterpart of the POSIX shell mock scripts
+// installed as fake `git`/`gh` executables. Why: Windows LookPath only
+// resolves files with executable extensions, so an extensionless shell script
+// on PATH is silently skipped and the real git/gh would run instead; cmd batch
+// shims are no alternative because cmd mangles arguments such as
+// `tag^{commit}` and embedded quotes. TestMain therefore builds
+// testdata/mockcli once per test run, and installMockCliExecutable copies it
+// next to a JSON config that selects which shell mock to emulate.
+
+// mockCliExecutablePath is the shared mockcli build TestMain produces on
+// Windows; empty on other platforms.
+var mockCliExecutablePath string
+
+// mockCliExecutableConfig mirrors mockCliConfig in testdata/mockcli/main.go.
+type mockCliExecutableConfig struct {
+	Mode        string                       `json:"mode"`
+	RefResolves bool                         `json:"refResolves,omitempty"`
+	Paths       map[string]mockCliPathConfig `json:"paths,omitempty"`
+	PathOrder   []string                     `json:"pathOrder,omitempty"`
+}
+
+// mockCliPathConfig mirrors mockCliPathConfig in testdata/mockcli/main.go.
+type mockCliPathConfig struct {
+	Exists          bool   `json:"exists"`
+	ShowOK          bool   `json:"showOK"`
+	ShowContent     string `json:"showContent,omitempty"`
+	ShowContentPath string `json:"showContentPath,omitempty"`
+	ShowStderr      string `json:"showStderr,omitempty"`
+	ProbeSleeps     bool   `json:"probeSleeps,omitempty"`
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+func runTestMain(m *testing.M) int {
+	if runtime.GOOS == "windows" {
+		buildDir, err := os.MkdirTemp("", "uloop-mockcli-")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create mockcli build directory: %v\n", err)
+			return 1
+		}
+		defer func() {
+			_ = os.RemoveAll(buildDir)
+		}()
+
+		executablePath := filepath.Join(buildDir, "mockcli.exe")
+		command := exec.Command("go", "build", "-o", executablePath, "./testdata/mockcli")
+		if output, err := command.CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to build mockcli: %v\n%s", err, output)
+			return 1
+		}
+		mockCliExecutablePath = executablePath
+	}
+	return m.Run()
+}
+
+// installMockCliExecutable installs the prebuilt mockcli binary as
+// <scriptPath>.exe with its config at <scriptPath>.mockconfig.json. Only used
+// on Windows; scriptPath is the extensionless path the POSIX shell mock would
+// occupy (e.g. .../bin/git), so PATH lookups resolve the same command name.
+func installMockCliExecutable(t *testing.T, scriptPath string, config mockCliExecutableConfig) {
+	t.Helper()
+
+	if mockCliExecutablePath == "" {
+		t.Fatal("mockcli executable was not built; TestMain only builds it on Windows")
+	}
+
+	copyMockCliExecutable(t, scriptPath+".exe")
+
+	configContent, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("failed to encode mockcli config: %v", err)
+	}
+	writeFile(t, scriptPath+".mockconfig.json", string(configContent))
+}
+
+func copyMockCliExecutable(t *testing.T, destinationPath string) {
+	t.Helper()
+
+	// A hard link avoids copying the binary for every test; both paths live in
+	// the same temp volume. Fall back to a byte copy when linking fails.
+	if err := os.Link(mockCliExecutablePath, destinationPath); err == nil {
+		return
+	}
+	source, err := os.Open(mockCliExecutablePath)
+	if err != nil {
+		t.Fatalf("failed to open mockcli executable: %v", err)
+	}
+	defer func() {
+		_ = source.Close()
+	}()
+	destination, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("failed to create mock executable: %v", err)
+	}
+	defer func() {
+		_ = destination.Close()
+	}()
+	if _, err := io.Copy(destination, source); err != nil {
+		t.Fatalf("failed to copy mock executable: %v", err)
+	}
+}
+
+// existenceMockCliConfig converts the shared existence fixture into the
+// mockcli config, preserving the sorted case-label order the generated shell
+// script uses.
+func existenceMockCliConfig(fixture mockGitExistenceFixture) mockCliExecutableConfig {
+	keys := make([]string, 0, len(fixture.paths))
+	for key := range fixture.paths {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	paths := make(map[string]mockCliPathConfig, len(fixture.paths))
+	for key, behavior := range fixture.paths {
+		paths[key] = mockCliPathConfig{
+			Exists:          behavior.exists,
+			ShowOK:          behavior.showOK,
+			ShowContent:     behavior.showContent,
+			ShowContentPath: behavior.showContentPath,
+			ShowStderr:      behavior.showStderr,
+			ProbeSleeps:     behavior.probeSleeps,
+		}
+	}
+
+	return mockCliExecutableConfig{
+		Mode:        "existence",
+		RefResolves: fixture.refResolves,
+		Paths:       paths,
+		PathOrder:   keys,
+	}
+}

--- a/cli/release-automation/internal/automation/mock_git_for_tests_test.go
+++ b/cli/release-automation/internal/automation/mock_git_for_tests_test.go
@@ -3,6 +3,7 @@ package automation
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -68,8 +69,12 @@ func setupMockGitBin(t *testing.T) (string, string) {
 func writeExistenceMockGit(t *testing.T, binDir string, fixture mockGitExistenceFixture) {
 	t.Helper()
 
-	script := buildExistenceMockGitScript(fixture)
 	path := filepath.Join(binDir, "git")
+	if runtime.GOOS == "windows" {
+		installMockCliExecutable(t, path, existenceMockCliConfig(fixture))
+		return
+	}
+	script := buildExistenceMockGitScript(fixture)
 	writeFile(t, path, script)
 	if err := os.Chmod(path, 0o755); err != nil {
 		t.Fatalf("failed to chmod mock git: %v", err)

--- a/cli/release-automation/internal/automation/protocol_minimum_version_guard_test.go
+++ b/cli/release-automation/internal/automation/protocol_minimum_version_guard_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -600,6 +601,11 @@ func buildProtocolMinimumVersionPin(projectRunnerVersion string) string {
 func writeProtocolMinimumVersionMockGit(t *testing.T, path string) {
 	t.Helper()
 
+	if runtime.GOOS == "windows" {
+		installMockCliExecutable(t, path, mockCliExecutableConfig{Mode: "protocolMinimumVersionGit"})
+		return
+	}
+
 	content := `#!/bin/sh
 set -eu
 
@@ -694,6 +700,11 @@ exit 1
 
 func writeProtocolMinimumVersionMockGH(t *testing.T, path string) {
 	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		installMockCliExecutable(t, path, mockCliExecutableConfig{Mode: "protocolMinimumVersionGh"})
+		return
+	}
 
 	content := `#!/bin/sh
 set -eu

--- a/cli/release-automation/internal/automation/testdata/mockcli/main.go
+++ b/cli/release-automation/internal/automation/testdata/mockcli/main.go
@@ -1,0 +1,406 @@
+// Command mockcli is the Windows stand-in for the POSIX shell mock scripts the
+// automation tests install as fake `git`/`gh` executables on PATH. Why: Windows
+// LookPath only resolves files with executable extensions, so an extensionless
+// shell script is silently skipped and the real git/gh would run instead, and
+// cmd batch files mangle arguments such as `tag^{commit}` or embedded quotes.
+// The binary is built once by TestMain and copied next to a JSON config file
+// (<name>.mockconfig.json) that selects which shell mock to emulate. Each mode
+// below is a line-by-line translation of the corresponding script generator in
+// the automation test files.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// mockCliConfig mirrors mockCliExecutableConfig in
+// internal/automation/mock_cli_executable_for_tests_test.go.
+type mockCliConfig struct {
+	Mode        string                       `json:"mode"`
+	RefResolves bool                         `json:"refResolves,omitempty"`
+	Paths       map[string]mockCliPathConfig `json:"paths,omitempty"`
+	PathOrder   []string                     `json:"pathOrder,omitempty"`
+}
+
+// mockCliPathConfig mirrors mockGitPathBehavior for the existence mode.
+type mockCliPathConfig struct {
+	Exists          bool   `json:"exists"`
+	ShowOK          bool   `json:"showOK"`
+	ShowContent     string `json:"showContent,omitempty"`
+	ShowContentPath string `json:"showContentPath,omitempty"`
+	ShowStderr      string `json:"showStderr,omitempty"`
+	ProbeSleeps     bool   `json:"probeSleeps,omitempty"`
+}
+
+func main() {
+	config, err := loadConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mockcli: %v\n", err)
+		os.Exit(1)
+	}
+
+	args := os.Args[1:]
+	switch config.Mode {
+	case "existence":
+		os.Exit(runExistenceGit(config, args))
+	case "sleeping":
+		// Mirrors writeSleepingMockGit: block long enough that a short context
+		// timeout reliably kills the probe mid-run.
+		time.Sleep(10 * time.Second)
+		os.Exit(0)
+	case "dispatcherMinimumVersionGit":
+		os.Exit(runDispatcherMinimumVersionGit(args))
+	case "protocolMinimumVersionGit":
+		os.Exit(runProtocolMinimumVersionGit(args))
+	case "protocolMinimumVersionGh":
+		os.Exit(runProtocolMinimumVersionGh(args))
+	default:
+		fmt.Fprintf(os.Stderr, "mockcli: unknown mode %q\n", config.Mode)
+		os.Exit(1)
+	}
+}
+
+func loadConfig() (mockCliConfig, error) {
+	executablePath, err := os.Executable()
+	if err != nil {
+		return mockCliConfig{}, fmt.Errorf("failed to locate executable: %w", err)
+	}
+	configPath := strings.TrimSuffix(executablePath, filepath.Ext(executablePath)) + ".mockconfig.json"
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return mockCliConfig{}, fmt.Errorf("failed to read config: %w", err)
+	}
+	config := mockCliConfig{}
+	if err := json.Unmarshal(content, &config); err != nil {
+		return mockCliConfig{}, fmt.Errorf("failed to decode config %s: %w", configPath, err)
+	}
+	return config, nil
+}
+
+// matchWildcard reports whether value matches a shell case label where `*`
+// matches any run of characters (including separators).
+func matchWildcard(pattern string, value string) bool {
+	segments := strings.Split(pattern, "*")
+	quoted := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		quoted = append(quoted, regexp.QuoteMeta(segment))
+	}
+	matched, err := regexp.MatchString("^"+strings.Join(quoted, ".*")+"$", value)
+	if err != nil {
+		return false
+	}
+	return matched
+}
+
+func appendLogLine(logEnvName string, args []string) {
+	logPath := os.Getenv(logEnvName)
+	if logPath == "" {
+		return
+	}
+	file, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mockcli: failed to open log: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	if _, err := fmt.Fprintf(file, "%s\n", strings.Join(args, " ")); err != nil {
+		fmt.Fprintf(os.Stderr, "mockcli: failed to append log: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func stripChdirFlag(args []string) []string {
+	if len(args) >= 2 && args[0] == "-C" {
+		return args[2:]
+	}
+	return args
+}
+
+func emitFileContent(path string) int {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mockcli: %v\n", err)
+		return 1
+	}
+	_, _ = os.Stdout.Write(content)
+	return 0
+}
+
+func argAt(args []string, index int) string {
+	if index < len(args) {
+		return args[index]
+	}
+	return ""
+}
+
+// runExistenceGit mirrors buildExistenceMockGitScript in
+// mock_git_for_tests_test.go.
+func runExistenceGit(config mockCliConfig, args []string) int {
+	args = stripChdirFlag(args)
+
+	switch argAt(args, 0) {
+	case "cat-file":
+		target := argAt(args, 2)
+		for _, key := range config.PathOrder {
+			if !matchWildcard("*:"+key, target) {
+				continue
+			}
+			behavior := config.Paths[key]
+			if behavior.ProbeSleeps {
+				time.Sleep(10 * time.Second)
+				return 0
+			}
+			if behavior.Exists {
+				return 0
+			}
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "unexpected cat-file target: %s\n", target)
+		return 1
+	case "rev-parse":
+		if argAt(args, 1) == "--verify" {
+			if config.RefResolves {
+				return 0
+			}
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "unexpected rev-parse: %s\n", strings.Join(args, " "))
+		return 1
+	case "show":
+		target := argAt(args, 1)
+		for _, key := range config.PathOrder {
+			if !matchWildcard("*:"+key, target) {
+				continue
+			}
+			behavior := config.Paths[key]
+			if behavior.ShowOK {
+				if behavior.ShowContentPath != "" {
+					return emitFileContent(behavior.ShowContentPath)
+				}
+				if behavior.ShowContent != "" {
+					fmt.Fprintf(os.Stdout, "%s", behavior.ShowContent)
+				}
+				return 0
+			}
+			if behavior.ShowStderr != "" {
+				fmt.Fprintf(os.Stderr, "%s\n", behavior.ShowStderr)
+			}
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "unexpected git show ref: %s\n", target)
+		return 1
+	default:
+		fmt.Fprintf(os.Stderr, "unexpected git command: %s\n", strings.Join(args, " "))
+		return 1
+	}
+}
+
+// envConditionalShowRule emits the file named by ContentEnv when that variable
+// is set, falls back to the file named by FallbackEnv when provided, and
+// otherwise reports MissingStderr (with {target} replaced) and exits 1.
+type envConditionalShowRule struct {
+	pattern       string
+	contentEnv    string
+	fallbackEnv   string
+	missingStderr string
+}
+
+type envConditionalCatFileRule struct {
+	pattern string
+	envName string
+}
+
+func runShowRules(rules []envConditionalShowRule, target string) int {
+	for _, rule := range rules {
+		if !matchWildcard(rule.pattern, target) {
+			continue
+		}
+		contentPath := os.Getenv(rule.contentEnv)
+		if contentPath == "" && rule.fallbackEnv != "" {
+			contentPath = os.Getenv(rule.fallbackEnv)
+		}
+		if contentPath == "" {
+			fmt.Fprintf(os.Stderr, "%s\n", strings.ReplaceAll(rule.missingStderr, "{target}", target))
+			return 1
+		}
+		return emitFileContent(contentPath)
+	}
+	fmt.Fprintf(os.Stderr, "unexpected git show ref: %s\n", target)
+	return 1
+}
+
+func runCatFileRules(rules []envConditionalCatFileRule, target string) int {
+	for _, rule := range rules {
+		if !matchWildcard(rule.pattern, target) {
+			continue
+		}
+		if os.Getenv(rule.envName) != "" {
+			return 0
+		}
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "unexpected cat-file target: %s\n", target)
+	return 1
+}
+
+// runDispatcherMinimumVersionGit mirrors writeDispatcherMinimumVersionMockGit
+// in dispatcher_minimum_version_guard_test.go.
+func runDispatcherMinimumVersionGit(args []string) int {
+	appendLogLine("GIT_LOG", args)
+
+	if argAt(args, 0) == "rev-parse" && argAt(args, 1) == "--show-toplevel" {
+		fmt.Fprintf(os.Stdout, "%s\n", os.Getenv("ULOOP_REPOSITORY_ROOT"))
+		return 0
+	}
+
+	args = stripChdirFlag(args)
+
+	showRules := []envConditionalShowRule{
+		{
+			pattern:       "dispatcher-v*:cli/dispatcher/dispatchercontract/dispatcher-contract.json",
+			contentEnv:    "GIT_RELEASE_CONTRACT",
+			missingStderr: "fatal: path 'cli/dispatcher/dispatchercontract/dispatcher-contract.json' exists on disk, but not in '{target}'",
+		},
+		{
+			pattern:       "dispatcher-v*:cli/dispatcher/dispatcher-contract.json",
+			contentEnv:    "GIT_PREVIOUS_RELEASE_CONTRACT",
+			missingStderr: "previous release not found",
+		},
+		{
+			pattern:       "dispatcher-v*:dispatcher/dispatcher-contract.json",
+			contentEnv:    "GIT_MIDDLE_RELEASE_CONTRACT",
+			missingStderr: "middle release not found",
+		},
+		{
+			pattern:       "dispatcher-v*:cli/dispatcher-contract.json",
+			contentEnv:    "GIT_LEGACY_RELEASE_CONTRACT",
+			missingStderr: "release not found",
+		},
+	}
+	catFileRules := []envConditionalCatFileRule{
+		{pattern: "dispatcher-v*:cli/dispatcher/dispatchercontract/dispatcher-contract.json", envName: "GIT_RELEASE_CONTRACT"},
+		{pattern: "dispatcher-v*:cli/dispatcher/dispatcher-contract.json", envName: "GIT_PREVIOUS_RELEASE_CONTRACT"},
+		{pattern: "dispatcher-v*:dispatcher/dispatcher-contract.json", envName: "GIT_MIDDLE_RELEASE_CONTRACT"},
+		{pattern: "dispatcher-v*:cli/dispatcher-contract.json", envName: "GIT_LEGACY_RELEASE_CONTRACT"},
+	}
+
+	switch argAt(args, 0) {
+	case "show":
+		return runShowRules(showRules, argAt(args, 1))
+	case "cat-file":
+		if argAt(args, 1) == "-e" {
+			return runCatFileRules(catFileRules, argAt(args, 2))
+		}
+	case "rev-parse":
+		if argAt(args, 1) == "--verify" {
+			// Dispatcher release refs used in these tests are always considered
+			// resolvable; the release publishing tests set up the associated
+			// fixtures.
+			return 0
+		}
+	}
+	fmt.Fprintf(os.Stderr, "unexpected git command: %s\n", strings.Join(args, " "))
+	return 1
+}
+
+// runProtocolMinimumVersionGit mirrors writeProtocolMinimumVersionMockGit in
+// protocol_minimum_version_guard_test.go.
+func runProtocolMinimumVersionGit(args []string) int {
+	appendLogLine("GIT_LOG", args)
+
+	if argAt(args, 0) == "rev-parse" && argAt(args, 1) == "--show-toplevel" {
+		fmt.Fprintf(os.Stdout, "%s\n", os.Getenv("ULOOP_REPOSITORY_ROOT"))
+		return 0
+	}
+
+	args = stripChdirFlag(args)
+
+	showRules := []envConditionalShowRule{
+		{pattern: "origin/v3-beta:Packages/src/project-runner-pin.json", contentEnv: "GIT_BASE_PIN"},
+		{pattern: "origin/v3-beta:*", contentEnv: "GIT_BASE_CONSTANTS"},
+		{
+			pattern:     "protocol-pr-head:cli/common/clicontract/contract.json",
+			contentEnv:  "GIT_HEAD_CONTRACT_CONTENT",
+			fallbackEnv: "GIT_HEAD_CONSTANTS",
+		},
+		{pattern: "protocol-pr-head:Packages/src/project-runner-pin.json", contentEnv: "GIT_HEAD_PIN"},
+		{pattern: "protocol-pr-head:*", contentEnv: "GIT_HEAD_CONSTANTS"},
+		{pattern: "protocol-release:Packages/src/project-runner-pin.json", contentEnv: "GIT_HEAD_PIN"},
+		{pattern: "protocol-release:*", contentEnv: "GIT_HEAD_CONSTANTS"},
+		{
+			pattern:       "uloop-project-runner-v*:cli/common/clicontract/contract.json",
+			contentEnv:    "GIT_RELEASE_CONTENT",
+			missingStderr: "fatal: path 'cli/common/clicontract/contract.json' exists on disk, but not in '{target}'",
+		},
+		{
+			pattern:       "uloop-project-runner-v*:common/clicontract/contract.json",
+			contentEnv:    "GIT_MIDDLE_RELEASE_CONTENT",
+			missingStderr: "middle release not found",
+		},
+		{
+			pattern:       "uloop-project-runner-v*:cli/contract.json",
+			contentEnv:    "GIT_LEGACY_RELEASE_CONTENT",
+			missingStderr: "release not found",
+		},
+	}
+	catFileRules := []envConditionalCatFileRule{
+		{pattern: "uloop-project-runner-v*:cli/common/clicontract/contract.json", envName: "GIT_RELEASE_CONTENT"},
+		{pattern: "uloop-project-runner-v*:common/clicontract/contract.json", envName: "GIT_MIDDLE_RELEASE_CONTENT"},
+		{pattern: "uloop-project-runner-v*:cli/contract.json", envName: "GIT_LEGACY_RELEASE_CONTENT"},
+	}
+
+	switch argAt(args, 0) {
+	case "show":
+		return runShowRules(showRules, argAt(args, 1))
+	case "cat-file":
+		if argAt(args, 1) == "-e" {
+			return runCatFileRules(catFileRules, argAt(args, 2))
+		}
+	case "rev-parse":
+		if argAt(args, 1) == "--verify" {
+			// Release/base/head refs used in these tests are always resolvable;
+			// the fallback flow only reaches rev-parse when a show has already
+			// failed.
+			return 0
+		}
+	}
+	fmt.Fprintf(os.Stderr, "unexpected git command: %s\n", strings.Join(args, " "))
+	return 1
+}
+
+// runProtocolMinimumVersionGh mirrors writeProtocolMinimumVersionMockGH in
+// protocol_minimum_version_guard_test.go.
+func runProtocolMinimumVersionGh(args []string) int {
+	appendLogLine("GH_LOG", args)
+
+	if argAt(args, 0) == "release" && argAt(args, 1) == "view" {
+		releaseView := os.Getenv("GH_RELEASE_VIEW")
+		if releaseView == "" {
+			releaseView = `{"isDraft":false,"assets":[{"name":"uloop-project-runner-darwin-amd64.tar.gz","size":1},{"name":"uloop-project-runner-darwin-amd64.tar.gz.sha256","size":1},{"name":"uloop-project-runner-darwin-arm64.tar.gz","size":1},{"name":"uloop-project-runner-darwin-arm64.tar.gz.sha256","size":1},{"name":"uloop-project-runner-windows-amd64.zip","size":1},{"name":"uloop-project-runner-windows-amd64.zip.sha256","size":1}]}`
+		}
+		fmt.Fprintf(os.Stdout, "%s\n", releaseView)
+		return 0
+	}
+
+	if argAt(args, 0) == "api" && argAt(args, 1) == "--paginate" {
+		if commentIDs := os.Getenv("GH_COMMENT_IDS"); commentIDs != "" {
+			fmt.Fprintf(os.Stdout, "%s\n", commentIDs)
+		}
+		return 0
+	}
+
+	if argAt(args, 0) == "api" && argAt(args, 1) == "--method" {
+		return 0
+	}
+
+	fmt.Fprintf(os.Stderr, "unexpected gh command: %s\n", strings.Join(args, " "))
+	return 1
+}


### PR DESCRIPTION
## Summary

Makes `go test ./...` pass on Windows for all four `cli/go.work` modules (common / dispatcher / project-runner / release-automation) and expands the CI Windows job from `cli/common/unityipc` only to the full suite.

This PR merges the originally planned PR-1 (test fixes) and PR-2 (CI expansion): the CI expansion is the verification harness for the test fixes, so combining them lets this PR's own Windows CI job prove the fixes.

## Baseline inventory (Windows 11, go1.26.3)

| Module | Failing tests | Root cause |
|--------|--------------|------------|
| common | 0 | — |
| dispatcher | 2 (`TestRunLaunchWritesReadyResponseAfterToolReadiness`, `TestRunLaunchRestartWritesProcessTransitionResponse`) | Injected resolver returns `/usr/bin/true`, which the launch flow really spawns; the path does not exist on Windows |
| project-runner | 5 (`TestRunControlPlayModeWithStateWait*`) | Fixtures listen on loopback TCP, but the Windows client dial always targets a named pipe → `UNITY_NOT_REACHABLE` |
| release-automation | 26 (`TestContractFileAtRef*`, `TestFileExistsAtRef*`, `TestRefExistsAtRef*`, `TestAnyOfFilesExists*`, `TestRunDispatcherMinimumVersionCheck_*`, `TestRunProtocolMinimumVersion*`, `TestRunMinimumCliReleaseProtocolCheck_*`) | Mock `git`/`gh` are extensionless POSIX shell scripts; Windows `LookPath` skips them and the real `git`/`gh` run instead |

## Fixes (one commit per concern)

1. **dispatcher** — `fakeUnityExecutablePath(t)` keeps `/usr/bin/true` on POSIX and writes a no-op `.bat` on Windows.
2. **project-runner** — `newLoopbackIpcListener(t)` serves a uniquely named local pipe (`winio.ListenPipe`) on Windows and keeps loopback TCP on POSIX; endpoints are built from the listener address. The repeated-response fixture now tolerates a poll connection the client abandons at its wait deadline (TCP hides that hangup in the socket buffer; a named pipe surfaces it as EOF).
3. **release-automation** — new `testdata/mockcli` Go program, built once by `TestMain` on Windows and installed as `git.exe`/`gh.exe` beside a JSON config selecting which shell mock to emulate. Each mode is a line-by-line translation of its script generator; the POSIX scripts are byte-identical to before. A `.cmd` batch shim was rejected because cmd mangles arguments such as `tag^{commit}` and embedded quotes (verified empirically: `some-tag^{commit}` arrives as `some-tag{commit}`).
4. **CI** — the `test-windows-installers` job now runs `go test ./...` in all four modules (same per-module style as `check-go-cli-source.sh`) and the stale "wider test suite still has Windows-incompatible tests" comment is updated.

## Skipped tests

None added. Existing `runtime.GOOS == "windows"` skips ("TCP endpoint injection is only used by this non-Windows client test") in `client_test.go` / `connection_retry_test.go` / `compile_wait_test.go` are untouched.

## Verification

- Windows (local): `go test -count=1 ./...` passes in all 4 modules; `gofmt`, `go vet`, `golangci-lint fmt --diff`, `golangci-lint run` all clean for the touched modules.
- POSIX: no behavioral changes intended (POSIX fixtures unchanged); this PR's ubuntu job is the regression check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

