### PR TITLE
feat: Pause point responses now show the actual resolved source line

### DIFF
--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -784,6 +784,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.Success, Is.True);
             Assert.That(response.Id, Is.EqualTo($"{FixtureFilePath}:{FixtureLine}"));
             Assert.That(response.ResolvedLine, Is.EqualTo(FixtureLine));
+            Assert.That(response.ResolvedLineText, Is.EqualTo("return sum;"));
             Assert.That(response.ResolvedMethod, Does.Contain("Add"));
 
             EnableBySourceLocationFixture fixture = new();

--- a/Assets/Tests/Editor/SourcePausePointSourceLineReaderTests.cs
+++ b/Assets/Tests/Editor/SourcePausePointSourceLineReaderTests.cs
@@ -1,0 +1,66 @@
+using System.IO;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies SourcePausePointSourceLineReader reads the trimmed text of a specific source
+    /// line from disk, and degrades to an empty string for missing files or out-of-range lines.
+    /// </summary>
+    [TestFixture]
+    public sealed class SourcePausePointSourceLineReaderTests
+    {
+        private string _tempFilePath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempFilePath = Path.GetTempFileName();
+            File.WriteAllLines(_tempFilePath, new[] { "line one", "    line two   ", "line three" });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            File.Delete(_tempFilePath);
+        }
+
+        [Test]
+        public void ReadLineText_WhenLineExists_ReturnsTrimmedText()
+        {
+            // Verifies the requested 1-based line is read and surrounding whitespace is trimmed.
+            string result = SourcePausePointSourceLineReader.ReadLineText(_tempFilePath, 2);
+
+            Assert.That(result, Is.EqualTo("line two"));
+        }
+
+        [Test]
+        public void ReadLineText_WhenLineNumberExceedsFileLength_ReturnsEmpty()
+        {
+            // Verifies a line number past the end of the file degrades to an empty string instead of throwing.
+            string result = SourcePausePointSourceLineReader.ReadLineText(_tempFilePath, 999);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void ReadLineText_WhenFileDoesNotExist_ReturnsEmpty()
+        {
+            // Verifies a missing file degrades to an empty string instead of throwing.
+            string result = SourcePausePointSourceLineReader.ReadLineText("/nonexistent/path/does-not-exist.cs", 1);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void ReadLineText_WhenLineNumberIsZeroOrNegative_ReturnsEmpty()
+        {
+            // Verifies non-positive line numbers (invalid 1-based input) degrade to an empty string.
+            Assert.That(SourcePausePointSourceLineReader.ReadLineText(_tempFilePath, 0), Is.Empty);
+            Assert.That(SourcePausePointSourceLineReader.ReadLineText(_tempFilePath, -1), Is.Empty);
+        }
+    }
+}

--- a/Assets/Tests/Editor/SourcePausePointSourceLineReaderTests.cs.meta
+++ b/Assets/Tests/Editor/SourcePausePointSourceLineReaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a186e19a9d9426baad3d8fc1bdd1439
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/PausePointTools.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,6 +49,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
     {
         public string Id { get; set; } = string.Empty;
         public int ResolvedLine { get; set; }
+        public string ResolvedLineText { get; set; } = string.Empty;
         public string ResolvedMethod { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
         public bool IsEnabled { get; set; }
@@ -354,9 +356,20 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 parameters.MaxHistory);
             PausePointResponse response = PausePointResponse.FromSnapshot(snapshot);
             response.ResolvedLine = resolveResult.Resolution.ResolvedLine;
+            response.ResolvedLineText = ReadResolvedLineText(parameters.File, resolveResult.Resolution.ResolvedLine);
             response.ResolvedMethod = resolveResult.Resolution.MethodDisplayName;
             response.Warning = MergeWarnings(CreateEnableWarning(), patchResult.Warning);
             return response;
+        }
+
+        // The resolved line can be rounded forward from the requested line (the Resolver picks
+        // the closest sequence point on or after it), so returning the actual source text lets
+        // the caller notice a mismatch immediately instead of assuming the requested line hit.
+        private static string ReadResolvedLineText(string requestedFile, int resolvedLine)
+        {
+            string normalizedFile = SourcePausePointPathNormalizer.ToForwardSlashes(requestedFile);
+            string absoluteFilePath = Path.Combine(UnityCliLoopPathResolver.GetProjectRoot(), normalizedFile);
+            return SourcePausePointSourceLineReader.ReadLineText(absoluteFilePath, resolvedLine);
         }
 
         // The derived id must use the originally requested file/line (not the resolved/rounded

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointSourceLineReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointSourceLineReader.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 {
@@ -15,13 +16,8 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 return string.Empty;
             }
 
-            string[] lines = File.ReadAllLines(absoluteFilePath);
-            if (lineNumber > lines.Length)
-            {
-                return string.Empty;
-            }
-
-            return lines[lineNumber - 1].Trim();
+            string line = File.ReadLines(absoluteFilePath).Skip(lineNumber - 1).FirstOrDefault();
+            return line != null ? line.Trim() : string.Empty;
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointSourceLineReader.cs
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointSourceLineReader.cs
@@ -1,0 +1,27 @@
+using System.IO;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Reads a single source line's trimmed text from disk, so a pause-point response can show
+    /// the AI agent exactly what code the resolved (possibly rounded-forward) line number maps to.
+    /// </summary>
+    internal static class SourcePausePointSourceLineReader
+    {
+        public static string ReadLineText(string absoluteFilePath, int lineNumber)
+        {
+            if (string.IsNullOrEmpty(absoluteFilePath) || lineNumber <= 0 || !File.Exists(absoluteFilePath))
+            {
+                return string.Empty;
+            }
+
+            string[] lines = File.ReadAllLines(absoluteFilePath);
+            if (lineNumber > lines.Length)
+            {
+                return string.Empty;
+            }
+
+            return lines[lineNumber - 1].Trim();
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointSourceLineReader.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/PausePoint/SourcePausePointSourceLineReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54ab67e3725046758bf545af7361d859
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- `enable-pause-point`'s response now includes the actual source text of the resolved line, so a pause point that got rounded forward to a different line than requested is immediately visible.

## User Impact
- Before: when a requested `--line` had no sequence point and the resolver rounded forward to the next executable line, the response only showed the line number. Confirming what code that number actually points to required manually opening the file.
- After: the response includes `ResolvedLineText`, the trimmed text of the resolved line, next to the existing `ResolvedLine` and `ResolvedMethod` fields — a rounding mismatch is visible without leaving the response.

## Changes
- `SourcePausePointSourceLineReader`: reads a single line's trimmed text from disk, degrading to an empty string for missing files or out-of-range lines.
- `PausePointTools.EnableBySourceLocation`: sets `ResolvedLineText` on the response using the resolved line number.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>` → 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path <repo> --filter-type regex --filter-value "PausePoint" --timeout-seconds 240` → 178/178 passed
- `dist/darwin-arm64/uloop enable-pause-point --file "Assets/Tests/Editor/PausePointToolsFixture.cs" --line 12` against a running Unity Editor → response includes `"ResolvedLineText": "return sum;"`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

