### PR TITLE
chore: fix launch command test formatting

### DIFF
--- a/Packages/src/Cli~/src/__tests__/launch-command.test.ts
+++ b/Packages/src/Cli~/src/__tests__/launch-command.test.ts
@@ -158,8 +158,7 @@ describe('launch command', () => {
 
   it('shows startup spinner before orchestrateLaunch resolves', async () => {
     let resolveLaunch:
-      | ((value: { action: 'focused'; projectPath: string; pid: number }) => void)
-      | undefined;
+      ((value: { action: 'focused'; projectPath: string; pid: number }) => void) | undefined;
     orchestrateLaunchMock.mockReturnValue(
       new Promise((resolve) => {
         resolveLaunch = resolve;


### PR DESCRIPTION
## Summary
- Fix the existing Prettier violation in the launch command test.

## Verification
- `npx prettier --check src/__tests__/launch-command.test.ts`: passed.
- `npm run test:unit -- --runTestsByPath src/__tests__/launch-command.test.ts`: 7 passed.
- `npm run lint`: passed with existing security warnings and 0 errors.
- `git diff origin/main...HEAD`: contains only `src/__tests__/launch-command.test.ts`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

