### PR TITLE
feat: find-game-objects now hints at Contains/Regex when Exact matching finds nothing

### DIFF
--- a/Assets/Tests/Editor/FindGameObjectsToolTests.cs
+++ b/Assets/Tests/Editor/FindGameObjectsToolTests.cs
@@ -89,7 +89,62 @@ namespace io.github.hatayama.UnityCliLoop.Tests.Editor
             Assert.That(response.ErrorMessage, Is.Not.Null);
             Assert.That(response.ErrorMessage, Does.Contain("At least one search criterion"));
         }
-        
+
+        [Test]
+        public async Task ExecuteAsync_WithExactModeZeroHits_ReturnsPartialMatchModeHint()
+        {
+            // Verifies a zero-hit Exact-mode name search returns a hint pointing at
+            // Contains/Regex, since Exact is the default and silently misses partial matches.
+            JObject paramsJson = new()            {
+                ["NamePattern"] = "Camera",
+                ["SearchMode"] = "Exact"
+            };
+
+            UnityCliLoopToolResponse baseResponse = await tool.ExecuteAsync(paramsJson, System.Threading.CancellationToken.None);
+            FindGameObjectsResponse response = baseResponse as FindGameObjectsResponse;
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TotalFound, Is.EqualTo(0));
+            Assert.That(response.Message, Is.Not.Null);
+            Assert.That(response.Message, Does.Contain("Exact match found nothing"));
+            Assert.That(response.Message, Does.Contain("--search-mode Contains"));
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WithContainsModeZeroHits_DoesNotReturnExactModeHint()
+        {
+            // Verifies the Exact-mode hint is scoped to Exact mode only, since Contains/Regex
+            // already support partial matching and have no equivalent trap to warn about.
+            JObject paramsJson = new()            {
+                ["NamePattern"] = "NoSuchObjectNameAtAll",
+                ["SearchMode"] = "Contains"
+            };
+
+            UnityCliLoopToolResponse baseResponse = await tool.ExecuteAsync(paramsJson, System.Threading.CancellationToken.None);
+            FindGameObjectsResponse response = baseResponse as FindGameObjectsResponse;
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TotalFound, Is.EqualTo(0));
+            Assert.That(response.Message, Is.Null);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_WithExactModeNonZeroHits_DoesNotReturnHint()
+        {
+            // Verifies the hint only appears on a zero-hit result, not alongside real matches.
+            JObject paramsJson = new()            {
+                ["NamePattern"] = "TestObject1",
+                ["SearchMode"] = "Exact"
+            };
+
+            UnityCliLoopToolResponse baseResponse = await tool.ExecuteAsync(paramsJson, System.Threading.CancellationToken.None);
+            FindGameObjectsResponse response = baseResponse as FindGameObjectsResponse;
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TotalFound, Is.EqualTo(1));
+            Assert.That(response.Message, Is.Null);
+        }
+
         [Test]
         public async Task ExecuteAsync_WithComponentSearch_FindsObjectsWithSpecificComponent()
         {

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsUseCase.cs
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/FindGameObjectsUseCase.cs
@@ -107,9 +107,10 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                 
                 FindGameObjectsResponse response = new()                {
                     Results = results.ToArray(),
-                    TotalFound = results.Count
+                    TotalFound = results.Count,
+                    Message = BuildZeroHitExactModeHint(parameters, results.Count)
                 };
-                
+
                 // Underlying services are synchronous; wrapping in Task.FromResult for API consistency.
                 return Task.FromResult(response);
             }
@@ -130,6 +131,24 @@ namespace io.github.hatayama.UnityCliLoop.FirstPartyTools
                     ErrorMessage = "Search execution failed. Please check the logs for details."
                 });
             }
+        }
+
+        /// <summary>
+        /// Builds a hint pointing agents at partial-matching search modes when an Exact name-pattern
+        /// search finds nothing, since Exact is the tool's default and a literal-looking pattern
+        /// (e.g. "Camera") silently misses partial matches (e.g. "Main Camera") without this hint.
+        /// </summary>
+        private static string BuildZeroHitExactModeHint(FindGameObjectsSchema parameters, int totalFound)
+        {
+            if (totalFound != 0 ||
+                parameters.SearchMode != SearchMode.Exact ||
+                string.IsNullOrEmpty(parameters.NamePattern))
+            {
+                return null;
+            }
+
+            return $"Exact match found nothing for name pattern '{parameters.NamePattern}'. " +
+                   "Try --search-mode Contains or Regex for partial matching.";
         }
 
         /// <summary>

--- a/Packages/src/Editor/FirstPartyTools/FindGameObjects/Skill/SKILL.md
+++ b/Packages/src/Editor/FirstPartyTools/FindGameObjects/Skill/SKILL.md
@@ -33,7 +33,7 @@ uloop find-game-objects [options]
 
 | Mode | Description |
 |------|-------------|
-| `Exact` | Exact name match (default) |
+| `Exact` | Exact name match (default). **Trap**: `--name-pattern "Camera"` will not match a GameObject named `"Main Camera"` — use `Contains` or `Regex` for partial matching. A zero-hit `Exact` search returns a `Message` hint pointing this out (see Output). |
 | `Path` | Hierarchy path search (e.g., `Canvas/Button`) |
 | `Regex` | Regular expression pattern |
 | `Contains` | Partial name match |
@@ -62,3 +62,7 @@ For `Selected` mode with **multiple** successfully serialized GameObjects, inlin
 - `Message` (string): Human-readable summary (e.g., "5 GameObjects exported")
 
 Single-selection and search-mode calls (`Exact`, `Path`, `Regex`, `Contains`) always return inline. No selection (`Selected` mode with empty selection) returns empty `Results` plus a `Message`.
+
+### Zero-hit Exact-mode hint
+
+If an `Exact` search with a non-empty `--name-pattern` finds nothing (`TotalFound: 0`), `Message` carries a hint suggesting `Contains` or `Regex` instead of leaving the zero hit unexplained. This does not change the default mode or matching logic — it only surfaces the same trap described above at the point it actually bites.


### PR DESCRIPTION
## Summary
- A zero-hit `find-game-objects` search now tells you why, instead of leaving you to guess.

## User Impact
- Before: `--name-pattern "Camera"` found nothing for a GameObject named `"Main Camera"`, because the default search mode is `Exact`. The response gave no indication that a partial-matching mode existed, so the zero hit looked like the object simply didn't exist.
- After: the default stays `Exact` (unchanged), but a zero-hit `Exact` search with a name pattern now returns a `Message` hint suggesting `--search-mode Contains` or `Regex` for partial matching.

## Changes
- `FindGameObjectsUseCase` now attaches a hint to the response `Message` when `TotalFound == 0`, `SearchMode == Exact`, and a name pattern was provided.
- Added tests covering: hint present on zero-hit Exact search, hint absent for `Contains` mode, hint absent when results are found.
- Documented the `Exact`-mode trap and the new hint in the tool's skill doc.

## Verification
- `uloop compile`: 0 errors / 0 warnings
- `uloop run-tests` (`FindGameObjectsToolTests`): 25/25 passed (22 pre-existing + 3 new)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hatayama/unity-cli-loop/pull/1868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

