### PR TITLE
feat: project runner commands can show their own detailed --help

### DIFF
--- a/cli/project-runner/internal/projectrunner/native_command_help.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help.go
@@ -1,0 +1,70 @@
+package projectrunner
+
+import (
+	"io"
+	"sort"
+
+	"github.com/hatayama/unity-cli-loop/common/clicore"
+	"github.com/hatayama/unity-cli-loop/common/tooldocs"
+)
+
+// runnerNativeCommandOptions lists the flags accepted by each runner-owned
+// native command. It lives with the runner binary (rather than the
+// dispatcher) so that adding a flag to a runner-owned command never requires
+// a dispatcher code change or release.
+var runnerNativeCommandOptions = map[string][]string{
+	clicore.PausePointAwaitCommandName: {
+		"--" + clicore.PausePointIDFlagName,
+		"--" + clicore.PausePointTimeoutFlagName,
+		"--" + clicore.PausePointLogsMaxCountFlagName,
+		"--" + clicore.PausePointCapturedVariablesFlagName,
+	},
+	clicore.PausePointStatusUserCommandName: {
+		"--" + clicore.PausePointIDFlagName,
+		"--" + clicore.PausePointCapturedVariablesFlagName,
+	},
+}
+
+// tryPrintNativeCommandHelp prints command-specific help for a runner-owned
+// native command and reports whether it did. The dispatcher forwards `--help`
+// for these commands to the pinned runner instead of keeping a hardcoded
+// options table, so this output must stay in sync with the runner's actual
+// flags by construction.
+func tryPrintNativeCommandHelp(command string, stdout io.Writer) bool {
+	if !clicore.IsRunnerOwnedCommandName(command) {
+		return false
+	}
+	printNativeCommandHelp(command, stdout)
+	return true
+}
+
+func printNativeCommandHelp(command string, stdout io.Writer) {
+	entry, _ := clicore.NativeCommand(command)
+	options := sortedNativeCommandOptions(runnerNativeCommandOptions[command])
+
+	clicore.WriteLine(stdout, "Usage:")
+	if len(options) > 0 {
+		clicore.WriteFormat(stdout, "  uloop %s [options]\n", command)
+		clicore.WriteLine(stdout, "")
+		clicore.WriteLine(stdout, entry.Description)
+		clicore.WriteLine(stdout, "")
+		clicore.WriteLine(stdout, "Options:")
+		for _, option := range options {
+			clicore.WriteFormat(stdout, "  %s\n", option)
+		}
+	} else {
+		clicore.WriteFormat(stdout, "  uloop %s\n", command)
+		clicore.WriteLine(stdout, "")
+		clicore.WriteLine(stdout, entry.Description)
+	}
+
+	clicore.WriteLine(stdout, "")
+	clicore.WriteLine(stdout, "Global options:")
+	clicore.WriteFormat(stdout, "  --%s <path>   Run against a Unity project outside the current directory\n", tooldocs.ProjectPathFlagName)
+}
+
+func sortedNativeCommandOptions(options []string) []string {
+	result := append([]string{}, options...)
+	sort.Strings(result)
+	return result
+}

--- a/cli/project-runner/internal/projectrunner/native_command_help_test.go
+++ b/cli/project-runner/internal/projectrunner/native_command_help_test.go
@@ -1,0 +1,76 @@
+package projectrunner
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// Verifies await-pause-point --help lists every flag the runner accepts for
+// that command, since the dispatcher forwards this help request here instead
+// of keeping its own hardcoded options table.
+func TestRunProjectLocalAwaitPausePointHelpListsExpectedFlags(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunProjectLocal(context.Background(), []string{"await-pause-point", "--help"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("await-pause-point --help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	for _, flag := range []string{"--id", "--timeout-seconds", "--matching-logs-max-count", "--captured-variables"} {
+		if !strings.Contains(stdout.String(), flag) {
+			t.Fatalf("await-pause-point --help must list %s: %s", flag, stdout.String())
+		}
+	}
+	if !strings.Contains(stdout.String(), "--project-path") {
+		t.Fatalf("await-pause-point --help must list the global --project-path option: %s", stdout.String())
+	}
+}
+
+// Verifies pause-point-status --help lists the flags it accepts.
+func TestRunProjectLocalPausePointStatusHelpListsExpectedFlags(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := RunProjectLocal(context.Background(), []string{"pause-point-status", "--help"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("pause-point-status --help failed: code=%d stderr=%s", code, stderr.String())
+	}
+	for _, flag := range []string{"--id", "--captured-variables"} {
+		if !strings.Contains(stdout.String(), flag) {
+			t.Fatalf("pause-point-status --help must list %s: %s", flag, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "--timeout-seconds") {
+		t.Fatalf("pause-point-status --help must not list await-pause-point-only flags: %s", stdout.String())
+	}
+}
+
+// Verifies list/sync/focus-window --help print only the global --project-path
+// option, since these commands take no command-specific flags.
+func TestRunProjectLocalNoOptionCommandsHelpListsOnlyGlobalOption(t *testing.T) {
+	for _, command := range []string{"list", "sync", "focus-window"} {
+		t.Run(command, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			code := RunProjectLocal(context.Background(), []string{command, "--help"}, &stdout, &stderr)
+
+			if code != 0 {
+				t.Fatalf("%s --help failed: code=%d stderr=%s", command, code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "--project-path") {
+				t.Fatalf("%s --help must list the global --project-path option: %s", command, stdout.String())
+			}
+			if strings.Contains(stdout.String(), "Options:") {
+				t.Fatalf("%s --help must not print a command-specific Options section: %s", command, stdout.String())
+			}
+		})
+	}
+}

--- a/cli/project-runner/internal/projectrunner/run.go
+++ b/cli/project-runner/internal/projectrunner/run.go
@@ -44,6 +44,9 @@ func RunProjectLocal(ctx context.Context, args []string, stdout io.Writer, stder
 		return 1
 	}
 	if clicore.ContainsHelpRequest(commandArgs) {
+		if tryPrintNativeCommandHelp(command, stdout) {
+			return 0
+		}
 		printRunnerUsage(stdout)
 		return 0
 	}


### PR DESCRIPTION
## Summary
- Runner-owned native commands (`await-pause-point`, `pause-point-status`, `list`, `sync`, `focus-window`) now have their `--help` flag list defined and rendered from the project runner binary itself.

## User Impact
- Today the dispatcher's `--help` output for these commands comes from a hardcoded options table that can drift out of sync with the pinned runner version, and requires a dispatcher code change (and release) whenever a runner-owned command gains a flag.
- This change is additive only: it adds the same help output inside the project runner, so a follow-up change can forward `--help` for these commands to the runner instead of the dispatcher's static table, keeping the flag list and its help text defined in one place.

## Changes
- Added `native_command_help.go` in `cli/project-runner`: a per-command option table and formatter matching the dispatcher's existing help layout (Usage, description, Options, Global options).
- Wired `RunProjectLocal`'s `--help` handling to print this command-specific help for runner-owned commands, falling back to the existing minimal runner usage otherwise.

## Verification
- `bash scripts/check-go-cli.sh` passed (fmt/vet/lint/tests/binary rebuild), exit code 0.
- Added tests asserting expected flags appear in `await-pause-point --help` / `pause-point-status --help`, and that `list`/`sync`/`focus-window --help` show only the global `--project-path` option with no command-specific Options section.
- Confirmed the new tests actually exercise the assertions by temporarily breaking one expected flag string and observing the test fail, then restoring it and re-running to green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

