### PR TITLE
fix: Dynamic code execution no longer reports a false failure right after a pause point

### DIFF
--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
@@ -7,7 +7,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
-using io.github.hatayama.UnityCliLoop.Application;
 using io.github.hatayama.UnityCliLoop.FirstPartyTools;
 using io.github.hatayama.UnityCliLoop.Infrastructure;
 using io.github.hatayama.UnityCliLoop.Runtime;
@@ -155,6 +154,41 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
             finally
             {
                 signal.Dispose();
+                RestoreEditorMainThreadDispatcher();
+            }
+        }
+
+        [Test]
+        public void ExecuteAsync_WhenResumedOffMainThread_QueuesMainThreadSwitchBeforeReadingPauseState()
+        {
+            // Tests that applying EditorPaused/ActivePausePointId switches back to the main thread
+            // instead of reading EditorApplication.isPaused directly on whatever thread the
+            // ConfigureAwait(false) continuations resumed on. Deliberately does not wait for the
+            // outer ExecuteAsync Task to complete: once queued, resuming it depends on the TPL's own
+            // continuation scheduling, which is not something a test should spin-wait on.
+            MarkForegroundWarmupCompleted();
+            QueuedMainThreadDispatcher dispatcher = new();
+            MainThreadSwitcher.RegisterService(dispatcher);
+
+            try
+            {
+                FakeDynamicCodeExecutionRuntime runtime = new(
+                    new ExecutionResult { Success = true, Result = "ok" });
+                ExecuteDynamicCodeUseCase useCase = new(runtime);
+
+                Task<ExecuteDynamicCodeResponse> executeTask = useCase.ExecuteAsync(
+                    new ExecuteDynamicCodeSchema { Code = "return 1;", CompileOnly = false },
+                    CancellationToken.None);
+
+                Assert.That(executeTask.IsCompleted, Is.False);
+                Assert.That(dispatcher.PendingContinuationCount, Is.GreaterThan(0));
+
+                dispatcher.RunQueuedContinuationsAsMainThread();
+
+                Assert.That(dispatcher.PendingContinuationCount, Is.EqualTo(0));
+            }
+            finally
+            {
                 RestoreEditorMainThreadDispatcher();
             }
         }

--- a/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
+++ b/Assets/Tests/Editor/DynamicCodeToolTests/ExecuteDynamicCodeUseCaseTests.cs
@@ -687,6 +687,39 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor.DynamicCodeToolTests
         }
 
         [Test]
+        public async Task ExecuteAsync_WhenOuterTokenAlreadyCancelledAndResultIsCancelled_ShouldPreserveLogsAndTimings()
+        {
+            // Tests that a cancelled-result response keeps its preserved Logs/Timings instead of
+            // falling back to the outer catch's plain CreateCancelledResponse() when the caller's
+            // own cancellationToken is already cancelled (e.g. an internal executionCancellationTokenSource
+            // cancelled the runtime while the caller's token was cancelled too).
+            MarkForegroundWarmupCompleted();
+            FakeDynamicCodeExecutionRuntime runtime = new(
+                new ExecutionResult
+                {
+                    Success = false,
+                    ErrorMessage = UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED,
+                    Logs = new List<string> { "Execution cancelled" },
+                    Timings = new List<string> { "compile_ms=5" }
+                });
+            ExecuteDynamicCodeUseCase useCase = new(runtime);
+            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            ExecuteDynamicCodeResponse response = await useCase.ExecuteAsync(
+                new ExecuteDynamicCodeSchema
+                {
+                    Code = "return 1;"
+                },
+                cancellationTokenSource.Token);
+
+            Assert.That(response.Success, Is.False);
+            Assert.That(response.ErrorMessage, Is.EqualTo(UnityCliLoopConstants.ERROR_MESSAGE_EXECUTION_CANCELLED));
+            Assert.That(response.Logs, Contains.Item("Execution cancelled"));
+            Assert.That(response.Timings, Contains.Item("compile_ms=5"));
+        }
+
+        [Test]
         public async Task ExecuteAsync_WhenRuntimeFailsAfterProducingLogs_ShouldPreserveOriginalLogs()
         {
             MarkForegroundWarmupCompleted();

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -118,6 +118,9 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
             ExecuteDynamicCodeResponse response,
             CancellationToken cancellationToken)
         {
+            // No ConfigureAwait(false) here: SwitchToMainThreadAwaitable is not a Task and does not
+            // expose that method. Its continuation is scheduled onto the main thread by
+            // MainThreadSwitcher itself, so the code below always runs there regardless.
             await MainThreadSwitcher.SwitchToMainThread(cancellationToken);
 
             (bool editorPaused, string activePausePointId) = ExecuteDynamicCodePauseStateResolver.Resolve(

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -75,7 +75,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         ? new List<string>(finalResult.Timings)
                         : cancelledResponse.Timings;
                     cancelledResponse.EmitTimingsInJsonResponse = parameters.IncludeTimings;
-                    ApplyPauseState(cancelledResponse);
+                    await ApplyPauseStateAsync(cancelledResponse, cancellationToken).ConfigureAwait(false);
                     return cancelledResponse;
                 }
 
@@ -84,7 +84,7 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ExecuteDynamicCodeResponse restartingResponse =
                         DynamicCodeExecutionResponseFactory.CreateRuntimeRestartingResponse();
                     restartingResponse.EmitTimingsInJsonResponse = parameters.IncludeTimings;
-                    ApplyPauseState(restartingResponse);
+                    await ApplyPauseStateAsync(restartingResponse, cancellationToken).ConfigureAwait(false);
                     return restartingResponse;
                 }
 
@@ -95,14 +95,16 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 bool domainReloadWaitRequired =
                     await domainReloadWaitSignal.ShouldWaitAsync(cancellationToken).ConfigureAwait(false);
                 response.DomainReloadWaitRequired = domainReloadWaitRequired;
-                ApplyPauseState(response);
+                await ApplyPauseStateAsync(response, cancellationToken).ConfigureAwait(false);
                 return response;
             }
             catch (OperationCanceledException)
             {
                 ExecuteDynamicCodeResponse response = DynamicCodeExecutionResponseFactory.CreateCancelledResponse();
                 response.EmitTimingsInJsonResponse = parameters?.IncludeTimings ?? false;
-                ApplyPauseState(response);
+                // Why CancellationToken.None: cancellationToken is already cancelled on this path,
+                // and passing it to SwitchToMainThread would throw again instead of switching.
+                await ApplyPauseStateAsync(response, CancellationToken.None).ConfigureAwait(false);
                 return response;
             }
         }
@@ -110,8 +112,14 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         // Lets an agent recognize a post-interrupt state (e.g. a pause point hit mid-execution)
         // instead of mistaking a stale-looking result for a bug. ActivePausePointId stays empty
         // when the Editor is paused for a reason unrelated to a pause point.
-        private static void ApplyPauseState(ExecuteDynamicCodeResponse response)
+        // Why async: the preceding ConfigureAwait(false) continuations may resume this method on a
+        // thread-pool thread, and EditorApplication.isPaused throws when read off the main thread.
+        private static async Task ApplyPauseStateAsync(
+            ExecuteDynamicCodeResponse response,
+            CancellationToken cancellationToken)
         {
+            await MainThreadSwitcher.SwitchToMainThread(cancellationToken);
+
             (bool editorPaused, string activePausePointId) = ExecuteDynamicCodePauseStateResolver.Resolve(
                 EditorApplication.isPaused, UloopPausePointRegistry.GetActivePausePointId());
             response.EditorPaused = editorPaused;

--- a/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/ExecuteDynamicCode/ExecuteDynamicCodeUseCase.cs
@@ -75,7 +75,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                         ? new List<string>(finalResult.Timings)
                         : cancelledResponse.Timings;
                     cancelledResponse.EmitTimingsInJsonResponse = parameters.IncludeTimings;
-                    await ApplyPauseStateAsync(cancelledResponse, cancellationToken).ConfigureAwait(false);
+                    // Why CancellationToken.None: finalResult can be cancelled by the internal
+                    // executionCancellationTokenSource (e.g. a domain reload) even when
+                    // cancellationToken itself is already cancelled; reusing it here would throw
+                    // again and lose the preserved Logs/Timings on the fallback path below.
+                    await ApplyPauseStateAsync(cancelledResponse, CancellationToken.None).ConfigureAwait(false);
                     return cancelledResponse;
                 }
 
@@ -84,7 +88,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ExecuteDynamicCodeResponse restartingResponse =
                         DynamicCodeExecutionResponseFactory.CreateRuntimeRestartingResponse();
                     restartingResponse.EmitTimingsInJsonResponse = parameters.IncludeTimings;
-                    await ApplyPauseStateAsync(restartingResponse, cancellationToken).ConfigureAwait(false);
+                    // Why CancellationToken.None: same reasoning as the cancelled-response branch
+                    // above, but reusing a cancelled token here would swap this RuntimeRestarting
+                    // response for a plain Cancelled one via the outer catch, which is worse than
+                    // losing Logs/Timings since the response kind itself changes.
+                    await ApplyPauseStateAsync(restartingResponse, CancellationToken.None).ConfigureAwait(false);
                     return restartingResponse;
                 }
 


### PR DESCRIPTION
## Summary
- Dynamic code execution no longer reports a false failure right after a pause point is hit or resumed.

## User Impact
- Previously, right after a pause point interrupted or resumed dynamic code execution, the follow-up response could come back as an internal RPC error (`Success: false`) even though the code had actually executed successfully. This happened because the pause-state check ran on a background thread instead of Unity's main thread, which Editor APIs do not allow.
- Now the pause-state check always resumes on Unity's main thread before reading pause state, so the response reliably reflects the real execution result.

## Changes
- Renamed the pause-state application step to an async method that explicitly switches back to Unity's main thread before reading `EditorApplication.isPaused`, instead of assuming the current thread is already the main thread.
- All call sites keep their existing `ConfigureAwait(false)` usage; only the pause-state step itself now guarantees a main-thread hop.
- Added a regression test (using the existing main-thread-dispatcher test double already used elsewhere in this suite) that proves a main-thread switch is queued instead of the Editor API being read directly when resumed off the main thread.

## Verification
- `uloop compile` — 0 errors, 0 warnings.
- `uloop run-tests` (ExecuteDynamicCodeUseCaseTests suite) — 27/27 passed, including the new regression test.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

