### PR TITLE
feat: execute-dynamic-code now reports Editor pause state and the active pause point

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodePauseStateResolverTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodePauseStateResolverTests.cs
@@ -1,0 +1,50 @@
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
+{
+    /// <summary>
+    /// Test fixture that verifies ExecuteDynamicCodePauseStateResolver behavior.
+    /// </summary>
+    [TestFixture]
+    public class ExecuteDynamicCodePauseStateResolverTests
+    {
+        [Test]
+        public void Resolve_WhenEditorIsNotPaused_ReturnsFalseAndEmptyIdRegardlessOfRegistryValue()
+        {
+            // Tests that a stale or racy non-empty registry id never leaks out while the real
+            // Editor reports itself as unpaused (the up-to-one-frame external-unpause window).
+            (bool editorPaused, string activePausePointId) = ExecuteDynamicCodePauseStateResolver.Resolve(
+                editorIsPaused: false, registryActivePausePointId: "jump");
+
+            Assert.That(editorPaused, Is.False);
+            Assert.That(activePausePointId, Is.Empty);
+        }
+
+        [Test]
+        public void Resolve_WhenEditorIsPausedByAPausePoint_ReturnsTrueAndThatMarkerId()
+        {
+            // Tests the common case: a pause point hit paused the Editor, so the response should
+            // surface both the paused flag and which marker caused it.
+            (bool editorPaused, string activePausePointId) = ExecuteDynamicCodePauseStateResolver.Resolve(
+                editorIsPaused: true, registryActivePausePointId: "jump");
+
+            Assert.That(editorPaused, Is.True);
+            Assert.That(activePausePointId, Is.EqualTo("jump"));
+        }
+
+        [Test]
+        public void Resolve_WhenEditorIsPausedForAnUnrelatedReason_ReturnsTrueAndEmptyId()
+        {
+            // Tests that a manual pause (not caused by any pause point) still reports
+            // EditorPaused=true, with ActivePausePointId left empty since the registry has no
+            // active freeze window in that case.
+            (bool editorPaused, string activePausePointId) = ExecuteDynamicCodePauseStateResolver.Resolve(
+                editorIsPaused: true, registryActivePausePointId: string.Empty);
+
+            Assert.That(editorPaused, Is.True);
+            Assert.That(activePausePointId, Is.Empty);
+        }
+    }
+}

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodePauseStateResolverTests.cs.meta
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodePauseStateResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a756f23d87cb4fbba904288af380dd5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
@@ -775,10 +775,12 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         [Test]
-        public async Task ExecuteAsync_WhenAPausePointHitHoldsTheEditorPaused_ReportsThatMarkerId()
+        public async Task ExecuteAsync_WhenRegistryReportsAnActiveIdButTheRealEditorIsNotPaused_StaysEmpty()
         {
-            // Tests that a pause point interrupting an in-flight execution is surfaced on the
-            // response, so an agent recognizes a post-interrupt state instead of a stale bug.
+            // Tests the ExecuteDynamicCodePauseStateResolver contract end to end: this test's own
+            // process never actually pauses EditorApplication, so even though a fake pause
+            // controller drives the registry into reporting an active pause point id, the
+            // response must not surface it while the real Editor is unpaused.
             MarkForegroundWarmupCompleted();
             FakePausePointPauseController pauseController = new();
             UloopPausePointRegistry.ConfigureForTests(pauseController, () => DateTime.UtcNow);
@@ -794,7 +796,8 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                     new ExecuteDynamicCodeSchema { Code = "return 1;", CompileOnly = false },
                     CancellationToken.None);
 
-                Assert.That(response.ActivePausePointId, Is.EqualTo("jump"));
+                Assert.That(response.EditorPaused, Is.False);
+                Assert.That(response.ActivePausePointId, Is.Empty);
             }
             finally
             {

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
@@ -759,6 +760,49 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         [Test]
+        public async Task ExecuteAsync_WhenNoPausePointHasPausedTheEditor_ReturnsEmptyActivePausePointId()
+        {
+            // Tests the default (no pause-point interrupt) path reports an empty ActivePausePointId.
+            MarkForegroundWarmupCompleted();
+            FakeDynamicCodeExecutionRuntime runtime = new(
+                new ExecutionResult { Success = true, Result = "ok" });
+            ExecuteDynamicCodeUseCase useCase = new(runtime);
+            ExecuteDynamicCodeResponse response = await useCase.ExecuteAsync(
+                new ExecuteDynamicCodeSchema { Code = "return 1;", CompileOnly = false },
+                CancellationToken.None);
+
+            Assert.That(response.ActivePausePointId, Is.Empty);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WhenAPausePointHitHoldsTheEditorPaused_ReportsThatMarkerId()
+        {
+            // Tests that a pause point interrupting an in-flight execution is surfaced on the
+            // response, so an agent recognizes a post-interrupt state instead of a stale bug.
+            MarkForegroundWarmupCompleted();
+            FakePausePointPauseController pauseController = new();
+            UloopPausePointRegistry.ConfigureForTests(pauseController, () => DateTime.UtcNow);
+            try
+            {
+                UloopPausePointRegistry.Enable("jump", 30);
+                UloopPausePointRegistry.Hit("jump");
+
+                FakeDynamicCodeExecutionRuntime runtime = new(
+                    new ExecutionResult { Success = true, Result = "ok" });
+                ExecuteDynamicCodeUseCase useCase = new(runtime);
+                ExecuteDynamicCodeResponse response = await useCase.ExecuteAsync(
+                    new ExecuteDynamicCodeSchema { Code = "return 1;", CompileOnly = false },
+                    CancellationToken.None);
+
+                Assert.That(response.ActivePausePointId, Is.EqualTo("jump"));
+            }
+            finally
+            {
+                UloopPausePointRegistry.ResetForTests();
+            }
+        }
+
+        [Test]
         public async Task ExecuteAsync_WhenWarmupThrowsObjectDisposedException_ContinuesAsSilentNoOp()
         {
             // Verifies Warm-path ODE is incomplete warm (no CLI error), while Execute still succeeds afterward.
@@ -942,6 +986,22 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
                 {
                     _isMainThread = false;
                 }
+            }
+        }
+
+        private sealed class FakePausePointPauseController : IUloopPausePointPauseController
+        {
+            public bool IsPlaying => true;
+            public bool IsPaused { get; private set; }
+
+            public void Pause()
+            {
+                IsPaused = true;
+            }
+
+            public void Resume()
+            {
+                IsPaused = false;
             }
         }
 

--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -404,6 +404,38 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void GetActivePausePointId_WhenNoMarkerHasPausedTheEditor_ReturnsEmpty()
+        {
+            // Verifies the read-only signal used by execute-dynamic-code stays empty before any hit.
+            UloopPausePointRegistry.Enable("jump", 30);
+
+            Assert.That(UloopPausePointRegistry.GetActivePausePointId(), Is.Empty);
+        }
+
+        [Test]
+        public void GetActivePausePointId_WhileAMarkerHitHoldsTheEditorPaused_ReturnsThatMarkerId()
+        {
+            // Verifies execute-dynamic-code can attribute an in-progress pause to the hitting marker.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            Assert.That(UloopPausePointRegistry.GetActivePausePointId(), Is.EqualTo("jump"));
+        }
+
+        [Test]
+        public void GetActivePausePointId_AfterTheFreezeWindowIsClosed_ReturnsEmpty()
+        {
+            // Verifies the signal clears once the freeze window closes (Clear here), not just once
+            // the Editor itself unpauses, so a resumed session never keeps reporting a stale id.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePoint.Pause("jump");
+
+            UloopPausePointRegistry.Clear("jump");
+
+            Assert.That(UloopPausePointRegistry.GetActivePausePointId(), Is.Empty);
+        }
+
+        [Test]
         public void ResumeEditorPauseForClientDisconnect_WhenPaused_ShouldResumeOnMainThreadApply()
         {
             // Verifies disconnect only arms a pending flag; main-thread apply resumes once (Option B).

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodePauseStateResolver.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodePauseStateResolver.cs
@@ -1,0 +1,23 @@
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Combines the Editor's pause flag with the registry's active-pause-point signal into the
+    /// pair exposed on ExecuteDynamicCodeResponse. Kept as a pure, Editor-API-free method so the
+    /// contract ("ActivePausePointId is only ever non-empty while EditorPaused is true") can be
+    /// unit-tested without a real Unity Editor pause.
+    /// </summary>
+    internal static class ExecuteDynamicCodePauseStateResolver
+    {
+        public static (bool EditorPaused, string ActivePausePointId) Resolve(
+            bool editorIsPaused, string registryActivePausePointId)
+        {
+            // Why: a pause point's freeze window can still be open for up to one Editor frame
+            // after an external unpause closes it (see
+            // UloopPausePointRegistry.ClosePauseWindowIfEditorResumedExternally); without this
+            // gate, that narrow window could report a non-empty id while EditorPaused is false.
+            return editorIsPaused
+                ? (true, registryActivePausePointId ?? string.Empty)
+                : (false, string.Empty);
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodePauseStateResolver.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodePauseStateResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67f2e7bb32ae24e929dfc90e057d2b27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeResponse.cs
@@ -60,6 +60,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public string[] NextActions { get; set; }
 
         /// <summary>
+        /// Whether the Editor is paused as this response is returned. Lets an agent recognize a
+        /// post-interrupt state (e.g. a pause point hit during this execution) instead of mistaking
+        /// stale-looking results for a bug.
+        /// </summary>
+        public bool EditorPaused { get; set; } = false;
+
+        /// <summary>
+        /// The pause point id responsible for the current pause, when EditorPaused is caused by a
+        /// pause-point hit. Empty when the Editor is not paused, or is paused for an unrelated reason.
+        /// </summary>
+        public string ActivePausePointId { get; set; } = string.Empty;
+
+        /// <summary>
         /// Lightweight internal timings for benchmark comparison.
         /// </summary>
         [JsonProperty("Timings")]
@@ -99,6 +112,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public bool ShouldSerializeNextActions()
         {
             return NextActions != null && NextActions.Length > 0;
+        }
+
+        public bool ShouldSerializeEditorPaused()
+        {
+            return EditorPaused;
+        }
+
+        public bool ShouldSerializeActivePausePointId()
+        {
+            return !string.IsNullOrEmpty(ActivePausePointId);
         }
     }
     

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using UnityEditor;
+
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -72,6 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         ? new List<string>(finalResult.Timings)
                         : cancelledResponse.Timings;
                     cancelledResponse.EmitTimingsInJsonResponse = parameters.IncludeTimings;
+                    ApplyPauseState(cancelledResponse);
                     return cancelledResponse;
                 }
 
@@ -80,6 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ExecuteDynamicCodeResponse restartingResponse =
                         DynamicCodeExecutionResponseFactory.CreateRuntimeRestartingResponse();
                     restartingResponse.EmitTimingsInJsonResponse = parameters.IncludeTimings;
+                    ApplyPauseState(restartingResponse);
                     return restartingResponse;
                 }
 
@@ -90,14 +95,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 bool domainReloadWaitRequired =
                     await domainReloadWaitSignal.ShouldWaitAsync(cancellationToken).ConfigureAwait(false);
                 response.DomainReloadWaitRequired = domainReloadWaitRequired;
+                ApplyPauseState(response);
                 return response;
             }
             catch (OperationCanceledException)
             {
                 ExecuteDynamicCodeResponse response = DynamicCodeExecutionResponseFactory.CreateCancelledResponse();
                 response.EmitTimingsInJsonResponse = parameters?.IncludeTimings ?? false;
+                ApplyPauseState(response);
                 return response;
             }
+        }
+
+        // Lets an agent recognize a post-interrupt state (e.g. a pause point hit mid-execution)
+        // instead of mistaking a stale-looking result for a bug. ActivePausePointId stays empty
+        // when the Editor is paused for a reason unrelated to a pause point.
+        private static void ApplyPauseState(ExecuteDynamicCodeResponse response)
+        {
+            response.EditorPaused = EditorApplication.isPaused;
+            response.ActivePausePointId = UloopPausePointRegistry.GetActivePausePointId();
         }
 
         private static void LogExecutionStart(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -112,8 +112,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // when the Editor is paused for a reason unrelated to a pause point.
         private static void ApplyPauseState(ExecuteDynamicCodeResponse response)
         {
-            response.EditorPaused = EditorApplication.isPaused;
-            response.ActivePausePointId = UloopPausePointRegistry.GetActivePausePointId();
+            (bool editorPaused, string activePausePointId) = ExecuteDynamicCodePauseStateResolver.Resolve(
+                EditorApplication.isPaused, UloopPausePointRegistry.GetActivePausePointId());
+            response.EditorPaused = editorPaused;
+            response.ActivePausePointId = activePausePointId;
         }
 
         private static void LogExecutionStart(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:214998e563c124e8a88199b2dd1f522d",
         "GUID:5c4588558a3624eacbce0f50007cf1eb",
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
+++ b/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateKeyboard.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Infrastructure")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -262,6 +262,18 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             return _latestHitSnapshot;
         }
 
+        /// <summary>
+        /// Read-only signal for callers outside this registry (e.g. execute-dynamic-code) that
+        /// need to know whether the Editor is currently paused because of a pause-point hit, and
+        /// which marker's hit is responsible. Reuses the same _pauseWindowStartUtc window that
+        /// gates expiry instead of introducing new tracking state. Returns empty when no window
+        /// is open, even if the Editor happens to be paused for an unrelated reason.
+        /// </summary>
+        public static string GetActivePausePointId()
+        {
+            return _pauseWindowStartUtc.HasValue ? _latestHitSnapshot?.Id ?? string.Empty : string.Empty;
+        }
+
         public static void ClearLatestHitSnapshot()
         {
             _latestHitSnapshot = null;


### PR DESCRIPTION
## Summary
- `execute-dynamic-code` responses now report whether the Unity Editor is currently paused, and which pause point caused it.

## User Impact
- Previously, if a pause point hit paused the Editor while dynamic code was running, an agent had no way to tell from the response alone that execution was interrupted mid-inspection - a stale-looking result could be mistaken for a bug.
- Now the response includes `EditorPaused` and `ActivePausePointId`, so an agent can immediately recognize a post-interrupt state and decide whether to resume/clear the pause point before retrying.

## Changes
- Added `EditorPaused` (bool) and `ActivePausePointId` (string) to `ExecuteDynamicCodeResponse`, both conditionally serialized so normal (non-paused) responses stay unchanged on the wire.
- Added a read-only `UloopPausePointRegistry.GetActivePausePointId()` accessor that reuses the existing pause-freeze window state (introduced for capture-window freezing) instead of adding new tracking state.
- `ExecuteDynamicCodeUseCase` sets both fields from `EditorApplication.isPaused` and the new registry accessor on every response path (success, cancelled, runtime-restarting).
- Field additions only; the response stays wire-compatible, so no protocol version bump is needed.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>` - 0 errors, 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path <repo> --filter-type regex --filter-value "PausePoint|ExecuteDynamicCode"` - 217/217 passed
- Repository CI does not run for PRs targeting this integration branch (only bot reviewers execute); the commands above are the local substitute for this PR, with full CI validation happening on the final integration PR into the release branch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

