### PR TITLE
feat: add Game View size tool

### DIFF
--- a/.agents/skills/uloop-set-game-view-size/SKILL.md
+++ b/.agents/skills/uloop-set-game-view-size/SKILL.md
@@ -10,38 +10,38 @@ Set or inspect the Unity Game View custom rendering resolution.
 
 ## Usage
 
-\`\`\`bash
+```bash
 uloop set-game-view-size [--width <width> --height <height>]
-\`\`\`
+```
 
 ## Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| \`--width\` | integer | unset | Target Game View rendering width in pixels. Provide with \`--height\` to change the resolution. |
-| \`--height\` | integer | unset | Target Game View rendering height in pixels. Provide with \`--width\` to change the resolution. |
+| `--width` | integer | unset | Target Game View rendering width in pixels. Provide with `--height` to change the resolution. |
+| `--height` | integer | unset | Target Game View rendering height in pixels. Provide with `--width` to change the resolution. |
 
 ## Output
 
 Returns JSON containing:
 
-- \`Success\`: Whether the request completed.
-- \`PreviousWidth\` / \`PreviousHeight\`: Resolution before the request.
-- \`CurrentWidth\` / \`CurrentHeight\`: Resolution after the request.
-- \`Changed\`: Whether the resolution changed.
-- \`Message\`: Human-readable status.
+- `Success`: Whether the request completed.
+- `PreviousWidth` / `PreviousHeight`: Resolution before the request.
+- `CurrentWidth` / `CurrentHeight`: Resolution after the request.
+- `Changed`: Whether the resolution changed.
+- `Message`: Human-readable status.
 
 ## Examples
 
-\`\`\`bash
+```bash
 # Read the current custom rendering resolution
 uloop set-game-view-size
 
 # Set a Full HD custom rendering resolution
 uloop set-game-view-size --width 1920 --height 1080
-\`\`\`
+```
 
 ## Notes
 
 - Width and height must be provided together when changing the resolution.
-- The tool uses Unity's public \`UnityEditor.PlayModeWindow\` API and does not require reflection.
+- The tool uses Unity's public `UnityEditor.PlayModeWindow` API and does not require reflection.

--- a/.agents/skills/uloop-set-game-view-size/SKILL.md
+++ b/.agents/skills/uloop-set-game-view-size/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: uloop-set-game-view-size
+toolName: set-game-view-size
+description: "Set or inspect the Unity Game View custom rendering resolution."
+---
+
+# uloop set-game-view-size
+
+Set or inspect the Unity Game View custom rendering resolution.
+
+## Usage
+
+\`\`\`bash
+uloop set-game-view-size [--width <width> --height <height>]
+\`\`\`
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| \`--width\` | integer | unset | Target Game View rendering width in pixels. Provide with \`--height\` to change the resolution. |
+| \`--height\` | integer | unset | Target Game View rendering height in pixels. Provide with \`--width\` to change the resolution. |
+
+## Output
+
+Returns JSON containing:
+
+- \`Success\`: Whether the request completed.
+- \`PreviousWidth\` / \`PreviousHeight\`: Resolution before the request.
+- \`CurrentWidth\` / \`CurrentHeight\`: Resolution after the request.
+- \`Changed\`: Whether the resolution changed.
+- \`Message\`: Human-readable status.
+
+## Examples
+
+\`\`\`bash
+# Read the current custom rendering resolution
+uloop set-game-view-size
+
+# Set a Full HD custom rendering resolution
+uloop set-game-view-size --width 1920 --height 1080
+\`\`\`
+
+## Notes
+
+- Width and height must be provided together when changing the resolution.
+- The tool uses Unity's public \`UnityEditor.PlayModeWindow\` API and does not require reflection.

--- a/.claude/skills/uloop-set-game-view-size/SKILL.md
+++ b/.claude/skills/uloop-set-game-view-size/SKILL.md
@@ -10,38 +10,38 @@ Set or inspect the Unity Game View custom rendering resolution.
 
 ## Usage
 
-\`\`\`bash
+```bash
 uloop set-game-view-size [--width <width> --height <height>]
-\`\`\`
+```
 
 ## Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| \`--width\` | integer | unset | Target Game View rendering width in pixels. Provide with \`--height\` to change the resolution. |
-| \`--height\` | integer | unset | Target Game View rendering height in pixels. Provide with \`--width\` to change the resolution. |
+| `--width` | integer | unset | Target Game View rendering width in pixels. Provide with `--height` to change the resolution. |
+| `--height` | integer | unset | Target Game View rendering height in pixels. Provide with `--width` to change the resolution. |
 
 ## Output
 
 Returns JSON containing:
 
-- \`Success\`: Whether the request completed.
-- \`PreviousWidth\` / \`PreviousHeight\`: Resolution before the request.
-- \`CurrentWidth\` / \`CurrentHeight\`: Resolution after the request.
-- \`Changed\`: Whether the resolution changed.
-- \`Message\`: Human-readable status.
+- `Success`: Whether the request completed.
+- `PreviousWidth` / `PreviousHeight`: Resolution before the request.
+- `CurrentWidth` / `CurrentHeight`: Resolution after the request.
+- `Changed`: Whether the resolution changed.
+- `Message`: Human-readable status.
 
 ## Examples
 
-\`\`\`bash
+```bash
 # Read the current custom rendering resolution
 uloop set-game-view-size
 
 # Set a Full HD custom rendering resolution
 uloop set-game-view-size --width 1920 --height 1080
-\`\`\`
+```
 
 ## Notes
 
 - Width and height must be provided together when changing the resolution.
-- The tool uses Unity's public \`UnityEditor.PlayModeWindow\` API and does not require reflection.
+- The tool uses Unity's public `UnityEditor.PlayModeWindow` API and does not require reflection.

--- a/.claude/skills/uloop-set-game-view-size/SKILL.md
+++ b/.claude/skills/uloop-set-game-view-size/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: uloop-set-game-view-size
+toolName: set-game-view-size
+description: "Set or inspect the Unity Game View custom rendering resolution."
+---
+
+# uloop set-game-view-size
+
+Set or inspect the Unity Game View custom rendering resolution.
+
+## Usage
+
+\`\`\`bash
+uloop set-game-view-size [--width <width> --height <height>]
+\`\`\`
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| \`--width\` | integer | unset | Target Game View rendering width in pixels. Provide with \`--height\` to change the resolution. |
+| \`--height\` | integer | unset | Target Game View rendering height in pixels. Provide with \`--width\` to change the resolution. |
+
+## Output
+
+Returns JSON containing:
+
+- \`Success\`: Whether the request completed.
+- \`PreviousWidth\` / \`PreviousHeight\`: Resolution before the request.
+- \`CurrentWidth\` / \`CurrentHeight\`: Resolution after the request.
+- \`Changed\`: Whether the resolution changed.
+- \`Message\`: Human-readable status.
+
+## Examples
+
+\`\`\`bash
+# Read the current custom rendering resolution
+uloop set-game-view-size
+
+# Set a Full HD custom rendering resolution
+uloop set-game-view-size --width 1920 --height 1080
+\`\`\`
+
+## Notes
+
+- Width and height must be provided together when changing the resolution.
+- The tool uses Unity's public \`UnityEditor.PlayModeWindow\` API and does not require reflection.

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize.meta
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59405e403b6b43069f2860df8030e5a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeResponse.cs
@@ -1,0 +1,17 @@
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Carries the resolution before and after a Set Game View Size request.
+    /// </summary>
+    public sealed class SetGameViewSizeResponse : UnityCliLoopToolResponse
+    {
+        public uint PreviousWidth { get; set; }
+        public uint PreviousHeight { get; set; }
+        public uint CurrentWidth { get; set; }
+        public uint CurrentHeight { get; set; }
+        public bool Changed { get; set; }
+        public string Message { get; set; } = "";
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeResponse.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeResponse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f481475c0a0b43f5b9906a8eeb369e7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeSchema.cs
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeSchema.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Describes the optional resolution parameters accepted by the Set Game View Size tool.
+    /// </summary>
+    public sealed class SetGameViewSizeSchema : UnityCliLoopToolSchema
+    {
+        [Description("Target Game View rendering width in pixels. Provide with Height to change the resolution.")]
+        public int? Width { get; set; }
+
+        [Description("Target Game View rendering height in pixels. Provide with Width to change the resolution.")]
+        public int? Height { get; set; }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeSchema.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeSchema.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d1f930fb6ea4049a4a894f91d750246
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeTool.cs
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeTool.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using io.github.hatayama.UnityCliLoop.ToolContracts;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Sets or reports the Unity Game View custom rendering resolution.
+    /// </summary>
+    [UnityCliLoopTool]
+    public sealed class SetGameViewSizeTool : UnityCliLoopTool<SetGameViewSizeSchema, SetGameViewSizeResponse>
+    {
+        public override string ToolName => "set-game-view-size";
+
+        protected override Task<SetGameViewSizeResponse> ExecuteAsync(
+            SetGameViewSizeSchema parameters,
+            CancellationToken ct)
+        {
+            SetGameViewSizeUseCase useCase = new();
+            return useCase.ExecuteAsync(parameters, ct);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeTool.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcf7213d197f44fdafa54e15f239719e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeUseCase.cs
@@ -1,0 +1,102 @@
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Applies and reports the Unity Game View custom rendering resolution.
+    /// </summary>
+    public sealed class SetGameViewSizeUseCase
+    {
+        private const string RenderingResolutionBaseName = "uloop";
+
+        /// <summary>
+        /// Reads the current resolution and optionally applies a paired width and height.
+        /// </summary>
+        public Task<SetGameViewSizeResponse> ExecuteAsync(
+            SetGameViewSizeSchema parameters,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            (uint previousWidth, uint previousHeight) = GetRenderingResolution();
+            bool hasWidth = parameters.Width.HasValue;
+            bool hasHeight = parameters.Height.HasValue;
+            if (hasWidth != hasHeight)
+            {
+                return Task.FromResult(CreateResponse(
+                    false,
+                    "Width and Height must be provided together.",
+                    previousWidth,
+                    previousHeight,
+                    previousWidth,
+                    previousHeight));
+            }
+
+            if (!hasWidth)
+            {
+                return Task.FromResult(CreateResponse(
+                    true,
+                    $"Current Game View rendering resolution is {previousWidth}x{previousHeight}.",
+                    previousWidth,
+                    previousHeight,
+                    previousWidth,
+                    previousHeight));
+            }
+
+            if (parameters.Width.Value <= 0 || parameters.Height.Value <= 0)
+            {
+                return Task.FromResult(CreateResponse(
+                    false,
+                    "Width and Height must be positive integers.",
+                    previousWidth,
+                    previousHeight,
+                    previousWidth,
+                    previousHeight));
+            }
+
+            PlayModeWindow.SetCustomRenderingResolution(
+                (uint)parameters.Width.Value,
+                (uint)parameters.Height.Value,
+                RenderingResolutionBaseName);
+
+            (uint currentWidth, uint currentHeight) = GetRenderingResolution();
+            return Task.FromResult(CreateResponse(
+                true,
+                $"Game View rendering resolution changed from {previousWidth}x{previousHeight} to {currentWidth}x{currentHeight}.",
+                previousWidth,
+                previousHeight,
+                currentWidth,
+                currentHeight));
+        }
+
+        private static (uint Width, uint Height) GetRenderingResolution()
+        {
+            uint width;
+            uint height;
+            PlayModeWindow.GetRenderingResolution(out width, out height);
+            return (width, height);
+        }
+
+        private static SetGameViewSizeResponse CreateResponse(
+            bool success,
+            string message,
+            uint previousWidth,
+            uint previousHeight,
+            uint currentWidth,
+            uint currentHeight)
+        {
+            return new SetGameViewSizeResponse
+            {
+                Success = success,
+                Message = message,
+                PreviousWidth = previousWidth,
+                PreviousHeight = previousHeight,
+                CurrentWidth = currentWidth,
+                CurrentHeight = currentHeight,
+                Changed = previousWidth != currentWidth || previousHeight != currentHeight
+            };
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeUseCase.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/SetGameViewSizeUseCase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eaf2f40386264131ae6a038f4da34aad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/Skill.meta
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/Skill.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5615f1d8a87645ecbe269d6428fc6744
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/Skill/SKILL.md
@@ -10,38 +10,38 @@ Set or inspect the Unity Game View custom rendering resolution.
 
 ## Usage
 
-\`\`\`bash
+```bash
 uloop set-game-view-size [--width <width> --height <height>]
-\`\`\`
+```
 
 ## Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| \`--width\` | integer | unset | Target Game View rendering width in pixels. Provide with \`--height\` to change the resolution. |
-| \`--height\` | integer | unset | Target Game View rendering height in pixels. Provide with \`--width\` to change the resolution. |
+| `--width` | integer | unset | Target Game View rendering width in pixels. Provide with `--height` to change the resolution. |
+| `--height` | integer | unset | Target Game View rendering height in pixels. Provide with `--width` to change the resolution. |
 
 ## Output
 
 Returns JSON containing:
 
-- \`Success\`: Whether the request completed.
-- \`PreviousWidth\` / \`PreviousHeight\`: Resolution before the request.
-- \`CurrentWidth\` / \`CurrentHeight\`: Resolution after the request.
-- \`Changed\`: Whether the resolution changed.
-- \`Message\`: Human-readable status.
+- `Success`: Whether the request completed.
+- `PreviousWidth` / `PreviousHeight`: Resolution before the request.
+- `CurrentWidth` / `CurrentHeight`: Resolution after the request.
+- `Changed`: Whether the resolution changed.
+- `Message`: Human-readable status.
 
 ## Examples
 
-\`\`\`bash
+```bash
 # Read the current custom rendering resolution
 uloop set-game-view-size
 
 # Set a Full HD custom rendering resolution
 uloop set-game-view-size --width 1920 --height 1080
-\`\`\`
+```
 
 ## Notes
 
 - Width and height must be provided together when changing the resolution.
-- The tool uses Unity's public \`UnityEditor.PlayModeWindow\` API and does not require reflection.
+- The tool uses Unity's public `UnityEditor.PlayModeWindow` API and does not require reflection.

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/Skill/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: uloop-set-game-view-size
+toolName: set-game-view-size
+description: "Set or inspect the Unity Game View custom rendering resolution."
+---
+
+# uloop set-game-view-size
+
+Set or inspect the Unity Game View custom rendering resolution.
+
+## Usage
+
+\`\`\`bash
+uloop set-game-view-size [--width <width> --height <height>]
+\`\`\`
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| \`--width\` | integer | unset | Target Game View rendering width in pixels. Provide with \`--height\` to change the resolution. |
+| \`--height\` | integer | unset | Target Game View rendering height in pixels. Provide with \`--width\` to change the resolution. |
+
+## Output
+
+Returns JSON containing:
+
+- \`Success\`: Whether the request completed.
+- \`PreviousWidth\` / \`PreviousHeight\`: Resolution before the request.
+- \`CurrentWidth\` / \`CurrentHeight\`: Resolution after the request.
+- \`Changed\`: Whether the resolution changed.
+- \`Message\`: Human-readable status.
+
+## Examples
+
+\`\`\`bash
+# Read the current custom rendering resolution
+uloop set-game-view-size
+
+# Set a Full HD custom rendering resolution
+uloop set-game-view-size --width 1920 --height 1080
+\`\`\`
+
+## Notes
+
+- Width and height must be provided together when changing the resolution.
+- The tool uses Unity's public \`UnityEditor.PlayModeWindow\` API and does not require reflection.

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/Skill/SKILL.md.meta
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/Skill/SKILL.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a72c1303fd8b4665a260bd45df3b67bc
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/UnityCLILoop.FirstPartyTools.SetGameViewSize.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/UnityCLILoop.FirstPartyTools.SetGameViewSize.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "UnityCLILoop.FirstPartyTools.SetGameViewSize.Editor",
+    "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
+    "references": [
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/src/Editor/FirstPartyTools/SetGameViewSize/UnityCLILoop.FirstPartyTools.SetGameViewSize.Editor.asmdef.meta
+++ b/Packages/src/Editor/FirstPartyTools/SetGameViewSize/UnityCLILoop.FirstPartyTools.SetGameViewSize.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 11dcde5fce434d9ebb7704b1f3b39bba
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/common/tools/default-tools.json
+++ b/cli/common/tools/default-tools.json
@@ -724,6 +724,23 @@
           }
         }
       }
+    },
+    {
+      "name": "set-game-view-size",
+      "description": "Set or inspect the Unity Game View custom rendering resolution.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "Width": {
+            "type": "integer",
+            "description": "Target Game View rendering width in pixels. Provide with Height to change the resolution."
+          },
+          "Height": {
+            "type": "integer",
+            "description": "Target Game View rendering height in pixels. Provide with Width to change the resolution."
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add the first-party `set-game-view-size` tool using the public `UnityEditor.PlayModeWindow` API
- support reading the current resolution or setting a paired width and height
- include previous/current dimensions and `Changed` in every response
- add the embedded CLI catalog entry and generate the Claude/Agents skill copies through the normal installer

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` -> `Success=true`, `ErrorCount=0`, `WarningCount=0`
- live CLI read returned `Success=true` for the current resolution
- live CLI changed `1280x720` to `1920x1080`, returning `Success=true` and `Changed=true` with matching previous/current values
- `DefaultToolsCatalogDriftTests` -> 1 passed, 0 failed, 0 skipped
- `go test ./tools` from `cli/common` -> pass
- `jq empty cli/common/tools/default-tools.json` -> pass
- no protocol version changes


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

