### PR TITLE
fix: suppress expected launch-time worker errors

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExternalCompilerPathResolverTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExternalCompilerPathResolverTests.cs
@@ -293,6 +293,70 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             }
         }
 
+        /// <summary>
+        /// Verifies a lifecycle transition during worker startup silently falls back to one-shot Roslyn.
+        /// </summary>
+        [Test]
+        public async Task CompileAsync_WhenWorkerLifecycleClosesDuringStartup_ShouldFallbackWithoutErrorLogs()
+        {
+            ExternalCompilerPaths externalCompilerPaths = ExternalCompilerPathResolver.Resolve();
+            Assert.That(externalCompilerPaths, Is.Not.Null, "Unity external compiler layout should be available.");
+
+            string sourcePath = Path.Combine(_tempDirectoryPath, "LifecycleFallbackSmoke.cs");
+            string dllPath = Path.Combine(_tempDirectoryPath, "LifecycleFallbackSmoke.dll");
+            File.WriteAllText(
+                sourcePath,
+                "public static class LifecycleFallbackSmoke { public static int Execute() { return 11; } }");
+            List<string> references = new DynamicReferenceSetBuilderService().BuildReferenceSet(
+                new List<string>(),
+                null,
+                externalCompilerPaths);
+            int buildCount = 0;
+            bool buildStarted = false;
+            bool buildFinished = false;
+
+            DynamicCompilationHealthMonitor.ResetForTests();
+            SharedRoslynCompilerWorkerHost.ShutdownForTests();
+            LogAssert.NoUnexpectedReceived();
+
+            Func<ExternalCompilerPaths, string, string, string, CompilerMessage[]> previousWorkerCompiler =
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(
+                    (ExternalCompilerPaths paths, string workerSourcePath, string workerAssemblyPath, string workerCompileResponseFilePath) =>
+                    {
+                        SharedRoslynCompilerWorkerHost.ShutdownForTests();
+                        return Array.Empty<CompilerMessage>();
+                    });
+
+            try
+            {
+                using CancellationTokenSource compileCancellationTokenSource = new CancellationTokenSource();
+                compileCancellationTokenSource.CancelAfter(FallbackCompileTimeoutMilliseconds);
+                DynamicCompilationBackendResult result = await RoslynCompilerBackend.CompileAsync(
+                    sourcePath,
+                    dllPath,
+                    references,
+                    externalCompilerPaths,
+                    new RoslynCompilerOptions(Array.Empty<string>(), false),
+                    compileCancellationTokenSource.Token,
+                    () => buildStarted = true,
+                    () => buildFinished = true,
+                    () => buildCount++);
+
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result.BackendKind, Is.EqualTo(DynamicCompilationBackendKind.OneShotRoslyn));
+                Assert.That(File.Exists(dllPath), Is.True);
+                Assert.That(buildCount, Is.EqualTo(1));
+                Assert.That(buildStarted, Is.True);
+                Assert.That(buildFinished, Is.True);
+                LogAssert.NoUnexpectedReceived();
+            }
+            finally
+            {
+                SharedRoslynCompilerWorkerHost.SwapWorkerAssemblyCompilerForTests(previousWorkerCompiler);
+                SharedRoslynCompilerWorkerHost.ShutdownForTests();
+            }
+        }
+
         [Test]
         public void ReportInfrastructureFallback_WhenCompilerPathLayoutIsKnown_ShouldIncludeLayoutKind()
         {

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UnityEngine.TestTools;
 using UnityEditor.Compilation;
 
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
@@ -17,6 +18,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
     [TestFixture]
     public class SharedRoslynCompilerWorkerHostTests
     {
+        /// <summary>
+        /// Verifies lifecycle closure is returned as a non-error compile outcome.
+        /// </summary>
+        [Test]
+        public void SharedWorkerCompileOutcome_WhenLifecycleCloses_ShouldCarryFailureReasonWithoutErrorLog()
+        {
+            DynamicCompilationHealthMonitor.ResetForTests();
+            LogAssert.NoUnexpectedReceived();
+
+            SharedWorkerCompileOutcome outcome = SharedWorkerCompileOutcome.Failed(
+                SharedWorkerFailureReasons.LifecycleClosed,
+                new { reason = "lifecycle_generation_advanced" });
+
+            Assert.That(outcome.Succeeded, Is.False);
+            Assert.That(outcome.FailureReason, Is.EqualTo(SharedWorkerFailureReasons.LifecycleClosed));
+            Assert.That(outcome.IsLifecycleClosed, Is.True);
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        /// <summary>
+        /// Verifies non-lifecycle worker failures retain their failure reason for error reporting.
+        /// </summary>
+        [Test]
+        public void SharedWorkerCompileOutcome_WhenWorkerStartFails_ShouldCarryFailureReason()
+        {
+            SharedWorkerCompileOutcome outcome = SharedWorkerCompileOutcome.Failed(
+                "worker_start_failed",
+                new { reason = "process_start_failed" });
+
+            Assert.That(outcome.Succeeded, Is.False);
+            Assert.That(outcome.FailureReason, Is.EqualTo("worker_start_failed"));
+        }
+
         [Test]
         public void ConfigureWorkerDotnetRuntimeEnvironment_WhenCalled_ShouldDisableMultilevelLookup()
         {

--- a/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/SharedRoslynCompilerWorkerHostTests.cs
@@ -22,11 +22,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         /// Verifies lifecycle closure is returned as a non-error compile outcome.
         /// </summary>
         [Test]
-        public void SharedWorkerCompileOutcome_WhenLifecycleCloses_ShouldCarryFailureReasonWithoutErrorLog()
+        public void SharedWorkerCompileOutcome_WhenLifecycleCloses_ShouldCarryLifecycleClosedReason()
         {
-            DynamicCompilationHealthMonitor.ResetForTests();
-            LogAssert.NoUnexpectedReceived();
-
             SharedWorkerCompileOutcome outcome = SharedWorkerCompileOutcome.Failed(
                 SharedWorkerFailureReasons.LifecycleClosed,
                 new { reason = "lifecycle_generation_advanced" });
@@ -34,7 +31,6 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             Assert.That(outcome.Succeeded, Is.False);
             Assert.That(outcome.FailureReason, Is.EqualTo(SharedWorkerFailureReasons.LifecycleClosed));
             Assert.That(outcome.IsLifecycleClosed, Is.True);
-            LogAssert.NoUnexpectedReceived();
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
@@ -66,7 +66,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static void ReportSharedWorkerLifecycleClosed(object context = null)
         {
             LogInfoOnce(
-                $"shared_worker_lifecycle_closed::{SharedWorkerFailureReasons.LifecycleClosed}",
+                SharedWorkerFailureReasons.LifecycleClosed,
                 "dynamic_code_shared_worker_lifecycle_closed",
                 "execute-dynamic-code shared Roslyn worker closed during an expected Unity lifecycle transition",
                 context ?? new { reason = SharedWorkerFailureReasons.LifecycleClosed });

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/Compilation/DynamicCompilationHealthMonitor.cs
@@ -63,6 +63,15 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 "Investigate worker startup, request handling, and Unity-version-specific runtime assumptions.");
         }
 
+        public static void ReportSharedWorkerLifecycleClosed(object context = null)
+        {
+            LogInfoOnce(
+                $"shared_worker_lifecycle_closed::{SharedWorkerFailureReasons.LifecycleClosed}",
+                "dynamic_code_shared_worker_lifecycle_closed",
+                "execute-dynamic-code shared Roslyn worker closed during an expected Unity lifecycle transition",
+                context ?? new { reason = SharedWorkerFailureReasons.LifecycleClosed });
+        }
+
         public static void ReportOneShotCompilerStartFailure(object context)
         {
             LogErrorOnce(
@@ -99,6 +108,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 humanNote: humanNote,
                 aiTodo: aiTodo);
             Debug.LogError(FormatConsoleErrorMessage(operation, message, context));
+        }
+
+        private static void LogInfoOnce(
+            string issueKey,
+            string operation,
+            string message,
+            object context)
+        {
+            string effectiveIssueKey = CreateEffectiveIssueKey(issueKey);
+
+            lock (ReportedIssueLock)
+            {
+                if (!ReportedIssues.Add(effectiveIssueKey))
+                {
+                    return;
+                }
+            }
+
+            VibeLogger.LogInfo(operation, message, context);
         }
 
         private static string CreateEffectiveIssueKey(string issueKey)

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/RoslynCompilerBackend.cs
@@ -71,29 +71,33 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     defineSymbols,
                     allowUnsafeCode);
 
-                CompilerMessage[] workerMessages = await SharedRoslynCompilerWorkerHost.TryCompileAsync(
+                SharedWorkerCompileOutcome workerOutcome = await SharedRoslynCompilerWorkerHost.TryCompileAsync(
                     workerRequestFilePath,
                     externalCompilerPaths,
                     ct,
                     markBuildStarted,
                     markBuildFinished,
                     incrementBuildCount).ConfigureAwait(false);
-                if (workerMessages != null)
+                UnityEngine.Debug.Assert(workerOutcome != null, "Shared worker compile outcome must not be null");
+                if (workerOutcome.Succeeded)
                 {
                     return new DynamicCompilationBackendResult(
-                        workerMessages,
+                        workerOutcome.Messages,
                         DynamicCompilationBackendKind.SharedRoslynWorker);
                 }
 
-                DynamicCompilationHealthMonitor.ReportSharedWorkerFallback(
-                    "worker_unavailable",
-                    new
-                    {
-                        platform = UnityEngine.Application.platform.ToString(),
-                        dotnet_host_path = externalCompilerPaths.DotnetHostPath,
-                        compiler_dll_path = externalCompilerPaths.CompilerDllPath,
-                        layout_kind = externalCompilerPaths.LayoutKind.ToString()
-                    });
+                if (!workerOutcome.IsLifecycleClosed)
+                {
+                    DynamicCompilationHealthMonitor.ReportSharedWorkerFallback(
+                        "worker_unavailable",
+                        new
+                        {
+                            platform = UnityEngine.Application.platform.ToString(),
+                            dotnet_host_path = externalCompilerPaths.DotnetHostPath,
+                            compiler_dll_path = externalCompilerPaths.CompilerDllPath,
+                            layout_kind = externalCompilerPaths.LayoutKind.ToString()
+                        });
+                }
 
                 ct.ThrowIfCancellationRequested();
                 OneShotCompileResult oneShotResult = await CompileWithOneShotAsync(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHost.cs
@@ -28,7 +28,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             EditorApplication.quitting += ShutdownForQuit;
         }
 
-        public static Task<CompilerMessage[]> TryCompileAsync(
+        public static Task<SharedWorkerCompileOutcome> TryCompileAsync(
             string requestFilePath,
             ExternalCompilerPaths externalCompilerPaths,
             CancellationToken ct,
@@ -47,7 +47,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ct);
         }
 
-        private static async Task<CompilerMessage[]> TryCompileWithRetriesAsync(
+        private static async Task<SharedWorkerCompileOutcome> TryCompileWithRetriesAsync(
             string requestFilePath,
             ExternalCompilerPaths externalCompilerPaths,
             CancellationToken ct,
@@ -71,7 +71,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
                 if (attemptResult.Succeeded)
                 {
-                    return attemptResult.Messages;
+                    return SharedWorkerCompileOutcome.SucceededWith(attemptResult.Messages);
                 }
 
                 ServiceValue.ExecuteWithStateLock(ServiceValue.ShutdownProcessLocked);
@@ -81,13 +81,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     continue;
                 }
 
-                DynamicCompilationHealthMonitor.ReportSharedWorkerFailure(
-                    attemptResult.FailureReason,
-                    AppendAttempt(attemptResult.FailureContext, attempt));
-                return null;
+                object failureContext = AppendAttempt(attemptResult.FailureContext, attempt);
+                if (attemptResult.FailureReason == SharedWorkerFailureReasons.LifecycleClosed)
+                {
+                    DynamicCompilationHealthMonitor.ReportSharedWorkerLifecycleClosed(failureContext);
+                }
+                else
+                {
+                    DynamicCompilationHealthMonitor.ReportSharedWorkerFailure(
+                        attemptResult.FailureReason,
+                        failureContext);
+                }
+
+                return SharedWorkerCompileOutcome.Failed(attemptResult.FailureReason, failureContext);
             }
 
-            return null;
+            return SharedWorkerCompileOutcome.Failed(
+                "worker_unknown_failure",
+                new { reason = "retry_loop_exhausted" });
         }
 
         private static async Task<WorkerAttemptResult> TryCompileOnceAsync(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHostResults.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/SharedRoslynCompilerWorkerHostResults.cs
@@ -2,6 +2,47 @@ using UnityEditor.Compilation;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
+    internal static class SharedWorkerFailureReasons
+    {
+        internal const string LifecycleClosed = "shared_worker_lifecycle_closed";
+    }
+
+    /// <summary>
+    /// Carries shared worker compilation messages and the reason for a failed compilation.
+    /// </summary>
+    internal sealed class SharedWorkerCompileOutcome
+    {
+        public CompilerMessage[] Messages { get; }
+
+        public string FailureReason { get; }
+
+        public object FailureContext { get; }
+
+        private SharedWorkerCompileOutcome(
+            CompilerMessage[] messages,
+            string failureReason,
+            object failureContext)
+        {
+            Messages = messages;
+            FailureReason = failureReason;
+            FailureContext = failureContext;
+        }
+
+        public bool Succeeded => Messages != null;
+
+        public bool IsLifecycleClosed => FailureReason == SharedWorkerFailureReasons.LifecycleClosed;
+
+        public static SharedWorkerCompileOutcome SucceededWith(CompilerMessage[] messages)
+        {
+            return new SharedWorkerCompileOutcome(messages, null, null);
+        }
+
+        public static SharedWorkerCompileOutcome Failed(string failureReason, object failureContext)
+        {
+            return new SharedWorkerCompileOutcome(null, failureReason, failureContext);
+        }
+    }
+
     /// <summary>
     /// Carries the result data produced by Worker Attempt behavior.
     /// </summary>
@@ -85,7 +126,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             return new WorkerStartupResult(
                 false,
                 false,
-                "shared_worker_lifecycle_closed",
+                SharedWorkerFailureReasons.LifecycleClosed,
                 new { reason = "lifecycle_generation_advanced" });
         }
     }


### PR DESCRIPTION
## Summary
- Launch readiness no longer reports expected shared Roslyn worker lifecycle races as Unity Console errors.
- Genuine shared worker failures retain their existing error severity.

## User Impact
- The readiness probe can race with Unity startup domain reload without producing misleading red Console entries.
- One-shot compilation fallback remains available when the shared worker closes during the lifecycle transition.

## Changes
- Carry shared worker failure reasons through a dedicated compile outcome.
- Suppress only lifecycle-closed failure and fallback diagnostics, with deduplicated informational telemetry.
- Add regression coverage for lifecycle closure while preserving coverage for real worker failures.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <PROJECT_ROOT>`: ErrorCount 0, WarningCount 0.
- Targeted EditMode tests: 45 passed, 0 failed.
- DynamicCodeToolTests: 226 passed, 1 unrelated pre-existing failure in FirstPartySchemaMetadataTests.
- Three `launch -r` E2E runs: readiness succeeded each time, and `get-logs --log-type Error` returned TotalCount 0.