### PR TITLE
docs: Preserve beta.48 as an attestation negative specimen

### DIFF
--- a/docs/release-recovery-runbook.md
+++ b/docs/release-recovery-runbook.md
@@ -93,10 +93,10 @@ preserved broken release: its tag commit is `2d8d1b94`, while its asset
 attestations carry `2c73c6ac`.
 
 This is the only current production specimen that can prove attestation
-mismatches fail against real release data. Use it to verify the publish
-workflow digest check, sync's `verify_cli_release_attestations`, and the
-dispatcher download-time verification reject a mismatched release. Do not pin
-this version; use beta.49 or later.
+mismatches fail against real release data. Use it to verify each of the
+following rejects a mismatched release: the publish workflow digest check,
+sync's `verify_cli_release_attestations`, and the dispatcher download-time
+verification. Do not pin this version; use beta.49 or later.
 
 - Do not start a new workflow run to publish a historical release. A later run
   cannot produce valid attestations for an earlier commit.

--- a/docs/release-recovery-runbook.md
+++ b/docs/release-recovery-runbook.md
@@ -86,6 +86,18 @@ gh run rerun <run-id> --repo <owner>/<repo> --failed
 
 ## Operational notes
 
+### Preserved negative attestation specimen
+
+Do not delete `uloop-project-runner-v3.0.0-beta.48`. It is an intentionally
+preserved broken release: its tag commit is `2d8d1b94`, while its asset
+attestations carry `2c73c6ac`.
+
+This is the only current production specimen that can prove attestation
+mismatches fail against real release data. Use it to verify the publish
+workflow digest check, sync's `verify_cli_release_attestations`, and the
+dispatcher download-time verification reject a mismatched release. Do not pin
+this version; use beta.49 or later.
+
 - Do not start a new workflow run to publish a historical release. A later run
   cannot produce valid attestations for an earlier commit.
 - Cancel an older run waiting for `cli-release` approval before retrying. The


### PR DESCRIPTION
## Summary
- Document that the broken beta.48 runner release is intentionally retained and must not be deleted.
- Direct consumers to beta.49 or later.

## Purpose
- beta.48 is the only current production negative specimen for exercising real attestation mismatches.
- Its tag commit is 2d8d1b94 while its asset attestation digest is 2c73c6ac.

## Coverage
- Identifies the publish workflow, release sync, and dispatcher download verification paths that can be checked against the specimen.

## Verification
- Markdown-only change. No runbook-content static test exists; reviewed the surrounding runbook for duplicate beta.48 guidance.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

