### PR TITLE
fix: automatically recover Unity servers after stale-port conflicts

### DIFF
--- a/Packages/src/Editor/Config/McpEditorSettings.cs
+++ b/Packages/src/Editor/Config/McpEditorSettings.cs
@@ -44,7 +44,8 @@ namespace io.github.hatayama.uLoopMCP
         public bool installSkillsFlat = true;
         
         // Session State Settings (moved from McpSessionManager)
-        // Default to true so the server starts automatically on fresh install
+        // This is the desired server state: automatic recovery failures preserve true,
+        // while an intentional stop changes it to false.
         public bool isServerRunning = true;
         public bool isAfterCompile = false;
         public bool isDomainReloadInProgress = false;
@@ -565,6 +566,18 @@ namespace io.github.hatayama.uLoopMCP
             UpdateSettings(settings => settings with
             {
                 isServerRunning = false,
+                serverSessionId = string.Empty
+            });
+        }
+
+        /// <summary>
+        /// Preserves the user's request for an active server after an automatic recovery failure.
+        /// </summary>
+        public static void MarkServerRecoveryPending()
+        {
+            UpdateSettings(settings => settings with
+            {
+                isServerRunning = true,
                 serverSessionId = string.Empty
             });
         }

--- a/Packages/src/Editor/Core/ApplicationServices/ServerStateWatchdog.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/ServerStateWatchdog.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Periodically reconciles persisted server intent with the server owned by this Unity editor.
+    /// </summary>
+    [InitializeOnLoad]
+    public static class ServerStateWatchdog
+    {
+        private static DateTime? lastCheckUtc;
+        private static DateTime? lastRecoveryAttemptUtc;
+
+        static ServerStateWatchdog()
+        {
+            if (AssetDatabase.IsAssetImportWorkerProcess())
+            {
+                return;
+            }
+
+            EditorApplication.update += OnEditorUpdate;
+        }
+
+        private static void OnEditorUpdate()
+        {
+            DateTime nowUtc = DateTime.UtcNow;
+            if (lastCheckUtc.HasValue &&
+                nowUtc - lastCheckUtc.Value < TimeSpan.FromSeconds(McpConstants.SERVER_STATE_WATCHDOG_INTERVAL_SECONDS))
+            {
+                return;
+            }
+
+            lastCheckUtc = nowUtc;
+            if (McpServerController.RecoveryTask != null && !McpServerController.RecoveryTask.IsCompleted)
+            {
+                return;
+            }
+
+            bool serverIsRunning = McpServerController.IsServerRunning;
+            WatchdogObservation observation = new(
+                McpEditorSettings.GetIsServerRunning(),
+                serverIsRunning,
+                McpEditorSettings.GetCustomPort(),
+                serverIsRunning ? McpServerController.ServerPort : null,
+                nowUtc,
+                lastRecoveryAttemptUtc,
+                McpServerController.IsStartupProtectionActive());
+            WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
+
+            if (action == WatchdogAction.RecoverServer)
+            {
+                lastRecoveryAttemptUtc = nowUtc;
+                Task recoveryTask = McpServerController.StartRecoveryIfNeededAsync(
+                    observation.settingsPort,
+                    false,
+                    CancellationToken.None);
+                _ = recoveryTask.ContinueWith(
+                    task => LogRecoveryFailure(task),
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted,
+                    TaskScheduler.FromCurrentSynchronizationContext());
+                return;
+            }
+
+            if (action == WatchdogAction.RewriteSettings)
+            {
+                McpServerController.SynchronizeRunningServerSettings();
+            }
+        }
+
+        private static void LogRecoveryFailure(Task recoveryTask)
+        {
+            VibeLogger.LogError(
+                "server_watchdog_recovery_failed",
+                recoveryTask.Exception?.GetBaseException().Message);
+        }
+    }
+}

--- a/Packages/src/Editor/Core/ApplicationServices/ServerStateWatchdog.cs.meta
+++ b/Packages/src/Editor/Core/ApplicationServices/ServerStateWatchdog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd1611761fe1c4d968cbc991b3c06e42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Core/ApplicationServices/ServerStateWatchdogService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/ServerStateWatchdogService.cs
@@ -1,0 +1,88 @@
+using System;
+
+namespace io.github.hatayama.uLoopMCP
+{
+    /// <summary>
+    /// Decides whether the persisted server state needs recovery or synchronization.
+    /// </summary>
+    public static class ServerStateWatchdogService
+    {
+        public const int RECOVERY_RETRY_INTERVAL_SECONDS = 30;
+
+        /// <summary>
+        /// Determines the action required to reconcile persisted and observed server state.
+        /// </summary>
+        public static WatchdogAction DecideAction(WatchdogObservation observation)
+        {
+            if (!observation.settingsClaimServerRunning)
+            {
+                return WatchdogAction.None;
+            }
+
+            if (observation.isStartupProtectionActive || observation.isBackgroundProcess)
+            {
+                return WatchdogAction.None;
+            }
+
+            if (observation.serverIsRunning)
+            {
+                bool hasPortMismatch = observation.serverPort.HasValue &&
+                    observation.serverPort.Value != observation.settingsPort;
+                return hasPortMismatch ? WatchdogAction.RewriteSettings : WatchdogAction.None;
+            }
+
+            if (observation.lastRecoveryAttemptUtc.HasValue &&
+                observation.currentUtc - observation.lastRecoveryAttemptUtc.Value < TimeSpan.FromSeconds(RECOVERY_RETRY_INTERVAL_SECONDS))
+            {
+                return WatchdogAction.None;
+            }
+
+            return WatchdogAction.RecoverServer;
+        }
+    }
+
+    /// <summary>
+    /// Describes the reconciliation action selected by the watchdog.
+    /// </summary>
+    public enum WatchdogAction
+    {
+        None,
+        RecoverServer,
+        RewriteSettings
+    }
+
+    /// <summary>
+    /// Immutable snapshot used to make watchdog decisions without side effects.
+    /// </summary>
+    public sealed class WatchdogObservation
+    {
+        public readonly bool settingsClaimServerRunning;
+        public readonly bool serverIsRunning;
+        public readonly int settingsPort;
+        public readonly int? serverPort;
+        public readonly DateTime currentUtc;
+        public readonly DateTime? lastRecoveryAttemptUtc;
+        public readonly bool isStartupProtectionActive;
+        public readonly bool isBackgroundProcess;
+
+        public WatchdogObservation(
+            bool settingsClaimServerRunning,
+            bool serverIsRunning,
+            int settingsPort,
+            int? serverPort,
+            DateTime currentUtc,
+            DateTime? lastRecoveryAttemptUtc,
+            bool isStartupProtectionActive = false,
+            bool isBackgroundProcess = false)
+        {
+            this.settingsClaimServerRunning = settingsClaimServerRunning;
+            this.serverIsRunning = serverIsRunning;
+            this.settingsPort = settingsPort;
+            this.serverPort = serverPort;
+            this.currentUtc = currentUtc;
+            this.lastRecoveryAttemptUtc = lastRecoveryAttemptUtc;
+            this.isStartupProtectionActive = isStartupProtectionActive;
+            this.isBackgroundProcess = isBackgroundProcess;
+        }
+    }
+}

--- a/Packages/src/Editor/Core/ApplicationServices/ServerStateWatchdogService.cs.meta
+++ b/Packages/src/Editor/Core/ApplicationServices/ServerStateWatchdogService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61eda7b8d5aba4e95a1c9c1ab465a1fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Core/ApplicationServices/SessionRecoveryService.cs
+++ b/Packages/src/Editor/Core/ApplicationServices/SessionRecoveryService.cs
@@ -114,8 +114,8 @@ namespace io.github.hatayama.uLoopMCP
                 }
                 else
                 {
-                    // Clear session when maximum retry count is reached
-                    McpEditorSettings.ClearServerSession();
+                    // Preserve the user's start intent so the watchdog can retry after the conflicting port is released.
+                    McpEditorSettings.MarkServerRecoveryPending();
                     return ValidationResult.Failure($"Failed to restore server after {MAX_RETRIES} retries: {ex.Message}");
                 }
             }

--- a/Packages/src/Editor/Server/McpServerController.cs
+++ b/Packages/src/Editor/Server/McpServerController.cs
@@ -45,6 +45,15 @@ namespace io.github.hatayama.uLoopMCP
         public static int ServerPort => mcpServer?.Port ?? McpEditorSettings.GetCustomPort();
 
         /// <summary>
+        /// Rewrites the persisted session to match the currently running server.
+        /// </summary>
+        internal static void SynchronizeRunningServerSettings()
+        {
+            Debug.Assert(mcpServer?.IsRunning == true, "A running server is required to synchronize settings.");
+            SaveRunningServerSession(mcpServer.Port);
+        }
+
+        /// <summary>
         /// Current recovery task. Can be awaited by other components to ensure recovery completes first.
         /// </summary>
         public static Task RecoveryTask => _currentRecoveryTask;
@@ -404,8 +413,8 @@ namespace io.github.hatayama.uLoopMCP
                 }
                 else
                 {
-                    // If it ultimately fails, clear the SessionState.
-                    McpEditorSettings.ClearServerSession();
+                    // Preserve the user's start intent so the watchdog can retry after the conflicting port is released.
+                    McpEditorSettings.MarkServerRecoveryPending();
                 }
             }
         }
@@ -482,7 +491,7 @@ namespace io.github.hatayama.uLoopMCP
                             "server_auto_recovery_failed",
                             $"Automatic recovery after unexpected exit failed: {task.Exception?.GetBaseException().Message}"
                         );
-                        McpEditorSettings.ClearServerSession();
+                        McpEditorSettings.MarkServerRecoveryPending();
                     }
                 }, TaskScheduler.FromCurrentSynchronizationContext());
             };
@@ -812,8 +821,8 @@ namespace io.github.hatayama.uLoopMCP
 
                 if (!started)
                 {
-                    // Ensure session reflects stopped state on failure
-                    McpEditorSettings.ClearServerSession();
+                    // Preserve the user's start intent so the watchdog can retry after the conflicting port is released.
+                    McpEditorSettings.MarkServerRecoveryPending();
                     McpEditorSettings.ClearReconnectingFlags();
                     Debug.LogError($"[{McpConstants.PROJECT_NAME}] Recovery failed: no available port to bind. SavedPort={savedPort}, LastAttemptPort={chosenPort}");
                     throw new InvalidOperationException($"Failed to bind any recovery port. SavedPort={savedPort}, LastAttemptPort={chosenPort}.");

--- a/Packages/src/Editor/Shared/Config/McpConstants.cs
+++ b/Packages/src/Editor/Shared/Config/McpConstants.cs
@@ -114,6 +114,7 @@ namespace io.github.hatayama.uLoopMCP
         
         // Reconnection settings
         public const int RECONNECTION_TIMEOUT_SECONDS = 10;
+        public const int SERVER_STATE_WATCHDOG_INTERVAL_SECONDS = 3;
         
         // TypeScript server related constants
         public const string TYPESCRIPT_SERVER_DIR = "TypeScriptServer~";

--- a/tests/ServerStateWatchdog.UnitTests/ServerStateWatchdog.UnitTests.csproj
+++ b/tests/ServerStateWatchdog.UnitTests/ServerStateWatchdog.UnitTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../Packages/src/Editor/Core/ApplicationServices/ServerStateWatchdogService.cs" Link="Production/ServerStateWatchdogService.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/ServerStateWatchdog.UnitTests/ServerStateWatchdogServiceTests.cs
+++ b/tests/ServerStateWatchdog.UnitTests/ServerStateWatchdogServiceTests.cs
@@ -1,0 +1,125 @@
+using System;
+using NUnit.Framework;
+
+namespace io.github.hatayama.uLoopMCP.UnitTests
+{
+    [TestFixture]
+    public sealed class ServerStateWatchdogServiceTests
+    {
+        /// <summary>
+        /// Verifies that a missing server is recovered when settings claim that it should run.
+        /// </summary>
+        [Test]
+        public void DecideAction_WhenSettingsClaimRunningButServerIsStopped_ShouldRecoverServer()
+        {
+            WatchdogObservation observation = new(
+                settingsClaimServerRunning: true,
+                serverIsRunning: false,
+                settingsPort: 6000,
+                serverPort: null,
+                currentUtc: DateTime.UtcNow,
+                lastRecoveryAttemptUtc: DateTime.UtcNow.AddSeconds(-31));
+
+            WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
+
+            Assert.That(action, Is.EqualTo(WatchdogAction.RecoverServer));
+        }
+
+        /// <summary>
+        /// Verifies that settings follow a running server after a port fallback.
+        /// </summary>
+        [Test]
+        public void DecideAction_WhenServerPortDiffersFromSettings_ShouldRewriteSettings()
+        {
+            WatchdogObservation observation = new(
+                settingsClaimServerRunning: true,
+                serverIsRunning: true,
+                settingsPort: 6000,
+                serverPort: 6001,
+                currentUtc: DateTime.UtcNow,
+                lastRecoveryAttemptUtc: null);
+
+            WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
+
+            Assert.That(action, Is.EqualTo(WatchdogAction.RewriteSettings));
+        }
+
+        /// <summary>
+        /// Verifies that an intentional stop is never undone by the watchdog.
+        /// </summary>
+        [Test]
+        public void DecideAction_WhenSettingsClaimStopped_ShouldDoNothing()
+        {
+            WatchdogObservation observation = new(
+                settingsClaimServerRunning: false,
+                serverIsRunning: false,
+                settingsPort: 6000,
+                serverPort: null,
+                currentUtc: DateTime.UtcNow,
+                lastRecoveryAttemptUtc: null);
+
+            WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
+
+            Assert.That(action, Is.EqualTo(WatchdogAction.None));
+        }
+
+        /// <summary>
+        /// Verifies that repeated recovery attempts are suppressed during the backoff window.
+        /// </summary>
+        [Test]
+        public void DecideAction_WhenRecoveryWasAttemptedRecently_ShouldDoNothing()
+        {
+            WatchdogObservation observation = new(
+                settingsClaimServerRunning: true,
+                serverIsRunning: false,
+                settingsPort: 6000,
+                serverPort: null,
+                currentUtc: DateTime.UtcNow,
+                lastRecoveryAttemptUtc: DateTime.UtcNow.AddSeconds(-29));
+
+            WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
+
+            Assert.That(action, Is.EqualTo(WatchdogAction.None));
+        }
+
+        /// <summary>
+        /// Verifies that startup protection temporarily suppresses recovery.
+        /// </summary>
+        [Test]
+        public void DecideAction_WhenStartupProtectionIsActive_ShouldDoNothing()
+        {
+            WatchdogObservation observation = new(
+                settingsClaimServerRunning: true,
+                serverIsRunning: false,
+                settingsPort: 6000,
+                serverPort: null,
+                currentUtc: DateTime.UtcNow,
+                lastRecoveryAttemptUtc: null,
+                isStartupProtectionActive: true);
+
+            WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
+
+            Assert.That(action, Is.EqualTo(WatchdogAction.None));
+        }
+
+        /// <summary>
+        /// Verifies that background Unity processes never start a server.
+        /// </summary>
+        [Test]
+        public void DecideAction_WhenRunningInBackgroundProcess_ShouldDoNothing()
+        {
+            WatchdogObservation observation = new(
+                settingsClaimServerRunning: true,
+                serverIsRunning: false,
+                settingsPort: 6000,
+                serverPort: null,
+                currentUtc: DateTime.UtcNow,
+                lastRecoveryAttemptUtc: null,
+                isBackgroundProcess: true);
+
+            WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
+
+            Assert.That(action, Is.EqualTo(WatchdogAction.None));
+        }
+    }
+}

--- a/tests/ServerStateWatchdog.UnitTests/ServerStateWatchdogServiceTests.cs
+++ b/tests/ServerStateWatchdog.UnitTests/ServerStateWatchdogServiceTests.cs
@@ -45,6 +45,25 @@ namespace io.github.hatayama.uLoopMCP.UnitTests
         }
 
         /// <summary>
+        /// Verifies that matching ports require no settings rewrite.
+        /// </summary>
+        [Test]
+        public void DecideAction_WhenServerPortMatchesSettings_ShouldDoNothing()
+        {
+            WatchdogObservation observation = new(
+                settingsClaimServerRunning: true,
+                serverIsRunning: true,
+                settingsPort: 6000,
+                serverPort: 6000,
+                currentUtc: DateTime.UtcNow,
+                lastRecoveryAttemptUtc: null);
+
+            WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
+
+            Assert.That(action, Is.EqualTo(WatchdogAction.None));
+        }
+
+        /// <summary>
         /// Verifies that an intentional stop is never undone by the watchdog.
         /// </summary>
         [Test]
@@ -80,6 +99,25 @@ namespace io.github.hatayama.uLoopMCP.UnitTests
             WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
 
             Assert.That(action, Is.EqualTo(WatchdogAction.None));
+        }
+
+        /// <summary>
+        /// Verifies that a stopped server is recovered on the first watchdog evaluation.
+        /// </summary>
+        [Test]
+        public void DecideAction_WhenNoRecoveryAttemptHasBeenRecorded_ShouldRecoverServer()
+        {
+            WatchdogObservation observation = new(
+                settingsClaimServerRunning: true,
+                serverIsRunning: false,
+                settingsPort: 6000,
+                serverPort: null,
+                currentUtc: DateTime.UtcNow,
+                lastRecoveryAttemptUtc: null);
+
+            WatchdogAction action = ServerStateWatchdogService.DecideAction(observation);
+
+            Assert.That(action, Is.EqualTo(WatchdogAction.RecoverServer));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- Unity automatically retries server recovery after a stale-port conflict while the editor remains open.
- A fallback port is written back to the project settings so the CLI can reconnect to the intended project.

## User Impact

- Automatic recovery failures no longer erase the user's intent to keep the server running.
- Intentional stops remain respected and are not undone by the watchdog.

## Changes

- Confirmed that background-process and startup-protection early returns, exhausted recovery retries, and unexpected-loop recovery faults previously had no later retry trigger.
- Preserved `isServerRunning=true` with an empty session ID for automatic recovery failures, while keeping `ClearServerSession()` for intentional stops.
- Added a throttled editor watchdog with pure decision logic for recovery, settings synchronization, intentional stop, startup protection, and background-process handling.

## Verification

- `dotnet test tests/ServerStateWatchdog.UnitTests/ServerStateWatchdog.UnitTests.csproj --no-restore` — 6 passed.
- `node dist/cli.bundle.cjs compile --project-path "$(git rev-parse --show-toplevel)"` — Success, 0 errors, 0 warnings.
- Known behavior: if every recovery bind attempt fails, the existing recovery path logs the failure and throws; the watchdog retries after its 30-second backoff.
