### PR TITLE
feat: dispatcher env override to use a locally built project runner

### DIFF
--- a/cli/dispatcher/internal/dispatcher/dispatcher_download.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_download.go
@@ -32,6 +32,18 @@ var (
 const dispatcherRealCLIReadyFileName = "READY"
 
 func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin, stderr io.Writer) (string, error) {
+	// Why: dogfooding checkouts pin an unpublished projectRunnerVersion that release-please
+	// stamps ahead of the matching GitHub release, so the normal download path 404s. This env
+	// var lets local development point at a locally built binary without touching the pin.
+	if overridePath, ok := dispatcherProjectRunnerPathOverride(); ok {
+		if !isExecutableFile(overridePath) {
+			return "", fmt.Errorf(
+				"%s is set to %q, but no executable file exists there",
+				nativepath.ProjectRunnerPathEnvName, overridePath)
+		}
+		return overridePath, nil
+	}
+
 	pin.ProjectRunnerVersion = strings.TrimSpace(pin.ProjectRunnerVersion)
 	if err := validateDispatcherProjectRunnerVersion(pin.ProjectRunnerVersion); err != nil {
 		return "", err
@@ -50,6 +62,11 @@ func resolveDispatcherRealCLI(ctx context.Context, pin dispatcherPin, stderr io.
 	}
 
 	return downloadDispatcherRealCLIForPin(ctx, cacheRoot, pin, runtime.GOOS, runtime.GOARCH, stderr)
+}
+
+func dispatcherProjectRunnerPathOverride() (string, bool) {
+	overridePath := strings.TrimSpace(os.Getenv(nativepath.ProjectRunnerPathEnvName))
+	return overridePath, overridePath != ""
 }
 
 func dispatcherSiblingRealCLIPath(pin dispatcherPin) (string, bool) {

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -297,6 +297,43 @@ func TestResolveDispatcherRealCLIRejectsInvalidProjectRunnerVersion(t *testing.T
 	}
 }
 
+func TestResolveDispatcherRealCLIUsesProjectRunnerPathOverrideWithoutDownloading(t *testing.T) {
+	// Verifies the dev escape-hatch env var returns the local binary and skips pin/cache/download entirely.
+	overrideDir := t.TempDir()
+	overridePath := filepath.Join(overrideDir, "uloop-project-runner")
+	if err := os.WriteFile(overridePath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("failed to write override binary: %v", err)
+	}
+	t.Setenv(nativepath.ProjectRunnerPathEnvName, overridePath)
+	t.Setenv(nativepath.CacheDirEnvName, t.TempDir())
+
+	resolvedPath, err := resolveDispatcherRealCLI(
+		context.Background(),
+		dispatcherPin{ProjectRunnerVersion: "not-a-real-published-version"},
+		io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolvedPath != overridePath {
+		t.Fatalf("resolvedPath = %q, want %q", resolvedPath, overridePath)
+	}
+}
+
+func TestResolveDispatcherRealCLIRejectsMissingProjectRunnerPathOverride(t *testing.T) {
+	// Verifies a clear error is returned when the override env var points at a missing file.
+	t.Setenv(nativepath.ProjectRunnerPathEnvName, filepath.Join(t.TempDir(), "missing-uloop-project-runner"))
+	t.Setenv(nativepath.CacheDirEnvName, t.TempDir())
+
+	_, err := resolveDispatcherRealCLI(context.Background(), dispatcherPin{ProjectRunnerVersion: "1.0.0"}, io.Discard)
+
+	if err == nil {
+		t.Fatal("expected an error for a missing override path")
+	}
+	if !strings.Contains(err.Error(), nativepath.ProjectRunnerPathEnvName) {
+		t.Fatalf("error message should mention %s: %v", nativepath.ProjectRunnerPathEnvName, err)
+	}
+}
+
 func TestEnforceDispatcherFreshnessRequiresManualUpdateWhenSelfUpdateDisabled(t *testing.T) {
 	// Verifies disabling mutation does not disable the minimum dispatcher version contract.
 	t.Setenv(dispatcherDisableSelfUpdateEnvName, "1")

--- a/cli/dispatcher/internal/dispatcher/dispatcher_test.go
+++ b/cli/dispatcher/internal/dispatcher/dispatcher_test.go
@@ -334,6 +334,21 @@ func TestResolveDispatcherRealCLIRejectsMissingProjectRunnerPathOverride(t *test
 	}
 }
 
+func TestResolveDispatcherRealCLIRejectsDirectoryProjectRunnerPathOverride(t *testing.T) {
+	// Verifies a clear error is returned when the override env var points at a directory instead of a binary.
+	t.Setenv(nativepath.ProjectRunnerPathEnvName, t.TempDir())
+	t.Setenv(nativepath.CacheDirEnvName, t.TempDir())
+
+	_, err := resolveDispatcherRealCLI(context.Background(), dispatcherPin{ProjectRunnerVersion: "1.0.0"}, io.Discard)
+
+	if err == nil {
+		t.Fatal("expected an error for a directory override path")
+	}
+	if !strings.Contains(err.Error(), nativepath.ProjectRunnerPathEnvName) {
+		t.Fatalf("error message should mention %s: %v", nativepath.ProjectRunnerPathEnvName, err)
+	}
+}
+
 func TestEnforceDispatcherFreshnessRequiresManualUpdateWhenSelfUpdateDisabled(t *testing.T) {
 	// Verifies disabling mutation does not disable the minimum dispatcher version contract.
 	t.Setenv(dispatcherDisableSelfUpdateEnvName, "1")

--- a/cli/dispatcher/internal/dispatcher/run_dispatcher.go
+++ b/cli/dispatcher/internal/dispatcher/run_dispatcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hatayama/unity-cli-loop/common/clicore"
 	"github.com/hatayama/unity-cli-loop/common/project"
 	sharedversion "github.com/hatayama/unity-cli-loop/common/version"
+	"github.com/hatayama/unity-cli-loop/dispatcher/internal/nativepath"
 	sharedupdate "github.com/hatayama/unity-cli-loop/dispatcher/internal/update"
 )
 
@@ -476,7 +477,12 @@ func dispatcherRealCLIResolutionError(projectRoot string, pin dispatcherPin, cau
 		Retryable:   true,
 		SafeToRetry: true,
 		ProjectRoot: projectRoot,
-		NextActions: []string{"Check network access to GitHub releases, then retry the command."},
+		NextActions: []string{
+			"Check network access to GitHub releases, then retry the command.",
+			"For dogfooding checkouts with an unpublished pin, set " +
+				nativepath.ProjectRunnerPathEnvName +
+				" to a locally built uloop-project-runner binary to bypass the download.",
+		},
 		Details: map[string]any{
 			"Cause":                cause.Error(),
 			"ProjectRunnerVersion": pin.ProjectRunnerVersion,

--- a/cli/dispatcher/internal/nativepath/path.go
+++ b/cli/dispatcher/internal/nativepath/path.go
@@ -8,12 +8,13 @@ import (
 )
 
 const (
-	InstallDirEnvName       = "ULOOP_INSTALL_DIR"
-	CacheDirEnvName         = "ULOOP_CACHE_DIR"
-	LocalAppDataEnvName     = "LOCALAPPDATA"
-	WindowsProgramsDirName  = "Programs"
-	ProductDirectoryName    = "uloop"
-	InstallBinDirectoryName = "bin"
+	InstallDirEnvName        = "ULOOP_INSTALL_DIR"
+	CacheDirEnvName          = "ULOOP_CACHE_DIR"
+	ProjectRunnerPathEnvName = "ULOOP_PROJECT_RUNNER_PATH"
+	LocalAppDataEnvName      = "LOCALAPPDATA"
+	WindowsProgramsDirName   = "Programs"
+	ProductDirectoryName     = "uloop"
+	InstallBinDirectoryName  = "bin"
 )
 
 // ErrUnsupportedOS marks platforms without native install directory conventions.


### PR DESCRIPTION
## Summary
- Local development checkouts can now point `uloop` at a locally built project runner binary instead of failing on every command.

## User Impact
- Dogfooding checkouts pin an unpublished `projectRunnerVersion` that release-please stamps ahead of the matching GitHub release. Every `uloop` command that needed the project runner (e.g. `compile`, `run-tests`) failed with a 404 download error, with no way around it short of hand-editing the release-please-managed pin.
- Setting `ULOOP_PROJECT_RUNNER_PATH` to a locally built `uloop-project-runner` binary now bypasses pin resolution, the cache lookup, and the download step entirely, so local development against unreleased protocol/runner changes works again. The download-failure error message also now suggests this env var as a next action.

## Changes
- `resolveDispatcherRealCLI` checks `ULOOP_PROJECT_RUNNER_PATH` first and returns that path directly (with a clear error if it does not point at an executable file) before touching pin validation, the sibling-binary check, the cache, or the download path.
- Added the `ProjectRunnerPathEnvName` constant to `nativepath`, alongside the existing `ULOOP_INSTALL_DIR` / `ULOOP_CACHE_DIR` env vars.
- Added a `NextActions` hint referencing the env var to the download-failure error in `run_dispatcher.go`.
- Added two Go unit tests covering the override (bypasses download) and the missing-file case (clear error).

## Verification
- `scripts/check-go-cli.sh` — all packages pass (fmt/vet/lint/test/build).
- Real end-to-end check: with `ULOOP_PROJECT_RUNNER_PATH` pointed at a locally built `dist/darwin-arm64/uloop-project-runner`, `uloop compile` went from a 404 download failure to `{"ErrorCount": 0, "WarningCount": 0, "Success": true}` against a running Unity Editor.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

