### PR TITLE
fix: make recovery readiness checks reach Unity connection errors

### DIFF
--- a/scripts/smoke-cli-recovery-readiness.go
+++ b/scripts/smoke-cli-recovery-readiness.go
@@ -222,6 +222,7 @@ func runStaleRecoveryStateIgnoredSequence(uloopPath string, sourceProjectPath st
 	if err := createMinimalUnityProject(projectPath); err != nil {
 		return err
 	}
+	// Why: the dispatcher requires the runner pin before this sequence can reach the connection failure assertion.
 	if err := copyProjectRunnerPin(sourceProjectPath, projectPath); err != nil {
 		return err
 	}

--- a/scripts/smoke-cli-recovery-readiness.go
+++ b/scripts/smoke-cli-recovery-readiness.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	stateRelativePath         = "Temp/UnityCliLoop/server-state.json"
+	projectRunnerPinPath      = ".uloop/project-runner-pin.json"
 	expectedDynamicCodeResult = "cli-recovery-readiness-e2e"
 	e2eDynamicCode            = `return "cli-recovery-readiness-e2e";`
 	timeoutExitCode           = 124
@@ -61,7 +62,7 @@ func run() error {
 	if err := runLiveRecoverySequence(opts); err != nil {
 		return err
 	}
-	if err := runStaleRecoveryStateIgnoredSequence(opts.uloopPath, opts.timeout); err != nil {
+	if err := runStaleRecoveryStateIgnoredSequence(opts.uloopPath, opts.projectPath, opts.timeout); err != nil {
 		return err
 	}
 
@@ -211,7 +212,7 @@ func runLiveRecoverySequence(opts options) error {
 	return assertDynamicCodeResult(dynamicPayload)
 }
 
-func runStaleRecoveryStateIgnoredSequence(uloopPath string, timeout time.Duration) error {
+func runStaleRecoveryStateIgnoredSequence(uloopPath string, sourceProjectPath string, timeout time.Duration) error {
 	projectPath, err := os.MkdirTemp("", "uloop-stale-state-")
 	if err != nil {
 		return err
@@ -219,6 +220,9 @@ func runStaleRecoveryStateIgnoredSequence(uloopPath string, timeout time.Duratio
 	defer os.RemoveAll(projectPath)
 
 	if err := createMinimalUnityProject(projectPath); err != nil {
+		return err
+	}
+	if err := copyProjectRunnerPin(sourceProjectPath, projectPath); err != nil {
 		return err
 	}
 	if err := writeStaleServerState(projectPath); err != nil {
@@ -242,6 +246,20 @@ func runStaleRecoveryStateIgnoredSequence(uloopPath string, timeout time.Duratio
 		return fmt.Errorf("stale recovery state should be ignored, not removed: %s", statePath)
 	}
 	return nil
+}
+
+func copyProjectRunnerPin(sourceProjectPath string, targetProjectPath string) error {
+	sourcePath := filepath.Join(sourceProjectPath, filepath.FromSlash(projectRunnerPinPath))
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return err
+	}
+
+	targetPath := filepath.Join(targetProjectPath, filepath.FromSlash(projectRunnerPinPath))
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(targetPath, data, 0o644)
 }
 
 func runUloop(uloopPath string, projectPath string, args []string, timeout time.Duration) commandResult {

--- a/scripts/test-smoke-cli-recovery-readiness.sh
+++ b/scripts/test-smoke-cli-recovery-readiness.sh
@@ -22,6 +22,8 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 mkdir -p "$PROJECT_PATH/Assets" "$PROJECT_PATH/ProjectSettings"
+mkdir -p "$PROJECT_PATH/.uloop"
+cp "$ROOT_DIR/.uloop/project-runner-pin.json" "$PROJECT_PATH/.uloop/project-runner-pin.json"
 
 cat > "$FAKE_ULOOP_SOURCE" <<'EOF'
 package main


### PR DESCRIPTION
## Summary
- Recovery/readiness smoke checks now exercise the intended Unity connection failure path for temporary projects.
- The self-test fixture supplies the runner pin required by the dispatcher.

## User Impact
- Stale recovery-state validation no longer fails early with a project-resolution error.

## Changes
- Copy the source project's .uloop/project-runner-pin.json into the temporary Unity project before running the stale-state check.
- Keep the fake project fixture aligned with the required project metadata.

## Verification
- sh scripts/test-smoke-cli-recovery-readiness.sh
- go run scripts/smoke-cli-recovery-readiness.go --project-path /Users/a12115/ghq/hatayama/unity-cli-loop --uloop-path dist/darwin-arm64/uloop --timeout 120 --launch-timeout 240

Refs: Mac POSIX E2E recovery/readiness fix specification, To-Dos 2-4.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

