### PR TITLE
feat: get-watch-values now flags a value that looks frozen

### DIFF
--- a/Assets/Tests/Editor/WatchResponseContractTests.cs
+++ b/Assets/Tests/Editor/WatchResponseContractTests.cs
@@ -40,6 +40,7 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                         Expression = "1 + 2",
                         MaxHistory = 20,
                         HistoryDroppedCount = 0,
+                        ValueFrozenHint = "",
                         History = new List<WatchHistoryResponse>
                         {
                             new()

--- a/Assets/Tests/Editor/WatchValueFreezeHintEvaluatorTests.cs
+++ b/Assets/Tests/Editor/WatchValueFreezeHintEvaluatorTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using io.github.hatayama.UnityCliLoop.FirstPartyTools;
+
+namespace io.github.hatayama.UnityCliLoop.Tests.Editor
+{
+    /// <summary>
+    /// Verifies WatchValueFreezeHintEvaluator's detection of a watch value that looks frozen.
+    /// </summary>
+    [TestFixture]
+    public sealed class WatchValueFreezeHintEvaluatorTests
+    {
+        [Test]
+        public void EvaluateFreezeHint_WhenHistoryHasFewerEntriesThanTheThreshold_ReturnsEmpty()
+        {
+            // Tests that a short history (not enough evaluations to judge staleness) never hints.
+            List<WatchHistoryResponse> history = CreateHistory("1", "1");
+
+            string hint = WatchValueFreezeHintEvaluator.EvaluateFreezeHint(history);
+
+            Assert.That(hint, Is.Empty);
+        }
+
+        [Test]
+        public void EvaluateFreezeHint_WhenRecentValuesAreIdentical_ReturnsHint()
+        {
+            // Tests the core case: the last several evaluations returned the same value.
+            List<WatchHistoryResponse> history = CreateHistory("1", "1", "1");
+
+            string hint = WatchValueFreezeHintEvaluator.EvaluateFreezeHint(history);
+
+            Assert.That(hint, Is.Not.Empty);
+            Assert.That(hint, Does.Contain("pause point"));
+        }
+
+        [Test]
+        public void EvaluateFreezeHint_WhenRecentValuesDiffer_ReturnsEmpty()
+        {
+            // Tests that a genuinely changing value is never flagged as frozen.
+            List<WatchHistoryResponse> history = CreateHistory("1", "2", "3");
+
+            string hint = WatchValueFreezeHintEvaluator.EvaluateFreezeHint(history);
+
+            Assert.That(hint, Is.Empty);
+        }
+
+        [Test]
+        public void EvaluateFreezeHint_WhenOnlyAnOlderEntryDiffers_ReturnsHintFromRecentWindowOnly()
+        {
+            // Tests that the check looks at the trailing window, not the whole history: an old
+            // change that happened before the most recent repeats must not suppress the hint.
+            List<WatchHistoryResponse> history = CreateHistory("0", "1", "1", "1");
+
+            string hint = WatchValueFreezeHintEvaluator.EvaluateFreezeHint(history);
+
+            Assert.That(hint, Is.Not.Empty);
+        }
+
+        [Test]
+        public void EvaluateFreezeHint_WhenARecentEvaluationFailed_ReturnsEmpty()
+        {
+            // Tests that evaluation errors are not mistaken for a frozen value; a failure is a
+            // distinct problem the freeze hint should not paper over.
+            List<WatchHistoryResponse> history = new()
+            {
+                CreateEntry("1", success: true),
+                CreateEntry("1", success: true),
+                CreateEntry(string.Empty, success: false)
+            };
+
+            string hint = WatchValueFreezeHintEvaluator.EvaluateFreezeHint(history);
+
+            Assert.That(hint, Is.Empty);
+        }
+
+        [Test]
+        public void EvaluateFreezeHint_WhenHistoryIsNull_ReturnsEmpty()
+        {
+            // Tests the defensive null-history path used before any evaluation has occurred.
+            string hint = WatchValueFreezeHintEvaluator.EvaluateFreezeHint(null);
+
+            Assert.That(hint, Is.Empty);
+        }
+
+        private static List<WatchHistoryResponse> CreateHistory(params string[] values)
+        {
+            List<WatchHistoryResponse> history = new();
+            foreach (string value in values)
+            {
+                history.Add(CreateEntry(value, success: true));
+            }
+
+            return history;
+        }
+
+        private static WatchHistoryResponse CreateEntry(string value, bool success)
+        {
+            return new WatchHistoryResponse
+            {
+                Success = success,
+                Value = value
+            };
+        }
+    }
+}

--- a/Assets/Tests/Editor/WatchValueFreezeHintEvaluatorTests.cs.meta
+++ b/Assets/Tests/Editor/WatchValueFreezeHintEvaluatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79660873126eb4e0da7759fb832776ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchTools.cs
@@ -64,17 +64,25 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         public IReadOnlyList<WatchHistoryResponse> History { get; set; } =
             Array.Empty<WatchHistoryResponse>();
 
+        /// <summary>
+        /// Non-empty when recent evaluations returned the same value, suggesting the linked
+        /// pause point has not been hit again since watches only refresh on a changed, paused frame.
+        /// </summary>
+        public string ValueFrozenHint { get; set; } = string.Empty;
+
         internal static WatchEntryResponse FromEntry(WatchExpressionEntry entry)
         {
+            List<WatchHistoryResponse> history = entry.CreateHistorySnapshot()
+                .Select(WatchHistoryResponse.FromEntry)
+                .ToList();
             return new WatchEntryResponse
             {
                 Id = entry.Id,
                 Expression = entry.Expression,
                 MaxHistory = entry.MaxHistory,
                 HistoryDroppedCount = entry.HistoryDroppedCount,
-                History = entry.CreateHistorySnapshot()
-                    .Select(WatchHistoryResponse.FromEntry)
-                    .ToList()
+                History = history,
+                ValueFrozenHint = WatchValueFreezeHintEvaluator.EvaluateFreezeHint(history)
             };
         }
     }

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchValueFreezeHintEvaluator.cs
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchValueFreezeHintEvaluator.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
+{
+    /// <summary>
+    /// Detects a watch expression whose recent evaluations returned the same value, so
+    /// get-watch-values can explain that watches only refresh on a changed, paused frame -
+    /// a value that looks stuck usually means the linked pause point has not been hit again.
+    /// </summary>
+    internal static class WatchValueFreezeHintEvaluator
+    {
+        internal const int MinIdenticalEvaluationsForHint = 3;
+
+        private const string FreezeHintMessageFormat =
+            "Value has not changed across the last {0} evaluations. Watch values only refresh " +
+            "when the Editor is paused on a changed frame, so confirm the linked pause point has " +
+            "been hit again if you expect this value to be different (a marker on a conditional " +
+            "line freezes after its first hit).";
+
+        public static string EvaluateFreezeHint(IReadOnlyList<WatchHistoryResponse> history)
+        {
+            if (history == null || history.Count < MinIdenticalEvaluationsForHint)
+            {
+                return string.Empty;
+            }
+
+            List<WatchHistoryResponse> recent = history
+                .Skip(history.Count - MinIdenticalEvaluationsForHint)
+                .ToList();
+            if (recent.Any(entry => !entry.Success))
+            {
+                return string.Empty;
+            }
+
+            string firstValue = recent[0].Value;
+            bool allIdentical = recent.All(entry => entry.Value == firstValue);
+            return allIdentical
+                ? string.Format(FreezeHintMessageFormat, MinIdenticalEvaluationsForHint)
+                : string.Empty;
+        }
+    }
+}

--- a/Packages/src/Editor/FirstPartyTools/Watch/WatchValueFreezeHintEvaluator.cs.meta
+++ b/Packages/src/Editor/FirstPartyTools/Watch/WatchValueFreezeHintEvaluator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac90dfc9fb77540fcb9018a2224dfc9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/cli/project-runner/internal/projectrunner/watch_types.go
+++ b/cli/project-runner/internal/projectrunner/watch_types.go
@@ -17,6 +17,7 @@ type watchEntryResponse struct {
 	Expression          string                 `json:"Expression"`
 	MaxHistory          int                    `json:"MaxHistory"`
 	HistoryDroppedCount int                    `json:"HistoryDroppedCount"`
+	ValueFrozenHint     string                 `json:"ValueFrozenHint"`
 	History             []watchHistoryResponse `json:"History"`
 }
 

--- a/tests/contracts/watch_response_contract.json
+++ b/tests/contracts/watch_response_contract.json
@@ -12,6 +12,7 @@
       "Expression": "1 + 2",
       "MaxHistory": 20,
       "HistoryDroppedCount": 0,
+      "ValueFrozenHint": "",
       "History": [
         {
           "FrameCount": 42,


### PR DESCRIPTION
## Summary
- `get-watch-values` now flags a watch entry whose value looks stuck, instead of leaving an agent to wonder why it never changes.

## User Impact
- Watch values only refresh while the Editor is paused on a changed frame. Agents repeatedly re-reading a watch after a pause point had stopped re-triggering saw the same value forever with no explanation - a recurring source of confusion in prior verification passes.
- Each watch entry now carries a `ValueFrozenHint` field that explains this refresh model and suggests confirming the linked pause point has been hit again, once the last few evaluations came back identical.

## Changes
- Added a pure `WatchValueFreezeHintEvaluator` (TDD, no Editor dependency) that flags an entry when its most recent evaluations (successful and identical) meet a small threshold.
- Wired the hint into `WatchEntryResponse.FromEntry` as a new `ValueFrozenHint` field.
- Mirrored the field addition in the shared Go/C# watch response contract (`tests/contracts/watch_response_contract.json`, `watch_types.go`) since a field addition needs both sides updated to keep the contract test green; wire-compatible, so no protocol version bump.

## Verification
- `dist/darwin-arm64/uloop compile --project-path <repo>` - 0 errors, 0 warnings
- `dist/darwin-arm64/uloop run-tests --project-path <repo> --filter-type regex --filter-value "Watch"` - 32/32 passed
- `scripts/check-go-cli.sh` - 0 lint issues, all Go packages pass (project-runner: 4.744s)
- Repository CI does not run for PRs targeting this integration branch (only bot reviewers execute); the commands above are the local substitute for this PR, with full CI validation happening on the final integration PR into the release branch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

