### PR TITLE
fix: Block releases with mismatched attestation digests

### DIFF
--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -293,6 +293,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/native-cli-publish.yml
           RECOVERY_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.recovery-target }}
         run: |
           set -eu
@@ -448,7 +449,7 @@ jobs:
             downloaded_bundle_path="${asset_directory}/${bundle_name}"
             verification_output_path="${asset_directory}/verification.json"
             digest_output_path="${asset_directory}/digests.txt"
-            gh attestation verify "${downloaded_asset_path}" --bundle "${downloaded_bundle_path}" --format json > "${verification_output_path}"
+            gh attestation verify "${downloaded_asset_path}" --repo "${GITHUB_REPOSITORY}" --bundle "${downloaded_bundle_path}" --signer-workflow "${SIGNER_WORKFLOW}" --format json > "${verification_output_path}"
             verification_count=$(jq 'length' "${verification_output_path}")
             digest_count=$(jq '[.[].verificationResult.signature.certificate.sourceRepositoryDigest | select(type == "string" and length > 0)] | length' "${verification_output_path}")
             if [ "${verification_count}" -eq 0 ] || [ "${verification_count}" -ne "${digest_count}" ]; then

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -425,6 +425,45 @@ jobs:
             fi
           done < release-input/release-assets.manifest
 
+      - name: Verify remote attestation digest matches release tag
+        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -eu
+          tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha')
+          if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved release commit ${RELEASE_SHA}." >&2
+            exit 1
+          fi
+          verification_directory=$(mktemp -d "${RUNNER_TEMP}/native-cli-attestation-verify.XXXXXX")
+          while IFS=' ' read -r checksum asset_path; do
+            asset_name=$(basename "${asset_path}")
+            bundle_name="${asset_name}.sigstore.json"
+            asset_directory="${verification_directory}/${asset_name}"
+            mkdir "${asset_directory}"
+            gh release download "${RELEASE_TAG}" --pattern "${asset_name}" --pattern "${bundle_name}" --dir "${asset_directory}"
+            downloaded_asset_path="${asset_directory}/${asset_name}"
+            downloaded_bundle_path="${asset_directory}/${bundle_name}"
+            verification_output_path="${asset_directory}/verification.json"
+            digest_output_path="${asset_directory}/digests.txt"
+            gh attestation verify "${downloaded_asset_path}" --bundle "${downloaded_bundle_path}" --format json > "${verification_output_path}"
+            verification_count=$(jq 'length' "${verification_output_path}")
+            digest_count=$(jq '[.[].verificationResult.signature.certificate.sourceRepositoryDigest | select(type == "string" and length > 0)] | length' "${verification_output_path}")
+            if [ "${verification_count}" -eq 0 ] || [ "${verification_count}" -ne "${digest_count}" ]; then
+              echo "Attestation verification did not return a source repository digest for ${asset_name}." >&2
+              exit 1
+            fi
+            jq -r '.[].verificationResult.signature.certificate.sourceRepositoryDigest' "${verification_output_path}" > "${digest_output_path}"
+            while IFS= read -r digest; do
+              if [ "${digest}" != "${tag_sha}" ]; then
+                echo "Attestation digest for ${asset_name} does not match release tag ${RELEASE_TAG}." >&2
+                exit 1
+              fi
+            done < "${digest_output_path}"
+          done < release-input/release-assets.manifest
+
       - name: Publish draft release
         if: env.DRY_RUN != 'true' && steps.draft.outputs.release_published != 'true'
         env:

--- a/.github/workflows/native-cli-publish.yml
+++ b/.github/workflows/native-cli-publish.yml
@@ -293,7 +293,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/native-cli-publish.yml
           RECOVERY_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.recovery-target }}
         run: |
           set -eu
@@ -431,6 +430,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/native-cli-publish.yml
         run: |
           set -eu
           tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha')

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -192,6 +192,15 @@ test_remote_attestation_digests_match_the_release_tag_before_publishing() {
   assert_before "      - name: Verify remote release assets" "      - name: Verify remote attestation digest matches release tag"
   assert_before "      - name: Verify remote attestation digest matches release tag" "      - name: Publish draft release"
   verification_section=$(remote_attestation_verification_section)
+  for required_environment in \
+    'GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}' \
+    'GITHUB_REPOSITORY: ${{ github.repository }}' \
+    'SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/native-cli-publish.yml'; do
+    if ! printf '%s\n' "${verification_section}" | grep -F -- "${required_environment}" >/dev/null 2>&1; then
+      echo "Remote attestation verification must define ${required_environment}." >&2
+      exit 1
+    fi
+  done
   tag_mismatch_guard='if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then
             echo "Release tag ${RELEASE_TAG} does not match approved release commit ${RELEASE_SHA}." >&2
             exit 1

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -144,7 +144,7 @@ test_recovery_dispatch_is_bound_to_the_resolver_target() {
   assert_contains 'compare_status=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${TARGET_SHA}...${GITHUB_SHA}" --jq '\''.status'\'')'
   assert_contains 'if [ "${compare_status}" != "ahead" ] && [ "${compare_status}" != "identical" ]; then'
   assert_contains 'printf '\''RELEASE_SHA=%s\n'\'' "${release_sha}" >> "$GITHUB_ENV"'
-  assert_count 2 'if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then'
+  assert_count 3 'if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then'
   assert_contains 'if [ -n "${tag_sha}" ] && [ "${tag_sha}" != "${RELEASE_SHA}" ]; then'
   assert_not_contains '--target "${GITHUB_SHA}"'
   assert_contains '--target "${RELEASE_SHA}"'
@@ -167,6 +167,21 @@ test_assets_are_attested_after_the_manifest_is_verified() {
   assert_before "      - name: Attach attestation bundles to release assets" "      - name: Upload native CLI assets"
   assert_before "      - name: Upload native CLI assets" "      - name: Verify remote release assets"
   assert_before "      - name: Verify remote release assets" "      - name: Publish draft release"
+}
+
+test_remote_attestation_digests_match_the_release_tag_before_publishing() {
+  # Verify the remote assets and their attached bundles are fail-closed checked
+  # against the release tag before the draft release becomes public.
+  assert_contains "      - name: Verify remote attestation digest matches release tag"
+  assert_contains "        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'"
+  assert_contains 'gh release download "${RELEASE_TAG}" --pattern "${asset_name}" --pattern "${bundle_name}" --dir "${asset_directory}"'
+  assert_contains 'gh attestation verify "${downloaded_asset_path}" --bundle "${downloaded_bundle_path}" --format json'
+  assert_contains '.verificationResult.signature.certificate.sourceRepositoryDigest'
+  assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'''
+  assert_contains 'if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then'
+  assert_contains 'if [ "${digest}" != "${tag_sha}" ]; then'
+  assert_before "      - name: Verify remote release assets" "      - name: Verify remote attestation digest matches release tag"
+  assert_before "      - name: Verify remote attestation digest matches release tag" "      - name: Publish draft release"
 }
 
 test_publish_rejects_manifest_and_existing_tag_mismatches() {
@@ -250,6 +265,7 @@ test_recovery_dispatch_is_bound_to_the_resolver_target
 test_publish_validates_metadata_without_checking_out_source
 test_checkout_free_publish_has_explicit_repository_context
 test_assets_are_attested_after_the_manifest_is_verified
+test_remote_attestation_digests_match_the_release_tag_before_publishing
 test_publish_rejects_manifest_and_existing_tag_mismatches
 test_release_tag_is_created_before_the_release
 test_recovery_target_403_errors_explain_the_manual_recovery

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -62,6 +62,14 @@ publish_draft_section() {
   ' "$WORKFLOW"
 }
 
+remote_attestation_verification_section() {
+  awk '
+    /^      - name: Verify remote attestation digest matches release tag$/ { printing = 1; next }
+    printing && /^      - name:/ { exit }
+    printing { print }
+  ' "$WORKFLOW"
+}
+
 post_publish_section() {
   awk '
     /^  post-publish:/ { printing = 1 }
@@ -180,8 +188,25 @@ test_remote_attestation_digests_match_the_release_tag_before_publishing() {
   assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'''
   assert_contains 'if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then'
   assert_contains 'if [ "${digest}" != "${tag_sha}" ]; then'
+  assert_contains 'if [ "${verification_count}" -eq 0 ] || [ "${verification_count}" -ne "${digest_count}" ]; then'
   assert_before "      - name: Verify remote release assets" "      - name: Verify remote attestation digest matches release tag"
   assert_before "      - name: Verify remote attestation digest matches release tag" "      - name: Publish draft release"
+  verification_section=$(remote_attestation_verification_section)
+  tag_mismatch_guard='if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then
+            echo "Release tag ${RELEASE_TAG} does not match approved release commit ${RELEASE_SHA}." >&2
+            exit 1
+          fi'
+  digest_mismatch_guard='if [ "${digest}" != "${tag_sha}" ]; then
+                echo "Attestation digest for ${asset_name} does not match release tag ${RELEASE_TAG}." >&2
+                exit 1
+              fi'
+  case "${verification_section}" in
+    *"${tag_mismatch_guard}"*"${digest_mismatch_guard}"*) ;;
+    *)
+      echo "Remote attestation verification must fail for tag or digest mismatches." >&2
+      exit 1
+      ;;
+  esac
 }
 
 test_publish_rejects_manifest_and_existing_tag_mismatches() {

--- a/scripts/test-native-cli-publish-workflow.sh
+++ b/scripts/test-native-cli-publish-workflow.sh
@@ -175,7 +175,7 @@ test_remote_attestation_digests_match_the_release_tag_before_publishing() {
   assert_contains "      - name: Verify remote attestation digest matches release tag"
   assert_contains "        if: env.SHOULD_PUBLISH == 'true' && env.DRY_RUN != 'true'"
   assert_contains 'gh release download "${RELEASE_TAG}" --pattern "${asset_name}" --pattern "${bundle_name}" --dir "${asset_directory}"'
-  assert_contains 'gh attestation verify "${downloaded_asset_path}" --bundle "${downloaded_bundle_path}" --format json'
+  assert_contains 'gh attestation verify "${downloaded_asset_path}" --repo "${GITHUB_REPOSITORY}" --bundle "${downloaded_bundle_path}" --signer-workflow "${SIGNER_WORKFLOW}" --format json'
   assert_contains '.verificationResult.signature.certificate.sourceRepositoryDigest'
   assert_contains 'gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '\''.sha'\'''
   assert_contains 'if [ "${tag_sha}" != "${RELEASE_SHA}" ]; then'


### PR DESCRIPTION
## Summary
- Prevent a draft native CLI release from becoming public unless every uploaded asset's attestation digest matches its release tag.

## User Impact
- A release published from a workflow run for a different commit is stopped before users can install it.
- This would have blocked the beta.48 artifact/tag mismatch before the draft was published.

## Changes
- Download each remote asset and its attached Sigstore bundle after upload.
- Verify all source repository digests against the release tag and approved release commit.
- Add static workflow coverage for the mandatory ordering and fail-closed checks.

## Verification
- C:\\Program Files\\Git\\bin\\bash.exe scripts/test-native-cli-publish-workflow.sh
- 
px --yes js-yaml .github/workflows/native-cli-publish.yml
- C:\\Program Files\\Git\\bin\\bash.exe -n scripts/test-native-cli-publish-workflow.sh
- git diff --check

Refs: release pipeline recurrence-prevention plan, PR-1

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

