### PR TITLE
fix: Launch no longer overclaims a crash for a stale UnityLockfile

### DIFF
--- a/cli/dispatcher/internal/dispatcher/launch.go
+++ b/cli/dispatcher/internal/dispatcher/launch.go
@@ -244,11 +244,7 @@ func startUnityAndWaitForReadiness(
 		return 1
 	}
 	if removedStaleTemp {
-		clicore.WriteFormat(stdout, "UnityLockfile found without active Unity process: %s\n", unityLockfilePath(projectRoot))
-		clicore.WriteLine(stdout, "Assuming previous crash. Cleaning Temp directory and continuing launch.")
-		clicore.WriteLine(stdout, "Deleted Temp directory.")
-		clicore.WriteLine(stdout, "Deleted UnityLockfile.")
-		clicore.WriteLine(stdout, "")
+		writeStaleUnityTempCleanupMessage(stdout, projectRoot)
 	}
 
 	unityVersion, err := resolveLaunchEditorVersion(projectRoot, options)
@@ -328,6 +324,17 @@ func cleanStaleUnityTemp(projectRoot string) (bool, error) {
 	}
 
 	return true, os.RemoveAll(filepath.Join(projectRoot, launchTempDirectoryName))
+}
+
+// A stale lockfile only proves no Unity process is currently running for this project;
+// it cannot distinguish a crash from a normal shutdown that left cleanup incomplete, so
+// the message must not assert a crash happened.
+func writeStaleUnityTempCleanupMessage(stdout io.Writer, projectRoot string) {
+	clicore.WriteFormat(stdout, "Stale UnityLockfile found (no active Unity process): %s\n", unityLockfilePath(projectRoot))
+	clicore.WriteLine(stdout, "Cleaning Temp directory and continuing launch.")
+	clicore.WriteLine(stdout, "Deleted Temp directory.")
+	clicore.WriteLine(stdout, "Deleted UnityLockfile.")
+	clicore.WriteLine(stdout, "")
 }
 
 func waitForUnityProcessExit(ctx context.Context, projectRoot string, pid int, pollInterval time.Duration, timeout time.Duration) error {

--- a/cli/dispatcher/internal/dispatcher/launch_test.go
+++ b/cli/dispatcher/internal/dispatcher/launch_test.go
@@ -790,6 +790,24 @@ func TestCleanStaleUnityTempDeletesTempWhenLockfileExists(t *testing.T) {
 	}
 }
 
+func TestWriteStaleUnityTempCleanupMessageDoesNotAssertCrash(t *testing.T) {
+	// Verifies the stale-lockfile message states the observed fact (no active Unity
+	// process) instead of overclaiming a crash, since a lockfile-only check cannot
+	// distinguish a crash from a normal shutdown that left cleanup incomplete.
+	projectRoot := createLaunchTestProject(t)
+	var stdout bytes.Buffer
+
+	writeStaleUnityTempCleanupMessage(&stdout, projectRoot)
+
+	output := stdout.String()
+	if strings.Contains(output, "crash") {
+		t.Fatalf("message must not assert a crash, got: %s", output)
+	}
+	if !strings.Contains(output, "Stale UnityLockfile found (no active Unity process)") {
+		t.Fatalf("message must state the observed fact neutrally, got: %s", output)
+	}
+}
+
 func TestWaitForUnityStartupMarkerReturnsAfterLockfileAppears(t *testing.T) {
 	// Verifies the startup marker wait returns as soon as Unity creates the lockfile.
 	projectRoot := createLaunchTestProject(t)


### PR DESCRIPTION
## Summary
- `uloop launch` no longer overclaims a crash when it finds a stale `UnityLockfile` and no running Unity process.

## User Impact
- Before: after a completely normal shutdown that simply left cleanup incomplete (e.g. the lockfile removal step didn't finish), the next `launch` printed "Assuming previous crash", which reads as an incorrect and anxiety-inducing diagnosis even though nothing actually went wrong.
- After: the message states the observed fact neutrally ("Stale UnityLockfile found (no active Unity process)") without asserting a crash. The stale-lockfile detection and cleanup behavior itself is unchanged — only the wording.

## Changes
- Extracted the stale-lockfile message block in `startUnityAndWaitForReadiness` into a dedicated `writeStaleUnityTempCleanupMessage` function and reworded it to avoid claiming a crash, since lockfile existence alone cannot distinguish a crash from a normal shutdown with incomplete cleanup.
- Added a unit test pinning the neutral wording and asserting the message never contains "crash".

## Verification
- `go vet ./...` (cli/dispatcher): clean
- `go test ./...` (cli/dispatcher): all packages pass, including the new `TestWriteStaleUnityTempCleanupMessageDoesNotAssertCrash`
- `golangci-lint fmt --diff` / `golangci-lint run` (cli/dispatcher): 0 issues
- `scripts/build-go-cli.sh`: rebuilt native binaries successfully


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

