### PR TITLE
fix: execute-dynamic-code no longer misattributes an active pause point during a Trace hit

### DIFF
--- a/Assets/Tests/Editor/PausePointTests.cs
+++ b/Assets/Tests/Editor/PausePointTests.cs
@@ -423,6 +423,35 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
         }
 
         [Test]
+        public void GetActivePausePointId_WhenATraceMarkerHitsWhileAnotherMarkerHoldsThePause_StaysOnTheOriginalMarker()
+        {
+            // Verifies a Trace-mode hit (which never pauses, e.g. fired via execute-dynamic-code
+            // or Step while already paused) does not steal attribution from the marker actually
+            // holding the Editor paused.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointRegistry.Enable("trace-marker", 30, UloopPausePointCaptureMode.Trace);
+            UloopPausePoint.Pause("jump");
+
+            UloopPausePoint.Pause("trace-marker");
+
+            Assert.That(UloopPausePointRegistry.GetActivePausePointId(), Is.EqualTo("jump"));
+        }
+
+        [Test]
+        public void GetActivePausePointId_WhenASecondMarkerHitsWhileAlreadyPaused_UpdatesToTheNewMarker()
+        {
+            // Verifies a second non-Trace hit while already paused becomes the new (only) reason
+            // the Editor stays paused, so attribution correctly moves to it.
+            UloopPausePointRegistry.Enable("jump", 30);
+            UloopPausePointRegistry.Enable("dash", 30);
+            UloopPausePoint.Pause("jump");
+
+            UloopPausePoint.Pause("dash");
+
+            Assert.That(UloopPausePointRegistry.GetActivePausePointId(), Is.EqualTo("dash"));
+        }
+
+        [Test]
         public void GetActivePausePointId_AfterTheFreezeWindowIsClosed_ReturnsEmpty()
         {
             // Verifies the signal clears once the freeze window closes (Clear here), not just once

--- a/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
+++ b/Packages/src/Runtime/PausePoints/UloopPausePointRegistry.cs
@@ -32,6 +32,13 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         // own hit freezes every marker's countdown for the duration of the inspection pause,
         // and the frozen duration is credited back to each entry's ExpiresAtUtc on resume.
         private static DateTime? _pauseWindowStartUtc;
+        // The id of the marker whose hit is actually holding the Editor paused. Kept separate
+        // from _latestHitSnapshot, which every hit overwrites (including Trace-mode hits that
+        // never pause): using _latestHitSnapshot here would let an unrelated Trace hit that
+        // occurs while already paused (e.g. via execute-dynamic-code or Step) misattribute the
+        // pause to itself. Overwritten by a later non-Trace hit, since a second marker hitting
+        // while already paused becomes the new (only) reason the Editor stays paused.
+        private static string _pauseWindowOwnerId;
         // One input can hit several markers in the same frame; tools need the full list,
         // not just the latest hit, to report every marker that interrupted them.
         private static readonly List<UloopPausePointSnapshot> _hitSnapshots = new();
@@ -233,6 +240,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             {
                 _pauseController.Pause();
                 _pauseWindowStartUtc ??= now;
+                _pauseWindowOwnerId = id;
             }
 
             int hitSequence = ++_nextHitSequence;
@@ -265,13 +273,15 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
         /// <summary>
         /// Read-only signal for callers outside this registry (e.g. execute-dynamic-code) that
         /// need to know whether the Editor is currently paused because of a pause-point hit, and
-        /// which marker's hit is responsible. Reuses the same _pauseWindowStartUtc window that
-        /// gates expiry instead of introducing new tracking state. Returns empty when no window
-        /// is open, even if the Editor happens to be paused for an unrelated reason.
+        /// which marker's hit is responsible. Reads _pauseWindowOwnerId rather than
+        /// _latestHitSnapshot, which every hit overwrites (including Trace-mode hits that never
+        /// pause) and would otherwise misattribute an open pause window to an unrelated marker.
+        /// Returns empty when no window is open, even if the Editor happens to be paused for an
+        /// unrelated reason.
         /// </summary>
         public static string GetActivePausePointId()
         {
-            return _pauseWindowStartUtc.HasValue ? _latestHitSnapshot?.Id ?? string.Empty : string.Empty;
+            return _pauseWindowStartUtc.HasValue ? _pauseWindowOwnerId ?? string.Empty : string.Empty;
         }
 
         public static void ClearLatestHitSnapshot()
@@ -370,6 +380,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
 
             DateTime pauseWindowStart = _pauseWindowStartUtc.Value;
             _pauseWindowStartUtc = null;
+            _pauseWindowOwnerId = null;
             foreach (UloopPausePointEntry entry in Entries.Values)
             {
                 entry.ExtendExpiryForPause(pauseWindowStart, now);
@@ -435,6 +446,7 @@ namespace io.github.hatayama.UnityCliLoop.Runtime
             _latestHitSnapshot = null;
             _hitSnapshots.Clear();
             _pauseWindowStartUtc = null;
+            _pauseWindowOwnerId = null;
             Interlocked.Exchange(ref _pendingClientDisconnectResume, 0);
             _pauseController = new UnityEditorPausePointPauseController();
             _nowProvider = () => DateTime.UtcNow;


### PR DESCRIPTION
## Summary
- Fixes a bug in the not-yet-released `ActivePausePointId` field (introduced earlier in this same integration branch): it could report the wrong marker as the cause of a pause.

## User Impact
- `execute-dynamic-code`'s `ActivePausePointId` could point at a marker that never actually paused Unity, if a `Trace`-mode marker (which is designed to never pause) happened to hit while a different marker's pause was already open — for example via `execute-dynamic-code` itself or `Step` while paused. This misattribution would mislead an agent trying to determine which marker is actually holding the Editor paused.

## Changes
- `UloopPausePointRegistry`: added a dedicated `_pauseWindowOwnerId` field, set only by hits that actually pause the Editor (`Mode != Trace`), and read by `GetActivePausePointId()` instead of the general-purpose `_latestHitSnapshot` (which every hit overwrites, including non-pausing `Trace` hits).
- Added two regression tests: a `Trace` hit during an open pause window no longer steals attribution, and a second non-`Trace` hit during an open window correctly becomes the new owner.

## Verification
- `uloop compile` — 0 errors / 0 warnings.
- `uloop run-tests --filter-value "PausePoint|ExecuteDynamicCode"` — 2219/2220 passed. The one failure (`FirstPartySchemaProperties_WhenLoaded_ShouldNotExposeDescriptionAttributes`) is pre-existing and unrelated: confirmed identical on `origin/v3-beta` today, in a file (`SetGameViewSizeSchema.cs`) untouched by this branch or any PR in this series.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

