### PR TITLE
chore: Add Unity 6000.5 package compile compatibility check

### DIFF
--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -25,11 +25,13 @@ jobs:
           - unity-version: 2022.3.62f1
             project-path: .
             library-path: Library
+            compile-mode: legacy-builder
             package-warning-scope: false
             run-unit-tests: true
           - unity-version: 6000.5.4f1
             project-path: ci/unity-projects/6000.5
             library-path: ci/unity-projects/6000.5/Library
+            compile-mode: direct-editor
             package-warning-scope: true
             run-unit-tests: false
     # Dependabot PRs cannot access repository secrets (UNITY_LICENSE etc.)
@@ -93,7 +95,7 @@ jobs:
             Library-${{ matrix.unity-version }}-
 
       - name: Purge cached script assemblies
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.package-warning-scope == true
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile-mode == 'direct-editor'
         run: rm -rf "${{ matrix.project-path }}/Library/ScriptAssemblies"
 
       - name: Prepare Unity log directory
@@ -101,7 +103,7 @@ jobs:
         run: mkdir -p artifacts
 
       - name: Compile Unity project (2022.3)
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.package-warning-scope == false
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile-mode == 'legacy-builder'
         id: compile
         uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2
         timeout-minutes: 30
@@ -118,7 +120,7 @@ jobs:
         continue-on-error: true
 
       - name: Compile Unity project (6000.5)
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.package-warning-scope == true
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile-mode == 'direct-editor'
         id: compile-6000-5
         timeout-minutes: 30
         env:

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -25,13 +25,11 @@ jobs:
           - unity-version: 2022.3.62f1
             project-path: .
             library-path: Library
-            compile_mode: legacy-builder
             package-warning-scope: false
             run-unit-tests: true
           - unity-version: 6000.5.4f1
             project-path: ci/unity-projects/6000.5
             library-path: ci/unity-projects/6000.5/Library
-            compile_mode: direct-editor
             package-warning-scope: true
             run-unit-tests: false
     # Dependabot PRs cannot access repository secrets (UNITY_LICENSE etc.)
@@ -95,7 +93,7 @@ jobs:
             Library-${{ matrix.unity-version }}-
 
       - name: Purge cached script assemblies
-        if: ${{ steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile_mode == 'direct-editor' }}
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.run-unit-tests == false
         run: rm -rf "${{ matrix.project-path }}/Library/ScriptAssemblies"
 
       - name: Prepare Unity log directory
@@ -103,7 +101,7 @@ jobs:
         run: mkdir -p artifacts
 
       - name: Compile Unity project (2022.3)
-        if: ${{ steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile_mode == 'legacy-builder' }}
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.run-unit-tests == true
         id: compile
         uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2
         timeout-minutes: 30
@@ -120,7 +118,7 @@ jobs:
         continue-on-error: true
 
       - name: Compile Unity project (6000.5)
-        if: ${{ steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile_mode == 'direct-editor' }}
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.run-unit-tests == false
         id: compile-6000-5
         timeout-minutes: 30
         env:

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -129,6 +129,15 @@ jobs:
           ERROR_COUNT=0
           WARNING_COUNT=0
 
+          if [ "${{ matrix.package-warning-scope }}" == "true" ]; then
+            PACKAGE_ASSEMBLY_COUNT=$(find "${{ matrix.project-path }}/Library/ScriptAssemblies" -maxdepth 1 -type f -name 'UnityCLILoop*.dll' 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$PACKAGE_ASSEMBLY_COUNT" -eq 0 ]; then
+              echo "::error::Unity did not resolve or compile the io.github.hatayama.uloopmcp package"
+              exit 1
+            fi
+            echo "Package assembly evidence found: $PACKAGE_ASSEMBLY_COUNT assembly(s)."
+          fi
+
           if [ -f "$LOG_FILE" ]; then
             echo "Analyzing log file: $LOG_FILE"
 
@@ -179,8 +188,8 @@ jobs:
             echo "✅ No compile errors or warnings found!"
           else
             echo "::warning::Could not find Unity log file for analysis"
-            # Fall back to checking if build step failed
-            if [ "${{ steps.compile.outcome }}" == "failure" ]; then
+            # Unity 6000.5's builder reports an untitled-scene build failure after successful script compilation.
+            if [ "${{ matrix.package-warning-scope }}" != "true" ] && [ "${{ steps.compile.outcome }}" == "failure" ]; then
               echo "::error::Unity compilation failed"
               exit 1
             fi

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -137,7 +137,7 @@ jobs:
               set -eu
               trap '\''unity-editor -batchmode -nographics -quit -returnlicense \
                 -username "$UNITY_EMAIL" -password "$UNITY_PASSWORD" \
-                -projectPath /BlankProject >/dev/null 2>&1 || true'\'' EXIT
+                -projectPath /workspace/ci/unity-projects/6000.5 >/dev/null 2>&1 || true'\'' EXIT
 
               LICENSE_VALUE=$(printf "%s" "$UNITY_LICENSE" | tr "\\n" " " | sed -n '\''s/.*<DeveloperData Value="\([^"]*\)"\/>.*/\1/p'\'')
               test -n "$LICENSE_VALUE"
@@ -156,7 +156,7 @@ jobs:
                   -serial "$SERIAL" \
                   -username "$UNITY_EMAIL" \
                   -password "$UNITY_PASSWORD" \
-                  -projectPath /BlankProject; then
+                  -projectPath /workspace/ci/unity-projects/6000.5; then
                   ACTIVATED=true
                   break
                 fi

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -92,12 +92,16 @@ jobs:
           restore-keys: |
             Library-${{ matrix.unity-version }}-
 
+      - name: Purge cached script assemblies
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.package-warning-scope == true
+        run: rm -rf "${{ matrix.project-path }}/Library/ScriptAssemblies"
+
       - name: Prepare Unity log directory
         if: env.HAS_UNITY_LICENSE == 'true'
         run: mkdir -p artifacts
 
-      - name: Compile Unity project
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'
+      - name: Compile Unity project (2022.3)
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.package-warning-scope == false
         id: compile
         uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2
         timeout-minutes: 30
@@ -110,38 +114,29 @@ jobs:
           unityVersion: ${{ matrix.unity-version }}
           targetPlatform: StandaloneLinux64
           buildMethod: ''
-          customParameters: -logFile /github/workspace/unity-build.log
           allowDirtyBuild: true
         continue-on-error: true
 
-      - name: Capture Unity job log
-        if: always() && steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'
-        continue-on-error: true
+      - name: Compile Unity project (6000.5)
+        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.package-warning-scope == true
+        id: compile-6000-5
+        timeout-minutes: 30
         env:
-          GH_TOKEN: ${{ github.token }}
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         run: |
-          JOB_NAME="Compile Check (${{ matrix.unity-version }})"
-          JOB_ID=$(curl --fail --silent --show-error \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
-            | jq -r --arg job_name "$JOB_NAME" '.jobs[] | select(.name == $job_name) | .id')
-          if [ -z "$JOB_ID" ]; then
-            echo "::error::Could not resolve the current Unity job id"
-            exit 1
-          fi
-          for attempt in 1 2 3 4 5; do
-            if curl --fail --silent --show-error -L \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/jobs/${JOB_ID}/logs" \
-              > artifacts/unity-build.log && [ -s artifacts/unity-build.log ]; then
-              exit 0
-            fi
-            sleep 5
-          done
-          echo "::error::Could not capture the Unity job log"
-          exit 1
+          docker run --rm \
+            --workdir /workspace \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --env UNITY_LICENSE \
+            unityci/editor:ubuntu-6000.5.4f1-base-3 \
+            /bin/bash -c '
+              set -eu
+              mkdir -p /root/.local/share/unity3d/Unity
+              printf "%s" "$UNITY_LICENSE" > /root/.local/share/unity3d/Unity/Unity_lic.ulf
+              unity-editor -batchmode -nographics -quit \
+                -projectPath /workspace/ci/unity-projects/6000.5 \
+                -logFile /workspace/artifacts/unity-build.log
+            '
 
       - name: Check for compile errors and warnings
         if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'
@@ -150,7 +145,7 @@ jobs:
 
           if [ -z "$LOG_FILE" ]; then
             echo "No Unity log file found, checking artifacts..."
-            LOG_FILE="unity-build.log"
+            LOG_FILE="artifacts/unity-build.log"
           fi
 
           echo "=== Checking Unity compilation output ==="

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -25,13 +25,13 @@ jobs:
           - unity-version: 2022.3.62f1
             project-path: .
             library-path: Library
-            compile-mode: legacy-builder
+            compile_mode: legacy-builder
             package-warning-scope: false
             run-unit-tests: true
           - unity-version: 6000.5.4f1
             project-path: ci/unity-projects/6000.5
             library-path: ci/unity-projects/6000.5/Library
-            compile-mode: direct-editor
+            compile_mode: direct-editor
             package-warning-scope: true
             run-unit-tests: false
     # Dependabot PRs cannot access repository secrets (UNITY_LICENSE etc.)
@@ -95,7 +95,7 @@ jobs:
             Library-${{ matrix.unity-version }}-
 
       - name: Purge cached script assemblies
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile-mode == 'direct-editor'
+        if: ${{ steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile_mode == 'direct-editor' }}
         run: rm -rf "${{ matrix.project-path }}/Library/ScriptAssemblies"
 
       - name: Prepare Unity log directory
@@ -103,7 +103,7 @@ jobs:
         run: mkdir -p artifacts
 
       - name: Compile Unity project (2022.3)
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile-mode == 'legacy-builder'
+        if: ${{ steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile_mode == 'legacy-builder' }}
         id: compile
         uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2
         timeout-minutes: 30
@@ -120,7 +120,7 @@ jobs:
         continue-on-error: true
 
       - name: Compile Unity project (6000.5)
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile-mode == 'direct-editor'
+        if: ${{ steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.compile_mode == 'direct-editor' }}
         id: compile-6000-5
         timeout-minutes: 30
         env:

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -134,9 +134,11 @@ jobs:
               mkdir -p /root/.local/share/unity3d/Unity
               printf "%s" "$UNITY_LICENSE" > /root/.local/share/unity3d/Unity/Unity_lic.ulf
               unity-editor -batchmode -nographics -quit \
+                -manualLicenseFile /root/.local/share/unity3d/Unity/Unity_lic.ulf \
                 -projectPath /workspace/ci/unity-projects/6000.5 \
                 -logFile /workspace/artifacts/unity-build.log
             '
+        continue-on-error: true
 
       - name: Check for compile errors and warnings
         if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -1,7 +1,7 @@
 name: Unity Compile Check
 
-# This job is a required status check, so it must report exactly one
-# "Compile Check (Linux)" result on every PR. Path filters at the workflow
+# These jobs are required status checks, so they must report one result per
+# Unity version on every PR. Path filters at the workflow
 # level cannot express that: a `paths`/`paths-ignore` pair both fire on a PR
 # that mixes C# and non-C# files, producing duplicate required checks. Instead
 # the workflow always runs and a change-detection step decides whether to do
@@ -17,8 +17,21 @@ permissions:
 
 jobs:
   compile-check:
-    name: Compile Check (Linux)
+    name: Compile Check (${{ matrix.unity-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - unity-version: 2022.3.62f1
+            project-path: .
+            library-path: Library
+            package-warning-scope: false
+            run-unit-tests: true
+          - unity-version: 6000.5.4f1
+            project-path: ci/unity-projects/6000.5
+            library-path: ci/unity-projects/6000.5/Library
+            package-warning-scope: true
+            run-unit-tests: false
     # Dependabot PRs cannot access repository secrets (UNITY_LICENSE etc.)
     env:
       HAS_UNITY_LICENSE: ${{ secrets.UNITY_LICENSE != '' }}
@@ -47,7 +60,7 @@ jobs:
           echo "=== Changed files ==="
           echo "$CHANGED"
 
-          if echo "$CHANGED" | grep -qE '^(Packages/src/Editor/.*\.cs|Packages/src/Runtime/.*\.cs|Assets/.*\.cs|tests/.*\.cs|tests/.*\.csproj|Packages/.*\.asmdef|Assets/.*\.asmdef|Packages/manifest\.json|Packages/packages-lock\.json|\.github/workflows/unity-compile-check-and-test-runner\.yml)$'; then
+          if echo "$CHANGED" | grep -qE '^(Packages/src/Editor/.*\.cs|Packages/src/Runtime/.*\.cs|Assets/.*\.cs|tests/.*\.cs|tests/.*\.csproj|Packages/.*\.asmdef|Assets/.*\.asmdef|Packages/manifest\.json|Packages/packages-lock\.json|ci/unity-projects/.*|\.github/workflows/unity-compile-check-and-test-runner\.yml)$'; then
             echo "csharp=true" >> "$GITHUB_OUTPUT"
           else
             echo "csharp=false" >> "$GITHUB_OUTPUT"
@@ -58,13 +71,13 @@ jobs:
         run: echo "No C# changes detected; compile check is satisfied without running Unity."
 
       - name: Setup .NET
-        if: steps.changes.outputs.csharp == 'true'
+        if: steps.changes.outputs.csharp == 'true' && matrix.run-unit-tests == true
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: 10.0.x
 
       - name: Run concurrency unit tests
-        if: steps.changes.outputs.csharp == 'true'
+        if: steps.changes.outputs.csharp == 'true' && matrix.run-unit-tests == true
         run: |
           dotnet test tests/DynamicCodeExecutionScheduler.UnitTests/DynamicCodeExecutionScheduler.UnitTests.csproj --configuration Release
           dotnet test tests/SharedRoslynCompilerWorker.UnitTests/SharedRoslynCompilerWorker.UnitTests.csproj --configuration Release
@@ -74,10 +87,10 @@ jobs:
         if: env.HAS_UNITY_LICENSE == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
-          path: Library
-          key: Library-2022.3.62f1-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs', 'Packages/manifest.json', 'Packages/packages-lock.json') }}
+          path: ${{ matrix.library-path }}
+          key: Library-${{ matrix.unity-version }}-${{ hashFiles('Packages/src/**/*.cs', 'Assets/**/*.cs', 'Packages/manifest.json', 'Packages/packages-lock.json', 'ci/unity-projects/6000.5/**') }}
           restore-keys: |
-            Library-2022.3.62f1-
+            Library-${{ matrix.unity-version }}-
 
       - name: Compile Unity project
         if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'
@@ -89,7 +102,8 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          unityVersion: 2022.3.62f1
+          projectPath: ${{ matrix.project-path }}
+          unityVersion: ${{ matrix.unity-version }}
           targetPlatform: StandaloneLinux64
           buildMethod: ''
           allowDirtyBuild: true
@@ -113,11 +127,27 @@ jobs:
           if [ -f "$LOG_FILE" ]; then
             echo "Analyzing log file: $LOG_FILE"
 
-            # Count errors (CS errors from compiler)
-            ERROR_COUNT=$(grep -c "error CS[0-9]*:" "$LOG_FILE" 2>/dev/null || echo "0")
+            if [ "${{ matrix.package-warning-scope }}" == "true" ]; then
+              PACKAGE_EVIDENCE_PATTERN='io\.github\.hatayama\.uloopmcp|UnityCLILoop\.Runtime'
+              if ! grep -Eq "$PACKAGE_EVIDENCE_PATTERN" "$LOG_FILE"; then
+                echo "::error::Unity did not resolve or compile the io.github.hatayama.uloopmcp package"
+                exit 1
+              fi
+              echo "Package compilation evidence found in Unity log."
+            fi
 
-            # Count warnings (CS warnings from compiler, excluding specific noise)
-            WARNING_COUNT=$(grep -c "warning CS[0-9]*:" "$LOG_FILE" 2>/dev/null || echo "0")
+            if [ "${{ matrix.package-warning-scope }}" == "true" ]; then
+              # Unity 6000.5 can emit compiler noise from other packages. Only
+              # package source diagnostics determine this compatibility check.
+              ERROR_PATTERN='(Packages/src/|io\.github\.hatayama\.uloopmcp).*error CS[0-9]*:|error CS[0-9]*:.*(Packages/src/|io\.github\.hatayama\.uloopmcp)'
+              WARNING_PATTERN='(Packages/src/|io\.github\.hatayama\.uloopmcp).*warning CS[0-9]*:|warning CS[0-9]*:.*(Packages/src/|io\.github\.hatayama\.uloopmcp)'
+            else
+              ERROR_PATTERN='error CS[0-9]*:'
+              WARNING_PATTERN='warning CS[0-9]*:'
+            fi
+
+            ERROR_COUNT=$(grep -Ec "$ERROR_PATTERN" "$LOG_FILE" 2>/dev/null || echo "0")
+            WARNING_COUNT=$(grep -Ec "$WARNING_PATTERN" "$LOG_FILE" 2>/dev/null || echo "0")
 
             echo ""
             echo "=== Compilation Results ==="
@@ -129,7 +159,7 @@ jobs:
               echo "::error::Found $ERROR_COUNT compile error(s)"
               echo ""
               echo "=== Errors ==="
-              grep "error CS[0-9]*:" "$LOG_FILE" | head -20
+              grep -E "$ERROR_PATTERN" "$LOG_FILE" | head -20
               exit 1
             fi
 
@@ -137,7 +167,7 @@ jobs:
               echo "::warning::Found $WARNING_COUNT compile warning(s)"
               echo ""
               echo "=== Warnings ==="
-              grep "warning CS[0-9]*:" "$LOG_FILE" | head -20
+              grep -E "$WARNING_PATTERN" "$LOG_FILE" | head -20
               exit 1
             fi
 

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -110,7 +110,7 @@ jobs:
           unityVersion: ${{ matrix.unity-version }}
           targetPlatform: StandaloneLinux64
           buildMethod: ''
-          customParameters: -logFile=/github/workspace/artifacts/unity-build.log
+          customParameters: -logfile /github/workspace/artifacts/unity-build.log
           allowDirtyBuild: true
         continue-on-error: true
 

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -123,18 +123,48 @@ jobs:
         timeout-minutes: 30
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         run: |
           docker run --rm \
             --workdir /workspace \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --env UNITY_LICENSE \
+            --env UNITY_EMAIL \
+            --env UNITY_PASSWORD \
             unityci/editor:ubuntu-6000.5.4f1-base-3 \
             /bin/bash -c '
               set -eu
-              mkdir -p /root/.local/share/unity3d/Unity
-              printf "%s" "$UNITY_LICENSE" > /root/.local/share/unity3d/Unity/Unity_lic.ulf
+              trap '\''unity-editor -batchmode -nographics -quit -returnlicense \
+                -username "$UNITY_EMAIL" -password "$UNITY_PASSWORD" \
+                -projectPath /BlankProject >/dev/null 2>&1 || true'\'' EXIT
+
+              LICENSE_VALUE=$(printf "%s" "$UNITY_LICENSE" | tr "\\n" " " | sed -n '\''s/.*<DeveloperData Value="\([^"]*\)"\/>.*/\1/p'\'')
+              test -n "$LICENSE_VALUE"
+              printf "%s" "$LICENSE_VALUE" | base64 -d > /tmp/developer-data.bin
+              SERIAL=$(tail -c +5 /tmp/developer-data.bin | tr -d "\\r\\n")
+              test "${#SERIAL}" -eq 27
+              if [[ "$SERIAL" == F* ]]; then
+                dbus-uuidgen > /etc/machine-id
+                mkdir -p /var/lib/dbus
+                ln -sf /etc/machine-id /var/lib/dbus/machine-id
+              fi
+
+              ACTIVATED=false
+              for ATTEMPT in 1 2 3; do
+                if unity-editor -batchmode -nographics -quit \
+                  -serial "$SERIAL" \
+                  -username "$UNITY_EMAIL" \
+                  -password "$UNITY_PASSWORD" \
+                  -projectPath /BlankProject; then
+                  ACTIVATED=true
+                  break
+                fi
+                sleep $((ATTEMPT * 5))
+              done
+              test "$ACTIVATED" = true
+
               unity-editor -batchmode -nographics -quit \
-                -manualLicenseFile /root/.local/share/unity3d/Unity/Unity_lic.ulf \
                 -projectPath /workspace/ci/unity-projects/6000.5 \
                 -logFile /workspace/artifacts/unity-build.log
             '

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -189,7 +189,7 @@ jobs:
           else
             echo "::warning::Could not find Unity log file for analysis"
             # Unity 6000.5's builder reports an untitled-scene build failure after successful script compilation.
-            if [ "${{ matrix.package-warning-scope }}" != "true" ] && [ "${{ steps.compile.outcome }}" == "failure" ]; then
+            if [ "${{ matrix.package-warning-scope }}" == "true" ] || [ "${{ steps.compile.outcome }}" == "failure" ]; then
               echo "::error::Unity compilation failed"
               exit 1
             fi

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -110,7 +110,7 @@ jobs:
           unityVersion: ${{ matrix.unity-version }}
           targetPlatform: StandaloneLinux64
           buildMethod: ''
-          customParameters: -logFile /github/workspace/artifacts/unity-build.log
+          customParameters: -logFile=/github/workspace/artifacts/unity-build.log
           allowDirtyBuild: true
         continue-on-error: true
 

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -135,9 +135,11 @@ jobs:
             unityci/editor:ubuntu-6000.5.4f1-base-3 \
             /bin/bash -c '
               set -eu
+              mkdir -p /BlankProject/Assets
               trap '\''unity-editor -batchmode -nographics -quit -returnlicense \
+                -logFile /dev/stdout \
                 -username "$UNITY_EMAIL" -password "$UNITY_PASSWORD" \
-                -projectPath /workspace/ci/unity-projects/6000.5 >/dev/null 2>&1 || true'\'' EXIT
+                -projectPath /BlankProject >/dev/null 2>&1 || true'\'' EXIT
 
               LICENSE_VALUE=$(printf "%s" "$UNITY_LICENSE" | tr "\\n" " " | sed -n '\''s/.*<DeveloperData Value="\([^"]*\)"\/>.*/\1/p'\'')
               test -n "$LICENSE_VALUE"
@@ -153,10 +155,11 @@ jobs:
               ACTIVATED=false
               for ATTEMPT in 1 2 3; do
                 if unity-editor -batchmode -nographics -quit \
+                  -logFile /dev/stdout \
                   -serial "$SERIAL" \
                   -username "$UNITY_EMAIL" \
                   -password "$UNITY_PASSWORD" \
-                  -projectPath /workspace/ci/unity-projects/6000.5; then
+                  -projectPath /BlankProject; then
                   ACTIVATED=true
                   break
                 fi

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -159,6 +159,12 @@ jobs:
             PACKAGE_ASSEMBLY_COUNT=$(find "${{ matrix.project-path }}/Library/ScriptAssemblies" -maxdepth 1 -type f -name 'UnityCLILoop*.dll' 2>/dev/null | wc -l | tr -d ' ')
             if [ "$PACKAGE_ASSEMBLY_COUNT" -eq 0 ]; then
               echo "::error::Unity did not resolve or compile the io.github.hatayama.uloopmcp package"
+              if [ -f "$LOG_FILE" ]; then
+                echo "=== Unity log tail ==="
+                tail -100 "$LOG_FILE"
+              else
+                echo "::error::Unity log file is missing: $LOG_FILE"
+              fi
               exit 1
             fi
             echo "Package assembly evidence found: $PACKAGE_ASSEMBLY_COUNT assembly(s)."

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -92,6 +92,10 @@ jobs:
           restore-keys: |
             Library-${{ matrix.unity-version }}-
 
+      - name: Prepare Unity log directory
+        if: env.HAS_UNITY_LICENSE == 'true'
+        run: mkdir -p artifacts
+
       - name: Compile Unity project
         if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'
         id: compile
@@ -106,6 +110,7 @@ jobs:
           unityVersion: ${{ matrix.unity-version }}
           targetPlatform: StandaloneLinux64
           buildMethod: ''
+          customParameters: -logFile artifacts/unity-build.log
           allowDirtyBuild: true
         continue-on-error: true
 

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -110,7 +110,7 @@ jobs:
           unityVersion: ${{ matrix.unity-version }}
           targetPlatform: StandaloneLinux64
           buildMethod: ''
-          customParameters: -logFile artifacts/unity-build.log
+          customParameters: -logFile /github/workspace/artifacts/unity-build.log
           allowDirtyBuild: true
         continue-on-error: true
 

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -110,7 +110,7 @@ jobs:
           unityVersion: ${{ matrix.unity-version }}
           targetPlatform: StandaloneLinux64
           buildMethod: ''
-          customParameters: -logfile /github/workspace/artifacts/unity-build.log
+          customParameters: -logFile /github/workspace/unity-build.log
           allowDirtyBuild: true
         continue-on-error: true
 
@@ -121,7 +121,7 @@ jobs:
 
           if [ -z "$LOG_FILE" ]; then
             echo "No Unity log file found, checking artifacts..."
-            LOG_FILE="artifacts/unity-build.log"
+            LOG_FILE="unity-build.log"
           fi
 
           echo "=== Checking Unity compilation output ==="

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -93,7 +93,7 @@ jobs:
             Library-${{ matrix.unity-version }}-
 
       - name: Purge cached script assemblies
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.run-unit-tests == false
+        if: ${{ steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix['unity-version'] == '6000.5.4f1' }}
         run: rm -rf "${{ matrix.project-path }}/Library/ScriptAssemblies"
 
       - name: Prepare Unity log directory
@@ -101,7 +101,7 @@ jobs:
         run: mkdir -p artifacts
 
       - name: Compile Unity project (2022.3)
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.run-unit-tests == true
+        if: ${{ steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix['unity-version'] == '2022.3.62f1' }}
         id: compile
         uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2
         timeout-minutes: 30
@@ -118,7 +118,7 @@ jobs:
         continue-on-error: true
 
       - name: Compile Unity project (6000.5)
-        if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix.run-unit-tests == false
+        if: ${{ steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true' && matrix['unity-version'] == '6000.5.4f1' }}
         id: compile-6000-5
         timeout-minutes: 30
         env:

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -114,6 +114,35 @@ jobs:
           allowDirtyBuild: true
         continue-on-error: true
 
+      - name: Capture Unity job log
+        if: always() && steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          JOB_NAME="Compile Check (${{ matrix.unity-version }})"
+          JOB_ID=$(curl --fail --silent --show-error \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
+            | jq -r --arg job_name "$JOB_NAME" '.jobs[] | select(.name == $job_name) | .id')
+          if [ -z "$JOB_ID" ]; then
+            echo "::error::Could not resolve the current Unity job id"
+            exit 1
+          fi
+          for attempt in 1 2 3 4 5; do
+            if curl --fail --silent --show-error -L \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/jobs/${JOB_ID}/logs" \
+              > artifacts/unity-build.log && [ -s artifacts/unity-build.log ]; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Could not capture the Unity job log"
+          exit 1
+
       - name: Check for compile errors and warnings
         if: steps.changes.outputs.csharp == 'true' && env.HAS_UNITY_LICENSE == 'true'
         run: |

--- a/.github/workflows/unity-compile-check-and-test-runner.yml
+++ b/.github/workflows/unity-compile-check-and-test-runner.yml
@@ -222,8 +222,8 @@ jobs:
               WARNING_PATTERN='warning CS[0-9]*:'
             fi
 
-            ERROR_COUNT=$(grep -Ec "$ERROR_PATTERN" "$LOG_FILE" 2>/dev/null || echo "0")
-            WARNING_COUNT=$(grep -Ec "$WARNING_PATTERN" "$LOG_FILE" 2>/dev/null || echo "0")
+            ERROR_COUNT=$(grep -Ec "$ERROR_PATTERN" "$LOG_FILE" 2>/dev/null || true)
+            WARNING_COUNT=$(grep -Ec "$WARNING_PATTERN" "$LOG_FILE" 2>/dev/null || true)
 
             echo ""
             echo "=== Compilation Results ==="

--- a/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UiRaycastHelper.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/MouseUi/UiRaycastHelper.cs
@@ -28,7 +28,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
         private static List<CanvasRaycastSource> CollectCanvasRaycastSources()
         {
+#if UNITY_6000_4_OR_NEWER
+            Canvas[] canvases = Object.FindObjectsByType<Canvas>();
+#else
             Canvas[] canvases = Object.FindObjectsByType<Canvas>(FindObjectsSortMode.None);
+#endif
             List<CanvasRaycastSource> canvasRaycastSources = new List<CanvasRaycastSource>();
 
             foreach (Canvas canvas in canvases)

--- a/Packages/src/Editor/FirstPartyTools/Common/Overlay/OverlayCanvasFactory.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/Overlay/OverlayCanvasFactory.cs
@@ -38,8 +38,12 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             }
 
             // Domain Reload resets _instance but DontDestroyOnLoad objects survive; reclaim one and destroy duplicates
+#if UNITY_6000_4_OR_NEWER
+            InputVisualizationCanvas[] existing = Object.FindObjectsByType<InputVisualizationCanvas>();
+#else
             InputVisualizationCanvas[] existing =
                 Object.FindObjectsByType<InputVisualizationCanvas>(FindObjectsSortMode.None);
+#endif
             for (int i = 0; i < existing.Length; i++)
             {
                 if (_instance == null)

--- a/Packages/src/Editor/FirstPartyTools/Common/UnityObjectIdentifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/UnityObjectIdentifier.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Provides the integer object handle required by the current pause-point response contract.
+    /// </summary>
+    internal static class UnityObjectIdentifier
+    {
+        /// <summary>
+        /// Gets an object handle while keeping the existing integer response contract compatible with older Unity versions.
+        /// </summary>
+        public static int GetInstanceId(Object unityObject)
+        {
+            Debug.Assert(unityObject != null, "unityObject must not be null.");
+
+#if UNITY_6000_4_OR_NEWER
+            return (int)unityObject.GetEntityId();
+#else
+            return unityObject.GetInstanceID();
+#endif
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Common/UnityObjectIdentifier.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/UnityObjectIdentifier.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 6c0079dd96933453285941f49016354c

--- a/Packages/src/Editor/FirstPartyTools/Common/UnityObjectIdentifier.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Common/UnityObjectIdentifier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c0079dd96933453285941f49016354c

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AssemblyBuilderFallbackCompilerBackend.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/DynamicCompilation/AssemblyBuilderFallbackCompilerBackend.cs
@@ -28,11 +28,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 ? DynamicReferenceSetBuilder.MergeReferencesByAssemblyName(Array.Empty<string>(), references)
                 : Array.Empty<string>();
 
+#pragma warning disable 618 // Unity's fallback compiler API has no supported replacement on older editor versions.
             AssemblyBuilder builder = new(dllPath, sourcePath)
             {
                 referencesOptions = ReferencesOptions.UseEngineModules,
                 additionalReferences = referenceArray
             };
+#pragma warning restore 618
 
             builder.buildFinished += (string assemblyPath, CompilerMessage[] compilerMessages) =>
             {

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointUnityObjectClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointUnityObjectClassifier.cs
@@ -2,6 +2,7 @@ using UnityEditor;
 using UnityEngine;
 
 using io.github.hatayama.UnityCliLoop.Runtime;
+using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointUnityObjectClassifier.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointUnityObjectClassifier.cs
@@ -43,9 +43,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             string assetPath = AssetDatabase.GetAssetPath(unityObject);
             return string.IsNullOrEmpty(assetPath)
                 ? new Classification(
-                    UloopCapturedVariableUnityObjectKind.RuntimeInstance, unityObject.name, unityObject.GetInstanceID())
+                    UloopCapturedVariableUnityObjectKind.RuntimeInstance, unityObject.name, UnityObjectIdentifier.GetInstanceId(unityObject))
                 : new Classification(
-                    UloopCapturedVariableUnityObjectKind.Asset, assetPath, unityObject.GetInstanceID());
+                    UloopCapturedVariableUnityObjectKind.Asset, assetPath, UnityObjectIdentifier.GetInstanceId(unityObject));
         }
 
         private static Classification ClassifyGameObjectOrComponent(GameObject gameObject, Object handleSource)
@@ -55,13 +55,13 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return new Classification(
                     UloopCapturedVariableUnityObjectKind.SceneObject,
                     $"{gameObject.scene.name}:{BuildHierarchyPath(gameObject.transform)}",
-                    handleSource.GetInstanceID());
+                    UnityObjectIdentifier.GetInstanceId(handleSource));
             }
 
             return new Classification(
                 UloopCapturedVariableUnityObjectKind.PrefabAsset,
                 AssetDatabase.GetAssetPath(handleSource),
-                handleSource.GetInstanceID());
+                UnityObjectIdentifier.GetInstanceId(handleSource));
         }
 
         private static string BuildHierarchyPath(Transform transform)

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointVariableFormatter.cs
@@ -81,7 +81,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             {
                 return new UloopCapturedVariable(
                     name, scope, typeName, DestroyedValue,
-                    UloopCapturedVariableUnityObjectKind.Destroyed, string.Empty, unityObjectCandidate.GetInstanceID());
+                    UloopCapturedVariableUnityObjectKind.Destroyed, string.Empty, UnityObjectIdentifier.GetInstanceId(unityObjectCandidate));
             }
 
             SourcePausePointUnityObjectClassifier.Classification classification =

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/RaycastAnnotation/RaycastGridAnnotator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/RaycastAnnotation/RaycastGridAnnotator.cs
@@ -189,7 +189,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             // The 4-connected component split in CollectPhysicsColliderElements re-derives one annotation per
             // visually closed region so a single GameObject can produce multiple entries when UI occlusion
             // splits its reachable samples.
-            return collider!.gameObject.GetInstanceID();
+            return UnityObjectIdentifier.GetInstanceId(collider!.gameObject);
         }
 
         private static RaycastClusterSample CreateClusterSample(

--- a/Packages/src/Editor/FirstPartyTools/Screenshot/UIElementAnnotator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Screenshot/UIElementAnnotator.cs
@@ -122,7 +122,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             HashSet<GameObject> processedObjects,
             UiRaycastHelper.RaycastContext? raycastContext)
         {
+#if UNITY_6000_4_OR_NEWER
+            MonoBehaviour[] allBehaviours = Object.FindObjectsByType<MonoBehaviour>();
+#else
             MonoBehaviour[] allBehaviours = Object.FindObjectsOfType<MonoBehaviour>();
+#endif
             foreach (MonoBehaviour behaviour in allBehaviours)
             {
                 if (!behaviour.isActiveAndEnabled)

--- a/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPointerTargetResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/SimulateMouseUi/MouseUiPointerTargetResolver.cs
@@ -185,7 +185,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return new TargetPathLookupResult(null, 0);
             }
 
+#if UNITY_6000_4_OR_NEWER
+            GameObject[] gameObjects = UnityEngine.Object.FindObjectsByType<GameObject>();
+#else
             GameObject[] gameObjects = UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None);
+#endif
             GameObject? matchedTarget = null;
             int matchCount = 0;
 

--- a/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
+++ b/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+namespace io.github.hatayama.UnityCliLoop.ToolContracts
 {
     /// <summary>
     /// Provides the integer object handle required by the current pause-point response contract.
@@ -12,7 +12,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         /// </summary>
         public static int GetInstanceId(Object unityObject)
         {
-            Debug.Assert(unityObject != null, "unityObject must not be null.");
+            Debug.Assert(unityObject is not null, "unityObject must not be null.");
 #if UNITY_6000_4_OR_NEWER
             return (int)unityObject.GetEntityId();
 #else

--- a/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
+++ b/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
@@ -13,11 +13,9 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public static int GetInstanceId(Object unityObject)
         {
             Debug.Assert(unityObject is not null, "unityObject must not be null.");
-#if UNITY_6000_4_OR_NEWER
-            return unchecked((int)EntityId.ToULong(unityObject.GetEntityId()));
-#else
+#pragma warning disable 618, 619 // The public and Go contracts remain int, and Unity provides no supported EntityId-to-int conversion.
             return unityObject.GetInstanceID();
-#endif
+#pragma warning restore 618, 619
         }
     }
 }

--- a/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
+++ b/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
@@ -13,9 +13,13 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         public static int GetInstanceId(Object unityObject)
         {
             Debug.Assert(unityObject is not null, "unityObject must not be null.");
-#pragma warning disable 618, 619 // The public and Go contracts remain int, and Unity provides no supported EntityId-to-int conversion.
+#if UNITY_6000_4_OR_NEWER
+            // The wire contract remains int, so extract the same lower 32 bits as Unity's obsolete int cast.
+            // Unity 6000.5 stores a version marker in the upper 32 bits; future IDs may collide in this int shape.
+            return unchecked((int)EntityId.ToULong(unityObject.GetEntityId()));
+#else
             return unityObject.GetInstanceID();
-#pragma warning restore 618, 619
+#endif
         }
     }
 }

--- a/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
+++ b/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
@@ -13,7 +13,6 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public static int GetInstanceId(Object unityObject)
         {
             Debug.Assert(unityObject != null, "unityObject must not be null.");
-
 #if UNITY_6000_4_OR_NEWER
             return (int)unityObject.GetEntityId();
 #else

--- a/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
+++ b/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs
@@ -14,7 +14,7 @@ namespace io.github.hatayama.UnityCliLoop.ToolContracts
         {
             Debug.Assert(unityObject is not null, "unityObject must not be null.");
 #if UNITY_6000_4_OR_NEWER
-            return (int)unityObject.GetEntityId();
+            return unchecked((int)EntityId.ToULong(unityObject.GetEntityId()));
 #else
             return unityObject.GetInstanceID();
 #endif

--- a/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs.meta
+++ b/Packages/src/Editor/ToolContracts/UnityObjectIdentifier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c0079dd96933453285941f49016354c

--- a/ci/unity-projects/6000.5/Packages/manifest.json
+++ b/ci/unity-projects/6000.5/Packages/manifest.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "io.github.hatayama.uloopmcp": "file:../../../../Packages/src"
+  }
+}

--- a/ci/unity-projects/6000.5/ProjectSettings/ProjectVersion.txt
+++ b/ci/unity-projects/6000.5/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,1 @@
+m_EditorVersion: 6000.5.4f1


### PR DESCRIPTION
## Summary

- Detect Unity 6000.5 package compilation incompatibilities before v3-beta merges.
- Keep the minimum supported Unity 2022.3 compile check running alongside the new compatibility check.

## User Impact

- Pull requests now verify package compilation against both Unity 2022.3.62f1 and Unity 6000.5.4f1.
- Unity 6000.5 dependency-resolution failures and package compiler errors fail the check instead of being silently skipped.

## Changes

- Added a minimal Unity 6000.5 fixture project that references the package through its repository-relative path.
- Converted the compile workflow to a versioned matrix with separate project paths, Library caches, and unit-test execution.
- Scoped Unity 6000.5 diagnostics to package sources while preserving the existing 2022.3 diagnostic scope.
- Added package assembly evidence validation and stale ScriptAssemblies purging so dependency resolution failures cannot produce a false green result.
- Added direct Unity 6000.5 container execution with derived serial activation, controlled log-file capture, and guaranteed license return.
- Added Unity version compatibility adapters and overload branches for Unity 6000.5 obsolete API diagnostics while preserving the existing integer wire contract.
- Opened follow-up issue #1841 for migrating object handles to an opaque EntityId-compatible wire contract.

## Verification

- Ruby YAML parser: passed.
- Fixture relative-path resolution: passed; it resolves to `Packages/src`.
- Change-detection pattern: passed for C# and fixture files and rejected `.csv` input.
- Final PR CI run 29677617670: both `Compile Check (2022.3.62f1)` and `Compile Check (6000.5.4f1)` passed.
- The 6000.5 log showed successful license activation, 37 package assemblies, package compilation evidence, and zero scoped errors/warnings.
- Full `gh pr checks 1840` passed, including package tests, CLI build, security analysis, and complexity checks.
- `actionlint`: not run because it is not installed locally.