### PR TITLE
fix: Paused pause points no longer risk auto-resuming mid-inspection

### DIFF
--- a/Assets/Tests/Editor/PausePointCaptureModeTests.cs
+++ b/Assets/Tests/Editor/PausePointCaptureModeTests.cs
@@ -125,13 +125,18 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         /// <summary>
-        /// Verifies expiry after a continuous hit reports a capture-window message and retains history.
+        /// Verifies expiry after a continuous hit's pause is resumed reports a capture-window
+        /// message and retains history. The hit itself freezes the capture window while the
+        /// Editor stays paused for inspection, so time elapsing before resume must not count.
         /// </summary>
         [Test]
-        public void Expire_WhenContinuousMarkerHasHits_DisarmsAndPreservesHistory()
+        public void Expire_WhenContinuousMarkerHasHitsAndIsResumed_DisarmsAndPreservesHistory()
         {
             UloopPausePointRegistry.Enable("jump", 1, UloopPausePointCaptureMode.Continuous, 20);
             UloopPausePointRegistry.Hit("jump");
+            _nowUtc = _nowUtc.AddSeconds(5);
+            UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
+            UloopPausePointRegistry.ApplyPendingClientDisconnectResume();
             _nowUtc = _nowUtc.AddSeconds(2);
 
             UloopPausePointSnapshot snapshot = UloopPausePointRegistry.GetStatus("jump");

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -366,6 +366,44 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void ClosePauseWindowIfEditorResumedExternally_WhenEditorUnpausedOutsideRegistry_ClosesWindowAndCreditsTime()
+        {
+            // Verifies an external unpause (control-play-mode Play/Stop, or the Editor's own
+            // pause button) that never calls back into Clear/ClearAll/ResumeEditorPause still
+            // closes the open freeze window, so the countdown resumes instead of staying frozen
+            // forever and expiry does not later over-credit game-running time.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+            _nowUtc = _nowUtc.AddSeconds(20);
+            _pauseController.ResumeExternally();
+
+            UloopPausePointRegistry.ClosePauseWindowIfEditorResumedExternally();
+
+            _nowUtc = _nowUtc.AddSeconds(25);
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
+            Assert.That(UloopPausePointRegistry.GetStatus("jump").Status, Is.EqualTo(UloopPausePointStatus.Hit));
+
+            _nowUtc = _nowUtc.AddSeconds(6);
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
+            Assert.That(UloopPausePointRegistry.GetStatus("jump").Status, Is.EqualTo(UloopPausePointStatus.Expired));
+        }
+
+        [Test]
+        public void ClosePauseWindowIfEditorResumedExternally_WhileStillPaused_KeepsWindowOpen()
+        {
+            // Verifies the close only triggers once the controller reports Unpaused; a stray call
+            // while still genuinely paused must not clear the freeze early.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+            _nowUtc = _nowUtc.AddSeconds(31);
+
+            UloopPausePointRegistry.ClosePauseWindowIfEditorResumedExternally();
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
+
+            Assert.That(UloopPausePointRegistry.GetStatus("jump").Status, Is.EqualTo(UloopPausePointStatus.Hit));
+        }
+
+        [Test]
         public void ResumeEditorPauseForClientDisconnect_WhenPaused_ShouldResumeOnMainThreadApply()
         {
             // Verifies disconnect only arms a pending flag; main-thread apply resumes once (Option B).
@@ -1044,6 +1082,13 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             public void Resume()
             {
                 ResumeCount++;
+                IsPaused = false;
+            }
+
+            // Simulates an external unpause (control-play-mode's Play/Stop, or the Editor's own
+            // pause button) that never calls back into this registry's Resume().
+            public void ResumeExternally()
+            {
                 IsPaused = false;
             }
         }

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -314,9 +314,10 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
-        public void ApplyCaptureWindowExpirations_WhenHitPastTimeout_ShouldExpireAndResume()
+        public void ApplyCaptureWindowExpirations_WhenHitPastTimeoutWhilePaused_DoesNotExpireUntilResumed()
         {
-            // Verifies abandoned SingleShot hits still expire at ExpiresAtUtc and resume without a Clear poll.
+            // Verifies a hit's own Editor pause freezes the capture window countdown, so an
+            // abandoned SingleShot hit does not expire mid-inspection even past its original timeout.
             UloopPausePointRegistry.Enable("jump", 30);
             UloopPausePoint.Pause("jump");
             _nowUtc = _nowUtc.AddSeconds(31);
@@ -324,8 +325,44 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             UloopPausePointRegistry.ApplyCaptureWindowExpirations();
 
             UloopPausePointSnapshot status = UloopPausePointRegistry.GetStatus("jump");
-            Assert.That(status.Status, Is.EqualTo(UloopPausePointStatus.Expired));
+            Assert.That(status.Status, Is.EqualTo(UloopPausePointStatus.Hit));
+            Assert.That(_pauseController.IsPaused, Is.True);
+        }
+
+        [Test]
+        public void ApplyCaptureWindowExpirations_AfterResumeFollowingFrozenPause_ExpiresOnlyAfterCreditedDeadline()
+        {
+            // Verifies the frozen duration is credited back to ExpiresAtUtc on resume: expiry
+            // does not fire at the original deadline, only after the extended one elapses.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+            _nowUtc = _nowUtc.AddSeconds(20);
+            UloopPausePointRegistry.ResumeEditorPauseForClientDisconnect();
+            UloopPausePointRegistry.ApplyPendingClientDisconnectResume();
             Assert.That(_pauseController.IsPaused, Is.False);
+
+            _nowUtc = _nowUtc.AddSeconds(25);
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
+            Assert.That(UloopPausePointRegistry.GetStatus("jump").Status, Is.EqualTo(UloopPausePointStatus.Hit));
+
+            _nowUtc = _nowUtc.AddSeconds(6);
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
+            Assert.That(UloopPausePointRegistry.GetStatus("jump").Status, Is.EqualTo(UloopPausePointStatus.Expired));
+        }
+
+        [Test]
+        public void ApplyCaptureWindowExpirations_WhenAnotherMarkerHoldsEditorPaused_FreezesUnrelatedMarkerToo()
+        {
+            // Verifies the freeze is registry-wide: an unrelated marker's countdown is also
+            // frozen for as long as any hit is holding the Editor paused for inspection.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointRegistry.Enable("dash", 10);
+            UloopPausePoint.Pause("jump");
+
+            _nowUtc = _nowUtc.AddSeconds(15);
+            UloopPausePointRegistry.ApplyCaptureWindowExpirations();
+
+            Assert.That(UloopPausePointRegistry.GetStatus("dash").Status, Is.EqualTo(UloopPausePointStatus.Enabled));
         }
 
         [Test]

--- a/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointEntry.cs
@@ -37,7 +37,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         public string Mode { get; }
         public int MaxHistory { get; }
         public DateTime EnabledAtUtc { get; }
-        public DateTime ExpiresAtUtc { get; }
+        public DateTime ExpiresAtUtc { get; private set; }
         public int Generation { get; }
         public string Status { get; private set; }
         public bool IsEnabled { get; private set; }
@@ -81,6 +81,26 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 ? "Pause point expired before it was hit."
                 : $"Pause point capture window expired after {HitCount} hit(s); capture history is preserved.";
             return true;
+        }
+
+        // Pushes ExpiresAtUtc forward by the length of an Editor-paused window, so the countdown
+        // does not keep running while a hit has stopped the Editor for inspection. Clamps the
+        // window start to EnabledAtUtc so a pause that began before this entry existed does not
+        // over-credit it.
+        public void ExtendExpiryForPause(DateTime pauseWindowStartUtc, DateTime pauseWindowEndUtc)
+        {
+            if (Status == UloopPausePointStatus.Cleared || Status == UloopPausePointStatus.Expired)
+            {
+                return;
+            }
+
+            DateTime effectiveStart = pauseWindowStartUtc > EnabledAtUtc ? pauseWindowStartUtc : EnabledAtUtc;
+            if (pauseWindowEndUtc <= effectiveStart)
+            {
+                return;
+            }
+
+            ExpiresAtUtc += pauseWindowEndUtc - effectiveStart;
         }
 
         public void MarkCleared(string clearedReason, string message = "Pause point cleared.")

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
@@ -27,7 +27,10 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 return;
             }
 
-            // Why while paused only: abandoned Hit windows must expire without a CLI poll.
+            // Why while paused only: abandoned Hit windows must expire without a CLI poll. This is
+            // a no-op while the pause was caused by a hit still holding the freeze window open
+            // (see UloopPausePointRegistry.TryExpire); it still matters for a manually-paused
+            // Editor, where an unrelated marker's timeout can still elapse.
             UloopPausePointRegistry.ApplyCaptureWindowExpirations();
         }
 

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRawCaptureLifecycle.cs
@@ -22,6 +22,11 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             // the pending flag must still be consumed on the main thread.
             UloopPausePointRegistry.ApplyPendingClientDisconnectResume();
 
+            // Why before the isPaused gate: control-play-mode's Play/Stop and the Editor's own
+            // pause button unpause without ever calling back into the registry, so an open pause
+            // window must be detected and closed here instead of only through Clear/ClearAll/etc.
+            UloopPausePointRegistry.ClosePauseWindowIfEditorResumedExternally();
+
             if (!EditorApplication.isPaused)
             {
                 return;

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -27,6 +27,11 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         // Why Interlocked: disconnect monitor / DisconnectAllClients run on the thread pool.
         private static int _pendingClientDisconnectResume;
         private static UloopPausePointSnapshot _latestHitSnapshot;
+        // Set when a hit pauses the Editor (see HitCore), cleared when ResumeEditorPause runs.
+        // While set, no entry's capture window is allowed to expire (see TryExpire): a marker's
+        // own hit freezes every marker's countdown for the duration of the inspection pause,
+        // and the frozen duration is credited back to each entry's ExpiresAtUtc on resume.
+        private static DateTime? _pauseWindowStartUtc;
         // One input can hit several markers in the same frame; tools need the full list,
         // not just the latest hit, to report every marker that interrupted them.
         private static readonly List<UloopPausePointSnapshot> _hitSnapshots = new();
@@ -77,7 +82,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
             UloopPausePointEntry entry = Entries[id];
             // Resolve expiry first so a clear after the timeout reports "expired", not a normal clear.
-            entry.ExpireIfNeeded(now);
+            TryExpire(entry, now);
             string message = !entry.IsEnabled && entry.Status == UloopPausePointStatus.Hit
                 ? "Pause point was already hit (auto-disarmed); nothing to clear."
                 : entry.Status switch
@@ -113,7 +118,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
                 }
 
                 // Resolve expiry first so ClearAll after timeout keeps AfterExpired visibility.
-                entry.ExpireIfNeeded(now);
+                TryExpire(entry, now);
                 clearedIds.Add(entry.Id);
                 entry.MarkCleared(clearedReason);
             }
@@ -139,7 +144,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
 
             UloopPausePointEntry entry = Entries[id];
-            if (entry.ExpireIfNeeded(now))
+            if (TryExpire(entry, now))
             {
                 ResumeEditorPause();
             }
@@ -203,7 +208,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             }
 
             UloopPausePointEntry entry = Entries[id];
-            if (entry.ExpireIfNeeded(now))
+            if (TryExpire(entry, now))
             {
                 ResumeEditorPause();
                 return entry.ToSnapshot(now, _pauseController);
@@ -227,6 +232,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             if (entry.Mode != UloopPausePointCaptureMode.Trace)
             {
                 _pauseController.Pause();
+                _pauseWindowStartUtc ??= now;
             }
 
             int hitSequence = ++_nextHitSequence;
@@ -273,7 +279,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             bool anyExpired = false;
             foreach (UloopPausePointEntry entry in Entries.Values)
             {
-                if (entry.ExpireIfNeeded(now))
+                if (TryExpire(entry, now))
                 {
                     anyExpired = true;
                 }
@@ -319,7 +325,33 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         private static void ResumeEditorPause()
         {
+            if (_pauseWindowStartUtc.HasValue)
+            {
+                DateTime pauseWindowStart = _pauseWindowStartUtc.Value;
+                DateTime pauseWindowEnd = NowUtc();
+                _pauseWindowStartUtc = null;
+                foreach (UloopPausePointEntry entry in Entries.Values)
+                {
+                    entry.ExtendExpiryForPause(pauseWindowStart, pauseWindowEnd);
+                }
+            }
+
             _pauseController.Resume();
+        }
+
+        // While a hit has the Editor paused, no entry may expire: the countdown is frozen for
+        // everyone until ResumeEditorPause credits the frozen duration back (see
+        // ExtendExpiryForPause). Without this gate, TryExpire callers would still expire a
+        // different marker mid-inspection even though wall-clock time during the pause should
+        // not count against it.
+        private static bool TryExpire(UloopPausePointEntry entry, DateTime now)
+        {
+            if (_pauseWindowStartUtc.HasValue)
+            {
+                return false;
+            }
+
+            return entry.ExpireIfNeeded(now);
         }
 
         // Drops the id's own hit-history entry and, if it currently owns the latest hit, that
@@ -365,6 +397,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _nextHitSequence = 0;
             _latestHitSnapshot = null;
             _hitSnapshots.Clear();
+            _pauseWindowStartUtc = null;
             Interlocked.Exchange(ref _pendingClientDisconnectResume, 0);
             _pauseController = new UnityEditorPausePointPauseController();
             _nowProvider = () => DateTime.UtcNow;

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -325,23 +325,48 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
         private static void ResumeEditorPause()
         {
-            if (_pauseWindowStartUtc.HasValue)
-            {
-                DateTime pauseWindowStart = _pauseWindowStartUtc.Value;
-                DateTime pauseWindowEnd = NowUtc();
-                _pauseWindowStartUtc = null;
-                foreach (UloopPausePointEntry entry in Entries.Values)
-                {
-                    entry.ExtendExpiryForPause(pauseWindowStart, pauseWindowEnd);
-                }
-            }
-
+            CreditPauseWindowAndClose(NowUtc());
             _pauseController.Resume();
         }
 
+        /// <summary>
+        /// Closes an open pause window when the Editor was unpaused through a path that never
+        /// calls back into this registry - control-play-mode's Play/Stop
+        /// (<c>ControlPlayModeUseCase</c> sets <c>EditorApplication.isPaused</c> directly) or the
+        /// Editor's own pause button. Without this, a window left open by such an external resume
+        /// would freeze every marker's countdown forever and later over-credit the elapsed
+        /// wall-clock time back onto ExpiresAtUtc. Call every main-thread Editor update.
+        /// </summary>
+        public static void ClosePauseWindowIfEditorResumedExternally()
+        {
+            if (!_pauseWindowStartUtc.HasValue || _pauseController.IsPaused)
+            {
+                return;
+            }
+
+            CreditPauseWindowAndClose(NowUtc());
+        }
+
+        // Credits the frozen duration (now - max(pauseWindowStart, EnabledAtUtc)) back onto every
+        // entry's ExpiresAtUtc and closes the window. A no-op when no window is open.
+        private static void CreditPauseWindowAndClose(DateTime now)
+        {
+            if (!_pauseWindowStartUtc.HasValue)
+            {
+                return;
+            }
+
+            DateTime pauseWindowStart = _pauseWindowStartUtc.Value;
+            _pauseWindowStartUtc = null;
+            foreach (UloopPausePointEntry entry in Entries.Values)
+            {
+                entry.ExtendExpiryForPause(pauseWindowStart, now);
+            }
+        }
+
         // While a hit has the Editor paused, no entry may expire: the countdown is frozen for
-        // everyone until ResumeEditorPause credits the frozen duration back (see
-        // ExtendExpiryForPause). Without this gate, TryExpire callers would still expire a
+        // everyone until the open window is closed and credits the frozen duration back (see
+        // CreditPauseWindowAndClose). Without this gate, TryExpire callers would still expire a
         // different marker mid-inspection even though wall-clock time during the pause should
         // not count against it.
         private static bool TryExpire(UloopPausePointEntry entry, DateTime now)


### PR DESCRIPTION
## Summary
- A pause point that stops the Editor for inspection no longer risks auto-resuming mid-inspection: the capture window's timeout is now frozen for as long as the Editor stays paused because of a hit.

## User Impact
- Before: after a hit paused the Editor, the marker's original timeout kept counting down against wall-clock time. Spending more than the configured timeout inspecting the paused state (reading captured variables, poking at the scene) could hit the deadline and auto-resume Unity out from under the investigation, silently discarding the paused window.
- After: the countdown freezes the moment a hit pauses the Editor, for every enabled marker, not just the one that hit. Resuming (via Clear, a client disconnect, or a fresh status poll after the freeze ends) credits the frozen duration back, so no time spent paused counts against any marker's timeout.

## Changes
- `UloopPausePointRegistry`: tracks a pause-window start timestamp when a hit pauses the Editor; rejects all expiry while that window is open; credits the frozen duration back onto every entry's `ExpiresAtUtc` on resume.
- `UloopPausePointEntry`: `ExpiresAtUtc` becomes mutable via a new `ExtendExpiryForPause` method used only by the registry.
- Updated two existing tests whose expectations assumed a marker could expire while its own pause was still open; added tests covering the freeze itself, credited-time expiry after resume, and the registry-wide (not just same-marker) scope of the freeze.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>` → 0 errors / 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path <repo> --filter-type regex --filter-value "PausePoint" --timeout-seconds 240` → 180/180 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

