### PR TITLE
fix: Simulate tools now say which pause point is blocking them instead of a generic paused error

### DIFF
--- a/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
+++ b/Assets/Tests/Editor/PlayModeToolPreflightServiceTests.cs
@@ -87,5 +87,31 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
                 Is.EqualTo("PlayMode is paused. Resume PlayMode before simulating UI input."));
         }
 
+        [Test]
+        public void FormatPausePointPausedMessage_WithSimulateKeyboardSuffix_ReturnsExpectedWireString()
+        {
+            // Verifies the pause-point-aware message names the active pause point so agents calling
+            // simulate-keyboard right after a pause-point hit see the real cause instead of a generic rejection.
+            Assert.That(
+                PlayModeToolPreflightService.FormatPausePointPausedMessage(
+                    "example-pause-point-id",
+                    SimulateKeyboardUseCase.PausedActionDescription),
+                Is.EqualTo(
+                    "PlayMode is paused because pause point 'example-pause-point-id' is active " +
+                    "(check pause-point-status). Resume PlayMode before simulating keyboard input."));
+        }
+
+        [Test]
+        public void FormatPausePointPausedMessage_WithSimulateMouseInputSuffix_ReturnsExpectedWireString()
+        {
+            // Verifies the pause-point-aware message stays byte-identical for SimulateMouseInput's suffix too.
+            Assert.That(
+                PlayModeToolPreflightService.FormatPausePointPausedMessage(
+                    "example-pause-point-id",
+                    SimulateMouseInputUseCase.PausedActionDescription),
+                Is.EqualTo(
+                    "PlayMode is paused because pause point 'example-pause-point-id' is active " +
+                    "(check pause-point-status). Resume PlayMode before simulating mouse input."));
+        }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Common/Preflight/PlayModeToolPreflightService.cs
+++ b/Packages/src/Editor/FirstPartyTools/Common/Preflight/PlayModeToolPreflightService.cs
@@ -2,6 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 
+using io.github.hatayama.UnityCliLoop.Runtime;
 using io.github.hatayama.UnityCliLoop.ToolContracts;
 
 namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
@@ -43,7 +44,11 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
 
             if (EditorApplication.isPaused)
             {
-                return ValidationResult.Failure(FormatPausedMessage(pausedActionDescription));
+                string activePausePointId = UloopPausePointRegistry.GetActivePausePointId();
+                string message = string.IsNullOrEmpty(activePausePointId)
+                    ? FormatPausedMessage(pausedActionDescription)
+                    : FormatPausePointPausedMessage(activePausePointId, pausedActionDescription);
+                return ValidationResult.Failure(message);
             }
 
             return ValidationResult.Success();
@@ -57,6 +62,19 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
         {
             Debug.Assert(!string.IsNullOrEmpty(pausedActionDescription), "pausedActionDescription must not be null or empty");
             return $"PlayMode is paused. Resume PlayMode before {pausedActionDescription}.";
+        }
+
+        /// <summary>
+        /// Composes the paused-mode failure message for the common case where a pause point is
+        /// what's holding PlayMode paused, so agents calling a simulate/record tool right after a
+        /// pause-point hit see the real cause instead of a generic "PlayMode is paused" rejection.
+        /// </summary>
+        public static string FormatPausePointPausedMessage(string pausePointId, string pausedActionDescription)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(pausePointId), "pausePointId must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(pausedActionDescription), "pausedActionDescription must not be null or empty");
+            return
+                $"PlayMode is paused because pause point '{pausePointId}' is active (check pause-point-status). Resume PlayMode before {pausedActionDescription}.";
         }
     }
 }

--- a/Packages/src/Editor/FirstPartyTools/Common/Preflight/UnityCLILoop.FirstPartyTools.Common.Preflight.Editor.asmdef
+++ b/Packages/src/Editor/FirstPartyTools/Common/Preflight/UnityCLILoop.FirstPartyTools.Common.Preflight.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "UnityCLILoop.FirstPartyTools.Common.Preflight.Editor",
     "rootNamespace": "io.github.hatayama.UnityCliLoop.FirstPartyTools",
     "references": [
-        "GUID:fc3fd32eddbee40e39c2d76dc184957b"
+        "GUID:fc3fd32eddbee40e39c2d76dc184957b",
+        "GUID:527f26a36b5043c2bd4d4036d04cd76d"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
+++ b/Packages/src/Runtime/PausePoints/AssemblyInfo.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseInput.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.SimulateMouseUi.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.ExecuteDynamicCode.Editor")]
+[assembly: InternalsVisibleTo("UnityCLILoop.FirstPartyTools.Common.Preflight.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Infrastructure")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.Editor")]
 [assembly: InternalsVisibleTo("UnityCLILoop.Tests.PlayMode")]


### PR DESCRIPTION
## Summary
- Simulate/record PlayMode tools (simulate-keyboard, simulate-mouse-input, simulate-mouse-ui, record-input, replay-input) now say which pause point is blocking them, instead of a generic "PlayMode is paused" rejection.

## User Impact
- Before: calling a simulate/record tool right after a pause point had fired could return an opaque "PlayMode is paused. Resume PlayMode before ..." error, with no indication that a pause point was the cause. This looked like an unexplained failure rather than an expected pause-point interaction.
- After: when an active pause point is holding PlayMode paused, the rejection names the pause point and points at `pause-point-status` for details, making the cause immediately clear. The message for the ordinary "manually paused" case is unchanged.

## Investigation
- The originally reported symptom ("simulate-keyboard returns a broken response right after a pause point fires") was traced to two candidate causes, and only one turned out to be real:
  - The interrupt-mid-action response path (when a pause point interrupts a simulation already in flight) was already fixed by a prior merged PR and returns a well-formed result with the real key/action name and `InterruptedByPausePoint: true`. Verified by reading the keyboard and mouse simulation response factories — no change needed here.
  - The actual gap, confirmed via live reproduction in the Unity Editor, is the shared preflight check's generic paused-rejection message, which doesn't mention a pause point even when one is the reason PlayMode is paused.

## Changes
- The shared PlayMode preflight check now looks up the active pause point when PlayMode is paused, and returns a pause-point-aware message when one is set.
- Added a corresponding assembly reference and internal-visibility grant so the preflight code can query the active pause point.
- Added unit tests pinning the new message text for two of the affected tools.

## Verification
- `uloop compile`: 0 errors, 0 warnings.
- `uloop run-tests` on `PlayModeToolPreflightServiceTests`: 8/8 passed (6 pre-existing + 2 new).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

