### PR TITLE
fix: Block package releases with invalid runner attestations

### DIFF
--- a/scripts/sync-release-please-package-releases.sh
+++ b/scripts/sync-release-please-package-releases.sh
@@ -433,6 +433,58 @@ wait_for_cli_release_ready() {
   done
 }
 
+fail_cli_release_attestation() {
+  asset_name=$1
+
+  printf 'Project runner release attestation is invalid for %s. See docs/release-recovery-runbook.md for recovery steps.\n' "$asset_name" >&2
+  exit 1
+}
+
+verify_cli_release_attestations() {
+  release_tag=$1
+  verification_directory="$TMP_DIR/$release_tag-attestations"
+  signer_workflow="$REPO_FULL_NAME/.github/workflows/native-cli-publish.yml"
+
+  mkdir "$verification_directory"
+  tag_digest_file="$verification_directory/tag-digest.txt"
+  gh api "repos/$REPO_FULL_NAME/commits/$release_tag" --jq '.sha' > "$tag_digest_file"
+  tag_digest=$(strip_carriage_returns < "$tag_digest_file")
+  [ -n "$tag_digest" ] || fail_cli_release_attestation "$release_tag"
+
+  asset_names=$(release_asset_requirements "scripts/verify-native-cli-release-assets.sh" "$release_tag") || fail_cli_release_attestation "$release_tag"
+  for asset_name in $asset_names; do
+    asset_directory="$verification_directory/$asset_name"
+    bundle_name="$asset_name.sigstore.json"
+    asset_path="$asset_directory/$asset_name"
+    bundle_path="$asset_directory/$bundle_name"
+    verification_output_path="$asset_directory/verification.json"
+    verification_count_path="$asset_directory/verification-count.txt"
+    digest_count_path="$asset_directory/digest-count.txt"
+    digest_output_path="$asset_directory/digests.txt"
+    normalized_digest_output_path="$asset_directory/normalized-digests.txt"
+
+    mkdir "$asset_directory"
+    gh release download "$release_tag" --repo "$REPO_FULL_NAME" --pattern "$asset_name" --pattern "$bundle_name" --dir "$asset_directory"
+    [ -s "$asset_path" ] || fail_cli_release_attestation "$asset_name"
+    [ -s "$bundle_path" ] || fail_cli_release_attestation "$asset_name"
+    gh attestation verify "$asset_path" --repo "$REPO_FULL_NAME" --bundle "$bundle_path" --signer-workflow "$signer_workflow" --format json > "$verification_output_path"
+    jq 'length' "$verification_output_path" > "$verification_count_path"
+    jq '[.[].verificationResult.signature.certificate.sourceRepositoryDigest | select(type == "string" and length > 0)] | length' "$verification_output_path" > "$digest_count_path"
+    verification_count=$(strip_carriage_returns < "$verification_count_path")
+    digest_count=$(strip_carriage_returns < "$digest_count_path")
+    if [ "$verification_count" -eq 0 ] || [ "$verification_count" -ne "$digest_count" ]; then
+      fail_cli_release_attestation "$asset_name"
+    fi
+    jq -r '.[].verificationResult.signature.certificate.sourceRepositoryDigest' "$verification_output_path" > "$digest_output_path"
+    strip_carriage_returns < "$digest_output_path" > "$normalized_digest_output_path"
+    while IFS= read -r digest; do
+      if [ "$digest" != "$tag_digest" ]; then
+        fail_cli_release_attestation "$asset_name"
+      fi
+    done < "$normalized_digest_output_path"
+  done
+}
+
 wait_for_dispatcher_release_ready() {
   release_tag=$1
   timeout_seconds=${DISPATCHER_RELEASE_WAIT_TIMEOUT_SECONDS:-600}
@@ -516,6 +568,7 @@ if [ -n "$cli_version" ] && jq -e --arg package_path "$CLI_PACKAGE_PATH" '.packa
     exit 0
   fi
   fetch_cli_release_tag "$cli_release_tag"
+  verify_cli_release_attestations "$cli_release_tag"
 fi
 
 minimum_dispatcher_version=$(jq -r '.minimumDispatcherVersion // empty' "$ROOT_DIR/$UNITY_PACKAGE_CLI_PIN_FILE" | strip_carriage_returns)

--- a/scripts/test-sync-release-please-package-releases.sh
+++ b/scripts/test-sync-release-please-package-releases.sh
@@ -140,6 +140,41 @@ if [ "$1" = "release" ] && [ "$2" = "edit" ]; then
   exit 0
 fi
 
+if [ "$1" = "api" ]; then
+  case "$2" in
+    repos/*/commits/*)
+      printf '%s\n' "${CLI_RELEASE_TARGET:-cli-release-sha}"
+      exit 0
+      ;;
+  esac
+fi
+
+if [ "$1" = "release" ] && [ "$2" = "download" ]; then
+  download_dir=""
+  previous_argument=""
+  for argument in "$@"; do
+    if [ "$previous_argument" = "--dir" ]; then
+      download_dir=$argument
+      break
+    fi
+    previous_argument=$argument
+  done
+  mkdir -p "$download_dir"
+  for argument in "$@"; do
+    case "$argument" in
+      uloop-project-runner-*.tar.gz|uloop-project-runner-*.zip|uloop-project-runner-*.sha256|*.sigstore.json)
+        printf '%s\n' "mock release asset" > "$download_dir/$argument"
+        ;;
+    esac
+  done
+  exit 0
+fi
+
+if [ "$1" = "attestation" ] && [ "$2" = "verify" ]; then
+  printf '[{"verificationResult":{"signature":{"certificate":{"sourceRepositoryDigest":"%s"}}}}]\n' "${CLI_ATTESTATION_DIGEST:-${CLI_RELEASE_TARGET:-cli-release-sha}}"
+  exit 0
+fi
+
 echo "unexpected gh command: $*" >&2
 exit 1
 MOCK_GH
@@ -425,6 +460,7 @@ run_sync() {
   cli_release_ready_after_attempts=${9:-}
   dispatcher_release_state=${10:-published}
   dispatcher_release_assets=${11:-complete}
+  cli_release_target=${CLI_RELEASE_TARGET:-$(cat "$work_dir/release-sha.txt")}
 
   touch "$work_dir/gh.log"
   touch "$work_dir/go.log"
@@ -443,6 +479,8 @@ run_sync() {
     CLI_RELEASE_STATE="$cli_release_state" \
     CLI_RELEASE_ASSETS="$cli_release_assets" \
     CLI_RELEASE_TAG="${CLI_RELEASE_TAG:-uloop-project-runner-v3.0.0-beta.6}" \
+    CLI_RELEASE_TARGET="$cli_release_target" \
+    CLI_ATTESTATION_DIGEST="${CLI_ATTESTATION_DIGEST:-$cli_release_target}" \
     CLI_RELEASE_WAIT_TIMEOUT_SECONDS="$cli_release_wait_timeout" \
     CLI_RELEASE_WAIT_INTERVAL_SECONDS="$cli_release_wait_interval" \
     CLI_RELEASE_READY_AFTER_ATTEMPTS="$cli_release_ready_after_attempts" \
@@ -543,6 +581,21 @@ test_waits_for_cli_assets_before_creating_root_release() {
   assert_contains "$work_dir/output.txt" "Project runner release uloop-project-runner-v3.0.0-beta.6 is not published with complete assets; package release sync will wait."
   assert_not_contains "$work_dir/gh.log" "release create v3.0.0-beta.6"
   assert_contains "$work_dir/github-output.txt" "ready=false"
+}
+
+# Verifies an attestation digest mismatch fails instead of waiting for a runner release that cannot recover.
+test_fails_for_cli_release_attestation_digest_mismatch() {
+  work_dir=$(create_release_repo cli-attestation-mismatch)
+  release_sha=$(cat "$work_dir/release-sha.txt")
+
+  if CLI_RELEASE_TARGET="$release_sha" CLI_ATTESTATION_DIGEST=wrong-digest run_sync "$work_dir" "" false ""; then
+    echo "Expected an attestation digest mismatch to fail." >&2
+    exit 1
+  fi
+
+  assert_contains "$work_dir/stderr.txt" "docs/release-recovery-runbook.md"
+  assert_not_contains "$work_dir/output.txt" "package release sync will wait"
+  assert_not_contains "$work_dir/gh.log" "release create v3.0.0-beta.6"
 }
 
 # Verifies package releases wait until the minimum dispatcher release has all dispatcher assets.
@@ -717,6 +770,7 @@ test_existing_draft_root_release_is_published
 test_existing_draft_root_release_without_release_commit_fails
 test_waits_for_cli_release_before_creating_root_release
 test_waits_for_cli_assets_before_creating_root_release
+test_fails_for_cli_release_attestation_digest_mismatch
 test_waits_for_dispatcher_assets_before_creating_root_release
 test_waits_when_dispatcher_asset_list_fails
 test_dispatcher_release_ready_uses_tag_generation_asset_list


### PR DESCRIPTION
## Summary
- Block package release synchronization when any required runner asset has an invalid attestation digest.

## User Impact
- A package release cannot ship while its pinned runner release contains an asset attested for a different commit.
- Permanent corruption fails immediately with recovery guidance instead of appearing as a temporary readiness delay.

## Changes
- Download and verify every required runner asset together with its attached Sigstore bundle.
- Require every source repository digest to match the runner release tag.
- Add a regression test for a mismatched digest and ensure no package release is created.
- Dispatcher attestation readiness remains a follow-up outside this PR's scope.

## Verification
- Git Bash sync release test suite passed.
- Git Bash POSIX syntax checks passed.
- git diff --check passed.

Refs: release pipeline recurrence-prevention plan, PR-2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

