### PR TITLE
fix(codex): migrate legacy env table configuration

### DIFF
--- a/Assets/Tests/Editor/CodexConfigTests.cs
+++ b/Assets/Tests/Editor/CodexConfigTests.cs
@@ -86,6 +86,46 @@ namespace io.github.hatayama.uLoopMCP
         }
 
         // ----------------------------------------------------------------
+        // Legacy table-style env migration
+        // ----------------------------------------------------------------
+
+        [Test]
+        public void RemoveLegacyEnvSection_Should_RemoveOnlyLegacyULoopEnvTable()
+        {
+            string toml = @"[mcp_servers.uLoopMCP]
+command = ""node""
+args = ['server.js']
+env = { ""UNITY_TCP_PORT"" = ""8700"" }
+
+[mcp_servers.uLoopMCP.env]
+UNITY_TCP_PORT = ""8700""
+
+[mcp_servers.other]
+command = ""python""
+";
+
+            string result = InvokeRemoveLegacyEnvSection(toml);
+
+            StringAssert.DoesNotContain("[mcp_servers.uLoopMCP.env]", result);
+            StringAssert.Contains("env = { \"UNITY_TCP_PORT\" = \"8700\" }", result);
+            StringAssert.Contains("[mcp_servers.other]", result);
+        }
+
+        [Test]
+        public void RemoveLegacyEnvSection_Should_ReturnUnchanged_WhenLegacyTableIsAbsent()
+        {
+            string toml = @"[mcp_servers.uLoopMCP]
+command = ""node""
+args = ['server.js']
+env = { ""UNITY_TCP_PORT"" = ""8700"" }
+";
+
+            string result = InvokeRemoveLegacyEnvSection(toml);
+
+            Assert.AreEqual(toml, result);
+        }
+
+        // ----------------------------------------------------------------
         // MakeRelativeToConfigurationRoot
         // ----------------------------------------------------------------
 
@@ -187,6 +227,13 @@ namespace io.github.hatayama.uLoopMCP
             MethodInfo method = CodexServiceType.GetMethod("NormalizeForCompare", PrivateStatic);
             Debug.Assert(method != null, "NormalizeForCompare method not found");
             return (string)method.Invoke(null, new object[] { path });
+        }
+
+        private static string InvokeRemoveLegacyEnvSection(string content)
+        {
+            MethodInfo method = CodexServiceType.GetMethod("RemoveLegacyEnvSection", PrivateStatic);
+            Debug.Assert(method != null, "RemoveLegacyEnvSection method not found");
+            return (string)method.Invoke(null, new object[] { content });
         }
     }
 }

--- a/Packages/src/Editor/Config/CodexTomlConfigService.cs
+++ b/Packages/src/Editor/Config/CodexTomlConfigService.cs
@@ -12,6 +12,9 @@ namespace io.github.hatayama.uLoopMCP
         private static readonly Regex SectionRegex = new Regex(
             @"(?ms)^\[mcp_servers\.uLoopMCP\]\s*.*?(?=^\[|\z)",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex LegacyEnvSectionRegex = new Regex(
+            @"(?ms)^\[mcp_servers\.uLoopMCP\.env\]\s*.*?(?=^\[|\z)",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private static readonly Regex AnyMcpServerRegex = new Regex(
             @"(?ms)^\[mcp_servers\.[^\]]+\]\s*.*?(?=^\[|\z)",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -50,6 +53,9 @@ namespace io.github.hatayama.uLoopMCP
             if (!File.Exists(path)) return true;
             string content = File.ReadAllText(path);
 
+            // Migrate the legacy table-style env section before writing the inline env value.
+            if (LegacyEnvSectionRegex.IsMatch(content)) return true;
+
             string serverAbsolutePath = UnityMcpPathResolver.GetTypeScriptServerPath();
             if (string.IsNullOrEmpty(serverAbsolutePath) || !File.Exists(serverAbsolutePath)) return false;
             string expectedArg0 = UnityMcpPathResolver.MakeRelativeToConfigurationRoot(serverAbsolutePath);
@@ -81,6 +87,7 @@ namespace io.github.hatayama.uLoopMCP
             string path = UnityMcpPathResolver.GetCodexConfigPath();
             EnsureDirectory(path);
             string content = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+            content = RemoveLegacyEnvSection(content);
 
             string serverPath = UnityMcpPathResolver.GetTypeScriptServerPath();
             if (string.IsNullOrEmpty(serverPath) || !File.Exists(serverPath))
@@ -135,6 +142,7 @@ namespace io.github.hatayama.uLoopMCP
 
             string content = File.ReadAllText(path);
             string result = SectionRegex.Replace(content, string.Empty);
+            result = LegacyEnvSectionRegex.Replace(result, string.Empty);
             if (ReferenceEquals(content, result))
             {
                 return;
@@ -153,6 +161,7 @@ namespace io.github.hatayama.uLoopMCP
             }
 
             string content = File.ReadAllText(path);
+            content = RemoveLegacyEnvSection(content);
 
             // If section not exists, create it first and reload
             if (!SectionRegex.IsMatch(content))
@@ -351,7 +360,12 @@ namespace io.github.hatayama.uLoopMCP
             string dir = Path.GetDirectoryName(filePath);
             if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
         }
+
+        private static string RemoveLegacyEnvSection(string content)
+        {
+            string result = LegacyEnvSectionRegex.Replace(content, string.Empty);
+            return Regex.Replace(result, @"(\r?\n){3,}", System.Environment.NewLine + System.Environment.NewLine);
+        }
     }
 }
-
 


### PR DESCRIPTION
## Summary

- detect the legacy `[mcp_servers.uLoopMCP.env]` table before Codex configuration updates
- remove the legacy table when auto-configuring, updating development settings, or deleting the configuration
- preserve unrelated MCP server sections during migration

## Problem

Older Codex configurations may contain both an inline `env` value and a legacy `[mcp_servers.uLoopMCP.env]` table. `AutoConfigure` replaces only the parent `[mcp_servers.uLoopMCP]` section, leaving the legacy child table behind. The resulting TOML defines `env` twice and Codex fails to reload the project configuration with a duplicate-key parse error.

## Test plan

- Added regression coverage for removing only the legacy uLoopMCP env table while preserving the inline env and unrelated MCP sections.
- Ran `io.github.hatayama.uLoopMCP.CodexConfigTests` with Unity 2022.3 LTS: **14 passed, 0 failed**.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Migrates legacy `[mcp_servers.uLoopMCP.env]` TOML tables during Codex configuration updates.
- Removes only the legacy `uLoopMCP` environment table while preserving inline environment settings and unrelated MCP server sections.
- Applies cleanup during auto-configuration, development settings updates, and configuration deletion.
- Adds regression tests for legacy-table removal and unchanged content when the table is absent.
- `CodexConfigTests` passes with 14 tests and 0 failures on Unity 2022.3 LTS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->