### PR TITLE
fix: Setup falls back to skill target selection when folders are missing

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -462,6 +462,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(installableTargets[1].DirName, Is.EqualTo(".codex"));
         }
 
+        [TestCase(true, 0, true)]
+        [TestCase(false, 0, true)]
+        [TestCase(false, 1, false)]
+        public void ResolveUseFirstInstallSkillsUi_ReturnsExpectedMode(
+            bool shouldUseFirstInstallSkillsUi,
+            int installableTargetCount,
+            bool expected)
+        {
+            // Verifies that empty installable target results fall back to the first-install skill UI.
+            bool actual = SetupWizardSkillsStepPresenter.ResolveUseFirstInstallSkillsUi(
+                shouldUseFirstInstallSkillsUi,
+                installableTargetCount);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
         [Test]
         public void ShouldUseFirstInstallSkillsUi_WhenVersionWasNeverSeen_ReturnsTrue()
         {

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs
@@ -65,13 +65,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool groupSkillsUnderUnityCliLoop,
             bool isInstallingSkills)
         {
+            List<SkillSetupTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
+            bool useFirstInstallSkillsUi = ResolveUseFirstInstallSkillsUi(
+                shouldUseFirstInstallSkillsUi,
+                installableTargets.Count);
             _skillsTargetList.Clear();
             ViewDataBinder.SetVisible(
                 _skillsTargetRow,
-                ShouldShowSkillsTargetRowForSetupWizard(shouldUseFirstInstallSkillsUi));
+                ShouldShowSkillsTargetRowForSetupWizard(useFirstInstallSkillsUi));
             ViewDataBinder.SetVisible(
                 _skillsTargetList,
-                ShouldShowSkillsTargetListForSetupWizard(canManageSkills, shouldUseFirstInstallSkillsUi));
+                ShouldShowSkillsTargetListForSetupWizard(canManageSkills, useFirstInstallSkillsUi));
 
             if (!canManageSkills)
             {
@@ -84,7 +88,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
-            if (shouldUseFirstInstallSkillsUi)
+            if (useFirstInstallSkillsUi)
             {
                 SkillSetupTargetInfo selectedTargetInfo = GetSelectedSkillTargetInfo(
                     targets,
@@ -101,8 +105,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                     selectedTargetInfo.InstallState));
                 return;
             }
-
-            List<SkillSetupTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
 
             foreach (SkillSetupTargetInfo target in installableTargets)
             {
@@ -124,15 +126,6 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 item.Add(statusLabel);
 
                 _skillsTargetList.Add(item);
-            }
-
-            if (installableTargets.Count == 0)
-            {
-                UpdateSkillsStatusLabel(
-                    "Create a tool folder to enable skill installation (.claude/, .agents/, etc.)");
-                _installSkillsButton.SetEnabled(false);
-                _installSkillsButton.text = "Install Skills";
-                return;
             }
 
             bool isCheckingSkills = installableTargets.Any(
@@ -173,6 +166,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             return targets
                 .Where(target => target.HasSkillsDirectory)
                 .ToList();
+        }
+
+        /// <summary>
+        /// Resolves whether the setup wizard should show the first-install skill UI.
+        /// </summary>
+        internal static bool ResolveUseFirstInstallSkillsUi(
+            bool shouldUseFirstInstallSkillsUi,
+            int installableTargetCount)
+        {
+            Debug.Assert(installableTargetCount >= 0, "installableTargetCount must not be negative");
+            return shouldUseFirstInstallSkillsUi || installableTargetCount == 0;
         }
 
         internal static bool ShouldShowSkillsTargetRowForSetupWizard(bool shouldUseFirstInstallSkillsUi)

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsWorkflowController.cs
@@ -225,12 +225,17 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             CancelSkillInstallStateRefresh();
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             List<SkillSetupTargetInfo> targets = DetectDisplayedSkillTargets(projectRoot);
-            List<SkillSetupTargetInfo> installableTargets = _shouldUseFirstInstallSkillsUi
+            List<SkillSetupTargetInfo> filteredTargets =
+                SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
+            bool useFirstInstallSkillsUi = SetupWizardSkillsStepPresenter.ResolveUseFirstInstallSkillsUi(
+                _shouldUseFirstInstallSkillsUi,
+                filteredTargets.Count);
+            List<SkillSetupTargetInfo> installableTargets = useFirstInstallSkillsUi
                 ? SetupWizardSkillsStepPresenter.GetFirstInstallableSkillTargets(
                     targets,
                     _skillsTarget,
                     !_installSkillsFlat)
-                : SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
+                : filteredTargets;
             if (installableTargets.Count == 0) return;
 
             bool shouldShowSkillsInstalledDialog =


### PR DESCRIPTION
## Summary
- Setup Wizard can install skills even when no existing skill folders are detected.
- Returning users see the target dropdown fallback instead of a disabled dead end.

## User Impact
- When `.claude/`, `.agents/`, or other skill folders are absent, Step 2 now keeps Install Skills available.
- Existing skill folders continue to use the multi-target status list.

## Changes
- Resolve the effective first-install UI mode from the detected installable target count.
- Reuse the same mode resolution for rendering and skill installation.
- Add coverage for first-install, empty-target fallback, and existing-target cases.

## Verification
- `dist/darwin-arm64/uloop compile --project-path "$(git rev-parse --show-toplevel)"` — passed with 0 errors and 0 warnings.
- `dist/darwin-arm64/uloop run-tests --project-path "$(git rev-parse --show-toplevel)" --filter-type exact --filter-value 'io.github.hatayama.UnityCliLoop.Tests.Editor.SetupWizardWindowTests.ResolveUseFirstInstallSkillsUi_ReturnsExpectedMode'` — 3/3 passed.
- Full EditMode suite completed with two pre-existing unrelated failures in schema metadata and mouse UI pointer resolution tests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

