### PR TITLE
fix: make stale-port connection errors actionable

### DIFF
--- a/Packages/src/Cli~/src/__tests__/cli-project-error.test.ts
+++ b/Packages/src/Cli~/src/__tests__/cli-project-error.test.ts
@@ -27,7 +27,7 @@ describe('getProjectResolutionErrorLines', () => {
       '  Connected to: /connected/project',
       '',
       'Another Unity instance was found, but it belongs to a different project.',
-      'This can happen when multiple Unity Editors leave a stale server port. Restart the target Unity with: uloop launch -r --project-path /expected/project',
+      'This can happen when multiple Unity Editors leave a stale server port. Restart the target Unity with: uloop launch -r /expected/project',
     ]);
   });
 
@@ -39,8 +39,8 @@ describe('getProjectResolutionErrorLines', () => {
       '',
       '  Project: /project/root',
       '',
-      'If you are using package 2.2.1 or later, wait several seconds for the watchdog to recover the server and retry.',
-      'If recovery does not complete, restart Unity with: uloop launch -r --project-path /project/root',
+      'If the installed package includes the server state watchdog, wait several seconds for it to recover the server and retry.',
+      'If recovery does not complete, restart Unity with: uloop launch -r /project/root',
     ]);
   });
 });

--- a/Packages/src/Cli~/src/__tests__/cli-project-error.test.ts
+++ b/Packages/src/Cli~/src/__tests__/cli-project-error.test.ts
@@ -27,7 +27,7 @@ describe('getProjectResolutionErrorLines', () => {
       '  Connected to: /connected/project',
       '',
       'Another Unity instance was found, but it belongs to a different project.',
-      'Start the Unity Editor for this project, or use --project-path to specify the target.',
+      'This can happen when multiple Unity Editors leave a stale server port. Restart the target Unity with: uloop launch -r --project-path /expected/project',
     ]);
   });
 
@@ -39,7 +39,8 @@ describe('getProjectResolutionErrorLines', () => {
       '',
       '  Project: /project/root',
       '',
-      'Start the server from: Window > Unity CLI Loop > Server',
+      'If you are using package 2.2.1 or later, wait several seconds for the watchdog to recover the server and retry.',
+      'If recovery does not complete, restart Unity with: uloop launch -r --project-path /project/root',
     ]);
   });
 });

--- a/Packages/src/Cli~/src/__tests__/execute-tool.test.ts
+++ b/Packages/src/Cli~/src/__tests__/execute-tool.test.ts
@@ -1,5 +1,6 @@
 import {
   appendCliTimingsToDynamicCodeResult,
+  diagnoseProjectMismatchError,
   diagnoseRetryableProjectConnectionError,
   isTransportDisconnectError,
   prewarmDynamicCodeAfterLaunch,
@@ -624,6 +625,64 @@ describe('diagnoseRetryableProjectConnectionError', () => {
     });
 
     expect(error).toBe(originalError);
+  });
+});
+
+describe('diagnoseProjectMismatchError', () => {
+  it('returns UnityNotRunningError when the target Unity process is absent', async () => {
+    const mismatch = new ProjectMismatchError('/expected', '/connected');
+
+    const error = await diagnoseProjectMismatchError(mismatch, '/expected', true, {
+      findRunningUnityProcessForProjectFn: jest.fn().mockResolvedValue(null),
+    });
+
+    expect(error).toBeInstanceOf(UnityNotRunningError);
+  });
+
+  it('returns a server-starting error when the target Unity process has a fresh startup lock', async () => {
+    const mismatch = new ProjectMismatchError('/expected', '/connected');
+
+    const error = await diagnoseProjectMismatchError(mismatch, '/expected', true, {
+      findRunningUnityProcessForProjectFn: jest.fn().mockResolvedValue({ pid: 1234 }),
+      existsSyncFn: jest.fn().mockReturnValue(true),
+      statSyncFn: jest.fn().mockReturnValue(createStatResult(Date.now())),
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('UNITY_SERVER_STARTING');
+  });
+
+  it('returns UnityServerNotRunningError when Unity is running without a startup lock', async () => {
+    const mismatch = new ProjectMismatchError('/expected', '/connected');
+
+    const error = await diagnoseProjectMismatchError(mismatch, '/expected', true, {
+      findRunningUnityProcessForProjectFn: jest.fn().mockResolvedValue({ pid: 1234 }),
+      existsSyncFn: jest.fn().mockReturnValue(false),
+    });
+
+    expect(error).toBeInstanceOf(UnityServerNotRunningError);
+  });
+
+  it('preserves ProjectMismatchError when process detection fails', async () => {
+    const mismatch = new ProjectMismatchError('/expected', '/connected');
+
+    const error = await diagnoseProjectMismatchError(mismatch, '/expected', true, {
+      findRunningUnityProcessForProjectFn: jest.fn().mockResolvedValue(undefined),
+    });
+
+    expect(error).toBe(mismatch);
+  });
+
+  it('preserves ProjectMismatchError when an explicit port disables diagnosis', async () => {
+    const mismatch = new ProjectMismatchError('/expected', '/connected');
+    const findRunningUnityProcessForProjectFn = jest.fn();
+
+    const error = await diagnoseProjectMismatchError(mismatch, '/expected', false, {
+      findRunningUnityProcessForProjectFn,
+    });
+
+    expect(error).toBe(mismatch);
+    expect(findRunningUnityProcessForProjectFn).not.toHaveBeenCalled();
   });
 });
 

--- a/Packages/src/Cli~/src/cli-project-error.ts
+++ b/Packages/src/Cli~/src/cli-project-error.ts
@@ -10,7 +10,8 @@ export function getProjectResolutionErrorLines(
       '',
       `  Project: ${error.projectRoot}`,
       '',
-      'Start the server from: Window > Unity CLI Loop > Server',
+      'If you are using package 2.2.1 or later, wait several seconds for the watchdog to recover the server and retry.',
+      `If recovery does not complete, restart Unity with: uloop launch -r --project-path ${error.projectRoot}`,
     ];
   }
 
@@ -31,6 +32,6 @@ export function getProjectResolutionErrorLines(
     `  Connected to: ${error.connectedProjectRoot}`,
     '',
     'Another Unity instance was found, but it belongs to a different project.',
-    'Start the Unity Editor for this project, or use --project-path to specify the target.',
+    `This can happen when multiple Unity Editors leave a stale server port. Restart the target Unity with: uloop launch -r --project-path ${error.expectedProjectRoot}`,
   ];
 }

--- a/Packages/src/Cli~/src/cli-project-error.ts
+++ b/Packages/src/Cli~/src/cli-project-error.ts
@@ -10,8 +10,8 @@ export function getProjectResolutionErrorLines(
       '',
       `  Project: ${error.projectRoot}`,
       '',
-      'If you are using package 2.2.1 or later, wait several seconds for the watchdog to recover the server and retry.',
-      `If recovery does not complete, restart Unity with: uloop launch -r --project-path ${error.projectRoot}`,
+      'If the installed package includes the server state watchdog, wait several seconds for it to recover the server and retry.',
+      `If recovery does not complete, restart Unity with: uloop launch -r ${error.projectRoot}`,
     ];
   }
 
@@ -32,6 +32,6 @@ export function getProjectResolutionErrorLines(
     `  Connected to: ${error.connectedProjectRoot}`,
     '',
     'Another Unity instance was found, but it belongs to a different project.',
-    `This can happen when multiple Unity Editors leave a stale server port. Restart the target Unity with: uloop launch -r --project-path ${error.expectedProjectRoot}`,
+    `This can happen when multiple Unity Editors leave a stale server port. Restart the target Unity with: uloop launch -r ${error.expectedProjectRoot}`,
   ];
 }

--- a/Packages/src/Cli~/src/execute-tool.ts
+++ b/Packages/src/Cli~/src/execute-tool.ts
@@ -21,7 +21,7 @@ import {
   UnityServerNotRunningError,
   validateProjectPath,
 } from './port-resolver.js';
-import { validateConnectedProject } from './project-validator.js';
+import { ProjectMismatchError, validateConnectedProject } from './project-validator.js';
 import { saveToolsCache, getCacheFilePath, ToolsCache, ToolDefinition } from './tool-cache.js';
 import { isToolEnabled } from './tool-settings-loader.js';
 import { VERSION } from './version.js';
@@ -253,6 +253,39 @@ export async function diagnoseRetryableProjectConnectionError(
   return new UnityServerNotRunningError(projectRoot);
 }
 
+export async function diagnoseProjectMismatchError(
+  error: unknown,
+  projectRoot: string | null,
+  shouldDiagnoseProjectState: boolean,
+  dependencies: ConnectionFailureDiagnosisDependencies = defaultConnectionFailureDiagnosisDependencies,
+): Promise<unknown> {
+  if (
+    !(error instanceof ProjectMismatchError) ||
+    !shouldDiagnoseProjectState ||
+    projectRoot === null
+  ) {
+    return error;
+  }
+
+  const runningProcess = await dependencies
+    .findRunningUnityProcessForProjectFn(projectRoot)
+    .catch(() => undefined);
+
+  if (runningProcess === undefined) {
+    return error;
+  }
+
+  if (runningProcess === null) {
+    return new UnityNotRunningError(projectRoot);
+  }
+
+  if (isServerStarting(projectRoot, dependencies)) {
+    return createServerStartingError(error);
+  }
+
+  return new UnityServerNotRunningError(projectRoot);
+}
+
 export async function shouldRetryWhenUnityProcessIsRunning(
   error: unknown,
   projectRoot: string | null,
@@ -421,9 +454,15 @@ async function throwFinalToolError(
   projectRoot: string | null,
   shouldDiagnoseProjectState: boolean,
 ): Promise<never> {
+  const diagnosedProjectMismatchError = await diagnoseProjectMismatchError(
+    error,
+    projectRoot,
+    shouldDiagnoseProjectState,
+  );
+
   if (
     await shouldPromoteToServerStartingError(
-      error,
+      diagnosedProjectMismatchError,
       toolName,
       projectRoot,
       shouldDiagnoseProjectState,
@@ -433,7 +472,7 @@ async function throwFinalToolError(
   }
 
   const diagnosedError = await diagnoseRetryableProjectConnectionError(
-    error,
+    diagnosedProjectMismatchError,
     projectRoot,
     shouldDiagnoseProjectState,
   );


### PR DESCRIPTION
## Summary
- CLI connection failures caused by a stale port now identify whether the target Unity Editor is absent, starting, or missing its server.
- Error output includes the next recovery command an AI agent can execute.

## User Impact
- A `PROJECT_MISMATCH` error is converted to a more actionable state when the target project can be inspected safely.
- Explicit `--port` usage and uncertain process inspection preserve the existing mismatch behavior.

## Changes
- Diagnose `ProjectMismatchError` using target-process detection and the startup lock.
- Route the shared final error path used by tool execution, tool listing, and tool synchronization through the diagnosis.
- Update Unity server and stale-port guidance with watchdog retry and `uloop launch -r <path>` instructions.

## Verification
- `npm run test:unit`: 23 suites, 293 tests passed.
- `npm run test:cli`: 24 suites, 338 tests passed.
- Changed-file ESLint: 0 errors, 4 existing security warnings.
- `npm run build`: passed.
- `npm run knip`: passed.
- Full `npm run lint` remains blocked by an existing Prettier error in `src/__tests__/launch-command.test.ts:161`, outside this change.
