### PR TITLE
fix: Keep the Setup Wizard skill target dropdown available

### DIFF
--- a/Assets/Tests/Editor/SetupWizardWindowTests.cs
+++ b/Assets/Tests/Editor/SetupWizardWindowTests.cs
@@ -479,6 +479,20 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void ResolveUseFirstInstallSkillsUi_WhenLatched_RemainsEnabled()
+        {
+            // Verifies that the first-install UI remains enabled after a target folder is created.
+            bool latchedMode = SetupWizardSkillsStepPresenter.ResolveUseFirstInstallSkillsUi(
+                shouldUseFirstInstallSkillsUi: false,
+                installableTargetCount: 0);
+            bool actual = SetupWizardSkillsStepPresenter.ResolveUseFirstInstallSkillsUi(
+                latchedMode,
+                installableTargetCount: 1);
+
+            Assert.That(actual, Is.True);
+        }
+
+        [Test]
         public void ShouldUseFirstInstallSkillsUi_WhenVersionWasNeverSeen_ReturnsTrue()
         {
             bool shouldUseFirstInstallUi = SetupWizardWindow.ShouldUseFirstInstallSkillsUi("");

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsStepPresenter.cs
@@ -66,16 +66,13 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool isInstallingSkills)
         {
             List<SkillSetupTargetInfo> installableTargets = FilterInstallableSkillTargets(targets);
-            bool useFirstInstallSkillsUi = ResolveUseFirstInstallSkillsUi(
-                shouldUseFirstInstallSkillsUi,
-                installableTargets.Count);
             _skillsTargetList.Clear();
             ViewDataBinder.SetVisible(
                 _skillsTargetRow,
-                ShouldShowSkillsTargetRowForSetupWizard(useFirstInstallSkillsUi));
+                ShouldShowSkillsTargetRowForSetupWizard(shouldUseFirstInstallSkillsUi));
             ViewDataBinder.SetVisible(
                 _skillsTargetList,
-                ShouldShowSkillsTargetListForSetupWizard(canManageSkills, useFirstInstallSkillsUi));
+                ShouldShowSkillsTargetListForSetupWizard(canManageSkills, shouldUseFirstInstallSkillsUi));
 
             if (!canManageSkills)
             {
@@ -88,7 +85,7 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
                 return;
             }
 
-            if (useFirstInstallSkillsUi)
+            if (shouldUseFirstInstallSkillsUi)
             {
                 SkillSetupTargetInfo selectedTargetInfo = GetSelectedSkillTargetInfo(
                     targets,

--- a/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsWorkflowController.cs
+++ b/Packages/src/Editor/Presentation/Setup/SetupWizardSkillsWorkflowController.cs
@@ -205,6 +205,11 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             bool canManageSkills,
             List<SkillSetupTargetInfo> targets)
         {
+            List<SkillSetupTargetInfo> installableTargets =
+                SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
+            _shouldUseFirstInstallSkillsUi = SetupWizardSkillsStepPresenter.ResolveUseFirstInstallSkillsUi(
+                _shouldUseFirstInstallSkillsUi,
+                installableTargets.Count);
             _groupSkillsToggle.SetEnabled(canManageSkills && !_isInstallingSkills);
             _skillsStepPresenter.Update(
                 canManageSkills,
@@ -225,17 +230,12 @@ namespace io.github.hatayama.UnityCliLoop.Presentation
             CancelSkillInstallStateRefresh();
             string projectRoot = UnityCliLoopPathResolver.GetProjectRoot();
             List<SkillSetupTargetInfo> targets = DetectDisplayedSkillTargets(projectRoot);
-            List<SkillSetupTargetInfo> filteredTargets =
-                SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
-            bool useFirstInstallSkillsUi = SetupWizardSkillsStepPresenter.ResolveUseFirstInstallSkillsUi(
-                _shouldUseFirstInstallSkillsUi,
-                filteredTargets.Count);
-            List<SkillSetupTargetInfo> installableTargets = useFirstInstallSkillsUi
+            List<SkillSetupTargetInfo> installableTargets = _shouldUseFirstInstallSkillsUi
                 ? SetupWizardSkillsStepPresenter.GetFirstInstallableSkillTargets(
                     targets,
                     _skillsTarget,
                     !_installSkillsFlat)
-                : filteredTargets;
+                : SetupWizardSkillsStepPresenter.FilterInstallableSkillTargets(targets);
             if (installableTargets.Count == 0) return;
 
             bool shouldShowSkillsInstalledDialog =


### PR DESCRIPTION
## Summary
- Keep the skill target dropdown visible after the first fallback is shown.
- Allow users to install multiple targets during one Setup Wizard session.

## User Impact
- Installing the first target no longer switches the wizard to the multi-target list immediately.
- Closing and reopening the wizard still allows the normal folder-based mode to be selected.

## Changes
- Latch the effective first-install mode in the workflow controller for the wizard lifetime.
- Use the latched mode consistently for rendering and installation.
- Add regression coverage for the latched resolver behavior.

## Verification
- Unity compile: 0 errors, 0 warnings.
- Focused resolver tests: 4 passed.
- Full EditMode suite: 2 pre-existing unrelated failures, 7 skipped; the new tests passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

