### PR TITLE
fix: align tool exit codes with response success

### DIFF
--- a/Assets/Tests/Editor/CompileResponseFactoryTests.cs
+++ b/Assets/Tests/Editor/CompileResponseFactoryTests.cs
@@ -77,12 +77,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CompileResponse response =
                 CompileResponseFactory.CreateResponse(result, forceRecompile: true);
 
-            Assert.That(response.Success, Is.Null);
+            Assert.That(response.Success, Is.False);
             Assert.That(response.ErrorCount, Is.Null);
             Assert.That(response.WarningCount, Is.Null);
             Assert.That(response.Errors, Is.Null);
             Assert.That(response.Warnings, Is.Null);
             Assert.That(response.Message, Is.EqualTo(ForceCompileUnknownResult.MessageText));
+            Assert.That(response.ErrorCode, Is.EqualTo(ForceCompileUnknownResult.ErrorCodeText));
+            Assert.That(response.NextActions, Is.Not.Empty);
         }
 
         [Test]
@@ -102,12 +104,14 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CompileResponse response =
                 CompileResponseFactory.CreateResponse(result, forceRecompile: true);
 
-            Assert.That(response.Success, Is.True);
+            Assert.That(response.Success, Is.False);
             Assert.That(response.ErrorCount, Is.Null);
             Assert.That(response.WarningCount, Is.Null);
             Assert.That(response.Errors, Is.Null);
             Assert.That(response.Warnings, Is.Null);
             Assert.That(response.Message, Is.EqualTo(ForceCompileUnknownResult.MessageText));
+            Assert.That(response.ErrorCode, Is.EqualTo(ForceCompileUnknownResult.ErrorCodeText));
+            Assert.That(response.NextActions, Is.Not.Empty);
         }
 
         [Test]
@@ -142,7 +146,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             CompileResponse response =
                 CompileResponseFactory.CreateResponse(result, forceRecompile: false);
 
-            Assert.That(response.Success, Is.Null);
+            Assert.That(response.Success, Is.False);
             Assert.That(response.ErrorCount, Is.EqualTo(1));
             Assert.That(response.WarningCount, Is.EqualTo(1));
             Assert.That(response.Errors, Is.Null);

--- a/Assets/Tests/Editor/CompileStatusBridgeCommandTests.cs
+++ b/Assets/Tests/Editor/CompileStatusBridgeCommandTests.cs
@@ -158,7 +158,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(response.Ready, Is.True);
             Assert.That(response.HasResult, Is.True);
-            Assert.That(response.Result["Success"]?.Type, Is.EqualTo(JTokenType.Null));
+            Assert.That(response.Result["Success"]?.Value<bool>(), Is.False);
             Assert.That(response.Result["ErrorCount"]?.Type, Is.EqualTo(JTokenType.Null));
             Assert.That(response.Result["Warnings"]?.Type, Is.EqualTo(JTokenType.Null));
             Assert.That(response.Result["Message"]?.ToString(), Does.Contain("reloaded scripts"));
@@ -216,11 +216,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
             Assert.That(response.Ready, Is.True);
             Assert.That(response.HasResult, Is.True);
-            Assert.That(response.Result["Success"]?.Type, Is.EqualTo(JTokenType.Null));
+            Assert.That(response.Result["Success"]?.Value<bool>(), Is.False);
             Assert.That(response.Result["ErrorCount"]?.Type, Is.EqualTo(JTokenType.Null));
             Assert.That(
                 response.Result["Message"]?.ToString(),
                 Is.EqualTo(ForceCompileUnknownResult.MessageText));
+            Assert.That(response.Result["ErrorCode"]?.ToString(), Is.EqualTo(ForceCompileUnknownResult.ErrorCodeText));
+            Assert.That(response.Result["NextActions"]?.Type, Is.EqualTo(JTokenType.Array));
         }
 
     }

--- a/Assets/Tests/Editor/JsonRpcRequestProcessorCliVersionGateTests.cs
+++ b/Assets/Tests/Editor/JsonRpcRequestProcessorCliVersionGateTests.cs
@@ -923,7 +923,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private sealed class SingleFlightTestResponse : UnityCliLoopToolResponse
         {
-            public bool Success { get; set; } = true;
         }
     }
 }

--- a/Assets/Tests/Editor/JsonRpcResponseFactoryWireShapeCharacterizationTests.cs
+++ b/Assets/Tests/Editor/JsonRpcResponseFactoryWireShapeCharacterizationTests.cs
@@ -143,7 +143,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private sealed class DeterministicSuccessResponse : UnityCliLoopToolResponse
         {
-            public bool Success { get; set; } = true;
         }
 
         private sealed class DeterministicSuccessTool : IUnityCliLoopTool

--- a/Assets/Tests/Editor/ToolExecutionSessionTests.cs
+++ b/Assets/Tests/Editor/ToolExecutionSessionTests.cs
@@ -256,7 +256,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
 
         private sealed class SessionTestResponse : UnityCliLoopToolResponse
         {
-            public bool Success { get; set; } = true;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/ClearConsole/ClearConsoleResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ClearConsole/ClearConsoleResponse.cs
@@ -11,11 +11,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class ClearConsoleResponse : UnityCliLoopToolResponse
     {
         /// <summary>
-        /// Whether the console clear operation was successful
-        /// </summary>
-        public bool Success { get; set; }
-
-        /// <summary>
         /// Number of logs that were cleared from the console
         /// </summary>
         public int ClearedLogCount { get; set; }
@@ -101,4 +96,4 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             LogCount = logCount;
         }
     }
-} 
+}

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResponse.cs
@@ -28,13 +28,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     public class CompileResponse : UnityCliLoopToolResponse
     {
         /// <summary>
-        /// Whether compilation was successful.
-        /// Null is used when the tool cannot reliably determine the result yet (e.g., forced recompile/domain reload),
-        /// to avoid misleading clients into treating "0 errors" as a confirmed success.
-        /// </summary>
-        public bool? Success { get; set; }
-
-        /// <summary>
         /// Number of compilation errors.
         /// Null is used when the tool intentionally does not provide details (e.g., forced recompile),
         /// because Unity reports errors/warnings after domain reload and clients should fetch logs later.
@@ -67,6 +60,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public string Message { get; set; }
 
+        public string ErrorCode { get; set; }
+
         /// <summary>
         /// Optional recovery steps when compile cannot proceed automatically.
         /// </summary>
@@ -82,7 +77,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// Create a new CompileResponse
         /// </summary>
         public CompileResponse(
-            bool? success,
+            bool success,
             int? errorCount,
             int? warningCount,
             CompileIssue[] errors,

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
@@ -84,7 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 warnings: null,
                 message: unknownResult.Message);
             response.ErrorCode = ForceCompileUnknownResult.ErrorCodeText;
-            response.NextActions = new[] { "Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result." };
+            response.NextActions = new[] { ForceCompileUnknownResult.NextActionText };
             return response;
         }
 

--- a/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/Compile/CompileResponseFactory.cs
@@ -39,7 +39,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             if (result.IsIndeterminate)
             {
                 return new CompileResponse(
-                    success: result.Success,
+                    success: result.Success == true,
                     errorCount: result.ErrorCount,
                     warningCount: result.WarningCount,
                     errors: null,
@@ -48,7 +48,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             CompileResponse response = new CompileResponse(
-                success: result.Success,
+                success: result.Success == true,
                 errorCount: result.Errors?.Length ?? 0,
                 warningCount: result.Warnings?.Length ?? 0,
                 errors: ToIssues(result.Errors),
@@ -75,14 +75,17 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static CompileResponse CreateForceCompileResult(CompileResult result)
         {
-            ForceCompileUnknownResult unknownResult = ForceCompileUnknownResult.Create(result.Success);
-            return new CompileResponse(
+            ForceCompileUnknownResult unknownResult = ForceCompileUnknownResult.Create();
+            CompileResponse response = new CompileResponse(
                 success: unknownResult.Success,
                 errorCount: unknownResult.ErrorCount,
                 warningCount: unknownResult.WarningCount,
                 errors: null,
                 warnings: null,
                 message: unknownResult.Message);
+            response.ErrorCode = ForceCompileUnknownResult.ErrorCodeText;
+            response.NextActions = new[] { "Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result." };
+            return response;
         }
 
         private static CompileIssue[] ToIssues(UnityEditor.Compilation.CompilerMessage[] messages)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
@@ -12,9 +12,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class ExecuteDynamicCodeResponse : UnityCliLoopToolResponse, IUnityCliLoopTimingResponse
     {
-        /// <summary>Execution success flag</summary>
-        public bool Success { get; set; }
-        
         /// <summary>Execution result</summary>
         public string Result { get; set; }
         

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -46,9 +46,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class PausePointResponse : UnityCliLoopToolResponse
     {
-        // Defaults to true so existing snapshot/clear paths keep their prior semantics.
-        // Only explicit validation failures set this to false.
-        public bool Success { get; set; } = true;
         public string Id { get; set; } = string.Empty;
         public int ResolvedLine { get; set; }
         public string ResolvedMethod { get; set; } = string.Empty;

--- a/Packages/src/Editor/FirstPartyTools/Raycast/RaycastResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/Raycast/RaycastResponse.cs
@@ -9,7 +9,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class RaycastResponse : UnityCliLoopToolResponse
     {
-        public bool Success { get; set; }
         public string Message { get; set; } = "";
         public bool Hit { get; set; }
         public string? HitGameObjectName { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RecordInput/RecordInputResponse.cs
@@ -9,7 +9,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class RecordInputResponse : UnityCliLoopToolResponse
     {
-        public bool Success { get; set; }
         public string Message { get; set; } = "";
         public string Action { get; set; } = "";
         public string? OutputPath { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ReplayInput/ReplayInputResponse.cs
@@ -9,7 +9,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class ReplayInputResponse : UnityCliLoopToolResponse
     {
-        public bool Success { get; set; }
         public string Message { get; set; } = "";
         public string Action { get; set; } = "";
         public string? InputPath { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/RunTests/RunTestsResponse.cs
@@ -20,11 +20,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             $"run-tests requires the Unity Test Framework package ({UnityCliLoopConstants.PACKAGE_NAME_TEST_FRAMEWORK}). Install it via Package Manager to use test execution.";
 
         /// <summary>
-        /// Whether test execution was successful
-        /// </summary>
-        public bool Success { get; set; }
-
-        /// <summary>
         /// Machine-readable execution status
         /// </summary>
         public string Status { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -57,7 +57,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     "CaptureMode.rendering requires PlayMode",
                     correlationId: correlationId
                 );
-                return new ScreenshotResponse();
+                return new ScreenshotResponse
+                {
+                    Success = false,
+                    Message = "Rendering screenshots require PlayMode, but Unity is currently in EditMode.",
+                    NextActions = new[] { "Start PlayMode with `uloop control-play-mode --action Play`, then retry the rendering screenshot." }
+                };
             }
 
             List<UIElementInfo> annotatedElements = new();
@@ -193,7 +198,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     "Play Mode view RenderTexture is not available. Open the Game view or Device Simulator and wait for a frame before retrying.",
                     correlationId: correlationId
                 );
-                return new ScreenshotResponse();
+                return new ScreenshotResponse
+                {
+                    Success = false,
+                    Message = "PlayMode rendering did not produce an image.",
+                    NextActions = new[] { "Open the Game view or Device Simulator, wait for a frame, then retry the rendering screenshot." }
+                };
             }
 
             int width = texture.width;
@@ -399,8 +409,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             return new ScreenshotResponse
             {
+                Success = false,
                 TimedOut = true,
                 Message = message,
+                NextActions = new[] { "Retry the screenshot after Unity finishes rendering the requested frame." },
                 Screenshots = screenshots,
             };
         }

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/ScreenshotUseCase.cs
@@ -306,7 +306,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 );
                 return new ScreenshotResponse
                 {
+                    Success = false,
                     Message = notFoundMessage,
+                    NextActions = new[] { "Open the requested Unity window, then retry the screenshot." }
                 };
             }
 

--- a/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateKeyboard/SimulateKeyboardResponse.cs
@@ -11,7 +11,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class SimulateKeyboardResponse : UnityCliLoopToolResponse
     {
-        public bool Success { get; set; }
         public string Message { get; set; } = "";
         public string Action { get; set; } = "";
         public string? KeyName { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseInput/SimulateMouseInputResponse.cs
@@ -11,7 +11,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class SimulateMouseInputResponse : UnityCliLoopToolResponse
     {
-        public bool Success { get; set; }
         public string Message { get; set; } = "";
         public string Action { get; set; } = "";
         public string? Button { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/SimulateMouseUiResponse.cs
@@ -11,7 +11,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public class SimulateMouseUiResponse : UnityCliLoopToolResponse
     {
-        public bool Success { get; set; }
         public string Message { get; set; } = "";
         public string Action { get; set; } = "";
         public string? HitGameObjectName { get; set; }

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
@@ -40,7 +40,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     /// </summary>
     public sealed class WatchResponse : UnityCliLoopToolResponse
     {
-        public bool Success { get; set; } = true;
         public string Id { get; set; } = string.Empty;
         public string Expression { get; set; } = string.Empty;
         public int MaxHistory { get; set; }

--- a/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
@@ -177,7 +177,7 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
                 ["Warnings"] = JValue.CreateNull(),
                 ["Message"] = message,
                 ["ErrorCode"] = ForceCompileUnknownResult.ErrorCodeText,
-                ["NextActions"] = new JArray("Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result."),
+                ["NextActions"] = new JArray(ForceCompileUnknownResult.NextActionText),
                 ["ProjectRoot"] = UnityCliLoopPathResolver.GetProjectRoot()
             };
         }

--- a/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
+++ b/Packages/src/Editor/Infrastructure/Api/CompileStatusBridgeCommand.cs
@@ -164,18 +164,20 @@ namespace io.github.hatayama.UnityCliLoop.Infrastructure
             if (pendingRequest.ForceRecompile)
             {
                 ForceCompileUnknownResult unknownForceCompileResult =
-                    ForceCompileUnknownResult.Create(null);
+                    ForceCompileUnknownResult.Create();
                 message = unknownForceCompileResult.Message;
             }
 
             return new JObject
             {
-                ["Success"] = JValue.CreateNull(),
+                ["Success"] = false,
                 ["ErrorCount"] = JValue.CreateNull(),
                 ["WarningCount"] = JValue.CreateNull(),
                 ["Errors"] = JValue.CreateNull(),
                 ["Warnings"] = JValue.CreateNull(),
                 ["Message"] = message,
+                ["ErrorCode"] = ForceCompileUnknownResult.ErrorCodeText,
+                ["NextActions"] = new JArray("Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result."),
                 ["ProjectRoot"] = UnityCliLoopPathResolver.GetProjectRoot()
             };
         }

--- a/Packages/src/Editor/ToolContracts/ForceCompileUnknownResult.cs
+++ b/Packages/src/Editor/ToolContracts/ForceCompileUnknownResult.cs
@@ -5,24 +5,25 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     /// </summary>
     public sealed class ForceCompileUnknownResult
     {
-        public const string MessageText = "Forced full compilation completed. Unity does not return a definitive compile result for this forced full compile path, so fields that Unity did not provide are intentionally null; run get-logs to inspect the compiler output.";
+        public const string MessageText = "Forced full compilation was triggered, but Unity did not provide a definitive result after domain reload.";
+        public const string ErrorCodeText = "COMPILE_RESULT_UNKNOWN";
 
-        private ForceCompileUnknownResult(bool? success)
+        private ForceCompileUnknownResult()
         {
-            Success = success;
+            Success = false;
             ErrorCount = null;
             WarningCount = null;
             Message = MessageText;
         }
 
-        public bool? Success { get; }
+        public bool Success { get; }
         public int? ErrorCount { get; }
         public int? WarningCount { get; }
         public string Message { get; }
 
-        public static ForceCompileUnknownResult Create(bool? success)
+        public static ForceCompileUnknownResult Create()
         {
-            return new ForceCompileUnknownResult(success);
+            return new ForceCompileUnknownResult();
         }
     }
 }

--- a/Packages/src/Editor/ToolContracts/ForceCompileUnknownResult.cs
+++ b/Packages/src/Editor/ToolContracts/ForceCompileUnknownResult.cs
@@ -7,6 +7,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     {
         public const string MessageText = "Forced full compilation was triggered, but Unity did not provide a definitive result after domain reload.";
         public const string ErrorCodeText = "COMPILE_RESULT_UNKNOWN";
+        public const string NextActionText = "Wait for domain reload to complete, then run `uloop compile` without --force-recompile to obtain a definitive result.";
 
         private ForceCompileUnknownResult()
         {

--- a/Packages/src/Editor/ToolContracts/ScreenshotResponse.cs
+++ b/Packages/src/Editor/ToolContracts/ScreenshotResponse.cs
@@ -37,6 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public List<ScreenshotInfo> Screenshots { get; set; } = new List<ScreenshotInfo>();
         public bool TimedOut { get; set; }
         public string Message { get; set; } = "";
+        public string[] NextActions { get; set; } = new string[0];
 
         public int ScreenshotCount => Screenshots.Count;
     }

--- a/Packages/src/Editor/ToolContracts/UnityCliLoopToolResponse.cs
+++ b/Packages/src/Editor/ToolContracts/UnityCliLoopToolResponse.cs
@@ -5,6 +5,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
     /// </summary>
     public abstract class UnityCliLoopToolResponse
     {
+        public bool Success { get; set; } = true;
     }
 
     public interface IUnityCliLoopTimingResponse

--- a/cli/dispatcher/internal/dispatcher/launch_ready.go
+++ b/cli/dispatcher/internal/dispatcher/launch_ready.go
@@ -16,7 +16,7 @@ const (
 	launchReadyMessage               = "Unity CLI Loop is ready."
 	launchAlreadyRunningReadyMessage = "Unity is already running and ready."
 	launchStoppedMessage             = "Unity process stopped."
-	launchNoProcessMessage           = "No Unity process is running for this project."
+	launchNoProcessMessage           = "No matching Unity process was found; it may have already exited."
 )
 
 type launchReadyResponse struct {

--- a/cli/dispatcher/internal/dispatcher/launch_test.go
+++ b/cli/dispatcher/internal/dispatcher/launch_test.go
@@ -254,7 +254,7 @@ func TestRunLaunchQuitDoesNotLaunchWhenUnityIsNotRunning(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code mismatch: %d stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "No Unity process is running") {
+	if !strings.Contains(stdout.String(), launchNoProcessMessage) {
 		t.Fatalf("stdout mismatch: %s", stdout.String())
 	}
 }

--- a/cli/project-runner/internal/projectrunner/compile_wait.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait.go
@@ -40,6 +40,7 @@ type compileCompletionOptions struct {
 }
 
 type compileStatusResponse struct {
+	Success                  bool            `json:"Success"`
 	Ready                    bool            `json:"Ready"`
 	HasResult                bool            `json:"HasResult"`
 	IsCompiling              bool            `json:"IsCompiling"`

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -472,8 +472,8 @@ func TestRunCompileWithDomainReloadWaitWritesRequestLifecycleVibeLogs(t *testing
 	var stderr bytes.Buffer
 
 	code := runCompileWithDomainReloadWaitWithDeps(context.Background(), connection, params, &stdout, &stderr, deps)
-	if code != 0 {
-		t.Fatalf("runCompileWithDomainReloadWait failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code != 1 {
+		t.Fatalf("expected failed compile envelope to exit 1: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 
 	logContent := readOnlyCliVibeLog(t, projectRoot)

--- a/cli/project-runner/internal/projectrunner/compile_wait_test.go
+++ b/cli/project-runner/internal/projectrunner/compile_wait_test.go
@@ -270,7 +270,7 @@ func TestWaitForCompileCompletionForceCompileWaitsForStoredResult(t *testing.T) 
 		return compileStatusResponse{
 			Ready:     true,
 			HasResult: true,
-			Result:    json.RawMessage(`{"Success":null,"ErrorCount":null,"Message":"Force compilation completed"}`),
+			Result:    json.RawMessage(`{"Success":false,"ErrorCount":null,"Message":"Force compilation completed"}`),
 		}, nil
 	})
 
@@ -295,8 +295,8 @@ func TestWaitForCompileCompletionForceCompileWaitsForStoredResult(t *testing.T) 
 	if err := json.Unmarshal(result, &payload); err != nil {
 		t.Fatalf("force compile result is not JSON: %v", err)
 	}
-	if payload["Success"] != nil {
-		t.Fatalf("force compile success should be unknown: %#v", payload["Success"])
+	if payload["Success"] != false {
+		t.Fatalf("force compile must fail closed when the result is unknown: %#v", payload["Success"])
 	}
 	if payload["ErrorCount"] != nil || payload["WarningCount"] != nil {
 		t.Fatalf("force compile counts should be unknown: %#v", payload)
@@ -529,7 +529,7 @@ func TestCompileResultReadinessWaitMode(t *testing.T) {
 	cases := map[string]compileReadinessWaitMode{
 		`{"Success":true}`: compileReadinessWaitWarmup,
 		`{"Success":false,"Errors":[{"Message":"boom"}]}`: compileReadinessWaitNone,
-		`{"Success":null,"Message":"indeterminate"}`:      compileReadinessWaitNone,
+		`{"Success":false,"Message":"indeterminate"}`:     compileReadinessWaitNone,
 		`{"Message":"indeterminate"}`:                     compileReadinessWaitNone,
 	}
 

--- a/cli/project-runner/internal/projectrunner/pause_point_logs.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_logs.go
@@ -72,6 +72,7 @@ type pausePointWaitResult struct {
 }
 
 type pausePointGetLogsResponse struct {
+	Success           bool                    `json:"Success"`
 	TotalCount        int                     `json:"TotalCount"`
 	DisplayedCount    int                     `json:"DisplayedCount"`
 	LogType           string                  `json:"LogType"`

--- a/cli/project-runner/internal/projectrunner/pause_point_types.go
+++ b/cli/project-runner/internal/projectrunner/pause_point_types.go
@@ -1,6 +1,7 @@
 package projectrunner
 
 type pausePointStatusResponse struct {
+	Success                         bool                             `json:"Success"`
 	Id                              string                           `json:"Id"`
 	Status                          string                           `json:"Status"`
 	IsEnabled                       bool                             `json:"IsEnabled"`

--- a/cli/project-runner/internal/projectrunner/run.go
+++ b/cli/project-runner/internal/projectrunner/run.go
@@ -92,9 +92,10 @@ func runTool(ctx context.Context, connection unityipc.Connection, command string
 		})
 		return 1
 	}
-	clicore.WriteJSON(stdout, stripDebugTimingResult(command, outcome.Result))
+	result := stripDebugTimingResult(command, outcome.Result)
+	clicore.WriteJSON(stdout, result)
 	writeDebugTiming(stderr, command, time.Since(startedAt), outcome)
-	return 0
+	return toolEnvelopeExitCode(result)
 }
 
 func runExecuteDynamicCodeWithDomainReloadWait(ctx context.Context, connection unityipc.Connection, params map[string]any, stdout io.Writer, stderr io.Writer) int {
@@ -143,9 +144,10 @@ func runExecuteDynamicCodeWithDomainReloadWait(ctx context.Context, connection u
 
 	spinner.Stop()
 	result := stripExecuteDynamicCodeControlResult(outcome.Result)
-	clicore.WriteJSON(stdout, stripDebugTimingResult(clicore.ExecuteDynamicCodeCommandName, result))
+	result = stripDebugTimingResult(clicore.ExecuteDynamicCodeCommandName, result)
+	clicore.WriteJSON(stdout, result)
 	writeDebugTiming(stderr, clicore.ExecuteDynamicCodeCommandName, time.Since(startedAt), outcome)
-	return 0
+	return toolEnvelopeExitCode(result)
 }
 
 func runCompileWithDomainReloadWait(ctx context.Context, connection unityipc.Connection, params map[string]any, stdout io.Writer, stderr io.Writer) int {
@@ -227,7 +229,7 @@ func runCompileWithDomainReloadWaitWithDeps(
 	spinner.Stop()
 	clicore.WriteJSON(stdout, result)
 	writeDebugTiming(stderr, clicore.CompileCommandName, time.Since(startedAt), outcome)
-	return 0
+	return toolEnvelopeExitCode(result)
 }
 
 func writePostCompileWarmupWarning(stderr io.Writer, err error) {

--- a/cli/project-runner/internal/projectrunner/tool_envelope_exit_code.go
+++ b/cli/project-runner/internal/projectrunner/tool_envelope_exit_code.go
@@ -1,0 +1,18 @@
+package projectrunner
+
+import "encoding/json"
+
+type toolEnvelopeSuccess struct {
+	Success *bool `json:"Success"`
+}
+
+func toolEnvelopeExitCode(result []byte) int {
+	var envelope toolEnvelopeSuccess
+	if err := json.Unmarshal(result, &envelope); err != nil || envelope.Success == nil {
+		return 1
+	}
+	if !*envelope.Success {
+		return 1
+	}
+	return 0
+}

--- a/cli/project-runner/internal/projectrunner/tool_envelope_exit_code_test.go
+++ b/cli/project-runner/internal/projectrunner/tool_envelope_exit_code_test.go
@@ -1,0 +1,38 @@
+package projectrunner
+
+import "testing"
+
+// Verifies a true tool envelope reports a successful process exit.
+func TestToolEnvelopeExitCodeReturnsZeroForSuccess(t *testing.T) {
+	if code := toolEnvelopeExitCode([]byte(`{"Success":true}`)); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}
+
+// Verifies a false tool envelope reports a failed process exit.
+func TestToolEnvelopeExitCodeReturnsOneForFailure(t *testing.T) {
+	if code := toolEnvelopeExitCode([]byte(`{"Success":false}`)); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}
+
+// Verifies a missing Success field fails closed.
+func TestToolEnvelopeExitCodeRejectsMissingSuccess(t *testing.T) {
+	if code := toolEnvelopeExitCode([]byte(`{"Message":"missing"}`)); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}
+
+// Verifies a non-boolean Success field fails closed.
+func TestToolEnvelopeExitCodeRejectsNonBooleanSuccess(t *testing.T) {
+	if code := toolEnvelopeExitCode([]byte(`{"Success":"true"}`)); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}
+
+// Verifies malformed tool JSON fails closed.
+func TestToolEnvelopeExitCodeRejectsMalformedJSON(t *testing.T) {
+	if code := toolEnvelopeExitCode([]byte(`{"Success":`)); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}

--- a/tests/contracts/compile_status_response_contract.json
+++ b/tests/contracts/compile_status_response_contract.json
@@ -1,4 +1,5 @@
 {
+  "Success": true,
   "Ready": true,
   "HasResult": true,
   "IsCompiling": true,
@@ -11,6 +12,7 @@
     "Errors": [],
     "Warnings": [],
     "Message": "Compile result is available.",
+    "ErrorCode": null,
     "NextActions": null,
     "ProjectRoot": null
   },

--- a/tests/contracts/get_logs_response_contract.json
+++ b/tests/contracts/get_logs_response_contract.json
@@ -1,4 +1,5 @@
 {
+  "Success": true,
   "TotalCount": 2,
   "DisplayedCount": 1,
   "LogType": "Error",

--- a/tests/contracts/pause_point_status_response_contract.json
+++ b/tests/contracts/pause_point_status_response_contract.json
@@ -1,4 +1,5 @@
 {
+  "Success": true,
   "Id": "Assets/Scripts/Enemy.cs:42",
   "Status": "Hit",
   "IsEnabled": true,


### PR DESCRIPTION
## Summary

Establishes the invariant that every Unity tool envelope with `Success:false` produces exit code 1, while `Success:true` produces exit code 0.

- Derives project-runner tool exit codes from strict top-level `Success` parsing; malformed, missing, and non-boolean values fail closed.
- Adds `Success` to the shared Unity response base and removes duplicate response fields.
- Makes forced compile result-unknown responses explicit failures with `COMPILE_RESULT_UNKNOWN` and a definitive-compile next action.
- Makes rendering screenshot failures explicit and actionable; preserves `launch -q` no-process behavior as an idempotent success with a message.

## Verification

- `go test ./internal/projectrunner -count=1`
- `go test ./internal/dispatcher -count=1`
- repo-local `uloop compile`: 0 errors, 0 warnings
- targeted EditMode tests: 20 passed, 0 failed

The full EditMode suite had the eight Windows-incompatible failures already recorded in the Windows verification results; the changed contract tests passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

